### PR TITLE
fix(ros2): merge service cache + group-restart on apps start (WDY-1720/1721)

### DIFF
--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -198,6 +198,32 @@ func (c *Client) getIsolation(appID string) string {
 	return c.appIsolation[appID]
 }
 
+// cacheAppServicesLocked records appID's services for stop/start-order and group
+// detection, MERGING into any existing entry rather than replacing it.
+//
+// A single-service redeploy (`wendy run --service X`) sends an AppConfig whose
+// Services map holds only X. Replacing would shrink the cached group to {X},
+// after which GroupRestartAppID no longer sees the app as a multi-service group
+// and the monitor restarts a wedged secondary as a lone container against the
+// primary's now-stale namespace PID — crash-looping forever on
+// `lstat /proc/<pid>/ns/ipc` (WDY-1721). Merging preserves the full service set,
+// including the dependsOn graph RestartGroup needs for ordering. Caller must
+// hold c.mu.
+func (c *Client) cacheAppServicesLocked(appID string, services map[string]*appconfig.ServiceConfig) {
+	if len(services) == 0 {
+		return
+	}
+	if c.appServices == nil {
+		c.appServices = make(map[string]map[string]*appconfig.ServiceConfig)
+	}
+	if c.appServices[appID] == nil {
+		c.appServices[appID] = make(map[string]*appconfig.ServiceConfig, len(services))
+	}
+	for name, svc := range services {
+		c.appServices[appID][name] = svc
+	}
+}
+
 // recordServiceIP stores the CNI-assigned IP for a service. Caller must hold c.mu.
 func (c *Client) recordServiceIP(appID, serviceName, ip string) {
 	if c.serviceIPs == nil {
@@ -931,10 +957,7 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 	// StartContainer PID tracking. c.mu is already held for the full function
 	// via defer c.mu.Unlock() above — no inner lock needed.
 	if len(appCfg.Services) > 0 {
-		if c.appServices == nil {
-			c.appServices = make(map[string]map[string]*appconfig.ServiceConfig)
-		}
-		c.appServices[appID] = appCfg.Services
+		c.cacheAppServicesLocked(appID, appCfg.Services)
 	}
 	if appCfg.Isolation != "" {
 		if c.appIsolation == nil {

--- a/go/internal/agent/containerd/groupservices_test.go
+++ b/go/internal/agent/containerd/groupservices_test.go
@@ -1,0 +1,39 @@
+package containerd
+
+import (
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+// TestCacheAppServicesLocked_MergeKeepsGroup covers WDY-1721: a single-service
+// redeploy (e.g. `wendy run --service talker`) must not shrink the cached
+// service set, or the monitor stops recognizing the app as a shared-namespace
+// group and restarts a wedged secondary against a stale primary PID.
+func TestCacheAppServicesLocked_MergeKeepsGroup(t *testing.T) {
+	c := &Client{}
+
+	// Initial full-group deploy: two services.
+	c.cacheAppServicesLocked("app", map[string]*appconfig.ServiceConfig{
+		"talker":   {Context: "./talker"},
+		"listener": {Context: "./listener", DependsOn: []string{"talker"}},
+	})
+	if got := len(c.appServices["app"]); got != 2 {
+		t.Fatalf("after full deploy: len = %d, want 2", got)
+	}
+
+	// Single-service redeploy of just the primary: must merge, not replace.
+	c.cacheAppServicesLocked("app", map[string]*appconfig.ServiceConfig{
+		"talker": {Context: "./talker"},
+	})
+	if got := len(c.appServices["app"]); got != 2 {
+		t.Fatalf("after --service talker redeploy: len = %d, want 2 (group must not shrink)", got)
+	}
+	if _, ok := c.appServices["app"]["listener"]; !ok {
+		t.Errorf("secondary 'listener' dropped from cached group after single-service redeploy")
+	}
+	// The dependsOn graph RestartGroup needs for ordering must be preserved.
+	if dep := c.appServices["app"]["listener"].DependsOn; len(dep) != 1 || dep[0] != "talker" {
+		t.Errorf("listener.DependsOn = %v, want [talker]", dep)
+	}
+}

--- a/go/internal/agent/services/container_service.go
+++ b/go/internal/agent/services/container_service.go
@@ -346,9 +346,8 @@ func (s *ContainerService) StartContainer(req *agentpb.StartContainerRequest, st
 	return s.streamContainerOutput(ctx, appName, postStartAgentHookFromContext(ctx), req.GetRestartPolicy(), stream)
 }
 
-// startGroup starts each service container in a multi-service app in detach
-// mode and sends a single Started response. Output from individual services
-// is discarded; use wendy device logs to tail per-service logs.
+// startGroup starts every service of a multi-service app in detach mode and
+// sends a single Started response (v1 streaming shape).
 func (s *ContainerService) startGroup(
 	ctx context.Context,
 	appName string,
@@ -356,32 +355,70 @@ func (s *ContainerService) startGroup(
 	restartPolicy *agentpb.RestartPolicy,
 	stream grpc.ServerStreamingServer[agentpb.RunContainerLayersResponse],
 ) error {
+	if err := s.startGroupDetached(ctx, appName, containerIDs, restartPolicy); err != nil {
+		return err
+	}
+	return stream.Send(&agentpb.RunContainerLayersResponse{
+		ResponseType: &agentpb.RunContainerLayersResponse_Started_{
+			Started: &agentpb.RunContainerLayersResponse_Started{},
+		},
+	})
+}
+
+// startGroupDetached starts every service container of a multi-service app in
+// detach mode (output is drained, not streamed — use `wendy device logs`).
+//
+// A shared-namespace group (shared-ipc / shared-network) is started via
+// RestartGroup so members come up in dependency order and each secondary's
+// namespace join is re-resolved against the freshly-started primary's live PID.
+// Starting members independently would re-attach a secondary to the primary's
+// old/dead namespace, leaving it crash-looping on a stale `/proc/<pid>/ns/*`
+// (WDY-1720 makes `apps start <appId>` work for groups; WDY-1721 keeps the
+// shared-namespace invariant across that restart).
+func (s *ContainerService) startGroupDetached(
+	ctx context.Context,
+	appName string,
+	containerIDs []string,
+	restartPolicy *agentpb.RestartPolicy,
+) error {
 	unlock := s.appMu.lockApp(appName)
 	defer unlock()
 
-	for _, id := range containerIDs {
-		outputCh, startErr := s.containerd.StartContainer(ctx, id, "", restartPolicy)
-		if startErr != nil {
-			return status.Errorf(codes.Internal, "failed to start service %q: %v", id, startErr)
-		}
-		// Drain the output channel in the background so the containerd goroutine
-		// does not block. The container runs independently after this.
-		go func(ch <-chan ContainerOutput) {
-			for range ch {
+	register := func(id string, ch <-chan ContainerOutput) {
+		// Drain in the background so the containerd output pipe never blocks.
+		go func(c <-chan ContainerOutput) {
+			for range c {
 			}
-		}(outputCh)
-
+		}(ch)
 		if s.monitor != nil {
 			s.monitor.ClearExplicitStop(id)
 		}
 		s.registerContainerWithMonitor(ctx, id, restartPolicy)
 	}
 
-	return stream.Send(&agentpb.RunContainerLayersResponse{
-		ResponseType: &agentpb.RunContainerLayersResponse_Started_{
-			Started: &agentpb.RunContainerLayersResponse_Started{},
-		},
-	})
+	// Shared-namespace groups must restart as a unit with namespace re-resolution.
+	if gr, ok := s.containerd.(GroupRestarter); ok && len(containerIDs) > 0 {
+		if appID, grouped := gr.GroupRestartAppID(ctx, containerIDs[0]); grouped {
+			channels, err := gr.RestartGroup(ctx, appID)
+			if err != nil {
+				return status.Errorf(codes.Internal, "failed to start app group %q: %v", appName, err)
+			}
+			for id, ch := range channels {
+				register(id, ch)
+			}
+			return nil
+		}
+	}
+
+	// Non-shared-namespace multi-service app: members are independent, start each.
+	for _, id := range containerIDs {
+		outputCh, startErr := s.containerd.StartContainer(ctx, id, "", restartPolicy)
+		if startErr != nil {
+			return status.Errorf(codes.Internal, "failed to start service %q: %v", id, startErr)
+		}
+		register(id, outputCh)
+	}
+	return nil
 }
 
 func postStartAgentHookFromContext(ctx context.Context) string {

--- a/go/internal/agent/services/container_service_v2.go
+++ b/go/internal/agent/services/container_service_v2.go
@@ -24,7 +24,20 @@ func NewContainerServiceV2(v1 *ContainerService) *ContainerServiceV2 {
 }
 
 func (s *ContainerServiceV2) StartContainer(req *agentpbv2.StartContainerRequest, stream grpc.ServerStreamingServer[agentpbv2.ContainerStreamResponse]) error {
-	return s.v1.streamContainerOutput(stream.Context(), req.GetAppName(), postStartAgentHookFromContext(stream.Context()), nil, &containerStreamV1Adapter{v2stream: stream})
+	ctx := stream.Context()
+	appName := req.GetAppName()
+
+	// Multi-service groups: start every service (detached) rather than rejecting
+	// a bare appID as ambiguous. Mirrors `apps stop <appId>`, which already acts
+	// on the whole group (WDY-1720). streamContainerOutput streams a single
+	// container and would otherwise fail with "has multiple service containers".
+	if s.v1.containerd != nil {
+		if ids, err := s.v1.containerd.ContainerIDsForApp(ctx, appName); err == nil && len(ids) > 1 {
+			return s.v1.startGroupDetached(ctx, appName, ids, nil)
+		}
+	}
+
+	return s.v1.streamContainerOutput(ctx, appName, postStartAgentHookFromContext(ctx), nil, &containerStreamV1Adapter{v2stream: stream})
 }
 
 func (s *ContainerServiceV2) AttachContainer(stream grpc.BidiStreamingServer[agentpbv2.AttachContainerRequest, agentpbv2.ContainerStreamResponse]) error {


### PR DESCRIPTION
## Summary
Two related multi-service-group fixes, ported from the stale #1141 and isolated from its bundled, now-redundant WDY-1717/1719 changes. Both still apply to current `main`.

### WDY-1721 — shared-ipc secondary crash-loops on a stale primary PID
`wendy run --service <primary>` sends an `AppConfig` whose `Services` map holds only that one service. The agent cached it with a plain **overwrite** (`c.appServices[appID] = appCfg.Services`), shrinking the cached group to a single service. The monitor then no longer recognized the shared-namespace group and restarted a wedged secondary as a lone container against the primary's now-dead namespace PID — crash-looping on `lstat /proc/<pid>/ns/ipc`.

Fix: new `cacheAppServicesLocked` **merges** into the existing entry, preserving the full service set and its `dependsOn` graph.

### WDY-1720 — `apps start <appId>` for a multi-service group
v2 `StartContainer` rejected a bare group appID. It now detects a group and starts it as a unit via `startGroupDetached`, which routes shared-namespace groups through `RestartGroup` so each secondary re-resolves the freshly-started primary's live PID.

## Why this is separate from #1141
#1141 bundled these with WDY-1717 (fixed on main by f49e7830) and WDY-1719 (superseded by main's CycloneDDS sidecar — the default RMW stays cyclonedds, so its default-flip was intentionally dropped here). This branch carries only the parts still missing from `main`.

## Testing
New `groupservices_test.go` covers the cache merge. `go build`, `go vet`, and the `containerd` + `services` package tests pass.

> ⚠️ Static fix — the original crash-loop was found on-device; a device repro of the merge fix is still worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)