### PR TITLE
feat(cli): record specific failure reasons for os install in analytics

### DIFF
--- a/go/cmd/wendy/main.go
+++ b/go/cmd/wendy/main.go
@@ -48,6 +48,11 @@ func main() {
 //     "dev" default or a CI branch build with a "-dev" suffix.
 //   - error_class (only when err != nil): bounded enum derived from err —
 //     never the error message text, which can leak hostnames or paths.
+//   - error_detail (only for catch-all classes "other"/"grpc_other"): a
+//     best-effort redacted excerpt of the error message, so failures that
+//     carry no specific reason code are still diagnosable. See
+//     analytics.RedactErrorDetail — this is deliberately relaxed from the
+//     error_class no-message-text rule, scoped to the unclassified buckets.
 func trackCommand(executed *cobra.Command, err error, dur time.Duration) {
 	if executed == nil {
 		return
@@ -69,7 +74,18 @@ func trackCommand(executed *cobra.Command, err error, dur time.Duration) {
 		"is_dev_build": strconv.FormatBool(version.IsDev(version.Version)),
 	}
 	if err != nil {
-		props["error_class"] = errorClass(err)
+		class := errorClass(err)
+		props["error_class"] = class
+		// For catch-all buckets the class alone says nothing about what
+		// happened, so attach a best-effort redacted detail. Classified
+		// buckets (install_* reasons, grpc_unavailable, context_*,
+		// user_cancelled, …) are self-describing and get no detail, keeping
+		// data collection and PII surface minimal.
+		if class == "other" || class == "grpc_other" {
+			if detail := analytics.RedactErrorDetail(err.Error()); detail != "" {
+				props["error_detail"] = detail
+			}
+		}
 	}
 	analytics.Track(event, props)
 
@@ -160,10 +176,12 @@ func milestoneFor(commandPath string, success bool) string {
 
 // errorClass maps an execution error to a bounded enum suitable for analytics.
 // It must never embed the error message, which can contain hostnames, paths,
-// or other user input.
+// or other user input. (The free-text detail lives in a separate, redacted
+// error_detail property set by trackCommand — never here.)
 //
 // User-cancellation sentinels are checked first so an outer wrap never
-// reclassifies them. gRPC errors are extracted via status.FromError, which
+// reclassifies them, then cancellation/deadline, then any command-supplied
+// commands.ReasonError code (see commands.WithReason), then gRPC codes. gRPC errors are extracted via status.FromError, which
 // walks the wrapped chain — substring matching on err.Error() would miss
 // errors wrapped via fmt.Errorf with a custom prefix or any future change to
 // grpc-go's stringification.
@@ -173,6 +191,23 @@ func errorClass(err error) string {
 	}
 	if errors.Is(err, commands.ErrUserCancelled) || errors.Is(err, commands.ErrDefaultCleared) {
 		return "user_cancelled"
+	}
+	// Cancellation and deadline are checked before any command-supplied reason
+	// so an install_* wrap of a cancelled/timed-out operation is never
+	// mislabeled as an install failure.
+	if errors.Is(err, context.Canceled) {
+		return "context_canceled"
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "context_deadline"
+	}
+	// A command may tag a failure with a bounded reason code (see
+	// commands.WithReason), which is more specific than the gRPC/"other"
+	// fallbacks below. gRPC transport errors are not wrapped this way, so this
+	// never hides grpc_unavailable/grpc_deadline/etc.
+	var re *commands.ReasonError
+	if errors.As(err, &re) && re.Reason != "" {
+		return re.Reason
 	}
 	// status.FromError returns ok=true only for real gRPC errors (those
 	// produced by the grpc package or implementing GRPCStatus()). For
@@ -193,12 +228,6 @@ func errorClass(err error) string {
 		default:
 			return "grpc_other"
 		}
-	}
-	if errors.Is(err, context.Canceled) {
-		return "context_canceled"
-	}
-	if errors.Is(err, context.DeadlineExceeded) {
-		return "context_deadline"
 	}
 	return "other"
 }

--- a/go/cmd/wendy/main_test.go
+++ b/go/cmd/wendy/main_test.go
@@ -347,6 +347,103 @@ func TestErrorClass_NeverLeaksMessageText(t *testing.T) {
 	}
 }
 
+func TestErrorClass_ReasonError(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"install_download", commands.WithReason("install_download", errors.New("boom")), "install_download"},
+		{"install_disk_write", commands.WithReason("install_disk_write", errors.New("io error")), "install_disk_write"},
+		{"wrapped_reason", fmt.Errorf("outer: %w", commands.WithReason("install_manifest", errors.New("x"))), "install_manifest"},
+		// Cancellation and deadline must win over a reason wrap.
+		{"reason_wrapping_cancel", commands.WithReason("install_disk_write", context.Canceled), "context_canceled"},
+		{"reason_wrapping_deadline", commands.WithReason("install_download", context.DeadlineExceeded), "context_deadline"},
+		{"reason_wrapping_user_cancel", commands.WithReason("install_disk_write", commands.ErrUserCancelled), "user_cancelled"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := errorClass(tc.err); got != tc.want {
+				t.Errorf("errorClass = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTrackCommand_ErrorDetailForCatchAll(t *testing.T) {
+	clearCIEnv(t)
+	events := captureAnalytics(t)
+	// The "failing" command returns errors.New("boom") → class "other".
+	executed, err := runWithArgs(t, []string{"wendy", "failing"})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	trackCommand(executed, err, time.Millisecond)
+
+	got := (*events)[0].props
+	if got["error_class"] != "other" {
+		t.Fatalf("error_class = %q, want %q", got["error_class"], "other")
+	}
+	if got["error_detail"] != "boom" {
+		t.Errorf("error_detail = %q, want %q", got["error_detail"], "boom")
+	}
+}
+
+func TestTrackCommand_ErrorDetailRedactsPII(t *testing.T) {
+	clearCIEnv(t)
+	events := captureAnalytics(t)
+	root := newTestRoot()
+	executed, _, err := root.Find([]string{"failing"})
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	leaky := errors.New("writing image: /dev/disk4: dial 192.168.1.10 failed for host secret.example.com")
+	trackCommand(executed, leaky, time.Millisecond)
+
+	detail := (*events)[0].props["error_detail"]
+	for _, leak := range []string{"/dev/disk4", "192.168.1.10", "secret.example.com"} {
+		if strings.Contains(detail, leak) {
+			t.Errorf("error_detail leaked %q: %q", leak, detail)
+		}
+	}
+	if !strings.Contains(detail, "writing image") {
+		t.Errorf("error_detail dropped structural text: %q", detail)
+	}
+}
+
+func TestTrackCommand_NoErrorDetailForClassifiedBuckets(t *testing.T) {
+	clearCIEnv(t)
+	events := captureAnalytics(t)
+	root := newTestRoot()
+	executed, _, err := root.Find([]string{"failing"})
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	// A gRPC Unavailable classifies as grpc_unavailable (not a catch-all), so
+	// no error_detail is attached even though the message has a hostname.
+	trackCommand(executed, status.Error(codes.Unavailable, "reach secret-host.example.com"), time.Millisecond)
+
+	got := (*events)[0].props
+	if got["error_class"] != "grpc_unavailable" {
+		t.Fatalf("error_class = %q, want grpc_unavailable", got["error_class"])
+	}
+	if _, present := got["error_detail"]; present {
+		t.Errorf("error_detail must be absent for classified buckets, got %q", got["error_detail"])
+	}
+}
+
+func TestTrackCommand_NoErrorDetailOnSuccess(t *testing.T) {
+	clearCIEnv(t)
+	events := captureAnalytics(t)
+	executed, err := runWithArgs(t, []string{"wendy", "run", "x"})
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	trackCommand(executed, nil, time.Millisecond)
+	if _, present := (*events)[0].props["error_detail"]; present {
+		t.Errorf("error_detail must be absent on success")
+	}
+}
+
 func TestFormatError_EnrollmentTokenUnavailableIsCloudError(t *testing.T) {
 	err := fmt.Errorf("creating enrollment token: %w", status.Error(codes.Unavailable, "connection refused"))
 

--- a/go/internal/cli/analytics/analytics.go
+++ b/go/internal/cli/analytics/analytics.go
@@ -31,6 +31,7 @@ type eventPayload struct {
 	DurationMS  int64  `json:"duration_ms,omitempty"`
 	Success     bool   `json:"success"`
 	ErrorClass  string `json:"error_class,omitempty"`
+	ErrorDetail string `json:"error_detail,omitempty"`
 	CLIVersion  string `json:"cli_version"`
 	OS          string `json:"os"`
 	Arch        string `json:"arch"`
@@ -111,6 +112,7 @@ func Track(event string, properties map[string]string) {
 		DurationMS:  parseInt64(properties["duration_ms"]),
 		Success:     parseBool(properties["success"]),
 		ErrorClass:  properties["error_class"],
+		ErrorDetail: properties["error_detail"],
 		CLIVersion:  version.Version,
 		OS:          runtime.GOOS,
 		Arch:        runtime.GOARCH,

--- a/go/internal/cli/analytics/redact.go
+++ b/go/internal/cli/analytics/redact.go
@@ -1,0 +1,78 @@
+package analytics
+
+import (
+	"regexp"
+	"strings"
+)
+
+// maxErrorDetailRunes caps the redacted detail so a pathological error can't
+// bloat the payload or the analytics store, and bounds residual leak surface.
+const maxErrorDetailRunes = 200
+
+const redactedToken = "[redacted]"
+
+// Redaction patterns, applied in order. This is best-effort PII scrubbing for
+// the error_detail field: it strips the common ways a Go error string carries
+// user- or environment-specific data (paths, hosts, addresses, emails) while
+// leaving the structural, non-sensitive text (errno phrases, fmt prefixes,
+// versions, device-type slugs) intact. Patterns are adapted from the agent-side
+// dmesg redactor.
+var (
+	// URLs first, so a host embedded in a URL doesn't survive as a bare FQDN.
+	reURL = regexp.MustCompile(`https?://\S+`)
+
+	// IPv6: a hex group followed by two or more ":hex" groups (empty groups
+	// allow the "::" compressed form). This also catches colon-form MAC
+	// addresses, which is fine — they are redacted either way.
+	reIPv6 = regexp.MustCompile(`[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{0,4}){2,}`)
+
+	// Email before FQDN so the domain part is consumed together with the
+	// local part (stripping the domain first would leave the username behind).
+	reEmail = regexp.MustCompile(`\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b`)
+
+	// Bare dotted hostnames / FQDNs. Requires an alphabetic TLD, so dotted
+	// version strings like "0.10.4" (digit-terminated) are not matched.
+	reFQDN = regexp.MustCompile(`\b([A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,}\b`)
+
+	// IPv4 dotted quad.
+	reIPv4 = regexp.MustCompile(`\b\d{1,3}(?:\.\d{1,3}){3}\b`)
+
+	// Hyphen-form MAC (colon-form is covered by reIPv6 above).
+	reMACHyphen = regexp.MustCompile(`\b(?:[0-9A-Fa-f]{2}-){5}[0-9A-Fa-f]{2}\b`)
+
+	// Windows absolute path (drive letter + backslash run).
+	reWinPath = regexp.MustCompile(`[A-Za-z]:\\[^\s]*`)
+
+	// Unix absolute path: a "/" that begins a path — anchored with \B so a "/"
+	// preceded by a word char (e.g. the "/" in "input/output") is NOT treated
+	// as a path root — followed by one or more "/segment" runs. Covers home,
+	// device, and temp paths (/Users, /home, /root, /dev, /tmp, /var, …).
+	reUnixPath = regexp.MustCompile(`\B/[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*`)
+)
+
+// RedactErrorDetail returns a best-effort PII-scrubbed, length-capped copy of an
+// error message suitable for the error_detail analytics field. It is not a
+// security boundary: it removes the common shapes of sensitive data, not every
+// conceivable one. Returns "" for an empty input.
+func RedactErrorDetail(msg string) string {
+	if msg == "" {
+		return ""
+	}
+	for _, re := range []*regexp.Regexp{
+		reURL,
+		reIPv6,
+		reEmail,
+		reFQDN,
+		reIPv4,
+		reMACHyphen,
+		reWinPath,
+		reUnixPath,
+	} {
+		msg = re.ReplaceAllString(msg, redactedToken)
+	}
+	msg = strings.TrimSpace(msg)
+	if r := []rune(msg); len(r) > maxErrorDetailRunes {
+		msg = strings.TrimSpace(string(r[:maxErrorDetailRunes]))
+	}
+	return msg
+}

--- a/go/internal/cli/analytics/redact.go
+++ b/go/internal/cli/analytics/redact.go
@@ -40,8 +40,19 @@ var (
 	// Hyphen-form MAC (colon-form is covered by reIPv6 above).
 	reMACHyphen = regexp.MustCompile(`\b(?:[0-9A-Fa-f]{2}-){5}[0-9A-Fa-f]{2}\b`)
 
+	// Windows UNC path (\\host\share\...). Matched before the drive-letter form
+	// so the leading double backslash is consumed as one token.
+	reUNCPath = regexp.MustCompile(`\\\\[^\s\\]+(?:\\[^\s]*)?`)
+
 	// Windows absolute path (drive letter + backslash run).
 	reWinPath = regexp.MustCompile(`[A-Za-z]:\\[^\s]*`)
+
+	// Collapse runs of adjacent redaction tokens (separated only by whitespace or
+	// path/address punctuation) into one, so the output neither reads as
+	// "[redacted] [redacted]" nor discloses how many tokens were stripped.
+	// Separators are matched only *between* tokens, never trailing, so the space
+	// before the following word survives.
+	reCollapse = regexp.MustCompile(regexp.QuoteMeta(redactedToken) + `(?:[\s:/\\.,-]*` + regexp.QuoteMeta(redactedToken) + `)+`)
 
 	// Unix absolute path: a "/" that begins a path — anchored with \B so a "/"
 	// preceded by a word char (e.g. the "/" in "input/output") is NOT treated
@@ -51,9 +62,13 @@ var (
 )
 
 // RedactErrorDetail returns a best-effort PII-scrubbed, length-capped copy of an
-// error message suitable for the error_detail analytics field. It is not a
-// security boundary: it removes the common shapes of sensitive data, not every
-// conceivable one. Returns "" for an empty input.
+// error message suitable for the error_detail analytics field. It is NOT a
+// security boundary: it is a denylist, so it removes only the shapes of
+// sensitive data it recognizes. Known residual gaps that are NOT stripped:
+// bare single-label hostnames (e.g. "my-laptop"), usernames that appear outside
+// a path (e.g. "for user alice"), and other free-form identifiers — a denylist
+// cannot tell these from ordinary words. Callers must treat the output as
+// reduced-risk, not PII-free. Returns "" for an empty input.
 func RedactErrorDetail(msg string) string {
 	if msg == "" {
 		return ""
@@ -65,11 +80,13 @@ func RedactErrorDetail(msg string) string {
 		reFQDN,
 		reIPv4,
 		reMACHyphen,
+		reUNCPath,
 		reWinPath,
 		reUnixPath,
 	} {
 		msg = re.ReplaceAllString(msg, redactedToken)
 	}
+	msg = reCollapse.ReplaceAllString(msg, redactedToken)
 	msg = strings.TrimSpace(msg)
 	if r := []rune(msg); len(r) > maxErrorDetailRunes {
 		msg = strings.TrimSpace(string(r[:maxErrorDetailRunes]))

--- a/go/internal/cli/analytics/redact.go
+++ b/go/internal/cli/analytics/redact.go
@@ -21,9 +21,15 @@ var (
 	// URLs first, so a host embedded in a URL doesn't survive as a bare FQDN.
 	reURL = regexp.MustCompile(`https?://\S+`)
 
+	// Colon-form MAC (e.g. "00:1a:7d:da:71:13"). Matched before reIPv6 so MAC
+	// redaction is deterministic and self-contained rather than relying on the
+	// IPv6 pattern to catch MACs as a side-effect (a coupling that would silently
+	// break if reIPv6 changed).
+	reMACColon = regexp.MustCompile(`\b(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b`)
+
 	// IPv6: a hex group followed by two or more ":hex" groups (empty groups
-	// allow the "::" compressed form). This also catches colon-form MAC
-	// addresses, which is fine — they are redacted either way.
+	// allow the "::" compressed form). Colon-form MACs are handled by
+	// reMACColon above; this only needs to cover genuine IPv6 literals.
 	reIPv6 = regexp.MustCompile(`[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{0,4}){2,}`)
 
 	// Email before FQDN so the domain part is consumed together with the
@@ -37,7 +43,7 @@ var (
 	// IPv4 dotted quad.
 	reIPv4 = regexp.MustCompile(`\b\d{1,3}(?:\.\d{1,3}){3}\b`)
 
-	// Hyphen-form MAC (colon-form is covered by reIPv6 above).
+	// Hyphen-form MAC (colon-form is covered by reMACColon above).
 	reMACHyphen = regexp.MustCompile(`\b(?:[0-9A-Fa-f]{2}-){5}[0-9A-Fa-f]{2}\b`)
 
 	// Windows UNC path (\\host\share\...). Matched before the drive-letter form
@@ -75,6 +81,7 @@ func RedactErrorDetail(msg string) string {
 	}
 	for _, re := range []*regexp.Regexp{
 		reURL,
+		reMACColon,
 		reIPv6,
 		reEmail,
 		reFQDN,

--- a/go/internal/cli/analytics/redact_test.go
+++ b/go/internal/cli/analytics/redact_test.go
@@ -61,10 +61,22 @@ func TestRedactErrorDetail_StripsPII(t *testing.T) {
 			survive: []string{"dial tcp", "no route to host"},
 		},
 		{
-			name:    "mac address",
+			name:    "mac address colon form",
 			in:      "bluetooth device 00:1a:7d:da:71:13 not found",
 			leaks:   []string{"00:1a:7d:da:71:13"},
 			survive: []string{"bluetooth device", "not found"},
+		},
+		{
+			name:    "mac address hyphen form",
+			in:      "bluetooth device 00-1A-7D-DA-71-13 not found",
+			leaks:   []string{"00-1A-7D-DA-71-13"},
+			survive: []string{"bluetooth device", "not found"},
+		},
+		{
+			name:    "windows named pipe",
+			in:      `dial \\.\pipe\wendy-agent-1234: access denied`,
+			leaks:   []string{`\\.\pipe`, "wendy-agent-1234"},
+			survive: []string{"dial", "access denied"},
 		},
 		{
 			name:    "email",

--- a/go/internal/cli/analytics/redact_test.go
+++ b/go/internal/cli/analytics/redact_test.go
@@ -31,6 +31,12 @@ func TestRedactErrorDetail_StripsPII(t *testing.T) {
 			survive: []string{"creating temp file", "access denied"},
 		},
 		{
+			name:    "windows unc path",
+			in:      `mounting: open \\fileserver\share\secret\image.img: network path not found`,
+			leaks:   []string{`\\fileserver`, "fileserver", "share", "secret"},
+			survive: []string{"mounting", "network path not found"},
+		},
+		{
 			name:    "url",
 			in:      "downloading: Get \"https://secret-host.example.com/images/wendyos.zip\": connection refused",
 			leaks:   []string{"secret-host.example.com", "secret-host", "/images/wendyos.zip"},
@@ -90,6 +96,19 @@ func TestRedactErrorDetail_PreservesSafeTokens(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Errorf("safe token %q was redacted: %q", want, got)
 		}
+	}
+}
+
+func TestRedactErrorDetail_CollapsesAdjacentTokens(t *testing.T) {
+	// Two paths separated only by whitespace/punctuation should not produce a
+	// run of "[redacted] [redacted]" — collapse keeps the output readable and
+	// avoids hinting at how many tokens were stripped.
+	got := RedactErrorDetail("copy /Users/a/x.img /Users/b/y.img failed")
+	if strings.Contains(got, "[redacted] [redacted]") || strings.Contains(got, "[redacted][redacted]") {
+		t.Errorf("adjacent redacted tokens were not collapsed: %q", got)
+	}
+	if !strings.Contains(got, "[redacted]") {
+		t.Errorf("expected at least one redaction: %q", got)
 	}
 }
 

--- a/go/internal/cli/analytics/redact_test.go
+++ b/go/internal/cli/analytics/redact_test.go
@@ -1,0 +1,108 @@
+package analytics
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRedactErrorDetail_StripsPII(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		in      string
+		leaks   []string // substrings that MUST NOT survive
+		survive []string // structural text that MUST survive
+	}{
+		{
+			name:    "unix home path",
+			in:      "opening image: open /Users/joannis/secret/wendyos.img: no such file or directory",
+			leaks:   []string{"/Users/joannis", "joannis", "secret", "wendyos.img"},
+			survive: []string{"opening image", "no such file or directory"},
+		},
+		{
+			name:    "device node",
+			in:      "writing image: /dev/disk4: input/output error",
+			leaks:   []string{"/dev/disk4"},
+			survive: []string{"writing image", "input/output error"},
+		},
+		{
+			name:    "windows path",
+			in:      `creating temp file: open C:\Users\joannis\AppData\wendyos-123.img: access denied`,
+			leaks:   []string{`C:\Users\joannis`, "joannis", "AppData"},
+			survive: []string{"creating temp file", "access denied"},
+		},
+		{
+			name:    "url",
+			in:      "downloading: Get \"https://secret-host.example.com/images/wendyos.zip\": connection refused",
+			leaks:   []string{"secret-host.example.com", "secret-host", "/images/wendyos.zip"},
+			survive: []string{"downloading", "connection refused"},
+		},
+		{
+			name:    "bare fqdn",
+			in:      "connecting to internal-registry.corp.example.net timed out",
+			leaks:   []string{"internal-registry.corp.example.net", "internal-registry"},
+			survive: []string{"connecting to", "timed out"},
+		},
+		{
+			name:    "ipv4",
+			in:      "dial tcp 192.168.1.42:8080: connect: connection refused",
+			leaks:   []string{"192.168.1.42"},
+			survive: []string{"dial tcp", "connection refused"},
+		},
+		{
+			name:    "ipv6",
+			in:      "dial tcp [2001:db8:85a3::8a2e:370:7334]:443: no route to host",
+			leaks:   []string{"2001:db8:85a3", "8a2e:370:7334"},
+			survive: []string{"dial tcp", "no route to host"},
+		},
+		{
+			name:    "mac address",
+			in:      "bluetooth device 00:1a:7d:da:71:13 not found",
+			leaks:   []string{"00:1a:7d:da:71:13"},
+			survive: []string{"bluetooth device", "not found"},
+		},
+		{
+			name:    "email",
+			in:      "auth failed for joannis@wendy.sh: invalid token",
+			leaks:   []string{"joannis@wendy.sh", "joannis"},
+			survive: []string{"auth failed", "invalid token"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RedactErrorDetail(tc.in)
+			for _, leak := range tc.leaks {
+				if strings.Contains(got, leak) {
+					t.Errorf("redacted output leaked %q\n  in:  %q\n  got: %q", leak, tc.in, got)
+				}
+			}
+			for _, s := range tc.survive {
+				if !strings.Contains(got, s) {
+					t.Errorf("redacted output dropped structural text %q\n  in:  %q\n  got: %q", s, tc.in, got)
+				}
+			}
+		})
+	}
+}
+
+func TestRedactErrorDetail_PreservesSafeTokens(t *testing.T) {
+	in := "version 0.10.4 not found for raspberry-pi-5"
+	got := RedactErrorDetail(in)
+	for _, want := range []string{"0.10.4", "raspberry-pi-5", "not found"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("safe token %q was redacted: %q", want, got)
+		}
+	}
+}
+
+func TestRedactErrorDetail_CapsLength(t *testing.T) {
+	in := strings.Repeat("abcdefghij ", 100) // 1100 runes, no PII
+	got := RedactErrorDetail(in)
+	if len([]rune(got)) > maxErrorDetailRunes {
+		t.Errorf("redacted output length = %d runes, want <= %d", len([]rune(got)), maxErrorDetailRunes)
+	}
+}
+
+func TestRedactErrorDetail_Empty(t *testing.T) {
+	if got := RedactErrorDetail(""); got != "" {
+		t.Errorf("RedactErrorDetail(\"\") = %q, want \"\"", got)
+	}
+}

--- a/go/internal/cli/assets/docs/clients/wendy-cli/analytics.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/analytics.md
@@ -34,13 +34,29 @@ Every event is an anonymous JSON object. The fields sent are:
 | `command_root` | string | Top-level command token |
 | `duration_ms` | integer | Command duration in milliseconds |
 | `success` | boolean | Whether the command completed without error |
-| `error_class` | string | Bounded enum describing the error category (never free-form error text) |
+| `error_class` | string | Bounded enum describing the error category (never free-form error text). Values include `user_cancelled`, `context_canceled`, `context_deadline`, `grpc_unavailable`, `grpc_deadline`, `grpc_unimplemented`, `grpc_other`, the `install_*` reason codes for `os install` failures (e.g. `install_download`, `install_disk_write`), and `other` for anything unclassified |
+| `error_detail` | string | Best-effort **redacted** excerpt of the error message. Sent **only** when `error_class` is a catch-all bucket (`other` or `grpc_other`); absent on success and for every classified error. See [redaction](#error_detail-redaction) |
 | `cli_version` | string | CLI version string |
 | `os` | string | Operating system (`GOOS`) |
 | `arch` | string | CPU architecture (`GOARCH`) |
 | `is_dev_build` | boolean | `true` when `cli_version == "dev"` |
 
-> **Privacy note:** Flag values, positional arguments, file paths, hostnames, and error message text are never included in telemetry payloads. Only the fields listed above are sent.
+> **Privacy note:** Flag values, positional arguments, and raw error message text are never included in classified telemetry. `error_class` is always a bounded enum. The one exception is `error_detail`: for *unclassified* failures (`error_class` `other`/`grpc_other`) a **redacted** excerpt of the error message is sent, with file paths, hostnames, IP addresses, MAC addresses, URLs, and email addresses stripped and the value capped at 200 characters. Redaction is best-effort — see the limitations below.
+
+## `error_detail` redaction
+
+When `error_class` is `other` or `grpc_other`, the CLI sends a redacted excerpt of the error message as `error_detail` so unclassified failures remain diagnosable. Before the value leaves the machine, the following patterns are replaced with `[redacted]`:
+
+- URLs (`http(s)://…`)
+- IPv4 and IPv6 addresses
+- MAC addresses (colon and hyphen forms)
+- Email addresses
+- Dotted hostnames / FQDNs
+- Absolute file paths — Unix (`/Users/…`, `/home/…`, `/dev/…`, `/tmp/…`, …), Windows drive paths (`C:\…`), and UNC paths (`\\host\share\…`)
+
+Structural text — errno phrases (`no space left on device`), `fmt.Errorf` prefix chains (`writing image:`), version strings, and device-type slugs — survives, and the result is capped at 200 Unicode code points.
+
+**Known limitations (best-effort, not a guarantee):** the redactor is a denylist, so it cannot strip data it can't recognize — a bare single-label hostname (`my-laptop`), a username that appears outside a path (`for user alice`), or other free-form identifiers may survive. It reduces, but does not eliminate, the chance of sensitive text reaching the backend.
 
 ## Opting out
 

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -152,20 +152,20 @@ Flags can be provided progressively — omitted values trigger interactive picke
 func runOSInstallDirect(imagePath string, driveID string, force bool, yesOverwriteInternal bool) error {
 	// Verify the image file exists.
 	if _, err := os.Stat(imagePath); err != nil {
-		return fmt.Errorf("image file: %w", err)
+		return WithReason(reasonInstallImageOpen, fmt.Errorf("image file: %w", err))
 	}
 
 	// Authenticate elevation before any disk-listing or write work. On
 	// Windows this offers a UAC re-launch when the current process isn't
 	// elevated; on Unix it pre-caches the sudo timestamp.
 	if err := preAuthElevation(); err != nil {
-		return err
+		return WithReason(reasonInstallElevation, err)
 	}
 
 	// Find the target drive.
 	drives, err := listAllDrives()
 	if err != nil {
-		return fmt.Errorf("listing drives: %w", err)
+		return WithReason(reasonInstallDriveList, fmt.Errorf("listing drives: %w", err))
 	}
 
 	var targetDrive *drive
@@ -176,7 +176,7 @@ func runOSInstallDirect(imagePath string, driveID string, force bool, yesOverwri
 		}
 	}
 	if targetDrive == nil {
-		return fmt.Errorf("drive %s not found", driveID)
+		return WithReason(reasonInstallDriveNotFound, fmt.Errorf("drive %s not found", driveID))
 	}
 
 	if err := confirmOverwriteInternalDrive(*targetDrive, force, yesOverwriteInternal); err != nil {
@@ -196,14 +196,14 @@ func runOSInstallDirect(imagePath string, driveID string, force bool, yesOverwri
 
 	stream, err := openLocalImageStream(imagePath)
 	if err != nil {
-		return fmt.Errorf("opening image: %w", err)
+		return WithReason(reasonInstallImageOpen, fmt.Errorf("opening image: %w", err))
 	}
 	defer stream.Close()
 
 	fmt.Printf("Writing image to %s...\n", targetDrive.DevicePath)
 	fmt.Println(elevationHint())
 	if err := writeImageToDisk(stream, stream.uncompressedSize, *targetDrive, nil); err != nil {
-		return fmt.Errorf("writing image: %w", err)
+		return WithReason(reasonInstallDiskWrite, fmt.Errorf("writing image: %w", err))
 	}
 
 	fmt.Printf("\nSuccessfully installed image on %s.\n", targetDrive.Name)
@@ -412,7 +412,7 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 	// Windows this offers a UAC re-launch when not elevated; on Unix it
 	// pre-caches the sudo timestamp.
 	if err := preAuthElevation(); err != nil {
-		return err
+		return WithReason(reasonInstallElevation, err)
 	}
 	// The download can take minutes or hours, which is longer than the default
 	// sudo credential cache window. Refresh in the background so the cached
@@ -426,7 +426,7 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 	if flagVersion != "" {
 		// Validate the requested version exists in the manifest.
 		if _, err := getImageInfo(device.Manifest, flagVersion, ""); err != nil {
-			return fmt.Errorf("version %q not found for %s", flagVersion, device.Name)
+			return WithReason(reasonInstallManifest, fmt.Errorf("version %q not found for %s", flagVersion, device.Name))
 		}
 		selectedVersion = flagVersion
 	}
@@ -436,7 +436,7 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 	if flagDrive != "" {
 		drives, err := listAllDrives()
 		if err != nil {
-			return fmt.Errorf("listing drives: %w", err)
+			return WithReason(reasonInstallDriveList, fmt.Errorf("listing drives: %w", err))
 		}
 		var found bool
 		for _, d := range drives {
@@ -447,7 +447,7 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 			}
 		}
 		if !found {
-			return fmt.Errorf("drive %s not found", flagDrive)
+			return WithReason(reasonInstallDriveNotFound, fmt.Errorf("drive %s not found", flagDrive))
 		}
 	} else {
 		fmt.Println()
@@ -497,7 +497,7 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 	// manifestStorage. Pass --storage to override.
 	ver, ok := device.Manifest.Versions[selectedVersion]
 	if !ok {
-		return fmt.Errorf("version %s not found in device manifest", selectedVersion)
+		return WithReason(reasonInstallManifest, fmt.Errorf("version %s not found in device manifest", selectedVersion))
 	}
 	storage := manifestStorage(ver, targetDrive.StorageType, targetDrive.MediaFixed, storageOverride)
 
@@ -527,7 +527,7 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 	fmt.Printf("\nPreparing %s %s image...\n", device.Name, selectedVersion)
 	imgInfo, err := getImageInfo(device.Manifest, selectedVersion, storage)
 	if err != nil {
-		return fmt.Errorf("getting image info: %w", err)
+		return WithReason(reasonInstallManifest, fmt.Errorf("getting image info: %w", err))
 	}
 
 	// Step 5a: Prefer the seekable-zstd fast path. When the manifest advertises a
@@ -564,7 +564,7 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 	if seekableZst == "" {
 		stream, err = openOSImageStream(deviceKey, imgInfo)
 		if err != nil {
-			return fmt.Errorf("opening OS image: %w", err)
+			return WithReason(reasonInstallImageOpen, fmt.Errorf("opening OS image: %w", err))
 		}
 		defer stream.Close()
 
@@ -677,7 +677,7 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 		// fast with the real error plus actionable hints. Integrity failures
 		// (bmap checksum/size mismatch) and unrecognized causes still fall back.
 		if isDeviceFlashFailure(primaryErr) {
-			return fmt.Errorf("%w\n%s", primary, flashDeviceFailureHint)
+			return WithReason(reasonInstallDiskWrite, fmt.Errorf("%w\n%s", primary, flashDeviceFailureHint))
 		}
 
 		// Bmap write failed (typically a checksum mismatch between the published
@@ -692,19 +692,19 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 		case seekableZst != "":
 			si, ferr := openSeekableZstd(seekableZst)
 			if ferr != nil {
-				return fmt.Errorf("%w; could not open image for full-image fallback: %v", primary, ferr)
+				return WithReason(reasonInstallDiskWrite, fmt.Errorf("%w; could not open image for full-image fallback: %v", primary, ferr))
 			}
 			fallbackReader, fallbackSize, fallbackCloser = si, si.Size(), si
 		case bmapPath != "":
 			fs, ferr := openOSImageStream(deviceKey, imgInfo)
 			if ferr != nil {
-				return fmt.Errorf("%w; could not open image for full-image fallback: %v", primary, ferr)
+				return WithReason(reasonInstallDiskWrite, fmt.Errorf("%w; could not open image for full-image fallback: %v", primary, ferr))
 			}
 			fallbackReader, fallbackSize, fallbackCloser = fs, fs.uncompressedSize, fs
 		default:
 			// Plain dd primary (no bmap): there is no faster path to fall back
 			// from, so surface the framed primary error directly.
-			return primary
+			return WithReason(reasonInstallDiskWrite, primary)
 		}
 		defer fallbackCloser.Close()
 		fallbackProg := tui.NewProgress(fmt.Sprintf("Writing to %s...", targetDrive.DevicePath))
@@ -727,7 +727,7 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 		if fm := fallbackFinal.(tui.ProgressModel); fm.Err() != nil {
 			// Both writes failed: surface the primary (real) error AND the
 			// fallback's, clearly labeled, so we never again debug the wrong one.
-			return combineFlashFailure(primary, fm.Err())
+			return WithReason(reasonInstallDiskWrite, combineFlashFailure(primary, fm.Err()))
 		}
 	}
 
@@ -739,7 +739,7 @@ func installLinuxImage(ctx context.Context, deviceKey string, device pickerDevic
 		// step is the bug from WDY-1118.
 		if hasProvisioningData {
 			ejectDisk(targetDrive)
-			return fmt.Errorf("the OS image was written to %s, but --wifi, --device-name, and --pre-enroll cannot be applied on this platform: writing to the device's config partition is not supported here. Re-run on a platform that supports config-partition provisioning to apply provisioning, or omit those flags to image without provisioning", targetDrive.Name)
+			return WithReason(reasonInstallProvisioning, fmt.Errorf("the OS image was written to %s, but --wifi, --device-name, and --pre-enroll cannot be applied on this platform: writing to the device's config partition is not supported here. Re-run on a platform that supports config-partition provisioning to apply provisioning, or omit those flags to image without provisioning", targetDrive.Name))
 		}
 		fmt.Println("\nNote: config-partition provisioning is not yet supported on this platform; skipping. The device will run the agent baked into the image and fetch updates after first boot.")
 	} else {
@@ -2151,7 +2151,7 @@ func installESP32Firmware(ctx context.Context, nightly bool, chip string, wifi w
 	fmt.Println("Fetching latest Wendy Lite firmware...")
 	asset, err := fetchFirmwareFromManifest(chip, nightly)
 	if err != nil {
-		return fmt.Errorf("fetching firmware: %w", err)
+		return WithReason(reasonInstallManifest, fmt.Errorf("fetching firmware: %w", err))
 	}
 	fmt.Printf("Found firmware: %s v%s\n", asset.Name, asset.Version)
 
@@ -2183,7 +2183,7 @@ func installESP32Firmware(ctx context.Context, nightly bool, chip string, wifi w
 
 	model := finalModel.(tui.ProgressModel)
 	if model.Err() != nil {
-		return model.Err()
+		return WithReason(reasonInstallDownload, model.Err())
 	}
 	defer os.Remove(fwPath)
 
@@ -2191,7 +2191,7 @@ func installESP32Firmware(ctx context.Context, nightly bool, chip string, wifi w
 
 	img, err := LoadEspFlashImage(fwPath)
 	if err != nil {
-		return fmt.Errorf("loading firmware image: %w", err)
+		return WithReason(reasonInstallImageOpen, fmt.Errorf("loading firmware image: %w", err))
 	}
 
 	confBytes, err := proto.Marshal(wendyConf)
@@ -2226,7 +2226,7 @@ func installESP32Firmware(ctx context.Context, nightly bool, chip string, wifi w
 
 	flashModel := flashFinal.(tui.ProgressModel)
 	if flashModel.Err() != nil {
-		return fmt.Errorf("flashing failed: %w", flashModel.Err())
+		return WithReason(reasonInstallDiskWrite, fmt.Errorf("flashing failed: %w", flashModel.Err()))
 	}
 
 	fmt.Printf("\nSuccessfully flashed Wendy Lite %s!\n", asset.Version)

--- a/go/internal/cli/commands/os_install_thor_shared.go
+++ b/go/internal/cli/commands/os_install_thor_shared.go
@@ -67,7 +67,7 @@ func installThor(ctx context.Context, version string, nightly, force bool, wifi 
 	// re-exec this replaces the process and does not return. Windows elevates
 	// separately via UAC when it installs the WinUSB driver (thorPrepareHost).
 	if err := ensureThorRootAccess(); err != nil {
-		return err
+		return WithReason(reasonInstallElevation, err)
 	}
 
 	cacheDir, err := osCacheDir()
@@ -77,7 +77,7 @@ func installThor(ctx context.Context, version string, nightly, force bool, wifi 
 
 	plan, err := planThorFlashpack(cacheDir, version, nightly)
 	if err != nil {
-		return err
+		return WithReason(reasonInstallManifest, err)
 	}
 
 	// Fail fast on a full disk, before the user starts cabling the Thor.
@@ -216,6 +216,14 @@ func installThor(ctx context.Context, version string, nightly, force bool, wifi 
 		case failedID == stepStage1:
 			fmt.Println()
 			fmt.Println(tui.WarningMessage("RCM boot failed — the Thor wasn't modified. Re-enter recovery mode and try again."))
+		}
+		switch failedID {
+		case stepDownload:
+			return WithReason(reasonInstallDownload, err)
+		case stepProvision:
+			return WithReason(reasonInstallProvisioning, err)
+		case stepStage1, stepStage2:
+			return WithReason(reasonInstallDiskWrite, err)
 		}
 		return err
 	}

--- a/go/internal/cli/commands/reason_error.go
+++ b/go/internal/cli/commands/reason_error.go
@@ -1,0 +1,45 @@
+package commands
+
+import "errors"
+
+// ReasonError tags an error with a bounded, PII-free analytics reason code.
+// The Reason is a low-cardinality constant (e.g. "install_download") that
+// errorClass reports as-is, so failures that would otherwise collapse into the
+// "other" bucket carry a specific reason. The wrapped error is preserved for
+// user-facing messages and errors.Is/As matching.
+type ReasonError struct {
+	Reason string
+	Err    error
+}
+
+func (e *ReasonError) Error() string { return e.Err.Error() }
+
+func (e *ReasonError) Unwrap() error { return e.Err }
+
+// WithReason tags err with a bounded analytics reason and returns it. It returns
+// nil when err is nil. If err already carries a ReasonError anywhere in its
+// chain, the existing (more specific) reason wins and err is returned unchanged —
+// WithReason never overwrites a reason set closer to the failure site.
+func WithReason(reason string, err error) error {
+	if err == nil {
+		return nil
+	}
+	var existing *ReasonError
+	if errors.As(err, &existing) {
+		return err
+	}
+	return &ReasonError{Reason: reason, Err: err}
+}
+
+// Install failure reason codes. All are prefixed "install_" so analytics can
+// group them, and each maps to a distinct stage of the OS/firmware install flow.
+const (
+	reasonInstallElevation     = "install_elevation"       // sudo/UAC elevation failed
+	reasonInstallDriveList     = "install_drive_list"      // enumerating drives failed
+	reasonInstallDriveNotFound = "install_drive_not_found" // target drive not present
+	reasonInstallManifest      = "install_manifest"        // device/version not in manifest / fetch failed
+	reasonInstallDownload      = "install_download"        // image/bmap/zst download failed
+	reasonInstallImageOpen     = "install_image_open"      // opening/streaming/decompressing image failed
+	reasonInstallDiskWrite     = "install_disk_write"      // writing the image to the drive failed
+	reasonInstallProvisioning  = "install_provisioning"    // config-partition provisioning unsupported/failed
+)

--- a/go/internal/cli/commands/reason_error_test.go
+++ b/go/internal/cli/commands/reason_error_test.go
@@ -1,0 +1,47 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestWithReason_NilPassthrough(t *testing.T) {
+	if err := WithReason("install_download", nil); err != nil {
+		t.Errorf("WithReason(_, nil) = %v, want nil", err)
+	}
+}
+
+func TestWithReason_TagsAndUnwraps(t *testing.T) {
+	base := errors.New("boom")
+	tagged := WithReason("install_disk_write", base)
+
+	var re *ReasonError
+	if !errors.As(tagged, &re) {
+		t.Fatal("tagged error is not a *ReasonError")
+	}
+	if re.Reason != "install_disk_write" {
+		t.Errorf("Reason = %q, want %q", re.Reason, "install_disk_write")
+	}
+	if !errors.Is(tagged, base) {
+		t.Error("tagged error lost the wrapped cause (errors.Is failed)")
+	}
+	if tagged.Error() != "boom" {
+		t.Errorf("Error() = %q, want %q", tagged.Error(), "boom")
+	}
+}
+
+func TestWithReason_DoesNotOverwriteExistingReason(t *testing.T) {
+	// The reason set closest to the failure site (install_download) must win,
+	// even when an outer layer re-tags with a different reason.
+	inner := WithReason("install_download", errors.New("net"))
+	outer := WithReason("install_disk_write", fmt.Errorf("wrapping: %w", inner))
+
+	var re *ReasonError
+	if !errors.As(outer, &re) {
+		t.Fatal("not a *ReasonError")
+	}
+	if re.Reason != "install_download" {
+		t.Errorf("Reason = %q, want the inner %q", re.Reason, "install_download")
+	}
+}

--- a/specs/2026-07-09-install-failure-analytics-design.md
+++ b/specs/2026-07-09-install-failure-analytics-design.md
@@ -1,0 +1,227 @@
+# Install / command failure reasons in analytics — design
+
+Date: 2026-07-09
+Branch: `jo/install-failure-analytics`
+Repos: `wendyos` (CLI) + `cloud` (telemetry ingestion/persistence)
+
+## Problem
+
+Every CLI invocation is tracked with a single analytics event (`command_executed`)
+carrying a bounded `error_class` enum on failure. `errorClass()` in
+`go/cmd/wendy/main.go` deliberately **never** embeds the error message text
+(paths/hostnames leak); this is guarded by `TestErrorClass_NeverLeaksMessageText`.
+
+Almost every `os install` (`wendy install`) failure is a plain
+`fmt.Errorf("downloading image: %w", …)` and therefore collapses into the
+catch-all `"other"` bucket. So when an install fails "for some other reason,"
+analytics gives us **no** signal about what actually happened — download vs
+disk-write vs missing drive vs elevation are indistinguishable, and the same is
+true for the generic `"other"` failures of every other command.
+
+## Goals
+
+- When `os install` fails, analytics records a **specific, bounded reason** for
+  the failure stage (download, disk write, drive not found, elevation, etc.).
+- For any command whose failure still lands in a catch-all bucket
+  (`other` / `grpc_other`), analytics records a **best-effort redacted** free-text
+  detail so we can see what happened without shipping raw PII.
+- Persist the new detail in the cloud so it is queryable.
+
+## Non-goals
+
+- Tagging every command's error sites with bounded codes. Install gets explicit
+  codes now; the mechanism is reusable and other commands can adopt it later.
+- A perfect/guaranteed PII scrubber. `error_detail` is best-effort by design
+  (approved trade-off), only populated for catch-all failures, length-capped.
+- Changing `error_class`'s existing contract: it stays bounded and PII-free.
+
+## Design
+
+Two layers, plus cloud persistence.
+
+### Layer 1 — bounded install reason codes (precise, zero-PII)
+
+A lightweight typed error in the `commands` package that carries a PII-free
+reason constant:
+
+```go
+// go/internal/cli/commands/reason_error.go
+type ReasonError struct {
+    Reason string // bounded, low-cardinality constant, e.g. "install_download"
+    Err    error
+}
+func (e *ReasonError) Error() string { return e.Err.Error() }
+func (e *ReasonError) Unwrap() error { return e.Err }
+
+// WithReason tags err with a bounded analytics reason. Returns nil if err is nil.
+// If err already carries a ReasonError (or is a cancellation), the existing
+// classification wins — WithReason never overwrites a more specific reason.
+func WithReason(reason string, err error) error
+```
+
+`errorClass()` (main.go) gains a check, ordered so cancellation always wins:
+
+1. `ErrUserCancelled` / `ErrDefaultCleared` → `user_cancelled` (unchanged, first)
+2. `context.Canceled` on the chain → `context_canceled` (moved ahead of ReasonError
+   so a ReasonError wrapping a cancelled context is never mislabeled)
+3. `context.DeadlineExceeded` on the chain → `context_deadline`
+4. **NEW:** `errors.As(err, *ReasonError)` with non-empty `Reason` → return `Reason`
+5. gRPC status codes (unchanged)
+6. `other` (unchanged)
+
+> Ordering note: today gRPC/context checks run before the `other` fallback. We
+> insert the ReasonError check after the cancellation/context checks and before
+> gRPC, because install reason codes are more specific than `grpc_*` for the
+> install path. A ReasonError never wraps a raw gRPC transport error in the
+> install flow, so this ordering does not hide `grpc_unavailable` etc.
+
+**Install reason codes** (all prefixed `install_` for easy grouping):
+
+| Code                        | Failure stage                                                        |
+|-----------------------------|----------------------------------------------------------------------|
+| `install_elevation`         | `preAuthElevation()` failed (sudo/UAC)                               |
+| `install_drive_list`        | `listAllDrives` / `listExternalDrives` failed                        |
+| `install_drive_not_found`   | requested/selected drive not present                                 |
+| `install_manifest`          | device/version not in manifest, or manifest fetch/parse failed       |
+| `install_download`          | image / bmap / seekable-zst download failed                          |
+| `install_image_open`        | opening/streaming/decompressing the image failed                     |
+| `install_disk_write`        | writing the image to the drive failed (see disk-write detail below)  |
+| `install_provisioning`      | config-partition provisioning unsupported/failed after a good flash  |
+
+The disk-write site reuses the existing `flash_error.go` classifier: when
+`isDeviceFlashFailure(err)` is true the failure is a device-level write
+(permission / read-only / no-space / I/O / device-gone / short-write) — still
+one code `install_disk_write`; the device-vs-integrity nuance is already framed
+in the error text and captured by `error_detail` if it reaches a catch-all.
+
+Wiring: tag the ~8 distinct failure points in `os_install.go`,
+`runOSInstallDirect`, `installThor`, `installESP32Firmware`, and
+`installLinuxDesktop` by wrapping their returned errors with `WithReason(...)`.
+This is explicit and precise — no string-matching classifier. `ErrUserCancelled`
+returns and interactive "Cancelled." paths are left untagged (they must stay
+`user_cancelled` / success).
+
+### Layer 2 — redacted `error_detail` (all commands, central, best-effort)
+
+- New field on the analytics event:
+  `ErrorDetail string \`json:"error_detail,omitempty"\`` in `eventPayload`
+  (`analytics.go`), mapped from `properties["error_detail"]` in `Track()`.
+- In `trackCommand` (main.go), when a failure's class is a **catch-all**
+  (`other` or `grpc_other`), set
+  `props["error_detail"] = analytics.RedactErrorDetail(err.Error())`.
+  Classified buckets (install codes, `grpc_unavailable`, `context_*`,
+  `user_cancelled`, …) do **not** get `error_detail` — the class already says
+  what happened, minimizing data collection and PII surface.
+
+**Redactor** — new `go/internal/cli/analytics/redact.go`,
+`func RedactErrorDetail(msg string) string`. No reusable redactor exists today;
+patterns are adapted from the agent-side dmesg redactor
+(`dmesg_logs_linux.go`). It replaces matches with `[redacted]` and then caps the
+result to 200 runes. Stripped, in order:
+
+1. IPv6 addresses (full + compressed)
+2. URLs (`https?://…`, up to whitespace)
+3. Email addresses
+4. `user@host` / bare FQDNs (dotted host labels)
+5. IPv4 addresses
+6. MAC addresses (colon and hyphen)
+7. Windows paths (`X:\…`)
+8. Unix home/device/temp paths (`/Users/…`, `/home/…`, `/root/…`, `/dev/…`,
+   `/tmp/…`, `/var/…`) and any remaining `/`-rooted absolute path segment run
+9. Collapse repeated `[redacted]` runs; trim; cap length
+
+Structural text is preserved: `"downloading image: unexpected EOF"`,
+`"no space left on device"`, `"connection refused"`, `"drive not found"`,
+version strings (`0.10.4`), and device type slugs (`raspberry-pi-5`) survive —
+these are the analytically-valuable, non-sensitive parts.
+
+### Cloud persistence (`cloud` repo)
+
+Ingestion is forward-compatible: `parseCLIEvent` uses a stock `JSONDecoder` over
+`CLIEventDTO`, which ignores unknown JSON keys. So the CLI can ship first; the
+cloud change below makes `error_detail` queryable.
+
+`swift/Sources/GRPCServices/CLITelemetry.swift`:
+
+- `CLIEventDTO`: add `var errorDetail: String?` + CodingKey
+  `case errorDetail = "error_detail"`.
+- `CLIEvent`: add `let errorDetail: String` (empty string = absent, matching the
+  `errorClass` convention).
+- `parseCLIEvent(fromJSON:)`: coalesce `dto.errorDetail ?? ""` into `CLIEvent`.
+- `CLIEventRecorder.record(_:)`: add `error_detail` to the INSERT column list and
+  values, writing SQL `NULL` when empty (mirror the `errorClass` nil-coalescing).
+
+New migration in `services/migrations/` (golang-migrate style, paired up/down):
+
+```sql
+-- NNNNNN_add_error_detail_to_cli_events.up.sql
+ALTER TABLE cli_events ADD COLUMN error_detail TEXT;
+```
+```sql
+-- NNNNNN_add_error_detail_to_cli_events.down.sql
+ALTER TABLE cli_events DROP COLUMN error_detail;
+```
+
+> Migration number: highest committed on cloud `main` is `000041`, so the next is
+> `000042`. Dormant/unmerged PRs (#261, wendy-auth) also reference `000040`–`000042`,
+> so the exact number is re-checked against `main` at implementation time and the
+> next free number used. There is a pre-existing `000039` collision unrelated to
+> this change.
+
+## Contract change (deliberate, approved)
+
+`error_class` remains bounded and PII-free. The new `error_detail` intentionally
+carries best-effort-redacted text, for catch-all failures only. Update the doc
+comments (main.go trackCommand header and `errorClass` doc) to state this
+policy explicitly. `TestErrorClass_NeverLeaksMessageText` stays green
+(`errorClass` still returns only the enum).
+
+## Testing
+
+CLI:
+- `redact_test.go`: table of inputs containing absolute paths, `/dev/diskN`,
+  Windows paths, `https://…`, FQDN hostnames, IPv4, IPv6, MAC, email →
+  assert each sensitive token is gone and replaced by `[redacted]`; assert
+  structural words (`downloading`, `no space left`, `raspberry-pi-5`) survive;
+  assert the 200-rune cap.
+- `errorClass` mapping: `ReasonError{Reason:"install_download"}` → that code;
+  `ReasonError` wrapping `context.Canceled` → `context_canceled`;
+  `ReasonError` wrapping `ErrUserCancelled` → `user_cancelled`;
+  empty-Reason `ReasonError` → falls through to `other`.
+- `trackCommand`: `other` failure → `error_detail` present and redacted;
+  `grpc_unavailable` failure → `error_detail` absent; success → absent.
+- install classification: representative stage errors wrapped by the install
+  flow map to the expected `install_*` codes (unit-level on the wrapping
+  helpers, not a full install run).
+
+Cloud:
+- `parseCLIEvent` decodes a payload with `error_detail` into a populated field,
+  and one without it into empty string.
+- Recorder/round-trip test (existing test harness for `cli_events`) asserts the
+  column persists.
+
+## Rollout / ordering
+
+1. CLI PR (wendyos): Layers 1 + 2. Safe to ship alone — cloud ignores the extra
+   key until its column exists; `error_detail` is simply dropped server-side.
+2. Cloud PR: DTO + recorder + migration `000042` (or next free). After deploy,
+   `error_detail` is persisted and queryable.
+
+## File-by-file change list
+
+wendyos:
+- `go/internal/cli/commands/reason_error.go` — **new**: `ReasonError`, `WithReason`.
+- `go/internal/cli/commands/os_install.go` (+ `os_install_direct`/thor/esp32/
+  linux-desktop paths) — wrap failure returns with `WithReason`.
+- `go/internal/cli/analytics/analytics.go` — add `ErrorDetail` to `eventPayload`
+  + map in `Track()`.
+- `go/internal/cli/analytics/redact.go` — **new**: `RedactErrorDetail`.
+- `go/cmd/wendy/main.go` — `errorClass` ReasonError check + reordering; set
+  `error_detail` in `trackCommand` for catch-all buckets; doc updates.
+- Tests: `redact_test.go` (new), `main_test.go` additions, install-classification test.
+
+cloud:
+- `swift/Sources/GRPCServices/CLITelemetry.swift` — DTO field + CodingKey,
+  `CLIEvent` field, `parseCLIEvent` coalesce, recorder INSERT.
+- `services/migrations/000042_add_error_detail_to_cli_events.{up,down}.sql` — **new**.
+- Cloud tests for parse + persistence.

--- a/specs/2026-07-09-install-failure-analytics-design.md
+++ b/specs/2026-07-09-install-failure-analytics-design.md
@@ -119,16 +119,20 @@ patterns are adapted from the agent-side dmesg redactor
 (`dmesg_logs_linux.go`). It replaces matches with `[redacted]` and then caps the
 result to 200 runes. Stripped, in order:
 
-1. IPv6 addresses (full + compressed)
-2. URLs (`https?://…`, up to whitespace)
-3. Email addresses
-4. `user@host` / bare FQDNs (dotted host labels)
-5. IPv4 addresses
-6. MAC addresses (colon and hyphen)
-7. Windows paths (`X:\…`)
-8. Unix home/device/temp paths (`/Users/…`, `/home/…`, `/root/…`, `/dev/…`,
+1. URLs (`https?://…`, up to whitespace) — first, so a host inside a URL never
+   survives as a bare FQDN
+2. Colon-form MAC addresses — matched before IPv6 so MAC redaction is
+   self-contained and not a fragile side-effect of the IPv6 pattern
+3. IPv6 addresses (full + compressed)
+4. Email addresses
+5. `user@host` / bare FQDNs (dotted host labels)
+6. IPv4 addresses
+7. Hyphen-form MAC addresses
+8. Windows UNC paths (`\\host\share\…`, also named pipes `\\.\pipe\…`) then
+   drive paths (`X:\…`)
+9. Unix home/device/temp paths (`/Users/…`, `/home/…`, `/root/…`, `/dev/…`,
    `/tmp/…`, `/var/…`) and any remaining `/`-rooted absolute path segment run
-9. Collapse repeated `[redacted]` runs; trim; cap length
+10. Collapse repeated `[redacted]` runs; trim; cap length
 
 Structural text is preserved: `"downloading image: unexpected EOF"`,
 `"no space left on device"`, `"connection refused"`, `"drive not found"`,
@@ -175,6 +179,33 @@ carries best-effort-redacted text, for catch-all failures only. Update the doc
 comments (main.go trackCommand header and `errorClass` doc) to state this
 policy explicitly. `TestErrorClass_NeverLeaksMessageText` stays green
 (`errorClass` still returns only the enum).
+
+## Privacy & compliance
+
+`error_detail` expands the data-collection surface (best-effort-redacted free
+text vs. a bounded enum), so the trade-off is scoped and gated:
+
+- **Opt-out gating (CLI, enforced).** `error_detail` is a plain field on the
+  same event payload as everything else, and `analytics.Track()` returns before
+  building that payload whenever analytics is disabled — via `wendy analytics
+  disable`, `WENDY_ANALYTICS=false`, or any CI environment (hard-disabled, no
+  opt-in escape hatch). There is no code path that sends `error_detail` when
+  analytics is off; the redactor is only ever reached for enabled, non-CI users.
+- **Redactor is reduced-risk, not a security boundary.** It is a denylist and
+  its residual gaps are documented in `RedactErrorDetail` and in the user-facing
+  `analytics.md`. It is not relied on as a guarantee.
+- **User disclosure.** The user-facing `analytics.md` discloses that a redacted
+  error excerpt may be sent for unclassified failures, lists what is stripped,
+  and states the best-effort limitation.
+
+**Follow-ups owned by the cloud/compliance side (not this CLI PR):** because a
+denylist can still let personal data through, once `error_detail` lands in
+`cli_events` it must be covered like any other personal-data-capable column —
+(1) a documented retention period for `cli_events` rows, (2) confirmation that
+account/device-deletion flows cover these rows (GDPR Art. 17), and (3) a ROPA
+entry / privacy-notice update reflecting the new field. These are tracked with
+the companion cloud migration PR, not the CLI change, since that is where the
+data is persisted and the lifecycle is controlled.
 
 ## Testing
 


### PR DESCRIPTION
## Problem

Every CLI failure is tracked with a single bounded `error_class` enum, and `errorClass()` deliberately never embeds the error message (paths/hostnames leak, guarded by `TestErrorClass_NeverLeaksMessageText`). Almost every `os install` (`wendy install`) failure is a plain `fmt.Errorf("downloading image: %w", …)` and collapses into the catch-all `"other"` bucket — so when an install fails "for some other reason," analytics gives us **no** signal about what actually happened (download vs disk-write vs missing drive vs elevation are indistinguishable). Same for every other command's `"other"` failures.

## What this does — two layers

**Layer 1 — bounded `install_*` reason codes (precise, zero-PII).**
New `commands.ReasonError` type + `WithReason(reason, err)` tag the distinct failure stages of the install flow. `errorClass()` returns the code, checked **after** the cancellation/deadline checks so Ctrl+C / timeouts always win, and before the gRPC fallbacks. Codes:

`install_elevation` · `install_drive_list` · `install_drive_not_found` · `install_manifest` · `install_download` · `install_image_open` · `install_disk_write` · `install_provisioning`

Wired into the Linux-image, direct (`[image] [drive]`), Thor (by failing step), and ESP32 install paths. The disk-write site reuses the existing `flash_error.go` device-failure classifier. Cloud/pre-enroll gRPC calls are intentionally left untagged so they keep their `grpc_*` class.

**Layer 2 — redacted `error_detail` (all commands, best-effort).**
New `error_detail` event field, populated **only** for the catch-all classes (`other` / `grpc_other`) via a new `analytics.RedactErrorDetail`. It strips file paths (`/Users`, `/dev/*`, `C:\…`), URLs, FQDNs/hostnames, IPv4/IPv6, MAC, and emails → `[redacted]`, and caps length to 200 runes. Structural text (`"no space left on device"`, fmt prefixes, version/device-type slugs) survives. `error_class` remains bounded and PII-free — this is a deliberate, scoped relaxation for the unclassified buckets, documented in the code.

## Ships independently
The cloud telemetry decoder ignores unknown JSON keys, so the CLI can send `error_detail` before the column exists. The companion cloud PR (wendylabsinc/cloud) adds the DTO field + migration to persist it.

## Tests
- `redact_test.go`: paths/URLs/hosts/IPv4+6/MAC/email are stripped, structural + safe tokens survive, 200-rune cap.
- `errorClass` mapping: `ReasonError` → its code; a `ReasonError` wrapping `context.Canceled` / `ErrUserCancelled` still classifies as cancellation.
- `trackCommand`: `other` → redacted `error_detail`; `grpc_unavailable` → no detail; success → no detail.
- `reason_error_test.go`: `WithReason` nil-passthrough, tagging/unwrap, no-overwrite of an inner reason.

Design doc: `specs/2026-07-09-install-failure-analytics-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiFJW1U8EPWRfHSPp7vjfb