### PR TITLE
feat: WendySim P1 — MuJoCo sim target: agent forwarding + wendy sim CLI

### DIFF
--- a/go/internal/agent/services/sim_service_v2.go
+++ b/go/internal/agent/services/sim_service_v2.go
@@ -1,24 +1,353 @@
 package services
 
 import (
+	"context"
+	"io"
+	"os"
+	"sort"
+	"sync"
+
 	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 
 	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
+	"github.com/wendylabsinc/wendy/go/proto/gen/simpb"
+)
+
+const (
+	// simBackendAddrEnv names the environment variable that points the agent
+	// at a running RobotBackendService (plaintext gRPC).
+	simBackendAddrEnv = "WENDY_SIM_BACKEND_ADDR"
+	// defaultSimBackendAddr is used when WENDY_SIM_BACKEND_ADDR is unset.
+	defaultSimBackendAddr = "localhost:9090"
+	// simBackendKey identifies the backend implementation. P1 supports a
+	// single MuJoCo backend; multi-backend selection (WENDY_SIM_BACKEND)
+	// comes later.
+	simBackendKey = "mujoco"
 )
 
 // SimService fronts a simulation backend (wendy.sim.v1.RobotBackendService,
 // running as a containerized service — MuJoCo first) toward the CLI/MCP. It
-// will own backend selection (WENDY_SIM_BACKEND) and per-session ControlLevel
-// gating before forwarding calls.
-//
-// P0 skeleton: every RPC returns Unimplemented via the embedded server; the
-// MuJoCo backend wiring lands with WendySim P1.
+// lazily dials the backend at WENDY_SIM_BACKEND_ADDR and forwards
+// observation/control/task calls, clamping task control levels to the
+// caller's session ControlLevel.
 type SimService struct {
 	agentpbv2.UnimplementedWendySimServiceServer
 	logger *zap.Logger
+
+	// dial is the backend dial seam (overridden in tests).
+	dial func(addr string) (simpb.RobotBackendServiceClient, io.Closer, error)
+
+	mu          sync.Mutex
+	backend     simpb.RobotBackendServiceClient
+	backendConn io.Closer
+	backendAddr string
+	worlds      map[string]*simWorld
 }
 
-// NewSimService builds the skeleton sim service.
+// simWorld is the in-memory bookkeeping for a created world; the backend owns
+// the authoritative state.
+type simWorld struct {
+	name     string
+	backend  string
+	robotIDs []string
+}
+
+// NewSimService builds the sim service. The backend is not dialed until the
+// first RPC needs it.
 func NewSimService(logger *zap.Logger) *SimService {
-	return &SimService{logger: logger}
+	return &SimService{
+		logger: logger,
+		dial:   dialSimBackend,
+		worlds: make(map[string]*simWorld),
+	}
+}
+
+// dialSimBackend opens a plaintext gRPC client to the backend. grpc.NewClient
+// is lazy, so reachability problems surface as codes.Unavailable on the first
+// forwarded RPC rather than here.
+func dialSimBackend(addr string) (simpb.RobotBackendServiceClient, io.Closer, error) {
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, nil, err
+	}
+	return simpb.NewRobotBackendServiceClient(conn), conn, nil
+}
+
+// client returns the backend client, dialing it on first use.
+func (s *SimService) client() (simpb.RobotBackendServiceClient, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.backend != nil {
+		return s.backend, nil
+	}
+	addr := os.Getenv(simBackendAddrEnv)
+	if addr == "" {
+		addr = defaultSimBackendAddr
+	}
+	client, conn, err := s.dial(addr)
+	if err != nil {
+		return nil, status.Errorf(codes.Unavailable,
+			"sim backend at %s unreachable (configure via %s): %v", addr, simBackendAddrEnv, err)
+	}
+	s.backend = client
+	s.backendConn = conn
+	s.backendAddr = addr
+	return client, nil
+}
+
+// Close releases the backend connection, if one was dialed.
+func (s *SimService) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.backendConn == nil {
+		return nil
+	}
+	err := s.backendConn.Close()
+	s.backend = nil
+	s.backendConn = nil
+	return err
+}
+
+// backendErr translates transport-level failures into an actionable message;
+// backend application errors pass through unchanged.
+func (s *SimService) backendErr(err error) error {
+	if status.Code(err) != codes.Unavailable {
+		return err
+	}
+	s.mu.Lock()
+	addr := s.backendAddr
+	s.mu.Unlock()
+	if addr == "" {
+		addr = defaultSimBackendAddr
+	}
+	return status.Errorf(codes.Unavailable,
+		"sim backend at %s unreachable (configure via %s): %v", addr, simBackendAddrEnv, err)
+}
+
+// --- Simulation lifecycle ---
+
+func (s *SimService) CreateSimulation(ctx context.Context, req *agentpbv2.CreateSimulationRequest) (*agentpbv2.CreateSimulationResponse, error) {
+	client, err := s.client()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.CreateWorld(ctx, &simpb.CreateWorldRequest{
+		Name:      req.GetName(),
+		SceneYaml: req.GetSceneYaml(),
+	})
+	if err != nil {
+		return nil, s.backendErr(err)
+	}
+
+	s.mu.Lock()
+	s.worlds[resp.GetWorldId()] = &simWorld{name: req.GetName(), backend: simBackendKey}
+	s.mu.Unlock()
+
+	if s.logger != nil {
+		s.logger.Info("sim: world created",
+			zap.String("world_id", resp.GetWorldId()), zap.String("name", req.GetName()))
+	}
+	return &agentpbv2.CreateSimulationResponse{
+		WorldId: resp.GetWorldId(),
+		Backend: simBackendKey,
+	}, nil
+}
+
+func (s *SimService) ListSimulations(_ context.Context, _ *agentpbv2.ListSimulationsRequest) (*agentpbv2.ListSimulationsResponse, error) {
+	s.mu.Lock()
+	sims := make([]*agentpbv2.SimulationInfo, 0, len(s.worlds))
+	for id, w := range s.worlds {
+		sims = append(sims, &agentpbv2.SimulationInfo{
+			WorldId:  id,
+			Name:     w.name,
+			Backend:  w.backend,
+			RobotIds: append([]string(nil), w.robotIDs...),
+		})
+	}
+	s.mu.Unlock()
+
+	sort.Slice(sims, func(i, j int) bool { return sims[i].WorldId < sims[j].WorldId })
+	return &agentpbv2.ListSimulationsResponse{Simulations: sims}, nil
+}
+
+func (s *SimService) ResetSimulation(ctx context.Context, req *agentpbv2.ResetSimulationRequest) (*agentpbv2.ResetSimulationResponse, error) {
+	client, err := s.client()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := client.Reset(ctx, &simpb.ResetRequest{WorldId: req.GetWorldId()}); err != nil {
+		return nil, s.backendErr(err)
+	}
+	return &agentpbv2.ResetSimulationResponse{}, nil
+}
+
+// --- Models ---
+
+func (s *SimService) ImportModel(stream agentpbv2.WendySimService_ImportModelServer) error {
+	client, err := s.client()
+	if err != nil {
+		return err
+	}
+	backendStream, err := client.LoadModel(stream.Context())
+	if err != nil {
+		return s.backendErr(err)
+	}
+	for {
+		chunk, recvErr := stream.Recv()
+		if recvErr == io.EOF {
+			break
+		}
+		if recvErr != nil {
+			return recvErr
+		}
+		if sendErr := backendStream.Send(chunk); sendErr != nil {
+			// Send failing means the backend closed the stream; the real
+			// error comes from CloseAndRecv.
+			break
+		}
+	}
+	resp, err := backendStream.CloseAndRecv()
+	if err != nil {
+		return s.backendErr(err)
+	}
+	return stream.SendAndClose(resp)
+}
+
+func (s *SimService) DescribeModel(ctx context.Context, req *simpb.DescribeModelRequest) (*simpb.DescribeModelResponse, error) {
+	client, err := s.client()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.DescribeModel(ctx, req)
+	if err != nil {
+		return nil, s.backendErr(err)
+	}
+	return resp, nil
+}
+
+func (s *SimService) SpawnRobot(ctx context.Context, req *simpb.SpawnRequest) (*simpb.SpawnResponse, error) {
+	client, err := s.client()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Spawn(ctx, req)
+	if err != nil {
+		return nil, s.backendErr(err)
+	}
+
+	s.mu.Lock()
+	if w, ok := s.worlds[req.GetWorldId()]; ok {
+		w.robotIDs = append(w.robotIDs, resp.GetRobotId())
+	}
+	s.mu.Unlock()
+	return resp, nil
+}
+
+// --- Observation ---
+
+func (s *SimService) GetState(ctx context.Context, req *simpb.GetStateRequest) (*simpb.GetStateResponse, error) {
+	client, err := s.client()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.GetState(ctx, req)
+	if err != nil {
+		return nil, s.backendErr(err)
+	}
+	return resp, nil
+}
+
+func (s *SimService) GetContacts(ctx context.Context, req *simpb.GetContactsRequest) (*simpb.GetContactsResponse, error) {
+	client, err := s.client()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.GetContacts(ctx, req)
+	if err != nil {
+		return nil, s.backendErr(err)
+	}
+	return resp, nil
+}
+
+func (s *SimService) GetCameraFrame(ctx context.Context, req *simpb.GetCameraFrameRequest) (*simpb.GetCameraFrameResponse, error) {
+	client, err := s.client()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.GetCameraFrame(ctx, req)
+	if err != nil {
+		return nil, s.backendErr(err)
+	}
+	return resp, nil
+}
+
+// --- Control ---
+
+func (s *SimService) SetVelocity(ctx context.Context, req *simpb.SetVelocityRequest) (*simpb.SetVelocityResponse, error) {
+	client, err := s.client()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.SetVelocity(ctx, req)
+	if err != nil {
+		return nil, s.backendErr(err)
+	}
+	return resp, nil
+}
+
+func (s *SimService) SetJointTargets(ctx context.Context, req *simpb.SetJointTargetsRequest) (*simpb.SetJointTargetsResponse, error) {
+	client, err := s.client()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.SetJointTargets(ctx, req)
+	if err != nil {
+		return nil, s.backendErr(err)
+	}
+	return resp, nil
+}
+
+// --- Tasks & replay ---
+
+func (s *SimService) RunTask(req *agentpbv2.RunSimTaskRequest, stream agentpbv2.WendySimService_RunTaskServer) error {
+	task := req.GetTask()
+	if task == nil {
+		return status.Error(codes.InvalidArgument, "task is required")
+	}
+	// Clamp the task's control level to the session's entitlement: a session
+	// level, when set, is a ceiling on how low-level the task may drive the
+	// robot.
+	if sess := req.GetSessionControlLevel(); sess != simpb.ControlLevel_CONTROL_LEVEL_UNSPECIFIED &&
+		sess < task.GetMaxControlLevel() {
+		task.MaxControlLevel = sess
+	}
+
+	client, err := s.client()
+	if err != nil {
+		return err
+	}
+	backendStream, err := client.RunTask(stream.Context(), task)
+	if err != nil {
+		return s.backendErr(err)
+	}
+	for {
+		event, recvErr := backendStream.Recv()
+		if recvErr == io.EOF {
+			return nil
+		}
+		if recvErr != nil {
+			return s.backendErr(recvErr)
+		}
+		if sendErr := stream.Send(event); sendErr != nil {
+			return sendErr
+		}
+	}
+}
+
+func (s *SimService) GetReplay(_ *agentpbv2.GetReplayRequest, _ agentpbv2.WendySimService_GetReplayServer) error {
+	return status.Error(codes.Unimplemented, "GetReplay is not implemented yet (WendySim P1)")
 }

--- a/go/internal/agent/services/sim_service_v2_test.go
+++ b/go/internal/agent/services/sim_service_v2_test.go
@@ -1,0 +1,410 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
+	"github.com/wendylabsinc/wendy/go/proto/gen/simpb"
+)
+
+// fakeRobotBackend is an in-process simpb.RobotBackendServiceServer that
+// records what the agent forwards to it.
+type fakeRobotBackend struct {
+	simpb.UnimplementedRobotBackendServiceServer
+
+	mu           sync.Mutex
+	worldCount   int
+	spawnCount   int
+	resetWorlds  []string
+	loadedSource *simpb.ModelSource
+	loadedData   []byte
+	lastRunTask  *simpb.RunTaskRequest
+	state        *simpb.GetStateResponse
+}
+
+func (f *fakeRobotBackend) CreateWorld(_ context.Context, req *simpb.CreateWorldRequest) (*simpb.CreateWorldResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.worldCount++
+	return &simpb.CreateWorldResponse{WorldId: fmt.Sprintf("world-%d", f.worldCount)}, nil
+}
+
+func (f *fakeRobotBackend) Spawn(_ context.Context, req *simpb.SpawnRequest) (*simpb.SpawnResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.spawnCount++
+	return &simpb.SpawnResponse{RobotId: fmt.Sprintf("robot-%d", f.spawnCount)}, nil
+}
+
+func (f *fakeRobotBackend) Reset(_ context.Context, req *simpb.ResetRequest) (*simpb.ResetResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.resetWorlds = append(f.resetWorlds, req.GetWorldId())
+	return &simpb.ResetResponse{}, nil
+}
+
+func (f *fakeRobotBackend) GetState(_ context.Context, _ *simpb.GetStateRequest) (*simpb.GetStateResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.state == nil {
+		return nil, status.Error(codes.NotFound, "no state configured")
+	}
+	return f.state, nil
+}
+
+func (f *fakeRobotBackend) LoadModel(stream grpc.ClientStreamingServer[simpb.LoadModelChunk, simpb.LoadModelResponse]) error {
+	var source *simpb.ModelSource
+	var data bytes.Buffer
+	for {
+		chunk, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		switch p := chunk.GetPayload().(type) {
+		case *simpb.LoadModelChunk_Source:
+			source = p.Source
+		case *simpb.LoadModelChunk_Data:
+			data.Write(p.Data)
+		}
+	}
+	if source == nil {
+		return status.Error(codes.InvalidArgument, "first chunk must carry the model source")
+	}
+	f.mu.Lock()
+	f.loadedSource = source
+	f.loadedData = data.Bytes()
+	f.mu.Unlock()
+	return stream.SendAndClose(&simpb.LoadModelResponse{ModelId: "model-" + source.GetName()})
+}
+
+func (f *fakeRobotBackend) RunTask(req *simpb.RunTaskRequest, stream grpc.ServerStreamingServer[simpb.TaskEvent]) error {
+	f.mu.Lock()
+	f.lastRunTask = req
+	f.mu.Unlock()
+	if err := stream.Send(&simpb.TaskEvent{
+		Event: &simpb.TaskEvent_Log{Log: &simpb.TaskLog{Message: "starting"}},
+	}); err != nil {
+		return err
+	}
+	return stream.Send(&simpb.TaskEvent{
+		Event: &simpb.TaskEvent_Result{Result: &simpb.TaskResult{Success: true, Summary: "done"}},
+	})
+}
+
+// startSimService wires a SimService (fronted by a real gRPC server) to an
+// in-process fake backend via the dial seam and returns a client for it.
+func startSimService(t *testing.T, backend simpb.RobotBackendServiceServer) agentpbv2.WendySimServiceClient {
+	t.Helper()
+
+	// Backend server on its own bufconn listener.
+	backendLis := bufconn.Listen(bufSize)
+	backendSrv := grpc.NewServer()
+	simpb.RegisterRobotBackendServiceServer(backendSrv, backend)
+	go func() { _ = backendSrv.Serve(backendLis) }()
+	t.Cleanup(func() { backendSrv.Stop(); _ = backendLis.Close() })
+
+	svc := NewSimService(zap.NewNop())
+	svc.dial = func(addr string) (simpb.RobotBackendServiceClient, io.Closer, error) {
+		conn, err := grpc.NewClient("passthrough:///sim-backend",
+			grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return backendLis.Dial() }),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		return simpb.NewRobotBackendServiceClient(conn), conn, nil
+	}
+	t.Cleanup(func() { _ = svc.Close() })
+
+	// Agent-facing server.
+	agentLis := bufconn.Listen(bufSize)
+	agentSrv := grpc.NewServer()
+	agentpbv2.RegisterWendySimServiceServer(agentSrv, svc)
+	go func() { _ = agentSrv.Serve(agentLis) }()
+	conn, err := grpc.NewClient("passthrough:///sim-agent",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return agentLis.Dial() }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close(); agentSrv.Stop(); _ = agentLis.Close() })
+	return agentpbv2.NewWendySimServiceClient(conn)
+}
+
+func TestSimService_CreateAndListSimulations(t *testing.T) {
+	backend := &fakeRobotBackend{}
+	client := startSimService(t, backend)
+	ctx := context.Background()
+
+	created, err := client.CreateSimulation(ctx, &agentpbv2.CreateSimulationRequest{Name: "flat-floor"})
+	if err != nil {
+		t.Fatalf("CreateSimulation: %v", err)
+	}
+	if created.GetWorldId() != "world-1" {
+		t.Errorf("world_id = %q; want world-1", created.GetWorldId())
+	}
+	if created.GetBackend() != "mujoco" {
+		t.Errorf("backend = %q; want mujoco", created.GetBackend())
+	}
+
+	if _, err := client.CreateSimulation(ctx, &agentpbv2.CreateSimulationRequest{Name: "obstacle-course"}); err != nil {
+		t.Fatalf("CreateSimulation #2: %v", err)
+	}
+
+	// SpawnRobot should append the robot id to the world's bookkeeping.
+	spawned, err := client.SpawnRobot(ctx, &simpb.SpawnRequest{WorldId: "world-1", ModelId: "model-go2"})
+	if err != nil {
+		t.Fatalf("SpawnRobot: %v", err)
+	}
+	if spawned.GetRobotId() != "robot-1" {
+		t.Errorf("robot_id = %q; want robot-1", spawned.GetRobotId())
+	}
+
+	list, err := client.ListSimulations(ctx, &agentpbv2.ListSimulationsRequest{})
+	if err != nil {
+		t.Fatalf("ListSimulations: %v", err)
+	}
+	if len(list.GetSimulations()) != 2 {
+		t.Fatalf("len(simulations) = %d; want 2", len(list.GetSimulations()))
+	}
+	first := list.GetSimulations()[0]
+	if first.GetWorldId() != "world-1" || first.GetName() != "flat-floor" || first.GetBackend() != "mujoco" {
+		t.Errorf("simulations[0] = %+v; want world-1/flat-floor/mujoco", first)
+	}
+	if len(first.GetRobotIds()) != 1 || first.GetRobotIds()[0] != "robot-1" {
+		t.Errorf("simulations[0].robot_ids = %v; want [robot-1]", first.GetRobotIds())
+	}
+	if second := list.GetSimulations()[1]; len(second.GetRobotIds()) != 0 {
+		t.Errorf("simulations[1].robot_ids = %v; want empty", second.GetRobotIds())
+	}
+}
+
+func TestSimService_GetStatePassthrough(t *testing.T) {
+	backend := &fakeRobotBackend{
+		state: &simpb.GetStateResponse{
+			BasePose: &simpb.Pose{X: 1.5, Y: -0.5, Z: 0.3, Qw: 1},
+			Joints:   []*simpb.JointState{{Name: "FL_hip", Position: 0.12, Velocity: -0.4}},
+			SimTimeS: 2.25,
+			Fallen:   true,
+		},
+	}
+	client := startSimService(t, backend)
+
+	resp, err := client.GetState(context.Background(), &simpb.GetStateRequest{WorldId: "world-1", RobotId: "robot-1"})
+	if err != nil {
+		t.Fatalf("GetState: %v", err)
+	}
+	if resp.GetBasePose().GetX() != 1.5 || resp.GetBasePose().GetQw() != 1 {
+		t.Errorf("base_pose = %+v; want x=1.5 qw=1", resp.GetBasePose())
+	}
+	if len(resp.GetJoints()) != 1 || resp.GetJoints()[0].GetName() != "FL_hip" {
+		t.Errorf("joints = %+v; want one FL_hip joint", resp.GetJoints())
+	}
+	if !resp.GetFallen() {
+		t.Error("fallen = false; want true")
+	}
+	if resp.GetSimTimeS() != 2.25 {
+		t.Errorf("sim_time_s = %v; want 2.25", resp.GetSimTimeS())
+	}
+}
+
+func TestSimService_ImportModelStreamPassthrough(t *testing.T) {
+	backend := &fakeRobotBackend{}
+	client := startSimService(t, backend)
+
+	stream, err := client.ImportModel(context.Background())
+	if err != nil {
+		t.Fatalf("ImportModel: %v", err)
+	}
+	if err := stream.Send(&simpb.LoadModelChunk{
+		Payload: &simpb.LoadModelChunk_Source{Source: &simpb.ModelSource{
+			Name:   "go2",
+			Format: simpb.ModelFormat_MODEL_FORMAT_MJCF,
+		}},
+	}); err != nil {
+		t.Fatalf("Send(source): %v", err)
+	}
+	for _, part := range []string{"chunk-one|", "chunk-two"} {
+		if err := stream.Send(&simpb.LoadModelChunk{
+			Payload: &simpb.LoadModelChunk_Data{Data: []byte(part)},
+		}); err != nil {
+			t.Fatalf("Send(data): %v", err)
+		}
+	}
+	resp, err := stream.CloseAndRecv()
+	if err != nil {
+		t.Fatalf("CloseAndRecv: %v", err)
+	}
+	if resp.GetModelId() != "model-go2" {
+		t.Errorf("model_id = %q; want model-go2", resp.GetModelId())
+	}
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if backend.loadedSource.GetName() != "go2" {
+		t.Errorf("backend source name = %q; want go2", backend.loadedSource.GetName())
+	}
+	if backend.loadedSource.GetFormat() != simpb.ModelFormat_MODEL_FORMAT_MJCF {
+		t.Errorf("backend source format = %v; want MJCF", backend.loadedSource.GetFormat())
+	}
+	if got := string(backend.loadedData); got != "chunk-one|chunk-two" {
+		t.Errorf("backend data = %q; want chunk-one|chunk-two", got)
+	}
+}
+
+func TestSimService_RunTaskClampsControlLevel(t *testing.T) {
+	tests := []struct {
+		name    string
+		session simpb.ControlLevel
+		task    simpb.ControlLevel
+		want    simpb.ControlLevel
+	}{
+		{
+			name:    "session lower than task clamps",
+			session: simpb.ControlLevel_CONTROL_LEVEL_MOTION,
+			task:    simpb.ControlLevel_CONTROL_LEVEL_JOINT,
+			want:    simpb.ControlLevel_CONTROL_LEVEL_MOTION,
+		},
+		{
+			name:    "session higher than task leaves task",
+			session: simpb.ControlLevel_CONTROL_LEVEL_PHYSICS,
+			task:    simpb.ControlLevel_CONTROL_LEVEL_MOTION,
+			want:    simpb.ControlLevel_CONTROL_LEVEL_MOTION,
+		},
+		{
+			name:    "unset session leaves task",
+			session: simpb.ControlLevel_CONTROL_LEVEL_UNSPECIFIED,
+			task:    simpb.ControlLevel_CONTROL_LEVEL_JOINT,
+			want:    simpb.ControlLevel_CONTROL_LEVEL_JOINT,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend := &fakeRobotBackend{}
+			client := startSimService(t, backend)
+
+			stream, err := client.RunTask(context.Background(), &agentpbv2.RunSimTaskRequest{
+				Task: &simpb.RunTaskRequest{
+					WorldId:         "world-1",
+					RobotId:         "robot-1",
+					SpecYaml:        "objectives: []",
+					MaxControlLevel: tt.task,
+				},
+				SessionControlLevel: tt.session,
+			})
+			if err != nil {
+				t.Fatalf("RunTask: %v", err)
+			}
+
+			var events []*simpb.TaskEvent
+			for {
+				ev, recvErr := stream.Recv()
+				if recvErr == io.EOF {
+					break
+				}
+				if recvErr != nil {
+					t.Fatalf("Recv: %v", recvErr)
+				}
+				events = append(events, ev)
+			}
+			if len(events) != 2 {
+				t.Fatalf("len(events) = %d; want 2", len(events))
+			}
+			if res := events[1].GetResult(); res == nil || !res.GetSuccess() {
+				t.Errorf("events[1] = %+v; want successful result", events[1])
+			}
+
+			backend.mu.Lock()
+			got := backend.lastRunTask.GetMaxControlLevel()
+			backend.mu.Unlock()
+			if got != tt.want {
+				t.Errorf("forwarded max_control_level = %v; want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSimService_RunTaskRequiresTask(t *testing.T) {
+	client := startSimService(t, &fakeRobotBackend{})
+
+	stream, err := client.RunTask(context.Background(), &agentpbv2.RunSimTaskRequest{})
+	if err != nil {
+		t.Fatalf("RunTask: %v", err)
+	}
+	_, err = stream.Recv()
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("error code = %v; want InvalidArgument", status.Code(err))
+	}
+}
+
+func TestSimService_GetReplayUnimplemented(t *testing.T) {
+	client := startSimService(t, &fakeRobotBackend{})
+
+	stream, err := client.GetReplay(context.Background(), &agentpbv2.GetReplayRequest{ReplayId: "r-1"})
+	if err != nil {
+		t.Fatalf("GetReplay: %v", err)
+	}
+	_, err = stream.Recv()
+	if status.Code(err) != codes.Unimplemented {
+		t.Errorf("error code = %v; want Unimplemented", status.Code(err))
+	}
+}
+
+func TestSimService_BackendDialFailureIsUnavailable(t *testing.T) {
+	svc := NewSimService(zap.NewNop())
+	svc.dial = func(addr string) (simpb.RobotBackendServiceClient, io.Closer, error) {
+		return nil, nil, errors.New("boom")
+	}
+
+	_, err := svc.CreateSimulation(context.Background(), &agentpbv2.CreateSimulationRequest{Name: "w"})
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("error code = %v; want Unavailable", status.Code(err))
+	}
+	if !strings.Contains(err.Error(), "WENDY_SIM_BACKEND_ADDR") {
+		t.Errorf("error %q should mention WENDY_SIM_BACKEND_ADDR", err.Error())
+	}
+}
+
+func TestSimService_BackendUnreachableIsUnavailable(t *testing.T) {
+	svc := NewSimService(zap.NewNop())
+	svc.dial = func(addr string) (simpb.RobotBackendServiceClient, io.Closer, error) {
+		conn, err := grpc.NewClient("passthrough:///unreachable",
+			grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+				return nil, errors.New("connection refused")
+			}),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		return simpb.NewRobotBackendServiceClient(conn), conn, nil
+	}
+	t.Cleanup(func() { _ = svc.Close() })
+
+	_, err := svc.CreateSimulation(context.Background(), &agentpbv2.CreateSimulationRequest{Name: "w"})
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("error code = %v; want Unavailable", status.Code(err))
+	}
+	if !strings.Contains(err.Error(), "WENDY_SIM_BACKEND_ADDR") {
+		t.Errorf("error %q should mention WENDY_SIM_BACKEND_ADDR", err.Error())
+	}
+}

--- a/go/internal/cli/commands/root.go
+++ b/go/internal/cli/commands/root.go
@@ -158,6 +158,8 @@ func NewRootCmd() *cobra.Command {
 	authCmd.Hidden = true
 	discoverCmd := newDiscoverCmd()
 	discoverCmd.Hidden = true
+	simCmd := newSimCmd()
+	simCmd.Hidden = true
 	osCmd := newOSCmd()
 	osCmd.Hidden = true
 	infoCmd := newInfoCmd()
@@ -228,6 +230,7 @@ func NewRootCmd() *cobra.Command {
 		jsonCmd,
 		authCmd,
 		discoverCmd,
+		simCmd,
 		osCmd,
 		infoCmd,
 		utilsCmd,

--- a/go/internal/cli/commands/sim.go
+++ b/go/internal/cli/commands/sim.go
@@ -1,0 +1,675 @@
+package commands
+
+import (
+	"archive/tar"
+	"bufio"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
+	"github.com/wendylabsinc/wendy/go/proto/gen/simpb"
+)
+
+// simModelChunkSize is the data-chunk size for streaming model archives to
+// the agent; small enough to stay well under gRPC message limits.
+const simModelChunkSize = 64 * 1024
+
+func newSimCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sim",
+		Short: "Manage robot simulations on the target device",
+	}
+
+	cmd.AddCommand(
+		newSimCreateCmd(),
+		newSimListCmd(),
+		newSimImportModelCmd(),
+		newSimDescribeModelCmd(),
+		newSimSpawnCmd(),
+		newSimStateCmd(),
+		newSimResetCmd(),
+	)
+
+	return cmd
+}
+
+func newSimCreateCmd() *cobra.Command {
+	var scenePath string
+
+	cmd := &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a simulation world",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			var sceneYAML string
+			if scenePath != "" {
+				data, err := os.ReadFile(scenePath)
+				if err != nil {
+					return fmt.Errorf("reading scene file: %w", err)
+				}
+				sceneYAML = string(data)
+			}
+
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			resp, err := conn.SimService.CreateSimulation(ctx, &agentpbv2.CreateSimulationRequest{
+				Name:      args[0],
+				SceneYaml: sceneYAML,
+			})
+			if err != nil {
+				return fmt.Errorf("creating simulation: %w", err)
+			}
+
+			if jsonOutput {
+				return printJSON(map[string]string{
+					"worldId": resp.GetWorldId(),
+					"backend": resp.GetBackend(),
+				})
+			}
+			cliSuccess("Simulation %s created.", args[0])
+			cliLogln("  World ID: %s (backend %s)", resp.GetWorldId(), resp.GetBackend())
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&scenePath, "scene", "", "Path to a scene description YAML file")
+	return cmd
+}
+
+func newSimListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List simulation worlds",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			resp, err := conn.SimService.ListSimulations(ctx, &agentpbv2.ListSimulationsRequest{})
+			if err != nil {
+				return fmt.Errorf("listing simulations: %w", err)
+			}
+
+			if jsonOutput {
+				type jsonSim struct {
+					WorldID  string   `json:"worldId"`
+					Name     string   `json:"name,omitempty"`
+					Backend  string   `json:"backend,omitempty"`
+					RobotIDs []string `json:"robotIds,omitempty"`
+				}
+				sims := make([]jsonSim, len(resp.GetSimulations()))
+				for i, s := range resp.GetSimulations() {
+					sims[i] = jsonSim{
+						WorldID:  s.GetWorldId(),
+						Name:     s.GetName(),
+						Backend:  s.GetBackend(),
+						RobotIDs: s.GetRobotIds(),
+					}
+				}
+				return printJSON(sims)
+			}
+
+			if len(resp.GetSimulations()) == 0 {
+				cliLogln("No simulations running.")
+				return nil
+			}
+			headers := []string{"World ID", "Name", "Backend", "Robots"}
+			var rows [][]string
+			for _, s := range resp.GetSimulations() {
+				rows = append(rows, []string{
+					s.GetWorldId(),
+					s.GetName(),
+					s.GetBackend(),
+					strings.Join(s.GetRobotIds(), ", "),
+				})
+			}
+			fmt.Print(tui.RenderTable(headers, rows))
+			return nil
+		},
+	}
+}
+
+func newSimImportModelCmd() *cobra.Command {
+	var menageriePath, name string
+
+	cmd := &cobra.Command{
+		Use:   "import-model [local-dir]",
+		Short: "Import a robot model into the simulation backend",
+		Long: "Import a robot model into the simulation backend.\n\n" +
+			"Either reference a bundled MuJoCo Menagerie model (--menagerie unitree_go2/go2.xml)\n" +
+			"or upload a local MJCF model directory (or .tar/.tar.gz archive of one).",
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			var localPath string
+			if len(args) == 1 {
+				localPath = args[0]
+			}
+			if err := validateImportModelSource(menageriePath, localPath); err != nil {
+				return err
+			}
+
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			stream, err := conn.SimService.ImportModel(ctx)
+			if err != nil {
+				return fmt.Errorf("importing model: %w", err)
+			}
+			if err := stream.Send(&simpb.LoadModelChunk{
+				Payload: &simpb.LoadModelChunk_Source{Source: &simpb.ModelSource{
+					Name:          name,
+					Format:        simpb.ModelFormat_MODEL_FORMAT_MJCF,
+					MenageriePath: menageriePath,
+				}},
+			}); err != nil {
+				return fmt.Errorf("sending model source: %w", err)
+			}
+
+			if localPath != "" {
+				sendErr := streamLocalModel(localPath, func(data []byte) error {
+					return stream.Send(&simpb.LoadModelChunk{
+						Payload: &simpb.LoadModelChunk_Data{Data: data},
+					})
+				})
+				// A local read error aborts the import (the broken stream is
+				// torn down with the connection). Send returning io.EOF means
+				// the stream broke; CloseAndRecv below surfaces the cause.
+				if sendErr != nil && sendErr != io.EOF {
+					return fmt.Errorf("reading model %s: %w", localPath, sendErr)
+				}
+			}
+
+			resp, err := stream.CloseAndRecv()
+			if err != nil {
+				return fmt.Errorf("importing model: %w", err)
+			}
+
+			if jsonOutput {
+				return printJSON(map[string]string{"modelId": resp.GetModelId()})
+			}
+			cliSuccess("Model %s imported.", name)
+			cliLogln("  Model ID: %s", resp.GetModelId())
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&menageriePath, "menagerie", "", "Bundled MuJoCo Menagerie model path (e.g. unitree_go2/go2.xml)")
+	cmd.Flags().StringVar(&name, "name", "", "Registry name for the model (e.g. go2)")
+	_ = cmd.MarkFlagRequired("name")
+	return cmd
+}
+
+func newSimDescribeModelCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "describe-model <model-id>",
+		Short: "Show the capability map of an imported model",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			resp, err := conn.SimService.DescribeModel(ctx, &simpb.DescribeModelRequest{ModelId: args[0]})
+			if err != nil {
+				return fmt.Errorf("describing model: %w", err)
+			}
+			caps := resp.GetCapabilities()
+
+			levels := make([]string, len(caps.GetSupportedControlLevels()))
+			for i, l := range caps.GetSupportedControlLevels() {
+				levels[i] = controlLevelName(l)
+			}
+
+			if jsonOutput {
+				type jsonJoint struct {
+					Name     string  `json:"name"`
+					Type     string  `json:"type,omitempty"`
+					RangeMin float64 `json:"rangeMin"`
+					RangeMax float64 `json:"rangeMax"`
+				}
+				type jsonActuator struct {
+					Name    string  `json:"name"`
+					Joint   string  `json:"joint,omitempty"`
+					CtrlMin float64 `json:"ctrlMin"`
+					CtrlMax float64 `json:"ctrlMax"`
+				}
+				type jsonSensor struct {
+					Name string `json:"name"`
+					Type string `json:"type,omitempty"`
+				}
+				type jsonSafety struct {
+					MaxLinearSpeedMps    float64 `json:"maxLinearSpeedMps"`
+					MaxAngularSpeedRadps float64 `json:"maxAngularSpeedRadps"`
+				}
+				out := struct {
+					Joints        []jsonJoint    `json:"joints,omitempty"`
+					Actuators     []jsonActuator `json:"actuators,omitempty"`
+					Sensors       []jsonSensor   `json:"sensors,omitempty"`
+					Cameras       []string       `json:"cameras,omitempty"`
+					ControlLevels []string       `json:"controlLevels,omitempty"`
+					SafetyLimits  *jsonSafety    `json:"safetyLimits,omitempty"`
+				}{
+					Cameras:       caps.GetCameras(),
+					ControlLevels: levels,
+				}
+				for _, j := range caps.GetJoints() {
+					out.Joints = append(out.Joints, jsonJoint{
+						Name: j.GetName(), Type: j.GetType(),
+						RangeMin: j.GetRangeMin(), RangeMax: j.GetRangeMax(),
+					})
+				}
+				for _, a := range caps.GetActuators() {
+					out.Actuators = append(out.Actuators, jsonActuator{
+						Name: a.GetName(), Joint: a.GetJoint(),
+						CtrlMin: a.GetCtrlMin(), CtrlMax: a.GetCtrlMax(),
+					})
+				}
+				for _, s := range caps.GetSensors() {
+					out.Sensors = append(out.Sensors, jsonSensor{Name: s.GetName(), Type: s.GetType()})
+				}
+				if sl := caps.GetSafetyLimits(); sl != nil {
+					out.SafetyLimits = &jsonSafety{
+						MaxLinearSpeedMps:    sl.GetMaxLinearSpeedMps(),
+						MaxAngularSpeedRadps: sl.GetMaxAngularSpeedRadps(),
+					}
+				}
+				return printJSON(out)
+			}
+
+			cliLogln("Model %s", args[0])
+			if len(caps.GetJoints()) > 0 {
+				cliLogln("Joints:")
+				headers := []string{"Name", "Type", "Range"}
+				var rows [][]string
+				for _, j := range caps.GetJoints() {
+					rows = append(rows, []string{
+						j.GetName(), j.GetType(),
+						fmt.Sprintf("[%.3f, %.3f]", j.GetRangeMin(), j.GetRangeMax()),
+					})
+				}
+				fmt.Print(tui.RenderTable(headers, rows))
+			}
+			if len(caps.GetActuators()) > 0 {
+				cliLogln("Actuators:")
+				headers := []string{"Name", "Joint", "Ctrl range"}
+				var rows [][]string
+				for _, a := range caps.GetActuators() {
+					rows = append(rows, []string{
+						a.GetName(), a.GetJoint(),
+						fmt.Sprintf("[%.3f, %.3f]", a.GetCtrlMin(), a.GetCtrlMax()),
+					})
+				}
+				fmt.Print(tui.RenderTable(headers, rows))
+			}
+			if len(caps.GetSensors()) > 0 {
+				var names []string
+				for _, s := range caps.GetSensors() {
+					names = append(names, fmt.Sprintf("%s (%s)", s.GetName(), s.GetType()))
+				}
+				cliLogln("Sensors: %s", strings.Join(names, ", "))
+			}
+			if len(caps.GetCameras()) > 0 {
+				cliLogln("Cameras: %s", strings.Join(caps.GetCameras(), ", "))
+			}
+			if len(levels) > 0 {
+				cliLogln("Control levels: %s", strings.Join(levels, ", "))
+			}
+			if sl := caps.GetSafetyLimits(); sl != nil {
+				cliLogln("Safety limits: %.2f m/s linear, %.2f rad/s angular",
+					sl.GetMaxLinearSpeedMps(), sl.GetMaxAngularSpeedRadps())
+			}
+			return nil
+		},
+	}
+}
+
+func newSimSpawnCmd() *cobra.Command {
+	var worldID, pos string
+
+	cmd := &cobra.Command{
+		Use:   "spawn <model-id>",
+		Short: "Spawn an imported model into a world",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			pose, err := parseSimPosition(pos)
+			if err != nil {
+				return err
+			}
+
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			resp, err := conn.SimService.SpawnRobot(ctx, &simpb.SpawnRequest{
+				WorldId: worldID,
+				ModelId: args[0],
+				Pose:    pose,
+			})
+			if err != nil {
+				return fmt.Errorf("spawning robot: %w", err)
+			}
+
+			if jsonOutput {
+				return printJSON(map[string]string{"robotId": resp.GetRobotId()})
+			}
+			cliSuccess("Robot spawned.")
+			cliLogln("  Robot ID: %s", resp.GetRobotId())
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&worldID, "world", "", "World ID to spawn into")
+	cmd.Flags().StringVar(&pos, "pos", "", "Spawn position as x,y,z in meters (default 0,0,0)")
+	_ = cmd.MarkFlagRequired("world")
+	return cmd
+}
+
+func newSimStateCmd() *cobra.Command {
+	var worldID, robotID string
+
+	cmd := &cobra.Command{
+		Use:   "state",
+		Short: "Show a robot's state (pose, joints, fallen)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			resp, err := conn.SimService.GetState(ctx, &simpb.GetStateRequest{
+				WorldId: worldID,
+				RobotId: robotID,
+			})
+			if err != nil {
+				return fmt.Errorf("getting state: %w", err)
+			}
+
+			if jsonOutput {
+				type jsonJointState struct {
+					Name     string  `json:"name"`
+					Position float64 `json:"position"`
+					Velocity float64 `json:"velocity"`
+				}
+				type jsonPose struct {
+					X  float64 `json:"x"`
+					Y  float64 `json:"y"`
+					Z  float64 `json:"z"`
+					Qw float64 `json:"qw"`
+					Qx float64 `json:"qx"`
+					Qy float64 `json:"qy"`
+					Qz float64 `json:"qz"`
+				}
+				out := struct {
+					BasePose *jsonPose        `json:"basePose,omitempty"`
+					Joints   []jsonJointState `json:"joints,omitempty"`
+					SimTimeS float64          `json:"simTimeS"`
+					Fallen   bool             `json:"fallen"`
+				}{SimTimeS: resp.GetSimTimeS(), Fallen: resp.GetFallen()}
+				if p := resp.GetBasePose(); p != nil {
+					out.BasePose = &jsonPose{
+						X: p.GetX(), Y: p.GetY(), Z: p.GetZ(),
+						Qw: p.GetQw(), Qx: p.GetQx(), Qy: p.GetQy(), Qz: p.GetQz(),
+					}
+				}
+				for _, j := range resp.GetJoints() {
+					out.Joints = append(out.Joints, jsonJointState{
+						Name: j.GetName(), Position: j.GetPosition(), Velocity: j.GetVelocity(),
+					})
+				}
+				return printJSON(out)
+			}
+
+			if p := resp.GetBasePose(); p != nil {
+				cliLogln("Position:    (%.3f, %.3f, %.3f) m", p.GetX(), p.GetY(), p.GetZ())
+				cliLogln("Orientation: (%.3f, %.3f, %.3f, %.3f) wxyz", p.GetQw(), p.GetQx(), p.GetQy(), p.GetQz())
+			}
+			cliLogln("Sim time:    %.3f s", resp.GetSimTimeS())
+			if resp.GetFallen() {
+				cliNotice("Robot has FALLEN")
+			} else {
+				cliLogln("Fallen:      no")
+			}
+			if len(resp.GetJoints()) > 0 {
+				headers := []string{"Joint", "Position", "Velocity"}
+				var rows [][]string
+				for _, j := range resp.GetJoints() {
+					rows = append(rows, []string{
+						j.GetName(),
+						fmt.Sprintf("%.4f", j.GetPosition()),
+						fmt.Sprintf("%.4f", j.GetVelocity()),
+					})
+				}
+				fmt.Print(tui.RenderTable(headers, rows))
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&worldID, "world", "", "World ID")
+	cmd.Flags().StringVar(&robotID, "robot", "", "Robot ID")
+	_ = cmd.MarkFlagRequired("world")
+	_ = cmd.MarkFlagRequired("robot")
+	return cmd
+}
+
+func newSimResetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "reset <world-id>",
+		Short: "Reset a simulation world to its initial state",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			if _, err := conn.SimService.ResetSimulation(ctx, &agentpbv2.ResetSimulationRequest{
+				WorldId: args[0],
+			}); err != nil {
+				return fmt.Errorf("resetting simulation: %w", err)
+			}
+
+			if jsonOutput {
+				return printJSON(map[string]string{"worldId": args[0], "status": "reset"})
+			}
+			cliSuccess("Simulation %s reset.", args[0])
+			return nil
+		},
+	}
+}
+
+// --- helpers ---
+
+func printJSON(v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(data))
+	return nil
+}
+
+// validateImportModelSource enforces exactly one model source: a bundled
+// Menagerie path or a local model path.
+func validateImportModelSource(menageriePath, localPath string) error {
+	switch {
+	case menageriePath == "" && localPath == "":
+		return fmt.Errorf("specify a model source: --menagerie <path> or a local model directory")
+	case menageriePath != "" && localPath != "":
+		return fmt.Errorf("--menagerie and a local model directory are mutually exclusive")
+	}
+	return nil
+}
+
+// controlLevelName renders a simpb.ControlLevel as a short lowercase name
+// (e.g. "motion").
+func controlLevelName(l simpb.ControlLevel) string {
+	return strings.ToLower(strings.TrimPrefix(l.String(), "CONTROL_LEVEL_"))
+}
+
+// parseSimPosition parses an "x,y,z" position (meters) into a Pose with
+// identity orientation. An empty string yields nil (backend default pose).
+func parseSimPosition(pos string) (*simpb.Pose, error) {
+	if pos == "" {
+		return nil, nil
+	}
+	parts := strings.Split(pos, ",")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid --pos %q: expected x,y,z", pos)
+	}
+	coords := make([]float64, 3)
+	for i, p := range parts {
+		v, err := strconv.ParseFloat(strings.TrimSpace(p), 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --pos %q: %q is not a number", pos, strings.TrimSpace(p))
+		}
+		coords[i] = v
+	}
+	// Identity orientation (qw=1); the proto also treats an all-zero
+	// quaternion as identity, but being explicit costs nothing.
+	return &simpb.Pose{X: coords[0], Y: coords[1], Z: coords[2], Qw: 1}, nil
+}
+
+// streamLocalModel streams a local model as tar data chunks. A directory is
+// tarred on the fly; a file is streamed as-is, transparently gunzipping
+// .tar.gz/.tgz archives so the wire always carries a plain tar.
+func streamLocalModel(path string, send func([]byte) error) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+
+	if info.IsDir() {
+		pr, pw := io.Pipe()
+		go func() {
+			pw.CloseWithError(tarDirectory(path, pw))
+		}()
+		if err := sendDataChunks(pr, send); err != nil {
+			_ = pr.CloseWithError(err)
+			return err
+		}
+		return nil
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	br := bufio.NewReader(f)
+	var r io.Reader = br
+	// Accept gzipped archives: sniff the gzip magic and decompress so the
+	// backend always receives a plain tar stream.
+	if magic, err := br.Peek(2); err == nil && magic[0] == 0x1f && magic[1] == 0x8b {
+		gz, err := gzip.NewReader(br)
+		if err != nil {
+			return fmt.Errorf("reading gzip archive: %w", err)
+		}
+		defer gz.Close()
+		r = gz
+	}
+	return sendDataChunks(r, send)
+}
+
+// tarDirectory writes a tar archive of dir to w. Entry names are relative to
+// dir (forward-slashed); only directories and regular files are archived.
+func tarDirectory(dir string, w io.Writer) error {
+	tw := tar.NewWriter(w)
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		if !info.IsDir() && !info.Mode().IsRegular() {
+			return nil // skip symlinks, sockets, etc.
+		}
+		hdr, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return err
+		}
+		hdr.Name = filepath.ToSlash(rel)
+		if info.IsDir() {
+			hdr.Name += "/"
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		_, err = io.Copy(tw, f)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+	return tw.Close()
+}
+
+// sendDataChunks reads r and calls send with successive chunks of at most
+// simModelChunkSize bytes.
+func sendDataChunks(r io.Reader, send func([]byte) error) error {
+	buf := make([]byte, simModelChunkSize)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			chunk := make([]byte, n)
+			copy(chunk, buf[:n])
+			if sendErr := send(chunk); sendErr != nil {
+				return sendErr
+			}
+		}
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+}

--- a/go/internal/cli/commands/sim_test.go
+++ b/go/internal/cli/commands/sim_test.go
@@ -1,0 +1,318 @@
+package commands
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/proto/gen/simpb"
+)
+
+func TestNewSimCmd_Subcommands(t *testing.T) {
+	cmd := newSimCmd()
+	if cmd.Use != "sim" {
+		t.Errorf("Use = %q; want sim", cmd.Use)
+	}
+	want := map[string]bool{
+		"create":         false,
+		"list":           false,
+		"import-model":   false,
+		"describe-model": false,
+		"spawn":          false,
+		"state":          false,
+		"reset":          false,
+	}
+	for _, sub := range cmd.Commands() {
+		if _, ok := want[sub.Name()]; ok {
+			want[sub.Name()] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("missing subcommand %q", name)
+		}
+	}
+}
+
+func TestValidateImportModelSource(t *testing.T) {
+	tests := []struct {
+		name      string
+		menagerie string
+		local     string
+		wantErr   bool
+	}{
+		{name: "menagerie only", menagerie: "unitree_go2/go2.xml", wantErr: false},
+		{name: "local only", local: "./my-model", wantErr: false},
+		{name: "neither", wantErr: true},
+		{name: "both", menagerie: "unitree_go2/go2.xml", local: "./my-model", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateImportModelSource(tt.menagerie, tt.local)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateImportModelSource(%q, %q) = %v; wantErr %v",
+					tt.menagerie, tt.local, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseSimPosition(t *testing.T) {
+	tests := []struct {
+		pos     string
+		want    *simpb.Pose
+		wantErr bool
+	}{
+		{pos: "", want: nil},
+		{pos: "1,2,0.5", want: &simpb.Pose{X: 1, Y: 2, Z: 0.5, Qw: 1}},
+		{pos: " -1.5 , 0 , 3 ", want: &simpb.Pose{X: -1.5, Y: 0, Z: 3, Qw: 1}},
+		{pos: "1,2", wantErr: true},
+		{pos: "1,2,3,4", wantErr: true},
+		{pos: "a,b,c", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.pos, func(t *testing.T) {
+			got, err := parseSimPosition(tt.pos)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseSimPosition(%q) error = %v; wantErr %v", tt.pos, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if (got == nil) != (tt.want == nil) {
+				t.Fatalf("parseSimPosition(%q) = %v; want %v", tt.pos, got, tt.want)
+			}
+			if got == nil {
+				return
+			}
+			if got.GetX() != tt.want.GetX() || got.GetY() != tt.want.GetY() ||
+				got.GetZ() != tt.want.GetZ() || got.GetQw() != tt.want.GetQw() {
+				t.Errorf("parseSimPosition(%q) = %+v; want %+v", tt.pos, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestControlLevelName(t *testing.T) {
+	if got := controlLevelName(simpb.ControlLevel_CONTROL_LEVEL_MOTION); got != "motion" {
+		t.Errorf("controlLevelName(MOTION) = %q; want motion", got)
+	}
+	if got := controlLevelName(simpb.ControlLevel_CONTROL_LEVEL_UNSPECIFIED); got != "unspecified" {
+		t.Errorf("controlLevelName(UNSPECIFIED) = %q; want unspecified", got)
+	}
+}
+
+func TestSendDataChunks(t *testing.T) {
+	// 2.5 chunks worth of data must arrive as 64KiB, 64KiB, 32KiB.
+	payload := bytes.Repeat([]byte{0xAB}, simModelChunkSize*2+simModelChunkSize/2)
+
+	var chunks [][]byte
+	err := sendDataChunks(bytes.NewReader(payload), func(data []byte) error {
+		chunks = append(chunks, data)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("sendDataChunks: %v", err)
+	}
+
+	var total []byte
+	for i, c := range chunks {
+		if len(c) > simModelChunkSize {
+			t.Errorf("chunk %d is %d bytes; want <= %d", i, len(c), simModelChunkSize)
+		}
+		total = append(total, c...)
+	}
+	if !bytes.Equal(total, payload) {
+		t.Errorf("reassembled payload differs: got %d bytes, want %d", len(total), len(payload))
+	}
+	if len(chunks) != 3 {
+		t.Errorf("len(chunks) = %d; want 3", len(chunks))
+	}
+}
+
+func TestSendDataChunks_Empty(t *testing.T) {
+	calls := 0
+	err := sendDataChunks(bytes.NewReader(nil), func([]byte) error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("sendDataChunks: %v", err)
+	}
+	if calls != 0 {
+		t.Errorf("send called %d times for empty input; want 0", calls)
+	}
+}
+
+// writeModelDir builds a small MJCF-shaped model directory.
+func writeModelDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "assets"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	files := map[string]string{
+		"robot.xml":        "<mujoco/>",
+		"assets/mesh.obj":  "v 0 0 0",
+		"assets/notes.txt": "hello",
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// readTarEntries maps entry name -> content for regular files in a tar stream.
+func readTarEntries(t *testing.T, r io.Reader) map[string]string {
+	t.Helper()
+	entries := map[string]string{}
+	tr := tar.NewReader(r)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("reading tar: %v", err)
+		}
+		if hdr.Typeflag == tar.TypeDir {
+			entries[hdr.Name] = ""
+			continue
+		}
+		data, err := io.ReadAll(tr)
+		if err != nil {
+			t.Fatalf("reading tar entry %s: %v", hdr.Name, err)
+		}
+		entries[hdr.Name] = string(data)
+	}
+	return entries
+}
+
+func TestTarDirectory(t *testing.T) {
+	dir := writeModelDir(t)
+
+	var buf bytes.Buffer
+	if err := tarDirectory(dir, &buf); err != nil {
+		t.Fatalf("tarDirectory: %v", err)
+	}
+
+	entries := readTarEntries(t, &buf)
+	if entries["robot.xml"] != "<mujoco/>" {
+		t.Errorf("robot.xml = %q; want <mujoco/>", entries["robot.xml"])
+	}
+	if entries["assets/mesh.obj"] != "v 0 0 0" {
+		t.Errorf("assets/mesh.obj = %q; want v 0 0 0", entries["assets/mesh.obj"])
+	}
+	if _, ok := entries["assets/"]; !ok {
+		t.Errorf("missing directory entry assets/; entries: %v", entries)
+	}
+}
+
+func TestStreamLocalModel_Directory(t *testing.T) {
+	dir := writeModelDir(t)
+
+	var streamed bytes.Buffer
+	err := streamLocalModel(dir, func(data []byte) error {
+		if len(data) > simModelChunkSize {
+			t.Errorf("chunk of %d bytes exceeds %d", len(data), simModelChunkSize)
+		}
+		streamed.Write(data)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("streamLocalModel: %v", err)
+	}
+
+	entries := readTarEntries(t, &streamed)
+	if entries["robot.xml"] != "<mujoco/>" {
+		t.Errorf("streamed tar robot.xml = %q; want <mujoco/>", entries["robot.xml"])
+	}
+	if entries["assets/notes.txt"] != "hello" {
+		t.Errorf("streamed tar assets/notes.txt = %q; want hello", entries["assets/notes.txt"])
+	}
+}
+
+func TestStreamLocalModel_GzippedTar(t *testing.T) {
+	// Build a .tar.gz and verify streamLocalModel transparently gunzips it so
+	// the wire carries a plain tar.
+	dir := writeModelDir(t)
+	var tarBuf bytes.Buffer
+	if err := tarDirectory(dir, &tarBuf); err != nil {
+		t.Fatalf("tarDirectory: %v", err)
+	}
+	plainTar := tarBuf.Bytes()
+
+	archive := filepath.Join(t.TempDir(), "model.tar.gz")
+	f, err := os.Create(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gz := gzip.NewWriter(f)
+	if _, err := gz.Write(plainTar); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var streamed bytes.Buffer
+	if err := streamLocalModel(archive, func(data []byte) error {
+		streamed.Write(data)
+		return nil
+	}); err != nil {
+		t.Fatalf("streamLocalModel: %v", err)
+	}
+	if !bytes.Equal(streamed.Bytes(), plainTar) {
+		t.Errorf("streamed bytes differ from the plain tar (%d vs %d bytes)",
+			streamed.Len(), len(plainTar))
+	}
+}
+
+func TestStreamLocalModel_PlainTarFile(t *testing.T) {
+	dir := writeModelDir(t)
+	var tarBuf bytes.Buffer
+	if err := tarDirectory(dir, &tarBuf); err != nil {
+		t.Fatalf("tarDirectory: %v", err)
+	}
+	archive := filepath.Join(t.TempDir(), "model.tar")
+	if err := os.WriteFile(archive, tarBuf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var streamed bytes.Buffer
+	if err := streamLocalModel(archive, func(data []byte) error {
+		streamed.Write(data)
+		return nil
+	}); err != nil {
+		t.Fatalf("streamLocalModel: %v", err)
+	}
+	if !bytes.Equal(streamed.Bytes(), tarBuf.Bytes()) {
+		t.Error("streamed plain tar differs from the source file")
+	}
+}
+
+func TestStreamLocalModel_Missing(t *testing.T) {
+	err := streamLocalModel(filepath.Join(t.TempDir(), "nope"), func([]byte) error { return nil })
+	if err == nil {
+		t.Error("streamLocalModel on a missing path should fail")
+	}
+}
+
+func TestSimImportModelCmd_RequiresName(t *testing.T) {
+	cmd := newSimImportModelCmd()
+	cmd.SetArgs([]string{"--menagerie", "unitree_go2/go2.xml"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	if err := cmd.Execute(); err == nil {
+		t.Error("import-model without --name should fail")
+	}
+}

--- a/go/internal/cli/grpcclient/client.go
+++ b/go/internal/cli/grpcclient/client.go
@@ -66,6 +66,7 @@ type AgentConnection struct {
 	TelemetryService    agentpb.WendyTelemetryServiceClient
 	FileSyncService     agentpb.WendyFileSyncServiceClient
 	TimeSyncService     agentpbv2.WendyTimeSyncServiceClient
+	SimService          agentpbv2.WendySimServiceClient
 	// observedServerOrg holds the org ID read from the device's server
 	// certificate during the TLS handshake (set by the OnServerIdentity sink
 	// wired in ConnectWithTLSAndPins). Written on the handshake goroutine, read
@@ -274,6 +275,7 @@ func newAgentConnection(conn *grpc.ClientConn) *AgentConnection {
 		TelemetryService:    agentpb.NewWendyTelemetryServiceClient(conn),
 		FileSyncService:     agentpb.NewWendyFileSyncServiceClient(conn),
 		TimeSyncService:     agentpbv2.NewWendyTimeSyncServiceClient(conn),
+		SimService:          agentpbv2.NewWendySimServiceClient(conn),
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements WendySim P1 on top of #1391 (stacked PR — base is `christos/wendysim-p0`):

- **Agent `SimService`** now forwards to a `RobotBackendService` backend dialed lazily at `WENDY_SIM_BACKEND_ADDR` (default `localhost:9090`): CreateSimulation→CreateWorld, ImportModel→LoadModel (client-stream passthrough), DescribeModel, SpawnRobot, GetState/GetContacts/GetCameraFrame, SetVelocity/SetJointTargets, Reset, RunTask (server-stream passthrough with session ControlLevel clamp). In-memory world bookkeeping backs ListSimulations. Unreachable backend → `Unavailable` naming the env var.
- **`AgentConnection`** gains a `SimService` client (grpcclient).
- **New hidden `wendy sim` command group**: create, list, import-model (Menagerie path or local dir/tar/tar.gz streamed as 64KiB tar chunks), describe-model, spawn, state, reset. Dual JSON/human output per house style.

## Test plan

- Unit: bufconn fake backend behind the dial seam — bookkeeping, passthroughs, ImportModel stream, ControlLevel clamp table; CLI arg parsing + tar chunking. `go test ./internal/agent/services ./internal/cli/commands` green; build/vet/gofmt clean.
- **E2E on macOS**: `wendysim:p1` container (:9090) ← native `wendy-agent` (:51151) ← CLI. `sim create → import-model --menagerie unitree_go2/go2.xml → spawn → state` returns the live Go2 base pose + 12 named joints; sim clock advances in real time; `fallen=true` after collapse (no controller until P2); reset + list verified.

Python counterpart: `wendylabsinc/wendysim` @ `a49c3ca`. Linear: WendySim P1 — Sim target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)