### PR TITLE
feat: WendySim P2 — task runner: GetReplay contract + wendy sim run/replay

### DIFF
--- a/Proto/wendy/sim/v1/robot_backend.proto
+++ b/Proto/wendy/sim/v1/robot_backend.proto
@@ -75,6 +75,10 @@ service RobotBackendService {
     // StopRecording finalizes a recording and returns a replay handle the
     // agent can fetch or point a viewer at (e.g. a Rerun .rrd).
     rpc StopRecording(StopRecordingRequest) returns (StopRecordingResponse);
+
+    // GetReplay downloads a finished replay (e.g. a Rerun .rrd) in chunks so
+    // the agent can relay it to the CLI without sharing a filesystem.
+    rpc GetReplay(GetReplayRequest) returns (stream GetReplayChunk);
 }
 
 // ControlLevel classifies how low-level a command is. The agent gates levels
@@ -351,4 +355,12 @@ message StopRecordingResponse {
     // an .rrd path inside the backend container (fetched via the agent) or a
     // viewer URL when the backend serves one.
     string uri = 2;
+}
+
+message GetReplayRequest {
+    string replay_id = 1;
+}
+
+message GetReplayChunk {
+    bytes data = 1;
 }

--- a/go/internal/agent/services/sim_service_v2.go
+++ b/go/internal/agent/services/sim_service_v2.go
@@ -348,6 +348,27 @@ func (s *SimService) RunTask(req *agentpbv2.RunSimTaskRequest, stream agentpbv2.
 	}
 }
 
-func (s *SimService) GetReplay(_ *agentpbv2.GetReplayRequest, _ agentpbv2.WendySimService_GetReplayServer) error {
-	return status.Error(codes.Unimplemented, "GetReplay is not implemented yet (WendySim P1)")
+func (s *SimService) GetReplay(req *agentpbv2.GetReplayRequest, stream agentpbv2.WendySimService_GetReplayServer) error {
+	client, err := s.client()
+	if err != nil {
+		return err
+	}
+	backendStream, err := client.GetReplay(stream.Context(), &simpb.GetReplayRequest{
+		ReplayId: req.GetReplayId(),
+	})
+	if err != nil {
+		return s.backendErr(err)
+	}
+	for {
+		chunk, recvErr := backendStream.Recv()
+		if recvErr == io.EOF {
+			return nil
+		}
+		if recvErr != nil {
+			return s.backendErr(recvErr)
+		}
+		if sendErr := stream.Send(&agentpbv2.GetReplayChunk{Data: chunk.GetData()}); sendErr != nil {
+			return sendErr
+		}
+	}
 }

--- a/go/internal/agent/services/sim_service_v2_test.go
+++ b/go/internal/agent/services/sim_service_v2_test.go
@@ -35,6 +35,8 @@ type fakeRobotBackend struct {
 	loadedData   []byte
 	lastRunTask  *simpb.RunTaskRequest
 	state        *simpb.GetStateResponse
+	// replays maps replay id -> chunks served by GetReplay.
+	replays map[string][][]byte
 }
 
 func (f *fakeRobotBackend) CreateWorld(_ context.Context, req *simpb.CreateWorldRequest) (*simpb.CreateWorldResponse, error) {
@@ -107,6 +109,21 @@ func (f *fakeRobotBackend) RunTask(req *simpb.RunTaskRequest, stream grpc.Server
 	return stream.Send(&simpb.TaskEvent{
 		Event: &simpb.TaskEvent_Result{Result: &simpb.TaskResult{Success: true, Summary: "done"}},
 	})
+}
+
+func (f *fakeRobotBackend) GetReplay(req *simpb.GetReplayRequest, stream grpc.ServerStreamingServer[simpb.GetReplayChunk]) error {
+	f.mu.Lock()
+	chunks, ok := f.replays[req.GetReplayId()]
+	f.mu.Unlock()
+	if !ok {
+		return status.Errorf(codes.NotFound, "replay %q not found", req.GetReplayId())
+	}
+	for _, c := range chunks {
+		if err := stream.Send(&simpb.GetReplayChunk{Data: c}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // startSimService wires a SimService (fronted by a real gRPC server) to an
@@ -356,16 +373,56 @@ func TestSimService_RunTaskRequiresTask(t *testing.T) {
 	}
 }
 
-func TestSimService_GetReplayUnimplemented(t *testing.T) {
-	client := startSimService(t, &fakeRobotBackend{})
+func TestSimService_GetReplayRelaysChunks(t *testing.T) {
+	chunks := [][]byte{
+		[]byte("rrd-header|"),
+		bytes.Repeat([]byte{0x42}, 3000),
+		[]byte("|rrd-footer"),
+	}
+	backend := &fakeRobotBackend{replays: map[string][][]byte{"r-1": chunks}}
+	client := startSimService(t, backend)
 
 	stream, err := client.GetReplay(context.Background(), &agentpbv2.GetReplayRequest{ReplayId: "r-1"})
 	if err != nil {
 		t.Fatalf("GetReplay: %v", err)
 	}
+
+	var got bytes.Buffer
+	recvCount := 0
+	for {
+		chunk, recvErr := stream.Recv()
+		if recvErr == io.EOF {
+			break
+		}
+		if recvErr != nil {
+			t.Fatalf("Recv: %v", recvErr)
+		}
+		recvCount++
+		got.Write(chunk.GetData())
+	}
+
+	if recvCount != len(chunks) {
+		t.Errorf("received %d chunks; want %d", recvCount, len(chunks))
+	}
+	want := bytes.Join(chunks, nil)
+	if !bytes.Equal(got.Bytes(), want) {
+		t.Errorf("relayed replay differs: got %d bytes, want %d", got.Len(), len(want))
+	}
+}
+
+func TestSimService_GetReplayNotFoundPassthrough(t *testing.T) {
+	client := startSimService(t, &fakeRobotBackend{})
+
+	stream, err := client.GetReplay(context.Background(), &agentpbv2.GetReplayRequest{ReplayId: "missing"})
+	if err != nil {
+		t.Fatalf("GetReplay: %v", err)
+	}
 	_, err = stream.Recv()
-	if status.Code(err) != codes.Unimplemented {
-		t.Errorf("error code = %v; want Unimplemented", status.Code(err))
+	if status.Code(err) != codes.NotFound {
+		t.Errorf("error code = %v; want NotFound", status.Code(err))
+	}
+	if err == nil || !strings.Contains(err.Error(), "missing") {
+		t.Errorf("error %v should carry the backend's message", err)
 	}
 }
 

--- a/go/internal/cli/commands/sim.go
+++ b/go/internal/cli/commands/sim.go
@@ -3,7 +3,9 @@ package commands
 import (
 	"archive/tar"
 	"bufio"
+	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -37,6 +39,8 @@ func newSimCmd() *cobra.Command {
 		newSimSpawnCmd(),
 		newSimStateCmd(),
 		newSimResetCmd(),
+		newSimRunCmd(),
+		newSimReplayCmd(),
 	)
 
 	return cmd
@@ -512,6 +516,175 @@ func newSimResetCmd() *cobra.Command {
 	}
 }
 
+func newSimRunCmd() *cobra.Command {
+	var worldID, robotID, controlLevel, outputPath string
+	var record bool
+
+	cmd := &cobra.Command{
+		Use:   "run <task.yaml>",
+		Short: "Run a task spec in a simulation and report the result",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			level, err := parseControlLevel(controlLevel)
+			if err != nil {
+				return err
+			}
+
+			specData, err := os.ReadFile(args[0])
+			if err != nil {
+				return fmt.Errorf("reading task spec: %w", err)
+			}
+			if len(bytes.TrimSpace(specData)) == 0 {
+				return fmt.Errorf("task spec %s is empty", args[0])
+			}
+
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			stream, err := conn.SimService.RunTask(ctx, &agentpbv2.RunSimTaskRequest{
+				Task: &simpb.RunTaskRequest{
+					WorldId:         worldID,
+					RobotId:         robotID,
+					SpecYaml:        string(specData),
+					MaxControlLevel: level,
+					Record:          record,
+				},
+				SessionControlLevel: level,
+			})
+			if err != nil {
+				return fmt.Errorf("running task: %w", err)
+			}
+
+			var result *simpb.TaskResult
+			for {
+				ev, recvErr := stream.Recv()
+				if recvErr == io.EOF {
+					break
+				}
+				if recvErr != nil {
+					return fmt.Errorf("running task: %w", recvErr)
+				}
+				if res := ev.GetResult(); res != nil {
+					result = res // rendered after the stream ends
+					continue
+				}
+				if jsonOutput {
+					if line, ok := taskEventJSONLine(ev); ok {
+						fmt.Println(line)
+					}
+					continue
+				}
+				switch e := ev.GetEvent().(type) {
+				case *simpb.TaskEvent_Progress:
+					cliLogln("[%7.2fs] %s", e.Progress.GetSimTimeS(), e.Progress.GetObjective())
+				case *simpb.TaskEvent_Log:
+					cliNotice("%s", e.Log.GetMessage())
+				}
+			}
+			if result == nil {
+				return fmt.Errorf("task stream ended without a result")
+			}
+
+			if jsonOutput {
+				if err := printJSON(taskResultJSON(result)); err != nil {
+					return err
+				}
+			} else {
+				fmt.Print(renderTaskResult(result))
+			}
+
+			if record && result.GetReplayId() != "" {
+				path := outputPath
+				if path == "" {
+					path = fmt.Sprintf("replay-%s.rrd", result.GetReplayId())
+				}
+				n, err := downloadReplay(ctx, conn.SimService, result.GetReplayId(), path)
+				if err != nil {
+					return fmt.Errorf("downloading replay: %w", err)
+				}
+				if jsonOutput {
+					if err := printJSON(map[string]any{
+						"replayId": result.GetReplayId(),
+						"path":     path,
+						"bytes":    n,
+					}); err != nil {
+						return err
+					}
+				} else {
+					cliSuccess("Replay saved to %s (%d bytes)", path, n)
+				}
+			}
+
+			if !result.GetSuccess() {
+				if summary := result.GetSummary(); summary != "" {
+					return fmt.Errorf("task failed: %s", summary)
+				}
+				return fmt.Errorf("task failed")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&worldID, "world", "", "World ID to run the task in")
+	cmd.Flags().StringVar(&robotID, "robot", "", "Robot ID to drive")
+	cmd.Flags().BoolVar(&record, "record", true, "Record a replay of the run")
+	cmd.Flags().StringVar(&controlLevel, "control-level", "motion",
+		"Highest control level the task may use (task, motion, joint, physics)")
+	cmd.Flags().StringVarP(&outputPath, "output", "o", "",
+		"Replay download path (default ./replay-<replay-id>.rrd)")
+	_ = cmd.MarkFlagRequired("world")
+	_ = cmd.MarkFlagRequired("robot")
+	return cmd
+}
+
+func newSimReplayCmd() *cobra.Command {
+	var outputPath string
+
+	cmd := &cobra.Command{
+		Use:   "replay <replay-id>",
+		Short: "Download a recorded replay (.rrd) from the simulation backend",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			path := outputPath
+			if path == "" {
+				path = fmt.Sprintf("replay-%s.rrd", args[0])
+			}
+
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			n, err := downloadReplay(ctx, conn.SimService, args[0], path)
+			if err != nil {
+				return fmt.Errorf("downloading replay: %w", err)
+			}
+
+			if jsonOutput {
+				return printJSON(map[string]any{
+					"replayId": args[0],
+					"path":     path,
+					"bytes":    n,
+				})
+			}
+			cliSuccess("Replay %s saved to %s (%d bytes)", args[0], path, n)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&outputPath, "output", "o", "",
+		"Output file path (default ./replay-<replay-id>.rrd)")
+	return cmd
+}
+
 // --- helpers ---
 
 func printJSON(v any) error {
@@ -539,6 +712,170 @@ func validateImportModelSource(menageriePath, localPath string) error {
 // (e.g. "motion").
 func controlLevelName(l simpb.ControlLevel) string {
 	return strings.ToLower(strings.TrimPrefix(l.String(), "CONTROL_LEVEL_"))
+}
+
+// parseControlLevel maps a --control-level flag value to a simpb.ControlLevel.
+func parseControlLevel(s string) (simpb.ControlLevel, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "task":
+		return simpb.ControlLevel_CONTROL_LEVEL_TASK, nil
+	case "motion":
+		return simpb.ControlLevel_CONTROL_LEVEL_MOTION, nil
+	case "joint":
+		return simpb.ControlLevel_CONTROL_LEVEL_JOINT, nil
+	case "physics":
+		return simpb.ControlLevel_CONTROL_LEVEL_PHYSICS, nil
+	default:
+		return simpb.ControlLevel_CONTROL_LEVEL_UNSPECIFIED,
+			fmt.Errorf("invalid --control-level %q: expected task, motion, joint, or physics", s)
+	}
+}
+
+// taskEventJSONLine renders a progress or log TaskEvent as a compact JSON
+// line for --json streaming output. Result events return ok=false — the final
+// result is printed as a JSON object instead.
+func taskEventJSONLine(ev *simpb.TaskEvent) (string, bool) {
+	var v any
+	switch e := ev.GetEvent().(type) {
+	case *simpb.TaskEvent_Progress:
+		v = struct {
+			Event     string  `json:"event"`
+			Objective string  `json:"objective,omitempty"`
+			SimTimeS  float64 `json:"simTimeS"`
+		}{Event: "progress", Objective: e.Progress.GetObjective(), SimTimeS: e.Progress.GetSimTimeS()}
+	case *simpb.TaskEvent_Log:
+		v = struct {
+			Event   string `json:"event"`
+			Message string `json:"message"`
+		}{Event: "log", Message: e.Log.GetMessage()}
+	default:
+		return "", false
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		return "", false
+	}
+	return string(data), true
+}
+
+// jsonTaskResult is the --json shape of a simpb.TaskResult.
+type jsonTaskResult struct {
+	Success           bool            `json:"success"`
+	Fell              bool            `json:"fell"`
+	CollisionCount    uint32          `json:"collisionCount"`
+	DistanceTraveledM float64         `json:"distanceTraveledM"`
+	Checks            []jsonTaskCheck `json:"checks,omitempty"`
+	ReplayID          string          `json:"replayId,omitempty"`
+	Summary           string          `json:"summary,omitempty"`
+}
+
+type jsonTaskCheck struct {
+	Name   string `json:"name"`
+	Passed bool   `json:"passed"`
+	Detail string `json:"detail,omitempty"`
+}
+
+func taskResultJSON(res *simpb.TaskResult) jsonTaskResult {
+	out := jsonTaskResult{
+		Success:           res.GetSuccess(),
+		Fell:              res.GetFell(),
+		CollisionCount:    res.GetCollisionCount(),
+		DistanceTraveledM: res.GetDistanceTraveledM(),
+		ReplayID:          res.GetReplayId(),
+		Summary:           res.GetSummary(),
+	}
+	for _, c := range res.GetChecks() {
+		out.Checks = append(out.Checks, jsonTaskCheck{
+			Name: c.GetName(), Passed: c.GetPassed(), Detail: c.GetDetail(),
+		})
+	}
+	return out
+}
+
+// renderTaskResult renders the human-readable summary block for a TaskResult.
+func renderTaskResult(res *simpb.TaskResult) string {
+	var b strings.Builder
+	if res.GetSuccess() {
+		b.WriteString("Task PASSED\n")
+	} else {
+		b.WriteString("Task FAILED\n")
+	}
+	fell := "no"
+	if res.GetFell() {
+		fell = "yes"
+	}
+	fmt.Fprintf(&b, "  Fell:       %s\n", fell)
+	fmt.Fprintf(&b, "  Distance:   %.2f m\n", res.GetDistanceTraveledM())
+	fmt.Fprintf(&b, "  Collisions: %d\n", res.GetCollisionCount())
+	if len(res.GetChecks()) > 0 {
+		b.WriteString("  Checks:\n")
+		for _, c := range res.GetChecks() {
+			mark := "✓"
+			if !c.GetPassed() {
+				mark = "✗"
+			}
+			fmt.Fprintf(&b, "    %s %s", mark, c.GetName())
+			if c.GetDetail() != "" {
+				fmt.Fprintf(&b, " — %s", c.GetDetail())
+			}
+			b.WriteByte('\n')
+		}
+	}
+	if res.GetSummary() != "" {
+		fmt.Fprintf(&b, "  Summary: %s\n", res.GetSummary())
+	}
+	return b.String()
+}
+
+// downloadReplay fetches a replay from the agent's sim service and writes it
+// to path, returning the number of bytes written.
+func downloadReplay(ctx context.Context, client agentpbv2.WendySimServiceClient, replayID, path string) (int64, error) {
+	stream, err := client.GetReplay(ctx, &agentpbv2.GetReplayRequest{ReplayId: replayID})
+	if err != nil {
+		return 0, err
+	}
+	return writeReplayFile(path, func() ([]byte, error) {
+		chunk, recvErr := stream.Recv()
+		if recvErr != nil {
+			return nil, recvErr
+		}
+		return chunk.GetData(), nil
+	})
+}
+
+// writeReplayFile drains recv (which returns io.EOF at end of stream) into
+// path and returns the number of bytes written. A partial file is removed on
+// error so a failed download never leaves a truncated replay behind.
+func writeReplayFile(path string, recv func() ([]byte, error)) (int64, error) {
+	f, err := os.Create(path)
+	if err != nil {
+		return 0, err
+	}
+	fail := func(cause error) (int64, error) {
+		_ = f.Close()
+		_ = os.Remove(path)
+		return 0, cause
+	}
+	var written int64
+	for {
+		data, recvErr := recv()
+		if recvErr == io.EOF {
+			break
+		}
+		if recvErr != nil {
+			return fail(recvErr)
+		}
+		n, writeErr := f.Write(data)
+		written += int64(n)
+		if writeErr != nil {
+			return fail(writeErr)
+		}
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(path)
+		return 0, err
+	}
+	return written, nil
 }
 
 // parseSimPosition parses an "x,y,z" position (meters) into a Pose with

--- a/go/internal/cli/commands/sim_test.go
+++ b/go/internal/cli/commands/sim_test.go
@@ -4,10 +4,15 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 
 	"github.com/wendylabsinc/wendy/go/proto/gen/simpb"
 )
@@ -25,6 +30,8 @@ func TestNewSimCmd_Subcommands(t *testing.T) {
 		"spawn":          false,
 		"state":          false,
 		"reset":          false,
+		"run":            false,
+		"replay":         false,
 	}
 	for _, sub := range cmd.Commands() {
 		if _, ok := want[sub.Name()]; ok {
@@ -304,6 +311,213 @@ func TestStreamLocalModel_Missing(t *testing.T) {
 	err := streamLocalModel(filepath.Join(t.TempDir(), "nope"), func([]byte) error { return nil })
 	if err == nil {
 		t.Error("streamLocalModel on a missing path should fail")
+	}
+}
+
+func TestParseControlLevel(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    simpb.ControlLevel
+		wantErr bool
+	}{
+		{in: "task", want: simpb.ControlLevel_CONTROL_LEVEL_TASK},
+		{in: "motion", want: simpb.ControlLevel_CONTROL_LEVEL_MOTION},
+		{in: "joint", want: simpb.ControlLevel_CONTROL_LEVEL_JOINT},
+		{in: "physics", want: simpb.ControlLevel_CONTROL_LEVEL_PHYSICS},
+		{in: "MOTION", want: simpb.ControlLevel_CONTROL_LEVEL_MOTION},
+		{in: " task ", want: simpb.ControlLevel_CONTROL_LEVEL_TASK},
+		{in: "", wantErr: true},
+		{in: "torque", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, err := parseControlLevel(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseControlLevel(%q) error = %v; wantErr %v", tt.in, err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("parseControlLevel(%q) = %v; want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSimRunCmd_FlagDefaults(t *testing.T) {
+	cmd := newSimRunCmd()
+
+	if f := cmd.Flags().Lookup("record"); f == nil || f.DefValue != "true" {
+		t.Errorf("--record default = %v; want true", f)
+	}
+	if f := cmd.Flags().Lookup("control-level"); f == nil || f.DefValue != "motion" {
+		t.Errorf("--control-level default = %v; want motion", f)
+	}
+	if f := cmd.Flags().Lookup("output"); f == nil || f.Shorthand != "o" {
+		t.Errorf("--output flag = %v; want shorthand -o", f)
+	}
+	for _, name := range []string{"world", "robot"} {
+		f := cmd.Flags().Lookup(name)
+		if f == nil {
+			t.Fatalf("missing --%s flag", name)
+		}
+		if req, ok := f.Annotations[cobra.BashCompOneRequiredFlag]; !ok || len(req) == 0 || req[0] != "true" {
+			t.Errorf("--%s should be required", name)
+		}
+	}
+}
+
+func TestSimRunCmd_RequiresWorldAndRobot(t *testing.T) {
+	cmd := newSimRunCmd()
+	cmd.SetArgs([]string{"task.yaml"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	if err := cmd.Execute(); err == nil {
+		t.Error("run without --world/--robot should fail")
+	}
+}
+
+func TestTaskEventJSONLine(t *testing.T) {
+	progress := &simpb.TaskEvent{Event: &simpb.TaskEvent_Progress{
+		Progress: &simpb.TaskProgress{Objective: "move_forward", SimTimeS: 1.5},
+	}}
+	line, ok := taskEventJSONLine(progress)
+	if !ok {
+		t.Fatal("taskEventJSONLine(progress) ok = false; want true")
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(line), &got); err != nil {
+		t.Fatalf("progress line %q is not JSON: %v", line, err)
+	}
+	if got["event"] != "progress" || got["objective"] != "move_forward" || got["simTimeS"] != 1.5 {
+		t.Errorf("progress line = %q; want event/objective/simTimeS fields", line)
+	}
+
+	logEv := &simpb.TaskEvent{Event: &simpb.TaskEvent_Log{Log: &simpb.TaskLog{Message: "spawned"}}}
+	line, ok = taskEventJSONLine(logEv)
+	if !ok {
+		t.Fatal("taskEventJSONLine(log) ok = false; want true")
+	}
+	if err := json.Unmarshal([]byte(line), &got); err != nil {
+		t.Fatalf("log line %q is not JSON: %v", line, err)
+	}
+	if got["event"] != "log" || got["message"] != "spawned" {
+		t.Errorf("log line = %q; want event/message fields", line)
+	}
+
+	result := &simpb.TaskEvent{Event: &simpb.TaskEvent_Result{Result: &simpb.TaskResult{Success: true}}}
+	if _, ok := taskEventJSONLine(result); ok {
+		t.Error("taskEventJSONLine(result) ok = true; want false (rendered separately)")
+	}
+}
+
+func TestTaskResultJSON(t *testing.T) {
+	got := taskResultJSON(&simpb.TaskResult{
+		Success:           false,
+		Fell:              true,
+		CollisionCount:    3,
+		DistanceTraveledM: 1.25,
+		Checks: []*simpb.CheckResult{
+			{Name: "not_fallen", Passed: false, Detail: "fell at 2.1s"},
+		},
+		ReplayId: "r-42",
+		Summary:  "robot fell",
+	})
+	if got.Success || !got.Fell || got.CollisionCount != 3 || got.DistanceTraveledM != 1.25 {
+		t.Errorf("taskResultJSON scalars = %+v", got)
+	}
+	if got.ReplayID != "r-42" || got.Summary != "robot fell" {
+		t.Errorf("taskResultJSON replay/summary = %+v", got)
+	}
+	if len(got.Checks) != 1 || got.Checks[0].Name != "not_fallen" || got.Checks[0].Passed ||
+		got.Checks[0].Detail != "fell at 2.1s" {
+		t.Errorf("taskResultJSON checks = %+v", got.Checks)
+	}
+}
+
+func TestRenderTaskResult(t *testing.T) {
+	passed := renderTaskResult(&simpb.TaskResult{
+		Success:           true,
+		DistanceTraveledM: 2.5,
+		Checks: []*simpb.CheckResult{
+			{Name: "not_fallen", Passed: true},
+			{Name: "reached_goal", Passed: true},
+		},
+		Summary: "walked 2.5 m",
+	})
+	for _, want := range []string{"Task PASSED", "Fell:       no", "Distance:   2.50 m",
+		"Collisions: 0", "✓ not_fallen", "✓ reached_goal", "Summary: walked 2.5 m"} {
+		if !strings.Contains(passed, want) {
+			t.Errorf("passed rendering missing %q:\n%s", want, passed)
+		}
+	}
+
+	failed := renderTaskResult(&simpb.TaskResult{
+		Success:        false,
+		Fell:           true,
+		CollisionCount: 2,
+		Checks: []*simpb.CheckResult{
+			{Name: "not_fallen", Passed: false, Detail: "fell at 2.1s"},
+		},
+	})
+	for _, want := range []string{"Task FAILED", "Fell:       yes", "Collisions: 2",
+		"✗ not_fallen — fell at 2.1s"} {
+		if !strings.Contains(failed, want) {
+			t.Errorf("failed rendering missing %q:\n%s", want, failed)
+		}
+	}
+	if strings.Contains(failed, "Summary:") {
+		t.Errorf("failed rendering should omit an empty summary:\n%s", failed)
+	}
+}
+
+func TestWriteReplayFile(t *testing.T) {
+	chunks := [][]byte{
+		[]byte("rrd|"),
+		bytes.Repeat([]byte{0x7F}, 1024),
+		[]byte("|end"),
+	}
+	path := filepath.Join(t.TempDir(), "replay.rrd")
+
+	i := 0
+	n, err := writeReplayFile(path, func() ([]byte, error) {
+		if i >= len(chunks) {
+			return nil, io.EOF
+		}
+		c := chunks[i]
+		i++
+		return c, nil
+	})
+	if err != nil {
+		t.Fatalf("writeReplayFile: %v", err)
+	}
+
+	want := bytes.Join(chunks, nil)
+	if n != int64(len(want)) {
+		t.Errorf("bytes written = %d; want %d", n, len(want))
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("file content differs: got %d bytes, want %d", len(got), len(want))
+	}
+}
+
+func TestWriteReplayFile_ErrorRemovesPartialFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "replay.rrd")
+	calls := 0
+	_, err := writeReplayFile(path, func() ([]byte, error) {
+		calls++
+		if calls == 1 {
+			return []byte("partial"), nil
+		}
+		return nil, errors.New("stream broke")
+	})
+	if err == nil || !strings.Contains(err.Error(), "stream broke") {
+		t.Fatalf("writeReplayFile error = %v; want stream broke", err)
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Errorf("partial file %s should have been removed (stat err = %v)", path, statErr)
 	}
 }
 

--- a/go/proto/gen/simpb/robot_backend.pb.go
+++ b/go/proto/gen/simpb/robot_backend.pb.go
@@ -2509,6 +2509,94 @@ func (x *StopRecordingResponse) GetUri() string {
 	return ""
 }
 
+type GetReplayRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ReplayId      string                 `protobuf:"bytes,1,opt,name=replay_id,json=replayId,proto3" json:"replay_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetReplayRequest) Reset() {
+	*x = GetReplayRequest{}
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[41]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetReplayRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetReplayRequest) ProtoMessage() {}
+
+func (x *GetReplayRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[41]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetReplayRequest.ProtoReflect.Descriptor instead.
+func (*GetReplayRequest) Descriptor() ([]byte, []int) {
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{41}
+}
+
+func (x *GetReplayRequest) GetReplayId() string {
+	if x != nil {
+		return x.ReplayId
+	}
+	return ""
+}
+
+type GetReplayChunk struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Data          []byte                 `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetReplayChunk) Reset() {
+	*x = GetReplayChunk{}
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[42]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetReplayChunk) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetReplayChunk) ProtoMessage() {}
+
+func (x *GetReplayChunk) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[42]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetReplayChunk.ProtoReflect.Descriptor instead.
+func (*GetReplayChunk) Descriptor() ([]byte, []int) {
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{42}
+}
+
+func (x *GetReplayChunk) GetData() []byte {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
 var File_wendy_sim_v1_robot_backend_proto protoreflect.FileDescriptor
 
 const file_wendy_sim_v1_robot_backend_proto_rawDesc = "" +
@@ -2667,7 +2755,11 @@ const file_wendy_sim_v1_robot_backend_proto_rawDesc = "" +
 	"\frecording_id\x18\x01 \x01(\tR\vrecordingId\"F\n" +
 	"\x15StopRecordingResponse\x12\x1b\n" +
 	"\treplay_id\x18\x01 \x01(\tR\breplayId\x12\x10\n" +
-	"\x03uri\x18\x02 \x01(\tR\x03uri*\x93\x01\n" +
+	"\x03uri\x18\x02 \x01(\tR\x03uri\"/\n" +
+	"\x10GetReplayRequest\x12\x1b\n" +
+	"\treplay_id\x18\x01 \x01(\tR\breplayId\"$\n" +
+	"\x0eGetReplayChunk\x12\x12\n" +
+	"\x04data\x18\x01 \x01(\fR\x04data*\x93\x01\n" +
 	"\fControlLevel\x12\x1d\n" +
 	"\x19CONTROL_LEVEL_UNSPECIFIED\x10\x00\x12\x16\n" +
 	"\x12CONTROL_LEVEL_TASK\x10\x01\x12\x18\n" +
@@ -2678,7 +2770,7 @@ const file_wendy_sim_v1_robot_backend_proto_rawDesc = "" +
 	"\x18MODEL_FORMAT_UNSPECIFIED\x10\x00\x12\x15\n" +
 	"\x11MODEL_FORMAT_MJCF\x10\x01\x12\x15\n" +
 	"\x11MODEL_FORMAT_URDF\x10\x02\x12\x14\n" +
-	"\x10MODEL_FORMAT_SDF\x10\x032\xff\b\n" +
+	"\x10MODEL_FORMAT_SDF\x10\x032\xcc\t\n" +
 	"\x13RobotBackendService\x12L\n" +
 	"\tLoadModel\x12\x1c.wendy.sim.v1.LoadModelChunk\x1a\x1f.wendy.sim.v1.LoadModelResponse(\x01\x12X\n" +
 	"\rDescribeModel\x12\".wendy.sim.v1.DescribeModelRequest\x1a#.wendy.sim.v1.DescribeModelResponse\x12R\n" +
@@ -2693,7 +2785,8 @@ const file_wendy_sim_v1_robot_backend_proto_rawDesc = "" +
 	"\x04Step\x12\x19.wendy.sim.v1.StepRequest\x1a\x1a.wendy.sim.v1.StepResponse\x12B\n" +
 	"\aRunTask\x12\x1c.wendy.sim.v1.RunTaskRequest\x1a\x17.wendy.sim.v1.TaskEvent0\x01\x12[\n" +
 	"\x0eStartRecording\x12#.wendy.sim.v1.StartRecordingRequest\x1a$.wendy.sim.v1.StartRecordingResponse\x12X\n" +
-	"\rStopRecording\x12\".wendy.sim.v1.StopRecordingRequest\x1a#.wendy.sim.v1.StopRecordingResponseB8Z6github.com/wendylabsinc/wendy/go/proto/gen/simpb;simpbb\x06proto3"
+	"\rStopRecording\x12\".wendy.sim.v1.StopRecordingRequest\x1a#.wendy.sim.v1.StopRecordingResponse\x12K\n" +
+	"\tGetReplay\x12\x1e.wendy.sim.v1.GetReplayRequest\x1a\x1c.wendy.sim.v1.GetReplayChunk0\x01B8Z6github.com/wendylabsinc/wendy/go/proto/gen/simpb;simpbb\x06proto3"
 
 var (
 	file_wendy_sim_v1_robot_backend_proto_rawDescOnce sync.Once
@@ -2708,7 +2801,7 @@ func file_wendy_sim_v1_robot_backend_proto_rawDescGZIP() []byte {
 }
 
 var file_wendy_sim_v1_robot_backend_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_wendy_sim_v1_robot_backend_proto_msgTypes = make([]protoimpl.MessageInfo, 42)
+var file_wendy_sim_v1_robot_backend_proto_msgTypes = make([]protoimpl.MessageInfo, 44)
 var file_wendy_sim_v1_robot_backend_proto_goTypes = []any{
 	(ControlLevel)(0),               // 0: wendy.sim.v1.ControlLevel
 	(ModelFormat)(0),                // 1: wendy.sim.v1.ModelFormat
@@ -2753,7 +2846,9 @@ var file_wendy_sim_v1_robot_backend_proto_goTypes = []any{
 	(*StartRecordingResponse)(nil),  // 40: wendy.sim.v1.StartRecordingResponse
 	(*StopRecordingRequest)(nil),    // 41: wendy.sim.v1.StopRecordingRequest
 	(*StopRecordingResponse)(nil),   // 42: wendy.sim.v1.StopRecordingResponse
-	nil,                             // 43: wendy.sim.v1.SetJointTargetsRequest.TargetsEntry
+	(*GetReplayRequest)(nil),        // 43: wendy.sim.v1.GetReplayRequest
+	(*GetReplayChunk)(nil),          // 44: wendy.sim.v1.GetReplayChunk
+	nil,                             // 45: wendy.sim.v1.SetJointTargetsRequest.TargetsEntry
 }
 var file_wendy_sim_v1_robot_backend_proto_depIdxs = []int32{
 	3,  // 0: wendy.sim.v1.LoadModelChunk.source:type_name -> wendy.sim.v1.ModelSource
@@ -2768,7 +2863,7 @@ var file_wendy_sim_v1_robot_backend_proto_depIdxs = []int32{
 	18, // 9: wendy.sim.v1.GetStateResponse.base_pose:type_name -> wendy.sim.v1.Pose
 	21, // 10: wendy.sim.v1.GetStateResponse.joints:type_name -> wendy.sim.v1.JointState
 	24, // 11: wendy.sim.v1.GetContactsResponse.contacts:type_name -> wendy.sim.v1.Contact
-	43, // 12: wendy.sim.v1.SetJointTargetsRequest.targets:type_name -> wendy.sim.v1.SetJointTargetsRequest.TargetsEntry
+	45, // 12: wendy.sim.v1.SetJointTargetsRequest.targets:type_name -> wendy.sim.v1.SetJointTargetsRequest.TargetsEntry
 	0,  // 13: wendy.sim.v1.RunTaskRequest.max_control_level:type_name -> wendy.sim.v1.ControlLevel
 	35, // 14: wendy.sim.v1.TaskEvent.progress:type_name -> wendy.sim.v1.TaskProgress
 	36, // 15: wendy.sim.v1.TaskEvent.log:type_name -> wendy.sim.v1.TaskLog
@@ -2788,22 +2883,24 @@ var file_wendy_sim_v1_robot_backend_proto_depIdxs = []int32{
 	33, // 29: wendy.sim.v1.RobotBackendService.RunTask:input_type -> wendy.sim.v1.RunTaskRequest
 	39, // 30: wendy.sim.v1.RobotBackendService.StartRecording:input_type -> wendy.sim.v1.StartRecordingRequest
 	41, // 31: wendy.sim.v1.RobotBackendService.StopRecording:input_type -> wendy.sim.v1.StopRecordingRequest
-	4,  // 32: wendy.sim.v1.RobotBackendService.LoadModel:output_type -> wendy.sim.v1.LoadModelResponse
-	6,  // 33: wendy.sim.v1.RobotBackendService.DescribeModel:output_type -> wendy.sim.v1.DescribeModelResponse
-	13, // 34: wendy.sim.v1.RobotBackendService.CreateWorld:output_type -> wendy.sim.v1.CreateWorldResponse
-	15, // 35: wendy.sim.v1.RobotBackendService.Spawn:output_type -> wendy.sim.v1.SpawnResponse
-	17, // 36: wendy.sim.v1.RobotBackendService.Reset:output_type -> wendy.sim.v1.ResetResponse
-	20, // 37: wendy.sim.v1.RobotBackendService.GetState:output_type -> wendy.sim.v1.GetStateResponse
-	23, // 38: wendy.sim.v1.RobotBackendService.GetContacts:output_type -> wendy.sim.v1.GetContactsResponse
-	26, // 39: wendy.sim.v1.RobotBackendService.GetCameraFrame:output_type -> wendy.sim.v1.GetCameraFrameResponse
-	28, // 40: wendy.sim.v1.RobotBackendService.SetVelocity:output_type -> wendy.sim.v1.SetVelocityResponse
-	30, // 41: wendy.sim.v1.RobotBackendService.SetJointTargets:output_type -> wendy.sim.v1.SetJointTargetsResponse
-	32, // 42: wendy.sim.v1.RobotBackendService.Step:output_type -> wendy.sim.v1.StepResponse
-	34, // 43: wendy.sim.v1.RobotBackendService.RunTask:output_type -> wendy.sim.v1.TaskEvent
-	40, // 44: wendy.sim.v1.RobotBackendService.StartRecording:output_type -> wendy.sim.v1.StartRecordingResponse
-	42, // 45: wendy.sim.v1.RobotBackendService.StopRecording:output_type -> wendy.sim.v1.StopRecordingResponse
-	32, // [32:46] is the sub-list for method output_type
-	18, // [18:32] is the sub-list for method input_type
+	43, // 32: wendy.sim.v1.RobotBackendService.GetReplay:input_type -> wendy.sim.v1.GetReplayRequest
+	4,  // 33: wendy.sim.v1.RobotBackendService.LoadModel:output_type -> wendy.sim.v1.LoadModelResponse
+	6,  // 34: wendy.sim.v1.RobotBackendService.DescribeModel:output_type -> wendy.sim.v1.DescribeModelResponse
+	13, // 35: wendy.sim.v1.RobotBackendService.CreateWorld:output_type -> wendy.sim.v1.CreateWorldResponse
+	15, // 36: wendy.sim.v1.RobotBackendService.Spawn:output_type -> wendy.sim.v1.SpawnResponse
+	17, // 37: wendy.sim.v1.RobotBackendService.Reset:output_type -> wendy.sim.v1.ResetResponse
+	20, // 38: wendy.sim.v1.RobotBackendService.GetState:output_type -> wendy.sim.v1.GetStateResponse
+	23, // 39: wendy.sim.v1.RobotBackendService.GetContacts:output_type -> wendy.sim.v1.GetContactsResponse
+	26, // 40: wendy.sim.v1.RobotBackendService.GetCameraFrame:output_type -> wendy.sim.v1.GetCameraFrameResponse
+	28, // 41: wendy.sim.v1.RobotBackendService.SetVelocity:output_type -> wendy.sim.v1.SetVelocityResponse
+	30, // 42: wendy.sim.v1.RobotBackendService.SetJointTargets:output_type -> wendy.sim.v1.SetJointTargetsResponse
+	32, // 43: wendy.sim.v1.RobotBackendService.Step:output_type -> wendy.sim.v1.StepResponse
+	34, // 44: wendy.sim.v1.RobotBackendService.RunTask:output_type -> wendy.sim.v1.TaskEvent
+	40, // 45: wendy.sim.v1.RobotBackendService.StartRecording:output_type -> wendy.sim.v1.StartRecordingResponse
+	42, // 46: wendy.sim.v1.RobotBackendService.StopRecording:output_type -> wendy.sim.v1.StopRecordingResponse
+	44, // 47: wendy.sim.v1.RobotBackendService.GetReplay:output_type -> wendy.sim.v1.GetReplayChunk
+	33, // [33:48] is the sub-list for method output_type
+	18, // [18:33] is the sub-list for method input_type
 	18, // [18:18] is the sub-list for extension type_name
 	18, // [18:18] is the sub-list for extension extendee
 	0,  // [0:18] is the sub-list for field type_name
@@ -2829,7 +2926,7 @@ func file_wendy_sim_v1_robot_backend_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_wendy_sim_v1_robot_backend_proto_rawDesc), len(file_wendy_sim_v1_robot_backend_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   42,
+			NumMessages:   44,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/go/proto/gen/simpb/robot_backend_grpc.pb.go
+++ b/go/proto/gen/simpb/robot_backend_grpc.pb.go
@@ -33,6 +33,7 @@ const (
 	RobotBackendService_RunTask_FullMethodName         = "/wendy.sim.v1.RobotBackendService/RunTask"
 	RobotBackendService_StartRecording_FullMethodName  = "/wendy.sim.v1.RobotBackendService/StartRecording"
 	RobotBackendService_StopRecording_FullMethodName   = "/wendy.sim.v1.RobotBackendService/StopRecording"
+	RobotBackendService_GetReplay_FullMethodName       = "/wendy.sim.v1.RobotBackendService/GetReplay"
 )
 
 // RobotBackendServiceClient is the client API for RobotBackendService service.
@@ -89,6 +90,9 @@ type RobotBackendServiceClient interface {
 	// StopRecording finalizes a recording and returns a replay handle the
 	// agent can fetch or point a viewer at (e.g. a Rerun .rrd).
 	StopRecording(ctx context.Context, in *StopRecordingRequest, opts ...grpc.CallOption) (*StopRecordingResponse, error)
+	// GetReplay downloads a finished replay (e.g. a Rerun .rrd) in chunks so
+	// the agent can relay it to the CLI without sharing a filesystem.
+	GetReplay(ctx context.Context, in *GetReplayRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[GetReplayChunk], error)
 }
 
 type robotBackendServiceClient struct {
@@ -251,6 +255,25 @@ func (c *robotBackendServiceClient) StopRecording(ctx context.Context, in *StopR
 	return out, nil
 }
 
+func (c *robotBackendServiceClient) GetReplay(ctx context.Context, in *GetReplayRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[GetReplayChunk], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &RobotBackendService_ServiceDesc.Streams[2], RobotBackendService_GetReplay_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[GetReplayRequest, GetReplayChunk]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type RobotBackendService_GetReplayClient = grpc.ServerStreamingClient[GetReplayChunk]
+
 // RobotBackendServiceServer is the server API for RobotBackendService service.
 // All implementations must embed UnimplementedRobotBackendServiceServer
 // for forward compatibility.
@@ -305,6 +328,9 @@ type RobotBackendServiceServer interface {
 	// StopRecording finalizes a recording and returns a replay handle the
 	// agent can fetch or point a viewer at (e.g. a Rerun .rrd).
 	StopRecording(context.Context, *StopRecordingRequest) (*StopRecordingResponse, error)
+	// GetReplay downloads a finished replay (e.g. a Rerun .rrd) in chunks so
+	// the agent can relay it to the CLI without sharing a filesystem.
+	GetReplay(*GetReplayRequest, grpc.ServerStreamingServer[GetReplayChunk]) error
 	mustEmbedUnimplementedRobotBackendServiceServer()
 }
 
@@ -356,6 +382,9 @@ func (UnimplementedRobotBackendServiceServer) StartRecording(context.Context, *S
 }
 func (UnimplementedRobotBackendServiceServer) StopRecording(context.Context, *StopRecordingRequest) (*StopRecordingResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method StopRecording not implemented")
+}
+func (UnimplementedRobotBackendServiceServer) GetReplay(*GetReplayRequest, grpc.ServerStreamingServer[GetReplayChunk]) error {
+	return status.Error(codes.Unimplemented, "method GetReplay not implemented")
 }
 func (UnimplementedRobotBackendServiceServer) mustEmbedUnimplementedRobotBackendServiceServer() {}
 func (UnimplementedRobotBackendServiceServer) testEmbeddedByValue()                             {}
@@ -612,6 +641,17 @@ func _RobotBackendService_StopRecording_Handler(srv interface{}, ctx context.Con
 	return interceptor(ctx, in, info, handler)
 }
 
+func _RobotBackendService_GetReplay_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(GetReplayRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(RobotBackendServiceServer).GetReplay(m, &grpc.GenericServerStream[GetReplayRequest, GetReplayChunk]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type RobotBackendService_GetReplayServer = grpc.ServerStreamingServer[GetReplayChunk]
+
 // RobotBackendService_ServiceDesc is the grpc.ServiceDesc for RobotBackendService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -677,6 +717,11 @@ var RobotBackendService_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "RunTask",
 			Handler:       _RobotBackendService_RunTask_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "GetReplay",
+			Handler:       _RobotBackendService_GetReplay_Handler,
 			ServerStreams: true,
 		},
 	},


### PR DESCRIPTION
## Summary

WendySim P2, stacked on #1392:

- **Contract:** `GetReplay` added to `wendy.sim.v1.RobotBackendService` — the agent can download finished replays (Rerun `.rrd`) from the backend container without a shared filesystem.
- **Agent:** `SimService.GetReplay` relays backend replay chunks to the caller (byte-exact, NOT_FOUND passthrough).
- **CLI:** `wendy sim run <task.yaml>` — streams TaskEvents (progress/logs), renders the TaskResult with per-check ✓/✗ and summary, exits non-zero on failure, auto-downloads the replay; `wendy sim replay <id> [-o file]`. JSONL mode for non-interactive use.

## Test plan

- Unit: replay relay (multi-chunk, byte-exact), NOT_FOUND passthrough, flag parsing, event rendering, replay-file write (partial-file cleanup). Build/vet/gofmt clean, both packages' tests green.
- **E2E on macOS** (with wendylabsinc/wendysim @ f093fc4): `wendy sim run examples/go2_walk_3m/task.yaml` → the Go2 **walked 3.00 m** (open-loop trot controller), all 3 checks passed (not_fallen, distance ≥ 2.5 m, 0 collisions), and the 1.28 MB `.rrd` replay downloaded through the full CLI → agent → container chain.

Linear: WendySim P2 — Run task/app in sim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)