### PR TITLE
feat: WendySim visual — wendy sim camera snapshot command

### DIFF
--- a/Proto/wendy/agent/services/v2/sim_service.proto
+++ b/Proto/wendy/agent/services/v2/sim_service.proto
@@ -45,6 +45,9 @@ service WendySimService {
     rpc SetVelocity(wendy.sim.v1.SetVelocityRequest) returns (wendy.sim.v1.SetVelocityResponse);
     rpc SetJointTargets(wendy.sim.v1.SetJointTargetsRequest) returns (wendy.sim.v1.SetJointTargetsResponse);
 
+    // Step advances sim time deterministically (pairs with SetClock pause).
+    rpc Step(wendy.sim.v1.StepRequest) returns (wendy.sim.v1.StepResponse);
+
     // --- Tasks & replay (backs `wendy sim run/evaluate`, `wendy replay`) ---
 
     // RunTask executes a task spec and streams progress, ending with a

--- a/Proto/wendy/agent/services/v2/sim_service.proto
+++ b/Proto/wendy/agent/services/v2/sim_service.proto
@@ -53,6 +53,20 @@ service WendySimService {
 
     // GetReplay downloads a finished replay (e.g. a Rerun .rrd) in chunks.
     rpc GetReplay(GetReplayRequest) returns (stream GetReplayChunk);
+
+    // --- Interactive tooling (forwarded to sim backends; Unimplemented on
+    // real-robot backends) ---
+
+    rpc SetClock(wendy.sim.v1.SetClockRequest) returns (wendy.sim.v1.SetClockResponse);
+    rpc ApplyForce(wendy.sim.v1.ApplyForceRequest) returns (wendy.sim.v1.ApplyForceResponse);
+    rpc Teleport(wendy.sim.v1.TeleportRequest) returns (wendy.sim.v1.TeleportResponse);
+    rpc SaveSnapshot(wendy.sim.v1.SaveSnapshotRequest) returns (wendy.sim.v1.SaveSnapshotResponse);
+    rpc RestoreSnapshot(wendy.sim.v1.RestoreSnapshotRequest) returns (wendy.sim.v1.RestoreSnapshotResponse);
+    rpc ReadSensors(wendy.sim.v1.ReadSensorsRequest) returns (wendy.sim.v1.ReadSensorsResponse);
+    rpc EditScene(wendy.sim.v1.EditSceneRequest) returns (wendy.sim.v1.EditSceneResponse);
+    rpc LoadPolicy(stream wendy.sim.v1.LoadPolicyChunk) returns (wendy.sim.v1.LoadPolicyResponse);
+    rpc ClearPolicy(wendy.sim.v1.ClearPolicyRequest) returns (wendy.sim.v1.ClearPolicyResponse);
+    rpc RenderVideo(wendy.sim.v1.RenderVideoRequest) returns (stream wendy.sim.v1.VideoChunk);
 }
 
 message CreateSimulationRequest {

--- a/Proto/wendy/sim/v1/robot_backend.proto
+++ b/Proto/wendy/sim/v1/robot_backend.proto
@@ -79,6 +79,41 @@ service RobotBackendService {
     // GetReplay downloads a finished replay (e.g. a Rerun .rrd) in chunks so
     // the agent can relay it to the CLI without sharing a filesystem.
     rpc GetReplay(GetReplayRequest) returns (stream GetReplayChunk);
+
+    // --- Interactive tooling (the sim-native workflow: pause, poke, edit) ---
+    // Simulation backends implement these; a real-robot backend returns
+    // Unimplemented (you cannot pause or teleport reality).
+
+    // SetClock pauses/resumes a world and scales its real-time pacing.
+    rpc SetClock(SetClockRequest) returns (SetClockResponse);
+
+    // ApplyForce applies an external force impulse to a robot's base — the
+    // programmatic version of shoving it in a viewer, used to test balance.
+    rpc ApplyForce(ApplyForceRequest) returns (ApplyForceResponse);
+
+    // Teleport moves a robot to a pose directly (physics-level edit).
+    rpc Teleport(TeleportRequest) returns (TeleportResponse);
+
+    // SaveSnapshot captures a world's exact physics state; RestoreSnapshot
+    // rewinds to it. Snapshots let a failure be reproduced deterministically.
+    rpc SaveSnapshot(SaveSnapshotRequest) returns (SaveSnapshotResponse);
+    rpc RestoreSnapshot(RestoreSnapshotRequest) returns (RestoreSnapshotResponse);
+
+    // ReadSensors returns current readings for the model's declared sensors
+    // (IMU, force, touch, rangefinder, ...).
+    rpc ReadSensors(ReadSensorsRequest) returns (ReadSensorsResponse);
+
+    // EditScene mutates a live world's static scenery without recreating it.
+    rpc EditScene(EditSceneRequest) returns (EditSceneResponse);
+
+    // LoadPolicy streams a trained policy (e.g. ONNX) that replaces the
+    // robot's built-in controller; ClearPolicy reverts to the built-in one.
+    rpc LoadPolicy(stream LoadPolicyChunk) returns (LoadPolicyResponse);
+    rpc ClearPolicy(ClearPolicyRequest) returns (ClearPolicyResponse);
+
+    // RenderVideo renders a video clip of the world (tracking or named
+    // camera) and streams the encoded file back.
+    rpc RenderVideo(RenderVideoRequest) returns (stream VideoChunk);
 }
 
 // ControlLevel classifies how low-level a command is. The agent gates levels
@@ -116,6 +151,9 @@ message ModelSource {
     // When set, the backend loads a bundled MuJoCo Menagerie model by path
     // (e.g. "unitree_go2/go2.xml") and no data chunks follow.
     string menagerie_path = 3;
+    // When set, replace this existing model in place (the edit-reload dev
+    // loop): robots spawned from it are respawned against the new model.
+    string replace_model_id = 4;
 }
 
 message LoadModelResponse {
@@ -343,6 +381,136 @@ message StartRecordingRequest {
 
 message StartRecordingResponse {
     string recording_id = 1;
+}
+
+message SetClockRequest {
+    string world_id = 1;
+    // True pauses physics stepping; false resumes it.
+    bool paused = 2;
+    // Real-time pacing multiplier (1.0 = real time, 10 = 10x fast-forward,
+    // 0 = leave the current factor unchanged).
+    double speed_factor = 3;
+}
+
+message SetClockResponse {
+    bool paused = 1;
+    double speed_factor = 2;
+}
+
+message ApplyForceRequest {
+    string world_id = 1;
+    string robot_id = 2;
+    // World-frame force in Newtons applied at the base's center of mass.
+    double fx_n = 3;
+    double fy_n = 4;
+    double fz_n = 5;
+    // How long the force is held, in sim seconds (0 = one physics step).
+    double duration_s = 6;
+}
+
+message ApplyForceResponse {}
+
+message TeleportRequest {
+    string world_id = 1;
+    string robot_id = 2;
+    Pose pose = 3;
+    // Also zero the robot's velocities (default behavior when true).
+    bool zero_velocity = 4;
+}
+
+message TeleportResponse {}
+
+message SaveSnapshotRequest {
+    string world_id = 1;
+}
+
+message SaveSnapshotResponse {
+    string snapshot_id = 1;
+}
+
+message RestoreSnapshotRequest {
+    string world_id = 1;
+    string snapshot_id = 2;
+}
+
+message RestoreSnapshotResponse {}
+
+message ReadSensorsRequest {
+    string world_id = 1;
+    string robot_id = 2;
+}
+
+message ReadSensorsResponse {
+    repeated SensorReading readings = 1;
+}
+
+message SensorReading {
+    string name = 1;
+    // Sensor type as reported by the engine (accelerometer, gyro, touch, ...).
+    string type = 2;
+    repeated double values = 3;
+}
+
+message EditSceneRequest {
+    string world_id = 1;
+    oneof op {
+        SceneBoxSpec add_box = 2;
+        // Obstacle id to remove.
+        string remove_id = 3;
+    }
+}
+
+message SceneBoxSpec {
+    string id = 1;
+    // Center position [x, y, z] in meters.
+    repeated double position = 2;
+    // Full extents [x, y, z] in meters.
+    repeated double size = 3;
+}
+
+message EditSceneResponse {}
+
+message LoadPolicyChunk {
+    oneof payload {
+        // First chunk: what the policy is and who it drives.
+        PolicySource source = 1;
+        // Subsequent chunks: the policy file bytes.
+        bytes data = 2;
+    }
+}
+
+message PolicySource {
+    string world_id = 1;
+    string robot_id = 2;
+    // Policy file format; "onnx" is the first supported value.
+    string format = 3;
+}
+
+message LoadPolicyResponse {
+    string policy_id = 1;
+}
+
+message ClearPolicyRequest {
+    string world_id = 1;
+    string robot_id = 2;
+}
+
+message ClearPolicyResponse {}
+
+message RenderVideoRequest {
+    string world_id = 1;
+    string robot_id = 2;
+    // Empty or "tracking" follows the robot; otherwise a model camera name.
+    string camera_name = 3;
+    double duration_s = 4;
+    uint32 fps = 5;
+    uint32 width = 6;
+    uint32 height = 7;
+}
+
+message VideoChunk {
+    // Encoded video bytes (mp4).
+    bytes data = 1;
 }
 
 message StopRecordingRequest {

--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -124,6 +124,14 @@ func main() {
 
 	logger.Info("Starting wendy-agent", zap.String("version", version.Version))
 
+	// Sim-only mode: run purely as a sim front (see simOnlyEnvVar). Services
+	// are constructed and registered as usual; only the containerd-backed
+	// loops and boot-time one-shots below are not launched.
+	simOnly := simOnlyMode()
+	if simOnly {
+		logger.Info("sim-only mode: container management disabled (WENDY_SIM_ONLY=1)")
+	}
+
 	configPath := "/etc/wendy-agent"
 	if envPath := os.Getenv("WENDY_CONFIG_PATH"); envPath != "" {
 		configPath = envPath
@@ -276,7 +284,7 @@ func main() {
 
 	var wg sync.WaitGroup
 
-	if monitor != nil {
+	if monitor != nil && !simOnly {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -288,7 +296,7 @@ func main() {
 		go monitor.ReconcileBootContainers(ctx)
 	}
 
-	if containerdClient != nil {
+	if containerdClient != nil && !simOnly {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -296,7 +304,7 @@ func main() {
 		}()
 	}
 
-	if ctrdClient != nil {
+	if ctrdClient != nil && !simOnly {
 		if err := ctrdClient.ReapOrphanedROS2Sidecars(ctx); err != nil {
 			logger.Warn("ROS 2 sidecar reap on boot failed", zap.Error(err))
 		}

--- a/go/cmd/wendy-agent/simonly.go
+++ b/go/cmd/wendy-agent/simonly.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"os"
+	"strconv"
+)
+
+// simOnlyEnvVar opts the agent into sim-only mode: the agent runs purely as a
+// sim front (e.g. natively on macOS with WENDY_SIM_BACKEND_ADDR pointing at a
+// sim container) where no containerd is available. All gRPC services are still
+// constructed and registered; only the containerd-backed background loops and
+// boot-time one-shots are not launched, silencing the otherwise constant
+// containerd dial timeouts.
+const simOnlyEnvVar = "WENDY_SIM_ONLY"
+
+// simOnlyMode reports whether WENDY_SIM_ONLY is set to a true boolean value
+// ("1", "true", ...). Unset, empty, or unparseable values mean off, so the
+// default behavior is unchanged.
+func simOnlyMode() bool {
+	v, err := strconv.ParseBool(os.Getenv(simOnlyEnvVar))
+	return err == nil && v
+}

--- a/go/cmd/wendy-agent/simonly_test.go
+++ b/go/cmd/wendy-agent/simonly_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestSimOnlyMode(t *testing.T) {
+	tests := []struct {
+		name  string
+		set   bool
+		value string
+		want  bool
+	}{
+		{name: "unset", set: false, want: false},
+		{name: "empty", set: true, value: "", want: false},
+		{name: "one", set: true, value: "1", want: true},
+		{name: "true", set: true, value: "true", want: true},
+		{name: "TRUE", set: true, value: "TRUE", want: true},
+		{name: "zero", set: true, value: "0", want: false},
+		{name: "false", set: true, value: "false", want: false},
+		{name: "garbage", set: true, value: "yes-please", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// t.Setenv registers cleanup restoring the original value, so it is
+			// safe to follow it with os.Unsetenv for the "unset" case.
+			t.Setenv(simOnlyEnvVar, tt.value)
+			if !tt.set {
+				if err := os.Unsetenv(simOnlyEnvVar); err != nil {
+					t.Fatalf("Unsetenv: %v", err)
+				}
+			}
+			if got := simOnlyMode(); got != tt.want {
+				t.Errorf("simOnlyMode() = %v, want %v (env set=%v value=%q)", got, tt.want, tt.set, tt.value)
+			}
+		})
+	}
+}

--- a/go/internal/agent/services/sim_service_v2.go
+++ b/go/internal/agent/services/sim_service_v2.go
@@ -311,6 +311,169 @@ func (s *SimService) SetJointTargets(ctx context.Context, req *simpb.SetJointTar
 	return resp, nil
 }
 
+func (s *SimService) Step(ctx context.Context, req *simpb.StepRequest) (*simpb.StepResponse, error) {
+	client, err := s.client()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Step(ctx, req)
+	if err != nil {
+		return nil, s.backendErr(err)
+	}
+	return resp, nil
+}
+
+// --- Interactive tooling ---
+
+func (s *SimService) SetClock(ctx context.Context, req *simpb.SetClockRequest) (*simpb.SetClockResponse, error) {
+	client, err := s.client()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.SetClock(ctx, req)
+	if err != nil {
+		return nil, s.backendErr(err)
+	}
+	return resp, nil
+}
+
+func (s *SimService) ApplyForce(ctx context.Context, req *simpb.ApplyForceRequest) (*simpb.ApplyForceResponse, error) {
+	client, err := s.client()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.ApplyForce(ctx, req)
+	if err != nil {
+		return nil, s.backendErr(err)
+	}
+	return resp, nil
+}
+
+func (s *SimService) Teleport(ctx context.Context, req *simpb.TeleportRequest) (*simpb.TeleportResponse, error) {
+	client, err := s.client()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Teleport(ctx, req)
+	if err != nil {
+		return nil, s.backendErr(err)
+	}
+	return resp, nil
+}
+
+func (s *SimService) SaveSnapshot(ctx context.Context, req *simpb.SaveSnapshotRequest) (*simpb.SaveSnapshotResponse, error) {
+	client, err := s.client()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.SaveSnapshot(ctx, req)
+	if err != nil {
+		return nil, s.backendErr(err)
+	}
+	return resp, nil
+}
+
+func (s *SimService) RestoreSnapshot(ctx context.Context, req *simpb.RestoreSnapshotRequest) (*simpb.RestoreSnapshotResponse, error) {
+	client, err := s.client()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.RestoreSnapshot(ctx, req)
+	if err != nil {
+		return nil, s.backendErr(err)
+	}
+	return resp, nil
+}
+
+func (s *SimService) ReadSensors(ctx context.Context, req *simpb.ReadSensorsRequest) (*simpb.ReadSensorsResponse, error) {
+	client, err := s.client()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.ReadSensors(ctx, req)
+	if err != nil {
+		return nil, s.backendErr(err)
+	}
+	return resp, nil
+}
+
+func (s *SimService) EditScene(ctx context.Context, req *simpb.EditSceneRequest) (*simpb.EditSceneResponse, error) {
+	client, err := s.client()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.EditScene(ctx, req)
+	if err != nil {
+		return nil, s.backendErr(err)
+	}
+	return resp, nil
+}
+
+func (s *SimService) LoadPolicy(stream agentpbv2.WendySimService_LoadPolicyServer) error {
+	client, err := s.client()
+	if err != nil {
+		return err
+	}
+	backendStream, err := client.LoadPolicy(stream.Context())
+	if err != nil {
+		return s.backendErr(err)
+	}
+	for {
+		chunk, recvErr := stream.Recv()
+		if recvErr == io.EOF {
+			break
+		}
+		if recvErr != nil {
+			return recvErr
+		}
+		if sendErr := backendStream.Send(chunk); sendErr != nil {
+			// Send failing means the backend closed the stream; the real
+			// error comes from CloseAndRecv.
+			break
+		}
+	}
+	resp, err := backendStream.CloseAndRecv()
+	if err != nil {
+		return s.backendErr(err)
+	}
+	return stream.SendAndClose(resp)
+}
+
+func (s *SimService) ClearPolicy(ctx context.Context, req *simpb.ClearPolicyRequest) (*simpb.ClearPolicyResponse, error) {
+	client, err := s.client()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.ClearPolicy(ctx, req)
+	if err != nil {
+		return nil, s.backendErr(err)
+	}
+	return resp, nil
+}
+
+func (s *SimService) RenderVideo(req *simpb.RenderVideoRequest, stream agentpbv2.WendySimService_RenderVideoServer) error {
+	client, err := s.client()
+	if err != nil {
+		return err
+	}
+	backendStream, err := client.RenderVideo(stream.Context(), req)
+	if err != nil {
+		return s.backendErr(err)
+	}
+	for {
+		chunk, recvErr := backendStream.Recv()
+		if recvErr == io.EOF {
+			return nil
+		}
+		if recvErr != nil {
+			return s.backendErr(recvErr)
+		}
+		if sendErr := stream.Send(chunk); sendErr != nil {
+			return sendErr
+		}
+	}
+}
+
 // --- Tasks & replay ---
 
 func (s *SimService) RunTask(req *agentpbv2.RunSimTaskRequest, stream agentpbv2.WendySimService_RunTaskServer) error {

--- a/go/internal/agent/services/sim_service_v2_test.go
+++ b/go/internal/agent/services/sim_service_v2_test.go
@@ -37,6 +37,125 @@ type fakeRobotBackend struct {
 	state        *simpb.GetStateResponse
 	// replays maps replay id -> chunks served by GetReplay.
 	replays map[string][][]byte
+
+	// Interactive tooling captures.
+	lastSetClock   *simpb.SetClockRequest
+	lastApplyForce *simpb.ApplyForceRequest
+	lastTeleport   *simpb.TeleportRequest
+	snapshotWorlds []string
+	lastRestore    *simpb.RestoreSnapshotRequest
+	sensorReadings []*simpb.SensorReading
+	lastEditScene  *simpb.EditSceneRequest
+	lastStep       *simpb.StepRequest
+	policySource   *simpb.PolicySource
+	policyData     []byte
+	clearedPolicy  *simpb.ClearPolicyRequest
+	// videoChunks are the chunks served by RenderVideo.
+	videoChunks [][]byte
+	lastRender  *simpb.RenderVideoRequest
+}
+
+func (f *fakeRobotBackend) SetClock(_ context.Context, req *simpb.SetClockRequest) (*simpb.SetClockResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.lastSetClock = req
+	return &simpb.SetClockResponse{Paused: req.GetPaused(), SpeedFactor: req.GetSpeedFactor()}, nil
+}
+
+func (f *fakeRobotBackend) ApplyForce(_ context.Context, req *simpb.ApplyForceRequest) (*simpb.ApplyForceResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.lastApplyForce = req
+	return &simpb.ApplyForceResponse{}, nil
+}
+
+func (f *fakeRobotBackend) Teleport(_ context.Context, req *simpb.TeleportRequest) (*simpb.TeleportResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.lastTeleport = req
+	return &simpb.TeleportResponse{}, nil
+}
+
+func (f *fakeRobotBackend) SaveSnapshot(_ context.Context, req *simpb.SaveSnapshotRequest) (*simpb.SaveSnapshotResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.snapshotWorlds = append(f.snapshotWorlds, req.GetWorldId())
+	return &simpb.SaveSnapshotResponse{SnapshotId: fmt.Sprintf("snap-%d", len(f.snapshotWorlds))}, nil
+}
+
+func (f *fakeRobotBackend) RestoreSnapshot(_ context.Context, req *simpb.RestoreSnapshotRequest) (*simpb.RestoreSnapshotResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.lastRestore = req
+	return &simpb.RestoreSnapshotResponse{}, nil
+}
+
+func (f *fakeRobotBackend) ReadSensors(_ context.Context, _ *simpb.ReadSensorsRequest) (*simpb.ReadSensorsResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return &simpb.ReadSensorsResponse{Readings: f.sensorReadings}, nil
+}
+
+func (f *fakeRobotBackend) EditScene(_ context.Context, req *simpb.EditSceneRequest) (*simpb.EditSceneResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.lastEditScene = req
+	return &simpb.EditSceneResponse{}, nil
+}
+
+func (f *fakeRobotBackend) Step(_ context.Context, req *simpb.StepRequest) (*simpb.StepResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.lastStep = req
+	return &simpb.StepResponse{SimTimeS: req.GetSeconds()}, nil
+}
+
+func (f *fakeRobotBackend) LoadPolicy(stream grpc.ClientStreamingServer[simpb.LoadPolicyChunk, simpb.LoadPolicyResponse]) error {
+	var source *simpb.PolicySource
+	var data bytes.Buffer
+	for {
+		chunk, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		switch p := chunk.GetPayload().(type) {
+		case *simpb.LoadPolicyChunk_Source:
+			source = p.Source
+		case *simpb.LoadPolicyChunk_Data:
+			data.Write(p.Data)
+		}
+	}
+	if source == nil {
+		return status.Error(codes.InvalidArgument, "first chunk must carry the policy source")
+	}
+	f.mu.Lock()
+	f.policySource = source
+	f.policyData = data.Bytes()
+	f.mu.Unlock()
+	return stream.SendAndClose(&simpb.LoadPolicyResponse{PolicyId: "policy-1"})
+}
+
+func (f *fakeRobotBackend) ClearPolicy(_ context.Context, req *simpb.ClearPolicyRequest) (*simpb.ClearPolicyResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.clearedPolicy = req
+	return &simpb.ClearPolicyResponse{}, nil
+}
+
+func (f *fakeRobotBackend) RenderVideo(req *simpb.RenderVideoRequest, stream grpc.ServerStreamingServer[simpb.VideoChunk]) error {
+	f.mu.Lock()
+	f.lastRender = req
+	chunks := f.videoChunks
+	f.mu.Unlock()
+	for _, c := range chunks {
+		if err := stream.Send(&simpb.VideoChunk{Data: c}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (f *fakeRobotBackend) CreateWorld(_ context.Context, req *simpb.CreateWorldRequest) (*simpb.CreateWorldResponse, error) {
@@ -438,6 +557,270 @@ func TestSimService_BackendDialFailureIsUnavailable(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "WENDY_SIM_BACKEND_ADDR") {
 		t.Errorf("error %q should mention WENDY_SIM_BACKEND_ADDR", err.Error())
+	}
+}
+
+func TestSimService_SetClockPassthrough(t *testing.T) {
+	backend := &fakeRobotBackend{}
+	client := startSimService(t, backend)
+
+	resp, err := client.SetClock(context.Background(), &simpb.SetClockRequest{
+		WorldId: "world-1", Paused: true, SpeedFactor: 4,
+	})
+	if err != nil {
+		t.Fatalf("SetClock: %v", err)
+	}
+	if !resp.GetPaused() || resp.GetSpeedFactor() != 4 {
+		t.Errorf("response = %+v; want paused=true speed=4", resp)
+	}
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if backend.lastSetClock.GetWorldId() != "world-1" || !backend.lastSetClock.GetPaused() ||
+		backend.lastSetClock.GetSpeedFactor() != 4 {
+		t.Errorf("forwarded request = %+v", backend.lastSetClock)
+	}
+}
+
+func TestSimService_ApplyForcePassthrough(t *testing.T) {
+	backend := &fakeRobotBackend{}
+	client := startSimService(t, backend)
+
+	if _, err := client.ApplyForce(context.Background(), &simpb.ApplyForceRequest{
+		WorldId: "world-1", RobotId: "robot-1", FxN: 30, FyN: -5, FzN: 1, DurationS: 0.2,
+	}); err != nil {
+		t.Fatalf("ApplyForce: %v", err)
+	}
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	got := backend.lastApplyForce
+	if got.GetRobotId() != "robot-1" || got.GetFxN() != 30 || got.GetFyN() != -5 ||
+		got.GetFzN() != 1 || got.GetDurationS() != 0.2 {
+		t.Errorf("forwarded request = %+v", got)
+	}
+}
+
+func TestSimService_TeleportPassthrough(t *testing.T) {
+	backend := &fakeRobotBackend{}
+	client := startSimService(t, backend)
+
+	if _, err := client.Teleport(context.Background(), &simpb.TeleportRequest{
+		WorldId: "world-1", RobotId: "robot-1",
+		Pose:         &simpb.Pose{X: 1, Y: 2, Z: 0.5, Qw: 1},
+		ZeroVelocity: true,
+	}); err != nil {
+		t.Fatalf("Teleport: %v", err)
+	}
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	got := backend.lastTeleport
+	if got.GetPose().GetX() != 1 || got.GetPose().GetZ() != 0.5 || !got.GetZeroVelocity() {
+		t.Errorf("forwarded request = %+v", got)
+	}
+}
+
+func TestSimService_SnapshotSaveAndRestorePassthrough(t *testing.T) {
+	backend := &fakeRobotBackend{}
+	client := startSimService(t, backend)
+	ctx := context.Background()
+
+	saved, err := client.SaveSnapshot(ctx, &simpb.SaveSnapshotRequest{WorldId: "world-1"})
+	if err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+	if saved.GetSnapshotId() != "snap-1" {
+		t.Errorf("snapshot_id = %q; want snap-1", saved.GetSnapshotId())
+	}
+
+	if _, err := client.RestoreSnapshot(ctx, &simpb.RestoreSnapshotRequest{
+		WorldId: "world-1", SnapshotId: saved.GetSnapshotId(),
+	}); err != nil {
+		t.Fatalf("RestoreSnapshot: %v", err)
+	}
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if len(backend.snapshotWorlds) != 1 || backend.snapshotWorlds[0] != "world-1" {
+		t.Errorf("snapshot worlds = %v; want [world-1]", backend.snapshotWorlds)
+	}
+	if backend.lastRestore.GetSnapshotId() != "snap-1" {
+		t.Errorf("restored snapshot = %q; want snap-1", backend.lastRestore.GetSnapshotId())
+	}
+}
+
+func TestSimService_ReadSensorsPassthrough(t *testing.T) {
+	backend := &fakeRobotBackend{
+		sensorReadings: []*simpb.SensorReading{
+			{Name: "imu_gyro", Type: "gyro", Values: []float64{0.1, -0.2, 0.05}},
+			{Name: "touch_fl", Type: "touch", Values: []float64{1}},
+		},
+	}
+	client := startSimService(t, backend)
+
+	resp, err := client.ReadSensors(context.Background(), &simpb.ReadSensorsRequest{
+		WorldId: "world-1", RobotId: "robot-1",
+	})
+	if err != nil {
+		t.Fatalf("ReadSensors: %v", err)
+	}
+	if len(resp.GetReadings()) != 2 {
+		t.Fatalf("len(readings) = %d; want 2", len(resp.GetReadings()))
+	}
+	if r := resp.GetReadings()[0]; r.GetName() != "imu_gyro" || r.GetType() != "gyro" ||
+		len(r.GetValues()) != 3 || r.GetValues()[1] != -0.2 {
+		t.Errorf("readings[0] = %+v", r)
+	}
+}
+
+func TestSimService_EditScenePassthrough(t *testing.T) {
+	backend := &fakeRobotBackend{}
+	client := startSimService(t, backend)
+	ctx := context.Background()
+
+	if _, err := client.EditScene(ctx, &simpb.EditSceneRequest{
+		WorldId: "world-1",
+		Op: &simpb.EditSceneRequest_AddBox{AddBox: &simpb.SceneBoxSpec{
+			Id: "crate", Position: []float64{1, 0, 0.25}, Size: []float64{0.5, 0.5, 0.5},
+		}},
+	}); err != nil {
+		t.Fatalf("EditScene(add_box): %v", err)
+	}
+	backend.mu.Lock()
+	box := backend.lastEditScene.GetAddBox()
+	backend.mu.Unlock()
+	if box.GetId() != "crate" || len(box.GetPosition()) != 3 || box.GetSize()[2] != 0.5 {
+		t.Errorf("forwarded add_box = %+v", box)
+	}
+
+	if _, err := client.EditScene(ctx, &simpb.EditSceneRequest{
+		WorldId: "world-1",
+		Op:      &simpb.EditSceneRequest_RemoveId{RemoveId: "crate"},
+	}); err != nil {
+		t.Fatalf("EditScene(remove): %v", err)
+	}
+	backend.mu.Lock()
+	removeID := backend.lastEditScene.GetRemoveId()
+	backend.mu.Unlock()
+	if removeID != "crate" {
+		t.Errorf("forwarded remove_id = %q; want crate", removeID)
+	}
+}
+
+func TestSimService_StepPassthrough(t *testing.T) {
+	backend := &fakeRobotBackend{}
+	client := startSimService(t, backend)
+
+	resp, err := client.Step(context.Background(), &simpb.StepRequest{WorldId: "world-1", Seconds: 2.5})
+	if err != nil {
+		t.Fatalf("Step: %v", err)
+	}
+	if resp.GetSimTimeS() != 2.5 {
+		t.Errorf("sim_time_s = %v; want 2.5", resp.GetSimTimeS())
+	}
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if backend.lastStep.GetWorldId() != "world-1" || backend.lastStep.GetSeconds() != 2.5 {
+		t.Errorf("forwarded request = %+v", backend.lastStep)
+	}
+}
+
+func TestSimService_LoadPolicyStreamPassthrough(t *testing.T) {
+	backend := &fakeRobotBackend{}
+	client := startSimService(t, backend)
+
+	stream, err := client.LoadPolicy(context.Background())
+	if err != nil {
+		t.Fatalf("LoadPolicy: %v", err)
+	}
+	if err := stream.Send(&simpb.LoadPolicyChunk{
+		Payload: &simpb.LoadPolicyChunk_Source{Source: &simpb.PolicySource{
+			WorldId: "world-1", RobotId: "robot-1", Format: "onnx",
+		}},
+	}); err != nil {
+		t.Fatalf("Send(source): %v", err)
+	}
+	parts := [][]byte{[]byte("onnx-head|"), bytes.Repeat([]byte{0x7f}, 2048), []byte("|onnx-tail")}
+	for _, part := range parts {
+		if err := stream.Send(&simpb.LoadPolicyChunk{
+			Payload: &simpb.LoadPolicyChunk_Data{Data: part},
+		}); err != nil {
+			t.Fatalf("Send(data): %v", err)
+		}
+	}
+	resp, err := stream.CloseAndRecv()
+	if err != nil {
+		t.Fatalf("CloseAndRecv: %v", err)
+	}
+	if resp.GetPolicyId() != "policy-1" {
+		t.Errorf("policy_id = %q; want policy-1", resp.GetPolicyId())
+	}
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if backend.policySource.GetWorldId() != "world-1" || backend.policySource.GetRobotId() != "robot-1" ||
+		backend.policySource.GetFormat() != "onnx" {
+		t.Errorf("backend policy source = %+v", backend.policySource)
+	}
+	if want := bytes.Join(parts, nil); !bytes.Equal(backend.policyData, want) {
+		t.Errorf("relayed policy differs: got %d bytes, want %d", len(backend.policyData), len(want))
+	}
+}
+
+func TestSimService_ClearPolicyPassthrough(t *testing.T) {
+	backend := &fakeRobotBackend{}
+	client := startSimService(t, backend)
+
+	if _, err := client.ClearPolicy(context.Background(), &simpb.ClearPolicyRequest{
+		WorldId: "world-1", RobotId: "robot-1",
+	}); err != nil {
+		t.Fatalf("ClearPolicy: %v", err)
+	}
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if backend.clearedPolicy.GetWorldId() != "world-1" || backend.clearedPolicy.GetRobotId() != "robot-1" {
+		t.Errorf("forwarded request = %+v", backend.clearedPolicy)
+	}
+}
+
+func TestSimService_RenderVideoRelaysChunks(t *testing.T) {
+	chunks := [][]byte{
+		[]byte("mp4-header|"),
+		bytes.Repeat([]byte{0x11}, 4000),
+		[]byte("|mp4-footer"),
+	}
+	backend := &fakeRobotBackend{videoChunks: chunks}
+	client := startSimService(t, backend)
+
+	stream, err := client.RenderVideo(context.Background(), &simpb.RenderVideoRequest{
+		WorldId: "world-1", RobotId: "robot-1", DurationS: 5, Fps: 15, Width: 640, Height: 480,
+	})
+	if err != nil {
+		t.Fatalf("RenderVideo: %v", err)
+	}
+
+	var got bytes.Buffer
+	recvCount := 0
+	for {
+		chunk, recvErr := stream.Recv()
+		if recvErr == io.EOF {
+			break
+		}
+		if recvErr != nil {
+			t.Fatalf("Recv: %v", recvErr)
+		}
+		recvCount++
+		got.Write(chunk.GetData())
+	}
+	if recvCount != len(chunks) {
+		t.Errorf("received %d chunks; want %d", recvCount, len(chunks))
+	}
+	if want := bytes.Join(chunks, nil); !bytes.Equal(got.Bytes(), want) {
+		t.Errorf("relayed video differs: got %d bytes, want %d", got.Len(), len(want))
+	}
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if backend.lastRender.GetDurationS() != 5 || backend.lastRender.GetFps() != 15 {
+		t.Errorf("forwarded request = %+v", backend.lastRender)
 	}
 }
 

--- a/go/internal/cli/commands/sim.go
+++ b/go/internal/cli/commands/sim.go
@@ -144,14 +144,17 @@ func newSimListCmd() *cobra.Command {
 }
 
 func newSimImportModelCmd() *cobra.Command {
-	var menageriePath, name string
+	var menageriePath, name, formatFlag string
 
 	cmd := &cobra.Command{
 		Use:   "import-model [local-dir]",
 		Short: "Import a robot model into the simulation backend",
 		Long: "Import a robot model into the simulation backend.\n\n" +
 			"Either reference a bundled MuJoCo Menagerie model (--menagerie unitree_go2/go2.xml)\n" +
-			"or upload a local MJCF model directory (or .tar/.tar.gz archive of one).",
+			"or upload a local model directory (or .tar/.tar.gz archive of one).\n" +
+			"The model format (mjcf, sdf, urdf) is auto-detected from the file\n" +
+			"extensions in a local source; override with --format. Which formats\n" +
+			"load depends on the backend (MuJoCo: mjcf; Gazebo: sdf, urdf).",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -161,6 +164,10 @@ func newSimImportModelCmd() *cobra.Command {
 				localPath = args[0]
 			}
 			if err := validateImportModelSource(menageriePath, localPath); err != nil {
+				return err
+			}
+			format, err := simutil.ResolveModelFormat(formatFlag, menageriePath, localPath)
+			if err != nil {
 				return err
 			}
 
@@ -177,7 +184,7 @@ func newSimImportModelCmd() *cobra.Command {
 			if err := stream.Send(&simpb.LoadModelChunk{
 				Payload: &simpb.LoadModelChunk_Source{Source: &simpb.ModelSource{
 					Name:          name,
-					Format:        simpb.ModelFormat_MODEL_FORMAT_MJCF,
+					Format:        format,
 					MenageriePath: menageriePath,
 				}},
 			}); err != nil {
@@ -214,6 +221,7 @@ func newSimImportModelCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&menageriePath, "menagerie", "", "Bundled MuJoCo Menagerie model path (e.g. unitree_go2/go2.xml)")
 	cmd.Flags().StringVar(&name, "name", "", "Registry name for the model (e.g. go2)")
+	cmd.Flags().StringVar(&formatFlag, "format", "", "Model format: mjcf, sdf, or urdf (default: auto-detect)")
 	_ = cmd.MarkFlagRequired("name")
 	return cmd
 }

--- a/go/internal/cli/commands/sim.go
+++ b/go/internal/cli/commands/sim.go
@@ -1412,11 +1412,9 @@ func newSimPolicyLoadCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
-			f, err := os.Open(args[0])
-			if err != nil {
+			if _, err := os.Stat(args[0]); err != nil {
 				return fmt.Errorf("opening policy file: %w", err)
 			}
-			defer f.Close()
 
 			conn, err := connectToAgent(ctx)
 			if err != nil {
@@ -1438,25 +1436,15 @@ func newSimPolicyLoadCmd() *cobra.Command {
 				return fmt.Errorf("sending policy source: %w", err)
 			}
 
-			buf := make([]byte, simutil.ModelChunkSize)
-			for {
-				n, readErr := f.Read(buf)
-				if n > 0 {
-					chunk := make([]byte, n)
-					copy(chunk, buf[:n])
-					if sendErr := stream.Send(&simpb.LoadPolicyChunk{
-						Payload: &simpb.LoadPolicyChunk_Data{Data: chunk},
-					}); sendErr != nil {
-						// The stream broke; CloseAndRecv surfaces the cause.
-						break
-					}
-				}
-				if readErr == io.EOF {
-					break
-				}
-				if readErr != nil {
-					return fmt.Errorf("reading policy %s: %w", args[0], readErr)
-				}
+			sendErr := simutil.StreamFileChunks(args[0], func(data []byte) error {
+				return stream.Send(&simpb.LoadPolicyChunk{
+					Payload: &simpb.LoadPolicyChunk_Data{Data: data},
+				})
+			})
+			// A local read error aborts the load. Send returning io.EOF means
+			// the stream broke; CloseAndRecv below surfaces the cause.
+			if sendErr != nil && sendErr != io.EOF {
+				return fmt.Errorf("reading policy %s: %w", args[0], sendErr)
 			}
 
 			resp, err := stream.CloseAndRecv()

--- a/go/internal/cli/commands/sim.go
+++ b/go/internal/cli/commands/sim.go
@@ -29,6 +29,7 @@ func newSimCmd() *cobra.Command {
 		newSimDescribeModelCmd(),
 		newSimSpawnCmd(),
 		newSimStateCmd(),
+		newSimCameraCmd(),
 		newSimResetCmd(),
 		newSimRunCmd(),
 		newSimReplayCmd(),
@@ -387,6 +388,73 @@ func newSimSpawnCmd() *cobra.Command {
 	cmd.Flags().StringVar(&pos, "pos", "", "Spawn position as x,y,z in meters (default 0,0,0)")
 	_ = cmd.MarkFlagRequired("world")
 	return cmd
+}
+
+func newSimCameraCmd() *cobra.Command {
+	var worldID, robotID, cameraName, outputPath string
+	var width, height uint32
+
+	cmd := &cobra.Command{
+		Use:   "camera",
+		Short: "Capture a camera frame from the simulation",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			resp, err := conn.SimService.GetCameraFrame(ctx, &simpb.GetCameraFrameRequest{
+				WorldId:    worldID,
+				RobotId:    robotID,
+				CameraName: cameraName,
+				Width:      width,
+				Height:     height,
+			})
+			if err != nil {
+				return fmt.Errorf("capturing camera frame: %w", err)
+			}
+
+			path := outputPath
+			if path == "" {
+				path = fmt.Sprintf("frame-%s.%s", worldID, frameExtension(resp.GetEncoding()))
+			}
+			if err := os.WriteFile(path, resp.GetImage(), 0o644); err != nil {
+				return fmt.Errorf("writing frame: %w", err)
+			}
+
+			if jsonOutput {
+				return printJSON(struct {
+					Path     string `json:"path"`
+					Bytes    int    `json:"bytes"`
+					Encoding string `json:"encoding"`
+				}{Path: path, Bytes: len(resp.GetImage()), Encoding: resp.GetEncoding()})
+			}
+			cliSuccess("Frame saved to %s (%d bytes, %s)", path, len(resp.GetImage()), resp.GetEncoding())
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&worldID, "world", "", "World ID (required)")
+	cmd.Flags().StringVar(&robotID, "robot", "", "Robot ID the tracking camera follows")
+	cmd.Flags().StringVar(&cameraName, "camera", "", "Model camera name (default: tracking view)")
+	cmd.Flags().StringVarP(&outputPath, "output", "o", "", "Output file (default frame-<world>.<ext>)")
+	cmd.Flags().Uint32Var(&width, "width", 640, "Frame width in pixels")
+	cmd.Flags().Uint32Var(&height, "height", 480, "Frame height in pixels")
+	_ = cmd.MarkFlagRequired("world")
+
+	return cmd
+}
+
+// frameExtension maps a camera frame encoding to a file extension.
+func frameExtension(encoding string) string {
+	switch strings.ToLower(encoding) {
+	case "jpeg", "jpg":
+		return "jpg"
+	default:
+		return "png"
+	}
 }
 
 func newSimStateCmd() *cobra.Command {

--- a/go/internal/cli/commands/sim.go
+++ b/go/internal/cli/commands/sim.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -38,6 +39,18 @@ func newSimCmd() *cobra.Command {
 		newSimResetCmd(),
 		newSimRunCmd(),
 		newSimReplayCmd(),
+		newSimPauseCmd(),
+		newSimResumeCmd(),
+		newSimSpeedCmd(),
+		newSimPushCmd(),
+		newSimTeleportCmd(),
+		newSimSnapshotCmd(),
+		newSimSensorsCmd(),
+		newSimSceneCmd(),
+		newSimPolicyCmd(),
+		newSimRecordCmd(),
+		newSimJointsCmd(),
+		newSimStepCmd(),
 	)
 
 	return cmd
@@ -149,7 +162,7 @@ func newSimListCmd() *cobra.Command {
 }
 
 func newSimImportModelCmd() *cobra.Command {
-	var menageriePath, name, formatFlag string
+	var menageriePath, name, formatFlag, replaceModelID string
 
 	cmd := &cobra.Command{
 		Use:   "import-model [local-dir]",
@@ -159,7 +172,9 @@ func newSimImportModelCmd() *cobra.Command {
 			"or upload a local model directory (or .tar/.tar.gz archive of one).\n" +
 			"The model format (mjcf, sdf, urdf) is auto-detected from the file\n" +
 			"extensions in a local source; override with --format. Which formats\n" +
-			"load depends on the backend (MuJoCo: mjcf; Gazebo: sdf, urdf).",
+			"load depends on the backend (MuJoCo: mjcf; Gazebo: sdf, urdf).\n\n" +
+			"Pass --replace <model-id> to reload an existing model in place: robots\n" +
+			"spawned from it are respawned against the new model (the edit-reload loop).",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -188,9 +203,10 @@ func newSimImportModelCmd() *cobra.Command {
 			}
 			if err := stream.Send(&simpb.LoadModelChunk{
 				Payload: &simpb.LoadModelChunk_Source{Source: &simpb.ModelSource{
-					Name:          name,
-					Format:        format,
-					MenageriePath: menageriePath,
+					Name:           name,
+					Format:         format,
+					MenageriePath:  menageriePath,
+					ReplaceModelId: replaceModelID,
 				}},
 			}); err != nil {
 				return fmt.Errorf("sending model source: %w", err)
@@ -227,6 +243,8 @@ func newSimImportModelCmd() *cobra.Command {
 	cmd.Flags().StringVar(&menageriePath, "menagerie", "", "Bundled MuJoCo Menagerie model path (e.g. unitree_go2/go2.xml)")
 	cmd.Flags().StringVar(&name, "name", "", "Registry name for the model (e.g. go2)")
 	cmd.Flags().StringVar(&formatFlag, "format", "", "Model format: mjcf, sdf, or urdf (default: auto-detect)")
+	cmd.Flags().StringVar(&replaceModelID, "replace", "",
+		"Replace this existing model in place (robots spawned from it are respawned)")
 	_ = cmd.MarkFlagRequired("name")
 	return cmd
 }
@@ -933,6 +951,803 @@ func newSimReplayCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&outputPath, "output", "o", "",
 		"Output file path (default ./replay-<replay-id>.rrd)")
+	return cmd
+}
+
+// --- Interactive tooling ---
+
+// setClock sends a SetClock request and renders the resulting clock state.
+func setClock(cmd *cobra.Command, worldID string, paused bool, speedFactor float64) error {
+	ctx := cmd.Context()
+	conn, err := connectToAgent(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	resp, err := conn.SimService.SetClock(ctx, &simpb.SetClockRequest{
+		WorldId:     worldID,
+		Paused:      paused,
+		SpeedFactor: speedFactor,
+	})
+	if err != nil {
+		return fmt.Errorf("setting sim clock: %w", err)
+	}
+
+	if jsonOutput {
+		return printJSON(map[string]any{
+			"paused":      resp.GetPaused(),
+			"speedFactor": resp.GetSpeedFactor(),
+		})
+	}
+	state := "running"
+	if resp.GetPaused() {
+		state = "paused"
+	}
+	cliSuccess("Simulation %s %s (speed %.2fx).", worldID, state, resp.GetSpeedFactor())
+	return nil
+}
+
+func newSimPauseCmd() *cobra.Command {
+	var worldID string
+
+	cmd := &cobra.Command{
+		Use:   "pause",
+		Short: "Pause a simulation world's physics",
+		Long: "Pause a simulation world's physics stepping.\n\n" +
+			"While paused, advance time deterministically with `wendy sim step`;\n" +
+			"resume real-time stepping with `wendy sim resume`.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return setClock(cmd, worldID, true, 0)
+		},
+	}
+
+	cmd.Flags().StringVar(&worldID, "world", "", "World ID (required)")
+	_ = cmd.MarkFlagRequired("world")
+	return cmd
+}
+
+func newSimResumeCmd() *cobra.Command {
+	var worldID string
+
+	cmd := &cobra.Command{
+		Use:   "resume",
+		Short: "Resume a paused simulation world",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return setClock(cmd, worldID, false, 0)
+		},
+	}
+
+	cmd.Flags().StringVar(&worldID, "world", "", "World ID (required)")
+	_ = cmd.MarkFlagRequired("world")
+	return cmd
+}
+
+func newSimSpeedCmd() *cobra.Command {
+	var worldID string
+
+	cmd := &cobra.Command{
+		Use:   "speed <factor>",
+		Short: "Set a simulation world's real-time pacing (1 = real time)",
+		Long: "Set a simulation world's real-time pacing multiplier: 1 = real time,\n" +
+			"10 = 10x fast-forward, 0.5 = half speed. Setting a speed also resumes\n" +
+			"a paused world.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			factor, err := strconv.ParseFloat(args[0], 64)
+			if err != nil {
+				return fmt.Errorf("invalid speed factor %q: expected a number", args[0])
+			}
+			if factor <= 0 {
+				return fmt.Errorf("speed factor must be positive (got %v)", factor)
+			}
+			return setClock(cmd, worldID, false, factor)
+		},
+	}
+
+	cmd.Flags().StringVar(&worldID, "world", "", "World ID (required)")
+	_ = cmd.MarkFlagRequired("world")
+	return cmd
+}
+
+func newSimPushCmd() *cobra.Command {
+	var worldID, robotID, force string
+	var duration float64
+
+	cmd := &cobra.Command{
+		Use:   "push",
+		Short: "Apply a force impulse to a robot's base (balance testing)",
+		Long: "Apply a world-frame force to a robot's base — the programmatic version\n" +
+			"of shoving it in a viewer, used to test balance and recovery.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			f, err := simutil.ParseVector3(force, "force")
+			if err != nil {
+				return err
+			}
+
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			if _, err := conn.SimService.ApplyForce(ctx, &simpb.ApplyForceRequest{
+				WorldId:   worldID,
+				RobotId:   robotID,
+				FxN:       f[0],
+				FyN:       f[1],
+				FzN:       f[2],
+				DurationS: duration,
+			}); err != nil {
+				return fmt.Errorf("applying force: %w", err)
+			}
+
+			if jsonOutput {
+				return printJSON(map[string]any{
+					"fx": f[0], "fy": f[1], "fz": f[2], "durationS": duration,
+				})
+			}
+			cliSuccess("Pushed %s: force (%.1f, %.1f, %.1f) N for %.2f s.", robotID, f[0], f[1], f[2], duration)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&worldID, "world", "", "World ID (required)")
+	cmd.Flags().StringVar(&robotID, "robot", "", "Robot ID (required)")
+	cmd.Flags().StringVar(&force, "force", "", "World-frame force as x,y,z in Newtons (required)")
+	cmd.Flags().Float64Var(&duration, "duration", 0.1, "How long the force is held, in sim seconds")
+	_ = cmd.MarkFlagRequired("world")
+	_ = cmd.MarkFlagRequired("robot")
+	_ = cmd.MarkFlagRequired("force")
+	return cmd
+}
+
+func newSimTeleportCmd() *cobra.Command {
+	var worldID, robotID, pos string
+
+	cmd := &cobra.Command{
+		Use:   "teleport",
+		Short: "Move a robot to a position directly (velocities are zeroed)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			pose, err := simutil.ParsePosition(pos)
+			if err != nil {
+				return err
+			}
+			if pose == nil {
+				return fmt.Errorf("--pos is required (x,y,z in meters)")
+			}
+
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			if _, err := conn.SimService.Teleport(ctx, &simpb.TeleportRequest{
+				WorldId:      worldID,
+				RobotId:      robotID,
+				Pose:         pose,
+				ZeroVelocity: true,
+			}); err != nil {
+				return fmt.Errorf("teleporting robot: %w", err)
+			}
+
+			if jsonOutput {
+				return printJSON(map[string]any{
+					"x": pose.GetX(), "y": pose.GetY(), "z": pose.GetZ(),
+				})
+			}
+			cliSuccess("Teleported %s to (%.3f, %.3f, %.3f).", robotID, pose.GetX(), pose.GetY(), pose.GetZ())
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&worldID, "world", "", "World ID (required)")
+	cmd.Flags().StringVar(&robotID, "robot", "", "Robot ID (required)")
+	cmd.Flags().StringVar(&pos, "pos", "", "Target position as x,y,z in meters (required)")
+	_ = cmd.MarkFlagRequired("world")
+	_ = cmd.MarkFlagRequired("robot")
+	_ = cmd.MarkFlagRequired("pos")
+	return cmd
+}
+
+func newSimSnapshotCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "snapshot",
+		Short: "Save and restore exact physics-state snapshots of a world",
+	}
+	cmd.AddCommand(newSimSnapshotSaveCmd(), newSimSnapshotRestoreCmd())
+	return cmd
+}
+
+func newSimSnapshotSaveCmd() *cobra.Command {
+	var worldID string
+
+	cmd := &cobra.Command{
+		Use:   "save",
+		Short: "Capture a world's exact physics state",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			resp, err := conn.SimService.SaveSnapshot(ctx, &simpb.SaveSnapshotRequest{WorldId: worldID})
+			if err != nil {
+				return fmt.Errorf("saving snapshot: %w", err)
+			}
+
+			if jsonOutput {
+				return printJSON(map[string]string{"snapshotId": resp.GetSnapshotId()})
+			}
+			cliSuccess("Snapshot saved.")
+			cliLogln("  Snapshot ID: %s", resp.GetSnapshotId())
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&worldID, "world", "", "World ID (required)")
+	_ = cmd.MarkFlagRequired("world")
+	return cmd
+}
+
+func newSimSnapshotRestoreCmd() *cobra.Command {
+	var worldID string
+
+	cmd := &cobra.Command{
+		Use:   "restore <snapshot-id>",
+		Short: "Rewind a world to a saved snapshot",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			if _, err := conn.SimService.RestoreSnapshot(ctx, &simpb.RestoreSnapshotRequest{
+				WorldId:    worldID,
+				SnapshotId: args[0],
+			}); err != nil {
+				return fmt.Errorf("restoring snapshot: %w", err)
+			}
+
+			if jsonOutput {
+				return printJSON(map[string]string{"snapshotId": args[0], "status": "restored"})
+			}
+			cliSuccess("Snapshot %s restored.", args[0])
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&worldID, "world", "", "World ID (required)")
+	_ = cmd.MarkFlagRequired("world")
+	return cmd
+}
+
+func newSimSensorsCmd() *cobra.Command {
+	var worldID, robotID string
+
+	cmd := &cobra.Command{
+		Use:   "sensors",
+		Short: "Read a robot's declared sensors (IMU, force, touch, ...)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			resp, err := conn.SimService.ReadSensors(ctx, &simpb.ReadSensorsRequest{
+				WorldId: worldID,
+				RobotId: robotID,
+			})
+			if err != nil {
+				return fmt.Errorf("reading sensors: %w", err)
+			}
+
+			if jsonOutput {
+				type jsonReading struct {
+					Name   string    `json:"name"`
+					Type   string    `json:"type,omitempty"`
+					Values []float64 `json:"values"`
+				}
+				readings := make([]jsonReading, len(resp.GetReadings()))
+				for i, r := range resp.GetReadings() {
+					readings[i] = jsonReading{Name: r.GetName(), Type: r.GetType(), Values: r.GetValues()}
+				}
+				return printJSON(readings)
+			}
+
+			if len(resp.GetReadings()) == 0 {
+				cliLogln("No sensor readings (does the model declare sensors?).")
+				return nil
+			}
+			headers := []string{"Sensor", "Type", "Values"}
+			var rows [][]string
+			for _, r := range resp.GetReadings() {
+				values := make([]string, len(r.GetValues()))
+				for i, v := range r.GetValues() {
+					values[i] = fmt.Sprintf("%.4f", v)
+				}
+				rows = append(rows, []string{r.GetName(), r.GetType(), strings.Join(values, ", ")})
+			}
+			fmt.Print(tui.RenderTable(headers, rows))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&worldID, "world", "", "World ID (required)")
+	cmd.Flags().StringVar(&robotID, "robot", "", "Robot ID (required)")
+	_ = cmd.MarkFlagRequired("world")
+	_ = cmd.MarkFlagRequired("robot")
+	return cmd
+}
+
+func newSimSceneCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "scene",
+		Short: "Edit a live world's static scenery",
+	}
+	cmd.AddCommand(newSimSceneAddBoxCmd(), newSimSceneRemoveCmd())
+	return cmd
+}
+
+func newSimSceneAddBoxCmd() *cobra.Command {
+	var worldID, id, pos, size string
+
+	cmd := &cobra.Command{
+		Use:   "add-box",
+		Short: "Add a static box obstacle to a live world",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			p, err := simutil.ParseVector3(pos, "position")
+			if err != nil {
+				return err
+			}
+			sz, err := simutil.ParseVector3(size, "size")
+			if err != nil {
+				return err
+			}
+
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			if _, err := conn.SimService.EditScene(ctx, &simpb.EditSceneRequest{
+				WorldId: worldID,
+				Op: &simpb.EditSceneRequest_AddBox{AddBox: &simpb.SceneBoxSpec{
+					Id:       id,
+					Position: p[:],
+					Size:     sz[:],
+				}},
+			}); err != nil {
+				return fmt.Errorf("adding box: %w", err)
+			}
+
+			if jsonOutput {
+				return printJSON(map[string]any{"id": id, "position": p[:], "size": sz[:]})
+			}
+			cliSuccess("Box %s added at (%.2f, %.2f, %.2f).", id, p[0], p[1], p[2])
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&worldID, "world", "", "World ID (required)")
+	cmd.Flags().StringVar(&id, "id", "", "Obstacle ID (required; used to remove it later)")
+	cmd.Flags().StringVar(&pos, "pos", "", "Center position as x,y,z in meters (required)")
+	cmd.Flags().StringVar(&size, "size", "", "Full extents as x,y,z in meters (required)")
+	_ = cmd.MarkFlagRequired("world")
+	_ = cmd.MarkFlagRequired("id")
+	_ = cmd.MarkFlagRequired("pos")
+	_ = cmd.MarkFlagRequired("size")
+	return cmd
+}
+
+func newSimSceneRemoveCmd() *cobra.Command {
+	var worldID, id string
+
+	cmd := &cobra.Command{
+		Use:   "remove",
+		Short: "Remove an obstacle from a live world",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			if _, err := conn.SimService.EditScene(ctx, &simpb.EditSceneRequest{
+				WorldId: worldID,
+				Op:      &simpb.EditSceneRequest_RemoveId{RemoveId: id},
+			}); err != nil {
+				return fmt.Errorf("removing obstacle: %w", err)
+			}
+
+			if jsonOutput {
+				return printJSON(map[string]string{"id": id, "status": "removed"})
+			}
+			cliSuccess("Obstacle %s removed.", id)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&worldID, "world", "", "World ID (required)")
+	cmd.Flags().StringVar(&id, "id", "", "Obstacle ID to remove (required)")
+	_ = cmd.MarkFlagRequired("world")
+	_ = cmd.MarkFlagRequired("id")
+	return cmd
+}
+
+func newSimPolicyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "policy",
+		Short: "Load and clear trained control policies on a simulated robot",
+	}
+	cmd.AddCommand(newSimPolicyLoadCmd(), newSimPolicyClearCmd())
+	return cmd
+}
+
+func newSimPolicyLoadCmd() *cobra.Command {
+	var worldID, robotID, format string
+
+	cmd := &cobra.Command{
+		Use:   "load <policy-file>",
+		Short: "Load a trained policy (e.g. ONNX) that replaces the built-in controller",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			f, err := os.Open(args[0])
+			if err != nil {
+				return fmt.Errorf("opening policy file: %w", err)
+			}
+			defer f.Close()
+
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			stream, err := conn.SimService.LoadPolicy(ctx)
+			if err != nil {
+				return fmt.Errorf("loading policy: %w", err)
+			}
+			if err := stream.Send(&simpb.LoadPolicyChunk{
+				Payload: &simpb.LoadPolicyChunk_Source{Source: &simpb.PolicySource{
+					WorldId: worldID,
+					RobotId: robotID,
+					Format:  format,
+				}},
+			}); err != nil {
+				return fmt.Errorf("sending policy source: %w", err)
+			}
+
+			buf := make([]byte, simutil.ModelChunkSize)
+			for {
+				n, readErr := f.Read(buf)
+				if n > 0 {
+					chunk := make([]byte, n)
+					copy(chunk, buf[:n])
+					if sendErr := stream.Send(&simpb.LoadPolicyChunk{
+						Payload: &simpb.LoadPolicyChunk_Data{Data: chunk},
+					}); sendErr != nil {
+						// The stream broke; CloseAndRecv surfaces the cause.
+						break
+					}
+				}
+				if readErr == io.EOF {
+					break
+				}
+				if readErr != nil {
+					return fmt.Errorf("reading policy %s: %w", args[0], readErr)
+				}
+			}
+
+			resp, err := stream.CloseAndRecv()
+			if err != nil {
+				return fmt.Errorf("loading policy: %w", err)
+			}
+
+			if jsonOutput {
+				return printJSON(map[string]string{"policyId": resp.GetPolicyId()})
+			}
+			cliSuccess("Policy loaded onto %s.", robotID)
+			cliLogln("  Policy ID: %s", resp.GetPolicyId())
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&worldID, "world", "", "World ID (required)")
+	cmd.Flags().StringVar(&robotID, "robot", "", "Robot ID (required)")
+	cmd.Flags().StringVar(&format, "format", "onnx", "Policy file format")
+	_ = cmd.MarkFlagRequired("world")
+	_ = cmd.MarkFlagRequired("robot")
+	return cmd
+}
+
+func newSimPolicyClearCmd() *cobra.Command {
+	var worldID, robotID string
+
+	cmd := &cobra.Command{
+		Use:   "clear",
+		Short: "Revert a robot to its built-in controller",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			if _, err := conn.SimService.ClearPolicy(ctx, &simpb.ClearPolicyRequest{
+				WorldId: worldID,
+				RobotId: robotID,
+			}); err != nil {
+				return fmt.Errorf("clearing policy: %w", err)
+			}
+
+			if jsonOutput {
+				return printJSON(map[string]string{"robotId": robotID, "status": "cleared"})
+			}
+			cliSuccess("Policy cleared; %s uses its built-in controller.", robotID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&worldID, "world", "", "World ID (required)")
+	cmd.Flags().StringVar(&robotID, "robot", "", "Robot ID (required)")
+	_ = cmd.MarkFlagRequired("world")
+	_ = cmd.MarkFlagRequired("robot")
+	return cmd
+}
+
+func newSimRecordCmd() *cobra.Command {
+	var worldID, robotID, cameraName, outputPath string
+	var duration float64
+	var fps, width, height uint32
+
+	cmd := &cobra.Command{
+		Use:   "record",
+		Short: "Render a video clip (mp4) of the simulation",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			stream, err := conn.SimService.RenderVideo(ctx, &simpb.RenderVideoRequest{
+				WorldId:    worldID,
+				RobotId:    robotID,
+				CameraName: cameraName,
+				DurationS:  duration,
+				Fps:        fps,
+				Width:      width,
+				Height:     height,
+			})
+			if err != nil {
+				return fmt.Errorf("rendering video: %w", err)
+			}
+
+			path := outputPath
+			if path == "" {
+				path = fmt.Sprintf("clip-%s.mp4", worldID)
+			}
+			n, err := simutil.WriteReplayFile(path, func() ([]byte, error) {
+				chunk, recvErr := stream.Recv()
+				if recvErr != nil {
+					return nil, recvErr
+				}
+				return chunk.GetData(), nil
+			})
+			if err != nil {
+				return fmt.Errorf("rendering video: %w", err)
+			}
+
+			if jsonOutput {
+				return printJSON(map[string]any{"path": path, "bytes": n})
+			}
+			cliSuccess("Video saved to %s (%d bytes).", path, n)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&worldID, "world", "", "World ID (required)")
+	cmd.Flags().StringVar(&robotID, "robot", "", "Robot ID the tracking camera follows (required)")
+	cmd.Flags().StringVar(&cameraName, "camera", "", "Model camera name (default: tracking view)")
+	cmd.Flags().Float64Var(&duration, "duration", 5, "Clip length in sim seconds")
+	cmd.Flags().Uint32Var(&fps, "fps", 15, "Frames per second")
+	cmd.Flags().Uint32Var(&width, "width", 640, "Frame width in pixels")
+	cmd.Flags().Uint32Var(&height, "height", 480, "Frame height in pixels")
+	cmd.Flags().StringVarP(&outputPath, "output", "o", "", "Output file (default clip-<world>.mp4)")
+	_ = cmd.MarkFlagRequired("world")
+	_ = cmd.MarkFlagRequired("robot")
+	return cmd
+}
+
+func newSimJointsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "joints",
+		Short: "Read and command a robot's joints (joint level, expert-gated)",
+	}
+	cmd.AddCommand(newSimJointsGetCmd(), newSimJointsSetCmd())
+	return cmd
+}
+
+func newSimJointsGetCmd() *cobra.Command {
+	var worldID, robotID string
+
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Show a robot's joint positions and velocities",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			resp, err := conn.SimService.GetState(ctx, &simpb.GetStateRequest{
+				WorldId: worldID,
+				RobotId: robotID,
+			})
+			if err != nil {
+				return fmt.Errorf("getting state: %w", err)
+			}
+
+			if jsonOutput {
+				type jsonJointState struct {
+					Name     string  `json:"name"`
+					Position float64 `json:"position"`
+					Velocity float64 `json:"velocity"`
+				}
+				joints := make([]jsonJointState, len(resp.GetJoints()))
+				for i, j := range resp.GetJoints() {
+					joints[i] = jsonJointState{Name: j.GetName(), Position: j.GetPosition(), Velocity: j.GetVelocity()}
+				}
+				return printJSON(joints)
+			}
+
+			if len(resp.GetJoints()) == 0 {
+				cliLogln("No joints reported.")
+				return nil
+			}
+			headers := []string{"Joint", "Position", "Velocity"}
+			var rows [][]string
+			for _, j := range resp.GetJoints() {
+				rows = append(rows, []string{
+					j.GetName(),
+					fmt.Sprintf("%.4f", j.GetPosition()),
+					fmt.Sprintf("%.4f", j.GetVelocity()),
+				})
+			}
+			fmt.Print(tui.RenderTable(headers, rows))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&worldID, "world", "", "World ID (required)")
+	cmd.Flags().StringVar(&robotID, "robot", "", "Robot ID (required)")
+	_ = cmd.MarkFlagRequired("world")
+	_ = cmd.MarkFlagRequired("robot")
+	return cmd
+}
+
+func newSimJointsSetCmd() *cobra.Command {
+	var worldID, robotID string
+
+	cmd := &cobra.Command{
+		Use:   "set <joint>=<target> [<joint>=<target>...]",
+		Short: "Command joint position targets (joint level, expert-gated)",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			targets, err := parseJointTargets(args)
+			if err != nil {
+				return err
+			}
+
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			if _, err := conn.SimService.SetJointTargets(ctx, &simpb.SetJointTargetsRequest{
+				WorldId: worldID,
+				RobotId: robotID,
+				Targets: targets,
+			}); err != nil {
+				return fmt.Errorf("setting joint targets: %w", err)
+			}
+
+			if jsonOutput {
+				return printJSON(targets)
+			}
+			cliSuccess("Set %d joint target(s) on %s.", len(targets), robotID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&worldID, "world", "", "World ID (required)")
+	cmd.Flags().StringVar(&robotID, "robot", "", "Robot ID (required)")
+	_ = cmd.MarkFlagRequired("world")
+	_ = cmd.MarkFlagRequired("robot")
+	return cmd
+}
+
+// parseJointTargets parses "name=value" args into a joint-target map.
+func parseJointTargets(args []string) (map[string]float64, error) {
+	targets := make(map[string]float64, len(args))
+	for _, arg := range args {
+		name, value, ok := strings.Cut(arg, "=")
+		name = strings.TrimSpace(name)
+		if !ok || name == "" {
+			return nil, fmt.Errorf("invalid joint target %q: expected <joint>=<value>", arg)
+		}
+		v, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid joint target %q: %q is not a number", arg, value)
+		}
+		targets[name] = v
+	}
+	return targets, nil
+}
+
+func newSimStepCmd() *cobra.Command {
+	var worldID string
+	var seconds float64
+
+	cmd := &cobra.Command{
+		Use:   "step",
+		Short: "Advance sim time deterministically (pairs with `wendy sim pause`)",
+		Long: "Advance a world's simulation time by a fixed amount and return the new\n" +
+			"sim time. Deterministic debugging tool: pause the world first\n" +
+			"(`wendy sim pause`), then step it in controlled increments.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			resp, err := conn.SimService.Step(ctx, &simpb.StepRequest{
+				WorldId: worldID,
+				Seconds: seconds,
+			})
+			if err != nil {
+				return fmt.Errorf("stepping simulation: %w", err)
+			}
+
+			if jsonOutput {
+				return printJSON(map[string]any{"simTimeS": resp.GetSimTimeS()})
+			}
+			cliSuccess("Stepped %.3f s; sim time is now %.3f s.", seconds, resp.GetSimTimeS())
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&worldID, "world", "", "World ID (required)")
+	cmd.Flags().Float64Var(&seconds, "seconds", 1, "Sim seconds to advance")
+	_ = cmd.MarkFlagRequired("world")
 	return cmd
 }
 

--- a/go/internal/cli/commands/sim.go
+++ b/go/internal/cli/commands/sim.go
@@ -51,6 +51,8 @@ func newSimCmd() *cobra.Command {
 		newSimRecordCmd(),
 		newSimJointsCmd(),
 		newSimStepCmd(),
+		newSimEvalCmd(),
+		newSimTeleopCmd(),
 	)
 
 	return cmd

--- a/go/internal/cli/commands/sim.go
+++ b/go/internal/cli/commands/sim.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -29,7 +31,10 @@ func newSimCmd() *cobra.Command {
 		newSimDescribeModelCmd(),
 		newSimSpawnCmd(),
 		newSimStateCmd(),
+		newSimWatchCmd(),
+		newSimDriveCmd(),
 		newSimCameraCmd(),
+		newSimViewerCmd(),
 		newSimResetCmd(),
 		newSimRunCmd(),
 		newSimReplayCmd(),
@@ -395,6 +400,185 @@ func newSimSpawnCmd() *cobra.Command {
 	cmd.Flags().StringVar(&worldID, "world", "", "World ID to spawn into")
 	cmd.Flags().StringVar(&pos, "pos", "", "Spawn position as x,y,z in meters (default 0,0,0)")
 	_ = cmd.MarkFlagRequired("world")
+	return cmd
+}
+
+func newSimDriveCmd() *cobra.Command {
+	var worldID, robotID string
+	var vx, vy, yaw float64
+	var stop bool
+
+	cmd := &cobra.Command{
+		Use:   "drive",
+		Short: "Command a base velocity (the robot keeps it until told otherwise)",
+		Long: "Command a base velocity for a simulated robot.\n\n" +
+			"The controller holds the command until the next drive (or a task takes\n" +
+			"over); the backend clamps it to the model's safety limits. Use --stop\n" +
+			"to halt.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			if stop {
+				vx, vy, yaw = 0, 0, 0
+			}
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			if _, err := conn.SimService.SetVelocity(ctx, &simpb.SetVelocityRequest{
+				WorldId:      worldID,
+				RobotId:      robotID,
+				VxMps:        vx,
+				VyMps:        vy,
+				YawRateRadps: yaw,
+			}); err != nil {
+				return fmt.Errorf("driving robot: %w", err)
+			}
+
+			if jsonOutput {
+				return printJSON(map[string]any{"vx": vx, "vy": vy, "yawRate": yaw})
+			}
+			if stop {
+				cliSuccess("Robot %s stopping.", robotID)
+			} else {
+				cliSuccess("Driving %s: vx=%.2f m/s, vy=%.2f m/s, yaw=%.2f rad/s", robotID, vx, vy, yaw)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&worldID, "world", "", "World ID (required)")
+	cmd.Flags().StringVar(&robotID, "robot", "", "Robot ID (required)")
+	cmd.Flags().Float64Var(&vx, "vx", 0, "Forward velocity in m/s (negative = backward)")
+	cmd.Flags().Float64Var(&vy, "vy", 0, "Lateral velocity in m/s")
+	cmd.Flags().Float64Var(&yaw, "yaw", 0, "Turn rate in rad/s (positive = counter-clockwise)")
+	cmd.Flags().BoolVar(&stop, "stop", false, "Halt the robot (zero all velocities)")
+	_ = cmd.MarkFlagRequired("world")
+	_ = cmd.MarkFlagRequired("robot")
+	return cmd
+}
+
+func newSimWatchCmd() *cobra.Command {
+	var worldID, robotID string
+	var interval time.Duration
+
+	cmd := &cobra.Command{
+		Use:   "watch",
+		Short: "Live-updating robot state (Ctrl-C to exit)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			for {
+				resp, err := conn.SimService.GetState(ctx, &simpb.GetStateRequest{
+					WorldId: worldID,
+					RobotId: robotID,
+				})
+				if err != nil {
+					return fmt.Errorf("getting state: %w", err)
+				}
+				if jsonOutput {
+					fmt.Println(watchJSONLine(resp))
+				} else {
+					// Home + clear-to-end keeps the display in place without
+					// flicker; the frame always ends in a newline.
+					fmt.Print("\033[H\033[2J" + renderWatchFrame(worldID, robotID, resp))
+				}
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-time.After(interval):
+				}
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&worldID, "world", "", "World ID (required)")
+	cmd.Flags().StringVar(&robotID, "robot", "", "Robot ID (required)")
+	cmd.Flags().DurationVar(&interval, "interval", 500*time.Millisecond, "Refresh interval")
+	_ = cmd.MarkFlagRequired("world")
+	_ = cmd.MarkFlagRequired("robot")
+	return cmd
+}
+
+// renderWatchFrame renders one sim watch frame: pose, status, and joints in
+// columns.
+func renderWatchFrame(worldID, robotID string, resp *simpb.GetStateResponse) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "wendy sim watch — world %s, robot %s (Ctrl-C to exit)\n\n", worldID, robotID)
+	if p := resp.GetBasePose(); p != nil {
+		fmt.Fprintf(&b, "  Position   x %+7.3f   y %+7.3f   z %+7.3f m\n", p.GetX(), p.GetY(), p.GetZ())
+	}
+	fmt.Fprintf(&b, "  Sim time   %.2f s\n", resp.GetSimTimeS())
+	if resp.GetFallen() {
+		b.WriteString("  Status     FALLEN\n")
+	} else {
+		b.WriteString("  Status     upright\n")
+	}
+	if joints := resp.GetJoints(); len(joints) > 0 {
+		b.WriteString("\n  Joint                 Position   Velocity\n")
+		for _, j := range joints {
+			fmt.Fprintf(&b, "  %-20s  %+8.3f   %+8.3f\n", j.GetName(), j.GetPosition(), j.GetVelocity())
+		}
+	}
+	return b.String()
+}
+
+// watchJSONLine renders one sim watch sample as a compact JSON line.
+func watchJSONLine(resp *simpb.GetStateResponse) string {
+	out := map[string]any{
+		"simTimeS": resp.GetSimTimeS(),
+		"fallen":   resp.GetFallen(),
+	}
+	if p := resp.GetBasePose(); p != nil {
+		out["x"], out["y"], out["z"] = p.GetX(), p.GetY(), p.GetZ()
+	}
+	b, _ := json.Marshal(out)
+	return string(b)
+}
+
+func newSimViewerCmd() *cobra.Command {
+	var urlFlag string
+	var port int
+
+	cmd := &cobra.Command{
+		Use:   "viewer",
+		Short: "Open the live sim viewer in the browser",
+		Long: "Open the sim backend's live Rerun web viewer in the browser.\n\n" +
+			"The viewer is served by the sim container when it runs with\n" +
+			"WENDYSIM_LIVE_VIEWER=1; the host defaults to the connected device.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			viewerURL := urlFlag
+			if viewerURL == "" {
+				host := "localhost"
+				if deviceFlag != "" {
+					host = deviceFlag
+					if h, _, err := net.SplitHostPort(deviceFlag); err == nil {
+						host = h
+					}
+				}
+				viewerURL = fmt.Sprintf("http://%s:%d/?url=rerun%%2Bhttp://%s:%d/proxy",
+					host, port, host, port-1)
+			}
+			if jsonOutput {
+				return printJSON(map[string]string{"url": viewerURL})
+			}
+			cliLogln("Opening %s", viewerURL)
+			if err := openBrowser(viewerURL); err != nil {
+				cliNotice("Could not open a browser: %v", err)
+				cliLogln("Open it manually: %s", viewerURL)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&urlFlag, "url", "", "Viewer URL (default: derived from the device host)")
+	cmd.Flags().IntVar(&port, "port", 9877, "Viewer web port on the sim host (gRPC proxy is port-1)")
 	return cmd
 }
 

--- a/go/internal/cli/commands/sim_eval.go
+++ b/go/internal/cli/commands/sim_eval.go
@@ -1,0 +1,189 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/simutil"
+	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
+	"github.com/wendylabsinc/wendy/go/proto/gen/simpb"
+)
+
+func newSimEvalCmd() *cobra.Command {
+	var worldID, robotID, controlLevel string
+	var episodes int
+
+	cmd := &cobra.Command{
+		Use:   "eval <task.yaml>",
+		Short: "Evaluate a task spec over multiple episodes and report statistics",
+		Long: "Run a task spec repeatedly (resetting the world before each episode) and\n" +
+			"report the success rate, distance statistics, and fall count. Exits\n" +
+			"non-zero when no episode succeeds.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			if episodes < 1 {
+				return fmt.Errorf("--episodes must be at least 1 (got %d)", episodes)
+			}
+			level, err := simutil.ParseControlLevel(controlLevel)
+			if err != nil {
+				return err
+			}
+			specData, err := os.ReadFile(args[0])
+			if err != nil {
+				return fmt.Errorf("reading task spec: %w", err)
+			}
+			if len(bytes.TrimSpace(specData)) == 0 {
+				return fmt.Errorf("task spec %s is empty", args[0])
+			}
+
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			results := make([]*simpb.TaskResult, 0, episodes)
+			for i := 0; i < episodes; i++ {
+				if _, err := conn.SimService.ResetSimulation(ctx, &agentpbv2.ResetSimulationRequest{
+					WorldId: worldID,
+				}); err != nil {
+					return fmt.Errorf("resetting simulation before episode %d: %w", i+1, err)
+				}
+
+				result, err := runEvalEpisode(ctx, conn.SimService, worldID, robotID, string(specData), level)
+				if err != nil {
+					return fmt.Errorf("episode %d: %w", i+1, err)
+				}
+				results = append(results, result)
+
+				if !jsonOutput {
+					outcome := "PASS"
+					if !result.GetSuccess() {
+						outcome = "FAIL"
+					}
+					fell := ""
+					if result.GetFell() {
+						fell = " (fell)"
+					}
+					cliLogln("Episode %d/%d: %s  distance %.2f m%s",
+						i+1, episodes, outcome, result.GetDistanceTraveledM(), fell)
+				}
+			}
+
+			summary := summarizeEval(results)
+			if jsonOutput {
+				if err := printJSON(summary); err != nil {
+					return err
+				}
+			} else {
+				fmt.Print(renderEvalSummary(summary))
+			}
+			if summary.Successes == 0 {
+				return fmt.Errorf("all %d episodes failed", episodes)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&worldID, "world", "", "World ID (required)")
+	cmd.Flags().StringVar(&robotID, "robot", "", "Robot ID (required)")
+	cmd.Flags().IntVar(&episodes, "episodes", 5, "Number of episodes to run")
+	cmd.Flags().StringVar(&controlLevel, "control-level", "motion",
+		"Highest control level the task may use (task, motion, joint, physics)")
+	_ = cmd.MarkFlagRequired("world")
+	_ = cmd.MarkFlagRequired("robot")
+	return cmd
+}
+
+// runEvalEpisode runs the task once and returns its final result, draining
+// (and discarding) progress/log events.
+func runEvalEpisode(ctx context.Context, client agentpbv2.WendySimServiceClient,
+	worldID, robotID, specYAML string, level simpb.ControlLevel) (*simpb.TaskResult, error) {
+	stream, err := client.RunTask(ctx, &agentpbv2.RunSimTaskRequest{
+		Task: &simpb.RunTaskRequest{
+			WorldId:         worldID,
+			RobotId:         robotID,
+			SpecYaml:        specYAML,
+			MaxControlLevel: level,
+		},
+		SessionControlLevel: level,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var result *simpb.TaskResult
+	for {
+		ev, recvErr := stream.Recv()
+		if recvErr == io.EOF {
+			break
+		}
+		if recvErr != nil {
+			return nil, recvErr
+		}
+		if res := ev.GetResult(); res != nil {
+			result = res
+		}
+	}
+	if result == nil {
+		return nil, fmt.Errorf("task stream ended without a result")
+	}
+	return result, nil
+}
+
+// evalSummary aggregates episode results for `wendy sim eval`.
+type evalSummary struct {
+	Episodes    int     `json:"episodes"`
+	Successes   int     `json:"successes"`
+	SuccessRate float64 `json:"successRate"`
+	Falls       int     `json:"falls"`
+	MeanDistM   float64 `json:"meanDistanceM"`
+	MinDistM    float64 `json:"minDistanceM"`
+	MaxDistM    float64 `json:"maxDistanceM"`
+}
+
+// summarizeEval computes success/distance/fall statistics over episodes.
+func summarizeEval(results []*simpb.TaskResult) evalSummary {
+	s := evalSummary{Episodes: len(results)}
+	if len(results) == 0 {
+		return s
+	}
+	var total float64
+	s.MinDistM = results[0].GetDistanceTraveledM()
+	for _, r := range results {
+		if r.GetSuccess() {
+			s.Successes++
+		}
+		if r.GetFell() {
+			s.Falls++
+		}
+		d := r.GetDistanceTraveledM()
+		total += d
+		if d < s.MinDistM {
+			s.MinDistM = d
+		}
+		if d > s.MaxDistM {
+			s.MaxDistM = d
+		}
+	}
+	s.MeanDistM = total / float64(len(results))
+	s.SuccessRate = float64(s.Successes) / float64(len(results))
+	return s
+}
+
+// renderEvalSummary renders the human-readable eval summary block.
+func renderEvalSummary(s evalSummary) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Evaluation over %d episode(s)\n", s.Episodes)
+	fmt.Fprintf(&b, "  Success rate: %.0f%% (%d/%d)\n", s.SuccessRate*100, s.Successes, s.Episodes)
+	fmt.Fprintf(&b, "  Distance:     mean %.2f m (min %.2f, max %.2f)\n", s.MeanDistM, s.MinDistM, s.MaxDistM)
+	fmt.Fprintf(&b, "  Falls:        %d\n", s.Falls)
+	return b.String()
+}

--- a/go/internal/cli/commands/sim_eval_test.go
+++ b/go/internal/cli/commands/sim_eval_test.go
@@ -1,0 +1,71 @@
+package commands
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/proto/gen/simpb"
+)
+
+func TestSummarizeEval(t *testing.T) {
+	results := []*simpb.TaskResult{
+		{Success: true, DistanceTraveledM: 3.0},
+		{Success: false, Fell: true, DistanceTraveledM: 1.0},
+		{Success: true, DistanceTraveledM: 2.0},
+		{Success: false, Fell: true, DistanceTraveledM: 0.5},
+	}
+	s := summarizeEval(results)
+	if s.Episodes != 4 || s.Successes != 2 || s.Falls != 2 {
+		t.Errorf("episodes/successes/falls = %d/%d/%d; want 4/2/2", s.Episodes, s.Successes, s.Falls)
+	}
+	if s.SuccessRate != 0.5 {
+		t.Errorf("success rate = %v; want 0.5", s.SuccessRate)
+	}
+	if s.MeanDistM != 1.625 || s.MinDistM != 0.5 || s.MaxDistM != 3.0 {
+		t.Errorf("distance mean/min/max = %v/%v/%v; want 1.625/0.5/3", s.MeanDistM, s.MinDistM, s.MaxDistM)
+	}
+}
+
+func TestSummarizeEval_Empty(t *testing.T) {
+	s := summarizeEval(nil)
+	if s.Episodes != 0 || s.Successes != 0 || s.SuccessRate != 0 {
+		t.Errorf("empty summary = %+v; want zeros", s)
+	}
+}
+
+func TestRenderEvalSummary(t *testing.T) {
+	out := renderEvalSummary(evalSummary{
+		Episodes: 4, Successes: 2, SuccessRate: 0.5,
+		Falls: 1, MeanDistM: 1.62, MinDistM: 0.5, MaxDistM: 3,
+	})
+	for _, want := range []string{
+		"4 episode(s)", "50% (2/4)", "mean 1.62 m (min 0.50, max 3.00)", "Falls:        1",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("summary missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestSimEvalCmd_Flags(t *testing.T) {
+	cmd := newSimEvalCmd()
+	for _, f := range []string{"world", "robot", "episodes", "control-level"} {
+		if cmd.Flags().Lookup(f) == nil {
+			t.Errorf("eval missing flag --%s", f)
+		}
+	}
+	if f := cmd.Flags().Lookup("episodes"); f != nil && f.DefValue != "5" {
+		t.Errorf("--episodes default = %s; want 5", f.DefValue)
+	}
+}
+
+func TestSimEvalCmd_RequiresWorldAndRobot(t *testing.T) {
+	cmd := newSimEvalCmd()
+	cmd.SetArgs([]string{"task.yaml"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	if err := cmd.Execute(); err == nil {
+		t.Error("eval without --world/--robot should fail")
+	}
+}

--- a/go/internal/cli/commands/sim_teleop.go
+++ b/go/internal/cli/commands/sim_teleop.go
@@ -1,0 +1,194 @@
+package commands
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"math"
+	"os"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	"github.com/wendylabsinc/wendy/go/proto/gen/simpb"
+)
+
+// Teleop increments per keypress.
+const (
+	teleopVxStepMps    = 0.1
+	teleopYawStepRadps = 0.2
+)
+
+func newSimTeleopCmd() *cobra.Command {
+	var worldID, robotID string
+
+	cmd := &cobra.Command{
+		Use:   "teleop",
+		Short: "Drive a simulated robot from the keyboard (WASD/arrows)",
+		Long: "Drive a simulated robot interactively. Each keypress adjusts the held\n" +
+			"velocity command and sends it to the robot:\n\n" +
+			"  w / up       forward  +0.1 m/s\n" +
+			"  s / down     backward -0.1 m/s\n" +
+			"  a / left     turn left  +0.2 rad/s\n" +
+			"  d / right    turn right -0.2 rad/s\n" +
+			"  space        stop (zero all velocities)\n" +
+			"  q / Ctrl-C   stop and quit",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			fd := int(os.Stdin.Fd())
+			if !term.IsTerminal(fd) {
+				return fmt.Errorf("teleop needs an interactive terminal (use `wendy sim drive` for scripted control)")
+			}
+
+			conn, err := connectToAgent(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			oldState, err := term.MakeRaw(fd)
+			if err != nil {
+				return fmt.Errorf("entering raw terminal mode: %w", err)
+			}
+			defer func() { _ = term.Restore(fd, oldState) }()
+
+			// Raw mode: lines end \r\n and Ctrl-C arrives as a plain byte
+			// (0x03) that the key loop turns into a stop-and-quit.
+			fmt.Print("wendy sim teleop — w/s speed, a/d turn, space stop, q quit\r\n")
+			err = runTeleopLoop(ctx, bufio.NewReader(os.Stdin), func(c teleopCommand) error {
+				if _, sendErr := conn.SimService.SetVelocity(ctx, &simpb.SetVelocityRequest{
+					WorldId:      worldID,
+					RobotId:      robotID,
+					VxMps:        c.vx,
+					YawRateRadps: c.yaw,
+				}); sendErr != nil {
+					return sendErr
+				}
+				fmt.Printf("\r%s", renderTeleopStatus(c))
+				return nil
+			})
+			fmt.Print("\r\n")
+			if err != nil {
+				return fmt.Errorf("teleop: %w", err)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&worldID, "world", "", "World ID (required)")
+	cmd.Flags().StringVar(&robotID, "robot", "", "Robot ID (required)")
+	_ = cmd.MarkFlagRequired("world")
+	_ = cmd.MarkFlagRequired("robot")
+	return cmd
+}
+
+// teleopCommand is the velocity command teleop holds on the robot.
+type teleopCommand struct {
+	vx  float64 // m/s, forward
+	yaw float64 // rad/s, counter-clockwise
+}
+
+// runTeleopLoop reads keys until quit/EOF, calling send whenever the held
+// command changes. It always sends a final stop (zeros) before returning.
+func runTeleopLoop(ctx context.Context, in *bufio.Reader, send func(teleopCommand) error) error {
+	var cmd teleopCommand
+	for {
+		if ctx.Err() != nil {
+			return sendTeleopStop(send)
+		}
+		key, err := readTeleopKey(in)
+		if err != nil {
+			// EOF or a closed stdin ends the session like q.
+			return sendTeleopStop(send)
+		}
+		changed, quit := applyTeleopKey(&cmd, key)
+		if quit {
+			return sendTeleopStop(send)
+		}
+		if changed {
+			if err := send(cmd); err != nil {
+				_ = sendTeleopStop(send)
+				return err
+			}
+		}
+	}
+}
+
+// sendTeleopStop sends the zero command; its error is returned so a dead
+// connection still surfaces at exit.
+func sendTeleopStop(send func(teleopCommand) error) error {
+	return send(teleopCommand{})
+}
+
+// readTeleopKey reads one key, decoding ANSI arrow-key escape sequences to
+// their WASD equivalents.
+func readTeleopKey(in *bufio.Reader) (byte, error) {
+	b, err := in.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	if b != 0x1b { // not an escape sequence
+		return b, nil
+	}
+	next, err := in.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	if next != '[' {
+		// A bare Escape (or unknown sequence): ignore via an unmapped byte.
+		return 0, nil
+	}
+	final, err := in.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	switch final {
+	case 'A': // up
+		return 'w', nil
+	case 'B': // down
+		return 's', nil
+	case 'C': // right
+		return 'd', nil
+	case 'D': // left
+		return 'a', nil
+	default:
+		return 0, nil
+	}
+}
+
+// applyTeleopKey applies one (already arrow-decoded) key to the held command.
+// changed reports whether the command should be (re)sent; quit ends the
+// session (the caller sends the final stop).
+func applyTeleopKey(c *teleopCommand, key byte) (changed, quit bool) {
+	switch key {
+	case 'w':
+		c.vx = roundTeleop(c.vx + teleopVxStepMps)
+	case 's':
+		c.vx = roundTeleop(c.vx - teleopVxStepMps)
+	case 'a':
+		c.yaw = roundTeleop(c.yaw + teleopYawStepRadps)
+	case 'd':
+		c.yaw = roundTeleop(c.yaw - teleopYawStepRadps)
+	case ' ':
+		c.vx, c.yaw = 0, 0
+	case 'q', 0x03: // q or Ctrl-C
+		c.vx, c.yaw = 0, 0
+		return false, true
+	default:
+		return false, false
+	}
+	return true, false
+}
+
+// roundTeleop keeps accumulated steps at one-decimal precision so repeated
+// float additions never drift (0.1+0.2 style artifacts).
+func roundTeleop(v float64) float64 {
+	return math.Round(v*10) / 10
+}
+
+// renderTeleopStatus renders the one-line held-command status (padded so a
+// shorter line fully overwrites a longer one under \r redraws).
+func renderTeleopStatus(c teleopCommand) string {
+	return fmt.Sprintf("vx %+5.1f m/s   yaw %+5.1f rad/s   (space stop, q quit)    ", c.vx, c.yaw)
+}

--- a/go/internal/cli/commands/sim_teleop_test.go
+++ b/go/internal/cli/commands/sim_teleop_test.go
@@ -1,0 +1,148 @@
+package commands
+
+import (
+	"bufio"
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestApplyTeleopKey(t *testing.T) {
+	var c teleopCommand
+
+	// Three forward steps accumulate without float drift.
+	for i := 0; i < 3; i++ {
+		if changed, quit := applyTeleopKey(&c, 'w'); !changed || quit {
+			t.Fatalf("w: changed/quit = %v/%v; want true/false", changed, quit)
+		}
+	}
+	if c.vx != 0.3 {
+		t.Errorf("vx after www = %v; want 0.3", c.vx)
+	}
+
+	applyTeleopKey(&c, 's')
+	if c.vx != 0.2 {
+		t.Errorf("vx after s = %v; want 0.2", c.vx)
+	}
+
+	applyTeleopKey(&c, 'a')
+	applyTeleopKey(&c, 'a')
+	if c.yaw != 0.4 {
+		t.Errorf("yaw after aa = %v; want 0.4", c.yaw)
+	}
+	applyTeleopKey(&c, 'd')
+	if c.yaw != 0.2 {
+		t.Errorf("yaw after d = %v; want 0.2", c.yaw)
+	}
+
+	// Space zeroes the command but keeps the session running.
+	if changed, quit := applyTeleopKey(&c, ' '); !changed || quit {
+		t.Errorf("space: changed/quit = %v/%v; want true/false", changed, quit)
+	}
+	if c.vx != 0 || c.yaw != 0 {
+		t.Errorf("command after space = %+v; want zeros", c)
+	}
+
+	// Unmapped keys change nothing.
+	c = teleopCommand{vx: 0.1}
+	if changed, quit := applyTeleopKey(&c, 'x'); changed || quit {
+		t.Errorf("x: changed/quit = %v/%v; want false/false", changed, quit)
+	}
+
+	// q and Ctrl-C quit with a zeroed command.
+	for _, key := range []byte{'q', 0x03} {
+		c = teleopCommand{vx: 0.5, yaw: 0.2}
+		if _, quit := applyTeleopKey(&c, key); !quit {
+			t.Errorf("key %#x should quit", key)
+		}
+		if c.vx != 0 || c.yaw != 0 {
+			t.Errorf("command after quit key %#x = %+v; want zeros", key, c)
+		}
+	}
+}
+
+func TestReadTeleopKey_DecodesArrows(t *testing.T) {
+	tests := []struct {
+		in   string
+		want byte
+	}{
+		{in: "w", want: 'w'},
+		{in: "\x1b[A", want: 'w'}, // up
+		{in: "\x1b[B", want: 's'}, // down
+		{in: "\x1b[C", want: 'd'}, // right
+		{in: "\x1b[D", want: 'a'}, // left
+		{in: "\x1b[Z", want: 0},   // unknown CSI final byte
+		{in: "\x1bx", want: 0},    // bare escape + non-CSI
+		{in: " ", want: ' '},
+	}
+	for _, tt := range tests {
+		got, err := readTeleopKey(bufio.NewReader(strings.NewReader(tt.in)))
+		if err != nil {
+			t.Errorf("readTeleopKey(%q): %v", tt.in, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("readTeleopKey(%q) = %#x; want %#x", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestRunTeleopLoop_SendsCommandsAndFinalStop(t *testing.T) {
+	// wwd then q: three command sends plus the final stop.
+	in := bufio.NewReader(strings.NewReader("wwdq"))
+	var sent []teleopCommand
+	err := runTeleopLoop(context.Background(), in, func(c teleopCommand) error {
+		sent = append(sent, c)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("runTeleopLoop: %v", err)
+	}
+	want := []teleopCommand{
+		{vx: 0.1},
+		{vx: 0.2},
+		{vx: 0.2, yaw: -0.2},
+		{}, // final stop from q
+	}
+	if len(sent) != len(want) {
+		t.Fatalf("sent %d commands (%v); want %d", len(sent), sent, len(want))
+	}
+	for i := range want {
+		if sent[i] != want[i] {
+			t.Errorf("sent[%d] = %+v; want %+v", i, sent[i], want[i])
+		}
+	}
+}
+
+func TestRunTeleopLoop_EOFSendsStop(t *testing.T) {
+	in := bufio.NewReader(strings.NewReader("w"))
+	var sent []teleopCommand
+	err := runTeleopLoop(context.Background(), in, func(c teleopCommand) error {
+		sent = append(sent, c)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("runTeleopLoop: %v", err)
+	}
+	if len(sent) != 2 || sent[1] != (teleopCommand{}) {
+		t.Errorf("sent = %v; want command then stop", sent)
+	}
+}
+
+func TestRenderTeleopStatus(t *testing.T) {
+	got := renderTeleopStatus(teleopCommand{vx: 0.3, yaw: -0.2})
+	for _, want := range []string{"vx  +0.3 m/s", "yaw  -0.2 rad/s", "q quit"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("status %q missing %q", got, want)
+		}
+	}
+}
+
+func TestSimTeleopCmd_Flags(t *testing.T) {
+	cmd := newSimTeleopCmd()
+	for _, f := range []string{"world", "robot"} {
+		if cmd.Flags().Lookup(f) == nil {
+			t.Errorf("teleop missing flag --%s", f)
+		}
+	}
+}

--- a/go/internal/cli/commands/sim_test.go
+++ b/go/internal/cli/commands/sim_test.go
@@ -38,6 +38,8 @@ func TestNewSimCmd_Subcommands(t *testing.T) {
 		"record":         false,
 		"joints":         false,
 		"step":           false,
+		"eval":           false,
+		"teleop":         false,
 	}
 	for _, sub := range cmd.Commands() {
 		if _, ok := want[sub.Name()]; ok {

--- a/go/internal/cli/commands/sim_test.go
+++ b/go/internal/cli/commands/sim_test.go
@@ -198,3 +198,40 @@ func TestSimImportModelCmd_RequiresName(t *testing.T) {
 		t.Error("import-model without --name should fail")
 	}
 }
+
+func TestRenderWatchFrame(t *testing.T) {
+	resp := &simpb.GetStateResponse{
+		BasePose: &simpb.Pose{X: 1.5, Y: 0, Z: 0.25},
+		SimTimeS: 12.34,
+		Fallen:   true,
+		Joints:   []*simpb.JointState{{Name: "FL_hip_joint", Position: 0.1, Velocity: -0.2}},
+	}
+	out := renderWatchFrame("world1", "robot3", resp)
+	for _, want := range []string{"world1", "robot3", "FALLEN", "FL_hip_joint", "12.34"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("watch frame missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestWatchJSONLine(t *testing.T) {
+	line := watchJSONLine(&simpb.GetStateResponse{
+		BasePose: &simpb.Pose{X: 2, Z: 0.3}, SimTimeS: 5, Fallen: false,
+	})
+	var got map[string]any
+	if err := json.Unmarshal([]byte(line), &got); err != nil {
+		t.Fatalf("not JSON: %v", err)
+	}
+	if got["x"] != 2.0 || got["fallen"] != false {
+		t.Errorf("unexpected fields: %v", got)
+	}
+}
+
+func TestSimDriveCmd_Flags(t *testing.T) {
+	cmd := newSimDriveCmd()
+	for _, f := range []string{"world", "robot", "vx", "vy", "yaw", "stop"} {
+		if cmd.Flags().Lookup(f) == nil {
+			t.Errorf("drive missing flag --%s", f)
+		}
+	}
+}

--- a/go/internal/cli/commands/sim_test.go
+++ b/go/internal/cli/commands/sim_test.go
@@ -26,6 +26,18 @@ func TestNewSimCmd_Subcommands(t *testing.T) {
 		"reset":          false,
 		"run":            false,
 		"replay":         false,
+		"pause":          false,
+		"resume":         false,
+		"speed":          false,
+		"push":           false,
+		"teleport":       false,
+		"snapshot":       false,
+		"sensors":        false,
+		"scene":          false,
+		"policy":         false,
+		"record":         false,
+		"joints":         false,
+		"step":           false,
 	}
 	for _, sub := range cmd.Commands() {
 		if _, ok := want[sub.Name()]; ok {
@@ -232,6 +244,97 @@ func TestSimDriveCmd_Flags(t *testing.T) {
 	for _, f := range []string{"world", "robot", "vx", "vy", "yaw", "stop"} {
 		if cmd.Flags().Lookup(f) == nil {
 			t.Errorf("drive missing flag --%s", f)
+		}
+	}
+}
+
+func TestSimInteractiveCmds_Flags(t *testing.T) {
+	tests := []struct {
+		name  string
+		cmd   *cobra.Command
+		flags []string
+	}{
+		{name: "pause", cmd: newSimPauseCmd(), flags: []string{"world"}},
+		{name: "resume", cmd: newSimResumeCmd(), flags: []string{"world"}},
+		{name: "speed", cmd: newSimSpeedCmd(), flags: []string{"world"}},
+		{name: "push", cmd: newSimPushCmd(), flags: []string{"world", "robot", "force", "duration"}},
+		{name: "teleport", cmd: newSimTeleportCmd(), flags: []string{"world", "robot", "pos"}},
+		{name: "snapshot save", cmd: newSimSnapshotSaveCmd(), flags: []string{"world"}},
+		{name: "snapshot restore", cmd: newSimSnapshotRestoreCmd(), flags: []string{"world"}},
+		{name: "sensors", cmd: newSimSensorsCmd(), flags: []string{"world", "robot"}},
+		{name: "scene add-box", cmd: newSimSceneAddBoxCmd(), flags: []string{"world", "id", "pos", "size"}},
+		{name: "scene remove", cmd: newSimSceneRemoveCmd(), flags: []string{"world", "id"}},
+		{name: "policy load", cmd: newSimPolicyLoadCmd(), flags: []string{"world", "robot", "format"}},
+		{name: "policy clear", cmd: newSimPolicyClearCmd(), flags: []string{"world", "robot"}},
+		{name: "record", cmd: newSimRecordCmd(), flags: []string{"world", "robot", "duration", "fps", "output", "camera", "width", "height"}},
+		{name: "joints get", cmd: newSimJointsGetCmd(), flags: []string{"world", "robot"}},
+		{name: "joints set", cmd: newSimJointsSetCmd(), flags: []string{"world", "robot"}},
+		{name: "step", cmd: newSimStepCmd(), flags: []string{"world", "seconds"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, f := range tt.flags {
+				if tt.cmd.Flags().Lookup(f) == nil {
+					t.Errorf("%s missing flag --%s", tt.name, f)
+				}
+			}
+		})
+	}
+}
+
+func TestSimSnapshotAndSceneCmd_Subcommands(t *testing.T) {
+	for _, tt := range []struct {
+		cmd  *cobra.Command
+		want []string
+	}{
+		{cmd: newSimSnapshotCmd(), want: []string{"save", "restore"}},
+		{cmd: newSimSceneCmd(), want: []string{"add-box", "remove"}},
+		{cmd: newSimPolicyCmd(), want: []string{"load", "clear"}},
+		{cmd: newSimJointsCmd(), want: []string{"get", "set"}},
+	} {
+		found := map[string]bool{}
+		for _, sub := range tt.cmd.Commands() {
+			found[sub.Name()] = true
+		}
+		for _, name := range tt.want {
+			if !found[name] {
+				t.Errorf("%s missing subcommand %q", tt.cmd.Name(), name)
+			}
+		}
+	}
+}
+
+func TestSimImportModelCmd_HasReplaceFlag(t *testing.T) {
+	cmd := newSimImportModelCmd()
+	if cmd.Flags().Lookup("replace") == nil {
+		t.Error("import-model missing flag --replace")
+	}
+}
+
+func TestSimSpeedCmd_RejectsBadFactor(t *testing.T) {
+	for _, arg := range []string{"abc", "0", "-2"} {
+		cmd := newSimSpeedCmd()
+		cmd.SetArgs([]string{arg, "--world", "w1"})
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
+		if err := cmd.Execute(); err == nil {
+			t.Errorf("speed %q should fail", arg)
+		}
+	}
+}
+
+func TestParseJointTargets(t *testing.T) {
+	got, err := parseJointTargets([]string{"FL_hip=0.5", "FR_hip=-0.25"})
+	if err != nil {
+		t.Fatalf("parseJointTargets: %v", err)
+	}
+	if len(got) != 2 || got["FL_hip"] != 0.5 || got["FR_hip"] != -0.25 {
+		t.Errorf("targets = %v", got)
+	}
+
+	for _, bad := range []string{"FL_hip", "FL_hip=abc", "=0.5"} {
+		if _, err := parseJointTargets([]string{bad}); err == nil {
+			t.Errorf("parseJointTargets(%q) should fail", bad)
 		}
 	}
 }

--- a/go/internal/cli/mcp/server_helpers_test.go
+++ b/go/internal/cli/mcp/server_helpers_test.go
@@ -110,6 +110,26 @@ func (s *mcpServer) callTool(ctx context.Context, name string, args map[string]a
 		return s.handleSimReplay(ctx, req)
 	case "sim_reset":
 		return s.handleSimReset(ctx, req)
+	case "sim_clock":
+		return s.handleSimClock(ctx, req)
+	case "sim_push":
+		return s.handleSimPush(ctx, req)
+	case "sim_teleport":
+		return s.handleSimTeleport(ctx, req)
+	case "sim_snapshot_save":
+		return s.handleSimSnapshotSave(ctx, req)
+	case "sim_snapshot_restore":
+		return s.handleSimSnapshotRestore(ctx, req)
+	case "sim_sensors":
+		return s.handleSimSensors(ctx, req)
+	case "sim_scene_edit":
+		return s.handleSimSceneEdit(ctx, req)
+	case "sim_policy_load":
+		return s.handleSimPolicyLoad(ctx, req)
+	case "sim_policy_clear":
+		return s.handleSimPolicyClear(ctx, req)
+	case "sim_record":
+		return s.handleSimRecord(ctx, req)
 	case "cloud_discover":
 		return s.handleCloudDiscover(ctx, req)
 	case "cloud_connect":

--- a/go/internal/cli/mcp/tools_guide.go
+++ b/go/internal/cli/mcp/tools_guide.go
@@ -42,7 +42,7 @@ Cloud-enrolled devices:
 - filesync_sync
 - provisioning_start / provisioning_status
 - sim_create / sim_list / sim_import_model / sim_describe_model / sim_spawn /
-  sim_state / sim_contacts / run_task_in_sim / sim_replay / sim_reset
+  sim_state / sim_contacts / sim_drive / run_task_in_sim / sim_replay / sim_viewer_url / sim_reset
 
 ## Deploying a workload
 
@@ -61,7 +61,7 @@ Robot simulation runs on the connected device. The typical workflow:
                           checks plus the last progress/log lines
 6. sim_replay           — download the recorded replay (.rrd) for review
 
-Observe with sim_state and sim_contacts; start over with sim_reset.
+Observe with sim_state and sim_contacts; drive directly with sim_drive (motion level); share the live view via sim_viewer_url; start over with sim_reset.
 Policy: task specs and their constraints may be edited freely and re-run, but
 changes to controller or application CODE must be proposed to the human for
 approval before running.

--- a/go/internal/cli/mcp/tools_guide.go
+++ b/go/internal/cli/mcp/tools_guide.go
@@ -42,7 +42,9 @@ Cloud-enrolled devices:
 - filesync_sync
 - provisioning_start / provisioning_status
 - sim_create / sim_list / sim_import_model / sim_describe_model / sim_spawn /
-  sim_state / sim_contacts / sim_drive / run_task_in_sim / sim_replay / sim_viewer_url / sim_reset
+  sim_state / sim_contacts / sim_sensors / sim_drive / run_task_in_sim / sim_replay /
+  sim_viewer_url / sim_reset / sim_clock / sim_push / sim_teleport / sim_snapshot_save /
+  sim_snapshot_restore / sim_scene_edit / sim_policy_load / sim_policy_clear / sim_record
 
 ## Deploying a workload
 
@@ -61,7 +63,14 @@ Robot simulation runs on the connected device. The typical workflow:
                           checks plus the last progress/log lines
 6. sim_replay           — download the recorded replay (.rrd) for review
 
-Observe with sim_state and sim_contacts; drive directly with sim_drive (motion level); share the live view via sim_viewer_url; start over with sim_reset.
+Observe with sim_state, sim_contacts, and sim_sensors; drive directly with sim_drive (motion level); share the live view via sim_viewer_url; start over with sim_reset.
+Interactive tooling: sim_clock pauses/resumes and fast-forwards a world;
+sim_push shoves the robot (balance testing); sim_teleport repositions it;
+sim_snapshot_save / sim_snapshot_restore capture and rewind exact physics
+state to reproduce failures; sim_scene_edit adds/removes obstacles in a live
+world; sim_policy_load swaps in a trained policy file (sim_policy_clear
+reverts); sim_record renders an mp4 clip to a local file (share the path);
+sim_import_model with replace_model_id hot-reloads an edited model.
 Policy: task specs and their constraints may be edited freely and re-run, but
 changes to controller or application CODE must be proposed to the human for
 approval before running.

--- a/go/internal/cli/mcp/tools_sim.go
+++ b/go/internal/cli/mcp/tools_sim.go
@@ -22,6 +22,9 @@ const maxSimTaskEventLines = 20
 // maxSimContacts bounds how many contact pairs sim_contacts returns.
 const maxSimContacts = 50
 
+// maxSimSensorReadings bounds how many readings sim_sensors returns.
+const maxSimSensorReadings = 50
+
 func (s *mcpServer) registerSimTools(srv *server.MCPServer) {
 	srv.AddTool(mcpgo.NewTool("sim_create",
 		mcpgo.WithDescription("Create a robot simulation world on the connected device. Returns the world_id and backend."),
@@ -43,7 +46,9 @@ func (s *mcpServer) registerSimTools(srv *server.MCPServer) {
 			"menagerie_path for a bundled MuJoCo Menagerie model, or local_path for a model directory "+
 			"or .tar/.tar.gz archive on this machine (it is streamed to the device). Format is "+
 			"auto-detected (mjcf/sdf/urdf; override with format) — which formats load depends on the "+
-			"backend (MuJoCo: mjcf; Gazebo: sdf, urdf). Returns the model_id."),
+			"backend (MuJoCo: mjcf; Gazebo: sdf, urdf). Set replace_model_id to reload an existing "+
+			"model in place (robots spawned from it are respawned — the edit-reload loop). "+
+			"Returns the model_id."),
 		mcpgo.WithString("name",
 			mcpgo.Required(),
 			mcpgo.Description("Registry name the model will be addressable by (e.g. \"go2\")"),
@@ -56,6 +61,9 @@ func (s *mcpServer) registerSimTools(srv *server.MCPServer) {
 		),
 		mcpgo.WithString("local_path",
 			mcpgo.Description("Local model directory or .tar/.tar.gz archive to upload"),
+		),
+		mcpgo.WithString("replace_model_id",
+			mcpgo.Description("Existing model ID to replace in place (robots spawned from it are respawned)"),
 		),
 	), s.handleSimImportModel)
 
@@ -190,6 +198,174 @@ func (s *mcpServer) registerSimTools(srv *server.MCPServer) {
 			mcpgo.Description("World ID to reset"),
 		),
 	), s.handleSimReset)
+
+	srv.AddTool(mcpgo.NewTool("sim_clock",
+		mcpgo.WithDescription("Pause/resume a simulation world and set its real-time pacing. "+
+			"paused=true freezes physics (advance deterministically with run_task_in_sim after resuming, "+
+			"or resume with paused=false); speed_factor scales pacing (1 = real time, 10 = 10x, "+
+			"0 = leave unchanged). Returns the resulting clock state."),
+		mcpgo.WithString("world_id",
+			mcpgo.Required(),
+			mcpgo.Description("World ID"),
+		),
+		mcpgo.WithBoolean("paused",
+			mcpgo.Description("true pauses physics stepping; false (default) resumes it"),
+		),
+		mcpgo.WithNumber("speed_factor",
+			mcpgo.Description("Real-time pacing multiplier (1 = real time, 10 = 10x; 0/omitted = unchanged)"),
+		),
+	), s.handleSimClock)
+
+	srv.AddTool(mcpgo.NewTool("sim_push",
+		mcpgo.WithDescription("Apply a world-frame force impulse to a robot's base — the programmatic "+
+			"shove, used to test balance and recovery. Check the effect with sim_state."),
+		mcpgo.WithString("world_id",
+			mcpgo.Required(),
+			mcpgo.Description("World ID"),
+		),
+		mcpgo.WithString("robot_id",
+			mcpgo.Required(),
+			mcpgo.Description("Robot ID returned by sim_spawn"),
+		),
+		mcpgo.WithString("force",
+			mcpgo.Required(),
+			mcpgo.Description("World-frame force as \"x,y,z\" in Newtons (e.g. \"30,0,0\")"),
+		),
+		mcpgo.WithNumber("duration_s",
+			mcpgo.Description("How long the force is held, in sim seconds (default 0.1; 0 = one physics step)"),
+		),
+	), s.handleSimPush)
+
+	srv.AddTool(mcpgo.NewTool("sim_teleport",
+		mcpgo.WithDescription("Move a robot to a position directly (physics-level edit); its velocities are zeroed"),
+		mcpgo.WithString("world_id",
+			mcpgo.Required(),
+			mcpgo.Description("World ID"),
+		),
+		mcpgo.WithString("robot_id",
+			mcpgo.Required(),
+			mcpgo.Description("Robot ID returned by sim_spawn"),
+		),
+		mcpgo.WithString("pos",
+			mcpgo.Required(),
+			mcpgo.Description("Target position as \"x,y,z\" in meters"),
+		),
+	), s.handleSimTeleport)
+
+	srv.AddTool(mcpgo.NewTool("sim_snapshot_save",
+		mcpgo.WithDescription("Capture a world's exact physics state; restore it later with "+
+			"sim_snapshot_restore to reproduce a scenario deterministically. Returns the snapshot_id."),
+		mcpgo.WithString("world_id",
+			mcpgo.Required(),
+			mcpgo.Description("World ID"),
+		),
+	), s.handleSimSnapshotSave)
+
+	srv.AddTool(mcpgo.NewTool("sim_snapshot_restore",
+		mcpgo.WithDescription("Rewind a world to a snapshot saved with sim_snapshot_save"),
+		mcpgo.WithString("world_id",
+			mcpgo.Required(),
+			mcpgo.Description("World ID"),
+		),
+		mcpgo.WithString("snapshot_id",
+			mcpgo.Required(),
+			mcpgo.Description("Snapshot ID returned by sim_snapshot_save"),
+		),
+	), s.handleSimSnapshotRestore)
+
+	srv.AddTool(mcpgo.NewTool("sim_sensors",
+		mcpgo.WithDescription("Read current values of a robot's declared sensors (IMU, force, touch, "+
+			"rangefinder, ...); at most 50 readings are returned"),
+		mcpgo.WithString("world_id",
+			mcpgo.Required(),
+			mcpgo.Description("World ID"),
+		),
+		mcpgo.WithString("robot_id",
+			mcpgo.Required(),
+			mcpgo.Description("Robot ID returned by sim_spawn"),
+		),
+	), s.handleSimSensors)
+
+	srv.AddTool(mcpgo.NewTool("sim_scene_edit",
+		mcpgo.WithDescription("Edit a live world's static scenery without recreating it. "+
+			"op=add_box adds a static box obstacle (requires id, pos, size); "+
+			"op=remove removes an obstacle by id."),
+		mcpgo.WithString("world_id",
+			mcpgo.Required(),
+			mcpgo.Description("World ID"),
+		),
+		mcpgo.WithString("op",
+			mcpgo.Required(),
+			mcpgo.Description("Scene operation: add_box or remove"),
+		),
+		mcpgo.WithString("id",
+			mcpgo.Required(),
+			mcpgo.Description("Obstacle ID (names a new box, or selects the one to remove)"),
+		),
+		mcpgo.WithString("pos",
+			mcpgo.Description("Box center as \"x,y,z\" in meters (add_box only)"),
+		),
+		mcpgo.WithString("size",
+			mcpgo.Description("Box full extents as \"x,y,z\" in meters (add_box only)"),
+		),
+	), s.handleSimSceneEdit)
+
+	srv.AddTool(mcpgo.NewTool("sim_policy_load",
+		mcpgo.WithDescription("Load a trained policy file (e.g. ONNX) from this machine onto a simulated "+
+			"robot, replacing its built-in controller. Revert with sim_policy_clear. Returns the policy_id."),
+		mcpgo.WithString("world_id",
+			mcpgo.Required(),
+			mcpgo.Description("World ID"),
+		),
+		mcpgo.WithString("robot_id",
+			mcpgo.Required(),
+			mcpgo.Description("Robot ID returned by sim_spawn"),
+		),
+		mcpgo.WithString("local_path",
+			mcpgo.Required(),
+			mcpgo.Description("Local policy file to upload (e.g. policy.onnx)"),
+		),
+		mcpgo.WithString("format",
+			mcpgo.Description("Policy file format (default onnx)"),
+		),
+	), s.handleSimPolicyLoad)
+
+	srv.AddTool(mcpgo.NewTool("sim_policy_clear",
+		mcpgo.WithDescription("Revert a robot to its built-in controller (undoes sim_policy_load)"),
+		mcpgo.WithString("world_id",
+			mcpgo.Required(),
+			mcpgo.Description("World ID"),
+		),
+		mcpgo.WithString("robot_id",
+			mcpgo.Required(),
+			mcpgo.Description("Robot ID returned by sim_spawn"),
+		),
+	), s.handleSimPolicyClear)
+
+	srv.AddTool(mcpgo.NewTool("sim_record",
+		mcpgo.WithDescription("Render a video clip (mp4) of the simulation and save it to a local file. "+
+			"Returns the saved path and size — share the path with the human; do not try to read the bytes."),
+		mcpgo.WithString("world_id",
+			mcpgo.Required(),
+			mcpgo.Description("World ID"),
+		),
+		mcpgo.WithString("robot_id",
+			mcpgo.Required(),
+			mcpgo.Description("Robot ID the tracking camera follows"),
+		),
+		mcpgo.WithNumber("duration_s",
+			mcpgo.Description("Clip length in sim seconds (default 5)"),
+		),
+		mcpgo.WithNumber("fps",
+			mcpgo.Description("Frames per second (default 15)"),
+		),
+		mcpgo.WithString("camera",
+			mcpgo.Description("Model camera name (default: tracking view)"),
+		),
+		mcpgo.WithString("output_path",
+			mcpgo.Description("Where to save the clip (default ./clip-<world-id>.mp4)"),
+		),
+	), s.handleSimRecord)
 }
 
 func (s *mcpServer) handleSimCreate(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -274,9 +450,10 @@ func (s *mcpServer) handleSimImportModel(ctx context.Context, req mcpgo.CallTool
 	}
 	if err := stream.Send(&simpb.LoadModelChunk{
 		Payload: &simpb.LoadModelChunk_Source{Source: &simpb.ModelSource{
-			Name:          name,
-			Format:        format,
-			MenageriePath: menageriePath,
+			Name:           name,
+			Format:         format,
+			MenageriePath:  menageriePath,
+			ReplaceModelId: stringParam(req, "replace_model_id"),
 		}},
 	}); err != nil {
 		return mcpgo.NewToolResultError(grpcErrString(err)), nil
@@ -691,4 +868,322 @@ func (s *mcpServer) handleSimViewerURL(_ context.Context, req mcpgo.CallToolRequ
 	url := fmt.Sprintf("http://%s:9877/?url=rerun%%2Bhttp://%s:9876/proxy", host, host)
 	return mcpgo.NewToolResultText(fmt.Sprintf(
 		"live viewer: %s (requires the sim container to run with WENDYSIM_LIVE_VIEWER=1)", url)), nil
+}
+
+func (s *mcpServer) handleSimClock(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	conn := s.GetConn()
+	if conn == nil {
+		return errNotConnected(), nil
+	}
+	worldID := stringParam(req, "world_id")
+	if worldID == "" {
+		return mcpgo.NewToolResultError("world_id is required"), nil
+	}
+	resp, err := conn.SimService.SetClock(ctx, &simpb.SetClockRequest{
+		WorldId:     worldID,
+		Paused:      req.GetBool("paused", false),
+		SpeedFactor: req.GetFloat("speed_factor", 0),
+	})
+	if err != nil {
+		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+	}
+	b, _ := json.MarshalIndent(map[string]any{
+		"paused":       resp.GetPaused(),
+		"speed_factor": resp.GetSpeedFactor(),
+	}, "", "  ")
+	return mcpgo.NewToolResultText(string(b)), nil
+}
+
+func (s *mcpServer) handleSimPush(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	conn := s.GetConn()
+	if conn == nil {
+		return errNotConnected(), nil
+	}
+	worldID := stringParam(req, "world_id")
+	robotID := stringParam(req, "robot_id")
+	if worldID == "" || robotID == "" {
+		return mcpgo.NewToolResultError("world_id and robot_id are required"), nil
+	}
+	force, err := simutil.ParseVector3(stringParam(req, "force"), "force")
+	if err != nil {
+		return mcpgo.NewToolResultError(err.Error()), nil
+	}
+	duration := req.GetFloat("duration_s", 0.1)
+
+	if _, err := conn.SimService.ApplyForce(ctx, &simpb.ApplyForceRequest{
+		WorldId:   worldID,
+		RobotId:   robotID,
+		FxN:       force[0],
+		FyN:       force[1],
+		FzN:       force[2],
+		DurationS: duration,
+	}); err != nil {
+		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+	}
+	return mcpgo.NewToolResultText(fmt.Sprintf(
+		"pushed %s with force (%.1f, %.1f, %.1f) N for %.2f s; check sim_state for the effect",
+		robotID, force[0], force[1], force[2], duration)), nil
+}
+
+func (s *mcpServer) handleSimTeleport(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	conn := s.GetConn()
+	if conn == nil {
+		return errNotConnected(), nil
+	}
+	worldID := stringParam(req, "world_id")
+	robotID := stringParam(req, "robot_id")
+	if worldID == "" || robotID == "" {
+		return mcpgo.NewToolResultError("world_id and robot_id are required"), nil
+	}
+	pose, err := simutil.ParsePosition(stringParam(req, "pos"))
+	if err != nil {
+		return mcpgo.NewToolResultError(err.Error()), nil
+	}
+	if pose == nil {
+		return mcpgo.NewToolResultError("pos is required (\"x,y,z\" in meters)"), nil
+	}
+
+	if _, err := conn.SimService.Teleport(ctx, &simpb.TeleportRequest{
+		WorldId:      worldID,
+		RobotId:      robotID,
+		Pose:         pose,
+		ZeroVelocity: true,
+	}); err != nil {
+		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+	}
+	return mcpgo.NewToolResultText(fmt.Sprintf("teleported %s to (%.3f, %.3f, %.3f); velocities zeroed",
+		robotID, pose.GetX(), pose.GetY(), pose.GetZ())), nil
+}
+
+func (s *mcpServer) handleSimSnapshotSave(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	conn := s.GetConn()
+	if conn == nil {
+		return errNotConnected(), nil
+	}
+	worldID := stringParam(req, "world_id")
+	if worldID == "" {
+		return mcpgo.NewToolResultError("world_id is required"), nil
+	}
+	resp, err := conn.SimService.SaveSnapshot(ctx, &simpb.SaveSnapshotRequest{WorldId: worldID})
+	if err != nil {
+		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+	}
+	b, _ := json.MarshalIndent(map[string]string{"snapshot_id": resp.GetSnapshotId()}, "", "  ")
+	return mcpgo.NewToolResultText(string(b)), nil
+}
+
+func (s *mcpServer) handleSimSnapshotRestore(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	conn := s.GetConn()
+	if conn == nil {
+		return errNotConnected(), nil
+	}
+	worldID := stringParam(req, "world_id")
+	snapshotID := stringParam(req, "snapshot_id")
+	if worldID == "" || snapshotID == "" {
+		return mcpgo.NewToolResultError("world_id and snapshot_id are required"), nil
+	}
+	if _, err := conn.SimService.RestoreSnapshot(ctx, &simpb.RestoreSnapshotRequest{
+		WorldId:    worldID,
+		SnapshotId: snapshotID,
+	}); err != nil {
+		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+	}
+	return mcpgo.NewToolResultText(fmt.Sprintf("world %s restored to snapshot %s", worldID, snapshotID)), nil
+}
+
+func (s *mcpServer) handleSimSensors(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	conn := s.GetConn()
+	if conn == nil {
+		return errNotConnected(), nil
+	}
+	worldID := stringParam(req, "world_id")
+	robotID := stringParam(req, "robot_id")
+	if worldID == "" || robotID == "" {
+		return mcpgo.NewToolResultError("world_id and robot_id are required"), nil
+	}
+	resp, err := conn.SimService.ReadSensors(ctx, &simpb.ReadSensorsRequest{
+		WorldId: worldID,
+		RobotId: robotID,
+	})
+	if err != nil {
+		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+	}
+	all := resp.GetReadings()
+	readings := []map[string]any{}
+	for i, r := range all {
+		if i >= maxSimSensorReadings {
+			break
+		}
+		readings = append(readings, map[string]any{
+			"name":   r.GetName(),
+			"type":   r.GetType(),
+			"values": r.GetValues(),
+		})
+	}
+	out := map[string]any{
+		"total_sensors": len(all),
+		"readings":      readings,
+	}
+	if len(all) > maxSimSensorReadings {
+		out["truncated"] = true
+	}
+	b, _ := json.MarshalIndent(out, "", "  ")
+	return mcpgo.NewToolResultText(string(b)), nil
+}
+
+func (s *mcpServer) handleSimSceneEdit(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	conn := s.GetConn()
+	if conn == nil {
+		return errNotConnected(), nil
+	}
+	worldID := stringParam(req, "world_id")
+	id := stringParam(req, "id")
+	if worldID == "" || id == "" {
+		return mcpgo.NewToolResultError("world_id and id are required"), nil
+	}
+
+	edit := &simpb.EditSceneRequest{WorldId: worldID}
+	var summary string
+	switch op := stringParam(req, "op"); op {
+	case "add_box":
+		pos, err := simutil.ParseVector3(stringParam(req, "pos"), "pos")
+		if err != nil {
+			return mcpgo.NewToolResultError(err.Error()), nil
+		}
+		size, err := simutil.ParseVector3(stringParam(req, "size"), "size")
+		if err != nil {
+			return mcpgo.NewToolResultError(err.Error()), nil
+		}
+		edit.Op = &simpb.EditSceneRequest_AddBox{AddBox: &simpb.SceneBoxSpec{
+			Id:       id,
+			Position: pos[:],
+			Size:     size[:],
+		}}
+		summary = fmt.Sprintf("box %s added at (%.2f, %.2f, %.2f) with size (%.2f, %.2f, %.2f)",
+			id, pos[0], pos[1], pos[2], size[0], size[1], size[2])
+	case "remove":
+		edit.Op = &simpb.EditSceneRequest_RemoveId{RemoveId: id}
+		summary = fmt.Sprintf("obstacle %s removed", id)
+	default:
+		return mcpgo.NewToolResultError(fmt.Sprintf("invalid op %q: expected add_box or remove", op)), nil
+	}
+
+	if _, err := conn.SimService.EditScene(ctx, edit); err != nil {
+		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+	}
+	return mcpgo.NewToolResultText(summary), nil
+}
+
+func (s *mcpServer) handleSimPolicyLoad(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	conn := s.GetConn()
+	if conn == nil {
+		return errNotConnected(), nil
+	}
+	worldID := stringParam(req, "world_id")
+	robotID := stringParam(req, "robot_id")
+	localPath := stringParam(req, "local_path")
+	if worldID == "" || robotID == "" || localPath == "" {
+		return mcpgo.NewToolResultError("world_id, robot_id, and local_path are required"), nil
+	}
+	format := stringParam(req, "format")
+	if format == "" {
+		format = "onnx"
+	}
+	if _, err := os.Stat(localPath); err != nil {
+		return mcpgo.NewToolResultError(fmt.Sprintf("opening policy file: %v", err)), nil
+	}
+
+	stream, err := conn.SimService.LoadPolicy(ctx)
+	if err != nil {
+		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+	}
+	if err := stream.Send(&simpb.LoadPolicyChunk{
+		Payload: &simpb.LoadPolicyChunk_Source{Source: &simpb.PolicySource{
+			WorldId: worldID,
+			RobotId: robotID,
+			Format:  format,
+		}},
+	}); err != nil {
+		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+	}
+
+	sendErr := simutil.StreamFileChunks(localPath, func(data []byte) error {
+		return stream.Send(&simpb.LoadPolicyChunk{
+			Payload: &simpb.LoadPolicyChunk_Data{Data: data},
+		})
+	})
+	// A local read error aborts the load. Send returning io.EOF means the
+	// stream broke; CloseAndRecv below surfaces the cause.
+	if sendErr != nil && sendErr != io.EOF {
+		return mcpgo.NewToolResultError(fmt.Sprintf("reading policy %s: %v", localPath, sendErr)), nil
+	}
+
+	resp, err := stream.CloseAndRecv()
+	if err != nil {
+		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+	}
+	b, _ := json.MarshalIndent(map[string]string{"policy_id": resp.GetPolicyId()}, "", "  ")
+	return mcpgo.NewToolResultText(string(b)), nil
+}
+
+func (s *mcpServer) handleSimPolicyClear(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	conn := s.GetConn()
+	if conn == nil {
+		return errNotConnected(), nil
+	}
+	worldID := stringParam(req, "world_id")
+	robotID := stringParam(req, "robot_id")
+	if worldID == "" || robotID == "" {
+		return mcpgo.NewToolResultError("world_id and robot_id are required"), nil
+	}
+	if _, err := conn.SimService.ClearPolicy(ctx, &simpb.ClearPolicyRequest{
+		WorldId: worldID,
+		RobotId: robotID,
+	}); err != nil {
+		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+	}
+	return mcpgo.NewToolResultText(fmt.Sprintf("policy cleared; %s uses its built-in controller", robotID)), nil
+}
+
+func (s *mcpServer) handleSimRecord(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	conn := s.GetConn()
+	if conn == nil {
+		return errNotConnected(), nil
+	}
+	worldID := stringParam(req, "world_id")
+	robotID := stringParam(req, "robot_id")
+	if worldID == "" || robotID == "" {
+		return mcpgo.NewToolResultError("world_id and robot_id are required"), nil
+	}
+
+	stream, err := conn.SimService.RenderVideo(ctx, &simpb.RenderVideoRequest{
+		WorldId:    worldID,
+		RobotId:    robotID,
+		CameraName: stringParam(req, "camera"),
+		DurationS:  req.GetFloat("duration_s", 5),
+		Fps:        uint32(req.GetInt("fps", 15)),
+	})
+	if err != nil {
+		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+	}
+
+	path := stringParam(req, "output_path")
+	if path == "" {
+		path = fmt.Sprintf("clip-%s.mp4", worldID)
+	}
+	n, err := simutil.WriteReplayFile(path, func() ([]byte, error) {
+		chunk, recvErr := stream.Recv()
+		if recvErr != nil {
+			return nil, recvErr
+		}
+		return chunk.GetData(), nil
+	})
+	if err != nil {
+		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+	}
+	b, _ := json.MarshalIndent(map[string]any{
+		"path":  path,
+		"bytes": n,
+	}, "", "  ")
+	return mcpgo.NewToolResultText(string(b)), nil
 }

--- a/go/internal/cli/mcp/tools_sim.go
+++ b/go/internal/cli/mcp/tools_sim.go
@@ -95,6 +95,37 @@ func (s *mcpServer) registerSimTools(srv *server.MCPServer) {
 		),
 	), s.handleSimState)
 
+	srv.AddTool(mcpgo.NewTool("sim_drive",
+		mcpgo.WithDescription("Command a base velocity for a simulated robot (motion level). The robot holds "+
+			"the command until the next sim_drive or a task takes over; the backend clamps to the model's "+
+			"safety limits. Omit all velocities (or send zeros) to stop. Poll sim_state to see the effect."),
+		mcpgo.WithString("world_id",
+			mcpgo.Required(),
+			mcpgo.Description("World ID"),
+		),
+		mcpgo.WithString("robot_id",
+			mcpgo.Required(),
+			mcpgo.Description("Robot ID returned by sim_spawn"),
+		),
+		mcpgo.WithNumber("vx",
+			mcpgo.Description("Forward velocity in m/s (negative = backward)"),
+		),
+		mcpgo.WithNumber("vy",
+			mcpgo.Description("Lateral velocity in m/s"),
+		),
+		mcpgo.WithNumber("yaw_rate",
+			mcpgo.Description("Turn rate in rad/s (positive = counter-clockwise)"),
+		),
+	), s.handleSimDrive)
+
+	srv.AddTool(mcpgo.NewTool("sim_viewer_url",
+		mcpgo.WithDescription("Get the URL of the sim's live browser viewer (served when the sim container "+
+			"runs with WENDYSIM_LIVE_VIEWER=1). Share it with the human so they can watch the simulation live."),
+		mcpgo.WithString("host",
+			mcpgo.Description("Sim host (default: the connected device's host)"),
+		),
+	), s.handleSimViewerURL)
+
 	srv.AddTool(mcpgo.NewTool("sim_contacts",
 		mcpgo.WithDescription("Get active contact pairs for a robot (body_a, body_b, force in Newtons); at most 50 are returned"),
 		mcpgo.WithString("world_id",
@@ -612,4 +643,52 @@ func (s *mcpServer) handleSimReset(ctx context.Context, req mcpgo.CallToolReques
 		return mcpgo.NewToolResultError(grpcErrString(err)), nil
 	}
 	return mcpgo.NewToolResultText(fmt.Sprintf("simulation %s reset", worldID)), nil
+}
+
+func (s *mcpServer) handleSimDrive(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	conn := s.GetConn()
+	if conn == nil {
+		return errNotConnected(), nil
+	}
+	worldID := stringParam(req, "world_id")
+	robotID := stringParam(req, "robot_id")
+	if worldID == "" || robotID == "" {
+		return mcpgo.NewToolResultError("world_id and robot_id are required"), nil
+	}
+	vx := req.GetFloat("vx", 0)
+	vy := req.GetFloat("vy", 0)
+	yawRate := req.GetFloat("yaw_rate", 0)
+
+	if _, err := conn.SimService.SetVelocity(ctx, &simpb.SetVelocityRequest{
+		WorldId:      worldID,
+		RobotId:      robotID,
+		VxMps:        vx,
+		VyMps:        vy,
+		YawRateRadps: yawRate,
+	}); err != nil {
+		return mcpgo.NewToolResultError(grpcErrString(err)), nil
+	}
+	if vx == 0 && vy == 0 && yawRate == 0 {
+		return mcpgo.NewToolResultText(fmt.Sprintf("robot %s stopping", robotID)), nil
+	}
+	return mcpgo.NewToolResultText(fmt.Sprintf(
+		"driving %s: vx=%.2f m/s, vy=%.2f m/s, yaw_rate=%.2f rad/s (holds until the next sim_drive)",
+		robotID, vx, vy, yawRate)), nil
+}
+
+func (s *mcpServer) handleSimViewerURL(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	host := stringParam(req, "host")
+	if host == "" {
+		conn := s.GetConn()
+		if conn == nil {
+			return errNotConnected(), nil
+		}
+		host = conn.Host
+	}
+	if host == "" {
+		host = "localhost"
+	}
+	url := fmt.Sprintf("http://%s:9877/?url=rerun%%2Bhttp://%s:9876/proxy", host, host)
+	return mcpgo.NewToolResultText(fmt.Sprintf(
+		"live viewer: %s (requires the sim container to run with WENDYSIM_LIVE_VIEWER=1)", url)), nil
 }

--- a/go/internal/cli/mcp/tools_sim.go
+++ b/go/internal/cli/mcp/tools_sim.go
@@ -108,7 +108,12 @@ func (s *mcpServer) registerSimTools(srv *server.MCPServer) {
 			"Provide the spec as inline YAML (spec_yaml) or a local file path (spec_path). "+
 			"Task specs and their constraints/checks may be edited freely and re-run to iterate. "+
 			"Changes to controller or application CODE must be proposed to the human for approval before running. "+
-			"When record is true, download the recording afterwards with sim_replay using the returned replay_id."),
+			"When record is true, download the recording afterwards with sim_replay using the returned replay_id. "+
+			"Spec schema — objective: list of {move_forward: {distance_m}} or {wait: {seconds}}; "+
+			"constraints: mapping (max_speed_mps, do_not_fall, avoid_collisions); "+
+			"checks: list of not_fallen, {distance_traveled: {min_m}}, {collision_count: {max}}. Example:\n"+
+			"objective:\n  - move_forward: {distance_m: 3.0}\nconstraints:\n  max_speed_mps: 0.5\n  do_not_fall: true\n"+
+			"checks:\n  - not_fallen\n  - distance_traveled: {min_m: 2.5}\n  - collision_count: {max: 0}"),
 		mcpgo.WithString("world_id",
 			mcpgo.Required(),
 			mcpgo.Description("World ID to run the task in"),

--- a/go/internal/cli/mcp/tools_sim.go
+++ b/go/internal/cli/mcp/tools_sim.go
@@ -39,9 +39,11 @@ func (s *mcpServer) registerSimTools(srv *server.MCPServer) {
 	), s.handleSimList)
 
 	srv.AddTool(mcpgo.NewTool("sim_import_model",
-		mcpgo.WithDescription("Import a robot model (MJCF) into the sim backend. Provide exactly one source: "+
+		mcpgo.WithDescription("Import a robot model into the sim backend. Provide exactly one source: "+
 			"menagerie_path for a bundled MuJoCo Menagerie model, or local_path for a model directory "+
-			"or .tar/.tar.gz archive on this machine (it is streamed to the device). Returns the model_id."),
+			"or .tar/.tar.gz archive on this machine (it is streamed to the device). Format is "+
+			"auto-detected (mjcf/sdf/urdf; override with format) — which formats load depends on the "+
+			"backend (MuJoCo: mjcf; Gazebo: sdf, urdf). Returns the model_id."),
 		mcpgo.WithString("name",
 			mcpgo.Required(),
 			mcpgo.Description("Registry name the model will be addressable by (e.g. \"go2\")"),
@@ -49,8 +51,11 @@ func (s *mcpServer) registerSimTools(srv *server.MCPServer) {
 		mcpgo.WithString("menagerie_path",
 			mcpgo.Description("Bundled MuJoCo Menagerie model path (e.g. \"unitree_go2/go2.xml\")"),
 		),
+		mcpgo.WithString("format",
+			mcpgo.Description("Model format: mjcf, sdf, or urdf (default: auto-detect from the source)"),
+		),
 		mcpgo.WithString("local_path",
-			mcpgo.Description("Local MJCF model directory or .tar/.tar.gz archive to upload"),
+			mcpgo.Description("Local model directory or .tar/.tar.gz archive to upload"),
 		),
 	), s.handleSimImportModel)
 
@@ -227,6 +232,10 @@ func (s *mcpServer) handleSimImportModel(ctx context.Context, req mcpgo.CallTool
 	if err := validateSimImportSource(menageriePath, localPath); err != nil {
 		return mcpgo.NewToolResultError(err.Error()), nil
 	}
+	format, err := simutil.ResolveModelFormat(stringParam(req, "format"), menageriePath, localPath)
+	if err != nil {
+		return mcpgo.NewToolResultError(err.Error()), nil
+	}
 
 	stream, err := conn.SimService.ImportModel(ctx)
 	if err != nil {
@@ -235,7 +244,7 @@ func (s *mcpServer) handleSimImportModel(ctx context.Context, req mcpgo.CallTool
 	if err := stream.Send(&simpb.LoadModelChunk{
 		Payload: &simpb.LoadModelChunk_Source{Source: &simpb.ModelSource{
 			Name:          name,
-			Format:        simpb.ModelFormat_MODEL_FORMAT_MJCF,
+			Format:        format,
 			MenageriePath: menageriePath,
 		}},
 	}); err != nil {

--- a/go/internal/cli/mcp/tools_sim_test.go
+++ b/go/internal/cli/mcp/tools_sim_test.go
@@ -37,6 +37,86 @@ type fakeSimServer struct {
 	importedBytes  int
 	lastRunTask    *agentpbv2.RunSimTaskRequest
 	resetWorldID   string
+
+	// Interactive tooling captures / fixtures.
+	lastSetClock   *simpb.SetClockRequest
+	lastApplyForce *simpb.ApplyForceRequest
+	lastTeleport   *simpb.TeleportRequest
+	lastRestore    *simpb.RestoreSnapshotRequest
+	sensorReadings []*simpb.SensorReading
+	lastEditScene  *simpb.EditSceneRequest
+	policySource   *simpb.PolicySource
+	policyBytes    int
+	clearedPolicy  *simpb.ClearPolicyRequest
+	videoChunks    [][]byte
+	lastRender     *simpb.RenderVideoRequest
+}
+
+func (f *fakeSimServer) SetClock(_ context.Context, req *simpb.SetClockRequest) (*simpb.SetClockResponse, error) {
+	f.lastSetClock = req
+	return &simpb.SetClockResponse{Paused: req.GetPaused(), SpeedFactor: req.GetSpeedFactor()}, nil
+}
+
+func (f *fakeSimServer) ApplyForce(_ context.Context, req *simpb.ApplyForceRequest) (*simpb.ApplyForceResponse, error) {
+	f.lastApplyForce = req
+	return &simpb.ApplyForceResponse{}, nil
+}
+
+func (f *fakeSimServer) Teleport(_ context.Context, req *simpb.TeleportRequest) (*simpb.TeleportResponse, error) {
+	f.lastTeleport = req
+	return &simpb.TeleportResponse{}, nil
+}
+
+func (f *fakeSimServer) SaveSnapshot(_ context.Context, _ *simpb.SaveSnapshotRequest) (*simpb.SaveSnapshotResponse, error) {
+	return &simpb.SaveSnapshotResponse{SnapshotId: "snap-1"}, nil
+}
+
+func (f *fakeSimServer) RestoreSnapshot(_ context.Context, req *simpb.RestoreSnapshotRequest) (*simpb.RestoreSnapshotResponse, error) {
+	f.lastRestore = req
+	return &simpb.RestoreSnapshotResponse{}, nil
+}
+
+func (f *fakeSimServer) ReadSensors(_ context.Context, _ *simpb.ReadSensorsRequest) (*simpb.ReadSensorsResponse, error) {
+	return &simpb.ReadSensorsResponse{Readings: f.sensorReadings}, nil
+}
+
+func (f *fakeSimServer) EditScene(_ context.Context, req *simpb.EditSceneRequest) (*simpb.EditSceneResponse, error) {
+	f.lastEditScene = req
+	return &simpb.EditSceneResponse{}, nil
+}
+
+func (f *fakeSimServer) LoadPolicy(stream grpc.ClientStreamingServer[simpb.LoadPolicyChunk, simpb.LoadPolicyResponse]) error {
+	for {
+		chunk, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		switch p := chunk.GetPayload().(type) {
+		case *simpb.LoadPolicyChunk_Source:
+			f.policySource = p.Source
+		case *simpb.LoadPolicyChunk_Data:
+			f.policyBytes += len(p.Data)
+		}
+	}
+	return stream.SendAndClose(&simpb.LoadPolicyResponse{PolicyId: "policy-1"})
+}
+
+func (f *fakeSimServer) ClearPolicy(_ context.Context, req *simpb.ClearPolicyRequest) (*simpb.ClearPolicyResponse, error) {
+	f.clearedPolicy = req
+	return &simpb.ClearPolicyResponse{}, nil
+}
+
+func (f *fakeSimServer) RenderVideo(req *simpb.RenderVideoRequest, stream grpc.ServerStreamingServer[simpb.VideoChunk]) error {
+	f.lastRender = req
+	for _, data := range f.videoChunks {
+		if err := stream.Send(&simpb.VideoChunk{Data: data}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (f *fakeSimServer) CreateSimulation(_ context.Context, req *agentpbv2.CreateSimulationRequest) (*agentpbv2.CreateSimulationResponse, error) {
@@ -152,7 +232,9 @@ func TestSimTools_NotConnected(t *testing.T) {
 	for _, tool := range []string{
 		"sim_create", "sim_list", "sim_import_model", "sim_describe_model",
 		"sim_spawn", "sim_state", "sim_contacts", "run_task_in_sim",
-		"sim_replay", "sim_reset",
+		"sim_replay", "sim_reset", "sim_clock", "sim_push", "sim_teleport",
+		"sim_snapshot_save", "sim_snapshot_restore", "sim_sensors",
+		"sim_scene_edit", "sim_policy_load", "sim_policy_clear", "sim_record",
 	} {
 		result, err := srv.callTool(context.Background(), tool, map[string]any{})
 		if err != nil {
@@ -714,5 +796,372 @@ func TestSimReset_ForwardsWorldID(t *testing.T) {
 	}
 	if fake.resetWorldID != "w1" {
 		t.Errorf("resetWorldID = %q; want w1", fake.resetWorldID)
+	}
+}
+
+func TestSimClock_ForwardsAndReturnsState(t *testing.T) {
+	fake := &fakeSimServer{}
+	conn := startFakeSimServer(t, fake)
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+
+	result, err := srv.callTool(context.Background(), "sim_clock", map[string]any{
+		"world_id": "w1", "paused": true, "speed_factor": 4.0,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result.Content)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(toolResultText(t, result)), &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if got["paused"] != true || got["speed_factor"] != 4.0 {
+		t.Errorf("sim_clock = %v; want paused=true speed_factor=4", got)
+	}
+	if fake.lastSetClock.GetWorldId() != "w1" || !fake.lastSetClock.GetPaused() ||
+		fake.lastSetClock.GetSpeedFactor() != 4 {
+		t.Errorf("forwarded request = %+v", fake.lastSetClock)
+	}
+}
+
+func TestSimPush_ForwardsForce(t *testing.T) {
+	fake := &fakeSimServer{}
+	conn := startFakeSimServer(t, fake)
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+
+	result, err := srv.callTool(context.Background(), "sim_push", map[string]any{
+		"world_id": "w1", "robot_id": "r1", "force": "30,0,-5", "duration_s": 0.25,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result.Content)
+	}
+	got := fake.lastApplyForce
+	if got.GetFxN() != 30 || got.GetFyN() != 0 || got.GetFzN() != -5 || got.GetDurationS() != 0.25 {
+		t.Errorf("forwarded request = %+v", got)
+	}
+}
+
+func TestSimPush_DefaultsDurationAndValidatesForce(t *testing.T) {
+	fake := &fakeSimServer{}
+	conn := startFakeSimServer(t, fake)
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+
+	if result, err := srv.callTool(context.Background(), "sim_push", map[string]any{
+		"world_id": "w1", "robot_id": "r1", "force": "30,0,0",
+	}); err != nil || result.IsError {
+		t.Fatalf("push without duration: err=%v result=%v", err, result)
+	}
+	if fake.lastApplyForce.GetDurationS() != 0.1 {
+		t.Errorf("default duration = %v; want 0.1", fake.lastApplyForce.GetDurationS())
+	}
+
+	for name, force := range map[string]string{"missing": "", "malformed": "1,2"} {
+		result, err := srv.callTool(context.Background(), "sim_push", map[string]any{
+			"world_id": "w1", "robot_id": "r1", "force": force,
+		})
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", name, err)
+		}
+		if !result.IsError {
+			t.Errorf("%s force: expected IsError=true", name)
+		}
+	}
+}
+
+func TestSimTeleport_ForwardsPoseWithZeroVelocity(t *testing.T) {
+	fake := &fakeSimServer{}
+	conn := startFakeSimServer(t, fake)
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+
+	result, err := srv.callTool(context.Background(), "sim_teleport", map[string]any{
+		"world_id": "w1", "robot_id": "r1", "pos": "1,2,0.5",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result.Content)
+	}
+	got := fake.lastTeleport
+	if got.GetPose().GetX() != 1 || got.GetPose().GetY() != 2 || got.GetPose().GetZ() != 0.5 {
+		t.Errorf("forwarded pose = %+v", got.GetPose())
+	}
+	if !got.GetZeroVelocity() {
+		t.Error("zero_velocity should be true")
+	}
+
+	missing, err := srv.callTool(context.Background(), "sim_teleport", map[string]any{
+		"world_id": "w1", "robot_id": "r1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !missing.IsError {
+		t.Error("teleport without pos: expected IsError=true")
+	}
+}
+
+func TestSimSnapshotSaveAndRestore(t *testing.T) {
+	fake := &fakeSimServer{}
+	conn := startFakeSimServer(t, fake)
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+
+	result, err := srv.callTool(context.Background(), "sim_snapshot_save", map[string]any{"world_id": "w1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result.Content)
+	}
+	var got map[string]string
+	if err := json.Unmarshal([]byte(toolResultText(t, result)), &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if got["snapshot_id"] != "snap-1" {
+		t.Errorf("snapshot_id = %q; want snap-1", got["snapshot_id"])
+	}
+
+	restore, err := srv.callTool(context.Background(), "sim_snapshot_restore", map[string]any{
+		"world_id": "w1", "snapshot_id": "snap-1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if restore.IsError {
+		t.Fatalf("unexpected error result: %v", restore.Content)
+	}
+	if fake.lastRestore.GetWorldId() != "w1" || fake.lastRestore.GetSnapshotId() != "snap-1" {
+		t.Errorf("forwarded restore = %+v", fake.lastRestore)
+	}
+}
+
+func TestSimSensors_ReturnsBoundedReadings(t *testing.T) {
+	fake := &fakeSimServer{}
+	for i := 0; i < 60; i++ {
+		fake.sensorReadings = append(fake.sensorReadings, &simpb.SensorReading{
+			Name: fmt.Sprintf("sensor-%d", i), Type: "touch", Values: []float64{1},
+		})
+	}
+	conn := startFakeSimServer(t, fake)
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+
+	result, err := srv.callTool(context.Background(), "sim_sensors", map[string]any{
+		"world_id": "w1", "robot_id": "r1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result.Content)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(toolResultText(t, result)), &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	readings, _ := got["readings"].([]any)
+	if len(readings) != maxSimSensorReadings {
+		t.Errorf("len(readings) = %d; want %d", len(readings), maxSimSensorReadings)
+	}
+	if got["total_sensors"] != float64(60) || got["truncated"] != true {
+		t.Errorf("total/truncated = %v/%v; want 60/true", got["total_sensors"], got["truncated"])
+	}
+}
+
+func TestSimSceneEdit_AddBoxAndRemove(t *testing.T) {
+	fake := &fakeSimServer{}
+	conn := startFakeSimServer(t, fake)
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+
+	result, err := srv.callTool(context.Background(), "sim_scene_edit", map[string]any{
+		"world_id": "w1", "op": "add_box", "id": "crate", "pos": "1,0,0.25", "size": "0.5,0.5,0.5",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result.Content)
+	}
+	box := fake.lastEditScene.GetAddBox()
+	if box.GetId() != "crate" || box.GetPosition()[0] != 1 || box.GetSize()[2] != 0.5 {
+		t.Errorf("forwarded add_box = %+v", box)
+	}
+
+	remove, err := srv.callTool(context.Background(), "sim_scene_edit", map[string]any{
+		"world_id": "w1", "op": "remove", "id": "crate",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if remove.IsError {
+		t.Fatalf("unexpected error result: %v", remove.Content)
+	}
+	if fake.lastEditScene.GetRemoveId() != "crate" {
+		t.Errorf("forwarded remove_id = %q; want crate", fake.lastEditScene.GetRemoveId())
+	}
+}
+
+func TestSimSceneEdit_Validation(t *testing.T) {
+	conn := startFakeSimServer(t, &fakeSimServer{})
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+
+	for name, args := range map[string]map[string]any{
+		"bad op":           {"world_id": "w1", "op": "add_sphere", "id": "s1"},
+		"add_box no pos":   {"world_id": "w1", "op": "add_box", "id": "b1", "size": "1,1,1"},
+		"add_box bad size": {"world_id": "w1", "op": "add_box", "id": "b1", "pos": "0,0,0", "size": "1,1"},
+		"missing id":       {"world_id": "w1", "op": "remove"},
+	} {
+		result, err := srv.callTool(context.Background(), "sim_scene_edit", args)
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", name, err)
+		}
+		if !result.IsError {
+			t.Errorf("%s: expected IsError=true", name)
+		}
+	}
+}
+
+func TestSimPolicyLoad_StreamsFile(t *testing.T) {
+	policy := filepath.Join(t.TempDir(), "policy.onnx")
+	if err := os.WriteFile(policy, []byte("onnx-model-bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fake := &fakeSimServer{}
+	conn := startFakeSimServer(t, fake)
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+
+	result, err := srv.callTool(context.Background(), "sim_policy_load", map[string]any{
+		"world_id": "w1", "robot_id": "r1", "local_path": policy,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result.Content)
+	}
+	var got map[string]string
+	if err := json.Unmarshal([]byte(toolResultText(t, result)), &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if got["policy_id"] != "policy-1" {
+		t.Errorf("policy_id = %q; want policy-1", got["policy_id"])
+	}
+	if fake.policySource.GetWorldId() != "w1" || fake.policySource.GetRobotId() != "r1" ||
+		fake.policySource.GetFormat() != "onnx" {
+		t.Errorf("policy source = %+v", fake.policySource)
+	}
+	if fake.policyBytes != len("onnx-model-bytes") {
+		t.Errorf("policy bytes = %d; want %d", fake.policyBytes, len("onnx-model-bytes"))
+	}
+}
+
+func TestSimPolicyLoad_MissingFile(t *testing.T) {
+	conn := startFakeSimServer(t, &fakeSimServer{})
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+
+	result, err := srv.callTool(context.Background(), "sim_policy_load", map[string]any{
+		"world_id": "w1", "robot_id": "r1",
+		"local_path": filepath.Join(t.TempDir(), "nope.onnx"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected IsError=true for a missing policy file")
+	}
+}
+
+func TestSimPolicyClear_Forwards(t *testing.T) {
+	fake := &fakeSimServer{}
+	conn := startFakeSimServer(t, fake)
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+
+	result, err := srv.callTool(context.Background(), "sim_policy_clear", map[string]any{
+		"world_id": "w1", "robot_id": "r1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result.Content)
+	}
+	if fake.clearedPolicy.GetWorldId() != "w1" || fake.clearedPolicy.GetRobotId() != "r1" {
+		t.Errorf("forwarded request = %+v", fake.clearedPolicy)
+	}
+}
+
+func TestSimRecord_WritesFileAndReturnsPathNotBytes(t *testing.T) {
+	fake := &fakeSimServer{videoChunks: [][]byte{[]byte("mp4|"), []byte("data")}}
+	conn := startFakeSimServer(t, fake)
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+
+	path := filepath.Join(t.TempDir(), "clip.mp4")
+	result, err := srv.callTool(context.Background(), "sim_record", map[string]any{
+		"world_id": "w1", "robot_id": "r1", "duration_s": 2.0, "fps": 30, "output_path": path,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result.Content)
+	}
+	text := toolResultText(t, result)
+	var got map[string]any
+	if err := json.Unmarshal([]byte(text), &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if got["path"] != path || got["bytes"] != float64(8) {
+		t.Errorf("sim_record = %v; want path/bytes=8", got)
+	}
+	if strings.Contains(text, "mp4|data") {
+		t.Error("sim_record must not return the video bytes")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "mp4|data" {
+		t.Errorf("file content = %q; want mp4|data", data)
+	}
+	if fake.lastRender.GetDurationS() != 2 || fake.lastRender.GetFps() != 30 {
+		t.Errorf("forwarded request = %+v", fake.lastRender)
+	}
+}
+
+func TestSimImportModel_ReplaceModelID(t *testing.T) {
+	fake := &fakeSimServer{}
+	conn := startFakeSimServer(t, fake)
+	srv := New(&config.Config{}, nil)
+	srv.SetConn(conn)
+
+	result, err := srv.callTool(context.Background(), "sim_import_model", map[string]any{
+		"name":             "go2",
+		"menagerie_path":   "unitree_go2/go2.xml",
+		"replace_model_id": "model-old",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %v", result.Content)
+	}
+	if fake.importedSource.GetReplaceModelId() != "model-old" {
+		t.Errorf("replace_model_id = %q; want model-old", fake.importedSource.GetReplaceModelId())
 	}
 }

--- a/go/internal/cli/simutil/simutil.go
+++ b/go/internal/cli/simutil/simutil.go
@@ -109,21 +109,31 @@ func ParsePosition(pos string) (*simpb.Pose, error) {
 	if pos == "" {
 		return nil, nil
 	}
-	parts := strings.Split(pos, ",")
-	if len(parts) != 3 {
-		return nil, fmt.Errorf("invalid position %q: expected x,y,z", pos)
-	}
-	coords := make([]float64, 3)
-	for i, p := range parts {
-		v, err := strconv.ParseFloat(strings.TrimSpace(p), 64)
-		if err != nil {
-			return nil, fmt.Errorf("invalid position %q: %q is not a number", pos, strings.TrimSpace(p))
-		}
-		coords[i] = v
+	coords, err := ParseVector3(pos, "position")
+	if err != nil {
+		return nil, err
 	}
 	// Identity orientation (qw=1); the proto also treats an all-zero
 	// quaternion as identity, but being explicit costs nothing.
 	return &simpb.Pose{X: coords[0], Y: coords[1], Z: coords[2], Qw: 1}, nil
+}
+
+// ParseVector3 parses an "x,y,z" triple of numbers; what names the value in
+// error messages (e.g. "force", "size").
+func ParseVector3(s, what string) ([3]float64, error) {
+	var coords [3]float64
+	parts := strings.Split(s, ",")
+	if len(parts) != 3 {
+		return coords, fmt.Errorf("invalid %s %q: expected x,y,z", what, s)
+	}
+	for i, p := range parts {
+		v, err := strconv.ParseFloat(strings.TrimSpace(p), 64)
+		if err != nil {
+			return coords, fmt.Errorf("invalid %s %q: %q is not a number", what, s, strings.TrimSpace(p))
+		}
+		coords[i] = v
+	}
+	return coords, nil
 }
 
 // DownloadReplay fetches a replay from the agent's sim service and writes it

--- a/go/internal/cli/simutil/simutil.go
+++ b/go/internal/cli/simutil/simutil.go
@@ -24,6 +24,62 @@ import (
 // agent; small enough to stay well under gRPC message limits.
 const ModelChunkSize = 64 * 1024
 
+// ResolveModelFormat picks the ModelFormat for an import. An explicit name
+// ("mjcf", "sdf", "urdf") wins; a Menagerie source is always MJCF; a local
+// source is sniffed by the file extensions it contains (.sdf/.urdf beat the
+// MJCF default only when no plain .xml is present alongside them).
+func ResolveModelFormat(explicit, menageriePath, localPath string) (simpb.ModelFormat, error) {
+	switch strings.ToLower(strings.TrimSpace(explicit)) {
+	case "mjcf":
+		return simpb.ModelFormat_MODEL_FORMAT_MJCF, nil
+	case "sdf":
+		return simpb.ModelFormat_MODEL_FORMAT_SDF, nil
+	case "urdf":
+		return simpb.ModelFormat_MODEL_FORMAT_URDF, nil
+	case "":
+	default:
+		return simpb.ModelFormat_MODEL_FORMAT_UNSPECIFIED,
+			fmt.Errorf("invalid model format %q (expected mjcf, sdf, or urdf)", explicit)
+	}
+	if menageriePath != "" || localPath == "" {
+		return simpb.ModelFormat_MODEL_FORMAT_MJCF, nil
+	}
+	return detectLocalModelFormat(localPath), nil
+}
+
+// detectLocalModelFormat sniffs a local model dir/archive path by extension.
+func detectLocalModelFormat(localPath string) simpb.ModelFormat {
+	var sawSDF, sawURDF, sawXML bool
+	note := func(name string) {
+		switch strings.ToLower(filepath.Ext(name)) {
+		case ".sdf":
+			sawSDF = true
+		case ".urdf":
+			sawURDF = true
+		case ".xml":
+			sawXML = true
+		}
+	}
+	if info, err := os.Stat(localPath); err == nil && info.IsDir() {
+		entries, _ := os.ReadDir(localPath)
+		for _, e := range entries {
+			note(e.Name())
+		}
+	} else {
+		// Archive: sniff by the archive's own name (foo.sdf.tar.gz etc.
+		// won't match; the backend still validates content).
+		note(strings.TrimSuffix(strings.TrimSuffix(localPath, ".gz"), ".tar"))
+	}
+	switch {
+	case sawSDF && !sawXML:
+		return simpb.ModelFormat_MODEL_FORMAT_SDF
+	case sawURDF && !sawXML:
+		return simpb.ModelFormat_MODEL_FORMAT_URDF
+	default:
+		return simpb.ModelFormat_MODEL_FORMAT_MJCF
+	}
+}
+
 // ControlLevelName renders a simpb.ControlLevel as a short lowercase name
 // (e.g. "motion").
 func ControlLevelName(l simpb.ControlLevel) string {

--- a/go/internal/cli/simutil/simutil.go
+++ b/go/internal/cli/simutil/simutil.go
@@ -187,6 +187,18 @@ func WriteReplayFile(path string, recv func() ([]byte, error)) (int64, error) {
 	return written, nil
 }
 
+// StreamFileChunks streams a single file's raw bytes to send in chunks of at
+// most ModelChunkSize (used for policy uploads, where the wire carries the
+// file verbatim — no tarring or gunzipping).
+func StreamFileChunks(path string, send func([]byte) error) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return sendDataChunks(f, send)
+}
+
 // StreamLocalModel streams a local model as tar data chunks. A directory is
 // tarred on the fly; a file is streamed as-is, transparently gunzipping
 // .tar.gz/.tgz archives so the wire always carries a plain tar.

--- a/go/internal/cli/simutil/simutil_test.go
+++ b/go/internal/cli/simutil/simutil_test.go
@@ -320,6 +320,41 @@ func TestStreamLocalModel_Missing(t *testing.T) {
 	}
 }
 
+func TestStreamFileChunks(t *testing.T) {
+	// A file larger than one chunk streams verbatim across chunk boundaries.
+	data := bytes.Repeat([]byte("policy!"), 20000) // ~140KB > 2 chunks
+	path := filepath.Join(t.TempDir(), "policy.onnx")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var got bytes.Buffer
+	chunkCount := 0
+	err := StreamFileChunks(path, func(chunk []byte) error {
+		if len(chunk) > ModelChunkSize {
+			t.Errorf("chunk of %d bytes exceeds ModelChunkSize", len(chunk))
+		}
+		chunkCount++
+		got.Write(chunk)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("StreamFileChunks: %v", err)
+	}
+	if !bytes.Equal(got.Bytes(), data) {
+		t.Errorf("streamed %d bytes; want %d, byte-exact", got.Len(), len(data))
+	}
+	if chunkCount < 3 {
+		t.Errorf("chunkCount = %d; want >= 3", chunkCount)
+	}
+}
+
+func TestStreamFileChunks_Missing(t *testing.T) {
+	err := StreamFileChunks(filepath.Join(t.TempDir(), "nope.onnx"), func([]byte) error { return nil })
+	if err == nil {
+		t.Error("StreamFileChunks on a missing path should fail")
+	}
+}
+
 func TestWriteReplayFile(t *testing.T) {
 	chunks := [][]byte{
 		[]byte("rrd|"),

--- a/go/internal/cli/simutil/simutil_test.go
+++ b/go/internal/cli/simutil/simutil_test.go
@@ -50,6 +50,38 @@ func TestParsePosition(t *testing.T) {
 	}
 }
 
+func TestParseVector3(t *testing.T) {
+	tests := []struct {
+		s       string
+		want    [3]float64
+		wantErr bool
+	}{
+		{s: "1,2,0.5", want: [3]float64{1, 2, 0.5}},
+		{s: " -30 , 0 , 5 ", want: [3]float64{-30, 0, 5}},
+		{s: "", wantErr: true},
+		{s: "1,2", wantErr: true},
+		{s: "1,2,3,4", wantErr: true},
+		{s: "a,b,c", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.s, func(t *testing.T) {
+			got, err := ParseVector3(tt.s, "force")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseVector3(%q) error = %v; wantErr %v", tt.s, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				if err != nil && !strings.Contains(err.Error(), "force") {
+					t.Errorf("error %q should name the value (force)", err.Error())
+				}
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ParseVector3(%q) = %v; want %v", tt.s, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestControlLevelName(t *testing.T) {
 	if got := ControlLevelName(simpb.ControlLevel_CONTROL_LEVEL_MOTION); got != "motion" {
 		t.Errorf("ControlLevelName(MOTION) = %q; want motion", got)

--- a/go/internal/cli/simutil/simutil_test.go
+++ b/go/internal/cli/simutil/simutil_test.go
@@ -339,3 +339,43 @@ func TestWriteReplayFile_ErrorRemovesPartialFile(t *testing.T) {
 		t.Errorf("partial file %s should have been removed (stat err = %v)", path, statErr)
 	}
 }
+
+func TestResolveModelFormat(t *testing.T) {
+	sdfDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sdfDir, "model.sdf"), []byte("<sdf/>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	urdfDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(urdfDir, "robot.urdf"), []byte("<robot/>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mjcfDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(mjcfDir, "scene.xml"), []byte("<mujoco/>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name, explicit, menagerie, local string
+		want                             simpb.ModelFormat
+		wantErr                          bool
+	}{
+		{"explicit sdf wins", "sdf", "", mjcfDir, simpb.ModelFormat_MODEL_FORMAT_SDF, false},
+		{"explicit urdf", "URDF", "", "", simpb.ModelFormat_MODEL_FORMAT_URDF, false},
+		{"invalid explicit", "step", "", "", 0, true},
+		{"menagerie is mjcf", "", "unitree_go2/go2.xml", "", simpb.ModelFormat_MODEL_FORMAT_MJCF, false},
+		{"sdf dir detected", "", "", sdfDir, simpb.ModelFormat_MODEL_FORMAT_SDF, false},
+		{"urdf dir detected", "", "", urdfDir, simpb.ModelFormat_MODEL_FORMAT_URDF, false},
+		{"xml dir stays mjcf", "", "", mjcfDir, simpb.ModelFormat_MODEL_FORMAT_MJCF, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ResolveModelFormat(tc.explicit, tc.menagerie, tc.local)
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("err = %v, wantErr %v", err, tc.wantErr)
+			}
+			if !tc.wantErr && got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/go/proto/gen/agentpb/v2/sim_service.pb.go
+++ b/go/proto/gen/agentpb/v2/sim_service.pb.go
@@ -536,7 +536,7 @@ const file_wendy_agent_services_v2_sim_service_proto_rawDesc = "" +
 	"\x10GetReplayRequest\x12\x1b\n" +
 	"\treplay_id\x18\x01 \x01(\tR\breplayId\"$\n" +
 	"\x0eGetReplayChunk\x12\x12\n" +
-	"\x04data\x18\x01 \x01(\fR\x04data2\xfe\x0f\n" +
+	"\x04data\x18\x01 \x01(\fR\x04data2\xbd\x10\n" +
 	"\x0fWendySimService\x12w\n" +
 	"\x10CreateSimulation\x120.wendy.agent.services.v2.CreateSimulationRequest\x1a1.wendy.agent.services.v2.CreateSimulationResponse\x12t\n" +
 	"\x0fListSimulations\x12/.wendy.agent.services.v2.ListSimulationsRequest\x1a0.wendy.agent.services.v2.ListSimulationsResponse\x12t\n" +
@@ -549,7 +549,8 @@ const file_wendy_agent_services_v2_sim_service_proto_rawDesc = "" +
 	"\vGetContacts\x12 .wendy.sim.v1.GetContactsRequest\x1a!.wendy.sim.v1.GetContactsResponse\x12[\n" +
 	"\x0eGetCameraFrame\x12#.wendy.sim.v1.GetCameraFrameRequest\x1a$.wendy.sim.v1.GetCameraFrameResponse\x12R\n" +
 	"\vSetVelocity\x12 .wendy.sim.v1.SetVelocityRequest\x1a!.wendy.sim.v1.SetVelocityResponse\x12^\n" +
-	"\x0fSetJointTargets\x12$.wendy.sim.v1.SetJointTargetsRequest\x1a%.wendy.sim.v1.SetJointTargetsResponse\x12P\n" +
+	"\x0fSetJointTargets\x12$.wendy.sim.v1.SetJointTargetsRequest\x1a%.wendy.sim.v1.SetJointTargetsResponse\x12=\n" +
+	"\x04Step\x12\x19.wendy.sim.v1.StepRequest\x1a\x1a.wendy.sim.v1.StepResponse\x12P\n" +
 	"\aRunTask\x12*.wendy.agent.services.v2.RunSimTaskRequest\x1a\x17.wendy.sim.v1.TaskEvent0\x01\x12a\n" +
 	"\tGetReplay\x12).wendy.agent.services.v2.GetReplayRequest\x1a'.wendy.agent.services.v2.GetReplayChunk0\x01\x12I\n" +
 	"\bSetClock\x12\x1d.wendy.sim.v1.SetClockRequest\x1a\x1e.wendy.sim.v1.SetClockResponse\x12O\n" +
@@ -599,35 +600,37 @@ var file_wendy_agent_services_v2_sim_service_proto_goTypes = []any{
 	(*simpb.GetCameraFrameRequest)(nil),   // 17: wendy.sim.v1.GetCameraFrameRequest
 	(*simpb.SetVelocityRequest)(nil),      // 18: wendy.sim.v1.SetVelocityRequest
 	(*simpb.SetJointTargetsRequest)(nil),  // 19: wendy.sim.v1.SetJointTargetsRequest
-	(*simpb.SetClockRequest)(nil),         // 20: wendy.sim.v1.SetClockRequest
-	(*simpb.ApplyForceRequest)(nil),       // 21: wendy.sim.v1.ApplyForceRequest
-	(*simpb.TeleportRequest)(nil),         // 22: wendy.sim.v1.TeleportRequest
-	(*simpb.SaveSnapshotRequest)(nil),     // 23: wendy.sim.v1.SaveSnapshotRequest
-	(*simpb.RestoreSnapshotRequest)(nil),  // 24: wendy.sim.v1.RestoreSnapshotRequest
-	(*simpb.ReadSensorsRequest)(nil),      // 25: wendy.sim.v1.ReadSensorsRequest
-	(*simpb.EditSceneRequest)(nil),        // 26: wendy.sim.v1.EditSceneRequest
-	(*simpb.LoadPolicyChunk)(nil),         // 27: wendy.sim.v1.LoadPolicyChunk
-	(*simpb.ClearPolicyRequest)(nil),      // 28: wendy.sim.v1.ClearPolicyRequest
-	(*simpb.RenderVideoRequest)(nil),      // 29: wendy.sim.v1.RenderVideoRequest
-	(*simpb.LoadModelResponse)(nil),       // 30: wendy.sim.v1.LoadModelResponse
-	(*simpb.DescribeModelResponse)(nil),   // 31: wendy.sim.v1.DescribeModelResponse
-	(*simpb.SpawnResponse)(nil),           // 32: wendy.sim.v1.SpawnResponse
-	(*simpb.GetStateResponse)(nil),        // 33: wendy.sim.v1.GetStateResponse
-	(*simpb.GetContactsResponse)(nil),     // 34: wendy.sim.v1.GetContactsResponse
-	(*simpb.GetCameraFrameResponse)(nil),  // 35: wendy.sim.v1.GetCameraFrameResponse
-	(*simpb.SetVelocityResponse)(nil),     // 36: wendy.sim.v1.SetVelocityResponse
-	(*simpb.SetJointTargetsResponse)(nil), // 37: wendy.sim.v1.SetJointTargetsResponse
-	(*simpb.TaskEvent)(nil),               // 38: wendy.sim.v1.TaskEvent
-	(*simpb.SetClockResponse)(nil),        // 39: wendy.sim.v1.SetClockResponse
-	(*simpb.ApplyForceResponse)(nil),      // 40: wendy.sim.v1.ApplyForceResponse
-	(*simpb.TeleportResponse)(nil),        // 41: wendy.sim.v1.TeleportResponse
-	(*simpb.SaveSnapshotResponse)(nil),    // 42: wendy.sim.v1.SaveSnapshotResponse
-	(*simpb.RestoreSnapshotResponse)(nil), // 43: wendy.sim.v1.RestoreSnapshotResponse
-	(*simpb.ReadSensorsResponse)(nil),     // 44: wendy.sim.v1.ReadSensorsResponse
-	(*simpb.EditSceneResponse)(nil),       // 45: wendy.sim.v1.EditSceneResponse
-	(*simpb.LoadPolicyResponse)(nil),      // 46: wendy.sim.v1.LoadPolicyResponse
-	(*simpb.ClearPolicyResponse)(nil),     // 47: wendy.sim.v1.ClearPolicyResponse
-	(*simpb.VideoChunk)(nil),              // 48: wendy.sim.v1.VideoChunk
+	(*simpb.StepRequest)(nil),             // 20: wendy.sim.v1.StepRequest
+	(*simpb.SetClockRequest)(nil),         // 21: wendy.sim.v1.SetClockRequest
+	(*simpb.ApplyForceRequest)(nil),       // 22: wendy.sim.v1.ApplyForceRequest
+	(*simpb.TeleportRequest)(nil),         // 23: wendy.sim.v1.TeleportRequest
+	(*simpb.SaveSnapshotRequest)(nil),     // 24: wendy.sim.v1.SaveSnapshotRequest
+	(*simpb.RestoreSnapshotRequest)(nil),  // 25: wendy.sim.v1.RestoreSnapshotRequest
+	(*simpb.ReadSensorsRequest)(nil),      // 26: wendy.sim.v1.ReadSensorsRequest
+	(*simpb.EditSceneRequest)(nil),        // 27: wendy.sim.v1.EditSceneRequest
+	(*simpb.LoadPolicyChunk)(nil),         // 28: wendy.sim.v1.LoadPolicyChunk
+	(*simpb.ClearPolicyRequest)(nil),      // 29: wendy.sim.v1.ClearPolicyRequest
+	(*simpb.RenderVideoRequest)(nil),      // 30: wendy.sim.v1.RenderVideoRequest
+	(*simpb.LoadModelResponse)(nil),       // 31: wendy.sim.v1.LoadModelResponse
+	(*simpb.DescribeModelResponse)(nil),   // 32: wendy.sim.v1.DescribeModelResponse
+	(*simpb.SpawnResponse)(nil),           // 33: wendy.sim.v1.SpawnResponse
+	(*simpb.GetStateResponse)(nil),        // 34: wendy.sim.v1.GetStateResponse
+	(*simpb.GetContactsResponse)(nil),     // 35: wendy.sim.v1.GetContactsResponse
+	(*simpb.GetCameraFrameResponse)(nil),  // 36: wendy.sim.v1.GetCameraFrameResponse
+	(*simpb.SetVelocityResponse)(nil),     // 37: wendy.sim.v1.SetVelocityResponse
+	(*simpb.SetJointTargetsResponse)(nil), // 38: wendy.sim.v1.SetJointTargetsResponse
+	(*simpb.StepResponse)(nil),            // 39: wendy.sim.v1.StepResponse
+	(*simpb.TaskEvent)(nil),               // 40: wendy.sim.v1.TaskEvent
+	(*simpb.SetClockResponse)(nil),        // 41: wendy.sim.v1.SetClockResponse
+	(*simpb.ApplyForceResponse)(nil),      // 42: wendy.sim.v1.ApplyForceResponse
+	(*simpb.TeleportResponse)(nil),        // 43: wendy.sim.v1.TeleportResponse
+	(*simpb.SaveSnapshotResponse)(nil),    // 44: wendy.sim.v1.SaveSnapshotResponse
+	(*simpb.RestoreSnapshotResponse)(nil), // 45: wendy.sim.v1.RestoreSnapshotResponse
+	(*simpb.ReadSensorsResponse)(nil),     // 46: wendy.sim.v1.ReadSensorsResponse
+	(*simpb.EditSceneResponse)(nil),       // 47: wendy.sim.v1.EditSceneResponse
+	(*simpb.LoadPolicyResponse)(nil),      // 48: wendy.sim.v1.LoadPolicyResponse
+	(*simpb.ClearPolicyResponse)(nil),     // 49: wendy.sim.v1.ClearPolicyResponse
+	(*simpb.VideoChunk)(nil),              // 50: wendy.sim.v1.VideoChunk
 }
 var file_wendy_agent_services_v2_sim_service_proto_depIdxs = []int32{
 	4,  // 0: wendy.agent.services.v2.ListSimulationsResponse.simulations:type_name -> wendy.agent.services.v2.SimulationInfo
@@ -644,43 +647,45 @@ var file_wendy_agent_services_v2_sim_service_proto_depIdxs = []int32{
 	17, // 11: wendy.agent.services.v2.WendySimService.GetCameraFrame:input_type -> wendy.sim.v1.GetCameraFrameRequest
 	18, // 12: wendy.agent.services.v2.WendySimService.SetVelocity:input_type -> wendy.sim.v1.SetVelocityRequest
 	19, // 13: wendy.agent.services.v2.WendySimService.SetJointTargets:input_type -> wendy.sim.v1.SetJointTargetsRequest
-	7,  // 14: wendy.agent.services.v2.WendySimService.RunTask:input_type -> wendy.agent.services.v2.RunSimTaskRequest
-	8,  // 15: wendy.agent.services.v2.WendySimService.GetReplay:input_type -> wendy.agent.services.v2.GetReplayRequest
-	20, // 16: wendy.agent.services.v2.WendySimService.SetClock:input_type -> wendy.sim.v1.SetClockRequest
-	21, // 17: wendy.agent.services.v2.WendySimService.ApplyForce:input_type -> wendy.sim.v1.ApplyForceRequest
-	22, // 18: wendy.agent.services.v2.WendySimService.Teleport:input_type -> wendy.sim.v1.TeleportRequest
-	23, // 19: wendy.agent.services.v2.WendySimService.SaveSnapshot:input_type -> wendy.sim.v1.SaveSnapshotRequest
-	24, // 20: wendy.agent.services.v2.WendySimService.RestoreSnapshot:input_type -> wendy.sim.v1.RestoreSnapshotRequest
-	25, // 21: wendy.agent.services.v2.WendySimService.ReadSensors:input_type -> wendy.sim.v1.ReadSensorsRequest
-	26, // 22: wendy.agent.services.v2.WendySimService.EditScene:input_type -> wendy.sim.v1.EditSceneRequest
-	27, // 23: wendy.agent.services.v2.WendySimService.LoadPolicy:input_type -> wendy.sim.v1.LoadPolicyChunk
-	28, // 24: wendy.agent.services.v2.WendySimService.ClearPolicy:input_type -> wendy.sim.v1.ClearPolicyRequest
-	29, // 25: wendy.agent.services.v2.WendySimService.RenderVideo:input_type -> wendy.sim.v1.RenderVideoRequest
-	1,  // 26: wendy.agent.services.v2.WendySimService.CreateSimulation:output_type -> wendy.agent.services.v2.CreateSimulationResponse
-	3,  // 27: wendy.agent.services.v2.WendySimService.ListSimulations:output_type -> wendy.agent.services.v2.ListSimulationsResponse
-	6,  // 28: wendy.agent.services.v2.WendySimService.ResetSimulation:output_type -> wendy.agent.services.v2.ResetSimulationResponse
-	30, // 29: wendy.agent.services.v2.WendySimService.ImportModel:output_type -> wendy.sim.v1.LoadModelResponse
-	31, // 30: wendy.agent.services.v2.WendySimService.DescribeModel:output_type -> wendy.sim.v1.DescribeModelResponse
-	32, // 31: wendy.agent.services.v2.WendySimService.SpawnRobot:output_type -> wendy.sim.v1.SpawnResponse
-	33, // 32: wendy.agent.services.v2.WendySimService.GetState:output_type -> wendy.sim.v1.GetStateResponse
-	34, // 33: wendy.agent.services.v2.WendySimService.GetContacts:output_type -> wendy.sim.v1.GetContactsResponse
-	35, // 34: wendy.agent.services.v2.WendySimService.GetCameraFrame:output_type -> wendy.sim.v1.GetCameraFrameResponse
-	36, // 35: wendy.agent.services.v2.WendySimService.SetVelocity:output_type -> wendy.sim.v1.SetVelocityResponse
-	37, // 36: wendy.agent.services.v2.WendySimService.SetJointTargets:output_type -> wendy.sim.v1.SetJointTargetsResponse
-	38, // 37: wendy.agent.services.v2.WendySimService.RunTask:output_type -> wendy.sim.v1.TaskEvent
-	9,  // 38: wendy.agent.services.v2.WendySimService.GetReplay:output_type -> wendy.agent.services.v2.GetReplayChunk
-	39, // 39: wendy.agent.services.v2.WendySimService.SetClock:output_type -> wendy.sim.v1.SetClockResponse
-	40, // 40: wendy.agent.services.v2.WendySimService.ApplyForce:output_type -> wendy.sim.v1.ApplyForceResponse
-	41, // 41: wendy.agent.services.v2.WendySimService.Teleport:output_type -> wendy.sim.v1.TeleportResponse
-	42, // 42: wendy.agent.services.v2.WendySimService.SaveSnapshot:output_type -> wendy.sim.v1.SaveSnapshotResponse
-	43, // 43: wendy.agent.services.v2.WendySimService.RestoreSnapshot:output_type -> wendy.sim.v1.RestoreSnapshotResponse
-	44, // 44: wendy.agent.services.v2.WendySimService.ReadSensors:output_type -> wendy.sim.v1.ReadSensorsResponse
-	45, // 45: wendy.agent.services.v2.WendySimService.EditScene:output_type -> wendy.sim.v1.EditSceneResponse
-	46, // 46: wendy.agent.services.v2.WendySimService.LoadPolicy:output_type -> wendy.sim.v1.LoadPolicyResponse
-	47, // 47: wendy.agent.services.v2.WendySimService.ClearPolicy:output_type -> wendy.sim.v1.ClearPolicyResponse
-	48, // 48: wendy.agent.services.v2.WendySimService.RenderVideo:output_type -> wendy.sim.v1.VideoChunk
-	26, // [26:49] is the sub-list for method output_type
-	3,  // [3:26] is the sub-list for method input_type
+	20, // 14: wendy.agent.services.v2.WendySimService.Step:input_type -> wendy.sim.v1.StepRequest
+	7,  // 15: wendy.agent.services.v2.WendySimService.RunTask:input_type -> wendy.agent.services.v2.RunSimTaskRequest
+	8,  // 16: wendy.agent.services.v2.WendySimService.GetReplay:input_type -> wendy.agent.services.v2.GetReplayRequest
+	21, // 17: wendy.agent.services.v2.WendySimService.SetClock:input_type -> wendy.sim.v1.SetClockRequest
+	22, // 18: wendy.agent.services.v2.WendySimService.ApplyForce:input_type -> wendy.sim.v1.ApplyForceRequest
+	23, // 19: wendy.agent.services.v2.WendySimService.Teleport:input_type -> wendy.sim.v1.TeleportRequest
+	24, // 20: wendy.agent.services.v2.WendySimService.SaveSnapshot:input_type -> wendy.sim.v1.SaveSnapshotRequest
+	25, // 21: wendy.agent.services.v2.WendySimService.RestoreSnapshot:input_type -> wendy.sim.v1.RestoreSnapshotRequest
+	26, // 22: wendy.agent.services.v2.WendySimService.ReadSensors:input_type -> wendy.sim.v1.ReadSensorsRequest
+	27, // 23: wendy.agent.services.v2.WendySimService.EditScene:input_type -> wendy.sim.v1.EditSceneRequest
+	28, // 24: wendy.agent.services.v2.WendySimService.LoadPolicy:input_type -> wendy.sim.v1.LoadPolicyChunk
+	29, // 25: wendy.agent.services.v2.WendySimService.ClearPolicy:input_type -> wendy.sim.v1.ClearPolicyRequest
+	30, // 26: wendy.agent.services.v2.WendySimService.RenderVideo:input_type -> wendy.sim.v1.RenderVideoRequest
+	1,  // 27: wendy.agent.services.v2.WendySimService.CreateSimulation:output_type -> wendy.agent.services.v2.CreateSimulationResponse
+	3,  // 28: wendy.agent.services.v2.WendySimService.ListSimulations:output_type -> wendy.agent.services.v2.ListSimulationsResponse
+	6,  // 29: wendy.agent.services.v2.WendySimService.ResetSimulation:output_type -> wendy.agent.services.v2.ResetSimulationResponse
+	31, // 30: wendy.agent.services.v2.WendySimService.ImportModel:output_type -> wendy.sim.v1.LoadModelResponse
+	32, // 31: wendy.agent.services.v2.WendySimService.DescribeModel:output_type -> wendy.sim.v1.DescribeModelResponse
+	33, // 32: wendy.agent.services.v2.WendySimService.SpawnRobot:output_type -> wendy.sim.v1.SpawnResponse
+	34, // 33: wendy.agent.services.v2.WendySimService.GetState:output_type -> wendy.sim.v1.GetStateResponse
+	35, // 34: wendy.agent.services.v2.WendySimService.GetContacts:output_type -> wendy.sim.v1.GetContactsResponse
+	36, // 35: wendy.agent.services.v2.WendySimService.GetCameraFrame:output_type -> wendy.sim.v1.GetCameraFrameResponse
+	37, // 36: wendy.agent.services.v2.WendySimService.SetVelocity:output_type -> wendy.sim.v1.SetVelocityResponse
+	38, // 37: wendy.agent.services.v2.WendySimService.SetJointTargets:output_type -> wendy.sim.v1.SetJointTargetsResponse
+	39, // 38: wendy.agent.services.v2.WendySimService.Step:output_type -> wendy.sim.v1.StepResponse
+	40, // 39: wendy.agent.services.v2.WendySimService.RunTask:output_type -> wendy.sim.v1.TaskEvent
+	9,  // 40: wendy.agent.services.v2.WendySimService.GetReplay:output_type -> wendy.agent.services.v2.GetReplayChunk
+	41, // 41: wendy.agent.services.v2.WendySimService.SetClock:output_type -> wendy.sim.v1.SetClockResponse
+	42, // 42: wendy.agent.services.v2.WendySimService.ApplyForce:output_type -> wendy.sim.v1.ApplyForceResponse
+	43, // 43: wendy.agent.services.v2.WendySimService.Teleport:output_type -> wendy.sim.v1.TeleportResponse
+	44, // 44: wendy.agent.services.v2.WendySimService.SaveSnapshot:output_type -> wendy.sim.v1.SaveSnapshotResponse
+	45, // 45: wendy.agent.services.v2.WendySimService.RestoreSnapshot:output_type -> wendy.sim.v1.RestoreSnapshotResponse
+	46, // 46: wendy.agent.services.v2.WendySimService.ReadSensors:output_type -> wendy.sim.v1.ReadSensorsResponse
+	47, // 47: wendy.agent.services.v2.WendySimService.EditScene:output_type -> wendy.sim.v1.EditSceneResponse
+	48, // 48: wendy.agent.services.v2.WendySimService.LoadPolicy:output_type -> wendy.sim.v1.LoadPolicyResponse
+	49, // 49: wendy.agent.services.v2.WendySimService.ClearPolicy:output_type -> wendy.sim.v1.ClearPolicyResponse
+	50, // 50: wendy.agent.services.v2.WendySimService.RenderVideo:output_type -> wendy.sim.v1.VideoChunk
+	27, // [27:51] is the sub-list for method output_type
+	3,  // [3:27] is the sub-list for method input_type
 	3,  // [3:3] is the sub-list for extension type_name
 	3,  // [3:3] is the sub-list for extension extendee
 	0,  // [0:3] is the sub-list for field type_name

--- a/go/proto/gen/agentpb/v2/sim_service.pb.go
+++ b/go/proto/gen/agentpb/v2/sim_service.pb.go
@@ -536,7 +536,7 @@ const file_wendy_agent_services_v2_sim_service_proto_rawDesc = "" +
 	"\x10GetReplayRequest\x12\x1b\n" +
 	"\treplay_id\x18\x01 \x01(\tR\breplayId\"$\n" +
 	"\x0eGetReplayChunk\x12\x12\n" +
-	"\x04data\x18\x01 \x01(\fR\x04data2\xcc\t\n" +
+	"\x04data\x18\x01 \x01(\fR\x04data2\xfe\x0f\n" +
 	"\x0fWendySimService\x12w\n" +
 	"\x10CreateSimulation\x120.wendy.agent.services.v2.CreateSimulationRequest\x1a1.wendy.agent.services.v2.CreateSimulationResponse\x12t\n" +
 	"\x0fListSimulations\x12/.wendy.agent.services.v2.ListSimulationsRequest\x1a0.wendy.agent.services.v2.ListSimulationsResponse\x12t\n" +
@@ -551,7 +551,19 @@ const file_wendy_agent_services_v2_sim_service_proto_rawDesc = "" +
 	"\vSetVelocity\x12 .wendy.sim.v1.SetVelocityRequest\x1a!.wendy.sim.v1.SetVelocityResponse\x12^\n" +
 	"\x0fSetJointTargets\x12$.wendy.sim.v1.SetJointTargetsRequest\x1a%.wendy.sim.v1.SetJointTargetsResponse\x12P\n" +
 	"\aRunTask\x12*.wendy.agent.services.v2.RunSimTaskRequest\x1a\x17.wendy.sim.v1.TaskEvent0\x01\x12a\n" +
-	"\tGetReplay\x12).wendy.agent.services.v2.GetReplayRequest\x1a'.wendy.agent.services.v2.GetReplayChunk0\x01BAZ?github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2;agentpbv2b\x06proto3"
+	"\tGetReplay\x12).wendy.agent.services.v2.GetReplayRequest\x1a'.wendy.agent.services.v2.GetReplayChunk0\x01\x12I\n" +
+	"\bSetClock\x12\x1d.wendy.sim.v1.SetClockRequest\x1a\x1e.wendy.sim.v1.SetClockResponse\x12O\n" +
+	"\n" +
+	"ApplyForce\x12\x1f.wendy.sim.v1.ApplyForceRequest\x1a .wendy.sim.v1.ApplyForceResponse\x12I\n" +
+	"\bTeleport\x12\x1d.wendy.sim.v1.TeleportRequest\x1a\x1e.wendy.sim.v1.TeleportResponse\x12U\n" +
+	"\fSaveSnapshot\x12!.wendy.sim.v1.SaveSnapshotRequest\x1a\".wendy.sim.v1.SaveSnapshotResponse\x12^\n" +
+	"\x0fRestoreSnapshot\x12$.wendy.sim.v1.RestoreSnapshotRequest\x1a%.wendy.sim.v1.RestoreSnapshotResponse\x12R\n" +
+	"\vReadSensors\x12 .wendy.sim.v1.ReadSensorsRequest\x1a!.wendy.sim.v1.ReadSensorsResponse\x12L\n" +
+	"\tEditScene\x12\x1e.wendy.sim.v1.EditSceneRequest\x1a\x1f.wendy.sim.v1.EditSceneResponse\x12O\n" +
+	"\n" +
+	"LoadPolicy\x12\x1d.wendy.sim.v1.LoadPolicyChunk\x1a .wendy.sim.v1.LoadPolicyResponse(\x01\x12R\n" +
+	"\vClearPolicy\x12 .wendy.sim.v1.ClearPolicyRequest\x1a!.wendy.sim.v1.ClearPolicyResponse\x12K\n" +
+	"\vRenderVideo\x12 .wendy.sim.v1.RenderVideoRequest\x1a\x18.wendy.sim.v1.VideoChunk0\x01BAZ?github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2;agentpbv2b\x06proto3"
 
 var (
 	file_wendy_agent_services_v2_sim_service_proto_rawDescOnce sync.Once
@@ -587,15 +599,35 @@ var file_wendy_agent_services_v2_sim_service_proto_goTypes = []any{
 	(*simpb.GetCameraFrameRequest)(nil),   // 17: wendy.sim.v1.GetCameraFrameRequest
 	(*simpb.SetVelocityRequest)(nil),      // 18: wendy.sim.v1.SetVelocityRequest
 	(*simpb.SetJointTargetsRequest)(nil),  // 19: wendy.sim.v1.SetJointTargetsRequest
-	(*simpb.LoadModelResponse)(nil),       // 20: wendy.sim.v1.LoadModelResponse
-	(*simpb.DescribeModelResponse)(nil),   // 21: wendy.sim.v1.DescribeModelResponse
-	(*simpb.SpawnResponse)(nil),           // 22: wendy.sim.v1.SpawnResponse
-	(*simpb.GetStateResponse)(nil),        // 23: wendy.sim.v1.GetStateResponse
-	(*simpb.GetContactsResponse)(nil),     // 24: wendy.sim.v1.GetContactsResponse
-	(*simpb.GetCameraFrameResponse)(nil),  // 25: wendy.sim.v1.GetCameraFrameResponse
-	(*simpb.SetVelocityResponse)(nil),     // 26: wendy.sim.v1.SetVelocityResponse
-	(*simpb.SetJointTargetsResponse)(nil), // 27: wendy.sim.v1.SetJointTargetsResponse
-	(*simpb.TaskEvent)(nil),               // 28: wendy.sim.v1.TaskEvent
+	(*simpb.SetClockRequest)(nil),         // 20: wendy.sim.v1.SetClockRequest
+	(*simpb.ApplyForceRequest)(nil),       // 21: wendy.sim.v1.ApplyForceRequest
+	(*simpb.TeleportRequest)(nil),         // 22: wendy.sim.v1.TeleportRequest
+	(*simpb.SaveSnapshotRequest)(nil),     // 23: wendy.sim.v1.SaveSnapshotRequest
+	(*simpb.RestoreSnapshotRequest)(nil),  // 24: wendy.sim.v1.RestoreSnapshotRequest
+	(*simpb.ReadSensorsRequest)(nil),      // 25: wendy.sim.v1.ReadSensorsRequest
+	(*simpb.EditSceneRequest)(nil),        // 26: wendy.sim.v1.EditSceneRequest
+	(*simpb.LoadPolicyChunk)(nil),         // 27: wendy.sim.v1.LoadPolicyChunk
+	(*simpb.ClearPolicyRequest)(nil),      // 28: wendy.sim.v1.ClearPolicyRequest
+	(*simpb.RenderVideoRequest)(nil),      // 29: wendy.sim.v1.RenderVideoRequest
+	(*simpb.LoadModelResponse)(nil),       // 30: wendy.sim.v1.LoadModelResponse
+	(*simpb.DescribeModelResponse)(nil),   // 31: wendy.sim.v1.DescribeModelResponse
+	(*simpb.SpawnResponse)(nil),           // 32: wendy.sim.v1.SpawnResponse
+	(*simpb.GetStateResponse)(nil),        // 33: wendy.sim.v1.GetStateResponse
+	(*simpb.GetContactsResponse)(nil),     // 34: wendy.sim.v1.GetContactsResponse
+	(*simpb.GetCameraFrameResponse)(nil),  // 35: wendy.sim.v1.GetCameraFrameResponse
+	(*simpb.SetVelocityResponse)(nil),     // 36: wendy.sim.v1.SetVelocityResponse
+	(*simpb.SetJointTargetsResponse)(nil), // 37: wendy.sim.v1.SetJointTargetsResponse
+	(*simpb.TaskEvent)(nil),               // 38: wendy.sim.v1.TaskEvent
+	(*simpb.SetClockResponse)(nil),        // 39: wendy.sim.v1.SetClockResponse
+	(*simpb.ApplyForceResponse)(nil),      // 40: wendy.sim.v1.ApplyForceResponse
+	(*simpb.TeleportResponse)(nil),        // 41: wendy.sim.v1.TeleportResponse
+	(*simpb.SaveSnapshotResponse)(nil),    // 42: wendy.sim.v1.SaveSnapshotResponse
+	(*simpb.RestoreSnapshotResponse)(nil), // 43: wendy.sim.v1.RestoreSnapshotResponse
+	(*simpb.ReadSensorsResponse)(nil),     // 44: wendy.sim.v1.ReadSensorsResponse
+	(*simpb.EditSceneResponse)(nil),       // 45: wendy.sim.v1.EditSceneResponse
+	(*simpb.LoadPolicyResponse)(nil),      // 46: wendy.sim.v1.LoadPolicyResponse
+	(*simpb.ClearPolicyResponse)(nil),     // 47: wendy.sim.v1.ClearPolicyResponse
+	(*simpb.VideoChunk)(nil),              // 48: wendy.sim.v1.VideoChunk
 }
 var file_wendy_agent_services_v2_sim_service_proto_depIdxs = []int32{
 	4,  // 0: wendy.agent.services.v2.ListSimulationsResponse.simulations:type_name -> wendy.agent.services.v2.SimulationInfo
@@ -614,21 +646,41 @@ var file_wendy_agent_services_v2_sim_service_proto_depIdxs = []int32{
 	19, // 13: wendy.agent.services.v2.WendySimService.SetJointTargets:input_type -> wendy.sim.v1.SetJointTargetsRequest
 	7,  // 14: wendy.agent.services.v2.WendySimService.RunTask:input_type -> wendy.agent.services.v2.RunSimTaskRequest
 	8,  // 15: wendy.agent.services.v2.WendySimService.GetReplay:input_type -> wendy.agent.services.v2.GetReplayRequest
-	1,  // 16: wendy.agent.services.v2.WendySimService.CreateSimulation:output_type -> wendy.agent.services.v2.CreateSimulationResponse
-	3,  // 17: wendy.agent.services.v2.WendySimService.ListSimulations:output_type -> wendy.agent.services.v2.ListSimulationsResponse
-	6,  // 18: wendy.agent.services.v2.WendySimService.ResetSimulation:output_type -> wendy.agent.services.v2.ResetSimulationResponse
-	20, // 19: wendy.agent.services.v2.WendySimService.ImportModel:output_type -> wendy.sim.v1.LoadModelResponse
-	21, // 20: wendy.agent.services.v2.WendySimService.DescribeModel:output_type -> wendy.sim.v1.DescribeModelResponse
-	22, // 21: wendy.agent.services.v2.WendySimService.SpawnRobot:output_type -> wendy.sim.v1.SpawnResponse
-	23, // 22: wendy.agent.services.v2.WendySimService.GetState:output_type -> wendy.sim.v1.GetStateResponse
-	24, // 23: wendy.agent.services.v2.WendySimService.GetContacts:output_type -> wendy.sim.v1.GetContactsResponse
-	25, // 24: wendy.agent.services.v2.WendySimService.GetCameraFrame:output_type -> wendy.sim.v1.GetCameraFrameResponse
-	26, // 25: wendy.agent.services.v2.WendySimService.SetVelocity:output_type -> wendy.sim.v1.SetVelocityResponse
-	27, // 26: wendy.agent.services.v2.WendySimService.SetJointTargets:output_type -> wendy.sim.v1.SetJointTargetsResponse
-	28, // 27: wendy.agent.services.v2.WendySimService.RunTask:output_type -> wendy.sim.v1.TaskEvent
-	9,  // 28: wendy.agent.services.v2.WendySimService.GetReplay:output_type -> wendy.agent.services.v2.GetReplayChunk
-	16, // [16:29] is the sub-list for method output_type
-	3,  // [3:16] is the sub-list for method input_type
+	20, // 16: wendy.agent.services.v2.WendySimService.SetClock:input_type -> wendy.sim.v1.SetClockRequest
+	21, // 17: wendy.agent.services.v2.WendySimService.ApplyForce:input_type -> wendy.sim.v1.ApplyForceRequest
+	22, // 18: wendy.agent.services.v2.WendySimService.Teleport:input_type -> wendy.sim.v1.TeleportRequest
+	23, // 19: wendy.agent.services.v2.WendySimService.SaveSnapshot:input_type -> wendy.sim.v1.SaveSnapshotRequest
+	24, // 20: wendy.agent.services.v2.WendySimService.RestoreSnapshot:input_type -> wendy.sim.v1.RestoreSnapshotRequest
+	25, // 21: wendy.agent.services.v2.WendySimService.ReadSensors:input_type -> wendy.sim.v1.ReadSensorsRequest
+	26, // 22: wendy.agent.services.v2.WendySimService.EditScene:input_type -> wendy.sim.v1.EditSceneRequest
+	27, // 23: wendy.agent.services.v2.WendySimService.LoadPolicy:input_type -> wendy.sim.v1.LoadPolicyChunk
+	28, // 24: wendy.agent.services.v2.WendySimService.ClearPolicy:input_type -> wendy.sim.v1.ClearPolicyRequest
+	29, // 25: wendy.agent.services.v2.WendySimService.RenderVideo:input_type -> wendy.sim.v1.RenderVideoRequest
+	1,  // 26: wendy.agent.services.v2.WendySimService.CreateSimulation:output_type -> wendy.agent.services.v2.CreateSimulationResponse
+	3,  // 27: wendy.agent.services.v2.WendySimService.ListSimulations:output_type -> wendy.agent.services.v2.ListSimulationsResponse
+	6,  // 28: wendy.agent.services.v2.WendySimService.ResetSimulation:output_type -> wendy.agent.services.v2.ResetSimulationResponse
+	30, // 29: wendy.agent.services.v2.WendySimService.ImportModel:output_type -> wendy.sim.v1.LoadModelResponse
+	31, // 30: wendy.agent.services.v2.WendySimService.DescribeModel:output_type -> wendy.sim.v1.DescribeModelResponse
+	32, // 31: wendy.agent.services.v2.WendySimService.SpawnRobot:output_type -> wendy.sim.v1.SpawnResponse
+	33, // 32: wendy.agent.services.v2.WendySimService.GetState:output_type -> wendy.sim.v1.GetStateResponse
+	34, // 33: wendy.agent.services.v2.WendySimService.GetContacts:output_type -> wendy.sim.v1.GetContactsResponse
+	35, // 34: wendy.agent.services.v2.WendySimService.GetCameraFrame:output_type -> wendy.sim.v1.GetCameraFrameResponse
+	36, // 35: wendy.agent.services.v2.WendySimService.SetVelocity:output_type -> wendy.sim.v1.SetVelocityResponse
+	37, // 36: wendy.agent.services.v2.WendySimService.SetJointTargets:output_type -> wendy.sim.v1.SetJointTargetsResponse
+	38, // 37: wendy.agent.services.v2.WendySimService.RunTask:output_type -> wendy.sim.v1.TaskEvent
+	9,  // 38: wendy.agent.services.v2.WendySimService.GetReplay:output_type -> wendy.agent.services.v2.GetReplayChunk
+	39, // 39: wendy.agent.services.v2.WendySimService.SetClock:output_type -> wendy.sim.v1.SetClockResponse
+	40, // 40: wendy.agent.services.v2.WendySimService.ApplyForce:output_type -> wendy.sim.v1.ApplyForceResponse
+	41, // 41: wendy.agent.services.v2.WendySimService.Teleport:output_type -> wendy.sim.v1.TeleportResponse
+	42, // 42: wendy.agent.services.v2.WendySimService.SaveSnapshot:output_type -> wendy.sim.v1.SaveSnapshotResponse
+	43, // 43: wendy.agent.services.v2.WendySimService.RestoreSnapshot:output_type -> wendy.sim.v1.RestoreSnapshotResponse
+	44, // 44: wendy.agent.services.v2.WendySimService.ReadSensors:output_type -> wendy.sim.v1.ReadSensorsResponse
+	45, // 45: wendy.agent.services.v2.WendySimService.EditScene:output_type -> wendy.sim.v1.EditSceneResponse
+	46, // 46: wendy.agent.services.v2.WendySimService.LoadPolicy:output_type -> wendy.sim.v1.LoadPolicyResponse
+	47, // 47: wendy.agent.services.v2.WendySimService.ClearPolicy:output_type -> wendy.sim.v1.ClearPolicyResponse
+	48, // 48: wendy.agent.services.v2.WendySimService.RenderVideo:output_type -> wendy.sim.v1.VideoChunk
+	26, // [26:49] is the sub-list for method output_type
+	3,  // [3:26] is the sub-list for method input_type
 	3,  // [3:3] is the sub-list for extension type_name
 	3,  // [3:3] is the sub-list for extension extendee
 	0,  // [0:3] is the sub-list for field type_name

--- a/go/proto/gen/agentpb/v2/sim_service_grpc.pb.go
+++ b/go/proto/gen/agentpb/v2/sim_service_grpc.pb.go
@@ -31,6 +31,7 @@ const (
 	WendySimService_GetCameraFrame_FullMethodName   = "/wendy.agent.services.v2.WendySimService/GetCameraFrame"
 	WendySimService_SetVelocity_FullMethodName      = "/wendy.agent.services.v2.WendySimService/SetVelocity"
 	WendySimService_SetJointTargets_FullMethodName  = "/wendy.agent.services.v2.WendySimService/SetJointTargets"
+	WendySimService_Step_FullMethodName             = "/wendy.agent.services.v2.WendySimService/Step"
 	WendySimService_RunTask_FullMethodName          = "/wendy.agent.services.v2.WendySimService/RunTask"
 	WendySimService_GetReplay_FullMethodName        = "/wendy.agent.services.v2.WendySimService/GetReplay"
 	WendySimService_SetClock_FullMethodName         = "/wendy.agent.services.v2.WendySimService/SetClock"
@@ -74,6 +75,8 @@ type WendySimServiceClient interface {
 	GetCameraFrame(ctx context.Context, in *simpb.GetCameraFrameRequest, opts ...grpc.CallOption) (*simpb.GetCameraFrameResponse, error)
 	SetVelocity(ctx context.Context, in *simpb.SetVelocityRequest, opts ...grpc.CallOption) (*simpb.SetVelocityResponse, error)
 	SetJointTargets(ctx context.Context, in *simpb.SetJointTargetsRequest, opts ...grpc.CallOption) (*simpb.SetJointTargetsResponse, error)
+	// Step advances sim time deterministically (pairs with SetClock pause).
+	Step(ctx context.Context, in *simpb.StepRequest, opts ...grpc.CallOption) (*simpb.StepResponse, error)
 	// RunTask executes a task spec and streams progress, ending with a
 	// TaskResult.
 	RunTask(ctx context.Context, in *RunSimTaskRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[simpb.TaskEvent], error)
@@ -206,6 +209,16 @@ func (c *wendySimServiceClient) SetJointTargets(ctx context.Context, in *simpb.S
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(simpb.SetJointTargetsResponse)
 	err := c.cc.Invoke(ctx, WendySimService_SetJointTargets_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *wendySimServiceClient) Step(ctx context.Context, in *simpb.StepRequest, opts ...grpc.CallOption) (*simpb.StepResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(simpb.StepResponse)
+	err := c.cc.Invoke(ctx, WendySimService_Step_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -391,6 +404,8 @@ type WendySimServiceServer interface {
 	GetCameraFrame(context.Context, *simpb.GetCameraFrameRequest) (*simpb.GetCameraFrameResponse, error)
 	SetVelocity(context.Context, *simpb.SetVelocityRequest) (*simpb.SetVelocityResponse, error)
 	SetJointTargets(context.Context, *simpb.SetJointTargetsRequest) (*simpb.SetJointTargetsResponse, error)
+	// Step advances sim time deterministically (pairs with SetClock pause).
+	Step(context.Context, *simpb.StepRequest) (*simpb.StepResponse, error)
 	// RunTask executes a task spec and streams progress, ending with a
 	// TaskResult.
 	RunTask(*RunSimTaskRequest, grpc.ServerStreamingServer[simpb.TaskEvent]) error
@@ -448,6 +463,9 @@ func (UnimplementedWendySimServiceServer) SetVelocity(context.Context, *simpb.Se
 }
 func (UnimplementedWendySimServiceServer) SetJointTargets(context.Context, *simpb.SetJointTargetsRequest) (*simpb.SetJointTargetsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method SetJointTargets not implemented")
+}
+func (UnimplementedWendySimServiceServer) Step(context.Context, *simpb.StepRequest) (*simpb.StepResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method Step not implemented")
 }
 func (UnimplementedWendySimServiceServer) RunTask(*RunSimTaskRequest, grpc.ServerStreamingServer[simpb.TaskEvent]) error {
 	return status.Error(codes.Unimplemented, "method RunTask not implemented")
@@ -693,6 +711,24 @@ func _WendySimService_SetJointTargets_Handler(srv interface{}, ctx context.Conte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _WendySimService_Step_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(simpb.StepRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WendySimServiceServer).Step(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: WendySimService_Step_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WendySimServiceServer).Step(ctx, req.(*simpb.StepRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _WendySimService_RunTask_Handler(srv interface{}, stream grpc.ServerStream) error {
 	m := new(RunSimTaskRequest)
 	if err := stream.RecvMsg(m); err != nil {
@@ -923,6 +959,10 @@ var WendySimService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SetJointTargets",
 			Handler:    _WendySimService_SetJointTargets_Handler,
+		},
+		{
+			MethodName: "Step",
+			Handler:    _WendySimService_Step_Handler,
 		},
 		{
 			MethodName: "SetClock",

--- a/go/proto/gen/agentpb/v2/sim_service_grpc.pb.go
+++ b/go/proto/gen/agentpb/v2/sim_service_grpc.pb.go
@@ -33,6 +33,16 @@ const (
 	WendySimService_SetJointTargets_FullMethodName  = "/wendy.agent.services.v2.WendySimService/SetJointTargets"
 	WendySimService_RunTask_FullMethodName          = "/wendy.agent.services.v2.WendySimService/RunTask"
 	WendySimService_GetReplay_FullMethodName        = "/wendy.agent.services.v2.WendySimService/GetReplay"
+	WendySimService_SetClock_FullMethodName         = "/wendy.agent.services.v2.WendySimService/SetClock"
+	WendySimService_ApplyForce_FullMethodName       = "/wendy.agent.services.v2.WendySimService/ApplyForce"
+	WendySimService_Teleport_FullMethodName         = "/wendy.agent.services.v2.WendySimService/Teleport"
+	WendySimService_SaveSnapshot_FullMethodName     = "/wendy.agent.services.v2.WendySimService/SaveSnapshot"
+	WendySimService_RestoreSnapshot_FullMethodName  = "/wendy.agent.services.v2.WendySimService/RestoreSnapshot"
+	WendySimService_ReadSensors_FullMethodName      = "/wendy.agent.services.v2.WendySimService/ReadSensors"
+	WendySimService_EditScene_FullMethodName        = "/wendy.agent.services.v2.WendySimService/EditScene"
+	WendySimService_LoadPolicy_FullMethodName       = "/wendy.agent.services.v2.WendySimService/LoadPolicy"
+	WendySimService_ClearPolicy_FullMethodName      = "/wendy.agent.services.v2.WendySimService/ClearPolicy"
+	WendySimService_RenderVideo_FullMethodName      = "/wendy.agent.services.v2.WendySimService/RenderVideo"
 )
 
 // WendySimServiceClient is the client API for WendySimService service.
@@ -69,6 +79,16 @@ type WendySimServiceClient interface {
 	RunTask(ctx context.Context, in *RunSimTaskRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[simpb.TaskEvent], error)
 	// GetReplay downloads a finished replay (e.g. a Rerun .rrd) in chunks.
 	GetReplay(ctx context.Context, in *GetReplayRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[GetReplayChunk], error)
+	SetClock(ctx context.Context, in *simpb.SetClockRequest, opts ...grpc.CallOption) (*simpb.SetClockResponse, error)
+	ApplyForce(ctx context.Context, in *simpb.ApplyForceRequest, opts ...grpc.CallOption) (*simpb.ApplyForceResponse, error)
+	Teleport(ctx context.Context, in *simpb.TeleportRequest, opts ...grpc.CallOption) (*simpb.TeleportResponse, error)
+	SaveSnapshot(ctx context.Context, in *simpb.SaveSnapshotRequest, opts ...grpc.CallOption) (*simpb.SaveSnapshotResponse, error)
+	RestoreSnapshot(ctx context.Context, in *simpb.RestoreSnapshotRequest, opts ...grpc.CallOption) (*simpb.RestoreSnapshotResponse, error)
+	ReadSensors(ctx context.Context, in *simpb.ReadSensorsRequest, opts ...grpc.CallOption) (*simpb.ReadSensorsResponse, error)
+	EditScene(ctx context.Context, in *simpb.EditSceneRequest, opts ...grpc.CallOption) (*simpb.EditSceneResponse, error)
+	LoadPolicy(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStreamingClient[simpb.LoadPolicyChunk, simpb.LoadPolicyResponse], error)
+	ClearPolicy(ctx context.Context, in *simpb.ClearPolicyRequest, opts ...grpc.CallOption) (*simpb.ClearPolicyResponse, error)
+	RenderVideo(ctx context.Context, in *simpb.RenderVideoRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[simpb.VideoChunk], error)
 }
 
 type wendySimServiceClient struct {
@@ -230,6 +250,118 @@ func (c *wendySimServiceClient) GetReplay(ctx context.Context, in *GetReplayRequ
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type WendySimService_GetReplayClient = grpc.ServerStreamingClient[GetReplayChunk]
 
+func (c *wendySimServiceClient) SetClock(ctx context.Context, in *simpb.SetClockRequest, opts ...grpc.CallOption) (*simpb.SetClockResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(simpb.SetClockResponse)
+	err := c.cc.Invoke(ctx, WendySimService_SetClock_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *wendySimServiceClient) ApplyForce(ctx context.Context, in *simpb.ApplyForceRequest, opts ...grpc.CallOption) (*simpb.ApplyForceResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(simpb.ApplyForceResponse)
+	err := c.cc.Invoke(ctx, WendySimService_ApplyForce_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *wendySimServiceClient) Teleport(ctx context.Context, in *simpb.TeleportRequest, opts ...grpc.CallOption) (*simpb.TeleportResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(simpb.TeleportResponse)
+	err := c.cc.Invoke(ctx, WendySimService_Teleport_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *wendySimServiceClient) SaveSnapshot(ctx context.Context, in *simpb.SaveSnapshotRequest, opts ...grpc.CallOption) (*simpb.SaveSnapshotResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(simpb.SaveSnapshotResponse)
+	err := c.cc.Invoke(ctx, WendySimService_SaveSnapshot_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *wendySimServiceClient) RestoreSnapshot(ctx context.Context, in *simpb.RestoreSnapshotRequest, opts ...grpc.CallOption) (*simpb.RestoreSnapshotResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(simpb.RestoreSnapshotResponse)
+	err := c.cc.Invoke(ctx, WendySimService_RestoreSnapshot_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *wendySimServiceClient) ReadSensors(ctx context.Context, in *simpb.ReadSensorsRequest, opts ...grpc.CallOption) (*simpb.ReadSensorsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(simpb.ReadSensorsResponse)
+	err := c.cc.Invoke(ctx, WendySimService_ReadSensors_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *wendySimServiceClient) EditScene(ctx context.Context, in *simpb.EditSceneRequest, opts ...grpc.CallOption) (*simpb.EditSceneResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(simpb.EditSceneResponse)
+	err := c.cc.Invoke(ctx, WendySimService_EditScene_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *wendySimServiceClient) LoadPolicy(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStreamingClient[simpb.LoadPolicyChunk, simpb.LoadPolicyResponse], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &WendySimService_ServiceDesc.Streams[3], WendySimService_LoadPolicy_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[simpb.LoadPolicyChunk, simpb.LoadPolicyResponse]{ClientStream: stream}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type WendySimService_LoadPolicyClient = grpc.ClientStreamingClient[simpb.LoadPolicyChunk, simpb.LoadPolicyResponse]
+
+func (c *wendySimServiceClient) ClearPolicy(ctx context.Context, in *simpb.ClearPolicyRequest, opts ...grpc.CallOption) (*simpb.ClearPolicyResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(simpb.ClearPolicyResponse)
+	err := c.cc.Invoke(ctx, WendySimService_ClearPolicy_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *wendySimServiceClient) RenderVideo(ctx context.Context, in *simpb.RenderVideoRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[simpb.VideoChunk], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &WendySimService_ServiceDesc.Streams[4], WendySimService_RenderVideo_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[simpb.RenderVideoRequest, simpb.VideoChunk]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type WendySimService_RenderVideoClient = grpc.ServerStreamingClient[simpb.VideoChunk]
+
 // WendySimServiceServer is the server API for WendySimService service.
 // All implementations must embed UnimplementedWendySimServiceServer
 // for forward compatibility.
@@ -264,6 +396,16 @@ type WendySimServiceServer interface {
 	RunTask(*RunSimTaskRequest, grpc.ServerStreamingServer[simpb.TaskEvent]) error
 	// GetReplay downloads a finished replay (e.g. a Rerun .rrd) in chunks.
 	GetReplay(*GetReplayRequest, grpc.ServerStreamingServer[GetReplayChunk]) error
+	SetClock(context.Context, *simpb.SetClockRequest) (*simpb.SetClockResponse, error)
+	ApplyForce(context.Context, *simpb.ApplyForceRequest) (*simpb.ApplyForceResponse, error)
+	Teleport(context.Context, *simpb.TeleportRequest) (*simpb.TeleportResponse, error)
+	SaveSnapshot(context.Context, *simpb.SaveSnapshotRequest) (*simpb.SaveSnapshotResponse, error)
+	RestoreSnapshot(context.Context, *simpb.RestoreSnapshotRequest) (*simpb.RestoreSnapshotResponse, error)
+	ReadSensors(context.Context, *simpb.ReadSensorsRequest) (*simpb.ReadSensorsResponse, error)
+	EditScene(context.Context, *simpb.EditSceneRequest) (*simpb.EditSceneResponse, error)
+	LoadPolicy(grpc.ClientStreamingServer[simpb.LoadPolicyChunk, simpb.LoadPolicyResponse]) error
+	ClearPolicy(context.Context, *simpb.ClearPolicyRequest) (*simpb.ClearPolicyResponse, error)
+	RenderVideo(*simpb.RenderVideoRequest, grpc.ServerStreamingServer[simpb.VideoChunk]) error
 	mustEmbedUnimplementedWendySimServiceServer()
 }
 
@@ -312,6 +454,36 @@ func (UnimplementedWendySimServiceServer) RunTask(*RunSimTaskRequest, grpc.Serve
 }
 func (UnimplementedWendySimServiceServer) GetReplay(*GetReplayRequest, grpc.ServerStreamingServer[GetReplayChunk]) error {
 	return status.Error(codes.Unimplemented, "method GetReplay not implemented")
+}
+func (UnimplementedWendySimServiceServer) SetClock(context.Context, *simpb.SetClockRequest) (*simpb.SetClockResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SetClock not implemented")
+}
+func (UnimplementedWendySimServiceServer) ApplyForce(context.Context, *simpb.ApplyForceRequest) (*simpb.ApplyForceResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ApplyForce not implemented")
+}
+func (UnimplementedWendySimServiceServer) Teleport(context.Context, *simpb.TeleportRequest) (*simpb.TeleportResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method Teleport not implemented")
+}
+func (UnimplementedWendySimServiceServer) SaveSnapshot(context.Context, *simpb.SaveSnapshotRequest) (*simpb.SaveSnapshotResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SaveSnapshot not implemented")
+}
+func (UnimplementedWendySimServiceServer) RestoreSnapshot(context.Context, *simpb.RestoreSnapshotRequest) (*simpb.RestoreSnapshotResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RestoreSnapshot not implemented")
+}
+func (UnimplementedWendySimServiceServer) ReadSensors(context.Context, *simpb.ReadSensorsRequest) (*simpb.ReadSensorsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ReadSensors not implemented")
+}
+func (UnimplementedWendySimServiceServer) EditScene(context.Context, *simpb.EditSceneRequest) (*simpb.EditSceneResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method EditScene not implemented")
+}
+func (UnimplementedWendySimServiceServer) LoadPolicy(grpc.ClientStreamingServer[simpb.LoadPolicyChunk, simpb.LoadPolicyResponse]) error {
+	return status.Error(codes.Unimplemented, "method LoadPolicy not implemented")
+}
+func (UnimplementedWendySimServiceServer) ClearPolicy(context.Context, *simpb.ClearPolicyRequest) (*simpb.ClearPolicyResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ClearPolicy not implemented")
+}
+func (UnimplementedWendySimServiceServer) RenderVideo(*simpb.RenderVideoRequest, grpc.ServerStreamingServer[simpb.VideoChunk]) error {
+	return status.Error(codes.Unimplemented, "method RenderVideo not implemented")
 }
 func (UnimplementedWendySimServiceServer) mustEmbedUnimplementedWendySimServiceServer() {}
 func (UnimplementedWendySimServiceServer) testEmbeddedByValue()                         {}
@@ -543,6 +715,168 @@ func _WendySimService_GetReplay_Handler(srv interface{}, stream grpc.ServerStrea
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type WendySimService_GetReplayServer = grpc.ServerStreamingServer[GetReplayChunk]
 
+func _WendySimService_SetClock_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(simpb.SetClockRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WendySimServiceServer).SetClock(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: WendySimService_SetClock_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WendySimServiceServer).SetClock(ctx, req.(*simpb.SetClockRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _WendySimService_ApplyForce_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(simpb.ApplyForceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WendySimServiceServer).ApplyForce(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: WendySimService_ApplyForce_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WendySimServiceServer).ApplyForce(ctx, req.(*simpb.ApplyForceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _WendySimService_Teleport_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(simpb.TeleportRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WendySimServiceServer).Teleport(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: WendySimService_Teleport_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WendySimServiceServer).Teleport(ctx, req.(*simpb.TeleportRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _WendySimService_SaveSnapshot_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(simpb.SaveSnapshotRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WendySimServiceServer).SaveSnapshot(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: WendySimService_SaveSnapshot_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WendySimServiceServer).SaveSnapshot(ctx, req.(*simpb.SaveSnapshotRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _WendySimService_RestoreSnapshot_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(simpb.RestoreSnapshotRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WendySimServiceServer).RestoreSnapshot(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: WendySimService_RestoreSnapshot_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WendySimServiceServer).RestoreSnapshot(ctx, req.(*simpb.RestoreSnapshotRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _WendySimService_ReadSensors_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(simpb.ReadSensorsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WendySimServiceServer).ReadSensors(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: WendySimService_ReadSensors_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WendySimServiceServer).ReadSensors(ctx, req.(*simpb.ReadSensorsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _WendySimService_EditScene_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(simpb.EditSceneRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WendySimServiceServer).EditScene(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: WendySimService_EditScene_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WendySimServiceServer).EditScene(ctx, req.(*simpb.EditSceneRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _WendySimService_LoadPolicy_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(WendySimServiceServer).LoadPolicy(&grpc.GenericServerStream[simpb.LoadPolicyChunk, simpb.LoadPolicyResponse]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type WendySimService_LoadPolicyServer = grpc.ClientStreamingServer[simpb.LoadPolicyChunk, simpb.LoadPolicyResponse]
+
+func _WendySimService_ClearPolicy_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(simpb.ClearPolicyRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WendySimServiceServer).ClearPolicy(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: WendySimService_ClearPolicy_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WendySimServiceServer).ClearPolicy(ctx, req.(*simpb.ClearPolicyRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _WendySimService_RenderVideo_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(simpb.RenderVideoRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(WendySimServiceServer).RenderVideo(m, &grpc.GenericServerStream[simpb.RenderVideoRequest, simpb.VideoChunk]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type WendySimService_RenderVideoServer = grpc.ServerStreamingServer[simpb.VideoChunk]
+
 // WendySimService_ServiceDesc is the grpc.ServiceDesc for WendySimService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -590,6 +924,38 @@ var WendySimService_ServiceDesc = grpc.ServiceDesc{
 			MethodName: "SetJointTargets",
 			Handler:    _WendySimService_SetJointTargets_Handler,
 		},
+		{
+			MethodName: "SetClock",
+			Handler:    _WendySimService_SetClock_Handler,
+		},
+		{
+			MethodName: "ApplyForce",
+			Handler:    _WendySimService_ApplyForce_Handler,
+		},
+		{
+			MethodName: "Teleport",
+			Handler:    _WendySimService_Teleport_Handler,
+		},
+		{
+			MethodName: "SaveSnapshot",
+			Handler:    _WendySimService_SaveSnapshot_Handler,
+		},
+		{
+			MethodName: "RestoreSnapshot",
+			Handler:    _WendySimService_RestoreSnapshot_Handler,
+		},
+		{
+			MethodName: "ReadSensors",
+			Handler:    _WendySimService_ReadSensors_Handler,
+		},
+		{
+			MethodName: "EditScene",
+			Handler:    _WendySimService_EditScene_Handler,
+		},
+		{
+			MethodName: "ClearPolicy",
+			Handler:    _WendySimService_ClearPolicy_Handler,
+		},
 	},
 	Streams: []grpc.StreamDesc{
 		{
@@ -605,6 +971,16 @@ var WendySimService_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "GetReplay",
 			Handler:       _WendySimService_GetReplay_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "LoadPolicy",
+			Handler:       _WendySimService_LoadPolicy_Handler,
+			ClientStreams: true,
+		},
+		{
+			StreamName:    "RenderVideo",
+			Handler:       _WendySimService_RenderVideo_Handler,
 			ServerStreams: true,
 		},
 	},

--- a/go/proto/gen/simpb/robot_backend.pb.go
+++ b/go/proto/gen/simpb/robot_backend.pb.go
@@ -224,8 +224,11 @@ type ModelSource struct {
 	// When set, the backend loads a bundled MuJoCo Menagerie model by path
 	// (e.g. "unitree_go2/go2.xml") and no data chunks follow.
 	MenageriePath string `protobuf:"bytes,3,opt,name=menagerie_path,json=menageriePath,proto3" json:"menagerie_path,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// When set, replace this existing model in place (the edit-reload dev
+	// loop): robots spawned from it are respawned against the new model.
+	ReplaceModelId string `protobuf:"bytes,4,opt,name=replace_model_id,json=replaceModelId,proto3" json:"replace_model_id,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *ModelSource) Reset() {
@@ -275,6 +278,13 @@ func (x *ModelSource) GetFormat() ModelFormat {
 func (x *ModelSource) GetMenageriePath() string {
 	if x != nil {
 		return x.MenageriePath
+	}
+	return ""
+}
+
+func (x *ModelSource) GetReplaceModelId() string {
+	if x != nil {
+		return x.ReplaceModelId
 	}
 	return ""
 }
@@ -2410,6 +2420,1285 @@ func (x *StartRecordingResponse) GetRecordingId() string {
 	return ""
 }
 
+type SetClockRequest struct {
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	WorldId string                 `protobuf:"bytes,1,opt,name=world_id,json=worldId,proto3" json:"world_id,omitempty"`
+	// True pauses physics stepping; false resumes it.
+	Paused bool `protobuf:"varint,2,opt,name=paused,proto3" json:"paused,omitempty"`
+	// Real-time pacing multiplier (1.0 = real time, 10 = 10x fast-forward,
+	// 0 = leave the current factor unchanged).
+	SpeedFactor   float64 `protobuf:"fixed64,3,opt,name=speed_factor,json=speedFactor,proto3" json:"speed_factor,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetClockRequest) Reset() {
+	*x = SetClockRequest{}
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[39]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetClockRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetClockRequest) ProtoMessage() {}
+
+func (x *SetClockRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[39]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetClockRequest.ProtoReflect.Descriptor instead.
+func (*SetClockRequest) Descriptor() ([]byte, []int) {
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{39}
+}
+
+func (x *SetClockRequest) GetWorldId() string {
+	if x != nil {
+		return x.WorldId
+	}
+	return ""
+}
+
+func (x *SetClockRequest) GetPaused() bool {
+	if x != nil {
+		return x.Paused
+	}
+	return false
+}
+
+func (x *SetClockRequest) GetSpeedFactor() float64 {
+	if x != nil {
+		return x.SpeedFactor
+	}
+	return 0
+}
+
+type SetClockResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Paused        bool                   `protobuf:"varint,1,opt,name=paused,proto3" json:"paused,omitempty"`
+	SpeedFactor   float64                `protobuf:"fixed64,2,opt,name=speed_factor,json=speedFactor,proto3" json:"speed_factor,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetClockResponse) Reset() {
+	*x = SetClockResponse{}
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[40]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetClockResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetClockResponse) ProtoMessage() {}
+
+func (x *SetClockResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[40]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetClockResponse.ProtoReflect.Descriptor instead.
+func (*SetClockResponse) Descriptor() ([]byte, []int) {
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{40}
+}
+
+func (x *SetClockResponse) GetPaused() bool {
+	if x != nil {
+		return x.Paused
+	}
+	return false
+}
+
+func (x *SetClockResponse) GetSpeedFactor() float64 {
+	if x != nil {
+		return x.SpeedFactor
+	}
+	return 0
+}
+
+type ApplyForceRequest struct {
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	WorldId string                 `protobuf:"bytes,1,opt,name=world_id,json=worldId,proto3" json:"world_id,omitempty"`
+	RobotId string                 `protobuf:"bytes,2,opt,name=robot_id,json=robotId,proto3" json:"robot_id,omitempty"`
+	// World-frame force in Newtons applied at the base's center of mass.
+	FxN float64 `protobuf:"fixed64,3,opt,name=fx_n,json=fxN,proto3" json:"fx_n,omitempty"`
+	FyN float64 `protobuf:"fixed64,4,opt,name=fy_n,json=fyN,proto3" json:"fy_n,omitempty"`
+	FzN float64 `protobuf:"fixed64,5,opt,name=fz_n,json=fzN,proto3" json:"fz_n,omitempty"`
+	// How long the force is held, in sim seconds (0 = one physics step).
+	DurationS     float64 `protobuf:"fixed64,6,opt,name=duration_s,json=durationS,proto3" json:"duration_s,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ApplyForceRequest) Reset() {
+	*x = ApplyForceRequest{}
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[41]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ApplyForceRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ApplyForceRequest) ProtoMessage() {}
+
+func (x *ApplyForceRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[41]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ApplyForceRequest.ProtoReflect.Descriptor instead.
+func (*ApplyForceRequest) Descriptor() ([]byte, []int) {
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{41}
+}
+
+func (x *ApplyForceRequest) GetWorldId() string {
+	if x != nil {
+		return x.WorldId
+	}
+	return ""
+}
+
+func (x *ApplyForceRequest) GetRobotId() string {
+	if x != nil {
+		return x.RobotId
+	}
+	return ""
+}
+
+func (x *ApplyForceRequest) GetFxN() float64 {
+	if x != nil {
+		return x.FxN
+	}
+	return 0
+}
+
+func (x *ApplyForceRequest) GetFyN() float64 {
+	if x != nil {
+		return x.FyN
+	}
+	return 0
+}
+
+func (x *ApplyForceRequest) GetFzN() float64 {
+	if x != nil {
+		return x.FzN
+	}
+	return 0
+}
+
+func (x *ApplyForceRequest) GetDurationS() float64 {
+	if x != nil {
+		return x.DurationS
+	}
+	return 0
+}
+
+type ApplyForceResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ApplyForceResponse) Reset() {
+	*x = ApplyForceResponse{}
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[42]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ApplyForceResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ApplyForceResponse) ProtoMessage() {}
+
+func (x *ApplyForceResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[42]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ApplyForceResponse.ProtoReflect.Descriptor instead.
+func (*ApplyForceResponse) Descriptor() ([]byte, []int) {
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{42}
+}
+
+type TeleportRequest struct {
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	WorldId string                 `protobuf:"bytes,1,opt,name=world_id,json=worldId,proto3" json:"world_id,omitempty"`
+	RobotId string                 `protobuf:"bytes,2,opt,name=robot_id,json=robotId,proto3" json:"robot_id,omitempty"`
+	Pose    *Pose                  `protobuf:"bytes,3,opt,name=pose,proto3" json:"pose,omitempty"`
+	// Also zero the robot's velocities (default behavior when true).
+	ZeroVelocity  bool `protobuf:"varint,4,opt,name=zero_velocity,json=zeroVelocity,proto3" json:"zero_velocity,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TeleportRequest) Reset() {
+	*x = TeleportRequest{}
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[43]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TeleportRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TeleportRequest) ProtoMessage() {}
+
+func (x *TeleportRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[43]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TeleportRequest.ProtoReflect.Descriptor instead.
+func (*TeleportRequest) Descriptor() ([]byte, []int) {
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{43}
+}
+
+func (x *TeleportRequest) GetWorldId() string {
+	if x != nil {
+		return x.WorldId
+	}
+	return ""
+}
+
+func (x *TeleportRequest) GetRobotId() string {
+	if x != nil {
+		return x.RobotId
+	}
+	return ""
+}
+
+func (x *TeleportRequest) GetPose() *Pose {
+	if x != nil {
+		return x.Pose
+	}
+	return nil
+}
+
+func (x *TeleportRequest) GetZeroVelocity() bool {
+	if x != nil {
+		return x.ZeroVelocity
+	}
+	return false
+}
+
+type TeleportResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TeleportResponse) Reset() {
+	*x = TeleportResponse{}
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[44]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TeleportResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TeleportResponse) ProtoMessage() {}
+
+func (x *TeleportResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[44]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TeleportResponse.ProtoReflect.Descriptor instead.
+func (*TeleportResponse) Descriptor() ([]byte, []int) {
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{44}
+}
+
+type SaveSnapshotRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	WorldId       string                 `protobuf:"bytes,1,opt,name=world_id,json=worldId,proto3" json:"world_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SaveSnapshotRequest) Reset() {
+	*x = SaveSnapshotRequest{}
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SaveSnapshotRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SaveSnapshotRequest) ProtoMessage() {}
+
+func (x *SaveSnapshotRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SaveSnapshotRequest.ProtoReflect.Descriptor instead.
+func (*SaveSnapshotRequest) Descriptor() ([]byte, []int) {
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{45}
+}
+
+func (x *SaveSnapshotRequest) GetWorldId() string {
+	if x != nil {
+		return x.WorldId
+	}
+	return ""
+}
+
+type SaveSnapshotResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SnapshotId    string                 `protobuf:"bytes,1,opt,name=snapshot_id,json=snapshotId,proto3" json:"snapshot_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SaveSnapshotResponse) Reset() {
+	*x = SaveSnapshotResponse{}
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[46]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SaveSnapshotResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SaveSnapshotResponse) ProtoMessage() {}
+
+func (x *SaveSnapshotResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[46]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SaveSnapshotResponse.ProtoReflect.Descriptor instead.
+func (*SaveSnapshotResponse) Descriptor() ([]byte, []int) {
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{46}
+}
+
+func (x *SaveSnapshotResponse) GetSnapshotId() string {
+	if x != nil {
+		return x.SnapshotId
+	}
+	return ""
+}
+
+type RestoreSnapshotRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	WorldId       string                 `protobuf:"bytes,1,opt,name=world_id,json=worldId,proto3" json:"world_id,omitempty"`
+	SnapshotId    string                 `protobuf:"bytes,2,opt,name=snapshot_id,json=snapshotId,proto3" json:"snapshot_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RestoreSnapshotRequest) Reset() {
+	*x = RestoreSnapshotRequest{}
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[47]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RestoreSnapshotRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RestoreSnapshotRequest) ProtoMessage() {}
+
+func (x *RestoreSnapshotRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[47]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RestoreSnapshotRequest.ProtoReflect.Descriptor instead.
+func (*RestoreSnapshotRequest) Descriptor() ([]byte, []int) {
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{47}
+}
+
+func (x *RestoreSnapshotRequest) GetWorldId() string {
+	if x != nil {
+		return x.WorldId
+	}
+	return ""
+}
+
+func (x *RestoreSnapshotRequest) GetSnapshotId() string {
+	if x != nil {
+		return x.SnapshotId
+	}
+	return ""
+}
+
+type RestoreSnapshotResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RestoreSnapshotResponse) Reset() {
+	*x = RestoreSnapshotResponse{}
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[48]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RestoreSnapshotResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RestoreSnapshotResponse) ProtoMessage() {}
+
+func (x *RestoreSnapshotResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[48]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RestoreSnapshotResponse.ProtoReflect.Descriptor instead.
+func (*RestoreSnapshotResponse) Descriptor() ([]byte, []int) {
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{48}
+}
+
+type ReadSensorsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	WorldId       string                 `protobuf:"bytes,1,opt,name=world_id,json=worldId,proto3" json:"world_id,omitempty"`
+	RobotId       string                 `protobuf:"bytes,2,opt,name=robot_id,json=robotId,proto3" json:"robot_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReadSensorsRequest) Reset() {
+	*x = ReadSensorsRequest{}
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[49]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReadSensorsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReadSensorsRequest) ProtoMessage() {}
+
+func (x *ReadSensorsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[49]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReadSensorsRequest.ProtoReflect.Descriptor instead.
+func (*ReadSensorsRequest) Descriptor() ([]byte, []int) {
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{49}
+}
+
+func (x *ReadSensorsRequest) GetWorldId() string {
+	if x != nil {
+		return x.WorldId
+	}
+	return ""
+}
+
+func (x *ReadSensorsRequest) GetRobotId() string {
+	if x != nil {
+		return x.RobotId
+	}
+	return ""
+}
+
+type ReadSensorsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Readings      []*SensorReading       `protobuf:"bytes,1,rep,name=readings,proto3" json:"readings,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReadSensorsResponse) Reset() {
+	*x = ReadSensorsResponse{}
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[50]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReadSensorsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReadSensorsResponse) ProtoMessage() {}
+
+func (x *ReadSensorsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[50]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReadSensorsResponse.ProtoReflect.Descriptor instead.
+func (*ReadSensorsResponse) Descriptor() ([]byte, []int) {
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{50}
+}
+
+func (x *ReadSensorsResponse) GetReadings() []*SensorReading {
+	if x != nil {
+		return x.Readings
+	}
+	return nil
+}
+
+type SensorReading struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Name  string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Sensor type as reported by the engine (accelerometer, gyro, touch, ...).
+	Type          string    `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
+	Values        []float64 `protobuf:"fixed64,3,rep,packed,name=values,proto3" json:"values,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SensorReading) Reset() {
+	*x = SensorReading{}
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[51]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SensorReading) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SensorReading) ProtoMessage() {}
+
+func (x *SensorReading) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[51]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SensorReading.ProtoReflect.Descriptor instead.
+func (*SensorReading) Descriptor() ([]byte, []int) {
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{51}
+}
+
+func (x *SensorReading) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *SensorReading) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *SensorReading) GetValues() []float64 {
+	if x != nil {
+		return x.Values
+	}
+	return nil
+}
+
+type EditSceneRequest struct {
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	WorldId string                 `protobuf:"bytes,1,opt,name=world_id,json=worldId,proto3" json:"world_id,omitempty"`
+	// Types that are valid to be assigned to Op:
+	//
+	//	*EditSceneRequest_AddBox
+	//	*EditSceneRequest_RemoveId
+	Op            isEditSceneRequest_Op `protobuf_oneof:"op"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EditSceneRequest) Reset() {
+	*x = EditSceneRequest{}
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[52]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EditSceneRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EditSceneRequest) ProtoMessage() {}
+
+func (x *EditSceneRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[52]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EditSceneRequest.ProtoReflect.Descriptor instead.
+func (*EditSceneRequest) Descriptor() ([]byte, []int) {
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{52}
+}
+
+func (x *EditSceneRequest) GetWorldId() string {
+	if x != nil {
+		return x.WorldId
+	}
+	return ""
+}
+
+func (x *EditSceneRequest) GetOp() isEditSceneRequest_Op {
+	if x != nil {
+		return x.Op
+	}
+	return nil
+}
+
+func (x *EditSceneRequest) GetAddBox() *SceneBoxSpec {
+	if x != nil {
+		if x, ok := x.Op.(*EditSceneRequest_AddBox); ok {
+			return x.AddBox
+		}
+	}
+	return nil
+}
+
+func (x *EditSceneRequest) GetRemoveId() string {
+	if x != nil {
+		if x, ok := x.Op.(*EditSceneRequest_RemoveId); ok {
+			return x.RemoveId
+		}
+	}
+	return ""
+}
+
+type isEditSceneRequest_Op interface {
+	isEditSceneRequest_Op()
+}
+
+type EditSceneRequest_AddBox struct {
+	AddBox *SceneBoxSpec `protobuf:"bytes,2,opt,name=add_box,json=addBox,proto3,oneof"`
+}
+
+type EditSceneRequest_RemoveId struct {
+	// Obstacle id to remove.
+	RemoveId string `protobuf:"bytes,3,opt,name=remove_id,json=removeId,proto3,oneof"`
+}
+
+func (*EditSceneRequest_AddBox) isEditSceneRequest_Op() {}
+
+func (*EditSceneRequest_RemoveId) isEditSceneRequest_Op() {}
+
+type SceneBoxSpec struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Id    string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// Center position [x, y, z] in meters.
+	Position []float64 `protobuf:"fixed64,2,rep,packed,name=position,proto3" json:"position,omitempty"`
+	// Full extents [x, y, z] in meters.
+	Size          []float64 `protobuf:"fixed64,3,rep,packed,name=size,proto3" json:"size,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SceneBoxSpec) Reset() {
+	*x = SceneBoxSpec{}
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[53]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SceneBoxSpec) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SceneBoxSpec) ProtoMessage() {}
+
+func (x *SceneBoxSpec) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[53]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SceneBoxSpec.ProtoReflect.Descriptor instead.
+func (*SceneBoxSpec) Descriptor() ([]byte, []int) {
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{53}
+}
+
+func (x *SceneBoxSpec) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *SceneBoxSpec) GetPosition() []float64 {
+	if x != nil {
+		return x.Position
+	}
+	return nil
+}
+
+func (x *SceneBoxSpec) GetSize() []float64 {
+	if x != nil {
+		return x.Size
+	}
+	return nil
+}
+
+type EditSceneResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EditSceneResponse) Reset() {
+	*x = EditSceneResponse{}
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[54]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EditSceneResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EditSceneResponse) ProtoMessage() {}
+
+func (x *EditSceneResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[54]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EditSceneResponse.ProtoReflect.Descriptor instead.
+func (*EditSceneResponse) Descriptor() ([]byte, []int) {
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{54}
+}
+
+type LoadPolicyChunk struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Payload:
+	//
+	//	*LoadPolicyChunk_Source
+	//	*LoadPolicyChunk_Data
+	Payload       isLoadPolicyChunk_Payload `protobuf_oneof:"payload"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LoadPolicyChunk) Reset() {
+	*x = LoadPolicyChunk{}
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[55]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LoadPolicyChunk) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LoadPolicyChunk) ProtoMessage() {}
+
+func (x *LoadPolicyChunk) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[55]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LoadPolicyChunk.ProtoReflect.Descriptor instead.
+func (*LoadPolicyChunk) Descriptor() ([]byte, []int) {
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{55}
+}
+
+func (x *LoadPolicyChunk) GetPayload() isLoadPolicyChunk_Payload {
+	if x != nil {
+		return x.Payload
+	}
+	return nil
+}
+
+func (x *LoadPolicyChunk) GetSource() *PolicySource {
+	if x != nil {
+		if x, ok := x.Payload.(*LoadPolicyChunk_Source); ok {
+			return x.Source
+		}
+	}
+	return nil
+}
+
+func (x *LoadPolicyChunk) GetData() []byte {
+	if x != nil {
+		if x, ok := x.Payload.(*LoadPolicyChunk_Data); ok {
+			return x.Data
+		}
+	}
+	return nil
+}
+
+type isLoadPolicyChunk_Payload interface {
+	isLoadPolicyChunk_Payload()
+}
+
+type LoadPolicyChunk_Source struct {
+	// First chunk: what the policy is and who it drives.
+	Source *PolicySource `protobuf:"bytes,1,opt,name=source,proto3,oneof"`
+}
+
+type LoadPolicyChunk_Data struct {
+	// Subsequent chunks: the policy file bytes.
+	Data []byte `protobuf:"bytes,2,opt,name=data,proto3,oneof"`
+}
+
+func (*LoadPolicyChunk_Source) isLoadPolicyChunk_Payload() {}
+
+func (*LoadPolicyChunk_Data) isLoadPolicyChunk_Payload() {}
+
+type PolicySource struct {
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	WorldId string                 `protobuf:"bytes,1,opt,name=world_id,json=worldId,proto3" json:"world_id,omitempty"`
+	RobotId string                 `protobuf:"bytes,2,opt,name=robot_id,json=robotId,proto3" json:"robot_id,omitempty"`
+	// Policy file format; "onnx" is the first supported value.
+	Format        string `protobuf:"bytes,3,opt,name=format,proto3" json:"format,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PolicySource) Reset() {
+	*x = PolicySource{}
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[56]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicySource) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicySource) ProtoMessage() {}
+
+func (x *PolicySource) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[56]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicySource.ProtoReflect.Descriptor instead.
+func (*PolicySource) Descriptor() ([]byte, []int) {
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{56}
+}
+
+func (x *PolicySource) GetWorldId() string {
+	if x != nil {
+		return x.WorldId
+	}
+	return ""
+}
+
+func (x *PolicySource) GetRobotId() string {
+	if x != nil {
+		return x.RobotId
+	}
+	return ""
+}
+
+func (x *PolicySource) GetFormat() string {
+	if x != nil {
+		return x.Format
+	}
+	return ""
+}
+
+type LoadPolicyResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	PolicyId      string                 `protobuf:"bytes,1,opt,name=policy_id,json=policyId,proto3" json:"policy_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LoadPolicyResponse) Reset() {
+	*x = LoadPolicyResponse{}
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[57]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LoadPolicyResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LoadPolicyResponse) ProtoMessage() {}
+
+func (x *LoadPolicyResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[57]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LoadPolicyResponse.ProtoReflect.Descriptor instead.
+func (*LoadPolicyResponse) Descriptor() ([]byte, []int) {
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{57}
+}
+
+func (x *LoadPolicyResponse) GetPolicyId() string {
+	if x != nil {
+		return x.PolicyId
+	}
+	return ""
+}
+
+type ClearPolicyRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	WorldId       string                 `protobuf:"bytes,1,opt,name=world_id,json=worldId,proto3" json:"world_id,omitempty"`
+	RobotId       string                 `protobuf:"bytes,2,opt,name=robot_id,json=robotId,proto3" json:"robot_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ClearPolicyRequest) Reset() {
+	*x = ClearPolicyRequest{}
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[58]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClearPolicyRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClearPolicyRequest) ProtoMessage() {}
+
+func (x *ClearPolicyRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[58]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClearPolicyRequest.ProtoReflect.Descriptor instead.
+func (*ClearPolicyRequest) Descriptor() ([]byte, []int) {
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{58}
+}
+
+func (x *ClearPolicyRequest) GetWorldId() string {
+	if x != nil {
+		return x.WorldId
+	}
+	return ""
+}
+
+func (x *ClearPolicyRequest) GetRobotId() string {
+	if x != nil {
+		return x.RobotId
+	}
+	return ""
+}
+
+type ClearPolicyResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ClearPolicyResponse) Reset() {
+	*x = ClearPolicyResponse{}
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[59]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClearPolicyResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClearPolicyResponse) ProtoMessage() {}
+
+func (x *ClearPolicyResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[59]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClearPolicyResponse.ProtoReflect.Descriptor instead.
+func (*ClearPolicyResponse) Descriptor() ([]byte, []int) {
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{59}
+}
+
+type RenderVideoRequest struct {
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	WorldId string                 `protobuf:"bytes,1,opt,name=world_id,json=worldId,proto3" json:"world_id,omitempty"`
+	RobotId string                 `protobuf:"bytes,2,opt,name=robot_id,json=robotId,proto3" json:"robot_id,omitempty"`
+	// Empty or "tracking" follows the robot; otherwise a model camera name.
+	CameraName    string  `protobuf:"bytes,3,opt,name=camera_name,json=cameraName,proto3" json:"camera_name,omitempty"`
+	DurationS     float64 `protobuf:"fixed64,4,opt,name=duration_s,json=durationS,proto3" json:"duration_s,omitempty"`
+	Fps           uint32  `protobuf:"varint,5,opt,name=fps,proto3" json:"fps,omitempty"`
+	Width         uint32  `protobuf:"varint,6,opt,name=width,proto3" json:"width,omitempty"`
+	Height        uint32  `protobuf:"varint,7,opt,name=height,proto3" json:"height,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RenderVideoRequest) Reset() {
+	*x = RenderVideoRequest{}
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[60]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RenderVideoRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RenderVideoRequest) ProtoMessage() {}
+
+func (x *RenderVideoRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[60]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RenderVideoRequest.ProtoReflect.Descriptor instead.
+func (*RenderVideoRequest) Descriptor() ([]byte, []int) {
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{60}
+}
+
+func (x *RenderVideoRequest) GetWorldId() string {
+	if x != nil {
+		return x.WorldId
+	}
+	return ""
+}
+
+func (x *RenderVideoRequest) GetRobotId() string {
+	if x != nil {
+		return x.RobotId
+	}
+	return ""
+}
+
+func (x *RenderVideoRequest) GetCameraName() string {
+	if x != nil {
+		return x.CameraName
+	}
+	return ""
+}
+
+func (x *RenderVideoRequest) GetDurationS() float64 {
+	if x != nil {
+		return x.DurationS
+	}
+	return 0
+}
+
+func (x *RenderVideoRequest) GetFps() uint32 {
+	if x != nil {
+		return x.Fps
+	}
+	return 0
+}
+
+func (x *RenderVideoRequest) GetWidth() uint32 {
+	if x != nil {
+		return x.Width
+	}
+	return 0
+}
+
+func (x *RenderVideoRequest) GetHeight() uint32 {
+	if x != nil {
+		return x.Height
+	}
+	return 0
+}
+
+type VideoChunk struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Encoded video bytes (mp4).
+	Data          []byte `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *VideoChunk) Reset() {
+	*x = VideoChunk{}
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[61]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *VideoChunk) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*VideoChunk) ProtoMessage() {}
+
+func (x *VideoChunk) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[61]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use VideoChunk.ProtoReflect.Descriptor instead.
+func (*VideoChunk) Descriptor() ([]byte, []int) {
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{61}
+}
+
+func (x *VideoChunk) GetData() []byte {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
 type StopRecordingRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	RecordingId   string                 `protobuf:"bytes,1,opt,name=recording_id,json=recordingId,proto3" json:"recording_id,omitempty"`
@@ -2419,7 +3708,7 @@ type StopRecordingRequest struct {
 
 func (x *StopRecordingRequest) Reset() {
 	*x = StopRecordingRequest{}
-	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[39]
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2431,7 +3720,7 @@ func (x *StopRecordingRequest) String() string {
 func (*StopRecordingRequest) ProtoMessage() {}
 
 func (x *StopRecordingRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[39]
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2444,7 +3733,7 @@ func (x *StopRecordingRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopRecordingRequest.ProtoReflect.Descriptor instead.
 func (*StopRecordingRequest) Descriptor() ([]byte, []int) {
-	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{39}
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *StopRecordingRequest) GetRecordingId() string {
@@ -2467,7 +3756,7 @@ type StopRecordingResponse struct {
 
 func (x *StopRecordingResponse) Reset() {
 	*x = StopRecordingResponse{}
-	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[40]
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2479,7 +3768,7 @@ func (x *StopRecordingResponse) String() string {
 func (*StopRecordingResponse) ProtoMessage() {}
 
 func (x *StopRecordingResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[40]
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2492,7 +3781,7 @@ func (x *StopRecordingResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopRecordingResponse.ProtoReflect.Descriptor instead.
 func (*StopRecordingResponse) Descriptor() ([]byte, []int) {
-	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{40}
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *StopRecordingResponse) GetReplayId() string {
@@ -2518,7 +3807,7 @@ type GetReplayRequest struct {
 
 func (x *GetReplayRequest) Reset() {
 	*x = GetReplayRequest{}
-	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[41]
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2530,7 +3819,7 @@ func (x *GetReplayRequest) String() string {
 func (*GetReplayRequest) ProtoMessage() {}
 
 func (x *GetReplayRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[41]
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2543,7 +3832,7 @@ func (x *GetReplayRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetReplayRequest.ProtoReflect.Descriptor instead.
 func (*GetReplayRequest) Descriptor() ([]byte, []int) {
-	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{41}
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *GetReplayRequest) GetReplayId() string {
@@ -2562,7 +3851,7 @@ type GetReplayChunk struct {
 
 func (x *GetReplayChunk) Reset() {
 	*x = GetReplayChunk{}
-	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[42]
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2574,7 +3863,7 @@ func (x *GetReplayChunk) String() string {
 func (*GetReplayChunk) ProtoMessage() {}
 
 func (x *GetReplayChunk) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[42]
+	mi := &file_wendy_sim_v1_robot_backend_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2587,7 +3876,7 @@ func (x *GetReplayChunk) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetReplayChunk.ProtoReflect.Descriptor instead.
 func (*GetReplayChunk) Descriptor() ([]byte, []int) {
-	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{42}
+	return file_wendy_sim_v1_robot_backend_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *GetReplayChunk) GetData() []byte {
@@ -2605,11 +3894,12 @@ const file_wendy_sim_v1_robot_backend_proto_rawDesc = "" +
 	"\x0eLoadModelChunk\x123\n" +
 	"\x06source\x18\x01 \x01(\v2\x19.wendy.sim.v1.ModelSourceH\x00R\x06source\x12\x14\n" +
 	"\x04data\x18\x02 \x01(\fH\x00R\x04dataB\t\n" +
-	"\apayload\"{\n" +
+	"\apayload\"\xa5\x01\n" +
 	"\vModelSource\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x121\n" +
 	"\x06format\x18\x02 \x01(\x0e2\x19.wendy.sim.v1.ModelFormatR\x06format\x12%\n" +
-	"\x0emenagerie_path\x18\x03 \x01(\tR\rmenageriePath\".\n" +
+	"\x0emenagerie_path\x18\x03 \x01(\tR\rmenageriePath\x12(\n" +
+	"\x10replace_model_id\x18\x04 \x01(\tR\x0ereplaceModelId\".\n" +
 	"\x11LoadModelResponse\x12\x19\n" +
 	"\bmodel_id\x18\x01 \x01(\tR\amodelId\"1\n" +
 	"\x14DescribeModelRequest\x12\x19\n" +
@@ -2750,7 +4040,85 @@ const file_wendy_sim_v1_robot_backend_proto_rawDesc = "" +
 	"\x15StartRecordingRequest\x12\x19\n" +
 	"\bworld_id\x18\x01 \x01(\tR\aworldId\";\n" +
 	"\x16StartRecordingResponse\x12!\n" +
-	"\frecording_id\x18\x01 \x01(\tR\vrecordingId\"9\n" +
+	"\frecording_id\x18\x01 \x01(\tR\vrecordingId\"g\n" +
+	"\x0fSetClockRequest\x12\x19\n" +
+	"\bworld_id\x18\x01 \x01(\tR\aworldId\x12\x16\n" +
+	"\x06paused\x18\x02 \x01(\bR\x06paused\x12!\n" +
+	"\fspeed_factor\x18\x03 \x01(\x01R\vspeedFactor\"M\n" +
+	"\x10SetClockResponse\x12\x16\n" +
+	"\x06paused\x18\x01 \x01(\bR\x06paused\x12!\n" +
+	"\fspeed_factor\x18\x02 \x01(\x01R\vspeedFactor\"\xa1\x01\n" +
+	"\x11ApplyForceRequest\x12\x19\n" +
+	"\bworld_id\x18\x01 \x01(\tR\aworldId\x12\x19\n" +
+	"\brobot_id\x18\x02 \x01(\tR\arobotId\x12\x11\n" +
+	"\x04fx_n\x18\x03 \x01(\x01R\x03fxN\x12\x11\n" +
+	"\x04fy_n\x18\x04 \x01(\x01R\x03fyN\x12\x11\n" +
+	"\x04fz_n\x18\x05 \x01(\x01R\x03fzN\x12\x1d\n" +
+	"\n" +
+	"duration_s\x18\x06 \x01(\x01R\tdurationS\"\x14\n" +
+	"\x12ApplyForceResponse\"\x94\x01\n" +
+	"\x0fTeleportRequest\x12\x19\n" +
+	"\bworld_id\x18\x01 \x01(\tR\aworldId\x12\x19\n" +
+	"\brobot_id\x18\x02 \x01(\tR\arobotId\x12&\n" +
+	"\x04pose\x18\x03 \x01(\v2\x12.wendy.sim.v1.PoseR\x04pose\x12#\n" +
+	"\rzero_velocity\x18\x04 \x01(\bR\fzeroVelocity\"\x12\n" +
+	"\x10TeleportResponse\"0\n" +
+	"\x13SaveSnapshotRequest\x12\x19\n" +
+	"\bworld_id\x18\x01 \x01(\tR\aworldId\"7\n" +
+	"\x14SaveSnapshotResponse\x12\x1f\n" +
+	"\vsnapshot_id\x18\x01 \x01(\tR\n" +
+	"snapshotId\"T\n" +
+	"\x16RestoreSnapshotRequest\x12\x19\n" +
+	"\bworld_id\x18\x01 \x01(\tR\aworldId\x12\x1f\n" +
+	"\vsnapshot_id\x18\x02 \x01(\tR\n" +
+	"snapshotId\"\x19\n" +
+	"\x17RestoreSnapshotResponse\"J\n" +
+	"\x12ReadSensorsRequest\x12\x19\n" +
+	"\bworld_id\x18\x01 \x01(\tR\aworldId\x12\x19\n" +
+	"\brobot_id\x18\x02 \x01(\tR\arobotId\"N\n" +
+	"\x13ReadSensorsResponse\x127\n" +
+	"\breadings\x18\x01 \x03(\v2\x1b.wendy.sim.v1.SensorReadingR\breadings\"O\n" +
+	"\rSensorReading\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
+	"\x04type\x18\x02 \x01(\tR\x04type\x12\x16\n" +
+	"\x06values\x18\x03 \x03(\x01R\x06values\"\x89\x01\n" +
+	"\x10EditSceneRequest\x12\x19\n" +
+	"\bworld_id\x18\x01 \x01(\tR\aworldId\x125\n" +
+	"\aadd_box\x18\x02 \x01(\v2\x1a.wendy.sim.v1.SceneBoxSpecH\x00R\x06addBox\x12\x1d\n" +
+	"\tremove_id\x18\x03 \x01(\tH\x00R\bremoveIdB\x04\n" +
+	"\x02op\"N\n" +
+	"\fSceneBoxSpec\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1a\n" +
+	"\bposition\x18\x02 \x03(\x01R\bposition\x12\x12\n" +
+	"\x04size\x18\x03 \x03(\x01R\x04size\"\x13\n" +
+	"\x11EditSceneResponse\"h\n" +
+	"\x0fLoadPolicyChunk\x124\n" +
+	"\x06source\x18\x01 \x01(\v2\x1a.wendy.sim.v1.PolicySourceH\x00R\x06source\x12\x14\n" +
+	"\x04data\x18\x02 \x01(\fH\x00R\x04dataB\t\n" +
+	"\apayload\"\\\n" +
+	"\fPolicySource\x12\x19\n" +
+	"\bworld_id\x18\x01 \x01(\tR\aworldId\x12\x19\n" +
+	"\brobot_id\x18\x02 \x01(\tR\arobotId\x12\x16\n" +
+	"\x06format\x18\x03 \x01(\tR\x06format\"1\n" +
+	"\x12LoadPolicyResponse\x12\x1b\n" +
+	"\tpolicy_id\x18\x01 \x01(\tR\bpolicyId\"J\n" +
+	"\x12ClearPolicyRequest\x12\x19\n" +
+	"\bworld_id\x18\x01 \x01(\tR\aworldId\x12\x19\n" +
+	"\brobot_id\x18\x02 \x01(\tR\arobotId\"\x15\n" +
+	"\x13ClearPolicyResponse\"\xca\x01\n" +
+	"\x12RenderVideoRequest\x12\x19\n" +
+	"\bworld_id\x18\x01 \x01(\tR\aworldId\x12\x19\n" +
+	"\brobot_id\x18\x02 \x01(\tR\arobotId\x12\x1f\n" +
+	"\vcamera_name\x18\x03 \x01(\tR\n" +
+	"cameraName\x12\x1d\n" +
+	"\n" +
+	"duration_s\x18\x04 \x01(\x01R\tdurationS\x12\x10\n" +
+	"\x03fps\x18\x05 \x01(\rR\x03fps\x12\x14\n" +
+	"\x05width\x18\x06 \x01(\rR\x05width\x12\x16\n" +
+	"\x06height\x18\a \x01(\rR\x06height\" \n" +
+	"\n" +
+	"VideoChunk\x12\x12\n" +
+	"\x04data\x18\x01 \x01(\fR\x04data\"9\n" +
 	"\x14StopRecordingRequest\x12!\n" +
 	"\frecording_id\x18\x01 \x01(\tR\vrecordingId\"F\n" +
 	"\x15StopRecordingResponse\x12\x1b\n" +
@@ -2770,7 +4138,7 @@ const file_wendy_sim_v1_robot_backend_proto_rawDesc = "" +
 	"\x18MODEL_FORMAT_UNSPECIFIED\x10\x00\x12\x15\n" +
 	"\x11MODEL_FORMAT_MJCF\x10\x01\x12\x15\n" +
 	"\x11MODEL_FORMAT_URDF\x10\x02\x12\x14\n" +
-	"\x10MODEL_FORMAT_SDF\x10\x032\xcc\t\n" +
+	"\x10MODEL_FORMAT_SDF\x10\x032\xfe\x0f\n" +
 	"\x13RobotBackendService\x12L\n" +
 	"\tLoadModel\x12\x1c.wendy.sim.v1.LoadModelChunk\x1a\x1f.wendy.sim.v1.LoadModelResponse(\x01\x12X\n" +
 	"\rDescribeModel\x12\".wendy.sim.v1.DescribeModelRequest\x1a#.wendy.sim.v1.DescribeModelResponse\x12R\n" +
@@ -2786,7 +4154,19 @@ const file_wendy_sim_v1_robot_backend_proto_rawDesc = "" +
 	"\aRunTask\x12\x1c.wendy.sim.v1.RunTaskRequest\x1a\x17.wendy.sim.v1.TaskEvent0\x01\x12[\n" +
 	"\x0eStartRecording\x12#.wendy.sim.v1.StartRecordingRequest\x1a$.wendy.sim.v1.StartRecordingResponse\x12X\n" +
 	"\rStopRecording\x12\".wendy.sim.v1.StopRecordingRequest\x1a#.wendy.sim.v1.StopRecordingResponse\x12K\n" +
-	"\tGetReplay\x12\x1e.wendy.sim.v1.GetReplayRequest\x1a\x1c.wendy.sim.v1.GetReplayChunk0\x01B8Z6github.com/wendylabsinc/wendy/go/proto/gen/simpb;simpbb\x06proto3"
+	"\tGetReplay\x12\x1e.wendy.sim.v1.GetReplayRequest\x1a\x1c.wendy.sim.v1.GetReplayChunk0\x01\x12I\n" +
+	"\bSetClock\x12\x1d.wendy.sim.v1.SetClockRequest\x1a\x1e.wendy.sim.v1.SetClockResponse\x12O\n" +
+	"\n" +
+	"ApplyForce\x12\x1f.wendy.sim.v1.ApplyForceRequest\x1a .wendy.sim.v1.ApplyForceResponse\x12I\n" +
+	"\bTeleport\x12\x1d.wendy.sim.v1.TeleportRequest\x1a\x1e.wendy.sim.v1.TeleportResponse\x12U\n" +
+	"\fSaveSnapshot\x12!.wendy.sim.v1.SaveSnapshotRequest\x1a\".wendy.sim.v1.SaveSnapshotResponse\x12^\n" +
+	"\x0fRestoreSnapshot\x12$.wendy.sim.v1.RestoreSnapshotRequest\x1a%.wendy.sim.v1.RestoreSnapshotResponse\x12R\n" +
+	"\vReadSensors\x12 .wendy.sim.v1.ReadSensorsRequest\x1a!.wendy.sim.v1.ReadSensorsResponse\x12L\n" +
+	"\tEditScene\x12\x1e.wendy.sim.v1.EditSceneRequest\x1a\x1f.wendy.sim.v1.EditSceneResponse\x12O\n" +
+	"\n" +
+	"LoadPolicy\x12\x1d.wendy.sim.v1.LoadPolicyChunk\x1a .wendy.sim.v1.LoadPolicyResponse(\x01\x12R\n" +
+	"\vClearPolicy\x12 .wendy.sim.v1.ClearPolicyRequest\x1a!.wendy.sim.v1.ClearPolicyResponse\x12K\n" +
+	"\vRenderVideo\x12 .wendy.sim.v1.RenderVideoRequest\x1a\x18.wendy.sim.v1.VideoChunk0\x01B8Z6github.com/wendylabsinc/wendy/go/proto/gen/simpb;simpbb\x06proto3"
 
 var (
 	file_wendy_sim_v1_robot_backend_proto_rawDescOnce sync.Once
@@ -2801,7 +4181,7 @@ func file_wendy_sim_v1_robot_backend_proto_rawDescGZIP() []byte {
 }
 
 var file_wendy_sim_v1_robot_backend_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_wendy_sim_v1_robot_backend_proto_msgTypes = make([]protoimpl.MessageInfo, 44)
+var file_wendy_sim_v1_robot_backend_proto_msgTypes = make([]protoimpl.MessageInfo, 67)
 var file_wendy_sim_v1_robot_backend_proto_goTypes = []any{
 	(ControlLevel)(0),               // 0: wendy.sim.v1.ControlLevel
 	(ModelFormat)(0),                // 1: wendy.sim.v1.ModelFormat
@@ -2844,11 +4224,34 @@ var file_wendy_sim_v1_robot_backend_proto_goTypes = []any{
 	(*CheckResult)(nil),             // 38: wendy.sim.v1.CheckResult
 	(*StartRecordingRequest)(nil),   // 39: wendy.sim.v1.StartRecordingRequest
 	(*StartRecordingResponse)(nil),  // 40: wendy.sim.v1.StartRecordingResponse
-	(*StopRecordingRequest)(nil),    // 41: wendy.sim.v1.StopRecordingRequest
-	(*StopRecordingResponse)(nil),   // 42: wendy.sim.v1.StopRecordingResponse
-	(*GetReplayRequest)(nil),        // 43: wendy.sim.v1.GetReplayRequest
-	(*GetReplayChunk)(nil),          // 44: wendy.sim.v1.GetReplayChunk
-	nil,                             // 45: wendy.sim.v1.SetJointTargetsRequest.TargetsEntry
+	(*SetClockRequest)(nil),         // 41: wendy.sim.v1.SetClockRequest
+	(*SetClockResponse)(nil),        // 42: wendy.sim.v1.SetClockResponse
+	(*ApplyForceRequest)(nil),       // 43: wendy.sim.v1.ApplyForceRequest
+	(*ApplyForceResponse)(nil),      // 44: wendy.sim.v1.ApplyForceResponse
+	(*TeleportRequest)(nil),         // 45: wendy.sim.v1.TeleportRequest
+	(*TeleportResponse)(nil),        // 46: wendy.sim.v1.TeleportResponse
+	(*SaveSnapshotRequest)(nil),     // 47: wendy.sim.v1.SaveSnapshotRequest
+	(*SaveSnapshotResponse)(nil),    // 48: wendy.sim.v1.SaveSnapshotResponse
+	(*RestoreSnapshotRequest)(nil),  // 49: wendy.sim.v1.RestoreSnapshotRequest
+	(*RestoreSnapshotResponse)(nil), // 50: wendy.sim.v1.RestoreSnapshotResponse
+	(*ReadSensorsRequest)(nil),      // 51: wendy.sim.v1.ReadSensorsRequest
+	(*ReadSensorsResponse)(nil),     // 52: wendy.sim.v1.ReadSensorsResponse
+	(*SensorReading)(nil),           // 53: wendy.sim.v1.SensorReading
+	(*EditSceneRequest)(nil),        // 54: wendy.sim.v1.EditSceneRequest
+	(*SceneBoxSpec)(nil),            // 55: wendy.sim.v1.SceneBoxSpec
+	(*EditSceneResponse)(nil),       // 56: wendy.sim.v1.EditSceneResponse
+	(*LoadPolicyChunk)(nil),         // 57: wendy.sim.v1.LoadPolicyChunk
+	(*PolicySource)(nil),            // 58: wendy.sim.v1.PolicySource
+	(*LoadPolicyResponse)(nil),      // 59: wendy.sim.v1.LoadPolicyResponse
+	(*ClearPolicyRequest)(nil),      // 60: wendy.sim.v1.ClearPolicyRequest
+	(*ClearPolicyResponse)(nil),     // 61: wendy.sim.v1.ClearPolicyResponse
+	(*RenderVideoRequest)(nil),      // 62: wendy.sim.v1.RenderVideoRequest
+	(*VideoChunk)(nil),              // 63: wendy.sim.v1.VideoChunk
+	(*StopRecordingRequest)(nil),    // 64: wendy.sim.v1.StopRecordingRequest
+	(*StopRecordingResponse)(nil),   // 65: wendy.sim.v1.StopRecordingResponse
+	(*GetReplayRequest)(nil),        // 66: wendy.sim.v1.GetReplayRequest
+	(*GetReplayChunk)(nil),          // 67: wendy.sim.v1.GetReplayChunk
+	nil,                             // 68: wendy.sim.v1.SetJointTargetsRequest.TargetsEntry
 }
 var file_wendy_sim_v1_robot_backend_proto_depIdxs = []int32{
 	3,  // 0: wendy.sim.v1.LoadModelChunk.source:type_name -> wendy.sim.v1.ModelSource
@@ -2863,47 +4266,71 @@ var file_wendy_sim_v1_robot_backend_proto_depIdxs = []int32{
 	18, // 9: wendy.sim.v1.GetStateResponse.base_pose:type_name -> wendy.sim.v1.Pose
 	21, // 10: wendy.sim.v1.GetStateResponse.joints:type_name -> wendy.sim.v1.JointState
 	24, // 11: wendy.sim.v1.GetContactsResponse.contacts:type_name -> wendy.sim.v1.Contact
-	45, // 12: wendy.sim.v1.SetJointTargetsRequest.targets:type_name -> wendy.sim.v1.SetJointTargetsRequest.TargetsEntry
+	68, // 12: wendy.sim.v1.SetJointTargetsRequest.targets:type_name -> wendy.sim.v1.SetJointTargetsRequest.TargetsEntry
 	0,  // 13: wendy.sim.v1.RunTaskRequest.max_control_level:type_name -> wendy.sim.v1.ControlLevel
 	35, // 14: wendy.sim.v1.TaskEvent.progress:type_name -> wendy.sim.v1.TaskProgress
 	36, // 15: wendy.sim.v1.TaskEvent.log:type_name -> wendy.sim.v1.TaskLog
 	37, // 16: wendy.sim.v1.TaskEvent.result:type_name -> wendy.sim.v1.TaskResult
 	38, // 17: wendy.sim.v1.TaskResult.checks:type_name -> wendy.sim.v1.CheckResult
-	2,  // 18: wendy.sim.v1.RobotBackendService.LoadModel:input_type -> wendy.sim.v1.LoadModelChunk
-	5,  // 19: wendy.sim.v1.RobotBackendService.DescribeModel:input_type -> wendy.sim.v1.DescribeModelRequest
-	12, // 20: wendy.sim.v1.RobotBackendService.CreateWorld:input_type -> wendy.sim.v1.CreateWorldRequest
-	14, // 21: wendy.sim.v1.RobotBackendService.Spawn:input_type -> wendy.sim.v1.SpawnRequest
-	16, // 22: wendy.sim.v1.RobotBackendService.Reset:input_type -> wendy.sim.v1.ResetRequest
-	19, // 23: wendy.sim.v1.RobotBackendService.GetState:input_type -> wendy.sim.v1.GetStateRequest
-	22, // 24: wendy.sim.v1.RobotBackendService.GetContacts:input_type -> wendy.sim.v1.GetContactsRequest
-	25, // 25: wendy.sim.v1.RobotBackendService.GetCameraFrame:input_type -> wendy.sim.v1.GetCameraFrameRequest
-	27, // 26: wendy.sim.v1.RobotBackendService.SetVelocity:input_type -> wendy.sim.v1.SetVelocityRequest
-	29, // 27: wendy.sim.v1.RobotBackendService.SetJointTargets:input_type -> wendy.sim.v1.SetJointTargetsRequest
-	31, // 28: wendy.sim.v1.RobotBackendService.Step:input_type -> wendy.sim.v1.StepRequest
-	33, // 29: wendy.sim.v1.RobotBackendService.RunTask:input_type -> wendy.sim.v1.RunTaskRequest
-	39, // 30: wendy.sim.v1.RobotBackendService.StartRecording:input_type -> wendy.sim.v1.StartRecordingRequest
-	41, // 31: wendy.sim.v1.RobotBackendService.StopRecording:input_type -> wendy.sim.v1.StopRecordingRequest
-	43, // 32: wendy.sim.v1.RobotBackendService.GetReplay:input_type -> wendy.sim.v1.GetReplayRequest
-	4,  // 33: wendy.sim.v1.RobotBackendService.LoadModel:output_type -> wendy.sim.v1.LoadModelResponse
-	6,  // 34: wendy.sim.v1.RobotBackendService.DescribeModel:output_type -> wendy.sim.v1.DescribeModelResponse
-	13, // 35: wendy.sim.v1.RobotBackendService.CreateWorld:output_type -> wendy.sim.v1.CreateWorldResponse
-	15, // 36: wendy.sim.v1.RobotBackendService.Spawn:output_type -> wendy.sim.v1.SpawnResponse
-	17, // 37: wendy.sim.v1.RobotBackendService.Reset:output_type -> wendy.sim.v1.ResetResponse
-	20, // 38: wendy.sim.v1.RobotBackendService.GetState:output_type -> wendy.sim.v1.GetStateResponse
-	23, // 39: wendy.sim.v1.RobotBackendService.GetContacts:output_type -> wendy.sim.v1.GetContactsResponse
-	26, // 40: wendy.sim.v1.RobotBackendService.GetCameraFrame:output_type -> wendy.sim.v1.GetCameraFrameResponse
-	28, // 41: wendy.sim.v1.RobotBackendService.SetVelocity:output_type -> wendy.sim.v1.SetVelocityResponse
-	30, // 42: wendy.sim.v1.RobotBackendService.SetJointTargets:output_type -> wendy.sim.v1.SetJointTargetsResponse
-	32, // 43: wendy.sim.v1.RobotBackendService.Step:output_type -> wendy.sim.v1.StepResponse
-	34, // 44: wendy.sim.v1.RobotBackendService.RunTask:output_type -> wendy.sim.v1.TaskEvent
-	40, // 45: wendy.sim.v1.RobotBackendService.StartRecording:output_type -> wendy.sim.v1.StartRecordingResponse
-	42, // 46: wendy.sim.v1.RobotBackendService.StopRecording:output_type -> wendy.sim.v1.StopRecordingResponse
-	44, // 47: wendy.sim.v1.RobotBackendService.GetReplay:output_type -> wendy.sim.v1.GetReplayChunk
-	33, // [33:48] is the sub-list for method output_type
-	18, // [18:33] is the sub-list for method input_type
-	18, // [18:18] is the sub-list for extension type_name
-	18, // [18:18] is the sub-list for extension extendee
-	0,  // [0:18] is the sub-list for field type_name
+	18, // 18: wendy.sim.v1.TeleportRequest.pose:type_name -> wendy.sim.v1.Pose
+	53, // 19: wendy.sim.v1.ReadSensorsResponse.readings:type_name -> wendy.sim.v1.SensorReading
+	55, // 20: wendy.sim.v1.EditSceneRequest.add_box:type_name -> wendy.sim.v1.SceneBoxSpec
+	58, // 21: wendy.sim.v1.LoadPolicyChunk.source:type_name -> wendy.sim.v1.PolicySource
+	2,  // 22: wendy.sim.v1.RobotBackendService.LoadModel:input_type -> wendy.sim.v1.LoadModelChunk
+	5,  // 23: wendy.sim.v1.RobotBackendService.DescribeModel:input_type -> wendy.sim.v1.DescribeModelRequest
+	12, // 24: wendy.sim.v1.RobotBackendService.CreateWorld:input_type -> wendy.sim.v1.CreateWorldRequest
+	14, // 25: wendy.sim.v1.RobotBackendService.Spawn:input_type -> wendy.sim.v1.SpawnRequest
+	16, // 26: wendy.sim.v1.RobotBackendService.Reset:input_type -> wendy.sim.v1.ResetRequest
+	19, // 27: wendy.sim.v1.RobotBackendService.GetState:input_type -> wendy.sim.v1.GetStateRequest
+	22, // 28: wendy.sim.v1.RobotBackendService.GetContacts:input_type -> wendy.sim.v1.GetContactsRequest
+	25, // 29: wendy.sim.v1.RobotBackendService.GetCameraFrame:input_type -> wendy.sim.v1.GetCameraFrameRequest
+	27, // 30: wendy.sim.v1.RobotBackendService.SetVelocity:input_type -> wendy.sim.v1.SetVelocityRequest
+	29, // 31: wendy.sim.v1.RobotBackendService.SetJointTargets:input_type -> wendy.sim.v1.SetJointTargetsRequest
+	31, // 32: wendy.sim.v1.RobotBackendService.Step:input_type -> wendy.sim.v1.StepRequest
+	33, // 33: wendy.sim.v1.RobotBackendService.RunTask:input_type -> wendy.sim.v1.RunTaskRequest
+	39, // 34: wendy.sim.v1.RobotBackendService.StartRecording:input_type -> wendy.sim.v1.StartRecordingRequest
+	64, // 35: wendy.sim.v1.RobotBackendService.StopRecording:input_type -> wendy.sim.v1.StopRecordingRequest
+	66, // 36: wendy.sim.v1.RobotBackendService.GetReplay:input_type -> wendy.sim.v1.GetReplayRequest
+	41, // 37: wendy.sim.v1.RobotBackendService.SetClock:input_type -> wendy.sim.v1.SetClockRequest
+	43, // 38: wendy.sim.v1.RobotBackendService.ApplyForce:input_type -> wendy.sim.v1.ApplyForceRequest
+	45, // 39: wendy.sim.v1.RobotBackendService.Teleport:input_type -> wendy.sim.v1.TeleportRequest
+	47, // 40: wendy.sim.v1.RobotBackendService.SaveSnapshot:input_type -> wendy.sim.v1.SaveSnapshotRequest
+	49, // 41: wendy.sim.v1.RobotBackendService.RestoreSnapshot:input_type -> wendy.sim.v1.RestoreSnapshotRequest
+	51, // 42: wendy.sim.v1.RobotBackendService.ReadSensors:input_type -> wendy.sim.v1.ReadSensorsRequest
+	54, // 43: wendy.sim.v1.RobotBackendService.EditScene:input_type -> wendy.sim.v1.EditSceneRequest
+	57, // 44: wendy.sim.v1.RobotBackendService.LoadPolicy:input_type -> wendy.sim.v1.LoadPolicyChunk
+	60, // 45: wendy.sim.v1.RobotBackendService.ClearPolicy:input_type -> wendy.sim.v1.ClearPolicyRequest
+	62, // 46: wendy.sim.v1.RobotBackendService.RenderVideo:input_type -> wendy.sim.v1.RenderVideoRequest
+	4,  // 47: wendy.sim.v1.RobotBackendService.LoadModel:output_type -> wendy.sim.v1.LoadModelResponse
+	6,  // 48: wendy.sim.v1.RobotBackendService.DescribeModel:output_type -> wendy.sim.v1.DescribeModelResponse
+	13, // 49: wendy.sim.v1.RobotBackendService.CreateWorld:output_type -> wendy.sim.v1.CreateWorldResponse
+	15, // 50: wendy.sim.v1.RobotBackendService.Spawn:output_type -> wendy.sim.v1.SpawnResponse
+	17, // 51: wendy.sim.v1.RobotBackendService.Reset:output_type -> wendy.sim.v1.ResetResponse
+	20, // 52: wendy.sim.v1.RobotBackendService.GetState:output_type -> wendy.sim.v1.GetStateResponse
+	23, // 53: wendy.sim.v1.RobotBackendService.GetContacts:output_type -> wendy.sim.v1.GetContactsResponse
+	26, // 54: wendy.sim.v1.RobotBackendService.GetCameraFrame:output_type -> wendy.sim.v1.GetCameraFrameResponse
+	28, // 55: wendy.sim.v1.RobotBackendService.SetVelocity:output_type -> wendy.sim.v1.SetVelocityResponse
+	30, // 56: wendy.sim.v1.RobotBackendService.SetJointTargets:output_type -> wendy.sim.v1.SetJointTargetsResponse
+	32, // 57: wendy.sim.v1.RobotBackendService.Step:output_type -> wendy.sim.v1.StepResponse
+	34, // 58: wendy.sim.v1.RobotBackendService.RunTask:output_type -> wendy.sim.v1.TaskEvent
+	40, // 59: wendy.sim.v1.RobotBackendService.StartRecording:output_type -> wendy.sim.v1.StartRecordingResponse
+	65, // 60: wendy.sim.v1.RobotBackendService.StopRecording:output_type -> wendy.sim.v1.StopRecordingResponse
+	67, // 61: wendy.sim.v1.RobotBackendService.GetReplay:output_type -> wendy.sim.v1.GetReplayChunk
+	42, // 62: wendy.sim.v1.RobotBackendService.SetClock:output_type -> wendy.sim.v1.SetClockResponse
+	44, // 63: wendy.sim.v1.RobotBackendService.ApplyForce:output_type -> wendy.sim.v1.ApplyForceResponse
+	46, // 64: wendy.sim.v1.RobotBackendService.Teleport:output_type -> wendy.sim.v1.TeleportResponse
+	48, // 65: wendy.sim.v1.RobotBackendService.SaveSnapshot:output_type -> wendy.sim.v1.SaveSnapshotResponse
+	50, // 66: wendy.sim.v1.RobotBackendService.RestoreSnapshot:output_type -> wendy.sim.v1.RestoreSnapshotResponse
+	52, // 67: wendy.sim.v1.RobotBackendService.ReadSensors:output_type -> wendy.sim.v1.ReadSensorsResponse
+	56, // 68: wendy.sim.v1.RobotBackendService.EditScene:output_type -> wendy.sim.v1.EditSceneResponse
+	59, // 69: wendy.sim.v1.RobotBackendService.LoadPolicy:output_type -> wendy.sim.v1.LoadPolicyResponse
+	61, // 70: wendy.sim.v1.RobotBackendService.ClearPolicy:output_type -> wendy.sim.v1.ClearPolicyResponse
+	63, // 71: wendy.sim.v1.RobotBackendService.RenderVideo:output_type -> wendy.sim.v1.VideoChunk
+	47, // [47:72] is the sub-list for method output_type
+	22, // [22:47] is the sub-list for method input_type
+	22, // [22:22] is the sub-list for extension type_name
+	22, // [22:22] is the sub-list for extension extendee
+	0,  // [0:22] is the sub-list for field type_name
 }
 
 func init() { file_wendy_sim_v1_robot_backend_proto_init() }
@@ -2920,13 +4347,21 @@ func file_wendy_sim_v1_robot_backend_proto_init() {
 		(*TaskEvent_Log)(nil),
 		(*TaskEvent_Result)(nil),
 	}
+	file_wendy_sim_v1_robot_backend_proto_msgTypes[52].OneofWrappers = []any{
+		(*EditSceneRequest_AddBox)(nil),
+		(*EditSceneRequest_RemoveId)(nil),
+	}
+	file_wendy_sim_v1_robot_backend_proto_msgTypes[55].OneofWrappers = []any{
+		(*LoadPolicyChunk_Source)(nil),
+		(*LoadPolicyChunk_Data)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_wendy_sim_v1_robot_backend_proto_rawDesc), len(file_wendy_sim_v1_robot_backend_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   44,
+			NumMessages:   67,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/go/proto/gen/simpb/robot_backend_grpc.pb.go
+++ b/go/proto/gen/simpb/robot_backend_grpc.pb.go
@@ -34,6 +34,16 @@ const (
 	RobotBackendService_StartRecording_FullMethodName  = "/wendy.sim.v1.RobotBackendService/StartRecording"
 	RobotBackendService_StopRecording_FullMethodName   = "/wendy.sim.v1.RobotBackendService/StopRecording"
 	RobotBackendService_GetReplay_FullMethodName       = "/wendy.sim.v1.RobotBackendService/GetReplay"
+	RobotBackendService_SetClock_FullMethodName        = "/wendy.sim.v1.RobotBackendService/SetClock"
+	RobotBackendService_ApplyForce_FullMethodName      = "/wendy.sim.v1.RobotBackendService/ApplyForce"
+	RobotBackendService_Teleport_FullMethodName        = "/wendy.sim.v1.RobotBackendService/Teleport"
+	RobotBackendService_SaveSnapshot_FullMethodName    = "/wendy.sim.v1.RobotBackendService/SaveSnapshot"
+	RobotBackendService_RestoreSnapshot_FullMethodName = "/wendy.sim.v1.RobotBackendService/RestoreSnapshot"
+	RobotBackendService_ReadSensors_FullMethodName     = "/wendy.sim.v1.RobotBackendService/ReadSensors"
+	RobotBackendService_EditScene_FullMethodName       = "/wendy.sim.v1.RobotBackendService/EditScene"
+	RobotBackendService_LoadPolicy_FullMethodName      = "/wendy.sim.v1.RobotBackendService/LoadPolicy"
+	RobotBackendService_ClearPolicy_FullMethodName     = "/wendy.sim.v1.RobotBackendService/ClearPolicy"
+	RobotBackendService_RenderVideo_FullMethodName     = "/wendy.sim.v1.RobotBackendService/RenderVideo"
 )
 
 // RobotBackendServiceClient is the client API for RobotBackendService service.
@@ -93,6 +103,29 @@ type RobotBackendServiceClient interface {
 	// GetReplay downloads a finished replay (e.g. a Rerun .rrd) in chunks so
 	// the agent can relay it to the CLI without sharing a filesystem.
 	GetReplay(ctx context.Context, in *GetReplayRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[GetReplayChunk], error)
+	// SetClock pauses/resumes a world and scales its real-time pacing.
+	SetClock(ctx context.Context, in *SetClockRequest, opts ...grpc.CallOption) (*SetClockResponse, error)
+	// ApplyForce applies an external force impulse to a robot's base — the
+	// programmatic version of shoving it in a viewer, used to test balance.
+	ApplyForce(ctx context.Context, in *ApplyForceRequest, opts ...grpc.CallOption) (*ApplyForceResponse, error)
+	// Teleport moves a robot to a pose directly (physics-level edit).
+	Teleport(ctx context.Context, in *TeleportRequest, opts ...grpc.CallOption) (*TeleportResponse, error)
+	// SaveSnapshot captures a world's exact physics state; RestoreSnapshot
+	// rewinds to it. Snapshots let a failure be reproduced deterministically.
+	SaveSnapshot(ctx context.Context, in *SaveSnapshotRequest, opts ...grpc.CallOption) (*SaveSnapshotResponse, error)
+	RestoreSnapshot(ctx context.Context, in *RestoreSnapshotRequest, opts ...grpc.CallOption) (*RestoreSnapshotResponse, error)
+	// ReadSensors returns current readings for the model's declared sensors
+	// (IMU, force, touch, rangefinder, ...).
+	ReadSensors(ctx context.Context, in *ReadSensorsRequest, opts ...grpc.CallOption) (*ReadSensorsResponse, error)
+	// EditScene mutates a live world's static scenery without recreating it.
+	EditScene(ctx context.Context, in *EditSceneRequest, opts ...grpc.CallOption) (*EditSceneResponse, error)
+	// LoadPolicy streams a trained policy (e.g. ONNX) that replaces the
+	// robot's built-in controller; ClearPolicy reverts to the built-in one.
+	LoadPolicy(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStreamingClient[LoadPolicyChunk, LoadPolicyResponse], error)
+	ClearPolicy(ctx context.Context, in *ClearPolicyRequest, opts ...grpc.CallOption) (*ClearPolicyResponse, error)
+	// RenderVideo renders a video clip of the world (tracking or named
+	// camera) and streams the encoded file back.
+	RenderVideo(ctx context.Context, in *RenderVideoRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[VideoChunk], error)
 }
 
 type robotBackendServiceClient struct {
@@ -274,6 +307,118 @@ func (c *robotBackendServiceClient) GetReplay(ctx context.Context, in *GetReplay
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type RobotBackendService_GetReplayClient = grpc.ServerStreamingClient[GetReplayChunk]
 
+func (c *robotBackendServiceClient) SetClock(ctx context.Context, in *SetClockRequest, opts ...grpc.CallOption) (*SetClockResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SetClockResponse)
+	err := c.cc.Invoke(ctx, RobotBackendService_SetClock_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *robotBackendServiceClient) ApplyForce(ctx context.Context, in *ApplyForceRequest, opts ...grpc.CallOption) (*ApplyForceResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ApplyForceResponse)
+	err := c.cc.Invoke(ctx, RobotBackendService_ApplyForce_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *robotBackendServiceClient) Teleport(ctx context.Context, in *TeleportRequest, opts ...grpc.CallOption) (*TeleportResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(TeleportResponse)
+	err := c.cc.Invoke(ctx, RobotBackendService_Teleport_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *robotBackendServiceClient) SaveSnapshot(ctx context.Context, in *SaveSnapshotRequest, opts ...grpc.CallOption) (*SaveSnapshotResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SaveSnapshotResponse)
+	err := c.cc.Invoke(ctx, RobotBackendService_SaveSnapshot_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *robotBackendServiceClient) RestoreSnapshot(ctx context.Context, in *RestoreSnapshotRequest, opts ...grpc.CallOption) (*RestoreSnapshotResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RestoreSnapshotResponse)
+	err := c.cc.Invoke(ctx, RobotBackendService_RestoreSnapshot_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *robotBackendServiceClient) ReadSensors(ctx context.Context, in *ReadSensorsRequest, opts ...grpc.CallOption) (*ReadSensorsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ReadSensorsResponse)
+	err := c.cc.Invoke(ctx, RobotBackendService_ReadSensors_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *robotBackendServiceClient) EditScene(ctx context.Context, in *EditSceneRequest, opts ...grpc.CallOption) (*EditSceneResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(EditSceneResponse)
+	err := c.cc.Invoke(ctx, RobotBackendService_EditScene_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *robotBackendServiceClient) LoadPolicy(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStreamingClient[LoadPolicyChunk, LoadPolicyResponse], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &RobotBackendService_ServiceDesc.Streams[3], RobotBackendService_LoadPolicy_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[LoadPolicyChunk, LoadPolicyResponse]{ClientStream: stream}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type RobotBackendService_LoadPolicyClient = grpc.ClientStreamingClient[LoadPolicyChunk, LoadPolicyResponse]
+
+func (c *robotBackendServiceClient) ClearPolicy(ctx context.Context, in *ClearPolicyRequest, opts ...grpc.CallOption) (*ClearPolicyResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ClearPolicyResponse)
+	err := c.cc.Invoke(ctx, RobotBackendService_ClearPolicy_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *robotBackendServiceClient) RenderVideo(ctx context.Context, in *RenderVideoRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[VideoChunk], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &RobotBackendService_ServiceDesc.Streams[4], RobotBackendService_RenderVideo_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[RenderVideoRequest, VideoChunk]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type RobotBackendService_RenderVideoClient = grpc.ServerStreamingClient[VideoChunk]
+
 // RobotBackendServiceServer is the server API for RobotBackendService service.
 // All implementations must embed UnimplementedRobotBackendServiceServer
 // for forward compatibility.
@@ -331,6 +476,29 @@ type RobotBackendServiceServer interface {
 	// GetReplay downloads a finished replay (e.g. a Rerun .rrd) in chunks so
 	// the agent can relay it to the CLI without sharing a filesystem.
 	GetReplay(*GetReplayRequest, grpc.ServerStreamingServer[GetReplayChunk]) error
+	// SetClock pauses/resumes a world and scales its real-time pacing.
+	SetClock(context.Context, *SetClockRequest) (*SetClockResponse, error)
+	// ApplyForce applies an external force impulse to a robot's base — the
+	// programmatic version of shoving it in a viewer, used to test balance.
+	ApplyForce(context.Context, *ApplyForceRequest) (*ApplyForceResponse, error)
+	// Teleport moves a robot to a pose directly (physics-level edit).
+	Teleport(context.Context, *TeleportRequest) (*TeleportResponse, error)
+	// SaveSnapshot captures a world's exact physics state; RestoreSnapshot
+	// rewinds to it. Snapshots let a failure be reproduced deterministically.
+	SaveSnapshot(context.Context, *SaveSnapshotRequest) (*SaveSnapshotResponse, error)
+	RestoreSnapshot(context.Context, *RestoreSnapshotRequest) (*RestoreSnapshotResponse, error)
+	// ReadSensors returns current readings for the model's declared sensors
+	// (IMU, force, touch, rangefinder, ...).
+	ReadSensors(context.Context, *ReadSensorsRequest) (*ReadSensorsResponse, error)
+	// EditScene mutates a live world's static scenery without recreating it.
+	EditScene(context.Context, *EditSceneRequest) (*EditSceneResponse, error)
+	// LoadPolicy streams a trained policy (e.g. ONNX) that replaces the
+	// robot's built-in controller; ClearPolicy reverts to the built-in one.
+	LoadPolicy(grpc.ClientStreamingServer[LoadPolicyChunk, LoadPolicyResponse]) error
+	ClearPolicy(context.Context, *ClearPolicyRequest) (*ClearPolicyResponse, error)
+	// RenderVideo renders a video clip of the world (tracking or named
+	// camera) and streams the encoded file back.
+	RenderVideo(*RenderVideoRequest, grpc.ServerStreamingServer[VideoChunk]) error
 	mustEmbedUnimplementedRobotBackendServiceServer()
 }
 
@@ -385,6 +553,36 @@ func (UnimplementedRobotBackendServiceServer) StopRecording(context.Context, *St
 }
 func (UnimplementedRobotBackendServiceServer) GetReplay(*GetReplayRequest, grpc.ServerStreamingServer[GetReplayChunk]) error {
 	return status.Error(codes.Unimplemented, "method GetReplay not implemented")
+}
+func (UnimplementedRobotBackendServiceServer) SetClock(context.Context, *SetClockRequest) (*SetClockResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SetClock not implemented")
+}
+func (UnimplementedRobotBackendServiceServer) ApplyForce(context.Context, *ApplyForceRequest) (*ApplyForceResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ApplyForce not implemented")
+}
+func (UnimplementedRobotBackendServiceServer) Teleport(context.Context, *TeleportRequest) (*TeleportResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method Teleport not implemented")
+}
+func (UnimplementedRobotBackendServiceServer) SaveSnapshot(context.Context, *SaveSnapshotRequest) (*SaveSnapshotResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SaveSnapshot not implemented")
+}
+func (UnimplementedRobotBackendServiceServer) RestoreSnapshot(context.Context, *RestoreSnapshotRequest) (*RestoreSnapshotResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RestoreSnapshot not implemented")
+}
+func (UnimplementedRobotBackendServiceServer) ReadSensors(context.Context, *ReadSensorsRequest) (*ReadSensorsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ReadSensors not implemented")
+}
+func (UnimplementedRobotBackendServiceServer) EditScene(context.Context, *EditSceneRequest) (*EditSceneResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method EditScene not implemented")
+}
+func (UnimplementedRobotBackendServiceServer) LoadPolicy(grpc.ClientStreamingServer[LoadPolicyChunk, LoadPolicyResponse]) error {
+	return status.Error(codes.Unimplemented, "method LoadPolicy not implemented")
+}
+func (UnimplementedRobotBackendServiceServer) ClearPolicy(context.Context, *ClearPolicyRequest) (*ClearPolicyResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ClearPolicy not implemented")
+}
+func (UnimplementedRobotBackendServiceServer) RenderVideo(*RenderVideoRequest, grpc.ServerStreamingServer[VideoChunk]) error {
+	return status.Error(codes.Unimplemented, "method RenderVideo not implemented")
 }
 func (UnimplementedRobotBackendServiceServer) mustEmbedUnimplementedRobotBackendServiceServer() {}
 func (UnimplementedRobotBackendServiceServer) testEmbeddedByValue()                             {}
@@ -652,6 +850,168 @@ func _RobotBackendService_GetReplay_Handler(srv interface{}, stream grpc.ServerS
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type RobotBackendService_GetReplayServer = grpc.ServerStreamingServer[GetReplayChunk]
 
+func _RobotBackendService_SetClock_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SetClockRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RobotBackendServiceServer).SetClock(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RobotBackendService_SetClock_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RobotBackendServiceServer).SetClock(ctx, req.(*SetClockRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _RobotBackendService_ApplyForce_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ApplyForceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RobotBackendServiceServer).ApplyForce(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RobotBackendService_ApplyForce_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RobotBackendServiceServer).ApplyForce(ctx, req.(*ApplyForceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _RobotBackendService_Teleport_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(TeleportRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RobotBackendServiceServer).Teleport(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RobotBackendService_Teleport_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RobotBackendServiceServer).Teleport(ctx, req.(*TeleportRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _RobotBackendService_SaveSnapshot_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SaveSnapshotRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RobotBackendServiceServer).SaveSnapshot(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RobotBackendService_SaveSnapshot_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RobotBackendServiceServer).SaveSnapshot(ctx, req.(*SaveSnapshotRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _RobotBackendService_RestoreSnapshot_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RestoreSnapshotRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RobotBackendServiceServer).RestoreSnapshot(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RobotBackendService_RestoreSnapshot_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RobotBackendServiceServer).RestoreSnapshot(ctx, req.(*RestoreSnapshotRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _RobotBackendService_ReadSensors_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ReadSensorsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RobotBackendServiceServer).ReadSensors(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RobotBackendService_ReadSensors_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RobotBackendServiceServer).ReadSensors(ctx, req.(*ReadSensorsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _RobotBackendService_EditScene_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(EditSceneRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RobotBackendServiceServer).EditScene(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RobotBackendService_EditScene_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RobotBackendServiceServer).EditScene(ctx, req.(*EditSceneRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _RobotBackendService_LoadPolicy_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(RobotBackendServiceServer).LoadPolicy(&grpc.GenericServerStream[LoadPolicyChunk, LoadPolicyResponse]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type RobotBackendService_LoadPolicyServer = grpc.ClientStreamingServer[LoadPolicyChunk, LoadPolicyResponse]
+
+func _RobotBackendService_ClearPolicy_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ClearPolicyRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RobotBackendServiceServer).ClearPolicy(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RobotBackendService_ClearPolicy_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RobotBackendServiceServer).ClearPolicy(ctx, req.(*ClearPolicyRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _RobotBackendService_RenderVideo_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(RenderVideoRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(RobotBackendServiceServer).RenderVideo(m, &grpc.GenericServerStream[RenderVideoRequest, VideoChunk]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type RobotBackendService_RenderVideoServer = grpc.ServerStreamingServer[VideoChunk]
+
 // RobotBackendService_ServiceDesc is the grpc.ServiceDesc for RobotBackendService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -707,6 +1067,38 @@ var RobotBackendService_ServiceDesc = grpc.ServiceDesc{
 			MethodName: "StopRecording",
 			Handler:    _RobotBackendService_StopRecording_Handler,
 		},
+		{
+			MethodName: "SetClock",
+			Handler:    _RobotBackendService_SetClock_Handler,
+		},
+		{
+			MethodName: "ApplyForce",
+			Handler:    _RobotBackendService_ApplyForce_Handler,
+		},
+		{
+			MethodName: "Teleport",
+			Handler:    _RobotBackendService_Teleport_Handler,
+		},
+		{
+			MethodName: "SaveSnapshot",
+			Handler:    _RobotBackendService_SaveSnapshot_Handler,
+		},
+		{
+			MethodName: "RestoreSnapshot",
+			Handler:    _RobotBackendService_RestoreSnapshot_Handler,
+		},
+		{
+			MethodName: "ReadSensors",
+			Handler:    _RobotBackendService_ReadSensors_Handler,
+		},
+		{
+			MethodName: "EditScene",
+			Handler:    _RobotBackendService_EditScene_Handler,
+		},
+		{
+			MethodName: "ClearPolicy",
+			Handler:    _RobotBackendService_ClearPolicy_Handler,
+		},
 	},
 	Streams: []grpc.StreamDesc{
 		{
@@ -722,6 +1114,16 @@ var RobotBackendService_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "GetReplay",
 			Handler:       _RobotBackendService_GetReplay_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "LoadPolicy",
+			Handler:       _RobotBackendService_LoadPolicy_Handler,
+			ClientStreams: true,
+		},
+		{
+			StreamName:    "RenderVideo",
+			Handler:       _RobotBackendService_RenderVideo_Handler,
 			ServerStreams: true,
 		},
 	},


### PR DESCRIPTION
## Summary

Stacked on #1394. Adds `wendy sim camera --world <id> [--robot <id>] [--camera <name>] [-o frame.png]` — captures a frame from a model camera or the backend's robot-tracking view via the already-forwarded `GetCameraFrame` RPC.

Python counterpart (wendylabsinc/wendysim @ 7e8959b): offscreen rendering (`GetCameraFrame` implementation), camera frames + obstacles + trajectory in Rerun replays, optional live web viewer (`WENDYSIM_LIVE_VIEWER=1`).

## Test plan

- Unit: command wiring + flag tests green; build/vet/gofmt clean.
- E2E on macOS: `wendy sim camera` returned a clean rendered PNG of the Go2; the recorded 3 m walk replay grew from 1.1 MB to 11.6 MB with the camera stream and plays back in the Rerun viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)