### PR TITLE
wendy run: offer to scaffold Wendy Lite ESP-IDF components on missing wendy.json

### DIFF
--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -696,7 +696,7 @@ func runCommand(ctx context.Context, opts runOptions) error {
 		if err := preflightMissingAppConfigForMacTarget(ctx, target, projectType); err != nil {
 			return err
 		}
-		if shouldOfferWendyLiteESPIDFScaffold(cfgMissing, projectType, target) && !opts.yes && isInteractiveTerminal() {
+		if shouldOfferWendyLiteESPIDFScaffold(cfgMissing, projectType, target) && !opts.yes && isInteractiveTerminal() && !jsonOutput {
 			scaffolded, err := promptAndScaffoldWendyLiteESPIDF(cwd)
 			if err != nil {
 				return err

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -696,6 +696,15 @@ func runCommand(ctx context.Context, opts runOptions) error {
 		if err := preflightMissingAppConfigForMacTarget(ctx, target, projectType); err != nil {
 			return err
 		}
+		if shouldOfferWendyLiteESPIDFScaffold(cfgMissing, projectType, target) {
+			scaffolded, err := promptAndScaffoldWendyLiteESPIDF(cwd)
+			if err != nil {
+				return err
+			}
+			if scaffolded {
+				cfgMissing = false
+			}
+		}
 	}
 
 	appCfg, err := ensureAppConfig(cfgPath, opts.yes)

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -696,7 +696,7 @@ func runCommand(ctx context.Context, opts runOptions) error {
 		if err := preflightMissingAppConfigForMacTarget(ctx, target, projectType); err != nil {
 			return err
 		}
-		if shouldOfferWendyLiteESPIDFScaffold(cfgMissing, projectType, target) {
+		if shouldOfferWendyLiteESPIDFScaffold(cfgMissing, projectType, target) && !opts.yes && isInteractiveTerminal() {
 			scaffolded, err := promptAndScaffoldWendyLiteESPIDF(cwd)
 			if err != nil {
 				return err

--- a/go/internal/cli/commands/wendylite_scaffold.go
+++ b/go/internal/cli/commands/wendylite_scaffold.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -64,6 +65,13 @@ func mergeIdfComponentDependencies(manifestPath string, components []string) err
 	}
 
 	deps := findOrAppendMappingKey(root, "dependencies")
+	if deps.Kind == yaml.ScalarNode && deps.Tag == "!!null" {
+		// "dependencies:" with nothing under it is a normal, common manifest
+		// shape (produced by IDF templates and hand-written stubs) that
+		// parses as a null scalar rather than an empty mapping. Upgrade it
+		// in place instead of treating it as malformed.
+		*deps = yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	}
 	if deps.Kind != yaml.MappingNode {
 		return fmt.Errorf("%s: \"dependencies\" is not a mapping", manifestPath)
 	}
@@ -190,6 +198,9 @@ func promptAndScaffoldWendyLiteESPIDF(cwd string) (bool, error) {
 	}
 	selected, err := wendyLiteComponentChecklistFn(items)
 	if err != nil {
+		if errors.Is(err, tui.ErrCancelled) {
+			return false, ErrUserCancelled
+		}
 		return false, err
 	}
 

--- a/go/internal/cli/commands/wendylite_scaffold.go
+++ b/go/internal/cli/commands/wendylite_scaffold.go
@@ -1,5 +1,13 @@
 package commands
 
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
 // shouldOfferWendyLiteESPIDFScaffold reports whether wendy run should offer to
 // scaffold Wendy Lite ESP-IDF components + a wendy.json for the current
 // project. True only when wendy.json is missing, the project directory looks
@@ -17,4 +25,89 @@ func shouldOfferWendyLiteESPIDFScaffold(cfgMissing bool, projectType string, tar
 		return false
 	}
 	return target.External.ConnectionType() == "USB"
+}
+
+const wendyLiteRepoURL = "https://github.com/wendylabsinc/wendy-lite.git"
+
+// mergeIdfComponentDependencies adds or updates one ESP-IDF Component Manager
+// git dependency per name in components, pointing at the matching
+// subdirectory of the wendy-lite repo, in the idf_component.yml at
+// manifestPath. Existing unrelated content is preserved; re-running with the
+// same components is a no-op.
+func mergeIdfComponentDependencies(manifestPath string, components []string) error {
+	var doc yaml.Node
+	data, err := os.ReadFile(manifestPath)
+	switch {
+	case err == nil:
+		if err := yaml.Unmarshal(data, &doc); err != nil {
+			return fmt.Errorf("parsing %s: %w", manifestPath, err)
+		}
+	case os.IsNotExist(err):
+		doc = yaml.Node{
+			Kind:    yaml.DocumentNode,
+			Content: []*yaml.Node{{Kind: yaml.MappingNode, Tag: "!!map"}},
+		}
+	default:
+		return fmt.Errorf("reading %s: %w", manifestPath, err)
+	}
+
+	if len(doc.Content) == 0 {
+		doc.Content = []*yaml.Node{{Kind: yaml.MappingNode, Tag: "!!map"}}
+	}
+	root := doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return fmt.Errorf("%s: expected a YAML mapping at the document root", manifestPath)
+	}
+
+	deps := findOrAppendMappingKey(root, "dependencies")
+
+	for _, name := range components {
+		dep := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+		dep.Content = append(dep.Content,
+			scalarNode("git"), scalarNode(wendyLiteRepoURL),
+			scalarNode("path"), scalarNode("components/"+name),
+		)
+		setMappingKey(deps, name, dep)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(manifestPath), 0o755); err != nil {
+		return fmt.Errorf("creating %s: %w", filepath.Dir(manifestPath), err)
+	}
+	out, err := yaml.Marshal(&doc)
+	if err != nil {
+		return fmt.Errorf("marshaling %s: %w", manifestPath, err)
+	}
+	if err := os.WriteFile(manifestPath, out, 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", manifestPath, err)
+	}
+	return nil
+}
+
+func scalarNode(v string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: v}
+}
+
+// findOrAppendMappingKey returns the value node for key in mapping, creating
+// an empty mapping node under that key if it doesn't already exist.
+func findOrAppendMappingKey(mapping *yaml.Node, key string) *yaml.Node {
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			return mapping.Content[i+1]
+		}
+	}
+	value := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	mapping.Content = append(mapping.Content, scalarNode(key), value)
+	return value
+}
+
+// setMappingKey sets key to value in mapping, overwriting any existing entry
+// with the same key in place (preserving the order of unrelated keys).
+func setMappingKey(mapping *yaml.Node, key string, value *yaml.Node) {
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			mapping.Content[i+1] = value
+			return
+		}
+	}
+	mapping.Content = append(mapping.Content, scalarNode(key), value)
 }

--- a/go/internal/cli/commands/wendylite_scaffold.go
+++ b/go/internal/cli/commands/wendylite_scaffold.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
 	"gopkg.in/yaml.v3"
 )
@@ -145,4 +146,70 @@ func writeWendyLiteESPIDFAppConfig(cwd string) error {
 	}
 	fmt.Printf("Created wendy.json for %s\n", dirName)
 	return nil
+}
+
+// wendyLiteESPIDFComponents lists the non-WASM Wendy Lite ESP-IDF components
+// offered by the scaffold checklist. WASM-only pieces (wendy_wasm,
+// wendy_hal_export, wendy_wasi_shim, wendy_safety, wendy_callback) are
+// intentionally excluded: this flow is for native ESP-IDF firmware, not WASM
+// apps.
+var wendyLiteESPIDFComponents = []string{
+	"wendy_hal",
+	"wendy_usb",
+	"wendy_wifi",
+	"wendy_ble_prov",
+	"wendy_cloud_prov",
+	"wendy_storage",
+	"wendy_uart",
+	"wendy_spi",
+	"wendy_sys",
+	"wendy_otel",
+	"wendy_ble",
+	"wendy_net",
+	"wendy_app_usb",
+}
+
+// wendyLiteComponentChecklistFn runs the component-selection checklist. It is
+// a package var so tests can stub it (mirrors confirmFn's testability
+// pattern in helpers.go).
+var wendyLiteComponentChecklistFn = func(items []tui.ChecklistItem) ([]tui.ChecklistItem, error) {
+	return tui.RunChecklist("Which Wendy Lite components do you want to add?", items)
+}
+
+// promptAndScaffoldWendyLiteESPIDF offers to add wendy-lite ESP-IDF
+// components to the project at cwd and, if accepted, writes a wendy.json.
+// Returns scaffolded=true iff wendy.json was written.
+func promptAndScaffoldWendyLiteESPIDF(cwd string) (bool, error) {
+	if !confirmFn("This looks like an ESP-IDF project without a wendy.json, and a USB-connected ESP32 was detected. Add Wendy Lite components and set up 'wendy run' for this project?") {
+		return false, nil
+	}
+
+	items := make([]tui.ChecklistItem, len(wendyLiteESPIDFComponents))
+	for i, name := range wendyLiteESPIDFComponents {
+		items[i] = tui.ChecklistItem{Label: name, Value: name, Selected: true}
+	}
+	selected, err := wendyLiteComponentChecklistFn(items)
+	if err != nil {
+		return false, err
+	}
+
+	names := make([]string, len(selected))
+	for i, item := range selected {
+		names[i] = item.Value
+	}
+
+	if len(names) > 0 {
+		manifestPath := filepath.Join(cwd, "main", "idf_component.yml")
+		if err := mergeIdfComponentDependencies(manifestPath, names); err != nil {
+			return false, fmt.Errorf("adding wendy-lite components: %w", err)
+		}
+		fmt.Printf("Added %d Wendy Lite component(s) to main/idf_component.yml\n", len(names))
+	} else {
+		fmt.Println("No Wendy Lite components were added. You can add idf_component.yml dependencies manually later.")
+	}
+
+	if err := writeWendyLiteESPIDFAppConfig(cwd); err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/go/internal/cli/commands/wendylite_scaffold.go
+++ b/go/internal/cli/commands/wendylite_scaffold.go
@@ -1,0 +1,20 @@
+package commands
+
+// shouldOfferWendyLiteESPIDFScaffold reports whether wendy run should offer to
+// scaffold Wendy Lite ESP-IDF components + a wendy.json for the current
+// project. True only when wendy.json is missing, the project directory looks
+// like an ESP-IDF project ("esp-idf" projectType, per detectProjectType), and
+// the already-resolved run target is a USB-connected wendy-lite provider
+// device.
+func shouldOfferWendyLiteESPIDFScaffold(cfgMissing bool, projectType string, target *SelectedDevice) bool {
+	if !cfgMissing || projectType != "esp-idf" || target == nil {
+		return false
+	}
+	if target.External == nil || target.Provider == nil {
+		return false
+	}
+	if target.Provider.Key() != "wendy-lite" {
+		return false
+	}
+	return target.External.ConnectionType() == "USB"
+}

--- a/go/internal/cli/commands/wendylite_scaffold.go
+++ b/go/internal/cli/commands/wendylite_scaffold.go
@@ -1,10 +1,12 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
 	"gopkg.in/yaml.v3"
 )
 
@@ -114,4 +116,33 @@ func setMappingKey(mapping *yaml.Node, key string, value *yaml.Node) {
 		}
 	}
 	mapping.Content = append(mapping.Content, scalarNode(key), value)
+}
+
+// newWendyLiteESPIDFAppConfig builds the minimal wendy.json contents for a
+// scaffolded native ESP-IDF wendy-lite project.
+func newWendyLiteESPIDFAppConfig(appID string) *appconfig.AppConfig {
+	return &appconfig.AppConfig{
+		AppID:    appID,
+		Version:  "0.1.0",
+		Platform: appconfig.PlatformWendyLite,
+		Language: "c",
+	}
+}
+
+// writeWendyLiteESPIDFAppConfig writes a scaffolded wendy.json into cwd,
+// deriving the app ID from the directory name (matching ensureAppConfig's
+// existing convention in helpers.go).
+func writeWendyLiteESPIDFAppConfig(cwd string) error {
+	cfgPath := filepath.Join(cwd, "wendy.json")
+	dirName := filepath.Base(cwd)
+
+	data, err := json.MarshalIndent(newWendyLiteESPIDFAppConfig(dirName), "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling config: %w", err)
+	}
+	if err := os.WriteFile(cfgPath, data, 0o644); err != nil {
+		return fmt.Errorf("writing wendy.json: %w", err)
+	}
+	fmt.Printf("Created wendy.json for %s\n", dirName)
+	return nil
 }

--- a/go/internal/cli/commands/wendylite_scaffold.go
+++ b/go/internal/cli/commands/wendylite_scaffold.go
@@ -52,6 +52,7 @@ func mergeIdfComponentDependencies(manifestPath string, components []string) err
 	}
 
 	if len(doc.Content) == 0 {
+		doc.Kind = yaml.DocumentNode
 		doc.Content = []*yaml.Node{{Kind: yaml.MappingNode, Tag: "!!map"}}
 	}
 	root := doc.Content[0]
@@ -60,6 +61,9 @@ func mergeIdfComponentDependencies(manifestPath string, components []string) err
 	}
 
 	deps := findOrAppendMappingKey(root, "dependencies")
+	if deps.Kind != yaml.MappingNode {
+		return fmt.Errorf("%s: \"dependencies\" is not a mapping", manifestPath)
+	}
 
 	for _, name := range components {
 		dep := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}

--- a/go/internal/cli/commands/wendylite_scaffold_test.go
+++ b/go/internal/cli/commands/wendylite_scaffold_test.go
@@ -2,10 +2,13 @@ package commands
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/wendylabsinc/wendy/go/internal/cli/providers"
 	"github.com/wendylabsinc/wendy/go/internal/shared/models"
+	"gopkg.in/yaml.v3"
 )
 
 // fakeDeviceProvider is a minimal providers.DeviceProvider test double whose
@@ -68,5 +71,117 @@ func TestShouldOfferWendyLiteESPIDFScaffold(t *testing.T) {
 				t.Errorf("shouldOfferWendyLiteESPIDFScaffold(%v, %q, ...) = %v, want %v", tt.cfgMissing, tt.projectType, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestMergeIdfComponentDependencies_CreatesNewFile(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "main", "idf_component.yml")
+
+	if err := mergeIdfComponentDependencies(manifestPath, []string{"wendy_hal", "wendy_usb"}); err != nil {
+		t.Fatalf("mergeIdfComponentDependencies: %v", err)
+	}
+
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("reading manifest: %v", err)
+	}
+
+	var parsed struct {
+		Dependencies map[string]struct {
+			Git  string `yaml:"git"`
+			Path string `yaml:"path"`
+		} `yaml:"dependencies"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parsing written manifest: %v", err)
+	}
+
+	for _, name := range []string{"wendy_hal", "wendy_usb"} {
+		dep, ok := parsed.Dependencies[name]
+		if !ok {
+			t.Fatalf("expected dependency %q, got %+v", name, parsed.Dependencies)
+		}
+		if dep.Git != "https://github.com/wendylabsinc/wendy-lite.git" {
+			t.Errorf("dep %q git = %q, want the wendy-lite repo URL", name, dep.Git)
+		}
+		if dep.Path != "components/"+name {
+			t.Errorf("dep %q path = %q, want %q", name, dep.Path, "components/"+name)
+		}
+	}
+}
+
+func TestMergeIdfComponentDependencies_PreservesExistingContent(t *testing.T) {
+	dir := t.TempDir()
+	mainDir := filepath.Join(dir, "main")
+	if err := os.MkdirAll(mainDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(mainDir, "idf_component.yml")
+	existing := "dependencies:\n  espressif/led_strip:\n    version: \"^2.0.0\"\n"
+	if err := os.WriteFile(manifestPath, []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mergeIdfComponentDependencies(manifestPath, []string{"wendy_hal"}); err != nil {
+		t.Fatalf("mergeIdfComponentDependencies: %v", err)
+	}
+
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed struct {
+		Dependencies map[string]map[string]string `yaml:"dependencies"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parsing written manifest: %v", err)
+	}
+	if parsed.Dependencies["espressif/led_strip"]["version"] != "^2.0.0" {
+		t.Errorf("existing dependency was clobbered: %+v", parsed.Dependencies)
+	}
+	if parsed.Dependencies["wendy_hal"]["git"] != "https://github.com/wendylabsinc/wendy-lite.git" {
+		t.Errorf("wendy_hal dependency not added: %+v", parsed.Dependencies)
+	}
+}
+
+func TestMergeIdfComponentDependencies_IdempotentReRun(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "main", "idf_component.yml")
+
+	if err := mergeIdfComponentDependencies(manifestPath, []string{"wendy_hal"}); err != nil {
+		t.Fatalf("first merge: %v", err)
+	}
+	first, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mergeIdfComponentDependencies(manifestPath, []string{"wendy_hal"}); err != nil {
+		t.Fatalf("second merge: %v", err)
+	}
+	second, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(first) != string(second) {
+		t.Errorf("re-running with the same selection changed the file:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+func TestMergeIdfComponentDependencies_MalformedYAMLErrors(t *testing.T) {
+	dir := t.TempDir()
+	mainDir := filepath.Join(dir, "main")
+	if err := os.MkdirAll(mainDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(mainDir, "idf_component.yml")
+	if err := os.WriteFile(manifestPath, []byte("not: valid: yaml: [broken"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mergeIdfComponentDependencies(manifestPath, []string{"wendy_hal"}); err == nil {
+		t.Fatal("expected an error for malformed existing YAML, got nil")
 	}
 }

--- a/go/internal/cli/commands/wendylite_scaffold_test.go
+++ b/go/internal/cli/commands/wendylite_scaffold_test.go
@@ -2,11 +2,13 @@ package commands
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/wendylabsinc/wendy/go/internal/cli/providers"
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
 	"github.com/wendylabsinc/wendy/go/internal/shared/models"
 	"gopkg.in/yaml.v3"
 )
@@ -238,5 +240,42 @@ func TestMergeIdfComponentDependencies_NonMappingDependenciesErrors(t *testing.T
 
 	if err := mergeIdfComponentDependencies(manifestPath, []string{"wendy_hal"}); err == nil {
 		t.Fatal("expected an error for non-mapping dependencies key, got nil")
+	}
+}
+
+func TestNewWendyLiteESPIDFAppConfig(t *testing.T) {
+	cfg := newWendyLiteESPIDFAppConfig("my-esp32-app")
+
+	if cfg.AppID != "my-esp32-app" {
+		t.Errorf("AppID = %q, want %q", cfg.AppID, "my-esp32-app")
+	}
+	if cfg.Platform != appconfig.PlatformWendyLite {
+		t.Errorf("Platform = %q, want %q", cfg.Platform, appconfig.PlatformWendyLite)
+	}
+	if cfg.Version == "" {
+		t.Error("Version must not be empty")
+	}
+}
+
+func TestWriteWendyLiteESPIDFAppConfig(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := writeWendyLiteESPIDFAppConfig(dir); err != nil {
+		t.Fatalf("writeWendyLiteESPIDFAppConfig: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "wendy.json"))
+	if err != nil {
+		t.Fatalf("reading wendy.json: %v", err)
+	}
+	var cfg appconfig.AppConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parsing wendy.json: %v", err)
+	}
+	if cfg.Platform != appconfig.PlatformWendyLite {
+		t.Errorf("Platform = %q, want %q", cfg.Platform, appconfig.PlatformWendyLite)
+	}
+	if cfg.AppID != filepath.Base(dir) {
+		t.Errorf("AppID = %q, want directory base name %q", cfg.AppID, filepath.Base(dir))
 	}
 }

--- a/go/internal/cli/commands/wendylite_scaffold_test.go
+++ b/go/internal/cli/commands/wendylite_scaffold_test.go
@@ -1,0 +1,72 @@
+package commands
+
+import (
+	"context"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/providers"
+	"github.com/wendylabsinc/wendy/go/internal/shared/models"
+)
+
+// fakeDeviceProvider is a minimal providers.DeviceProvider test double whose
+// Key() is configurable; every other method is a no-op stub.
+type fakeDeviceProvider struct{ key string }
+
+func (f fakeDeviceProvider) Key() string         { return f.key }
+func (f fakeDeviceProvider) DisplayName() string { return "" }
+func (f fakeDeviceProvider) IsAvailable(ctx context.Context) bool         { return true }
+func (f fakeDeviceProvider) CheckRequirements(ctx context.Context) error  { return nil }
+func (f fakeDeviceProvider) DiscoverDevices(ctx context.Context) ([]models.ExternalDevice, error) {
+	return nil, nil
+}
+func (f fakeDeviceProvider) SupportedBuildTypes() []string  { return nil }
+func (f fakeDeviceProvider) CanBuild(projectPath string) bool { return false }
+func (f fakeDeviceProvider) Build(ctx context.Context, device models.ExternalDevice, projectPath, projectType, product string, debug bool) (*providers.BuiltApp, error) {
+	return nil, nil
+}
+func (f fakeDeviceProvider) Run(ctx context.Context, app *providers.BuiltApp, detach bool, output chan<- providers.RunOutput) error {
+	return nil
+}
+func (f fakeDeviceProvider) Stop(ctx context.Context, app *providers.BuiltApp) error { return nil }
+func (f fakeDeviceProvider) GetDeviceInfo(ctx context.Context, device models.ExternalDevice) (*providers.ProviderDeviceInfo, error) {
+	return nil, nil
+}
+
+func TestShouldOfferWendyLiteESPIDFScaffold(t *testing.T) {
+	usbWendyLite := &SelectedDevice{
+		External: &models.ExternalDevice{ConnectionInfo: map[string]string{"type": "USB"}},
+		Provider: fakeDeviceProvider{key: "wendy-lite"},
+	}
+	lanWendyLite := &SelectedDevice{
+		External: &models.ExternalDevice{ConnectionInfo: map[string]string{"type": "LAN"}},
+		Provider: fakeDeviceProvider{key: "wendy-lite"},
+	}
+	usbOtherProvider := &SelectedDevice{
+		External: &models.ExternalDevice{ConnectionInfo: map[string]string{"type": "USB"}},
+		Provider: fakeDeviceProvider{key: "docker"},
+	}
+
+	tests := []struct {
+		name        string
+		cfgMissing  bool
+		projectType string
+		target      *SelectedDevice
+		want        bool
+	}{
+		{"all conditions met", true, "esp-idf", usbWendyLite, true},
+		{"wendy.json already present", false, "esp-idf", usbWendyLite, false},
+		{"not an esp-idf project shape", true, "docker", usbWendyLite, false},
+		{"wendy-lite over LAN, not USB", true, "esp-idf", lanWendyLite, false},
+		{"USB but not the wendy-lite provider", true, "esp-idf", usbOtherProvider, false},
+		{"nil target", true, "esp-idf", nil, false},
+		{"target with no External/Provider (agent path)", true, "esp-idf", &SelectedDevice{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldOfferWendyLiteESPIDFScaffold(tt.cfgMissing, tt.projectType, tt.target)
+			if got != tt.want {
+				t.Errorf("shouldOfferWendyLiteESPIDFScaffold(%v, %q, ...) = %v, want %v", tt.cfgMissing, tt.projectType, got, tt.want)
+			}
+		})
+	}
+}

--- a/go/internal/cli/commands/wendylite_scaffold_test.go
+++ b/go/internal/cli/commands/wendylite_scaffold_test.go
@@ -19,14 +19,14 @@ import (
 // Key() is configurable; every other method is a no-op stub.
 type fakeDeviceProvider struct{ key string }
 
-func (f fakeDeviceProvider) Key() string         { return f.key }
-func (f fakeDeviceProvider) DisplayName() string { return "" }
-func (f fakeDeviceProvider) IsAvailable(ctx context.Context) bool         { return true }
-func (f fakeDeviceProvider) CheckRequirements(ctx context.Context) error  { return nil }
+func (f fakeDeviceProvider) Key() string                                 { return f.key }
+func (f fakeDeviceProvider) DisplayName() string                         { return "" }
+func (f fakeDeviceProvider) IsAvailable(ctx context.Context) bool        { return true }
+func (f fakeDeviceProvider) CheckRequirements(ctx context.Context) error { return nil }
 func (f fakeDeviceProvider) DiscoverDevices(ctx context.Context) ([]models.ExternalDevice, error) {
 	return nil, nil
 }
-func (f fakeDeviceProvider) SupportedBuildTypes() []string  { return nil }
+func (f fakeDeviceProvider) SupportedBuildTypes() []string    { return nil }
 func (f fakeDeviceProvider) CanBuild(projectPath string) bool { return false }
 func (f fakeDeviceProvider) Build(ctx context.Context, device models.ExternalDevice, projectPath, projectType, product string, debug bool) (*providers.BuiltApp, error) {
 	return nil, nil
@@ -235,13 +235,60 @@ func TestMergeIdfComponentDependencies_NonMappingDependenciesErrors(t *testing.T
 		t.Fatal(err)
 	}
 	manifestPath := filepath.Join(mainDir, "idf_component.yml")
-	// Create manifest with dependencies: key but no mapping value (empty scalar)
-	if err := os.WriteFile(manifestPath, []byte("dependencies:\n"), 0o644); err != nil {
+	// Create manifest with a dependencies: key whose value is a genuinely
+	// wrong shape (a string scalar, not null and not a mapping).
+	if err := os.WriteFile(manifestPath, []byte("dependencies: \"oops\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	if err := mergeIdfComponentDependencies(manifestPath, []string{"wendy_hal"}); err == nil {
 		t.Fatal("expected an error for non-mapping dependencies key, got nil")
+	}
+}
+
+func TestMergeIdfComponentDependencies_NullDependenciesUpgraded(t *testing.T) {
+	dir := t.TempDir()
+	mainDir := filepath.Join(dir, "main")
+	if err := os.MkdirAll(mainDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(mainDir, "idf_component.yml")
+	// "dependencies:" with nothing under it parses as a null scalar, not a
+	// mapping. This is a common, legitimate manifest shape (e.g. produced by
+	// IDF templates) and must be upgraded to an empty mapping, not rejected.
+	if err := os.WriteFile(manifestPath, []byte("dependencies:\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mergeIdfComponentDependencies(manifestPath, []string{"wendy_hal", "wendy_usb"}); err != nil {
+		t.Fatalf("mergeIdfComponentDependencies on null dependencies: %v", err)
+	}
+
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed struct {
+		Dependencies map[string]struct {
+			Git  string `yaml:"git"`
+			Path string `yaml:"path"`
+		} `yaml:"dependencies"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parsing written manifest: %v", err)
+	}
+
+	for _, name := range []string{"wendy_hal", "wendy_usb"} {
+		dep, ok := parsed.Dependencies[name]
+		if !ok {
+			t.Fatalf("expected dependency %q, got %+v", name, parsed.Dependencies)
+		}
+		if dep.Git != "https://github.com/wendylabsinc/wendy-lite.git" {
+			t.Errorf("dep %q git = %q, want the wendy-lite repo URL", name, dep.Git)
+		}
+		if dep.Path != "components/"+name {
+			t.Errorf("dep %q path = %q, want %q", name, dep.Path, "components/"+name)
+		}
 	}
 }
 
@@ -374,8 +421,8 @@ func TestPromptAndScaffoldWendyLiteESPIDF_ChecklistCancelled(t *testing.T) {
 
 	dir := t.TempDir()
 	scaffolded, err := promptAndScaffoldWendyLiteESPIDF(dir)
-	if !errors.Is(err, tui.ErrCancelled) {
-		t.Fatalf("expected tui.ErrCancelled, got %v", err)
+	if !errors.Is(err, ErrUserCancelled) {
+		t.Fatalf("expected ErrUserCancelled, got %v", err)
 	}
 	if scaffolded {
 		t.Error("expected scaffolded=false on cancellation")

--- a/go/internal/cli/commands/wendylite_scaffold_test.go
+++ b/go/internal/cli/commands/wendylite_scaffold_test.go
@@ -3,11 +3,13 @@ package commands
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/wendylabsinc/wendy/go/internal/cli/providers"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
 	"github.com/wendylabsinc/wendy/go/internal/shared/models"
 	"gopkg.in/yaml.v3"
@@ -277,5 +279,108 @@ func TestWriteWendyLiteESPIDFAppConfig(t *testing.T) {
 	}
 	if cfg.AppID != filepath.Base(dir) {
 		t.Errorf("AppID = %q, want directory base name %q", cfg.AppID, filepath.Base(dir))
+	}
+}
+
+func TestPromptAndScaffoldWendyLiteESPIDF_Declined(t *testing.T) {
+	origConfirm := confirmFn
+	defer func() { confirmFn = origConfirm }()
+	confirmFn = func(string) bool { return false }
+
+	origChecklist := wendyLiteComponentChecklistFn
+	defer func() { wendyLiteComponentChecklistFn = origChecklist }()
+	wendyLiteComponentChecklistFn = func([]tui.ChecklistItem) ([]tui.ChecklistItem, error) {
+		t.Fatal("must not prompt checklist when the initial confirm is declined")
+		return nil, nil
+	}
+
+	dir := t.TempDir()
+	scaffolded, err := promptAndScaffoldWendyLiteESPIDF(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if scaffolded {
+		t.Error("expected scaffolded=false when confirm is declined")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "wendy.json")); statErr == nil {
+		t.Error("wendy.json must not be written when confirm is declined")
+	}
+}
+
+func TestPromptAndScaffoldWendyLiteESPIDF_AllComponentsSelected(t *testing.T) {
+	origConfirm := confirmFn
+	defer func() { confirmFn = origConfirm }()
+	confirmFn = func(string) bool { return true }
+
+	origChecklist := wendyLiteComponentChecklistFn
+	defer func() { wendyLiteComponentChecklistFn = origChecklist }()
+	wendyLiteComponentChecklistFn = func(items []tui.ChecklistItem) ([]tui.ChecklistItem, error) {
+		return items, nil // simulate the user keeping every pre-selected item
+	}
+
+	dir := t.TempDir()
+	scaffolded, err := promptAndScaffoldWendyLiteESPIDF(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !scaffolded {
+		t.Fatal("expected scaffolded=true")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "wendy.json")); statErr != nil {
+		t.Errorf("expected wendy.json to be written: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "main", "idf_component.yml")); statErr != nil {
+		t.Errorf("expected main/idf_component.yml to be written: %v", statErr)
+	}
+}
+
+func TestPromptAndScaffoldWendyLiteESPIDF_NoComponentsSelected(t *testing.T) {
+	origConfirm := confirmFn
+	defer func() { confirmFn = origConfirm }()
+	confirmFn = func(string) bool { return true }
+
+	origChecklist := wendyLiteComponentChecklistFn
+	defer func() { wendyLiteComponentChecklistFn = origChecklist }()
+	wendyLiteComponentChecklistFn = func([]tui.ChecklistItem) ([]tui.ChecklistItem, error) {
+		return nil, nil // simulate the user unchecking every item
+	}
+
+	dir := t.TempDir()
+	scaffolded, err := promptAndScaffoldWendyLiteESPIDF(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !scaffolded {
+		t.Fatal("expected scaffolded=true even with zero components selected")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "wendy.json")); statErr != nil {
+		t.Errorf("expected wendy.json to still be written: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "main", "idf_component.yml")); statErr == nil {
+		t.Error("idf_component.yml must not be written when zero components are selected")
+	}
+}
+
+func TestPromptAndScaffoldWendyLiteESPIDF_ChecklistCancelled(t *testing.T) {
+	origConfirm := confirmFn
+	defer func() { confirmFn = origConfirm }()
+	confirmFn = func(string) bool { return true }
+
+	origChecklist := wendyLiteComponentChecklistFn
+	defer func() { wendyLiteComponentChecklistFn = origChecklist }()
+	wendyLiteComponentChecklistFn = func([]tui.ChecklistItem) ([]tui.ChecklistItem, error) {
+		return nil, tui.ErrCancelled
+	}
+
+	dir := t.TempDir()
+	scaffolded, err := promptAndScaffoldWendyLiteESPIDF(dir)
+	if !errors.Is(err, tui.ErrCancelled) {
+		t.Fatalf("expected tui.ErrCancelled, got %v", err)
+	}
+	if scaffolded {
+		t.Error("expected scaffolded=false on cancellation")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "wendy.json")); statErr == nil {
+		t.Error("wendy.json must not be written when the checklist is cancelled")
 	}
 }

--- a/go/internal/cli/commands/wendylite_scaffold_test.go
+++ b/go/internal/cli/commands/wendylite_scaffold_test.go
@@ -185,3 +185,58 @@ func TestMergeIdfComponentDependencies_MalformedYAMLErrors(t *testing.T) {
 		t.Fatal("expected an error for malformed existing YAML, got nil")
 	}
 }
+
+func TestMergeIdfComponentDependencies_EmptyExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	mainDir := filepath.Join(dir, "main")
+	if err := os.MkdirAll(mainDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(mainDir, "idf_component.yml")
+	// Create a 0-byte file (empty manifest)
+	if err := os.WriteFile(manifestPath, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mergeIdfComponentDependencies(manifestPath, []string{"wendy_hal"}); err != nil {
+		t.Fatalf("mergeIdfComponentDependencies on empty file: %v", err)
+	}
+
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var parsed struct {
+		Dependencies map[string]struct {
+			Git  string `yaml:"git"`
+			Path string `yaml:"path"`
+		} `yaml:"dependencies"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parsing written manifest: %v", err)
+	}
+
+	if dep, ok := parsed.Dependencies["wendy_hal"]; !ok {
+		t.Fatalf("expected wendy_hal dependency, got %+v", parsed.Dependencies)
+	} else if dep.Git != "https://github.com/wendylabsinc/wendy-lite.git" {
+		t.Errorf("git URL = %q, want wendy-lite repo", dep.Git)
+	}
+}
+
+func TestMergeIdfComponentDependencies_NonMappingDependenciesErrors(t *testing.T) {
+	dir := t.TempDir()
+	mainDir := filepath.Join(dir, "main")
+	if err := os.MkdirAll(mainDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(mainDir, "idf_component.yml")
+	// Create manifest with dependencies: key but no mapping value (empty scalar)
+	if err := os.WriteFile(manifestPath, []byte("dependencies:\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mergeIdfComponentDependencies(manifestPath, []string{"wendy_hal"}); err == nil {
+		t.Fatal("expected an error for non-mapping dependencies key, got nil")
+	}
+}

--- a/specs/2026-07-31-wendy-run-esp32-usb-component-scaffold-design.md
+++ b/specs/2026-07-31-wendy-run-esp32-usb-component-scaffold-design.md
@@ -1,0 +1,224 @@
+# `wendy run` — propose Wendy Lite ESP-IDF component install on missing `wendy.json`
+
+Date: 2026-07-31
+Status: Approved (design)
+
+## Goal
+
+When a developer runs `wendy run` inside an **existing, bare ESP-IDF project**
+(their own `CMakeLists.txt` + `main/`, no `wendy.json` yet) with a **USB-connected
+ESP32** plugged in, the CLI should notice this shape and offer to:
+
+1. Add selected Wendy Lite ESP-IDF components
+   (https://github.com/wendylabsinc/wendy-lite/tree/main/components) to the
+   project as ESP-IDF Component Manager git dependencies.
+2. Generate a minimal `wendy.json` so the project becomes buildable/flashable
+   via the existing `wendy run` path immediately afterward.
+
+This is a native-firmware flow (developer writes their own ESP-IDF `main.c`)
+distinct from the existing WASM-app flow (`wendy init` → Swift/WASM app run on
+top of the prebuilt Wendy Lite firmware). WASM-only components are never
+offered here.
+
+## Background & precedent
+
+Investigation of the current codebase found the building blocks already exist
+— only the "no `wendy.json` yet" bootstrap path is missing:
+
+- **Device targeting**: `resolveRunTarget` → `resolveTarget`/`resolveTargetInner`
+  (`go/internal/cli/commands/helpers.go:1758,1788`) is the single funnel for
+  device selection in every command, producing a `SelectedDevice`
+  (`helpers.go:723`) with `Agent`/`Bluetooth`/`External+Provider` variants.
+  `providers.AvailableProviders()` (`helpers.go:1911,2303`) is queried
+  unconditionally — discovery runs even with no `wendy.json` present.
+- **Wendy Lite USB discovery already works**: `MicroWendyProvider`
+  (`go/internal/cli/providers/microwendy.go`, key `"wendy-lite"`) discovers
+  devices via mDNS *and* USB serial in `DiscoverDevices` (lines 56-102), using
+  `discovery.GetSerialDiscovery()` /
+  `go/internal/shared/discovery/serial_discovery.go` (OS-specific enumeration
+  in `serial_{darwin,linux,windows}.go`). `models.ExternalDevice.ConnectionType()`
+  already reports `"USB"` vs `"LAN"` vs `"BLE"` for a resolved device.
+- **Build routing is file-shape based, not `wendy.json`-based**: `Build`
+  (`microwendy.go:113-122`) switches on a `projectType` string computed by
+  `detectProjectType` (`go/internal/cli/commands/docker.go:200-246`), which
+  checks (in precedence order) compose files, Dockerfile, `Package.swift` →
+  `"swift"`, `*.xcodeproj`, Python markers, then
+  `espidftoolchain.IsEspIdfProject(dir)` → `"esp-idf"`. None of this reads
+  `wendy.json` — it inspects the directory. So once a `wendy.json` exists at
+  all, `buildEspIdf` (`microwendy.go:220-274`) already builds
+  (`espidftoolchain.EnsureVersion` → `idf.py set-target` → `idf.py build`) and
+  flashes existing ESP-IDF projects correctly.
+- **`Platform: "wendy-lite"`** is already a distinct enum value
+  (`go/internal/shared/appconfig/appconfig.go:116`), and `Language`
+  (`appconfig.go:236`, schema `wendy.schema.json:30-33`) is a free-form,
+  unvalidated string that nothing currently reads for routing — no schema
+  changes needed.
+- **No component-dependency management exists yet**: nothing in the repo
+  touches `idf_component.yml`, the ESP-IDF Component Registry, or clones
+  `wendy-lite`. `go/internal/cli/espidftoolchain/toolchain.go` only manages the
+  SDK/toolchain itself (`EnsureVersion`, `IsEspIdfProject`, `IdfCommandContext`)
+  — this is genuinely new.
+- **UI primitives to reuse**: `tui.ConfirmDefaultYes`
+  (`go/internal/cli/tui/confirm.go:169`) and the existing multi-select
+  checklist `tui.ChecklistModel`/`RunChecklist`
+  (`go/internal/cli/tui/checklist.go:23,215`), already used for the
+  entitlements picker (`go/internal/cli/commands/init_cmd.go:1004-1013`).
+  `gopkg.in/yaml.v3` is already a repo dependency.
+
+The only genuinely new capability is: detect this specific opportunity, ask,
+and write `idf_component.yml` + `wendy.json`.
+
+## Decisions (from brainstorming)
+
+- **Scope**: existing bare ESP-IDF projects only. Scaffolding a brand-new
+  project from an empty directory is explicitly out of scope for this PR.
+- **Install mechanism**: ESP-IDF Component Manager (`idf_component.yml` git
+  dependency), not vendoring/cloning and not a git submodule. No new
+  fetch/clone code in the CLI — `idf.py build`'s existing component manager
+  (already invoked by `buildEspIdf`) resolves it.
+- **Component set offered**: user picks via checklist; WASM-related components
+  (`wendy_wasm`, `wendy_hal_export`, `wendy_wasi_shim`, `wendy_safety`,
+  `wendy_callback`) are never offered in this flow.
+
+## Architecture
+
+### 1. Trigger detection
+
+New function, e.g. `shouldOfferWendyLiteESPIDFScaffold(cwd string, target
+SelectedDevice) bool`, called from the existing missing-config branch in
+`go/internal/cli/commands/run.go` (`cfgMissing` handling around lines
+674-699/781-799, alongside the existing `preflightMissingAppConfigForMacTarget`
+pattern). True only when **all** of:
+
+1. `wendy.json` is absent (`cfgMissing`).
+2. `espidftoolchain.IsEspIdfProject(cwd)` is true.
+3. `target.External != nil && target.Provider != nil &&
+   target.Provider.Key() == "wendy-lite" && target.External.ConnectionType() ==
+   "USB"`.
+
+No new discovery code — `target` is whatever `resolveRunTarget` already
+resolved (interactive picker or default device), and that picker already
+surfaces USB wendy-lite devices today.
+
+### 2. Confirm + component selection
+
+New function `promptAndScaffoldWendyLiteESPIDF(cwd string) error`:
+
+- `tui.ConfirmDefaultYes`: *"This looks like an ESP-IDF project without a
+  wendy.json, and a USB-connected ESP32 was detected. Add Wendy Lite
+  components and set up `wendy run` for this project?"* Decline → return a
+  sentinel (no-op); caller falls through to today's existing behavior
+  unchanged.
+- `tui.RunChecklist("Which Wendy Lite components do you want to add?", items)`
+  with items built from a static list (non-WASM only):
+  `wendy_hal`, `wendy_usb`, `wendy_wifi`, `wendy_ble_prov`, `wendy_cloud_prov`,
+  `wendy_storage`, `wendy_uart`, `wendy_spi`, `wendy_sys`, `wendy_otel`,
+  `wendy_ble`, `wendy_net`, `wendy_app_usb`. All pre-selected
+  (`ChecklistItem.Selected = true`) by default; user can uncheck.
+  `ErrCancelled` → abort, no files written.
+
+### 3. Writing `main/idf_component.yml`
+
+New function `mergeIdfComponentDependencies(path string, components []string)
+error` in a new file, e.g.
+`go/internal/cli/commands/wendylite_scaffold.go`:
+
+- Target path: `<projectPath>/main/idf_component.yml` (ESP-IDF's per-component
+  manifest convention for the `main` component).
+- Parse with `yaml.v3` into a `yaml.Node` (not a plain map) so existing
+  formatting/comments/unrelated dependencies are preserved on write.
+- Ensure a `dependencies:` mapping node exists; for each selected component,
+  add/overwrite only that key:
+  ```yaml
+  dependencies:
+    wendy_hal:
+      git: "https://github.com/wendylabsinc/wendy-lite.git"
+      path: "components/wendy_hal"
+  ```
+- Idempotent: re-running with the same selection produces no diff; re-running
+  with a different selection only touches the changed keys.
+- If the file doesn't exist, create it with just the `dependencies:` block.
+- If zero components were selected in the checklist, skip this step entirely
+  (see Error handling).
+
+### 4. Writing `wendy.json`
+
+Reuse the existing `wendy.json` writer used by `wendy init`
+(`go/internal/cli/commands/init_cmd.go`, the same code path that produces
+`AppID`/`Version`/`Entitlements`), called with `Platform:
+appconfig.PlatformWendyLite` and a descriptive `Language` value (e.g. `"c"`).
+No schema/appconfig changes required — `Language` is already free-form and
+`PlatformWendyLite` already exists.
+
+### 5. Continuation
+
+After `wendy.json` exists, control returns to the normal `wendy run` flow.
+Nothing about `resolveRunTarget`/`detectProjectType`/`buildEspIdf` changes —
+the project now simply looks, to that existing code, exactly like a
+hand-written ESP-IDF wendy-lite project already would.
+
+## Data flow
+
+```
+wendy run (cwd = bare ESP-IDF project, no wendy.json)
+  → resolveRunTarget()                     [existing, unchanged]
+      → USB-connected wendy-lite device resolved
+  → cfgMissing == true
+  → shouldOfferWendyLiteESPIDFScaffold() == true   [new]
+      → confirm (tui.ConfirmDefaultYes)            [new]
+      → checklist (tui.RunChecklist)                [new]
+      → mergeIdfComponentDependencies(main/idf_component.yml)  [new]
+      → write wendy.json (Platform: wendy-lite)     [new, reuses init writer]
+  → existing wendy run flow continues:
+      detectProjectType() → "esp-idf" → buildEspIdf() → idf.py build → flash
+```
+
+## Error handling
+
+- **Declined confirm**: no-op, falls through to whatever `wendy run` does
+  today for a `wendy.json`-less directory (existing generic scaffold prompt,
+  unchanged).
+- **Zero components selected**: skip the `idf_component.yml` write, still
+  write `wendy.json`, print a note that no components were added and they can
+  be added later (re-running `wendy run` won't re-offer the scaffold once
+  `wendy.json` exists — a future manual command, if ever needed, is out of
+  scope here).
+- **`idf_component.yml` write failure** (permissions, malformed existing YAML
+  that fails to parse): abort before writing `wendy.json`, surface a clear
+  error, leave the project untouched — no half-configured state.
+- **Ctrl+C at either prompt**: `tui.ErrCancelled` propagates, abort cleanly,
+  no files written.
+
+## Testing
+
+- **Trigger detection**: table-driven unit test over the 3-condition matrix
+  (`wendy.json` present/absent × ESP-IDF shape yes/no × device
+  provider/connection-type combinations) asserting
+  `shouldOfferWendyLiteESPIDFScaffold`'s boolean result.
+- **`mergeIdfComponentDependencies`**: unit tests for: empty/non-existent file,
+  file with pre-existing unrelated dependencies (must be preserved), file with
+  a subset of wendy-lite deps already present (idempotency + only-changed-keys
+  behavior), malformed YAML (must error, not panic or clobber).
+- **Manual / hardware**: end-to-end `wendy run` against a real USB-connected
+  ESP32 with a bare ESP-IDF project is out of scope for CI — hardware-unverified,
+  called out explicitly in the PR like other WendyOS device-facing changes.
+
+## Scope (v1, YAGNI)
+
+- Existing bare ESP-IDF projects only — no from-scratch scaffold of a new
+  project in an empty directory.
+- ESP-IDF Component Manager git dependency only — no vendoring, no submodules.
+- Non-WASM components only, offered via a static list — no dynamic fetch of
+  the current component list from the wendy-lite repo/registry.
+- `main/idf_component.yml` only — no support for projects with a non-standard
+  main-component layout.
+
+## Out of scope / future
+
+- From-scratch scaffold for an empty directory with a USB ESP32 plugged in.
+- A standalone `wendy project add-component`-style command to add/remove
+  wendy-lite components after initial scaffold.
+- Dynamically listing available components by querying the wendy-lite repo at
+  runtime instead of a static list.
+- Pinning to a specific `wendy-lite` git ref/tag (currently `main`, matching
+  existing precedent in `init_cmd.go:1610`'s Swift package dependency).

--- a/specs/2026-07-31-wendy-run-esp32-usb-component-scaffold-plan.md
+++ b/specs/2026-07-31-wendy-run-esp32-usb-component-scaffold-plan.md
@@ -1,0 +1,951 @@
+# Wendy Run ESP-IDF Component Scaffold Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When `wendy run` is invoked in an existing bare ESP-IDF project (no
+`wendy.json` yet) with a USB-connected ESP32 detected as the run target,
+propose adding selected Wendy Lite ESP-IDF components (as an ESP-IDF Component
+Manager git dependency) and generate a minimal `wendy.json` so the project
+becomes runnable via the existing `wendy run` path immediately afterward.
+
+**Architecture:** All new code lives in one new file,
+`go/internal/cli/commands/wendylite_scaffold.go` (package `commands`), plus a
+~15-line edit to the existing `cfgMissing` branch in
+`go/internal/cli/commands/run.go`. No new packages, no schema changes, no new
+external dependencies — `gopkg.in/yaml.v3` and the existing `tui.ConfirmDefaultYes`
+/ `tui.RunChecklist` primitives are reused. Build routing
+(`detectProjectType` → `"esp-idf"` → `buildEspIdf`) is untouched; this plan
+only adds the missing "no `wendy.json` yet" bootstrap step ahead of it.
+
+**Tech Stack:** Go, `gopkg.in/yaml.v3` (already a dependency), Bubble Tea /
+`go/internal/cli/tui` (already a dependency), standard library
+`encoding/json`, `os`, `path/filepath`.
+
+## Global Constraints
+
+- Scope is existing bare ESP-IDF projects only — do not scaffold a brand-new
+  project from an empty directory (that's explicitly out of scope).
+- Install mechanism is the ESP-IDF Component Manager (`idf_component.yml` git
+  dependency) only — no vendoring/cloning, no git submodules, no new fetch
+  code.
+- WASM-only components (`wendy_wasm`, `wendy_hal_export`, `wendy_wasi_shim`,
+  `wendy_safety`, `wendy_callback`) must never appear in the offered checklist.
+- Component dependency git URL is `https://github.com/wendylabsinc/wendy-lite.git`
+  on branch `main`, path `components/<name>` per component — matching the
+  existing precedent in `go/internal/cli/commands/init_cmd.go:1610`.
+- `wendy.json` fields for this flow: `Platform: appconfig.PlatformWendyLite`
+  (`"wendy-lite"`), `Language: "c"` (free-form field, not validated/routed on
+  anywhere in the codebase today).
+- `idf_component.yml` merges must be non-destructive: preserve any existing
+  unrelated content/dependencies in the file, and be idempotent on re-run.
+- No new go.mod dependencies — `gopkg.in/yaml.v3` is already vendored
+  (see `go/internal/cli/commands/compose.go` for existing `yaml.Node` usage
+  precedent).
+- All test commands below assume the working directory is the repo root
+  (where `go.mod` lives); source lives under `go/internal/...` but the module
+  root is the repo root, so import paths are
+  `github.com/wendylabsinc/wendy/go/internal/...`.
+
+---
+
+### Task 1: Trigger detection — `shouldOfferWendyLiteESPIDFScaffold`
+
+**Files:**
+- Create: `go/internal/cli/commands/wendylite_scaffold.go`
+- Test: `go/internal/cli/commands/wendylite_scaffold_test.go`
+
+**Interfaces:**
+- Consumes: `SelectedDevice` (`go/internal/cli/commands/helpers.go:723`, fields
+  `External *models.ExternalDevice`, `Provider providers.DeviceProvider`),
+  `providers.DeviceProvider` interface (`go/internal/cli/providers/provider.go`,
+  method `Key() string`), `models.ExternalDevice.ConnectionType() string`
+  (`go/internal/shared/models/external_device.go:36`, returns `"USB"`/`"LAN"`/`"BLE"`/`""`).
+- Produces: `func shouldOfferWendyLiteESPIDFScaffold(cfgMissing bool, projectType string, target *SelectedDevice) bool`
+  — used by Task 5.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `go/internal/cli/commands/wendylite_scaffold_test.go`:
+
+```go
+package commands
+
+import (
+	"context"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/providers"
+	"github.com/wendylabsinc/wendy/go/internal/shared/models"
+)
+
+// fakeDeviceProvider is a minimal providers.DeviceProvider test double whose
+// Key() is configurable; every other method is a no-op stub.
+type fakeDeviceProvider struct{ key string }
+
+func (f fakeDeviceProvider) Key() string         { return f.key }
+func (f fakeDeviceProvider) DisplayName() string { return "" }
+func (f fakeDeviceProvider) IsAvailable(ctx context.Context) bool         { return true }
+func (f fakeDeviceProvider) CheckRequirements(ctx context.Context) error  { return nil }
+func (f fakeDeviceProvider) DiscoverDevices(ctx context.Context) ([]models.ExternalDevice, error) {
+	return nil, nil
+}
+func (f fakeDeviceProvider) SupportedBuildTypes() []string  { return nil }
+func (f fakeDeviceProvider) CanBuild(projectPath string) bool { return false }
+func (f fakeDeviceProvider) Build(ctx context.Context, device models.ExternalDevice, projectPath, projectType, product string, debug bool) (*providers.BuiltApp, error) {
+	return nil, nil
+}
+func (f fakeDeviceProvider) Run(ctx context.Context, app *providers.BuiltApp, detach bool, output chan<- providers.RunOutput) error {
+	return nil
+}
+func (f fakeDeviceProvider) Stop(ctx context.Context, app *providers.BuiltApp) error { return nil }
+func (f fakeDeviceProvider) GetDeviceInfo(ctx context.Context, device models.ExternalDevice) (*providers.ProviderDeviceInfo, error) {
+	return nil, nil
+}
+
+func TestShouldOfferWendyLiteESPIDFScaffold(t *testing.T) {
+	usbWendyLite := &SelectedDevice{
+		External: &models.ExternalDevice{ConnectionInfo: map[string]string{"type": "USB"}},
+		Provider: fakeDeviceProvider{key: "wendy-lite"},
+	}
+	lanWendyLite := &SelectedDevice{
+		External: &models.ExternalDevice{ConnectionInfo: map[string]string{"type": "LAN"}},
+		Provider: fakeDeviceProvider{key: "wendy-lite"},
+	}
+	usbOtherProvider := &SelectedDevice{
+		External: &models.ExternalDevice{ConnectionInfo: map[string]string{"type": "USB"}},
+		Provider: fakeDeviceProvider{key: "docker"},
+	}
+
+	tests := []struct {
+		name        string
+		cfgMissing  bool
+		projectType string
+		target      *SelectedDevice
+		want        bool
+	}{
+		{"all conditions met", true, "esp-idf", usbWendyLite, true},
+		{"wendy.json already present", false, "esp-idf", usbWendyLite, false},
+		{"not an esp-idf project shape", true, "docker", usbWendyLite, false},
+		{"wendy-lite over LAN, not USB", true, "esp-idf", lanWendyLite, false},
+		{"USB but not the wendy-lite provider", true, "esp-idf", usbOtherProvider, false},
+		{"nil target", true, "esp-idf", nil, false},
+		{"target with no External/Provider (agent path)", true, "esp-idf", &SelectedDevice{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldOfferWendyLiteESPIDFScaffold(tt.cfgMissing, tt.projectType, tt.target)
+			if got != tt.want {
+				t.Errorf("shouldOfferWendyLiteESPIDFScaffold(%v, %q, ...) = %v, want %v", tt.cfgMissing, tt.projectType, got, tt.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./go/internal/cli/commands/... -run TestShouldOfferWendyLiteESPIDFScaffold -v`
+Expected: FAIL — `shouldOfferWendyLiteESPIDFScaffold` and `fakeDeviceProvider` compile errors (undefined).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `go/internal/cli/commands/wendylite_scaffold.go`:
+
+```go
+package commands
+
+// shouldOfferWendyLiteESPIDFScaffold reports whether wendy run should offer to
+// scaffold Wendy Lite ESP-IDF components + a wendy.json for the current
+// project. True only when wendy.json is missing, the project directory looks
+// like an ESP-IDF project ("esp-idf" projectType, per detectProjectType), and
+// the already-resolved run target is a USB-connected wendy-lite provider
+// device.
+func shouldOfferWendyLiteESPIDFScaffold(cfgMissing bool, projectType string, target *SelectedDevice) bool {
+	if !cfgMissing || projectType != "esp-idf" || target == nil {
+		return false
+	}
+	if target.External == nil || target.Provider == nil {
+		return false
+	}
+	if target.Provider.Key() != "wendy-lite" {
+		return false
+	}
+	return target.External.ConnectionType() == "USB"
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./go/internal/cli/commands/... -run TestShouldOfferWendyLiteESPIDFScaffold -v`
+Expected: PASS (all 7 subtests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/cli/commands/wendylite_scaffold.go go/internal/cli/commands/wendylite_scaffold_test.go
+git commit -m "Add trigger detection for wendy-lite ESP-IDF scaffold offer"
+```
+
+---
+
+### Task 2: Merge wendy-lite components into `idf_component.yml`
+
+**Files:**
+- Modify: `go/internal/cli/commands/wendylite_scaffold.go`
+- Modify: `go/internal/cli/commands/wendylite_scaffold_test.go`
+
+**Interfaces:**
+- Consumes: `gopkg.in/yaml.v3` (`yaml.Node`, `yaml.Unmarshal`, `yaml.Marshal`),
+  already a repo dependency (see `go/internal/cli/commands/compose.go` for
+  existing `yaml.Node` usage).
+- Produces: `func mergeIdfComponentDependencies(manifestPath string, components []string) error`
+  — used by Task 4. Writes/updates a `dependencies:` mapping keyed by
+  component name, each value `{git: "https://github.com/wendylabsinc/wendy-lite.git", path: "components/<name>"}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Go requires a single, consolidated `import (...)` block at the top of the
+file — update the one at the top of
+`go/internal/cli/commands/wendylite_scaffold_test.go` (from Task 1) to:
+
+```go
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/providers"
+	"github.com/wendylabsinc/wendy/go/internal/shared/models"
+	"gopkg.in/yaml.v3"
+)
+```
+
+Then append the following test functions after `TestShouldOfferWendyLiteESPIDFScaffold`:
+
+```go
+func TestMergeIdfComponentDependencies_CreatesNewFile(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "main", "idf_component.yml")
+
+	if err := mergeIdfComponentDependencies(manifestPath, []string{"wendy_hal", "wendy_usb"}); err != nil {
+		t.Fatalf("mergeIdfComponentDependencies: %v", err)
+	}
+
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("reading manifest: %v", err)
+	}
+
+	var parsed struct {
+		Dependencies map[string]struct {
+			Git  string `yaml:"git"`
+			Path string `yaml:"path"`
+		} `yaml:"dependencies"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parsing written manifest: %v", err)
+	}
+
+	for _, name := range []string{"wendy_hal", "wendy_usb"} {
+		dep, ok := parsed.Dependencies[name]
+		if !ok {
+			t.Fatalf("expected dependency %q, got %+v", name, parsed.Dependencies)
+		}
+		if dep.Git != "https://github.com/wendylabsinc/wendy-lite.git" {
+			t.Errorf("dep %q git = %q, want the wendy-lite repo URL", name, dep.Git)
+		}
+		if dep.Path != "components/"+name {
+			t.Errorf("dep %q path = %q, want %q", name, dep.Path, "components/"+name)
+		}
+	}
+}
+
+func TestMergeIdfComponentDependencies_PreservesExistingContent(t *testing.T) {
+	dir := t.TempDir()
+	mainDir := filepath.Join(dir, "main")
+	if err := os.MkdirAll(mainDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(mainDir, "idf_component.yml")
+	existing := "dependencies:\n  espressif/led_strip:\n    version: \"^2.0.0\"\n"
+	if err := os.WriteFile(manifestPath, []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mergeIdfComponentDependencies(manifestPath, []string{"wendy_hal"}); err != nil {
+		t.Fatalf("mergeIdfComponentDependencies: %v", err)
+	}
+
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed struct {
+		Dependencies map[string]map[string]string `yaml:"dependencies"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parsing written manifest: %v", err)
+	}
+	if parsed.Dependencies["espressif/led_strip"]["version"] != "^2.0.0" {
+		t.Errorf("existing dependency was clobbered: %+v", parsed.Dependencies)
+	}
+	if parsed.Dependencies["wendy_hal"]["git"] != "https://github.com/wendylabsinc/wendy-lite.git" {
+		t.Errorf("wendy_hal dependency not added: %+v", parsed.Dependencies)
+	}
+}
+
+func TestMergeIdfComponentDependencies_IdempotentReRun(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "main", "idf_component.yml")
+
+	if err := mergeIdfComponentDependencies(manifestPath, []string{"wendy_hal"}); err != nil {
+		t.Fatalf("first merge: %v", err)
+	}
+	first, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mergeIdfComponentDependencies(manifestPath, []string{"wendy_hal"}); err != nil {
+		t.Fatalf("second merge: %v", err)
+	}
+	second, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(first) != string(second) {
+		t.Errorf("re-running with the same selection changed the file:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+func TestMergeIdfComponentDependencies_MalformedYAMLErrors(t *testing.T) {
+	dir := t.TempDir()
+	mainDir := filepath.Join(dir, "main")
+	if err := os.MkdirAll(mainDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(mainDir, "idf_component.yml")
+	if err := os.WriteFile(manifestPath, []byte("not: valid: yaml: [broken"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mergeIdfComponentDependencies(manifestPath, []string{"wendy_hal"}); err == nil {
+		t.Fatal("expected an error for malformed existing YAML, got nil")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./go/internal/cli/commands/... -run TestMergeIdfComponentDependencies -v`
+Expected: FAIL — `mergeIdfComponentDependencies` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add an `import (...)` block at the top of
+`go/internal/cli/commands/wendylite_scaffold.go` (Task 1 left this file with
+no imports, so this is the file's first import block):
+
+```go
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+```
+
+Then append the following after `shouldOfferWendyLiteESPIDFScaffold`:
+
+```go
+const wendyLiteRepoURL = "https://github.com/wendylabsinc/wendy-lite.git"
+
+// mergeIdfComponentDependencies adds or updates one ESP-IDF Component Manager
+// git dependency per name in components, pointing at the matching
+// subdirectory of the wendy-lite repo, in the idf_component.yml at
+// manifestPath. Existing unrelated content is preserved; re-running with the
+// same components is a no-op.
+func mergeIdfComponentDependencies(manifestPath string, components []string) error {
+	var doc yaml.Node
+	data, err := os.ReadFile(manifestPath)
+	switch {
+	case err == nil:
+		if err := yaml.Unmarshal(data, &doc); err != nil {
+			return fmt.Errorf("parsing %s: %w", manifestPath, err)
+		}
+	case os.IsNotExist(err):
+		doc = yaml.Node{
+			Kind:    yaml.DocumentNode,
+			Content: []*yaml.Node{{Kind: yaml.MappingNode, Tag: "!!map"}},
+		}
+	default:
+		return fmt.Errorf("reading %s: %w", manifestPath, err)
+	}
+
+	if len(doc.Content) == 0 {
+		doc.Content = []*yaml.Node{{Kind: yaml.MappingNode, Tag: "!!map"}}
+	}
+	root := doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return fmt.Errorf("%s: expected a YAML mapping at the document root", manifestPath)
+	}
+
+	deps := findOrAppendMappingKey(root, "dependencies")
+
+	for _, name := range components {
+		dep := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+		dep.Content = append(dep.Content,
+			scalarNode("git"), scalarNode(wendyLiteRepoURL),
+			scalarNode("path"), scalarNode("components/"+name),
+		)
+		setMappingKey(deps, name, dep)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(manifestPath), 0o755); err != nil {
+		return fmt.Errorf("creating %s: %w", filepath.Dir(manifestPath), err)
+	}
+	out, err := yaml.Marshal(&doc)
+	if err != nil {
+		return fmt.Errorf("marshaling %s: %w", manifestPath, err)
+	}
+	if err := os.WriteFile(manifestPath, out, 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", manifestPath, err)
+	}
+	return nil
+}
+
+func scalarNode(v string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: v}
+}
+
+// findOrAppendMappingKey returns the value node for key in mapping, creating
+// an empty mapping node under that key if it doesn't already exist.
+func findOrAppendMappingKey(mapping *yaml.Node, key string) *yaml.Node {
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			return mapping.Content[i+1]
+		}
+	}
+	value := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	mapping.Content = append(mapping.Content, scalarNode(key), value)
+	return value
+}
+
+// setMappingKey sets key to value in mapping, overwriting any existing entry
+// with the same key in place (preserving the order of unrelated keys).
+func setMappingKey(mapping *yaml.Node, key string, value *yaml.Node) {
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			mapping.Content[i+1] = value
+			return
+		}
+	}
+	mapping.Content = append(mapping.Content, scalarNode(key), value)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./go/internal/cli/commands/... -run TestMergeIdfComponentDependencies -v`
+Expected: PASS (all 4 subtests/functions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/cli/commands/wendylite_scaffold.go go/internal/cli/commands/wendylite_scaffold_test.go
+git commit -m "Add idf_component.yml merge for wendy-lite component dependencies"
+```
+
+---
+
+### Task 3: Generate `wendy.json` for the scaffolded project
+
+**Files:**
+- Modify: `go/internal/cli/commands/wendylite_scaffold.go`
+- Modify: `go/internal/cli/commands/wendylite_scaffold_test.go`
+
+**Interfaces:**
+- Consumes: `appconfig.AppConfig` struct and `appconfig.PlatformWendyLite`
+  constant (`go/internal/shared/appconfig/appconfig.go:116,225-260`).
+- Produces: `func newWendyLiteESPIDFAppConfig(appID string) *appconfig.AppConfig`
+  and `func writeWendyLiteESPIDFAppConfig(cwd string) error` — used by Task 4.
+
+- [ ] **Step 1: Write the failing tests**
+
+Update the consolidated `import (...)` block at the top of
+`go/internal/cli/commands/wendylite_scaffold_test.go` to:
+
+```go
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/providers"
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	"github.com/wendylabsinc/wendy/go/internal/shared/models"
+	"gopkg.in/yaml.v3"
+)
+```
+
+Then append the following test functions after the Task 2 tests:
+
+```go
+func TestNewWendyLiteESPIDFAppConfig(t *testing.T) {
+	cfg := newWendyLiteESPIDFAppConfig("my-esp32-app")
+
+	if cfg.AppID != "my-esp32-app" {
+		t.Errorf("AppID = %q, want %q", cfg.AppID, "my-esp32-app")
+	}
+	if cfg.Platform != appconfig.PlatformWendyLite {
+		t.Errorf("Platform = %q, want %q", cfg.Platform, appconfig.PlatformWendyLite)
+	}
+	if cfg.Version == "" {
+		t.Error("Version must not be empty")
+	}
+}
+
+func TestWriteWendyLiteESPIDFAppConfig(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := writeWendyLiteESPIDFAppConfig(dir); err != nil {
+		t.Fatalf("writeWendyLiteESPIDFAppConfig: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "wendy.json"))
+	if err != nil {
+		t.Fatalf("reading wendy.json: %v", err)
+	}
+	var cfg appconfig.AppConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parsing wendy.json: %v", err)
+	}
+	if cfg.Platform != appconfig.PlatformWendyLite {
+		t.Errorf("Platform = %q, want %q", cfg.Platform, appconfig.PlatformWendyLite)
+	}
+	if cfg.AppID != filepath.Base(dir) {
+		t.Errorf("AppID = %q, want directory base name %q", cfg.AppID, filepath.Base(dir))
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./go/internal/cli/commands/... -run 'TestNewWendyLiteESPIDFAppConfig|TestWriteWendyLiteESPIDFAppConfig' -v`
+Expected: FAIL — both functions undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Update the `import (...)` block at the top of
+`go/internal/cli/commands/wendylite_scaffold.go` to:
+
+```go
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	"gopkg.in/yaml.v3"
+)
+```
+
+Then append the following after the Task 2 functions:
+
+```go
+// newWendyLiteESPIDFAppConfig builds the minimal wendy.json contents for a
+// scaffolded native ESP-IDF wendy-lite project.
+func newWendyLiteESPIDFAppConfig(appID string) *appconfig.AppConfig {
+	return &appconfig.AppConfig{
+		AppID:    appID,
+		Version:  "0.1.0",
+		Platform: appconfig.PlatformWendyLite,
+		Language: "c",
+	}
+}
+
+// writeWendyLiteESPIDFAppConfig writes a scaffolded wendy.json into cwd,
+// deriving the app ID from the directory name (matching ensureAppConfig's
+// existing convention in helpers.go).
+func writeWendyLiteESPIDFAppConfig(cwd string) error {
+	cfgPath := filepath.Join(cwd, "wendy.json")
+	dirName := filepath.Base(cwd)
+
+	data, err := json.MarshalIndent(newWendyLiteESPIDFAppConfig(dirName), "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling config: %w", err)
+	}
+	if err := os.WriteFile(cfgPath, data, 0o644); err != nil {
+		return fmt.Errorf("writing wendy.json: %w", err)
+	}
+	fmt.Printf("Created wendy.json for %s\n", dirName)
+	return nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./go/internal/cli/commands/... -run 'TestNewWendyLiteESPIDFAppConfig|TestWriteWendyLiteESPIDFAppConfig' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/cli/commands/wendylite_scaffold.go go/internal/cli/commands/wendylite_scaffold_test.go
+git commit -m "Add wendy.json generation for scaffolded wendy-lite ESP-IDF projects"
+```
+
+---
+
+### Task 4: Interactive confirm + checklist glue
+
+**Files:**
+- Modify: `go/internal/cli/commands/wendylite_scaffold.go`
+- Modify: `go/internal/cli/commands/wendylite_scaffold_test.go`
+
+**Interfaces:**
+- Consumes: `confirmFn` (package var, `go/internal/cli/commands/helpers.go:340`,
+  `func(question string) bool`, already stubbable in tests — see
+  `go/internal/cli/commands/docker_test.go:302` for the pattern), `tui.ChecklistItem`
+  / `tui.RunChecklist` (`go/internal/cli/tui/checklist.go:12,215`),
+  `mergeIdfComponentDependencies` (Task 2), `writeWendyLiteESPIDFAppConfig`
+  (Task 3).
+- Produces: `func promptAndScaffoldWendyLiteESPIDF(cwd string) (bool, error)`
+  — used by Task 5. Returns `(true, nil)` iff the user confirmed and
+  `wendy.json` was written; `(false, nil)` iff the user declined; `(false, err)`
+  on any failure (including checklist cancellation).
+
+- [ ] **Step 1: Write the failing tests**
+
+Update the consolidated `import (...)` block at the top of
+`go/internal/cli/commands/wendylite_scaffold_test.go` to:
+
+```go
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/providers"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	"github.com/wendylabsinc/wendy/go/internal/shared/models"
+	"gopkg.in/yaml.v3"
+)
+```
+
+Then append the following test functions after the Task 3 tests:
+
+```go
+func TestPromptAndScaffoldWendyLiteESPIDF_Declined(t *testing.T) {
+	origConfirm := confirmFn
+	defer func() { confirmFn = origConfirm }()
+	confirmFn = func(string) bool { return false }
+
+	origChecklist := wendyLiteComponentChecklistFn
+	defer func() { wendyLiteComponentChecklistFn = origChecklist }()
+	wendyLiteComponentChecklistFn = func([]tui.ChecklistItem) ([]tui.ChecklistItem, error) {
+		t.Fatal("must not prompt checklist when the initial confirm is declined")
+		return nil, nil
+	}
+
+	dir := t.TempDir()
+	scaffolded, err := promptAndScaffoldWendyLiteESPIDF(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if scaffolded {
+		t.Error("expected scaffolded=false when confirm is declined")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "wendy.json")); statErr == nil {
+		t.Error("wendy.json must not be written when confirm is declined")
+	}
+}
+
+func TestPromptAndScaffoldWendyLiteESPIDF_AllComponentsSelected(t *testing.T) {
+	origConfirm := confirmFn
+	defer func() { confirmFn = origConfirm }()
+	confirmFn = func(string) bool { return true }
+
+	origChecklist := wendyLiteComponentChecklistFn
+	defer func() { wendyLiteComponentChecklistFn = origChecklist }()
+	wendyLiteComponentChecklistFn = func(items []tui.ChecklistItem) ([]tui.ChecklistItem, error) {
+		return items, nil // simulate the user keeping every pre-selected item
+	}
+
+	dir := t.TempDir()
+	scaffolded, err := promptAndScaffoldWendyLiteESPIDF(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !scaffolded {
+		t.Fatal("expected scaffolded=true")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "wendy.json")); statErr != nil {
+		t.Errorf("expected wendy.json to be written: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "main", "idf_component.yml")); statErr != nil {
+		t.Errorf("expected main/idf_component.yml to be written: %v", statErr)
+	}
+}
+
+func TestPromptAndScaffoldWendyLiteESPIDF_NoComponentsSelected(t *testing.T) {
+	origConfirm := confirmFn
+	defer func() { confirmFn = origConfirm }()
+	confirmFn = func(string) bool { return true }
+
+	origChecklist := wendyLiteComponentChecklistFn
+	defer func() { wendyLiteComponentChecklistFn = origChecklist }()
+	wendyLiteComponentChecklistFn = func([]tui.ChecklistItem) ([]tui.ChecklistItem, error) {
+		return nil, nil // simulate the user unchecking every item
+	}
+
+	dir := t.TempDir()
+	scaffolded, err := promptAndScaffoldWendyLiteESPIDF(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !scaffolded {
+		t.Fatal("expected scaffolded=true even with zero components selected")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "wendy.json")); statErr != nil {
+		t.Errorf("expected wendy.json to still be written: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "main", "idf_component.yml")); statErr == nil {
+		t.Error("idf_component.yml must not be written when zero components are selected")
+	}
+}
+
+func TestPromptAndScaffoldWendyLiteESPIDF_ChecklistCancelled(t *testing.T) {
+	origConfirm := confirmFn
+	defer func() { confirmFn = origConfirm }()
+	confirmFn = func(string) bool { return true }
+
+	origChecklist := wendyLiteComponentChecklistFn
+	defer func() { wendyLiteComponentChecklistFn = origChecklist }()
+	wendyLiteComponentChecklistFn = func([]tui.ChecklistItem) ([]tui.ChecklistItem, error) {
+		return nil, tui.ErrCancelled
+	}
+
+	dir := t.TempDir()
+	scaffolded, err := promptAndScaffoldWendyLiteESPIDF(dir)
+	if !errors.Is(err, tui.ErrCancelled) {
+		t.Fatalf("expected tui.ErrCancelled, got %v", err)
+	}
+	if scaffolded {
+		t.Error("expected scaffolded=false on cancellation")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "wendy.json")); statErr == nil {
+		t.Error("wendy.json must not be written when the checklist is cancelled")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./go/internal/cli/commands/... -run TestPromptAndScaffoldWendyLiteESPIDF -v`
+Expected: FAIL — `promptAndScaffoldWendyLiteESPIDF` and `wendyLiteComponentChecklistFn` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Update the `import (...)` block at the top of
+`go/internal/cli/commands/wendylite_scaffold.go` to:
+
+```go
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	"gopkg.in/yaml.v3"
+)
+```
+
+Then append the following after the Task 3 functions:
+
+```go
+// wendyLiteESPIDFComponents lists the non-WASM Wendy Lite ESP-IDF components
+// offered by the scaffold checklist. WASM-only pieces (wendy_wasm,
+// wendy_hal_export, wendy_wasi_shim, wendy_safety, wendy_callback) are
+// intentionally excluded: this flow is for native ESP-IDF firmware, not WASM
+// apps.
+var wendyLiteESPIDFComponents = []string{
+	"wendy_hal",
+	"wendy_usb",
+	"wendy_wifi",
+	"wendy_ble_prov",
+	"wendy_cloud_prov",
+	"wendy_storage",
+	"wendy_uart",
+	"wendy_spi",
+	"wendy_sys",
+	"wendy_otel",
+	"wendy_ble",
+	"wendy_net",
+	"wendy_app_usb",
+}
+
+// wendyLiteComponentChecklistFn runs the component-selection checklist. It is
+// a package var so tests can stub it (mirrors confirmFn's testability
+// pattern in helpers.go).
+var wendyLiteComponentChecklistFn = func(items []tui.ChecklistItem) ([]tui.ChecklistItem, error) {
+	return tui.RunChecklist("Which Wendy Lite components do you want to add?", items)
+}
+
+// promptAndScaffoldWendyLiteESPIDF offers to add wendy-lite ESP-IDF
+// components to the project at cwd and, if accepted, writes a wendy.json.
+// Returns scaffolded=true iff wendy.json was written.
+func promptAndScaffoldWendyLiteESPIDF(cwd string) (bool, error) {
+	if !confirmFn("This looks like an ESP-IDF project without a wendy.json, and a USB-connected ESP32 was detected. Add Wendy Lite components and set up 'wendy run' for this project?") {
+		return false, nil
+	}
+
+	items := make([]tui.ChecklistItem, len(wendyLiteESPIDFComponents))
+	for i, name := range wendyLiteESPIDFComponents {
+		items[i] = tui.ChecklistItem{Label: name, Value: name, Selected: true}
+	}
+	selected, err := wendyLiteComponentChecklistFn(items)
+	if err != nil {
+		return false, err
+	}
+
+	names := make([]string, len(selected))
+	for i, item := range selected {
+		names[i] = item.Value
+	}
+
+	if len(names) > 0 {
+		manifestPath := filepath.Join(cwd, "main", "idf_component.yml")
+		if err := mergeIdfComponentDependencies(manifestPath, names); err != nil {
+			return false, fmt.Errorf("adding wendy-lite components: %w", err)
+		}
+		fmt.Printf("Added %d Wendy Lite component(s) to main/idf_component.yml\n", len(names))
+	} else {
+		fmt.Println("No Wendy Lite components were added. You can add idf_component.yml dependencies manually later.")
+	}
+
+	if err := writeWendyLiteESPIDFAppConfig(cwd); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./go/internal/cli/commands/... -run TestPromptAndScaffoldWendyLiteESPIDF -v`
+Expected: PASS (all 4 subtests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/cli/commands/wendylite_scaffold.go go/internal/cli/commands/wendylite_scaffold_test.go
+git commit -m "Add confirm+checklist glue for wendy-lite ESP-IDF scaffold"
+```
+
+---
+
+### Task 5: Wire into `wendy run`'s missing-config path
+
+**Files:**
+- Modify: `go/internal/cli/commands/run.go:674-690` (the `cfgMissing` branch in
+  `runCommand`)
+
+**Interfaces:**
+- Consumes: `shouldOfferWendyLiteESPIDFScaffold` (Task 1),
+  `promptAndScaffoldWendyLiteESPIDF` (Task 4).
+- Produces: nothing new — this task only wires existing functions into the
+  existing control flow.
+
+- [ ] **Step 1: Make the change**
+
+In `go/internal/cli/commands/run.go`, the current block reads:
+
+```go
+	if cfgMissing {
+		target, err = resolveRunTarget(ctx, runResolveOptions(opts)...)
+		if err != nil {
+			return err
+		}
+		if err := preflightMissingAppConfigForMacTarget(ctx, target, projectType); err != nil {
+			return err
+		}
+	}
+```
+
+Replace it with:
+
+```go
+	if cfgMissing {
+		target, err = resolveRunTarget(ctx, runResolveOptions(opts)...)
+		if err != nil {
+			return err
+		}
+		if err := preflightMissingAppConfigForMacTarget(ctx, target, projectType); err != nil {
+			return err
+		}
+		if shouldOfferWendyLiteESPIDFScaffold(cfgMissing, projectType, target) {
+			scaffolded, err := promptAndScaffoldWendyLiteESPIDF(cwd)
+			if err != nil {
+				return err
+			}
+			if scaffolded {
+				cfgMissing = false
+			}
+		}
+	}
+```
+
+This runs immediately after the existing Mac-target preflight, using the
+already-resolved `target` and already-computed `projectType` — no new
+discovery or device resolution. If the user declines the offer,
+`cfgMissing` stays `true` and the existing `ensureAppConfig` call
+(`run.go`, a few lines below) falls through to its current generic
+"No wendy.json found... Create one?" behavior, unchanged. If the user
+accepts, `cfgMissing` becomes `false` and `ensureAppConfig` simply loads the
+`wendy.json` this task's flow just wrote.
+
+- [ ] **Step 2: Build and run the full package test suite**
+
+Run: `go build ./go/... && go test ./go/internal/cli/commands/... -v`
+Expected: build succeeds; all tests pass, including the new
+`TestShouldOfferWendyLiteESPIDFScaffold`, `TestMergeIdfComponentDependencies*`,
+`TestNewWendyLiteESPIDFAppConfig`, `TestWriteWendyLiteESPIDFAppConfig`, and
+`TestPromptAndScaffoldWendyLiteESPIDF*` from Tasks 1-4, plus every
+pre-existing test in the package (confirming the edit didn't regress the
+Mac-target preflight or the generic `ensureAppConfig` path).
+
+- [ ] **Step 3: Manual / hardware verification (not automatable in CI)**
+
+Document in the PR description, exercised manually against a real
+USB-connected ESP32 running Wendy Lite firmware:
+1. In an empty directory: `idf.py create-project` (or copy an existing bare
+   ESP-IDF example) to get a `CMakeLists.txt` + `main/` with no `wendy.json`.
+2. Plug in a USB-connected ESP32.
+3. Run `wendy run` and confirm the new prompt appears, the checklist shows
+   only the 13 non-WASM components, and accepting writes both
+   `main/idf_component.yml` (with the selected components as git
+   dependencies) and `wendy.json` (`platform: "wendy-lite"`).
+4. Re-run `wendy run` and confirm it proceeds straight to
+   `idf.py build`/flash using the now-present `wendy.json` (no re-prompt).
+5. Confirm declining the initial prompt falls back to today's existing
+   generic "No wendy.json found..." behavior.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add go/internal/cli/commands/run.go
+git commit -m "Wire wendy-lite ESP-IDF scaffold offer into wendy run's missing-config path"
+```


### PR DESCRIPTION
## Summary
- When `wendy run` is invoked in an existing bare ESP-IDF project (has `CMakeLists.txt`/`main/`, no `wendy.json` yet) and a USB-connected Wendy Lite ESP32 is detected as the run target, the CLI now offers to add selected non-WASM Wendy Lite ESP-IDF components (github.com/wendylabsinc/wendy-lite) to `main/idf_component.yml` as ESP-IDF Component Manager git dependencies, and generate a minimal `wendy.json` (`platform: "wendy-lite"`) so the project becomes immediately runnable via the existing `wendy run` → `detectProjectType` → `buildEspIdf` path.
- All new logic lives in `go/internal/cli/commands/wendylite_scaffold.go` (+ `_test.go`); wiring into `run.go`'s existing `cfgMissing` branch is a 1-line additive condition change.
- Design + implementation plan: `specs/2026-07-31-wendy-run-esp32-usb-component-scaffold-design.md`, `specs/2026-07-31-wendy-run-esp32-usb-component-scaffold-plan.md`.

## Notes for reviewers
- **Hardware-unverified**: no end-to-end run against a real USB-connected ESP32 has been performed. Manual verification steps are in the plan doc's Task 5.
- The 13 offered component names/paths were validated only against this repo's in-tree `wendy-lite` skill docs, not the live `wendy-lite` repo — a renamed/removed component there would surface as an `idf.py` component-manager resolution failure at build time, not at scaffold time.
- The git dependency tracks `wendy-lite`'s `main` branch (unpinned), matching the existing precedent in `init_cmd.go`'s Swift package dependency.
- The offer fires before the device's `NativeAppSupport` is known — a wendy-lite board whose firmware doesn't support native apps will scaffold successfully and then fail later in `buildEspIdf`. Considered acceptable for v1 per the approved design's YAGNI scope, but worth knowing.
- A few minor/cosmetic findings were reviewed and deliberately parked rather than fixed (recorded during development): a stray `idf_component.yml` could be written if a project has a non-standard main-component layout; a `cfgMissing = false` write in `run.go` is currently a dead store since `ensureAppConfig` re-derives file presence from disk; the checklist prompt renders to stdout while the confirm prompt renders to stderr (inconsistent, both patterns exist elsewhere in the codebase); `wendy_app_usb`'s inclusion in the "non-WASM" list is debatable per its own doc comment and may be worth a sanity check with whoever owns `wendy-lite`.

## Test plan
- [x] `go build ./...` clean (whole module)
- [x] `go vet ./...` clean (whole module)
- [x] `gofmt -l -s .` clean (whole module)
- [x] `go test ./...` — all packages pass, 0 failures (whole module)
- [x] New unit tests for trigger detection, `idf_component.yml` merge (including edge cases: empty file, null `dependencies:` key, non-mapping `dependencies:` key, idempotency), `wendy.json` generation, and the confirm/checklist glue (declined, all-selected, zero-selected, cancelled)
- [ ] Manual hardware verification against a real USB-connected ESP32 running a bare ESP-IDF project (not performed in this environment — see plan doc Task 5, Step 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HPsTyouFgfJRovipoXTdS