### PR TITLE
Add wendy sandbox CLI command to install/run the local control plane

### DIFF
--- a/go/internal/cli/commands/root.go
+++ b/go/internal/cli/commands/root.go
@@ -112,6 +112,7 @@ func NewRootCmd() *cobra.Command {
 
 	root.AddGroup(
 		&cobra.Group{ID: "develop", Title: "Develop & Deploy:"},
+		&cobra.Group{ID: "sandbox", Title: "Sandbox:"},
 		&cobra.Group{ID: "manage", Title: "Manage:"},
 		&cobra.Group{ID: "cloud", Title: "Cloud:"},
 		&cobra.Group{ID: "settings", Title: "Settings:"},
@@ -129,6 +130,10 @@ func NewRootCmd() *cobra.Command {
 	// command can only be attached to one parent.
 	installCmd := newOSInstallCmd()
 	installCmd.GroupID = "develop"
+
+	// Sandbox
+	sandboxCmd := newSandboxCmd()
+	sandboxCmd.GroupID = "sandbox"
 
 	// Manage
 	projectCmd := newProjectCmd()
@@ -214,6 +219,8 @@ func NewRootCmd() *cobra.Command {
 		runCmd,
 		appCmd,
 		installCmd,
+		// Sandbox
+		sandboxCmd,
 		// Manage
 		projectCmd,
 		deviceCmd,

--- a/go/internal/cli/commands/root.go
+++ b/go/internal/cli/commands/root.go
@@ -3,6 +3,7 @@ package commands
 
 import (
 	"os"
+	"runtime"
 
 	"github.com/spf13/cobra"
 	"github.com/wendylabsinc/wendy/go/internal/cli/analytics"
@@ -134,6 +135,9 @@ func NewRootCmd() *cobra.Command {
 	// Sandbox
 	sandboxCmd := newSandboxCmd()
 	sandboxCmd.GroupID = "sandbox"
+	// macOS-only (launchd, ~/Library paths); hide from help/completion elsewhere
+	// rather than showing a command group that can't work on the host OS.
+	sandboxCmd.Hidden = runtime.GOOS != "darwin"
 
 	// Manage
 	projectCmd := newProjectCmd()

--- a/go/internal/cli/commands/sandbox.go
+++ b/go/internal/cli/commands/sandbox.go
@@ -1,0 +1,196 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+func newSandboxCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sandbox",
+		Short: "Manage the local Wendy Sandbox control plane",
+		Long: "Install and run the local control-plane service that Wendy Sandbox\n" +
+			"(the native macOS app) uses for session containers, terminal, and the sim viewer.",
+	}
+	var purge bool
+	uninstallCmd := &cobra.Command{
+		Use:   "uninstall",
+		Short: "Unload and remove the local control plane",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSandboxUninstall(context.Background(), cmd, purge)
+		},
+	}
+	uninstallCmd.Flags().BoolVar(&purge, "purge", false, "also remove the cached install directory")
+
+	cmd.AddCommand(
+		&cobra.Command{
+			Use:   "install",
+			Short: "Install and start the local control plane (safe to re-run)",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return runSandboxInstall(context.Background(), cmd)
+			},
+		},
+		&cobra.Command{
+			Use:   "start",
+			Short: "Start the local control plane",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return runSandboxStart(context.Background(), cmd)
+			},
+		},
+		&cobra.Command{
+			Use:   "stop",
+			Short: "Stop the local control plane",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return runSandboxStop(context.Background(), cmd)
+			},
+		},
+		&cobra.Command{
+			Use:   "status",
+			Short: "Report whether the local control plane is running",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return runSandboxStatus(context.Background(), cmd)
+			},
+		},
+		uninstallCmd,
+	)
+	return cmd
+}
+
+func runSandboxInstall(ctx context.Context, cmd *cobra.Command) error {
+	if _, err := exec.LookPath("node"); err != nil {
+		return fmt.Errorf("node is required but not found on PATH; run: brew install node")
+	}
+	if _, err := exec.LookPath("npm"); err != nil {
+		return fmt.Errorf("npm is required but not found on PATH; run: brew install node")
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolving home directory: %w", err)
+	}
+	installDir := filepath.Join(home, ".wendy", "sandbox", "control-plane")
+
+	cmd.Println("Fetching latest control-plane release…")
+	rel, err := fetchControlPlaneRelease(ctx)
+	if err != nil {
+		return err
+	}
+	assetURL, err := findControlPlaneAsset(rel)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(installDir, 0o755); err != nil {
+		return fmt.Errorf("creating %s: %w", installDir, err)
+	}
+	if err := downloadAndExtractControlPlaneRelease(ctx, assetURL, installDir); err != nil {
+		return err
+	}
+
+	cmd.Println("Installing dependencies…")
+	npmCmd := exec.CommandContext(ctx, "npm", "ci", "--omit=dev")
+	npmCmd.Dir = installDir
+	npmCmd.Stdout, npmCmd.Stderr = os.Stdout, os.Stderr
+	if err := npmCmd.Run(); err != nil {
+		return fmt.Errorf("npm ci --omit=dev in %s: %w", installDir, err)
+	}
+
+	creds, err := readOrGenerateSandboxCredentials()
+	if err != nil {
+		return err
+	}
+
+	dataDir := filepath.Join(home, "Library", "Application Support", "WendySandboxNative", "control-plane-data")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		return fmt.Errorf("creating %s: %w", dataDir, err)
+	}
+	logPath := filepath.Join(home, "Library", "Logs", "wendy-sandbox-control-plane.log")
+
+	plist, err := renderSandboxPlist(sandboxPlistParams{
+		Label: sandboxLaunchAgentLabel, WorkDir: installDir, LogPath: logPath,
+		Port: "8787", AdminUser: creds.User, AdminPassword: creds.Password, DataDir: dataDir,
+	})
+	if err != nil {
+		return err
+	}
+	plistPath, err := sandboxLaunchctlPlistPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		return fmt.Errorf("creating %s: %w", filepath.Dir(plistPath), err)
+	}
+	if err := os.WriteFile(plistPath, []byte(plist), 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", plistPath, err)
+	}
+
+	// Unload first (ignore errors — it may not be loaded yet) so a re-run of
+	// install picks up a new plist/version instead of launchd keeping the old one.
+	_ = unloadSandboxLaunchAgent(ctx)
+	if err := loadSandboxLaunchAgent(ctx, plistPath); err != nil {
+		return err
+	}
+
+	cmd.Println("control-plane installed and running on http://localhost:8787")
+	cmd.Println("Check status any time with: wendy sandbox status")
+	return nil
+}
+
+func runSandboxStart(ctx context.Context, cmd *cobra.Command) error {
+	target := sandboxLaunchdTarget()
+	if err := sandboxCommandContext(ctx, "launchctl", "kickstart", "-k", target).Run(); err != nil {
+		return fmt.Errorf("launchctl kickstart %s: %w (not installed yet? run: wendy sandbox install)", target, err)
+	}
+	cmd.Println("control-plane started.")
+	return nil
+}
+
+func runSandboxStop(ctx context.Context, cmd *cobra.Command) error {
+	target := sandboxLaunchdTarget()
+	if err := sandboxCommandContext(ctx, "launchctl", "kill", "SIGTERM", target).Run(); err != nil {
+		return fmt.Errorf("launchctl kill SIGTERM %s: %w", target, err)
+	}
+	cmd.Println("control-plane stopped.")
+	return nil
+}
+
+func runSandboxStatus(ctx context.Context, cmd *cobra.Command) error {
+	running, err := sandboxLaunchAgentStatus(ctx)
+	if err != nil {
+		return err
+	}
+	if running {
+		cmd.Printf("control-plane is installed and loaded (%s)\n", sandboxLaunchdTarget())
+	} else {
+		cmd.Println("control-plane is not installed; run: wendy sandbox install")
+	}
+	return nil
+}
+
+func runSandboxUninstall(ctx context.Context, cmd *cobra.Command, purge bool) error {
+	if err := unloadSandboxLaunchAgent(ctx); err != nil {
+		cmd.PrintErrln("warning:", err)
+	}
+	plistPath, err := sandboxLaunchctlPlistPath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(plistPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing %s: %w", plistPath, err)
+	}
+	if purge {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return err
+		}
+		if err := os.RemoveAll(filepath.Join(home, ".wendy", "sandbox")); err != nil {
+			return fmt.Errorf("removing install directory: %w", err)
+		}
+	}
+	cmd.Println("control-plane uninstalled.")
+	return nil
+}

--- a/go/internal/cli/commands/sandbox.go
+++ b/go/internal/cli/commands/sandbox.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -59,14 +60,37 @@ func newSandboxCmd() *cobra.Command {
 		},
 		uninstallCmd,
 	)
+
+	// Every subcommand here drives launchd and ~/Library paths, so none of them
+	// can work off-darwin. root.go also hides the group elsewhere, but Hidden
+	// only suppresses help/completion — this is what actually stops execution
+	// before it fails confusingly on a missing launchctl.
+	//
+	// Deliberately PreRunE on each subcommand rather than PersistentPreRunE on
+	// the group: cobra runs only the *nearest* PersistentPreRunE in the chain, so
+	// a group-level one would shadow the root command's (config load, analytics
+	// init, provider setup). PreRunE is a separate chain and composes cleanly.
+	// None of these subcommands define their own PreRunE.
+	for _, sub := range cmd.Commands() {
+		sub.PreRunE = func(cmd *cobra.Command, args []string) error {
+			return sandboxPlatformGuard(runtime.GOOS)
+		}
+	}
 	return cmd
 }
 
-func runSandboxInstall(ctx context.Context, cmd *cobra.Command) error {
-	if runtime.GOOS != "darwin" {
+func sandboxPlatformGuard(goos string) error {
+	if goos != "darwin" {
 		return fmt.Errorf("wendy sandbox is only supported on macOS")
 	}
-	if _, err := exec.LookPath("node"); err != nil {
+	return nil
+}
+
+func runSandboxInstall(ctx context.Context, cmd *cobra.Command) error {
+	// Keep the resolved path: the plist invokes node by absolute path so launchd
+	// doesn't have to find it on a PATH that never includes nvm/fnm/asdf/volta.
+	nodePath, err := exec.LookPath("node")
+	if err != nil {
 		return fmt.Errorf("node is required but not found on PATH; run: brew install node")
 	}
 	if _, err := exec.LookPath("npm"); err != nil {
@@ -78,6 +102,12 @@ func runSandboxInstall(ctx context.Context, cmd *cobra.Command) error {
 		return fmt.Errorf("resolving home directory: %w", err)
 	}
 	installDir := filepath.Join(home, ".wendy", "sandbox", "control-plane")
+
+	// Unload before touching the install directory (ignore errors — it may not be
+	// loaded yet). `npm ci` wipes node_modules wholesale, so leaving an old
+	// KeepAlive-managed agent running through the download would crash-loop it for
+	// the whole install.
+	_ = unloadSandboxLaunchAgent(ctx)
 
 	cmd.Println("Fetching latest control-plane release…")
 	rel, err := fetchControlPlaneRelease(ctx)
@@ -115,7 +145,7 @@ func runSandboxInstall(ctx context.Context, cmd *cobra.Command) error {
 	logPath := filepath.Join(home, "Library", "Logs", "wendy-sandbox-control-plane.log")
 
 	plist, err := renderSandboxPlist(sandboxPlistParams{
-		Label: sandboxLaunchAgentLabel, WorkDir: installDir, LogPath: logPath,
+		Label: sandboxLaunchAgentLabel, NodePath: nodePath, WorkDir: installDir, LogPath: logPath,
 		Port: "8787", AdminUser: creds.User, AdminPassword: creds.Password, DataDir: dataDir,
 	})
 	if err != nil {
@@ -128,20 +158,41 @@ func runSandboxInstall(ctx context.Context, cmd *cobra.Command) error {
 	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
 		return fmt.Errorf("creating %s: %w", filepath.Dir(plistPath), err)
 	}
-	if err := os.WriteFile(plistPath, []byte(plist), 0o644); err != nil {
+	// 0600, not 0644: this plist embeds the admin password in cleartext. launchd
+	// reads it fine at 0600 since it runs as the same user.
+	if err := os.WriteFile(plistPath, []byte(plist), 0o600); err != nil {
 		return fmt.Errorf("writing %s: %w", plistPath, err)
 	}
 
-	// Unload first (ignore errors — it may not be loaded yet) so a re-run of
-	// install picks up a new plist/version instead of launchd keeping the old one.
-	_ = unloadSandboxLaunchAgent(ctx)
 	if err := loadSandboxLaunchAgent(ctx, plistPath); err != nil {
 		return err
 	}
 
-	cmd.Println("control-plane installed and running on http://localhost:8787")
+	if sandboxWaitForPort(ctx, "8787", 3*time.Second) {
+		cmd.Println("control-plane installed and running on http://localhost:8787")
+	} else {
+		cmd.Println("control-plane installed and starting on http://localhost:8787 (not answering yet)")
+	}
 	cmd.Println("Check status any time with: wendy sandbox status")
 	return nil
+}
+
+// sandboxWaitForPort polls the port until it answers or timeout elapses.
+func sandboxWaitForPort(ctx context.Context, port string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		if sandboxPortIsListening(ctx, port) {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
 }
 
 func runSandboxStart(ctx context.Context, cmd *cobra.Command) error {
@@ -174,6 +225,16 @@ func runSandboxStop(ctx context.Context, cmd *cobra.Command) error {
 	// With KeepAlive: true in the plist, `launchctl kill` just gets the job
 	// respawned by launchd — the only way to actually stop it is to take it
 	// out of launchd's control entirely via bootout (unloadSandboxLaunchAgent).
+	// Check status first: bootout on an already-unloaded job exits 3 ("No such
+	// process"), so this keeps a repeated `stop` idempotent, mirroring `start`.
+	running, err := sandboxLaunchAgentStatus(ctx)
+	if err != nil {
+		return err
+	}
+	if !running {
+		cmd.Println("control-plane already stopped.")
+		return nil
+	}
 	if err := unloadSandboxLaunchAgent(ctx); err != nil {
 		return err
 	}
@@ -181,15 +242,34 @@ func runSandboxStop(ctx context.Context, cmd *cobra.Command) error {
 	return nil
 }
 
+// runSandboxStatus distinguishes three states, because "not loaded in launchd"
+// alone means neither "not installed" (the plist may be on disk, just booted
+// out by `stop`) nor "healthy" (KeepAlive keeps a crash-looping job loaded).
 func runSandboxStatus(ctx context.Context, cmd *cobra.Command) error {
-	running, err := sandboxLaunchAgentStatus(ctx)
+	plistPath, err := sandboxLaunchctlPlistPath()
 	if err != nil {
 		return err
 	}
-	if running {
-		cmd.Printf("control-plane is installed and loaded (%s)\n", sandboxLaunchdTarget())
-	} else {
+	if _, err := os.Stat(plistPath); os.IsNotExist(err) {
 		cmd.Println("control-plane is not installed; run: wendy sandbox install")
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("checking %s: %w", plistPath, err)
+	}
+
+	loaded, err := sandboxLaunchAgentStatus(ctx)
+	if err != nil {
+		return err
+	}
+	if !loaded {
+		cmd.Println("control-plane is installed but stopped; run: wendy sandbox start")
+		return nil
+	}
+
+	if sandboxPortIsListening(ctx, "8787") {
+		cmd.Printf("control-plane is installed and running (%s)\n", sandboxLaunchdTarget())
+	} else {
+		cmd.Println("control-plane is loaded but not responding on port 8787 — it may be crash-looping; check ~/Library/Logs/wendy-sandbox-control-plane.log")
 	}
 	return nil
 }

--- a/go/internal/cli/commands/sandbox.go
+++ b/go/internal/cli/commands/sandbox.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 
 	"github.com/spf13/cobra"
 )
@@ -62,6 +63,9 @@ func newSandboxCmd() *cobra.Command {
 }
 
 func runSandboxInstall(ctx context.Context, cmd *cobra.Command) error {
+	if runtime.GOOS != "darwin" {
+		return fmt.Errorf("wendy sandbox is only supported on macOS")
+	}
 	if _, err := exec.LookPath("node"); err != nil {
 		return fmt.Errorf("node is required but not found on PATH; run: brew install node")
 	}
@@ -141,18 +145,37 @@ func runSandboxInstall(ctx context.Context, cmd *cobra.Command) error {
 }
 
 func runSandboxStart(ctx context.Context, cmd *cobra.Command) error {
-	target := sandboxLaunchdTarget()
-	if err := sandboxCommandContext(ctx, "launchctl", "kickstart", "-k", target).Run(); err != nil {
-		return fmt.Errorf("launchctl kickstart %s: %w (not installed yet? run: wendy sandbox install)", target, err)
+	// The plist has KeepAlive: true, so the only correct way to (re)start a
+	// stopped agent is to bootstrap it back into launchd — `kickstart` only
+	// affects an already-loaded job and does nothing for one that was
+	// bootout'd. Check status first so re-running start on an already-running
+	// service is a friendly no-op instead of a "already bootstrapped" error
+	// from launchctl.
+	running, err := sandboxLaunchAgentStatus(ctx)
+	if err != nil {
+		return err
+	}
+	if running {
+		cmd.Println("control-plane already running.")
+		return nil
+	}
+	plistPath, err := sandboxLaunchctlPlistPath()
+	if err != nil {
+		return err
+	}
+	if err := loadSandboxLaunchAgent(ctx, plistPath); err != nil {
+		return fmt.Errorf("%w (not installed yet? run: wendy sandbox install)", err)
 	}
 	cmd.Println("control-plane started.")
 	return nil
 }
 
 func runSandboxStop(ctx context.Context, cmd *cobra.Command) error {
-	target := sandboxLaunchdTarget()
-	if err := sandboxCommandContext(ctx, "launchctl", "kill", "SIGTERM", target).Run(); err != nil {
-		return fmt.Errorf("launchctl kill SIGTERM %s: %w", target, err)
+	// With KeepAlive: true in the plist, `launchctl kill` just gets the job
+	// respawned by launchd — the only way to actually stop it is to take it
+	// out of launchd's control entirely via bootout (unloadSandboxLaunchAgent).
+	if err := unloadSandboxLaunchAgent(ctx); err != nil {
+		return err
 	}
 	cmd.Println("control-plane stopped.")
 	return nil

--- a/go/internal/cli/commands/sandbox_credentials.go
+++ b/go/internal/cli/commands/sandbox_credentials.go
@@ -1,0 +1,73 @@
+package commands
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// sandboxAdminCredentials is the exact JSON shape desktop-native's
+// AdminCredentialStore reads/writes (Sources/WendySandbox/AdminCredentials.swift)
+// — plain "user"/"password" keys, no key transformation.
+type sandboxAdminCredentials struct {
+	User     string `json:"user"`
+	Password string `json:"password"`
+}
+
+func sandboxCredentialsPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home directory: %w", err)
+	}
+	return filepath.Join(home, "Library", "Application Support", "WendySandboxNative", "admin-credentials.json"), nil
+}
+
+func readOrGenerateSandboxCredentials() (sandboxAdminCredentials, error) {
+	path, err := sandboxCredentialsPath()
+	if err != nil {
+		return sandboxAdminCredentials{}, err
+	}
+	return readOrGenerateSandboxCredentialsAt(path)
+}
+
+// readOrGenerateSandboxCredentialsAt reads path if it already holds valid
+// credentials (written by either the Swift app or a prior CLI run), or
+// generates and persists a fresh one — so whichever side runs first defines
+// the shared secret and the other always reads it back.
+func readOrGenerateSandboxCredentialsAt(path string) (sandboxAdminCredentials, error) {
+	if data, err := os.ReadFile(path); err == nil {
+		var creds sandboxAdminCredentials
+		if err := json.Unmarshal(data, &creds); err == nil && creds.User != "" && creds.Password != "" {
+			return creds, nil
+		}
+	}
+	password, err := generateSandboxPassword()
+	if err != nil {
+		return sandboxAdminCredentials{}, fmt.Errorf("generating admin password: %w", err)
+	}
+	creds := sandboxAdminCredentials{User: "admin", Password: password}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return sandboxAdminCredentials{}, fmt.Errorf("creating %s: %w", filepath.Dir(path), err)
+	}
+	data, err := json.Marshal(creds)
+	if err != nil {
+		return sandboxAdminCredentials{}, err
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return sandboxAdminCredentials{}, fmt.Errorf("writing %s: %w", path, err)
+	}
+	return creds, nil
+}
+
+// generateSandboxPassword matches AdminCredentialStore.randomPassword in
+// desktop-native: 18 random bytes, base64 URL-safe, no padding.
+func generateSandboxPassword() (string, error) {
+	buf := make([]byte, 18)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}

--- a/go/internal/cli/commands/sandbox_credentials_test.go
+++ b/go/internal/cli/commands/sandbox_credentials_test.go
@@ -1,0 +1,71 @@
+package commands
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadOrGenerateSandboxCredentialsAt_GeneratesWhenMissing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "admin-credentials.json")
+
+	creds, err := readOrGenerateSandboxCredentialsAt(path)
+	if err != nil {
+		t.Fatalf("readOrGenerateSandboxCredentialsAt: %v", err)
+	}
+	if creds.User != "admin" {
+		t.Errorf("User = %q, want admin", creds.User)
+	}
+	if len(creds.Password) == 0 {
+		t.Error("Password is empty")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading persisted file: %v", err)
+	}
+	var onDisk sandboxAdminCredentials
+	if err := json.Unmarshal(data, &onDisk); err != nil {
+		t.Fatalf("unmarshalling persisted file: %v", err)
+	}
+	if onDisk != creds {
+		t.Errorf("persisted %+v != returned %+v", onDisk, creds)
+	}
+}
+
+func TestReadOrGenerateSandboxCredentialsAt_ReadsExisting(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "admin-credentials.json")
+	want := sandboxAdminCredentials{User: "someone", Password: "existing-secret"}
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := readOrGenerateSandboxCredentialsAt(path)
+	if err != nil {
+		t.Fatalf("readOrGenerateSandboxCredentialsAt: %v", err)
+	}
+	if got != want {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestReadOrGenerateSandboxCredentialsAt_IsIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "admin-credentials.json")
+
+	first, err := readOrGenerateSandboxCredentialsAt(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := readOrGenerateSandboxCredentialsAt(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Errorf("second call generated a different password: %+v != %+v", first, second)
+	}
+}

--- a/go/internal/cli/commands/sandbox_launchd.go
+++ b/go/internal/cli/commands/sandbox_launchd.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"text/template"
+	"time"
 )
 
 const sandboxLaunchAgentLabel = "sh.wendy.sandbox-control-plane"
@@ -20,7 +22,12 @@ var (
 )
 
 type sandboxPlistParams struct {
-	Label         string
+	Label string
+	// NodePath is the absolute path to the node binary, resolved by the installer
+	// via exec.LookPath. launchd runs with a minimal environment, so relying on a
+	// PATH search here would break every version-manager install (nvm/fnm/asdf/
+	// volta) that isn't under a Homebrew prefix.
+	NodePath      string
 	WorkDir       string
 	LogPath       string
 	Port          string
@@ -37,8 +44,7 @@ const sandboxPlistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 	<string>{{.Label}}</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>/usr/bin/env</string>
-		<string>node</string>
+		<string>{{.NodePath}}</string>
 		<string>dist/index.js</string>
 	</array>
 	<key>WorkingDirectory</key>
@@ -81,6 +87,7 @@ func renderSandboxPlist(p sandboxPlistParams) (string, error) {
 	}
 	p.Label, p.WorkDir, p.LogPath, p.Port = esc(p.Label), esc(p.WorkDir), esc(p.LogPath), esc(p.Port)
 	p.AdminUser, p.AdminPassword, p.DataDir = esc(p.AdminUser), esc(p.AdminPassword), esc(p.DataDir)
+	p.NodePath = esc(p.NodePath)
 
 	tmpl, err := template.New("sandbox-plist").Parse(sandboxPlistTemplate)
 	if err != nil {
@@ -142,4 +149,18 @@ func sandboxLaunchAgentStatus(ctx context.Context) (bool, error) {
 		return false, fmt.Errorf("launchctl print %s: %w", target, err)
 	}
 	return true, nil
+}
+
+// sandboxPortIsListening reports whether something accepts TCP connections on
+// the given local port. Being loaded in launchd is not the same as being alive:
+// with KeepAlive: true a crash-looping control-plane stays registered forever,
+// so this is the only signal that distinguishes "running" from "respawning".
+func sandboxPortIsListening(ctx context.Context, port string) bool {
+	d := net.Dialer{Timeout: 200 * time.Millisecond}
+	conn, err := d.DialContext(ctx, "tcp", "localhost:"+port)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
 }

--- a/go/internal/cli/commands/sandbox_launchd.go
+++ b/go/internal/cli/commands/sandbox_launchd.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -12,6 +13,11 @@ import (
 )
 
 const sandboxLaunchAgentLabel = "sh.wendy.sandbox-control-plane"
+
+var (
+	// sandboxCommandContext is overridable for testing purposes.
+	sandboxCommandContext = exec.CommandContext
+)
 
 type sandboxPlistParams struct {
 	Label         string
@@ -100,7 +106,7 @@ func sandboxLaunchdTarget() string {
 }
 
 func loadSandboxLaunchAgent(ctx context.Context, plistPath string) error {
-	cmd := exec.CommandContext(ctx, "launchctl", "bootstrap", fmt.Sprintf("gui/%d", os.Getuid()), plistPath)
+	cmd := sandboxCommandContext(ctx, "launchctl", "bootstrap", fmt.Sprintf("gui/%d", os.Getuid()), plistPath)
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("launchctl bootstrap %s: %w", plistPath, err)
@@ -110,7 +116,7 @@ func loadSandboxLaunchAgent(ctx context.Context, plistPath string) error {
 
 func unloadSandboxLaunchAgent(ctx context.Context) error {
 	target := sandboxLaunchdTarget()
-	cmd := exec.CommandContext(ctx, "launchctl", "bootout", target)
+	cmd := sandboxCommandContext(ctx, "launchctl", "bootout", target)
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("launchctl bootout %s: %w", target, err)
@@ -121,11 +127,19 @@ func unloadSandboxLaunchAgent(ctx context.Context) error {
 // sandboxLaunchAgentStatus reports whether the LaunchAgent is registered with
 // launchd. `launchctl print` exits non-zero when the service isn't loaded —
 // that's the normal "not installed" case, not an error to surface.
+// Returns (false, nil) if the service is not loaded, (true, nil) if it is loaded,
+// and (false, error) if launchctl itself cannot be executed.
 func sandboxLaunchAgentStatus(ctx context.Context) (bool, error) {
 	target := sandboxLaunchdTarget()
-	cmd := exec.CommandContext(ctx, "launchctl", "print", target)
+	cmd := sandboxCommandContext(ctx, "launchctl", "print", target)
 	if err := cmd.Run(); err != nil {
-		return false, nil
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			// launchctl ran but exited non-zero — service not loaded
+			return false, nil
+		}
+		// launchctl itself couldn't run — a real failure
+		return false, fmt.Errorf("launchctl print %s: %w", target, err)
 	}
 	return true, nil
 }

--- a/go/internal/cli/commands/sandbox_launchd.go
+++ b/go/internal/cli/commands/sandbox_launchd.go
@@ -1,0 +1,131 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+const sandboxLaunchAgentLabel = "sh.wendy.sandbox-control-plane"
+
+type sandboxPlistParams struct {
+	Label         string
+	WorkDir       string
+	LogPath       string
+	Port          string
+	AdminUser     string
+	AdminPassword string
+	DataDir       string
+}
+
+const sandboxPlistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>{{.Label}}</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/bin/env</string>
+		<string>node</string>
+		<string>dist/index.js</string>
+	</array>
+	<key>WorkingDirectory</key>
+	<string>{{.WorkDir}}</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PORT</key>
+		<string>{{.Port}}</string>
+		<key>DRIVER</key>
+		<string>docker</string>
+		<key>PUBLIC_HOST</key>
+		<string>localhost</string>
+		<key>ADMIN_USER</key>
+		<string>{{.AdminUser}}</string>
+		<key>ADMIN_PASSWORD</key>
+		<string>{{.AdminPassword}}</string>
+		<key>DATA_DIR</key>
+		<string>{{.DataDir}}</string>
+		<key>PATH</key>
+		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+	</dict>
+	<key>StandardOutPath</key>
+	<string>{{.LogPath}}</string>
+	<key>StandardErrorPath</key>
+	<string>{{.LogPath}}</string>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<true/>
+</dict>
+</plist>
+`
+
+// renderSandboxPlist fills the launchd plist template. Fields are XML-escaped
+// before substitution since AdminPassword is base64url in practice but this
+// keeps the function correct regardless.
+func renderSandboxPlist(p sandboxPlistParams) (string, error) {
+	esc := func(s string) string {
+		return strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;").Replace(s)
+	}
+	p.Label, p.WorkDir, p.LogPath, p.Port = esc(p.Label), esc(p.WorkDir), esc(p.LogPath), esc(p.Port)
+	p.AdminUser, p.AdminPassword, p.DataDir = esc(p.AdminUser), esc(p.AdminPassword), esc(p.DataDir)
+
+	tmpl, err := template.New("sandbox-plist").Parse(sandboxPlistTemplate)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, p); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func sandboxLaunchctlPlistPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home directory: %w", err)
+	}
+	return filepath.Join(home, "Library", "LaunchAgents", sandboxLaunchAgentLabel+".plist"), nil
+}
+
+func sandboxLaunchdTarget() string {
+	return fmt.Sprintf("gui/%d/%s", os.Getuid(), sandboxLaunchAgentLabel)
+}
+
+func loadSandboxLaunchAgent(ctx context.Context, plistPath string) error {
+	cmd := exec.CommandContext(ctx, "launchctl", "bootstrap", fmt.Sprintf("gui/%d", os.Getuid()), plistPath)
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("launchctl bootstrap %s: %w", plistPath, err)
+	}
+	return nil
+}
+
+func unloadSandboxLaunchAgent(ctx context.Context) error {
+	target := sandboxLaunchdTarget()
+	cmd := exec.CommandContext(ctx, "launchctl", "bootout", target)
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("launchctl bootout %s: %w", target, err)
+	}
+	return nil
+}
+
+// sandboxLaunchAgentStatus reports whether the LaunchAgent is registered with
+// launchd. `launchctl print` exits non-zero when the service isn't loaded —
+// that's the normal "not installed" case, not an error to surface.
+func sandboxLaunchAgentStatus(ctx context.Context) (bool, error) {
+	target := sandboxLaunchdTarget()
+	cmd := exec.CommandContext(ctx, "launchctl", "print", target)
+	if err := cmd.Run(); err != nil {
+		return false, nil
+	}
+	return true, nil
+}

--- a/go/internal/cli/commands/sandbox_launchd_test.go
+++ b/go/internal/cli/commands/sandbox_launchd_test.go
@@ -9,7 +9,8 @@ import (
 
 func TestRenderSandboxPlist_SubstitutesAllFields(t *testing.T) {
 	xml, err := renderSandboxPlist(sandboxPlistParams{
-		Label: "sh.wendy.sandbox-control-plane", WorkDir: "/tmp/cp", LogPath: "/tmp/cp.log",
+		Label: "sh.wendy.sandbox-control-plane", NodePath: "/Users/me/.nvm/versions/node/v22.0.0/bin/node",
+		WorkDir: "/tmp/cp", LogPath: "/tmp/cp.log",
 		Port: "8787", AdminUser: "admin", AdminPassword: "s3cr3t", DataDir: "/tmp/cp-data",
 	})
 	if err != nil {
@@ -17,6 +18,8 @@ func TestRenderSandboxPlist_SubstitutesAllFields(t *testing.T) {
 	}
 	for _, want := range []string{
 		"<string>sh.wendy.sandbox-control-plane</string>",
+		"<string>/Users/me/.nvm/versions/node/v22.0.0/bin/node</string>",
+		"<string>dist/index.js</string>",
 		"<string>/tmp/cp</string>",
 		"<string>/tmp/cp.log</string>",
 		"<string>8787</string>",
@@ -30,11 +33,17 @@ func TestRenderSandboxPlist_SubstitutesAllFields(t *testing.T) {
 			t.Errorf("rendered plist missing %q\nfull output:\n%s", want, xml)
 		}
 	}
+	// launchd must invoke node by absolute path — a PATH search would miss
+	// nvm/fnm/asdf/volta installs entirely.
+	if strings.Contains(xml, "/usr/bin/env") {
+		t.Errorf("rendered plist still shells out via /usr/bin/env instead of the resolved node path\nfull output:\n%s", xml)
+	}
 }
 
 func TestRenderSandboxPlist_EscapesXMLSpecialCharacters(t *testing.T) {
 	xml, err := renderSandboxPlist(sandboxPlistParams{
-		Label: "sh.wendy.sandbox-control-plane", WorkDir: "/tmp/cp", LogPath: "/tmp/cp.log",
+		Label: "sh.wendy.sandbox-control-plane", NodePath: `/opt/no&de/bin/node`,
+		WorkDir: "/tmp/cp", LogPath: "/tmp/cp.log",
 		Port: "8787", AdminUser: "admin", AdminPassword: `a&b<c>d`, DataDir: "/tmp/cp-data",
 	})
 	if err != nil {
@@ -45,6 +54,9 @@ func TestRenderSandboxPlist_EscapesXMLSpecialCharacters(t *testing.T) {
 	}
 	if !strings.Contains(xml, "a&amp;b&lt;c&gt;d") {
 		t.Errorf("rendered plist missing escaped password\nfull output:\n%s", xml)
+	}
+	if !strings.Contains(xml, "/opt/no&amp;de/bin/node") {
+		t.Errorf("rendered plist missing escaped node path\nfull output:\n%s", xml)
 	}
 }
 

--- a/go/internal/cli/commands/sandbox_launchd_test.go
+++ b/go/internal/cli/commands/sandbox_launchd_test.go
@@ -1,0 +1,47 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderSandboxPlist_SubstitutesAllFields(t *testing.T) {
+	xml, err := renderSandboxPlist(sandboxPlistParams{
+		Label: "sh.wendy.sandbox-control-plane", WorkDir: "/tmp/cp", LogPath: "/tmp/cp.log",
+		Port: "8787", AdminUser: "admin", AdminPassword: "s3cr3t", DataDir: "/tmp/cp-data",
+	})
+	if err != nil {
+		t.Fatalf("renderSandboxPlist: %v", err)
+	}
+	for _, want := range []string{
+		"<string>sh.wendy.sandbox-control-plane</string>",
+		"<string>/tmp/cp</string>",
+		"<string>/tmp/cp.log</string>",
+		"<string>8787</string>",
+		"<string>admin</string>",
+		"<string>s3cr3t</string>",
+		"<string>/tmp/cp-data</string>",
+		"<key>KeepAlive</key>",
+		"<true/>",
+	} {
+		if !strings.Contains(xml, want) {
+			t.Errorf("rendered plist missing %q\nfull output:\n%s", want, xml)
+		}
+	}
+}
+
+func TestRenderSandboxPlist_EscapesXMLSpecialCharacters(t *testing.T) {
+	xml, err := renderSandboxPlist(sandboxPlistParams{
+		Label: "sh.wendy.sandbox-control-plane", WorkDir: "/tmp/cp", LogPath: "/tmp/cp.log",
+		Port: "8787", AdminUser: "admin", AdminPassword: `a&b<c>d`, DataDir: "/tmp/cp-data",
+	})
+	if err != nil {
+		t.Fatalf("renderSandboxPlist: %v", err)
+	}
+	if strings.Contains(xml, "a&b<c>d") {
+		t.Error("rendered plist contains un-escaped XML special characters in the password")
+	}
+	if !strings.Contains(xml, "a&amp;b&lt;c&gt;d") {
+		t.Errorf("rendered plist missing escaped password\nfull output:\n%s", xml)
+	}
+}

--- a/go/internal/cli/commands/sandbox_launchd_test.go
+++ b/go/internal/cli/commands/sandbox_launchd_test.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"context"
+	"os/exec"
 	"strings"
 	"testing"
 )
@@ -43,5 +45,50 @@ func TestRenderSandboxPlist_EscapesXMLSpecialCharacters(t *testing.T) {
 	}
 	if !strings.Contains(xml, "a&amp;b&lt;c&gt;d") {
 		t.Errorf("rendered plist missing escaped password\nfull output:\n%s", xml)
+	}
+}
+
+func TestSandboxLaunchAgentStatus_ExitErrorIsNotSurfaced(t *testing.T) {
+	// Test that when launchctl exits non-zero (e.g., service not loaded),
+	// we return (false, nil), not an error. We inject a 'false' command
+	// to simulate this scenario.
+	oldCommand := sandboxCommandContext
+	defer func() { sandboxCommandContext = oldCommand }()
+
+	// Inject a command that exits non-zero (mimics launchctl exiting 1)
+	sandboxCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return exec.Command("false")
+	}
+
+	running, err := sandboxLaunchAgentStatus(context.Background())
+	if err != nil {
+		t.Errorf("expected (false, nil) but got error: %v", err)
+	}
+	if running != false {
+		t.Errorf("expected running=false, got running=%v", running)
+	}
+}
+
+func TestSandboxLaunchAgentStatus_RealErrorIsSurfaced(t *testing.T) {
+	// Test that when launchctl itself can't run (e.g., not found),
+	// we return (false, error), not (false, nil). We inject a command
+	// that can't be executed to simulate this scenario.
+	oldCommand := sandboxCommandContext
+	defer func() { sandboxCommandContext = oldCommand }()
+
+	// Inject a command that can't be found (mimics launchctl not being on PATH)
+	sandboxCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return exec.Command("wendy-sandbox-launchd-test-nonexistent-xyz-binary")
+	}
+
+	running, err := sandboxLaunchAgentStatus(context.Background())
+	if err == nil {
+		t.Error("expected error when launchctl can't be executed, got nil")
+	}
+	if running != false {
+		t.Errorf("expected running=false when error occurs, got running=%v", running)
+	}
+	if !strings.Contains(err.Error(), "launchctl print") {
+		t.Errorf("expected error message to mention 'launchctl print', got: %v", err)
 	}
 }

--- a/go/internal/cli/commands/sandbox_release.go
+++ b/go/internal/cli/commands/sandbox_release.go
@@ -32,7 +32,8 @@ type sandboxRelease struct {
 
 // fetchControlPlaneRelease resolves the control-plane-latest release. Uses the
 // tags endpoint, not /releases/latest — that endpoint excludes prereleases,
-// and control-plane-latest is published as one (see control-plane-release.yml).
+// and control-plane-latest is published as one (see control-plane-release.yml
+// in the wendylabsinc/wendy-sandbox repo).
 func fetchControlPlaneRelease(ctx context.Context) (*sandboxRelease, error) {
 	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/tags/%s", controlPlaneReleaseRepo, controlPlaneReleaseTag)
 	req, err := newGitHubAPIGetRequest(url)
@@ -108,6 +109,10 @@ func extractControlPlaneTarGz(r io.Reader, destDir string) error {
 			continue // the bare "control-plane" dir entry, or something outside it
 		}
 		target := filepath.Join(destDir, rel)
+		// Prevent path traversal: ensure target stays within destDir.
+		if !strings.HasPrefix(target, filepath.Clean(destDir)+string(os.PathSeparator)) {
+			return fmt.Errorf("control-plane tarball entry %q escapes destination directory", hdr.Name)
+		}
 		switch hdr.Typeflag {
 		case tar.TypeDir:
 			if err := os.MkdirAll(target, 0o755); err != nil {

--- a/go/internal/cli/commands/sandbox_release.go
+++ b/go/internal/cli/commands/sandbox_release.go
@@ -21,7 +21,14 @@ const (
 )
 
 type sandboxReleaseAsset struct {
-	Name               string `json:"name"`
+	Name string `json:"name"`
+	// URL is the api.github.com asset endpoint
+	// (https://api.github.com/repos/{owner}/{repo}/releases/assets/{id}). This is
+	// the only download URL that works for a private repo — see
+	// findControlPlaneAsset.
+	URL string `json:"url"`
+	// BrowserDownloadURL is the objects.githubusercontent.com URL. Kept for error
+	// messages/diagnostics only; it cannot be fetched for a private repo.
 	BrowserDownloadURL string `json:"browser_download_url"`
 }
 
@@ -34,6 +41,12 @@ type sandboxRelease struct {
 // tags endpoint, not /releases/latest — that endpoint excludes prereleases,
 // and control-plane-latest is published as one (see control-plane-release.yml
 // in the wendylabsinc/wendy-sandbox repo).
+//
+// wendylabsinc/wendy-sandbox is a private repo, so every request here (metadata
+// and asset download alike) must carry the GITHUB_TOKEN that
+// newGitHubAPIGetRequest attaches. GitHub masks private-repo permission errors
+// as 404, so a missing token looks identical to a missing tag — hence the
+// combined error message below.
 func fetchControlPlaneRelease(ctx context.Context) (*sandboxRelease, error) {
 	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/tags/%s", controlPlaneReleaseRepo, controlPlaneReleaseTag)
 	req, err := newGitHubAPIGetRequest(url)
@@ -48,7 +61,10 @@ func fetchControlPlaneRelease(ctx context.Context) (*sandboxRelease, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("fetching control-plane release: unexpected status %d (tag %s not published yet?)", resp.StatusCode, controlPlaneReleaseTag)
+		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			return nil, fmt.Errorf("fetching control-plane release: status %d — either the %s tag isn't published yet, or GITHUB_TOKEN is missing/lacks access to the private %s repo", resp.StatusCode, controlPlaneReleaseTag, controlPlaneReleaseRepo)
+		}
+		return nil, fmt.Errorf("fetching control-plane release: unexpected status %d", resp.StatusCode)
 	}
 	var rel sandboxRelease
 	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
@@ -57,23 +73,37 @@ func fetchControlPlaneRelease(ctx context.Context) (*sandboxRelease, error) {
 	return &rel, nil
 }
 
+// findControlPlaneAsset returns the asset's API URL
+// (https://api.github.com/repos/{owner}/{repo}/releases/assets/{id}), NOT its
+// browser_download_url. Do not "simplify" this back to browser_download_url:
+// wendylabsinc/wendy-sandbox is private, and its browser download URL requires a
+// signed short-lived redirect that an API token cannot mint, so an
+// unauthenticated fetch just 404s. The asset API URL, requested with
+// `Accept: application/octet-stream` and the GITHUB_TOKEN Authorization header,
+// is GitHub's documented path for downloading a private release asset.
 func findControlPlaneAsset(rel *sandboxRelease) (string, error) {
 	for _, a := range rel.Assets {
 		if a.Name == controlPlaneReleaseAsset {
-			return a.BrowserDownloadURL, nil
+			return a.URL, nil
 		}
 	}
 	return "", fmt.Errorf("control-plane release %s has no %s asset", rel.TagName, controlPlaneReleaseAsset)
 }
 
 // downloadAndExtractControlPlaneRelease streams the release tarball straight
-// into destDir without buffering the whole download in memory.
-func downloadAndExtractControlPlaneRelease(ctx context.Context, downloadURL, destDir string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+// into destDir without buffering the whole download in memory. assetAPIURL must
+// be the api.github.com asset endpoint (see findControlPlaneAsset) so the
+// request carries GITHUB_TOKEN — required for the private source repo.
+func downloadAndExtractControlPlaneRelease(ctx context.Context, assetAPIURL, destDir string) error {
+	req, err := newGitHubAPIGetRequest(assetAPIURL)
 	if err != nil {
 		return fmt.Errorf("building control-plane download request: %w", err)
 	}
-	client := &http.Client{Timeout: 5 * time.Minute}
+	// Overrides the JSON Accept newGitHubAPIGetRequest sets: this endpoint returns
+	// the asset bytes only when asked for octet-stream.
+	req.Header.Set("Accept", "application/octet-stream")
+	req = req.WithContext(ctx)
+	client := newGitHubAPIClient(5 * time.Minute)
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("downloading control-plane release: %w", err)

--- a/go/internal/cli/commands/sandbox_release.go
+++ b/go/internal/cli/commands/sandbox_release.go
@@ -1,0 +1,138 @@
+package commands
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	controlPlaneReleaseRepo  = "wendylabsinc/wendy-sandbox"
+	controlPlaneReleaseTag   = "control-plane-latest"
+	controlPlaneReleaseAsset = "control-plane.tar.gz"
+)
+
+type sandboxReleaseAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+type sandboxRelease struct {
+	TagName string                `json:"tag_name"`
+	Assets  []sandboxReleaseAsset `json:"assets"`
+}
+
+// fetchControlPlaneRelease resolves the control-plane-latest release. Uses the
+// tags endpoint, not /releases/latest — that endpoint excludes prereleases,
+// and control-plane-latest is published as one (see control-plane-release.yml).
+func fetchControlPlaneRelease(ctx context.Context) (*sandboxRelease, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/tags/%s", controlPlaneReleaseRepo, controlPlaneReleaseTag)
+	req, err := newGitHubAPIGetRequest(url)
+	if err != nil {
+		return nil, fmt.Errorf("building control-plane release request: %w", err)
+	}
+	req = req.WithContext(ctx)
+	client := newGitHubAPIClient(30 * time.Second)
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching control-plane release: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetching control-plane release: unexpected status %d (tag %s not published yet?)", resp.StatusCode, controlPlaneReleaseTag)
+	}
+	var rel sandboxRelease
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return nil, fmt.Errorf("decoding control-plane release response: %w", err)
+	}
+	return &rel, nil
+}
+
+func findControlPlaneAsset(rel *sandboxRelease) (string, error) {
+	for _, a := range rel.Assets {
+		if a.Name == controlPlaneReleaseAsset {
+			return a.BrowserDownloadURL, nil
+		}
+	}
+	return "", fmt.Errorf("control-plane release %s has no %s asset", rel.TagName, controlPlaneReleaseAsset)
+}
+
+// downloadAndExtractControlPlaneRelease streams the release tarball straight
+// into destDir without buffering the whole download in memory.
+func downloadAndExtractControlPlaneRelease(ctx context.Context, downloadURL, destDir string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return fmt.Errorf("building control-plane download request: %w", err)
+	}
+	client := &http.Client{Timeout: 5 * time.Minute}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("downloading control-plane release: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("downloading control-plane release: unexpected status %d", resp.StatusCode)
+	}
+	return extractControlPlaneTarGz(resp.Body, destDir)
+}
+
+// extractControlPlaneTarGz unpacks a control-plane release tarball (whose
+// entries are all prefixed "control-plane/") into destDir, stripping that
+// prefix so destDir itself becomes the control-plane directory.
+func extractControlPlaneTarGz(r io.Reader, destDir string) error {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return fmt.Errorf("opening control-plane tarball: %w", err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	wrote := false
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("reading control-plane tarball: %w", err)
+		}
+		rel := strings.TrimPrefix(hdr.Name, "control-plane/")
+		if rel == "" || rel == hdr.Name {
+			continue // the bare "control-plane" dir entry, or something outside it
+		}
+		target := filepath.Join(destDir, rel)
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return fmt.Errorf("creating %s: %w", target, err)
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return fmt.Errorf("creating %s: %w", filepath.Dir(target), err)
+			}
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(hdr.Mode))
+			if err != nil {
+				return fmt.Errorf("writing %s: %w", target, err)
+			}
+			if _, err := io.Copy(f, tr); err != nil {
+				f.Close()
+				return fmt.Errorf("writing %s: %w", target, err)
+			}
+			if err := f.Close(); err != nil {
+				return fmt.Errorf("closing %s: %w", target, err)
+			}
+			wrote = true
+		}
+	}
+	if !wrote {
+		return fmt.Errorf("control-plane tarball contained no regular files")
+	}
+	return nil
+}

--- a/go/internal/cli/commands/sandbox_release_test.go
+++ b/go/internal/cli/commands/sandbox_release_test.go
@@ -1,0 +1,93 @@
+package commands
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func makeControlPlaneTarGz(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, content := range files {
+		hdr := &tar.Header{Name: name, Mode: 0o644, Size: int64(len(content))}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("WriteHeader(%s): %v", name, err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatalf("Write(%s): %v", name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar Close: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gzip Close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestExtractControlPlaneTarGz_StripsTopLevelDirAndWritesFiles(t *testing.T) {
+	data := makeControlPlaneTarGz(t, map[string]string{
+		"control-plane/package.json":  `{"name":"sandbox-control-plane"}`,
+		"control-plane/dist/index.js": "console.log('hi')",
+	})
+	dest := t.TempDir()
+
+	if err := extractControlPlaneTarGz(bytes.NewReader(data), dest); err != nil {
+		t.Fatalf("extractControlPlaneTarGz: %v", err)
+	}
+
+	pkg, err := os.ReadFile(filepath.Join(dest, "package.json"))
+	if err != nil {
+		t.Fatalf("reading extracted package.json: %v", err)
+	}
+	if string(pkg) != `{"name":"sandbox-control-plane"}` {
+		t.Errorf("package.json content = %q", pkg)
+	}
+	idx, err := os.ReadFile(filepath.Join(dest, "dist", "index.js"))
+	if err != nil {
+		t.Fatalf("reading extracted dist/index.js: %v", err)
+	}
+	if string(idx) != "console.log('hi')" {
+		t.Errorf("dist/index.js content = %q", idx)
+	}
+}
+
+func TestExtractControlPlaneTarGz_EmptyTarballErrors(t *testing.T) {
+	data := makeControlPlaneTarGz(t, map[string]string{})
+	dest := t.TempDir()
+
+	if err := extractControlPlaneTarGz(bytes.NewReader(data), dest); err == nil {
+		t.Fatal("expected error for a tarball with no regular files, got nil")
+	}
+}
+
+func TestFindControlPlaneAsset_ReturnsMatchingAssetURL(t *testing.T) {
+	rel := &sandboxRelease{
+		TagName: "control-plane-latest",
+		Assets: []sandboxReleaseAsset{
+			{Name: "other-file.txt", BrowserDownloadURL: "https://example.com/other"},
+			{Name: "control-plane.tar.gz", BrowserDownloadURL: "https://example.com/control-plane.tar.gz"},
+		},
+	}
+	url, err := findControlPlaneAsset(rel)
+	if err != nil {
+		t.Fatalf("findControlPlaneAsset: %v", err)
+	}
+	if url != "https://example.com/control-plane.tar.gz" {
+		t.Errorf("url = %q", url)
+	}
+}
+
+func TestFindControlPlaneAsset_MissingAssetErrors(t *testing.T) {
+	rel := &sandboxRelease{TagName: "control-plane-latest", Assets: nil}
+	if _, err := findControlPlaneAsset(rel); err == nil {
+		t.Fatal("expected error when the release has no matching asset")
+	}
+}

--- a/go/internal/cli/commands/sandbox_release_test.go
+++ b/go/internal/cli/commands/sandbox_release_test.go
@@ -68,6 +68,24 @@ func TestExtractControlPlaneTarGz_EmptyTarballErrors(t *testing.T) {
 	}
 }
 
+func TestExtractControlPlaneTarGz_RejectsPathTraversal(t *testing.T) {
+	data := makeControlPlaneTarGz(t, map[string]string{
+		"control-plane/../escape.txt": "malicious content",
+		"control-plane/safe.txt":      "safe content",
+	})
+	dest := t.TempDir()
+
+	if err := extractControlPlaneTarGz(bytes.NewReader(data), dest); err == nil {
+		t.Fatal("expected error for path traversal attack, got nil")
+	}
+
+	// Verify no file was written outside destDir
+	escapePath := filepath.Join(filepath.Dir(dest), "escape.txt")
+	if _, err := os.Stat(escapePath); err == nil {
+		t.Fatalf("path traversal file was created at %s", escapePath)
+	}
+}
+
 func TestFindControlPlaneAsset_ReturnsMatchingAssetURL(t *testing.T) {
 	rel := &sandboxRelease{
 		TagName: "control-plane-latest",

--- a/go/internal/cli/commands/sandbox_release_test.go
+++ b/go/internal/cli/commands/sandbox_release_test.go
@@ -86,20 +86,44 @@ func TestExtractControlPlaneTarGz_RejectsPathTraversal(t *testing.T) {
 	}
 }
 
-func TestFindControlPlaneAsset_ReturnsMatchingAssetURL(t *testing.T) {
+// The API asset URL — not browser_download_url — is what works for a private
+// repo, so findControlPlaneAsset must return the former.
+func TestFindControlPlaneAsset_ReturnsAPIAssetURLNotBrowserURL(t *testing.T) {
 	rel := &sandboxRelease{
 		TagName: "control-plane-latest",
 		Assets: []sandboxReleaseAsset{
-			{Name: "other-file.txt", BrowserDownloadURL: "https://example.com/other"},
-			{Name: "control-plane.tar.gz", BrowserDownloadURL: "https://example.com/control-plane.tar.gz"},
+			{
+				Name:               "other-file.txt",
+				URL:                "https://api.github.com/repos/wendylabsinc/wendy-sandbox/releases/assets/1",
+				BrowserDownloadURL: "https://example.com/other",
+			},
+			{
+				Name:               "control-plane.tar.gz",
+				URL:                "https://api.github.com/repos/wendylabsinc/wendy-sandbox/releases/assets/2",
+				BrowserDownloadURL: "https://example.com/control-plane.tar.gz",
+			},
 		},
 	}
 	url, err := findControlPlaneAsset(rel)
 	if err != nil {
 		t.Fatalf("findControlPlaneAsset: %v", err)
 	}
-	if url != "https://example.com/control-plane.tar.gz" {
-		t.Errorf("url = %q", url)
+	if url != "https://api.github.com/repos/wendylabsinc/wendy-sandbox/releases/assets/2" {
+		t.Errorf("url = %q; want the api.github.com asset URL, not browser_download_url", url)
+	}
+}
+
+// The asset API URL must be accepted by newGitHubAPIGetRequest's host check, or
+// downloadAndExtractControlPlaneRelease can never authenticate.
+func TestGitHubAPIAssetURLIsAcceptedByRequestBuilder(t *testing.T) {
+	const assetURL = "https://api.github.com/repos/wendylabsinc/wendy-sandbox/releases/assets/42"
+	req, err := newGitHubAPIGetRequest(assetURL)
+	if err != nil {
+		t.Fatalf("newGitHubAPIGetRequest(%q): %v", assetURL, err)
+	}
+	req.Header.Set("Accept", "application/octet-stream")
+	if got := req.Header.Get("Accept"); got != "application/octet-stream" {
+		t.Errorf("Accept = %q, want application/octet-stream", got)
 	}
 }
 

--- a/go/internal/cli/commands/sandbox_test.go
+++ b/go/internal/cli/commands/sandbox_test.go
@@ -1,0 +1,216 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// fakeLaunchctl swaps sandboxCommandContext for a recorder that decides each
+// invocation's exit status from its launchctl subcommand. loaded controls what
+// `launchctl print` reports, which is how start/stop decide whether to act.
+type fakeLaunchctl struct {
+	loaded bool
+	calls  []string
+}
+
+func (f *fakeLaunchctl) install(t *testing.T) {
+	t.Helper()
+	old := sandboxCommandContext
+	t.Cleanup(func() { sandboxCommandContext = old })
+	sandboxCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		sub := ""
+		if len(args) > 0 {
+			sub = args[0]
+		}
+		f.calls = append(f.calls, sub)
+		if sub == "print" && !f.loaded {
+			return exec.Command("false") // launchctl exits non-zero when not loaded
+		}
+		return exec.Command("true")
+	}
+}
+
+func (f *fakeLaunchctl) called(sub string) bool {
+	for _, c := range f.calls {
+		if c == sub {
+			return true
+		}
+	}
+	return false
+}
+
+func newTestSandboxCmd(out *bytes.Buffer) *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	return cmd
+}
+
+func TestRunSandboxStart_AlreadyRunningDoesNotBootstrap(t *testing.T) {
+	fake := &fakeLaunchctl{loaded: true}
+	fake.install(t)
+
+	var out bytes.Buffer
+	if err := runSandboxStart(context.Background(), newTestSandboxCmd(&out)); err != nil {
+		t.Fatalf("runSandboxStart: %v", err)
+	}
+	if !strings.Contains(out.String(), "already running") {
+		t.Errorf("output = %q, want it to mention 'already running'", out.String())
+	}
+	if fake.called("bootstrap") {
+		t.Errorf("start bootstrapped an already-running agent; calls = %v", fake.calls)
+	}
+}
+
+func TestRunSandboxStart_NotRunningBootstraps(t *testing.T) {
+	fake := &fakeLaunchctl{loaded: false}
+	fake.install(t)
+
+	var out bytes.Buffer
+	if err := runSandboxStart(context.Background(), newTestSandboxCmd(&out)); err != nil {
+		t.Fatalf("runSandboxStart: %v", err)
+	}
+	if !fake.called("bootstrap") {
+		t.Errorf("start did not bootstrap a stopped agent; calls = %v", fake.calls)
+	}
+	if !strings.Contains(out.String(), "control-plane started") {
+		t.Errorf("output = %q, want it to report the agent started", out.String())
+	}
+}
+
+func TestRunSandboxStop_AlreadyStoppedDoesNotBootout(t *testing.T) {
+	// `launchctl bootout` on an unloaded job exits 3 ("No such process"), so stop
+	// must check status first to stay idempotent.
+	fake := &fakeLaunchctl{loaded: false}
+	fake.install(t)
+
+	var out bytes.Buffer
+	if err := runSandboxStop(context.Background(), newTestSandboxCmd(&out)); err != nil {
+		t.Fatalf("runSandboxStop: %v", err)
+	}
+	if !strings.Contains(out.String(), "already stopped") {
+		t.Errorf("output = %q, want it to mention 'already stopped'", out.String())
+	}
+	if fake.called("bootout") {
+		t.Errorf("stop booted out an already-stopped agent; calls = %v", fake.calls)
+	}
+}
+
+func TestRunSandboxStop_RunningBootsOut(t *testing.T) {
+	fake := &fakeLaunchctl{loaded: true}
+	fake.install(t)
+
+	var out bytes.Buffer
+	if err := runSandboxStop(context.Background(), newTestSandboxCmd(&out)); err != nil {
+		t.Fatalf("runSandboxStop: %v", err)
+	}
+	if !fake.called("bootout") {
+		t.Errorf("stop did not boot out a running agent; calls = %v", fake.calls)
+	}
+	if !strings.Contains(out.String(), "control-plane stopped") {
+		t.Errorf("output = %q, want it to report the agent stopped", out.String())
+	}
+}
+
+func TestRunSandboxStatus_NoPlistReportsNotInstalled(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	fake := &fakeLaunchctl{loaded: false}
+	fake.install(t)
+
+	var out bytes.Buffer
+	if err := runSandboxStatus(context.Background(), newTestSandboxCmd(&out)); err != nil {
+		t.Fatalf("runSandboxStatus: %v", err)
+	}
+	if !strings.Contains(out.String(), "not installed") {
+		t.Errorf("output = %q, want it to report the control-plane is not installed", out.String())
+	}
+}
+
+// After `stop`, the plist is still on disk and `start` would work — status must
+// say "installed but stopped", not "not installed".
+func TestRunSandboxStatus_PlistPresentButUnloadedReportsStopped(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	plistPath, err := sandboxLaunchctlPlistPath()
+	if err != nil {
+		t.Fatalf("sandboxLaunchctlPlistPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(plistPath, []byte("<plist/>"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	fake := &fakeLaunchctl{loaded: false}
+	fake.install(t)
+
+	var out bytes.Buffer
+	if err := runSandboxStatus(context.Background(), newTestSandboxCmd(&out)); err != nil {
+		t.Fatalf("runSandboxStatus: %v", err)
+	}
+	if !strings.Contains(out.String(), "installed but stopped") {
+		t.Errorf("output = %q, want it to report the control-plane is installed but stopped", out.String())
+	}
+}
+
+func TestSandboxPlatformGuard(t *testing.T) {
+	if err := sandboxPlatformGuard("darwin"); err != nil {
+		t.Errorf("sandboxPlatformGuard(darwin) = %v, want nil", err)
+	}
+	for _, goos := range []string{"linux", "windows"} {
+		err := sandboxPlatformGuard(goos)
+		if err == nil {
+			t.Errorf("sandboxPlatformGuard(%s) = nil, want an error", goos)
+			continue
+		}
+		if !strings.Contains(err.Error(), "only supported on macOS") {
+			t.Errorf("sandboxPlatformGuard(%s) = %v, want it to mention macOS", goos, err)
+		}
+	}
+}
+
+// The guard must cover the whole group, not just install — and it must not be a
+// group-level PersistentPreRunE, which cobra would let shadow the root
+// command's (config/analytics/provider init).
+func TestSandboxCmd_EverySubcommandIsPlatformGuarded(t *testing.T) {
+	sandbox := newSandboxCmd()
+	if sandbox.PersistentPreRunE != nil {
+		t.Error("sandbox group defines PersistentPreRunE; it would shadow the root command's")
+	}
+	subs := sandbox.Commands()
+	if len(subs) != 5 {
+		t.Fatalf("expected 5 sandbox subcommands, got %d", len(subs))
+	}
+	for _, sub := range subs {
+		if sub.PreRunE == nil {
+			t.Errorf("subcommand %q has no platform guard", sub.Name())
+		}
+	}
+}
+
+func TestSandboxPortIsListening(t *testing.T) {
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	_, port, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatalf("SplitHostPort: %v", err)
+	}
+	if !sandboxPortIsListening(context.Background(), port) {
+		t.Errorf("sandboxPortIsListening(%s) = false while a listener is open", port)
+	}
+	ln.Close()
+	if sandboxPortIsListening(context.Background(), port) {
+		t.Errorf("sandboxPortIsListening(%s) = true after the listener closed", port)
+	}
+}

--- a/specs/2026-08-02-wendy-sandbox-cli-install-design.md
+++ b/specs/2026-08-02-wendy-sandbox-cli-install-design.md
@@ -1,0 +1,129 @@
+# `wendy sandbox` — CLI-managed local control-plane for Wendy Sandbox
+
+**Date:** 2026-08-02
+**Status:** Design (approved for planning)
+
+## Background
+
+Sub-project 1 (already landed, `wendylabsinc/wendy-sandbox` PR #57) decoupled
+the Wendy Sandbox native macOS app (`desktop-native/`) from bundling/spawning
+its own "control-plane" — a Node.js dev-sandbox backend that manages Docker
+session containers, terminal (ttyd), and the sim viewer for local development.
+Instead, the app polls `http://localhost:8787/admin` and shows a "Setup"
+button when nothing answers. That button currently does nothing (stubbed).
+
+Clarifying the ecosystem this sits in, since names collide:
+- **`wendy-agent`** (this repo, `wendyos`) is the production on-device agent
+  that runs on real WendyOS hardware — a server.
+- **`WendyAgentMac`** (this repo, `swift/WendyAgentMac`) is a separate,
+  in-progress local background agent for the Mac, analogous to `wendy-agent`
+  but for macOS — also a server, unrelated to control-plane.
+- **control-plane** is neither of those. It is dev/sandbox tooling that a
+  *client* (the companion app / "visual CLI") uses locally to spin up
+  simulated session containers for development — closer in spirit to a
+  simulator add-on than to a production agent.
+- **This sub-project** gives the `wendy` CLI a way to install and run
+  control-plane locally, so the Setup button has something real to invoke.
+
+## Goal
+
+A new `wendy sandbox` command group that installs, starts, stops, and reports
+the status of a local control-plane instance on port 8787, without requiring
+the user to clone `wendy-sandbox` or manually run `npm`.
+
+## Design
+
+### Two-repo dependency
+
+control-plane's source lives in the private `wendy-sandbox` repo. Rather than
+have the CLI `git clone` it (tying install to git + repo access), `wendy-sandbox`
+gains a new CI workflow that builds `control-plane/` (`npm run build` → `dist/`)
+and attaches a versioned tarball to a GitHub Release. The workflow publishes
+a rolling "latest" release on every push to `main` that touches
+`control-plane/` — no manual tagging step, so `wendy sandbox install` always
+fetches the newest working build. `wendy sandbox install` downloads the
+latest release tarball rather than touching git at all. This is a
+prerequisite for this design and is planned/implemented separately in the
+`wendy-sandbox` repo — see the companion plan there.
+
+### Command shape
+
+Follows this codebase's existing `newXxxCmd()` / `root.AddCommand` pattern
+(`go/internal/cli/commands/root.go`):
+
+- `wendy sandbox install` — one-time setup (idempotent: safe to re-run).
+- `wendy sandbox start` / `stop` / `status` — thin `launchctl` wrappers over
+  the installed LaunchAgent.
+- `wendy sandbox uninstall` — unloads and removes the LaunchAgent, and (with
+  `--purge`) the cached install directory.
+
+Registered as a new top-level command with its own `GroupID` (a `sandbox`
+group, or folded into `develop` — implementation's call), matching how
+`wendy install` is wired today.
+
+### `install` steps
+
+1. **Check `node`/`npm`** via `exec.LookPath`, matching the existing
+   toolchain-check pattern (`swifttoolchain/toolchain.go`,
+   `espidftoolchain/toolchain.go`). If missing, error with an actionable
+   message ("run: brew install node") rather than attempting to provision
+   Node itself — this codebase has no precedent for downloading/checksumming
+   a language runtime outside the Swift SDK installers, and requiring Node on
+   PATH matches how every other toolchain dependency in this CLI is handled.
+2. **Download the latest control-plane release tarball** from the
+   `wendy-sandbox` repo's GitHub Releases into a cache dir
+   (`~/.wendy/sandbox/control-plane/<version>/`), verifying it's a
+   fresh/complete download before proceeding (checksum if the release
+   provides one, else at least a non-empty-archive sanity check).
+3. **`npm ci --production`** inside that directory.
+4. **Read-or-generate admin credentials.** Read
+   `~/Library/Application Support/WendySandboxNative/admin-credentials.json`
+   if it exists (the Swift app's own format: `{"user": "...", "password":
+   "..."}`, written by `AdminCredentialStore.load` in `desktop-native`); if it
+   doesn't exist yet (app never launched), generate a random password and
+   write the file in that same format, so whichever side runs first defines
+   the shared secret and the other side always reads it — no more manual
+   credential copying, which directly closes a gap flagged in sub-project 1's
+   final review (a 401/credential mismatch being misreported as "not
+   running").
+5. **Write and load a launchd LaunchAgent**
+   (`~/Library/LaunchAgents/sh.wendy.sandbox-control-plane.plist`):
+   `KeepAlive: true` (macOS has no other supervisor for this, per this
+   repo's own note in the WendyAgentMac provisioning docs), `RunAtLoad:
+   true`, environment `PORT=8787`, `DRIVER=docker`, `ADMIN_USER`/
+   `ADMIN_PASSWORD` from step 4, working directory the cache dir from step 2,
+   program the built `dist/` entrypoint via `node`. `launchctl bootstrap
+   gui/$UID <plist>` (or `load`, matching whichever `launchctl` invocation
+   style this codebase already uses elsewhere, if any — otherwise the modern
+   `bootstrap`/`bootout` subcommands).
+6. Print a success message pointing at `wendy sandbox status`.
+
+### `start` / `stop` / `status`
+
+Thin wrappers: `launchctl kickstart`/`kill`/`print` against the label from
+step 5's plist. `status` reports whether the LaunchAgent is loaded and
+whether port 8787 is actually accepting connections (a loaded-but-crashed
+LaunchAgent is a real state `launchd` can be in).
+
+### `uninstall`
+
+`launchctl bootout` the LaunchAgent, remove the plist. `--purge` additionally
+removes the cached install directory (not the credentials file, which the app
+also owns and may still need).
+
+### Error handling
+
+Every failure path gets an actionable message (matching this codebase's
+`fmt.Errorf("...: %w", err)` convention) — "port 8787 already in use by
+something else," "npm ci failed, see <log path>," "no GitHub release found."
+No silent fallbacks: if a step fails, `install` stops and reports it rather
+than leaving a half-configured LaunchAgent.
+
+### Testing
+
+Unit-testable pieces: credential-file read-or-generate logic (pure,
+file-based), plist-content generation (pure string/template building, given
+inputs). `launchctl`/`npm`/network calls themselves are integration-level and
+follow this codebase's existing pattern of gating on tool availability
+(mirrors `apple_container_setup.go`'s `term.IsTerminal` + confirm-prompt
+shape) rather than mocking `os/exec` wholesale.

--- a/specs/2026-08-02-wendy-sandbox-cli-install-plan.md
+++ b/specs/2026-08-02-wendy-sandbox-cli-install-plan.md
@@ -969,11 +969,13 @@ Expected: install succeeds, the `curl` returns a 200/401 (proving something real
 - [ ] **Step 2: status / stop / start**
 
 ```bash
-wendy sandbox status   # reports loaded
+wendy sandbox status   # "control-plane is installed and running" (loaded AND port 8787 answers)
 wendy sandbox stop
-wendy sandbox status   # still "loaded" (launchd keeps the registration even when the process is down) — confirm via `curl` above failing instead
+wendy sandbox status   # "control-plane is installed but stopped; run: wendy sandbox start" — the plist stays on disk, the job is booted out of launchd
+wendy sandbox stop     # idempotent: "control-plane already stopped."
 wendy sandbox start
 ```
+Note: `status` reports three states — not installed (no plist), installed but stopped (plist present, not loaded in launchd), and running (loaded *and* answering on port 8787). A loaded job that doesn't answer on 8787 is reported as possibly crash-looping, not as running.
 
 - [ ] **Step 3: Re-run install (idempotency)**
 

--- a/specs/2026-08-02-wendy-sandbox-cli-install-plan.md
+++ b/specs/2026-08-02-wendy-sandbox-cli-install-plan.md
@@ -1,0 +1,995 @@
+# `wendy sandbox` CLI command Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `wendy sandbox {install,start,stop,status,uninstall}` so the Wendy Sandbox native macOS app's "Setup" button (currently a stub) has a real command to invoke: install/run the local control-plane dev-sandbox backend as a launchd-managed background service.
+
+**Architecture:** `wendy sandbox install` downloads the latest control-plane release tarball (published by the companion `control-plane-release.yml` workflow in `wendy-sandbox`), unpacks it, runs `npm ci --omit=dev`, reads-or-generates the same admin-credentials JSON file the Swift app uses, writes a launchd `LaunchAgent` plist, and loads it. `start`/`stop`/`status`/`uninstall` are thin `launchctl` wrappers.
+
+**Tech Stack:** Go 1.26, cobra, stdlib only (`net/http`, `archive/tar`, `compress/gzip`, `text/template`, `os/exec`) — no new go.mod dependencies.
+
+**Depends on:** `wendy-sandbox` repo plan `desktop-native/docs/superpowers/plans/2026-08-02-control-plane-release-workflow.md` (must be merged and have produced at least one `control-plane-latest` release before this plan's manual-verification task can succeed — the unit-testable tasks don't need it).
+
+## Global Constraints
+
+- Repo/tag to fetch releases from: `wendylabsinc/wendy-sandbox`, tag `control-plane-latest`, asset `control-plane.tar.gz`. Note: this is a **prerelease** tag, so it must be fetched via `GET /repos/<repo>/releases/tags/<tag>`, NOT `/releases/latest` (GitHub's `/latest` endpoint explicitly excludes prereleases and would 404).
+- Admin credentials file: `~/Library/Application Support/WendySandboxNative/admin-credentials.json`, JSON shape `{"user": "...", "password": "..."}` (exact keys, no snake_case — matches `AdminCredentialStore` in `desktop-native/Sources/WendySandbox/AdminCredentials.swift`). Password format when generated fresh: 18 random bytes, base64 URL-safe, no padding (matches `AdminCredentialStore.randomPassword`).
+- Fixed port: `8787` (matches `AppConfig.preferredPort` in `desktop-native`).
+- launchd LaunchAgent label: `sh.wendy.sandbox-control-plane`.
+- Install directory: `~/.wendy/sandbox/control-plane/`.
+- Package: all new files go in `package commands` (`go/internal/cli/commands/`) — NOT `providers`, because the GitHub API helpers this needs (`newGitHubAPIClient`, `newGitHubAPIGetRequest` in `github.go`) live in `commands`, and `providers` cannot import `commands` (commands already imports providers, e.g. for `apple_container_setup.go` — importing the other way would be circular).
+- Every task must leave `make vet`, `gofmt -l -s .` (empty output), and `make test` (from `go/`) green.
+
+---
+
+### Task 1: Release fetch + download/extract
+
+**Files:**
+- Create: `go/internal/cli/commands/sandbox_release.go`
+- Test: `go/internal/cli/commands/sandbox_release_test.go`
+
+**Interfaces:**
+- Produces: `fetchControlPlaneRelease(ctx context.Context) (*sandboxRelease, error)`, `findControlPlaneAsset(rel *sandboxRelease) (url string, err error)`, `downloadAndExtractControlPlaneRelease(ctx context.Context, downloadURL, destDir string) error`, `extractControlPlaneTarGz(r io.Reader, destDir string) error` (exposed for the test to exercise without real HTTP).
+- Consumes (existing, same package): `newGitHubAPIClient(timeout time.Duration) *http.Client`, `newGitHubAPIGetRequest(rawURL string) (*http.Request, error)` (both in `github.go`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+package commands
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func makeControlPlaneTarGz(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, content := range files {
+		hdr := &tar.Header{Name: name, Mode: 0o644, Size: int64(len(content))}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("WriteHeader(%s): %v", name, err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatalf("Write(%s): %v", name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar Close: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gzip Close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestExtractControlPlaneTarGz_StripsTopLevelDirAndWritesFiles(t *testing.T) {
+	data := makeControlPlaneTarGz(t, map[string]string{
+		"control-plane/package.json":     `{"name":"sandbox-control-plane"}`,
+		"control-plane/dist/index.js":    "console.log('hi')",
+	})
+	dest := t.TempDir()
+
+	if err := extractControlPlaneTarGz(bytes.NewReader(data), dest); err != nil {
+		t.Fatalf("extractControlPlaneTarGz: %v", err)
+	}
+
+	pkg, err := os.ReadFile(filepath.Join(dest, "package.json"))
+	if err != nil {
+		t.Fatalf("reading extracted package.json: %v", err)
+	}
+	if string(pkg) != `{"name":"sandbox-control-plane"}` {
+		t.Errorf("package.json content = %q", pkg)
+	}
+	idx, err := os.ReadFile(filepath.Join(dest, "dist", "index.js"))
+	if err != nil {
+		t.Fatalf("reading extracted dist/index.js: %v", err)
+	}
+	if string(idx) != "console.log('hi')" {
+		t.Errorf("dist/index.js content = %q", idx)
+	}
+}
+
+func TestExtractControlPlaneTarGz_EmptyTarballErrors(t *testing.T) {
+	data := makeControlPlaneTarGz(t, map[string]string{})
+	dest := t.TempDir()
+
+	if err := extractControlPlaneTarGz(bytes.NewReader(data), dest); err == nil {
+		t.Fatal("expected error for a tarball with no regular files, got nil")
+	}
+}
+
+func TestFindControlPlaneAsset_ReturnsMatchingAssetURL(t *testing.T) {
+	rel := &sandboxRelease{
+		TagName: "control-plane-latest",
+		Assets: []sandboxReleaseAsset{
+			{Name: "other-file.txt", BrowserDownloadURL: "https://example.com/other"},
+			{Name: "control-plane.tar.gz", BrowserDownloadURL: "https://example.com/control-plane.tar.gz"},
+		},
+	}
+	url, err := findControlPlaneAsset(rel)
+	if err != nil {
+		t.Fatalf("findControlPlaneAsset: %v", err)
+	}
+	if url != "https://example.com/control-plane.tar.gz" {
+		t.Errorf("url = %q", url)
+	}
+}
+
+func TestFindControlPlaneAsset_MissingAssetErrors(t *testing.T) {
+	rel := &sandboxRelease{TagName: "control-plane-latest", Assets: nil}
+	if _, err := findControlPlaneAsset(rel); err == nil {
+		t.Fatal("expected error when the release has no matching asset")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run (from `go/`): `go test ./internal/cli/commands/... -run TestExtractControlPlaneTarGz -run TestFindControlPlaneAsset -v`
+Expected: FAIL to build — none of `extractControlPlaneTarGz`, `sandboxRelease`, `sandboxReleaseAsset`, `findControlPlaneAsset` exist yet.
+
+- [ ] **Step 3: Implement**
+
+```go
+package commands
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	controlPlaneReleaseRepo  = "wendylabsinc/wendy-sandbox"
+	controlPlaneReleaseTag   = "control-plane-latest"
+	controlPlaneReleaseAsset = "control-plane.tar.gz"
+)
+
+type sandboxReleaseAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+type sandboxRelease struct {
+	TagName string                 `json:"tag_name"`
+	Assets  []sandboxReleaseAsset  `json:"assets"`
+}
+
+// fetchControlPlaneRelease resolves the control-plane-latest release. Uses the
+// tags endpoint, not /releases/latest — that endpoint excludes prereleases,
+// and control-plane-latest is published as one (see control-plane-release.yml).
+func fetchControlPlaneRelease(ctx context.Context) (*sandboxRelease, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/tags/%s", controlPlaneReleaseRepo, controlPlaneReleaseTag)
+	req, err := newGitHubAPIGetRequest(url)
+	if err != nil {
+		return nil, fmt.Errorf("building control-plane release request: %w", err)
+	}
+	req = req.WithContext(ctx)
+	client := newGitHubAPIClient(30 * time.Second)
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching control-plane release: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetching control-plane release: unexpected status %d (tag %s not published yet?)", resp.StatusCode, controlPlaneReleaseTag)
+	}
+	var rel sandboxRelease
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return nil, fmt.Errorf("decoding control-plane release response: %w", err)
+	}
+	return &rel, nil
+}
+
+func findControlPlaneAsset(rel *sandboxRelease) (string, error) {
+	for _, a := range rel.Assets {
+		if a.Name == controlPlaneReleaseAsset {
+			return a.BrowserDownloadURL, nil
+		}
+	}
+	return "", fmt.Errorf("control-plane release %s has no %s asset", rel.TagName, controlPlaneReleaseAsset)
+}
+
+// downloadAndExtractControlPlaneRelease streams the release tarball straight
+// into destDir without buffering the whole download in memory.
+func downloadAndExtractControlPlaneRelease(ctx context.Context, downloadURL, destDir string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return fmt.Errorf("building control-plane download request: %w", err)
+	}
+	client := &http.Client{Timeout: 5 * time.Minute}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("downloading control-plane release: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("downloading control-plane release: unexpected status %d", resp.StatusCode)
+	}
+	return extractControlPlaneTarGz(resp.Body, destDir)
+}
+
+// extractControlPlaneTarGz unpacks a control-plane release tarball (whose
+// entries are all prefixed "control-plane/") into destDir, stripping that
+// prefix so destDir itself becomes the control-plane directory.
+func extractControlPlaneTarGz(r io.Reader, destDir string) error {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return fmt.Errorf("opening control-plane tarball: %w", err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	wrote := false
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("reading control-plane tarball: %w", err)
+		}
+		rel := strings.TrimPrefix(hdr.Name, "control-plane/")
+		if rel == "" || rel == hdr.Name {
+			continue // the bare "control-plane" dir entry, or something outside it
+		}
+		target := filepath.Join(destDir, rel)
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return fmt.Errorf("creating %s: %w", target, err)
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return fmt.Errorf("creating %s: %w", filepath.Dir(target), err)
+			}
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(hdr.Mode))
+			if err != nil {
+				return fmt.Errorf("writing %s: %w", target, err)
+			}
+			if _, err := io.Copy(f, tr); err != nil {
+				f.Close()
+				return fmt.Errorf("writing %s: %w", target, err)
+			}
+			if err := f.Close(); err != nil {
+				return fmt.Errorf("closing %s: %w", target, err)
+			}
+			wrote = true
+		}
+	}
+	if !wrote {
+		return fmt.Errorf("control-plane tarball contained no regular files")
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run (from `go/`): `go test ./internal/cli/commands/... -run TestExtractControlPlaneTarGz -run TestFindControlPlaneAsset -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/cli/commands/sandbox_release.go go/internal/cli/commands/sandbox_release_test.go
+git commit -m "feat: add control-plane release fetch/download/extract"
+```
+
+---
+
+### Task 2: Admin credentials read-or-generate
+
+**Files:**
+- Create: `go/internal/cli/commands/sandbox_credentials.go`
+- Test: `go/internal/cli/commands/sandbox_credentials_test.go`
+
+**Interfaces:**
+- Produces: `sandboxAdminCredentials{User, Password string}`, `readOrGenerateSandboxCredentialsAt(path string) (sandboxAdminCredentials, error)` (the injectable, testable core), `readOrGenerateSandboxCredentials() (sandboxAdminCredentials, error)` (resolves the real path and calls the above), `sandboxCredentialsPath() (string, error)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+package commands
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadOrGenerateSandboxCredentialsAt_GeneratesWhenMissing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "admin-credentials.json")
+
+	creds, err := readOrGenerateSandboxCredentialsAt(path)
+	if err != nil {
+		t.Fatalf("readOrGenerateSandboxCredentialsAt: %v", err)
+	}
+	if creds.User != "admin" {
+		t.Errorf("User = %q, want admin", creds.User)
+	}
+	if len(creds.Password) == 0 {
+		t.Error("Password is empty")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading persisted file: %v", err)
+	}
+	var onDisk sandboxAdminCredentials
+	if err := json.Unmarshal(data, &onDisk); err != nil {
+		t.Fatalf("unmarshalling persisted file: %v", err)
+	}
+	if onDisk != creds {
+		t.Errorf("persisted %+v != returned %+v", onDisk, creds)
+	}
+}
+
+func TestReadOrGenerateSandboxCredentialsAt_ReadsExisting(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "admin-credentials.json")
+	want := sandboxAdminCredentials{User: "someone", Password: "existing-secret"}
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := readOrGenerateSandboxCredentialsAt(path)
+	if err != nil {
+		t.Fatalf("readOrGenerateSandboxCredentialsAt: %v", err)
+	}
+	if got != want {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestReadOrGenerateSandboxCredentialsAt_IsIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "admin-credentials.json")
+
+	first, err := readOrGenerateSandboxCredentialsAt(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := readOrGenerateSandboxCredentialsAt(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Errorf("second call generated a different password: %+v != %+v", first, second)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run (from `go/`): `go test ./internal/cli/commands/... -run TestReadOrGenerateSandboxCredentials -v`
+Expected: FAIL to build — `sandboxAdminCredentials`/`readOrGenerateSandboxCredentialsAt` don't exist.
+
+- [ ] **Step 3: Implement**
+
+```go
+package commands
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// sandboxAdminCredentials is the exact JSON shape desktop-native's
+// AdminCredentialStore reads/writes (Sources/WendySandbox/AdminCredentials.swift)
+// — plain "user"/"password" keys, no key transformation.
+type sandboxAdminCredentials struct {
+	User     string `json:"user"`
+	Password string `json:"password"`
+}
+
+func sandboxCredentialsPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home directory: %w", err)
+	}
+	return filepath.Join(home, "Library", "Application Support", "WendySandboxNative", "admin-credentials.json"), nil
+}
+
+func readOrGenerateSandboxCredentials() (sandboxAdminCredentials, error) {
+	path, err := sandboxCredentialsPath()
+	if err != nil {
+		return sandboxAdminCredentials{}, err
+	}
+	return readOrGenerateSandboxCredentialsAt(path)
+}
+
+// readOrGenerateSandboxCredentialsAt reads path if it already holds valid
+// credentials (written by either the Swift app or a prior CLI run), or
+// generates and persists a fresh one — so whichever side runs first defines
+// the shared secret and the other always reads it back.
+func readOrGenerateSandboxCredentialsAt(path string) (sandboxAdminCredentials, error) {
+	if data, err := os.ReadFile(path); err == nil {
+		var creds sandboxAdminCredentials
+		if err := json.Unmarshal(data, &creds); err == nil && creds.User != "" && creds.Password != "" {
+			return creds, nil
+		}
+	}
+	password, err := generateSandboxPassword()
+	if err != nil {
+		return sandboxAdminCredentials{}, fmt.Errorf("generating admin password: %w", err)
+	}
+	creds := sandboxAdminCredentials{User: "admin", Password: password}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return sandboxAdminCredentials{}, fmt.Errorf("creating %s: %w", filepath.Dir(path), err)
+	}
+	data, err := json.Marshal(creds)
+	if err != nil {
+		return sandboxAdminCredentials{}, err
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return sandboxAdminCredentials{}, fmt.Errorf("writing %s: %w", path, err)
+	}
+	return creds, nil
+}
+
+// generateSandboxPassword matches AdminCredentialStore.randomPassword in
+// desktop-native: 18 random bytes, base64 URL-safe, no padding.
+func generateSandboxPassword() (string, error) {
+	buf := make([]byte, 18)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run (from `go/`): `go test ./internal/cli/commands/... -run TestReadOrGenerateSandboxCredentials -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/cli/commands/sandbox_credentials.go go/internal/cli/commands/sandbox_credentials_test.go
+git commit -m "feat: read-or-generate shared admin credentials for the sandbox control plane"
+```
+
+---
+
+### Task 3: launchd plist generation + launchctl wrappers
+
+**Files:**
+- Create: `go/internal/cli/commands/sandbox_launchd.go`
+- Test: `go/internal/cli/commands/sandbox_launchd_test.go`
+
+**Interfaces:**
+- Produces: `sandboxLaunchAgentLabel` (const `"sh.wendy.sandbox-control-plane"`), `sandboxPlistParams{Label, WorkDir, LogPath, Port, AdminUser, AdminPassword, DataDir string}`, `renderSandboxPlist(p sandboxPlistParams) (string, error)`, `sandboxLaunchctlPlistPath() (string, error)`, `loadSandboxLaunchAgent(ctx context.Context, plistPath string) error`, `unloadSandboxLaunchAgent(ctx context.Context) error`, `sandboxLaunchAgentStatus(ctx context.Context) (running bool, err error)`.
+- Consumes: none new (stdlib `text/template`, `os/exec` only).
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderSandboxPlist_SubstitutesAllFields(t *testing.T) {
+	xml, err := renderSandboxPlist(sandboxPlistParams{
+		Label: "sh.wendy.sandbox-control-plane", WorkDir: "/tmp/cp", LogPath: "/tmp/cp.log",
+		Port: "8787", AdminUser: "admin", AdminPassword: "s3cr3t", DataDir: "/tmp/cp-data",
+	})
+	if err != nil {
+		t.Fatalf("renderSandboxPlist: %v", err)
+	}
+	for _, want := range []string{
+		"<string>sh.wendy.sandbox-control-plane</string>",
+		"<string>/tmp/cp</string>",
+		"<string>/tmp/cp.log</string>",
+		"<string>8787</string>",
+		"<string>admin</string>",
+		"<string>s3cr3t</string>",
+		"<string>/tmp/cp-data</string>",
+		"<key>KeepAlive</key>",
+		"<true/>",
+	} {
+		if !strings.Contains(xml, want) {
+			t.Errorf("rendered plist missing %q\nfull output:\n%s", want, xml)
+		}
+	}
+}
+
+func TestRenderSandboxPlist_EscapesXMLSpecialCharacters(t *testing.T) {
+	xml, err := renderSandboxPlist(sandboxPlistParams{
+		Label: "sh.wendy.sandbox-control-plane", WorkDir: "/tmp/cp", LogPath: "/tmp/cp.log",
+		Port: "8787", AdminUser: "admin", AdminPassword: `a&b<c>d`, DataDir: "/tmp/cp-data",
+	})
+	if err != nil {
+		t.Fatalf("renderSandboxPlist: %v", err)
+	}
+	if strings.Contains(xml, "a&b<c>d") {
+		t.Error("rendered plist contains un-escaped XML special characters in the password")
+	}
+	if !strings.Contains(xml, "a&amp;b&lt;c&gt;d") {
+		t.Errorf("rendered plist missing escaped password\nfull output:\n%s", xml)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run (from `go/`): `go test ./internal/cli/commands/... -run TestRenderSandboxPlist -v`
+Expected: FAIL to build — `renderSandboxPlist`/`sandboxPlistParams` don't exist.
+
+- [ ] **Step 3: Implement**
+
+```go
+package commands
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+const sandboxLaunchAgentLabel = "sh.wendy.sandbox-control-plane"
+
+type sandboxPlistParams struct {
+	Label         string
+	WorkDir       string
+	LogPath       string
+	Port          string
+	AdminUser     string
+	AdminPassword string
+	DataDir       string
+}
+
+const sandboxPlistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>{{.Label}}</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/bin/env</string>
+		<string>node</string>
+		<string>dist/index.js</string>
+	</array>
+	<key>WorkingDirectory</key>
+	<string>{{.WorkDir}}</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PORT</key>
+		<string>{{.Port}}</string>
+		<key>DRIVER</key>
+		<string>docker</string>
+		<key>PUBLIC_HOST</key>
+		<string>localhost</string>
+		<key>ADMIN_USER</key>
+		<string>{{.AdminUser}}</string>
+		<key>ADMIN_PASSWORD</key>
+		<string>{{.AdminPassword}}</string>
+		<key>DATA_DIR</key>
+		<string>{{.DataDir}}</string>
+		<key>PATH</key>
+		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+	</dict>
+	<key>StandardOutPath</key>
+	<string>{{.LogPath}}</string>
+	<key>StandardErrorPath</key>
+	<string>{{.LogPath}}</string>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<true/>
+</dict>
+</plist>
+`
+
+// renderSandboxPlist fills the launchd plist template. Fields are XML-escaped
+// before substitution since AdminPassword is base64url in practice but this
+// keeps the function correct regardless.
+func renderSandboxPlist(p sandboxPlistParams) (string, error) {
+	esc := func(s string) string {
+		return strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;").Replace(s)
+	}
+	p.Label, p.WorkDir, p.LogPath, p.Port = esc(p.Label), esc(p.WorkDir), esc(p.LogPath), esc(p.Port)
+	p.AdminUser, p.AdminPassword, p.DataDir = esc(p.AdminUser), esc(p.AdminPassword), esc(p.DataDir)
+
+	tmpl, err := template.New("sandbox-plist").Parse(sandboxPlistTemplate)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, p); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func sandboxLaunchctlPlistPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home directory: %w", err)
+	}
+	return filepath.Join(home, "Library", "LaunchAgents", sandboxLaunchAgentLabel+".plist"), nil
+}
+
+func sandboxLaunchdTarget() string {
+	return fmt.Sprintf("gui/%d/%s", os.Getuid(), sandboxLaunchAgentLabel)
+}
+
+func loadSandboxLaunchAgent(ctx context.Context, plistPath string) error {
+	cmd := exec.CommandContext(ctx, "launchctl", "bootstrap", fmt.Sprintf("gui/%d", os.Getuid()), plistPath)
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("launchctl bootstrap %s: %w", plistPath, err)
+	}
+	return nil
+}
+
+func unloadSandboxLaunchAgent(ctx context.Context) error {
+	target := sandboxLaunchdTarget()
+	cmd := exec.CommandContext(ctx, "launchctl", "bootout", target)
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("launchctl bootout %s: %w", target, err)
+	}
+	return nil
+}
+
+// sandboxLaunchAgentStatus reports whether the LaunchAgent is registered with
+// launchd. `launchctl print` exits non-zero when the service isn't loaded —
+// that's the normal "not installed" case, not an error to surface.
+func sandboxLaunchAgentStatus(ctx context.Context) (bool, error) {
+	target := sandboxLaunchdTarget()
+	cmd := exec.CommandContext(ctx, "launchctl", "print", target)
+	if err := cmd.Run(); err != nil {
+		return false, nil
+	}
+	return true, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run (from `go/`): `go test ./internal/cli/commands/... -run TestRenderSandboxPlist -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/cli/commands/sandbox_launchd.go go/internal/cli/commands/sandbox_launchd_test.go
+git commit -m "feat: add launchd plist generation and launchctl wrappers for the sandbox control plane"
+```
+
+---
+
+### Task 4: `wendy sandbox` cobra command + registration
+
+**Files:**
+- Create: `go/internal/cli/commands/sandbox.go`
+- Modify: `go/internal/cli/commands/root.go`
+
+**Interfaces:**
+- Consumes (Tasks 1-3, same package): `fetchControlPlaneRelease`, `findControlPlaneAsset`, `downloadAndExtractControlPlaneRelease`, `readOrGenerateSandboxCredentials`, `sandboxPlistParams`, `renderSandboxPlist`, `sandboxLaunchctlPlistPath`, `loadSandboxLaunchAgent`, `unloadSandboxLaunchAgent`, `sandboxLaunchAgentStatus`, `sandboxLaunchAgentLabel`.
+- Produces: `newSandboxCmd() *cobra.Command`.
+
+There's no unit-testable "failing test first" step for this task — it's cobra command wiring plus an install/start/stop/status/uninstall orchestration function that shells out to real system state (network, npm, launchd). Verification is: it builds, `wendy sandbox --help` shows the expected subcommands, and Task 5's manual verification exercises the real behavior end-to-end.
+
+- [ ] **Step 1: Write `sandbox.go`**
+
+```go
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+func newSandboxCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sandbox",
+		Short: "Manage the local Wendy Sandbox control plane",
+		Long: "Install and run the local control-plane service that Wendy Sandbox\n" +
+			"(the native macOS app) uses for session containers, terminal, and the sim viewer.",
+	}
+	var purge bool
+	uninstallCmd := &cobra.Command{
+		Use:   "uninstall",
+		Short: "Unload and remove the local control plane",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSandboxUninstall(context.Background(), cmd, purge)
+		},
+	}
+	uninstallCmd.Flags().BoolVar(&purge, "purge", false, "also remove the cached install directory")
+
+	cmd.AddCommand(
+		&cobra.Command{
+			Use:   "install",
+			Short: "Install and start the local control plane (safe to re-run)",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return runSandboxInstall(context.Background(), cmd)
+			},
+		},
+		&cobra.Command{
+			Use:   "start",
+			Short: "Start the local control plane",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return runSandboxStart(context.Background(), cmd)
+			},
+		},
+		&cobra.Command{
+			Use:   "stop",
+			Short: "Stop the local control plane",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return runSandboxStop(context.Background(), cmd)
+			},
+		},
+		&cobra.Command{
+			Use:   "status",
+			Short: "Report whether the local control plane is running",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return runSandboxStatus(context.Background(), cmd)
+			},
+		},
+		uninstallCmd,
+	)
+	return cmd
+}
+
+func runSandboxInstall(ctx context.Context, cmd *cobra.Command) error {
+	if _, err := exec.LookPath("node"); err != nil {
+		return fmt.Errorf("node is required but not found on PATH; run: brew install node")
+	}
+	if _, err := exec.LookPath("npm"); err != nil {
+		return fmt.Errorf("npm is required but not found on PATH; run: brew install node")
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolving home directory: %w", err)
+	}
+	installDir := filepath.Join(home, ".wendy", "sandbox", "control-plane")
+
+	cmd.Println("Fetching latest control-plane release…")
+	rel, err := fetchControlPlaneRelease(ctx)
+	if err != nil {
+		return err
+	}
+	assetURL, err := findControlPlaneAsset(rel)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(installDir, 0o755); err != nil {
+		return fmt.Errorf("creating %s: %w", installDir, err)
+	}
+	if err := downloadAndExtractControlPlaneRelease(ctx, assetURL, installDir); err != nil {
+		return err
+	}
+
+	cmd.Println("Installing dependencies…")
+	npmCmd := exec.CommandContext(ctx, "npm", "ci", "--omit=dev")
+	npmCmd.Dir = installDir
+	npmCmd.Stdout, npmCmd.Stderr = os.Stdout, os.Stderr
+	if err := npmCmd.Run(); err != nil {
+		return fmt.Errorf("npm ci --omit=dev in %s: %w", installDir, err)
+	}
+
+	creds, err := readOrGenerateSandboxCredentials()
+	if err != nil {
+		return err
+	}
+
+	dataDir := filepath.Join(home, "Library", "Application Support", "WendySandboxNative", "control-plane-data")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		return fmt.Errorf("creating %s: %w", dataDir, err)
+	}
+	logPath := filepath.Join(home, "Library", "Logs", "wendy-sandbox-control-plane.log")
+
+	plist, err := renderSandboxPlist(sandboxPlistParams{
+		Label: sandboxLaunchAgentLabel, WorkDir: installDir, LogPath: logPath,
+		Port: "8787", AdminUser: creds.User, AdminPassword: creds.Password, DataDir: dataDir,
+	})
+	if err != nil {
+		return err
+	}
+	plistPath, err := sandboxLaunchctlPlistPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		return fmt.Errorf("creating %s: %w", filepath.Dir(plistPath), err)
+	}
+	if err := os.WriteFile(plistPath, []byte(plist), 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", plistPath, err)
+	}
+
+	// Unload first (ignore errors — it may not be loaded yet) so a re-run of
+	// install picks up a new plist/version instead of launchd keeping the old one.
+	_ = unloadSandboxLaunchAgent(ctx)
+	if err := loadSandboxLaunchAgent(ctx, plistPath); err != nil {
+		return err
+	}
+
+	cmd.Println("control-plane installed and running on http://localhost:8787")
+	cmd.Println("Check status any time with: wendy sandbox status")
+	return nil
+}
+
+func runSandboxStart(ctx context.Context, cmd *cobra.Command) error {
+	target := sandboxLaunchdTarget()
+	if err := exec.CommandContext(ctx, "launchctl", "kickstart", "-k", target).Run(); err != nil {
+		return fmt.Errorf("launchctl kickstart %s: %w (not installed yet? run: wendy sandbox install)", target, err)
+	}
+	cmd.Println("control-plane started.")
+	return nil
+}
+
+func runSandboxStop(ctx context.Context, cmd *cobra.Command) error {
+	target := sandboxLaunchdTarget()
+	if err := exec.CommandContext(ctx, "launchctl", "kill", "SIGTERM", target).Run(); err != nil {
+		return fmt.Errorf("launchctl kill SIGTERM %s: %w", target, err)
+	}
+	cmd.Println("control-plane stopped.")
+	return nil
+}
+
+func runSandboxStatus(ctx context.Context, cmd *cobra.Command) error {
+	running, err := sandboxLaunchAgentStatus(ctx)
+	if err != nil {
+		return err
+	}
+	if running {
+		cmd.Printf("control-plane is installed and loaded (%s)\n", sandboxLaunchdTarget())
+	} else {
+		cmd.Println("control-plane is not installed; run: wendy sandbox install")
+	}
+	return nil
+}
+
+func runSandboxUninstall(ctx context.Context, cmd *cobra.Command, purge bool) error {
+	if err := unloadSandboxLaunchAgent(ctx); err != nil {
+		cmd.PrintErrln("warning:", err)
+	}
+	plistPath, err := sandboxLaunchctlPlistPath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(plistPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing %s: %w", plistPath, err)
+	}
+	if purge {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return err
+		}
+		if err := os.RemoveAll(filepath.Join(home, ".wendy", "sandbox")); err != nil {
+			return fmt.Errorf("removing install directory: %w", err)
+		}
+	}
+	cmd.Println("control-plane uninstalled.")
+	return nil
+}
+```
+
+- [ ] **Step 2: Register in `root.go`**
+
+Add `"sandbox"` to the `root.AddGroup(...)` call (near `root.go:113-118`):
+
+```go
+root.AddGroup(
+    &cobra.Group{ID: "develop", Title: "Develop & Deploy:"},
+    &cobra.Group{ID: "sandbox", Title: "Sandbox:"},
+    &cobra.Group{ID: "manage", Title: "Manage:"},
+    &cobra.Group{ID: "cloud", Title: "Cloud:"},
+    &cobra.Group{ID: "settings", Title: "Settings:"},
+)
+```
+
+Construct and assign the group near the other command constructions (~`root.go:120-149`):
+
+```go
+sandboxCmd := newSandboxCmd()
+sandboxCmd.GroupID = "sandbox"
+```
+
+Add it to the `root.AddCommand(...)` call (~`root.go:211-242`) in display order alongside the other visible commands.
+
+- [ ] **Step 3: Build and smoke-check help output**
+
+Run (from `go/`):
+```bash
+go build ./... && go run ./cmd/wendy sandbox --help
+```
+Expected: shows `install`, `start`, `stop`, `status`, `uninstall` subcommands with the short descriptions above.
+
+- [ ] **Step 4: Run the full test suite and formatting/vet gates**
+
+Run (from `go/`):
+```bash
+gofmt -l -s .    # must print nothing
+go vet ./...
+make test
+```
+Expected: `gofmt -l -s .` empty, `go vet` clean, all tests pass (including Tasks 1-3's new tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go/internal/cli/commands/sandbox.go go/internal/cli/commands/root.go
+git commit -m "feat: add wendy sandbox command group"
+```
+
+---
+
+### Task 5: Manual verification
+
+Requires the companion `wendy-sandbox` plan's workflow to have published at least one `control-plane-latest` release, and Docker Desktop running locally (control-plane's driver).
+
+- [ ] **Step 1: Fresh install**
+
+```bash
+wendy sandbox install
+curl -u "$(plutil -extract user raw -o - ~/Library/Application\ Support/WendySandboxNative/admin-credentials.json):$(plutil -extract password raw -o - ~/Library/Application\ Support/WendySandboxNative/admin-credentials.json)" http://localhost:8787/admin
+```
+Expected: install succeeds, the `curl` returns a 200/401 (proving something real is listening and using the same credentials the CLI wrote/read).
+
+- [ ] **Step 2: status / stop / start**
+
+```bash
+wendy sandbox status   # reports loaded
+wendy sandbox stop
+wendy sandbox status   # still "loaded" (launchd keeps the registration even when the process is down) — confirm via `curl` above failing instead
+wendy sandbox start
+```
+
+- [ ] **Step 3: Re-run install (idempotency)**
+
+```bash
+wendy sandbox install
+```
+Expected: succeeds again without error, credentials file is unchanged (same password as Step 1), LaunchAgent reloads cleanly.
+
+- [ ] **Step 4: Uninstall**
+
+```bash
+wendy sandbox uninstall --purge
+launchctl print gui/$(id -u)/sh.wendy.sandbox-control-plane   # should now report "could not find service"
+ls ~/.wendy/sandbox   # should not exist
+```
+
+- [ ] **Step 5: End-to-end with desktop-native**
+
+With `wendy-sandbox`'s `desktop-native` app built from the `decouple-control-plane` branch (or its merged result), launch the app with NO control plane running, click Setup once wired to actually invoke `wendy sandbox install` (this plan doesn't wire the button itself — that's a follow-up in `desktop-native` once this CLI command exists; for now, run `wendy sandbox install` manually from a terminal while the app is open) and confirm the app's gated routes come alive within a few seconds without a restart.


### PR DESCRIPTION
## Summary
- New `wendy sandbox {install,start,stop,status,uninstall}` command group so the Wendy Sandbox native macOS app's Setup button (currently a stub, wendylabsinc/wendy-sandbox PR #57) has something real to invoke: install and run the local Node.js control-plane dev-sandbox backend as a launchd-managed background service, without cloning a private repo or running npm by hand.
- `install`: checks node/npm on PATH → downloads the latest `control-plane-latest` release tarball from the private `wendylabsinc/wendy-sandbox` repo (authenticated via the GitHub API asset endpoint, not the public redirect URL) → extracts it (guarded against tar-slip/path-traversal) → `npm ci --omit=dev` → reads-or-generates the same admin-credentials JSON file the Swift macOS app uses, so credentials are always shared (no manual copying) → writes a launchd LaunchAgent plist (0600, absolute node path so nvm/fnm/asdf installs work) → bootstraps it.
- `start`/`stop`: launchctl bootstrap/bootout (idempotent both ways).
- `status`: three real states — not installed / installed but stopped / running (with a port-8787 liveness probe, since a loaded-but-crashed LaunchAgent is a real launchd state).
- The whole command group is hidden and guarded on non-macOS.
- Design/plan: `specs/2026-08-02-wendy-sandbox-cli-install-design.md`, `specs/2026-08-02-wendy-sandbox-cli-install-plan.md`.
- **Depends on** wendylabsinc/wendy-sandbox PR #58 (`control-plane-release.yml`) being merged and having published at least one `control-plane-latest` release before `install` can succeed end-to-end.

## Known verification gap
The full `install → npm ci → plist load → live service` cycle has never been exercised end-to-end, because the sibling release-publishing PR is still open. What WAS verified directly against the real system: `wendy sandbox status`/`uninstall` behave correctly on a clean (never-installed) state, and `wendy sandbox install` correctly reaches the real (authenticated) GitHub API and fails with the exact expected actionable message on the not-yet-published release tag — confirming the pipeline up through release-fetch works. Whoever completes end-to-end verification should specifically confirm: (a) the asset download authenticates correctly against the private repo in practice (unit-tested, not live-tested); (b) `DATA_DIR`/`PUBLIC_HOST`/`DRIVER=docker` are the exact env vars control-plane reads; (c) `dist/index.js` is the real entrypoint in the published tarball; (d) the tarball's entries are all `control-plane/`-prefixed as `extractControlPlaneTarGz` expects.

## Test plan
- [x] `gofmt -l -s .`, `go vet ./...`, `go build ./...` all clean.
- [x] `go test ./... -count=1 -timeout 120s` — 0 failures across 59 packages, including 22 new tests for this feature (release fetch/extract incl. path-traversal rejection, credentials read-or-generate, plist rendering incl. XML-escaping, launchctl status/start/stop state machine, platform guard).
- [x] Verified the merge onto current `main` (26 commits ahead of this branch's fork point) is conflict-free and the merged result builds/vets/tests clean.
- [ ] Manual: once wendy-sandbox PR #58 merges and publishes a release, run `wendy sandbox install` for real and confirm the app's Setup flow works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JUDbn5YFiJkcHuzi8PQgTq