### PR TITLE
feat: add guided Unitree G1 installer

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
@@ -87,29 +87,41 @@ The lab obtained both from the historical
 [Unitree G1 package folder](https://drive.google.com/drive/folders/1ho17ectOxi7FbaRFdpAbP4tet8BJWjbm).
 Wendy does not control that folder, so this experimental flow does not download
 from it automatically. A production release requires publisher-controlled
-artifacts and trusted checksums in the Wendy manifest.
+artifacts and trusted checksums or signatures in the Wendy manifest. For the
+lab run, the CLI calculates and prints SHA-256 fingerprints for both selected
+files. Those fingerprints make the exact test inputs reproducible but do not
+prove their publisher or safety.
 
 The interactive flow:
 
 1. Selects **Unitree G1 JetPack 6.2**.
 2. Asks for the folder containing the paired packages and validates both exact
    filenames as non-empty regular files.
-3. Lists external drives by model, device path, and size, then includes the
+3. Reads both complete files, prints their SHA-256 fingerprints, explains the
+   missing trust anchor, and requires the operator to type
+   `UNVERIFIED UNITREE LAB FLASH`. `--force` cannot bypass this acceptance.
+4. Lists external drives by model, device path, and size, then includes the
    hardware serial (when available) in the final destructive-write review.
-4. Accepts only a fixed external SSD of at least 1 TB, then shows one final
-   destructive-write summary before erasing it.
-5. Streams the bzip2 rootfs image to the replacement NVMe and syncs the write.
-6. Pauses while the operator installs the replacement NVMe in PC2 and preserves
+5. Accepts only a fixed external SSD of at least 1 TB, then shows one final
+   destructive-write summary and re-hashes the image before erasing the drive.
+6. Streams the bzip2 rootfs image to the replacement NVMe and syncs the write.
+7. Pauses while the operator installs the replacement NVMe in PC2 and preserves
    the original drive.
-7. Shows the verified PWR/REC and PC2 USB-C recovery instructions, then waits for
+8. Shows the verified PWR/REC and PC2 USB-C recovery instructions, then waits for
    an Orin NX APX device.
-8. Refuses to invoke Unitree's vendor script if any additional recovery-mode
+9. Refuses to invoke Unitree's vendor script if any additional recovery-mode
    Jetson is connected, because that script cannot be safely pinned to one USB
    path.
-9. Validates archive paths, extracts `Jetpack_6.2_nx.tar.bz2` into a temporary
-   workspace, and runs its single `Linux_for_Tegra/flash_nx_module.sh` under
-   `sudo`.
-10. Prints the normal-boot and `192.168.123.164` verification commands.
+10. Re-hashes the firmware archive, then extracts it with a constrained
+    in-process extractor:
+    absolute/traversal paths, duplicate paths, special files, writes through
+    symlinks, forward hard links, more than 1,000,000 entries, and more than
+    200 GiB of expanded regular-file data are rejected. Regular files are
+    materialized before any validated in-tree links are created.
+11. Locates the single regular `Linux_for_Tegra/flash_nx_module.sh`, prints its
+    SHA-256, exact temporary working directory, and exact `sudo` command, then
+    requires a second confirmation before execution.
+12. Prints the normal-boot and `192.168.123.164` verification commands.
 
 This target flashes only the G1's open Jetson development computer, PC2. It
 must never be used on the separate motion-control computer. The command does

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
@@ -9,6 +9,7 @@ The command presents a unified device picker that lists Linux targets (Raspberry
 - **Jetson Orin Nano / AGX Orin** -> download a recovery flashpack -> verify the module/carrier -> update QSPI and NVMe/eMMC together
 - **Raspberry Pi targets** -> download OS image -> write to SD/NVMe -> write config partition
 - **Jetson AGX Thor** -> download flashpack -> boot over USB recovery -> flash QSPI and internal NVMe
+- **Unitree G1 (experimental)** -> select the paired local Unitree JetPack 6.2 packages -> image a replacement NVMe -> follow the guided PC2 PWR/REC sequence -> flash matching Orin NX module firmware
 - **ESP32 targets** → detect USB serial port → download firmware `.bin` → flash over serial
 
 ```sh
@@ -23,6 +24,10 @@ wendy install --device-type raspberry-pi-5 --version 0.10.4 --drive /dev/disk4 -
 
 # Jetson AGX Thor: flash over USB recovery (macOS, Linux, and Windows)
 wendy install --device-type jetson-agx-thor
+
+# Unitree G1: open the guided picker on an Ubuntu x86-64 host
+# (the package folder and replacement NVMe are selected in the UI)
+wendy install --device-type unitree-g1
 
 # Orin Nano: full QSPI + NVMe recovery (macOS or Linux)
 wendy install --device-type jetson-orin-nano
@@ -62,6 +67,53 @@ is not supported for ESP32 targets (Wendy Lite firmware is not built by the
 per-PR pipeline).
 `--pr` is mutually exclusive with `--nightly`, `--version`, and a positional
 image path.
+
+## Unitree G1 experimental path
+
+Select **Unitree G1** under the **Robots** section of the normal `wendy install`
+picker. The installer deliberately keeps the rootfs image and PC2 module
+firmware behind one installation choice so they cannot be mixed across
+releases.
+
+The first hardware-test version requires an Ubuntu x86-64 host and a local
+folder containing this exact pair from the same Unitree G1 JetPack 6.2 release:
+
+```text
+g1-nx-j6.2.img.bz2
+Jetpack_6.2_nx.tar.bz2
+```
+
+The lab obtained both from the historical
+[Unitree G1 package folder](https://drive.google.com/drive/folders/1ho17ectOxi7FbaRFdpAbP4tet8BJWjbm).
+Wendy does not control that folder, so this experimental flow does not download
+from it automatically. A production release requires publisher-controlled
+artifacts and trusted checksums in the Wendy manifest.
+
+The interactive flow:
+
+1. Selects **Unitree G1 JetPack 6.2**.
+2. Asks for the folder containing the paired packages and validates both exact
+   filenames as non-empty regular files.
+3. Lists external drives by model, device path, and size, then includes the
+   hardware serial (when available) in the final destructive-write review.
+4. Accepts only a fixed external SSD of at least 1 TB, then shows one final
+   destructive-write summary before erasing it.
+5. Streams the bzip2 rootfs image to the replacement NVMe and syncs the write.
+6. Pauses while the operator installs the replacement NVMe in PC2 and preserves
+   the original drive.
+7. Shows the verified PWR/REC and PC2 USB-C recovery instructions, then waits for
+   an Orin NX APX device.
+8. Refuses to invoke Unitree's vendor script if any additional recovery-mode
+   Jetson is connected, because that script cannot be safely pinned to one USB
+   path.
+9. Validates archive paths, extracts `Jetpack_6.2_nx.tar.bz2` into a temporary
+   workspace, and runs its single `Linux_for_Tegra/flash_nx_module.sh` under
+   `sudo`.
+10. Prints the normal-boot and `192.168.123.164` verification commands.
+
+This target flashes only the G1's open Jetson development computer, PC2. It
+must never be used on the separate motion-control computer. The command does
+not issue joint commands or perform a motion test.
 
 ---
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
@@ -9,7 +9,7 @@ The command presents a unified device picker that lists Linux targets (Raspberry
 - **Jetson Orin Nano / AGX Orin** -> download a recovery flashpack -> verify the module/carrier -> update QSPI and NVMe/eMMC together
 - **Raspberry Pi targets** -> download OS image -> write to SD/NVMe -> write config partition
 - **Jetson AGX Thor** -> download flashpack -> boot over USB recovery -> flash QSPI and internal NVMe
-- **Unitree G1 (experimental)** -> download and verify the official paired Unitree JetPack 6.2 packages -> image a replacement NVMe -> follow the guided PC2 PWR/REC sequence -> flash matching Orin NX module firmware
+- **Unitree G1** -> download and verify the official paired Unitree JetPack 6.2 packages -> image a replacement NVMe -> follow the guided PC2 PWR/REC sequence -> flash matching Orin NX module firmware
 - **ESP32 targets** → detect USB serial port → download firmware `.bin` → flash over serial
 
 ```sh
@@ -68,7 +68,7 @@ per-PR pipeline).
 `--pr` is mutually exclusive with `--nightly`, `--version`, and a positional
 image path.
 
-## Unitree G1 experimental path
+## Unitree G1
 
 Select **Unitree G1** under the **Robots** section of the normal `wendy install`
 picker. The installer deliberately keeps the rootfs image and PC2 module

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
@@ -87,6 +87,19 @@ g1-nx-j6.2.img.bz2
 Jetpack_6.2_nx.tar.bz2
 ```
 
+> **Required order:** Flash the replacement NVMe first. Install that NVMe in
+> PC2, then put PC2 into APX recovery mode and flash the matching Orin NX module
+> firmware. Do not perform the firmware step before the JetPack 6.2 NVMe is
+> installed.
+
+The two files have separate roles:
+
+1. **Stage 1 — NVMe system image:** `g1-nx-j6.2.img.bz2` is written to the
+   replacement P310/NVMe while the drive is attached to the Ubuntu host.
+2. **Stage 2 — Orin NX module firmware:** `Jetpack_6.2_nx.tar.bz2` remains on
+   the Ubuntu host. After installing the replacement NVMe in PC2, the CLI uses
+   this package to flash the module through PC2's recovery USB-C connection.
+
 The guide currently points to the
 [JetPack 6.2 Google Drive folder](https://drive.google.com/drive/folders/1ho17ectOxi7FbaRFdpAbP4tet8BJWjbm).
 The CLI uses the two stable file IDs from that official link, checks their exact
@@ -102,15 +115,16 @@ The interactive flow:
 2. Downloads or resumes both official-source packages into Wendy's cache.
 3. Validates both exact sizes and pinned SHA-256 values, reusing a cached file
    only after its full hash matches.
-4. Lists external drives by model, device path, and size, then includes the
+4. Begins **Stage 1 of 2 — NVMe system image**, lists external drives by model,
+   device path, and size, then includes the
    hardware serial (when available) in the final destructive-write review.
 5. Accepts only a fixed external SSD of at least 1 TB, then shows one final
    destructive-write summary and re-hashes the image before erasing the drive.
 6. Streams the bzip2 rootfs image to the replacement NVMe and syncs the write.
 7. Pauses while the operator installs the replacement NVMe in PC2 and preserves
    the original drive.
-8. Shows the verified PWR/REC and PC2 USB-C recovery instructions, then waits for
-   an Orin NX APX device.
+8. Begins **Stage 2 of 2 — Orin NX module firmware**, shows the verified PWR/REC
+   and PC2 USB-C recovery instructions, then waits for an Orin NX APX device.
 9. Refuses to invoke Unitree's vendor script if any additional recovery-mode
    Jetson is connected, because that script cannot be safely pinned to one USB
    path.

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
@@ -75,8 +75,12 @@ picker. The installer deliberately keeps the rootfs image and PC2 module
 firmware behind one installation choice so they cannot be mixed across
 releases.
 
-The first hardware-test version requires an Ubuntu x86-64 host and a local
-folder containing this exact pair from the same Unitree G1 JetPack 6.2 release:
+> **Host requirement:** Run this flow from an Ubuntu Linux PC with an Intel or
+> AMD x86-64 processor. Windows, macOS (including Apple Silicon), and ARM Linux
+> hosts cannot run the Unitree flashing tools and are rejected by the CLI.
+
+The first hardware-test version also requires a local folder containing this
+exact pair from the same Unitree G1 JetPack 6.2 release:
 
 ```text
 g1-nx-j6.2.img.bz2

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
@@ -9,7 +9,7 @@ The command presents a unified device picker that lists Linux targets (Raspberry
 - **Jetson Orin Nano / AGX Orin** -> download a recovery flashpack -> verify the module/carrier -> update QSPI and NVMe/eMMC together
 - **Raspberry Pi targets** -> download OS image -> write to SD/NVMe -> write config partition
 - **Jetson AGX Thor** -> download flashpack -> boot over USB recovery -> flash QSPI and internal NVMe
-- **Unitree G1 (experimental)** -> select the paired local Unitree JetPack 6.2 packages -> image a replacement NVMe -> follow the guided PC2 PWR/REC sequence -> flash matching Orin NX module firmware
+- **Unitree G1 (experimental)** -> download and verify the official paired Unitree JetPack 6.2 packages -> image a replacement NVMe -> follow the guided PC2 PWR/REC sequence -> flash matching Orin NX module firmware
 - **ESP32 targets** → detect USB serial port → download firmware `.bin` → flash over serial
 
 ```sh
@@ -26,7 +26,7 @@ wendy install --device-type raspberry-pi-5 --version 0.10.4 --drive /dev/disk4 -
 wendy install --device-type jetson-agx-thor
 
 # Unitree G1: open the guided picker on an Ubuntu x86-64 host
-# (the package folder and replacement NVMe are selected in the UI)
+# (the official packages are downloaded automatically; select the replacement NVMe in the UI)
 wendy install --device-type unitree-g1
 
 # Orin Nano: full QSPI + NVMe recovery (macOS or Linux)
@@ -79,31 +79,29 @@ releases.
 > AMD x86-64 processor. Windows, macOS (including Apple Silicon), and ARM Linux
 > hosts cannot run the Unitree flashing tools and are rejected by the CLI.
 
-The first hardware-test version also requires a local folder containing this
-exact pair from the same Unitree G1 JetPack 6.2 release:
+The installer downloads this exact pair from the source linked by
+[NVIDIA's official G1 JetPack 6 flashing guide](https://nvlabs.github.io/GR00T-WholeBodyControl/references/jetpack6.html):
 
 ```text
 g1-nx-j6.2.img.bz2
 Jetpack_6.2_nx.tar.bz2
 ```
 
-The lab obtained both from the historical
-[Unitree G1 package folder](https://drive.google.com/drive/folders/1ho17ectOxi7FbaRFdpAbP4tet8BJWjbm).
-Wendy does not control that folder, so this experimental flow does not download
-from it automatically. A production release requires publisher-controlled
-artifacts and trusted checksums or signatures in the Wendy manifest. For the
-lab run, the CLI calculates and prints SHA-256 fingerprints for both selected
-files. Those fingerprints make the exact test inputs reproducible but do not
-prove their publisher or safety.
+The guide currently points to the
+[JetPack 6.2 Google Drive folder](https://drive.google.com/drive/folders/1ho17ectOxi7FbaRFdpAbP4tet8BJWjbm).
+The CLI uses the two stable file IDs from that official link, checks their exact
+byte lengths, and requires both downloads to match SHA-256 values pinned in
+reviewed CLI source. A changed or corrupted upstream file is rejected before
+any destructive action. Completed downloads are cached under
+`~/.cache/wendy/os-images/unitree-g1/6.2/` on the Ubuntu host; interrupted
+downloads remain as `.partial` files and resume on the next run.
 
 The interactive flow:
 
 1. Selects **Unitree G1 JetPack 6.2**.
-2. Asks for the folder containing the paired packages and validates both exact
-   filenames as non-empty regular files.
-3. Reads both complete files, prints their SHA-256 fingerprints, explains the
-   missing trust anchor, and requires the operator to type
-   `UNVERIFIED UNITREE LAB FLASH`. `--force` cannot bypass this acceptance.
+2. Downloads or resumes both official-source packages into Wendy's cache.
+3. Validates both exact sizes and pinned SHA-256 values, reusing a cached file
+   only after its full hash matches.
 4. Lists external drives by model, device path, and size, then includes the
    hardware serial (when available) in the final destructive-write review.
 5. Accepts only a fixed external SSD of at least 1 TB, then shows one final

--- a/go/internal/cli/commands/disklister_linux.go
+++ b/go/internal/cli/commands/disklister_linux.go
@@ -43,6 +43,8 @@ type drive struct {
 	DevicePath  string // e.g. /dev/sdb
 	RawPath     string // same as DevicePath on Linux
 	Name        string // human-readable name
+	Model       string // hardware model reported by lsblk
+	Serial      string // hardware serial reported by lsblk
 	Size        string // human-readable size
 	SizeBytes   int64  // size in bytes
 	IsRemovable bool
@@ -66,6 +68,8 @@ type lsblkDevice struct {
 	Hotplug    flexBool      `json:"hotplug"`
 	Transport  string        `json:"tran"`
 	Rotational flexBool      `json:"rota"`
+	Model      string        `json:"model"`
+	Serial     string        `json:"serial"`
 	Mountpoint string        `json:"mountpoint"`
 	Children   []lsblkDevice `json:"children"`
 }
@@ -84,7 +88,7 @@ func listExternalDrives() ([]drive, error) {
 }
 
 func listDrivesLinux() ([]drive, error) {
-	out, err := exec.Command("lsblk", "--json", "--bytes", "-o", "NAME,SIZE,TYPE,RM,HOTPLUG,TRAN,ROTA,MOUNTPOINT").Output()
+	out, err := exec.Command("lsblk", "--json", "--bytes", "-o", "NAME,SIZE,TYPE,RM,HOTPLUG,TRAN,ROTA,MODEL,SERIAL,MOUNTPOINT").Output()
 	if err != nil {
 		return nil, fmt.Errorf("running lsblk: %w", err)
 	}
@@ -118,10 +122,16 @@ func listDrivesLinux() ([]drive, error) {
 		} else if dev.Transport == "usb" {
 			storageType = StorageUSB
 		}
+		displayName := strings.TrimSpace(dev.Model)
+		if displayName == "" {
+			displayName = dev.Name
+		}
 		drives = append(drives, drive{
 			DevicePath: devPath,
 			RawPath:    devPath,
-			Name:       dev.Name,
+			Name:       displayName,
+			Model:      strings.TrimSpace(dev.Model),
+			Serial:     strings.TrimSpace(dev.Serial),
 			Size:       humanize.Bytes(uint64(sizeBytes)),
 			SizeBytes:  sizeBytes,
 			// IsRemovable reflects our external-ness predicate so downstream code

--- a/go/internal/cli/commands/manifest.go
+++ b/go/internal/cli/commands/manifest.go
@@ -463,6 +463,12 @@ const orinDeviceType = "jetson-agx-orin"
 
 const orinNanoDeviceType = "jetson-orin-nano"
 
+// unitreeG1DeviceType is the built-in experimental installer target for the
+// Unitree G1's Orin NX development computer (PC2). It remains built-in rather
+// than manifest-backed until Wendy publishes the paired Unitree rootfs and
+// module-firmware artifacts with trusted checksums.
+const unitreeG1DeviceType = "unitree-g1"
+
 func isT234RecoveryDevice(deviceType string) bool {
 	return deviceType == orinDeviceType || deviceType == orinNanoDeviceType
 }

--- a/go/internal/cli/commands/manifest.go
+++ b/go/internal/cli/commands/manifest.go
@@ -463,10 +463,9 @@ const orinDeviceType = "jetson-agx-orin"
 
 const orinNanoDeviceType = "jetson-orin-nano"
 
-// unitreeG1DeviceType is the built-in experimental installer target for the
-// Unitree G1's Orin NX development computer (PC2). It remains built-in rather
-// than manifest-backed until Wendy publishes the paired Unitree rootfs and
-// module-firmware artifacts with trusted checksums.
+// unitreeG1DeviceType is the built-in guided installer target for the Unitree
+// G1's Orin NX development computer (PC2). It remains built-in because its
+// paired vendor system image and module-firmware flow is not manifest-backed.
 const unitreeG1DeviceType = "unitree-g1"
 
 func isT234RecoveryDevice(deviceType string) bool {

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -54,6 +54,15 @@ type unitreeG1InstallOptions struct {
 	Force   bool
 }
 
+const unitreeG1HostRequirement = "Ubuntu Linux on an Intel/AMD x86-64 PC"
+
+func validateUnitreeG1Host(goos, goarch string) error {
+	if goos == "linux" && goarch == "amd64" {
+		return nil
+	}
+	return fmt.Errorf("Unitree G1 flashing requires %s; Windows, macOS, and ARM hosts are unsupported (detected %s/%s)", unitreeG1HostRequirement, goos, goarch)
+}
+
 const (
 	preEnrollAuto   preEnrollMode = iota // prompt if interactive terminal + auth session exists
 	preEnrollForced                      // --pre-enroll explicitly set to true
@@ -365,7 +374,7 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 		}
 		items = append(items, tui.PickerItem{
 			Name:        "Unitree G1",
-			Description: "JetPack 6.2 · PC2 Orin NX · experimental",
+			Description: "JetPack 6.2 · requires x86-64 Ubuntu Linux (no Windows, macOS, or ARM)",
 			Section:     "Robots",
 			SortKey:     "0_robots_unitree_g1",
 			Value:       unitreeG1DeviceType,

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -460,7 +460,7 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 
 	if selected == unitreeG1DeviceType {
 		if nightly {
-			return fmt.Errorf("--nightly is not available for the experimental Unitree G1 installer")
+			return fmt.Errorf("--nightly is not available for the Unitree G1 installer")
 		}
 		if rootfsOnly || storageOverride != "" || noBmap || yesOverwriteInternal {
 			return fmt.Errorf("--rootfs-only, --storage, --no-bmap, and --yes-overwrite-internal do not apply to the Unitree G1 installer")

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -48,6 +48,12 @@ type t234InstallOptions struct {
 	PreEnroll     preEnrollOptions
 }
 
+type unitreeG1InstallOptions struct {
+	Version string
+	Drive   string
+	Force   bool
+}
+
 const (
 	preEnrollAuto   preEnrollMode = iota // prompt if interactive terminal + auth session exists
 	preEnrollForced                      // --pre-enroll explicitly set to true
@@ -343,8 +349,26 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 			Name:        dev.Name,
 			Description: displayVersion,
 			Section:     "WendyOS",
-			SortKey:     "0_wendyos_" + strings.ToLower(dev.Name),
+			SortKey:     "1_wendyos_" + strings.ToLower(dev.Name),
 			Value:       dev.Key,
+		})
+	}
+
+	// G1 uses a vendor rootfs image plus matching PC2 module firmware instead
+	// of a WendyOS recovery flashpack. Keep the pair behind one picker entry so
+	// users cannot accidentally select mismatched artifacts. Once signed,
+	// Wendy-controlled artifacts are published this can move into the manifest.
+	if prNumber == 0 && (flagDeviceType == "" || flagDeviceType == unitreeG1DeviceType) {
+		deviceMap[unitreeG1DeviceType] = pickerDevice{
+			Name:    "Unitree G1",
+			Version: "(experimental · JetPack 6.2)",
+		}
+		items = append(items, tui.PickerItem{
+			Name:        "Unitree G1",
+			Description: "JetPack 6.2 · PC2 Orin NX · experimental",
+			Section:     "Robots",
+			SortKey:     "0_robots_unitree_g1",
+			Value:       unitreeG1DeviceType,
 		})
 	}
 
@@ -370,7 +394,7 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 				Name:        esp.name,
 				Description: espVersion,
 				Section:     "Wendy Lite",
-				SortKey:     "1_lite_" + strings.ToLower(esp.name),
+				SortKey:     "2_lite_" + strings.ToLower(esp.name),
 				Value:       esp.key,
 			})
 		}
@@ -379,7 +403,7 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 			Name:        "Linux Desktop",
 			Description: "Install wendy-agent on an existing Linux machine",
 			Section:     "Linux Desktop",
-			SortKey:     "2_linux_desktop",
+			SortKey:     "3_linux_desktop",
 			Value:       linuxDesktopValue,
 		})
 
@@ -387,7 +411,7 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 			Name:        "Headless Mac",
 			Description: "Install wendy-agent on an existing Mac (Apple Silicon)",
 			Section:     "Headless Mac",
-			SortKey:     "3_headless_mac",
+			SortKey:     "4_headless_mac",
 			Value:       headlessMacValue,
 		})
 	}
@@ -423,6 +447,23 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 		if err != nil {
 			return err
 		}
+	}
+
+	if selected == unitreeG1DeviceType {
+		if nightly {
+			return fmt.Errorf("--nightly is not available for the experimental Unitree G1 installer")
+		}
+		if rootfsOnly || storageOverride != "" || noBmap || yesOverwriteInternal {
+			return fmt.Errorf("--rootfs-only, --storage, --no-bmap, and --yes-overwrite-internal do not apply to the Unitree G1 installer")
+		}
+		if wifi.SSID != "" || wifi.Password != "" || len(wifi.Entries) > 0 || wifi.NoWifi || deviceName != "" || preOpts.mode == preEnrollForced || preOpts.cloudGRPC != "" {
+			return fmt.Errorf("WiFi, device-name, and pre-enrollment options are not yet available for the Unitree G1 vendor image")
+		}
+		return installUnitreeG1(ctx, unitreeG1InstallOptions{
+			Version: flagVersion,
+			Drive:   flagDrive,
+			Force:   force,
+		})
 	}
 
 	// Thor flashes over USB recovery via its flashpack, never to a drive. The

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -370,7 +370,7 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 	if prNumber == 0 && (flagDeviceType == "" || flagDeviceType == unitreeG1DeviceType) {
 		deviceMap[unitreeG1DeviceType] = pickerDevice{
 			Name:    "Unitree G1",
-			Version: "(experimental · JetPack 6.2)",
+			Version: "(JetPack 6.2)",
 		}
 		items = append(items, tui.PickerItem{
 			Name:        "Unitree G1",

--- a/go/internal/cli/commands/os_install_unitree_g1_artifacts_linux.go
+++ b/go/internal/cli/commands/os_install_unitree_g1_artifacts_linux.go
@@ -1,0 +1,316 @@
+//go:build linux
+
+package commands
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+	"golang.org/x/sys/unix"
+)
+
+const unitreeG1OfficialGuide = "https://nvlabs.github.io/GR00T-WholeBodyControl/references/jetpack6.html"
+
+type unitreeG1Artifact struct {
+	Name   string
+	URL    string
+	Size   int64
+	SHA256 string
+}
+
+// These Google Drive file IDs are the two downloads linked by NVIDIA's
+// official G1 JetPack 6 guide. Sizes and SHA-256 values were recorded from the
+// complete source files on 2026-08-04. Any upstream replacement must be
+// reviewed and deliberately re-pinned here before the installer will use it.
+var unitreeG1OfficialArtifacts = []unitreeG1Artifact{
+	{
+		Name:   unitreeG1ImageName,
+		URL:    "https://drive.usercontent.google.com/download?id=1I7gb8L3qqDhNHMDclMcD1GgmcCSlrrhy&export=download&confirm=t",
+		Size:   3_973_265_059,
+		SHA256: "8902fba85a2fbd05893deec10b43d8116661762a718e479bade1ae685e123b3d",
+	},
+	{
+		Name:   unitreeG1FirmwareName,
+		URL:    "https://drive.usercontent.google.com/download?id=1bcED2Vy64fyOWIBxK9ck0iXA_Lo9TOyg&export=download&confirm=t",
+		Size:   9_938_108_888,
+		SHA256: "1ce5da305006a070aa00593561dd432d2c60fcb69dc4c25cb5ee13dbbd74e2fc",
+	},
+}
+
+func resolveOfficialUnitreeG1Packages(ctx context.Context) (unitreeG1Packages, unitreeG1Fingerprints, error) {
+	cacheRoot, err := osCacheDir()
+	if err != nil {
+		return unitreeG1Packages{}, unitreeG1Fingerprints{}, fmt.Errorf("resolving G1 artifact cache: %w", err)
+	}
+	cacheDir := filepath.Join(cacheRoot, "unitree-g1", unitreeG1Version)
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		return unitreeG1Packages{}, unitreeG1Fingerprints{}, fmt.Errorf("creating G1 artifact cache: %w", err)
+	}
+
+	paths := make(map[string]string, len(unitreeG1OfficialArtifacts))
+	digests := make(map[string]string, len(unitreeG1OfficialArtifacts))
+	for _, artifact := range unitreeG1OfficialArtifacts {
+		path, err := resolveOfficialUnitreeG1Artifact(ctx, cacheDir, artifact)
+		if err != nil {
+			return unitreeG1Packages{}, unitreeG1Fingerprints{}, err
+		}
+		paths[artifact.Name] = path
+		digests[artifact.Name] = artifact.SHA256
+	}
+
+	return unitreeG1Packages{
+			Image:    paths[unitreeG1ImageName],
+			Firmware: paths[unitreeG1FirmwareName],
+		}, unitreeG1Fingerprints{
+			Image:    digests[unitreeG1ImageName],
+			Firmware: digests[unitreeG1FirmwareName],
+		}, nil
+}
+
+func resolveOfficialUnitreeG1Artifact(ctx context.Context, cacheDir string, artifact unitreeG1Artifact) (string, error) {
+	if err := validateUnitreeG1ArtifactMetadata(artifact); err != nil {
+		return "", err
+	}
+	finalPath := filepath.Join(cacheDir, artifact.Name)
+	if valid, err := verifyCachedUnitreeG1Artifact(finalPath, artifact); err != nil {
+		return "", err
+	} else if valid {
+		fmt.Println(tui.SuccessMessage("Using verified cached " + artifact.Name + "."))
+		return finalPath, nil
+	}
+
+	partialPath := finalPath + ".partial"
+	partialSize, err := unitreeG1PartialSize(partialPath, artifact.Size)
+	if err != nil {
+		return "", err
+	}
+	remaining := artifact.Size - partialSize
+	if available, ok := diskAvailBytes(cacheDir); ok && available < remaining {
+		return "", fmt.Errorf("not enough free space for %s: need %.1f GiB more in %s, only %.1f GiB is available",
+			artifact.Name, float64(remaining)/(1<<30), cacheDir, float64(available)/(1<<30))
+	}
+
+	if err := downloadOfficialUnitreeG1Artifact(ctx, artifact, partialPath); err != nil {
+		return "", err
+	}
+	fingerprint, err := fingerprintUnitreeG1Artifact(partialPath)
+	if err != nil {
+		return "", fmt.Errorf("verifying downloaded %s: %w", artifact.Name, err)
+	}
+	if !strings.EqualFold(fingerprint, artifact.SHA256) {
+		_ = os.Remove(partialPath)
+		return "", fmt.Errorf("official %s checksum mismatch: got %s, expected %s; the upstream file may have changed, so Wendy refuses to flash it",
+			artifact.Name, fingerprint, artifact.SHA256)
+	}
+	if err := os.Rename(partialPath, finalPath); err != nil {
+		return "", fmt.Errorf("caching verified %s: %w", artifact.Name, err)
+	}
+	return finalPath, nil
+}
+
+func validateUnitreeG1ArtifactMetadata(artifact unitreeG1Artifact) error {
+	if artifact.Name == "" || filepath.Base(artifact.Name) != artifact.Name || artifact.URL == "" || artifact.Size <= 0 {
+		return fmt.Errorf("invalid built-in G1 artifact metadata for %q", artifact.Name)
+	}
+	digest, err := hex.DecodeString(artifact.SHA256)
+	if err != nil || len(digest) != 32 {
+		return fmt.Errorf("invalid built-in SHA-256 for %s", artifact.Name)
+	}
+	return nil
+}
+
+func verifyCachedUnitreeG1Artifact(filePath string, artifact unitreeG1Artifact) (bool, error) {
+	info, err := os.Lstat(filePath)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("inspecting cached %s: %w", artifact.Name, err)
+	}
+	if !info.Mode().IsRegular() {
+		return false, fmt.Errorf("cached %s must be a regular file, not a directory or symlink", artifact.Name)
+	}
+	if info.Size() != artifact.Size {
+		if err := os.Remove(filePath); err != nil {
+			return false, fmt.Errorf("discarding incomplete cached %s: %w", artifact.Name, err)
+		}
+		return false, nil
+	}
+	fingerprint, err := fingerprintUnitreeG1Artifact(filePath)
+	if err != nil {
+		return false, fmt.Errorf("verifying cached %s: %w", artifact.Name, err)
+	}
+	if strings.EqualFold(fingerprint, artifact.SHA256) {
+		return true, nil
+	}
+	if err := os.Remove(filePath); err != nil {
+		return false, fmt.Errorf("discarding checksum-mismatched cached %s: %w", artifact.Name, err)
+	}
+	return false, nil
+}
+
+func unitreeG1PartialSize(filePath string, expected int64) (int64, error) {
+	info, err := os.Lstat(filePath)
+	if os.IsNotExist(err) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	if !info.Mode().IsRegular() {
+		return 0, fmt.Errorf("partial G1 artifact %s must be a regular file", filePath)
+	}
+	if info.Size() > expected {
+		if err := os.Remove(filePath); err != nil {
+			return 0, fmt.Errorf("discarding oversized partial G1 artifact: %w", err)
+		}
+		return 0, nil
+	}
+	return info.Size(), nil
+}
+
+func downloadOfficialUnitreeG1Artifact(ctx context.Context, artifact unitreeG1Artifact, partialPath string) error {
+	downloadCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	progress := tui.NewProgress("Downloading official " + artifact.Name + "...")
+	program := tui.NewProgressProgram(progress)
+	sendProgress := throttledProgress(program, 33*time.Millisecond)
+	resultCh := make(chan error, 1)
+	go func() {
+		client := &http.Client{Timeout: 6 * time.Hour}
+		var err error
+		for attempt := 1; attempt <= 3; attempt++ {
+			err = resumeUnitreeG1Artifact(downloadCtx, client, artifact, partialPath, sendProgress)
+			if err == nil || downloadCtx.Err() != nil || attempt == 3 {
+				break
+			}
+			select {
+			case <-downloadCtx.Done():
+				err = downloadCtx.Err()
+			case <-time.After(time.Duration(attempt) * time.Second):
+			}
+		}
+		resultCh <- err
+		program.Send(tui.ProgressDoneMsg{Err: err})
+	}()
+	final, runErr := program.Run()
+	if runErr != nil {
+		cancel()
+	}
+	resultErr := <-resultCh
+	if runErr != nil {
+		return fmt.Errorf("download progress TUI: %w", runErr)
+	}
+	if err := final.(tui.ProgressModel).Err(); err != nil {
+		return err
+	}
+	return resultErr
+}
+
+func resumeUnitreeG1Artifact(ctx context.Context, client *http.Client, artifact unitreeG1Artifact, partialPath string, onProgress func(downloaded, total int64)) error {
+	fd, err := unix.Open(partialPath, unix.O_WRONLY|unix.O_CREAT|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0o600)
+	if err != nil {
+		return fmt.Errorf("opening partial %s: %w", artifact.Name, err)
+	}
+	file := os.NewFile(uintptr(fd), partialPath)
+	if file == nil {
+		_ = unix.Close(fd)
+		return fmt.Errorf("opening partial %s", artifact.Name)
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	offset := info.Size()
+	if offset > artifact.Size {
+		return fmt.Errorf("partial %s is larger than the expected official artifact", artifact.Name)
+	}
+	if onProgress != nil {
+		onProgress(offset, artifact.Size)
+	}
+	if offset == artifact.Size {
+		return nil
+	}
+	if _, err := file.Seek(offset, io.SeekStart); err != nil {
+		return err
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, artifact.URL, nil)
+	if err != nil {
+		return err
+	}
+	if offset > 0 {
+		request.Header.Set("Range", fmt.Sprintf("bytes=%d-", offset))
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return fmt.Errorf("downloading %s: %w", artifact.Name, err)
+	}
+	defer response.Body.Close()
+
+	if offset > 0 && response.StatusCode == http.StatusOK {
+		if err := file.Truncate(0); err != nil {
+			return err
+		}
+		if _, err := file.Seek(0, io.SeekStart); err != nil {
+			return err
+		}
+		offset = 0
+	} else if offset > 0 {
+		if response.StatusCode != http.StatusPartialContent {
+			return fmt.Errorf("resuming %s: expected HTTP 206, got %d", artifact.Name, response.StatusCode)
+		}
+		wantPrefix := fmt.Sprintf("bytes %d-", offset)
+		if !strings.HasPrefix(response.Header.Get("Content-Range"), wantPrefix) {
+			return fmt.Errorf("resuming %s: invalid Content-Range %q", artifact.Name, response.Header.Get("Content-Range"))
+		}
+	} else if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusPartialContent {
+		return fmt.Errorf("downloading %s: HTTP %d", artifact.Name, response.StatusCode)
+	}
+
+	remaining := artifact.Size - offset
+	if response.ContentLength >= 0 && response.ContentLength != remaining {
+		return fmt.Errorf("downloading %s: server reports %d remaining bytes, expected %d", artifact.Name, response.ContentLength, remaining)
+	}
+	written := offset
+	buffer := make([]byte, 4<<20)
+	for written < artifact.Size {
+		limit := artifact.Size - written
+		if int64(len(buffer)) > limit {
+			buffer = buffer[:limit]
+		}
+		n, readErr := response.Body.Read(buffer)
+		if n > 0 {
+			if _, err := file.Write(buffer[:n]); err != nil {
+				return fmt.Errorf("caching %s: %w", artifact.Name, err)
+			}
+			written += int64(n)
+			if onProgress != nil {
+				onProgress(written, artifact.Size)
+			}
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return fmt.Errorf("reading %s: %w", artifact.Name, readErr)
+		}
+	}
+	if written != artifact.Size {
+		return fmt.Errorf("downloaded %s is incomplete: got %d bytes, expected %d", artifact.Name, written, artifact.Size)
+	}
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("syncing %s: %w", artifact.Name, err)
+	}
+	return nil
+}

--- a/go/internal/cli/commands/os_install_unitree_g1_artifacts_linux.go
+++ b/go/internal/cli/commands/os_install_unitree_g1_artifacts_linux.go
@@ -45,34 +45,32 @@ var unitreeG1OfficialArtifacts = []unitreeG1Artifact{
 	},
 }
 
-func resolveOfficialUnitreeG1Packages(ctx context.Context) (unitreeG1Packages, unitreeG1Fingerprints, error) {
+func resolveOfficialUnitreeG1Packages(ctx context.Context) (unitreeG1Packages, error) {
 	cacheRoot, err := osCacheDir()
 	if err != nil {
-		return unitreeG1Packages{}, unitreeG1Fingerprints{}, fmt.Errorf("resolving G1 artifact cache: %w", err)
+		return unitreeG1Packages{}, fmt.Errorf("resolving G1 artifact cache: %w", err)
 	}
 	cacheDir := filepath.Join(cacheRoot, "unitree-g1", unitreeG1Version)
 	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
-		return unitreeG1Packages{}, unitreeG1Fingerprints{}, fmt.Errorf("creating G1 artifact cache: %w", err)
+		return unitreeG1Packages{}, fmt.Errorf("creating G1 artifact cache: %w", err)
 	}
 
-	paths := make(map[string]string, len(unitreeG1OfficialArtifacts))
-	digests := make(map[string]string, len(unitreeG1OfficialArtifacts))
+	resolved := make(map[string]unitreeG1ResolvedArtifact, len(unitreeG1OfficialArtifacts))
 	for _, artifact := range unitreeG1OfficialArtifacts {
 		path, err := resolveOfficialUnitreeG1Artifact(ctx, cacheDir, artifact)
 		if err != nil {
-			return unitreeG1Packages{}, unitreeG1Fingerprints{}, err
+			return unitreeG1Packages{}, err
 		}
-		paths[artifact.Name] = path
-		digests[artifact.Name] = artifact.SHA256
+		resolved[artifact.Name] = unitreeG1ResolvedArtifact{
+			Path:   path,
+			SHA256: artifact.SHA256,
+		}
 	}
 
 	return unitreeG1Packages{
-			Image:    paths[unitreeG1ImageName],
-			Firmware: paths[unitreeG1FirmwareName],
-		}, unitreeG1Fingerprints{
-			Image:    digests[unitreeG1ImageName],
-			Firmware: digests[unitreeG1FirmwareName],
-		}, nil
+		Image:    resolved[unitreeG1ImageName],
+		Firmware: resolved[unitreeG1FirmwareName],
+	}, nil
 }
 
 func resolveOfficialUnitreeG1Artifact(ctx context.Context, cacheDir string, artifact unitreeG1Artifact) (string, error) {

--- a/go/internal/cli/commands/os_install_unitree_g1_host_test.go
+++ b/go/internal/cli/commands/os_install_unitree_g1_host_test.go
@@ -1,0 +1,43 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateUnitreeG1Host(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		goos    string
+		goarch  string
+		wantErr bool
+	}{
+		{name: "x86-64 Linux", goos: "linux", goarch: "amd64"},
+		{name: "ARM Linux", goos: "linux", goarch: "arm64", wantErr: true},
+		{name: "Intel macOS", goos: "darwin", goarch: "amd64", wantErr: true},
+		{name: "Apple Silicon macOS", goos: "darwin", goarch: "arm64", wantErr: true},
+		{name: "Windows", goos: "windows", goarch: "amd64", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateUnitreeG1Host(tt.goos, tt.goarch)
+			if !tt.wantErr {
+				if err != nil {
+					t.Fatalf("validateUnitreeG1Host() error = %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("validateUnitreeG1Host() error = nil, want unsupported-host error")
+			}
+			for _, want := range []string{unitreeG1HostRequirement, tt.goos + "/" + tt.goarch} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q does not contain %q", err, want)
+				}
+			}
+		})
+	}
+}

--- a/go/internal/cli/commands/os_install_unitree_g1_linux.go
+++ b/go/internal/cli/commands/os_install_unitree_g1_linux.go
@@ -29,16 +29,13 @@ const (
 	unitreeG1ImageName         = "g1-nx-j6.2.img.bz2"
 	unitreeG1FirmwareName      = "Jetpack_6.2_nx.tar.bz2"
 	unitreeG1MinDriveBytes     = int64(900_000_000_000)
-	unitreeG1HistoricalSource  = "https://drive.google.com/drive/folders/1ho17ectOxi7FbaRFdpAbP4tet8BJWjbm"
-	unitreeG1TrustPhrase       = "UNVERIFIED UNITREE LAB FLASH"
 	unitreeG1MaxArchiveEntries = 1_000_000
 	unitreeG1MaxExtractedSize  = int64(200 << 30)
 )
 
 type unitreeG1Packages struct {
-	Directory string
-	Image     string
-	Firmware  string
+	Image    string
+	Firmware string
 }
 
 type unitreeG1Fingerprints struct {
@@ -64,33 +61,11 @@ func installUnitreeG1(ctx context.Context, opts unitreeG1InstallOptions) error {
 	fmt.Println("Host requirement: " + unitreeG1HostRequirement + ".")
 	fmt.Println(tui.WarningMessage("Experimental hardware flow: this erases a replacement NVMe and updates PC2 module firmware. It never flashes the G1 motion-control computer."))
 	fmt.Println("The original G1 NVMe must be removed and preserved before continuing.")
-	fmt.Println("Historical lab package source: " + unitreeG1HistoricalSource)
+	fmt.Println("Official source: " + unitreeG1OfficialGuide)
 	fmt.Println()
 
-	packageDir, err := tui.PromptTextWithDefault(
-		"Unitree package folder",
-		fmt.Sprintf("must contain %s and %s", unitreeG1ImageName, unitreeG1FirmwareName),
-		".",
-		func(value string) error {
-			_, err := resolveUnitreeG1Packages(value)
-			return err
-		},
-	)
+	packages, fingerprints, err := resolveOfficialUnitreeG1Packages(ctx)
 	if err != nil {
-		if errors.Is(err, tui.ErrCancelled) {
-			return ErrUserCancelled
-		}
-		return err
-	}
-	packages, err := resolveUnitreeG1Packages(packageDir)
-	if err != nil {
-		return err
-	}
-	fingerprints, err := fingerprintUnitreeG1Packages(packages)
-	if err != nil {
-		return err
-	}
-	if err := acceptUnverifiedUnitreeG1Artifacts(fingerprints); err != nil {
 		return err
 	}
 
@@ -200,7 +175,7 @@ func installUnitreeG1(ctx context.Context, opts unitreeG1InstallOptions) error {
 	fmt.Printf("  Directory: %s\n", filepath.Dir(script))
 	fmt.Println("  Command:   sudo ./flash_nx_module.sh")
 	fmt.Println(tui.WarningMessage("Do not power off the G1 or disconnect USB until flash_nx_module.sh reports success."))
-	confirmed, err := tui.Confirm("Run this unverified vendor script with root privileges?")
+	confirmed, err := tui.Confirm("Run this pinned official-source vendor script with root privileges?")
 	if err != nil {
 		return err
 	}
@@ -233,49 +208,6 @@ func selectUnitreeG1Version(requested string) (string, error) {
 			Value:       unitreeG1Version,
 		},
 	})
-}
-
-func resolveUnitreeG1Packages(dir string) (unitreeG1Packages, error) {
-	dir = strings.TrimSpace(dir)
-	if dir == "" {
-		return unitreeG1Packages{}, fmt.Errorf("package folder is required")
-	}
-	abs, err := filepath.Abs(dir)
-	if err != nil {
-		return unitreeG1Packages{}, fmt.Errorf("resolving package folder: %w", err)
-	}
-	result := unitreeG1Packages{
-		Directory: abs,
-		Image:     filepath.Join(abs, unitreeG1ImageName),
-		Firmware:  filepath.Join(abs, unitreeG1FirmwareName),
-	}
-	for _, path := range []string{result.Image, result.Firmware} {
-		info, err := os.Lstat(path)
-		if err != nil {
-			return unitreeG1Packages{}, fmt.Errorf("required package %s: %w", filepath.Base(path), err)
-		}
-		if !info.Mode().IsRegular() {
-			return unitreeG1Packages{}, fmt.Errorf("required package %s must be a regular file, not a directory or symlink", filepath.Base(path))
-		}
-		if info.Size() == 0 {
-			return unitreeG1Packages{}, fmt.Errorf("required package %s is empty", filepath.Base(path))
-		}
-	}
-	return result, nil
-}
-
-func fingerprintUnitreeG1Packages(packages unitreeG1Packages) (unitreeG1Fingerprints, error) {
-	fmt.Println()
-	fmt.Println(tui.Header("Fingerprinting selected Unitree artifacts"))
-	image, err := fingerprintUnitreeG1Artifact(packages.Image)
-	if err != nil {
-		return unitreeG1Fingerprints{}, err
-	}
-	firmware, err := fingerprintUnitreeG1Artifact(packages.Firmware)
-	if err != nil {
-		return unitreeG1Fingerprints{}, err
-	}
-	return unitreeG1Fingerprints{Image: image, Firmware: firmware}, nil
 }
 
 type unitreeG1HashResult struct {
@@ -335,34 +267,6 @@ func hashUnitreeG1File(filePath string, progress func(read, total int64)) (strin
 			return "", readErr
 		}
 	}
-}
-
-func acceptUnverifiedUnitreeG1Artifacts(fingerprints unitreeG1Fingerprints) error {
-	fmt.Println()
-	fmt.Println(tui.Header("Artifact trust review"))
-	fmt.Println(tui.WarningMessage("Wendy has no trusted manifest checksums or signatures for these historical Unitree files."))
-	fmt.Println("The hashes below identify the exact selected bytes for this lab run; they do not prove who published them or that they are safe.")
-	fmt.Printf("  %s\n    sha256:%s\n", unitreeG1ImageName, fingerprints.Image)
-	fmt.Printf("  %s\n    sha256:%s\n", unitreeG1FirmwareName, fingerprints.Firmware)
-	fmt.Println("The firmware archive contains a vendor script that will be shown again and executed with sudo after constrained extraction.")
-	fmt.Println("Production installation remains blocked until Wendy publishes authenticated artifacts and pins both hashes in its manifest.")
-	fmt.Println()
-	_, err := tui.PromptText(
-		"Type "+unitreeG1TrustPhrase+" to continue",
-		"lab-only acceptance; --force does not bypass this",
-		validateUnitreeG1TrustPhrase,
-	)
-	if errors.Is(err, tui.ErrCancelled) {
-		return ErrUserCancelled
-	}
-	return err
-}
-
-func validateUnitreeG1TrustPhrase(value string) error {
-	if value != unitreeG1TrustPhrase {
-		return fmt.Errorf("type %s exactly", unitreeG1TrustPhrase)
-	}
-	return nil
 }
 
 func recheckUnitreeG1Artifact(filePath, acceptedDigest, purpose string) error {
@@ -787,14 +691,12 @@ func findUnitreeG1FlashScript(root string) (string, error) {
 }
 
 func runUnitreeG1FirmwareScript(ctx context.Context, script string) error {
-	// SECURITY: This draft-only lab path intentionally runs operator-selected,
-	// unverified Unitree firmware as root because no authenticated publisher
-	// artifacts exist yet. The UI fingerprints both artifacts, requires typed
-	// risk acceptance, extracts without following archive links, shows the exact
-	// script hash/working directory/command, and requires a second confirmation.
-	// Production enablement must replace this exception with Wendy-controlled,
-	// signed or manifest-pinned artifacts; a locally calculated hash alone does
-	// not establish authenticity.
+	// SECURITY: The archive comes from the link published by NVIDIA's official
+	// G1 JetPack 6 guide and must match a SHA-256 pinned in reviewed CLI source.
+	// The installer re-hashes it immediately before constrained extraction,
+	// shows the extracted script hash, directory, and exact sudo command, then
+	// requires an additional confirmation. Updating the executable bytes requires
+	// an explicit source-and-hash review rather than trusting a mutable download.
 	cmd := exec.CommandContext(ctx, "sudo", "./flash_nx_module.sh")
 	cmd.Dir = filepath.Dir(script)
 	cmd.Stdin = os.Stdin

--- a/go/internal/cli/commands/os_install_unitree_g1_linux.go
+++ b/go/internal/cli/commands/os_install_unitree_g1_linux.go
@@ -48,7 +48,7 @@ func installUnitreeG1(ctx context.Context, opts unitreeG1InstallOptions) error {
 		return err
 	}
 	if !isInteractiveTerminal() {
-		return fmt.Errorf("the experimental Unitree G1 installer currently requires an interactive terminal")
+		return fmt.Errorf("the Unitree G1 installer requires an interactive terminal")
 	}
 
 	version, err := selectUnitreeG1Version(opts.Version)
@@ -59,7 +59,8 @@ func installUnitreeG1(ctx context.Context, opts unitreeG1InstallOptions) error {
 	fmt.Println()
 	fmt.Println(tui.Header("Install Unitree G1 PC2 · JetPack " + version))
 	fmt.Println("Host requirement: " + unitreeG1HostRequirement + ".")
-	fmt.Println(tui.WarningMessage("Experimental hardware flow: this erases a replacement NVMe and updates PC2 module firmware. It never flashes the G1 motion-control computer."))
+	fmt.Println("This installation writes a replacement NVMe and updates the matching PC2 module firmware.")
+	fmt.Println("It does not flash the G1 motion-control computer.")
 	fmt.Println("The original G1 NVMe must be removed and preserved before continuing.")
 	fmt.Println("Official source: " + unitreeG1OfficialGuide)
 	fmt.Println()
@@ -203,7 +204,7 @@ func installUnitreeG1(ctx context.Context, opts unitreeG1InstallOptions) error {
 
 func selectUnitreeG1Version(requested string) (string, error) {
 	if requested != "" && requested != unitreeG1Version {
-		return "", fmt.Errorf("Unitree G1 version %q is unavailable; this experimental installer supports %s", requested, unitreeG1Version)
+		return "", fmt.Errorf("Unitree G1 version %q is unavailable; this installer supports %s", requested, unitreeG1Version)
 	}
 	if requested != "" || !isInteractiveTerminal() {
 		return unitreeG1Version, nil

--- a/go/internal/cli/commands/os_install_unitree_g1_linux.go
+++ b/go/internal/cli/commands/os_install_unitree_g1_linux.go
@@ -6,6 +6,8 @@ import (
 	"archive/tar"
 	"compress/bzip2"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -14,24 +16,34 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/rcm"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 )
 
 const (
-	unitreeG1Version          = "6.2"
-	unitreeG1ImageName        = "g1-nx-j6.2.img.bz2"
-	unitreeG1FirmwareName     = "Jetpack_6.2_nx.tar.bz2"
-	unitreeG1MinDriveBytes    = int64(900_000_000_000)
-	unitreeG1HistoricalSource = "https://drive.google.com/drive/folders/1ho17ectOxi7FbaRFdpAbP4tet8BJWjbm"
+	unitreeG1Version           = "6.2"
+	unitreeG1ImageName         = "g1-nx-j6.2.img.bz2"
+	unitreeG1FirmwareName      = "Jetpack_6.2_nx.tar.bz2"
+	unitreeG1MinDriveBytes     = int64(900_000_000_000)
+	unitreeG1HistoricalSource  = "https://drive.google.com/drive/folders/1ho17ectOxi7FbaRFdpAbP4tet8BJWjbm"
+	unitreeG1TrustPhrase       = "UNVERIFIED UNITREE LAB FLASH"
+	unitreeG1MaxArchiveEntries = 1_000_000
+	unitreeG1MaxExtractedSize  = int64(200 << 30)
 )
 
 type unitreeG1Packages struct {
 	Directory string
 	Image     string
 	Firmware  string
+}
+
+type unitreeG1Fingerprints struct {
+	Image    string
+	Firmware string
 }
 
 func installUnitreeG1(ctx context.Context, opts unitreeG1InstallOptions) error {
@@ -73,6 +85,13 @@ func installUnitreeG1(ctx context.Context, opts unitreeG1InstallOptions) error {
 	if err != nil {
 		return err
 	}
+	fingerprints, err := fingerprintUnitreeG1Packages(packages)
+	if err != nil {
+		return err
+	}
+	if err := acceptUnverifiedUnitreeG1Artifacts(fingerprints); err != nil {
+		return err
+	}
 
 	if err := preAuthElevation(); err != nil {
 		return err
@@ -94,7 +113,9 @@ func installUnitreeG1(ctx context.Context, opts unitreeG1InstallOptions) error {
 	fmt.Printf("  Device: %s\n", target.DevicePath)
 	fmt.Printf("  Size:   %s\n", target.Size)
 	fmt.Printf("  Image:  %s\n", filepath.Base(packages.Image))
+	fmt.Printf("          sha256:%s\n", fingerprints.Image)
 	fmt.Printf("  PC2:    %s\n", filepath.Base(packages.Firmware))
+	fmt.Printf("          sha256:%s\n", fingerprints.Firmware)
 
 	if !opts.Force {
 		fmt.Println()
@@ -105,6 +126,9 @@ func installUnitreeG1(ctx context.Context, opts unitreeG1InstallOptions) error {
 		if !confirmed {
 			return ErrUserCancelled
 		}
+	}
+	if err := recheckUnitreeG1Artifact(packages.Image, fingerprints.Image, "before the destructive write"); err != nil {
+		return err
 	}
 
 	stream, err := streamBzip2Image(packages.Image)
@@ -153,16 +177,35 @@ func installUnitreeG1(ctx context.Context, opts unitreeG1InstallOptions) error {
 		return err
 	}
 	fmt.Println(tui.SuccessMessage("Detected " + dev.Describe() + " in APX recovery mode."))
+	if err := recheckUnitreeG1Artifact(packages.Firmware, fingerprints.Firmware, "before extraction and privileged execution"); err != nil {
+		return err
+	}
 
 	workspace, script, err := extractUnitreeG1Firmware(ctx, packages.Firmware)
 	if err != nil {
 		return err
 	}
 	defer os.RemoveAll(workspace)
+	scriptHash, err := hashUnitreeG1File(script, nil)
+	if err != nil {
+		return fmt.Errorf("fingerprinting extracted flash script: %w", err)
+	}
 
 	fmt.Println()
 	fmt.Println(tui.Header("Flashing matching Unitree PC2 module firmware"))
+	fmt.Printf("  Archive:   sha256:%s\n", fingerprints.Firmware)
+	fmt.Printf("  Script:    %s\n", strings.TrimPrefix(script, workspace+string(filepath.Separator)))
+	fmt.Printf("  Script:    sha256:%s\n", scriptHash)
+	fmt.Printf("  Directory: %s\n", filepath.Dir(script))
+	fmt.Println("  Command:   sudo ./flash_nx_module.sh")
 	fmt.Println(tui.WarningMessage("Do not power off the G1 or disconnect USB until flash_nx_module.sh reports success."))
+	confirmed, err := tui.Confirm("Run this unverified vendor script with root privileges?")
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		return ErrUserCancelled
+	}
 	if err := runUnitreeG1FirmwareScript(ctx, script); err != nil {
 		return err
 	}
@@ -218,6 +261,120 @@ func resolveUnitreeG1Packages(dir string) (unitreeG1Packages, error) {
 		}
 	}
 	return result, nil
+}
+
+func fingerprintUnitreeG1Packages(packages unitreeG1Packages) (unitreeG1Fingerprints, error) {
+	fmt.Println()
+	fmt.Println(tui.Header("Fingerprinting selected Unitree artifacts"))
+	image, err := fingerprintUnitreeG1Artifact(packages.Image)
+	if err != nil {
+		return unitreeG1Fingerprints{}, err
+	}
+	firmware, err := fingerprintUnitreeG1Artifact(packages.Firmware)
+	if err != nil {
+		return unitreeG1Fingerprints{}, err
+	}
+	return unitreeG1Fingerprints{Image: image, Firmware: firmware}, nil
+}
+
+type unitreeG1HashResult struct {
+	digest string
+	err    error
+}
+
+func fingerprintUnitreeG1Artifact(filePath string) (string, error) {
+	progress := tui.NewProgress("Calculating SHA-256 for " + filepath.Base(filePath) + "...")
+	program := tui.NewProgressProgram(progress)
+	sendProgress := throttledProgress(program, 33*time.Millisecond)
+	resultCh := make(chan unitreeG1HashResult, 1)
+	go func() {
+		digest, err := hashUnitreeG1File(filePath, sendProgress)
+		resultCh <- unitreeG1HashResult{digest: digest, err: err}
+		program.Send(tui.ProgressDoneMsg{Err: err})
+	}()
+	final, runErr := program.Run()
+	result := <-resultCh
+	if runErr != nil {
+		return "", fmt.Errorf("fingerprint progress TUI: %w", runErr)
+	}
+	if err := final.(tui.ProgressModel).Err(); err != nil {
+		return "", err
+	}
+	return result.digest, result.err
+}
+
+func hashUnitreeG1File(filePath string, progress func(read, total int64)) (string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return "", err
+	}
+	hash := sha256.New()
+	buffer := make([]byte, 4<<20)
+	var read int64
+	for {
+		n, readErr := file.Read(buffer)
+		if n > 0 {
+			if _, err := hash.Write(buffer[:n]); err != nil {
+				return "", err
+			}
+			read += int64(n)
+			if progress != nil {
+				progress(read, info.Size())
+			}
+		}
+		if errors.Is(readErr, io.EOF) {
+			return hex.EncodeToString(hash.Sum(nil)), nil
+		}
+		if readErr != nil {
+			return "", readErr
+		}
+	}
+}
+
+func acceptUnverifiedUnitreeG1Artifacts(fingerprints unitreeG1Fingerprints) error {
+	fmt.Println()
+	fmt.Println(tui.Header("Artifact trust review"))
+	fmt.Println(tui.WarningMessage("Wendy has no trusted manifest checksums or signatures for these historical Unitree files."))
+	fmt.Println("The hashes below identify the exact selected bytes for this lab run; they do not prove who published them or that they are safe.")
+	fmt.Printf("  %s\n    sha256:%s\n", unitreeG1ImageName, fingerprints.Image)
+	fmt.Printf("  %s\n    sha256:%s\n", unitreeG1FirmwareName, fingerprints.Firmware)
+	fmt.Println("The firmware archive contains a vendor script that will be shown again and executed with sudo after constrained extraction.")
+	fmt.Println("Production installation remains blocked until Wendy publishes authenticated artifacts and pins both hashes in its manifest.")
+	fmt.Println()
+	_, err := tui.PromptText(
+		"Type "+unitreeG1TrustPhrase+" to continue",
+		"lab-only acceptance; --force does not bypass this",
+		validateUnitreeG1TrustPhrase,
+	)
+	if errors.Is(err, tui.ErrCancelled) {
+		return ErrUserCancelled
+	}
+	return err
+}
+
+func validateUnitreeG1TrustPhrase(value string) error {
+	if value != unitreeG1TrustPhrase {
+		return fmt.Errorf("type %s exactly", unitreeG1TrustPhrase)
+	}
+	return nil
+}
+
+func recheckUnitreeG1Artifact(filePath, acceptedDigest, purpose string) error {
+	fmt.Println()
+	fmt.Println(tui.Header("Rechecking accepted artifact " + purpose))
+	actualDigest, err := fingerprintUnitreeG1Artifact(filePath)
+	if err != nil {
+		return err
+	}
+	if actualDigest != acceptedDigest {
+		return fmt.Errorf("%s changed after artifact trust acceptance: accepted sha256:%s, current sha256:%s", filepath.Base(filePath), acceptedDigest, actualDigest)
+	}
+	return nil
 }
 
 func selectUnitreeG1Drive(ctx context.Context, requested string) (drive, error) {
@@ -328,17 +485,13 @@ func pickUnitreeG1RecoveryDevice() (rcm.RecoveryDevice, error) {
 }
 
 func extractUnitreeG1Firmware(ctx context.Context, archive string) (workspace, script string, err error) {
-	if err := validateUnitreeG1Archive(archive); err != nil {
-		return "", "", err
-	}
 	workspace, err = os.MkdirTemp("", "wendy-unitree-g1-")
 	if err != nil {
 		return "", "", err
 	}
-	cmd := exec.CommandContext(ctx, "tar", "--bzip2", "--extract", "--file", archive, "--directory", workspace, "--no-same-owner", "--no-same-permissions")
-	if output, extractErr := cmd.CombinedOutput(); extractErr != nil {
+	if extractErr := extractUnitreeG1Archive(ctx, archive, workspace); extractErr != nil {
 		os.RemoveAll(workspace)
-		return "", "", fmt.Errorf("extracting Unitree firmware archive: %w: %s", extractErr, strings.TrimSpace(string(output)))
+		return "", "", extractErr
 	}
 	script, err = findUnitreeG1FlashScript(workspace)
 	if err != nil {
@@ -348,46 +501,253 @@ func extractUnitreeG1Firmware(ctx context.Context, archive string) (workspace, s
 	return workspace, script, nil
 }
 
-func validateUnitreeG1Archive(archive string) error {
+type unitreeG1ArchiveLink struct {
+	name   string
+	target string
+}
+
+type unitreeG1ArchiveDirectory struct {
+	path string
+	mode os.FileMode
+}
+
+func extractUnitreeG1Archive(ctx context.Context, archive, root string) error {
 	file, err := os.Open(archive)
 	if err != nil {
 		return fmt.Errorf("opening Unitree firmware archive: %w", err)
 	}
 	defer file.Close()
-	return validateUnitreeG1Tar(bzip2.NewReader(file))
+	if err := extractUnitreeG1Tar(ctx, bzip2.NewReader(file), root); err != nil {
+		return fmt.Errorf("extracting Unitree firmware archive: %w", err)
+	}
+	return nil
 }
 
-func validateUnitreeG1Tar(source io.Reader) error {
+func extractUnitreeG1Tar(ctx context.Context, source io.Reader, root string) error {
+	root, err := filepath.Abs(root)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return err
+	}
+	rootInfo, err := os.Lstat(root)
+	if err != nil {
+		return err
+	}
+	if !rootInfo.IsDir() || rootInfo.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("archive extraction root %q must be a real directory", root)
+	}
+
 	reader := tar.NewReader(source)
+	seen := make(map[string]byte)
+	var hardLinks []unitreeG1ArchiveLink
+	var symbolicLinks []unitreeG1ArchiveLink
+	var directories []unitreeG1ArchiveDirectory
+	var extractedBytes int64
+	entries := 0
+
 	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		header, err := reader.Next()
 		if errors.Is(err, io.EOF) {
-			return nil
+			break
 		}
 		if err != nil {
 			return fmt.Errorf("reading Unitree firmware archive: %w", err)
 		}
-		if !safeUnitreeG1ArchivePath(header.Name) {
-			return fmt.Errorf("Unitree firmware archive contains unsafe path %q", header.Name)
+		entries++
+		if entries > unitreeG1MaxArchiveEntries {
+			return fmt.Errorf("archive exceeds the %d-entry safety limit", unitreeG1MaxArchiveEntries)
 		}
+
+		cleanName, destination, err := unitreeG1ArchiveDestination(root, header.Name)
+		if err != nil {
+			return err
+		}
+		if ancestor, ok := unitreeG1SymlinkAncestor(cleanName, seen); ok {
+			return fmt.Errorf("archive entry %q would write through symlink %q", header.Name, ancestor)
+		}
+
+		var kind byte
 		switch header.Typeflag {
-		case tar.TypeReg, tar.TypeRegA, tar.TypeDir:
+		case tar.TypeReg, tar.TypeRegA:
+			kind = 'f'
+		case tar.TypeDir:
+			kind = 'd'
+		case tar.TypeSymlink:
+			kind = 's'
+		case tar.TypeLink:
+			kind = 'h'
+		default:
+			return fmt.Errorf("archive contains unsupported entry type %d at %q", header.Typeflag, header.Name)
+		}
+		if previous, ok := seen[cleanName]; ok {
+			if kind == 'd' && previous == 'd' {
+				continue
+			}
+			return fmt.Errorf("archive contains duplicate path %q", header.Name)
+		}
+		seen[cleanName] = kind
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := makeUnitreeG1ArchiveDirs(root, destination); err != nil {
+				return err
+			}
+			if destination != root {
+				directories = append(directories, unitreeG1ArchiveDirectory{
+					path: destination,
+					mode: os.FileMode(header.Mode) & 0o777,
+				})
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			if destination == root {
+				return fmt.Errorf("archive regular file %q resolves to the extraction root", header.Name)
+			}
+			if header.Size < 0 || header.Size > unitreeG1MaxExtractedSize-extractedBytes {
+				return fmt.Errorf("archive exceeds the %d GiB extracted-size safety limit", unitreeG1MaxExtractedSize>>30)
+			}
+			if err := makeUnitreeG1ArchiveDirs(root, filepath.Dir(destination)); err != nil {
+				return err
+			}
+			output, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+			if err != nil {
+				return fmt.Errorf("creating archive file %q: %w", header.Name, err)
+			}
+			written, copyErr := io.Copy(output, &unitreeG1ContextReader{ctx: ctx, reader: reader})
+			closeErr := output.Close()
+			if copyErr != nil {
+				return fmt.Errorf("extracting archive file %q: %w", header.Name, copyErr)
+			}
+			if closeErr != nil {
+				return fmt.Errorf("closing archive file %q: %w", header.Name, closeErr)
+			}
+			if written != header.Size {
+				return fmt.Errorf("archive file %q declared %d bytes but produced %d", header.Name, header.Size, written)
+			}
+			extractedBytes += written
+			if err := os.Chmod(destination, os.FileMode(header.Mode)&0o777); err != nil {
+				return fmt.Errorf("setting archive file mode for %q: %w", header.Name, err)
+			}
 		case tar.TypeSymlink:
 			if path.IsAbs(header.Linkname) {
-				return fmt.Errorf("Unitree firmware archive symlink %q has an absolute target", header.Name)
+				return fmt.Errorf("archive symlink %q has an absolute target", header.Name)
 			}
 			resolved := path.Join(path.Dir(header.Name), header.Linkname)
 			if !safeUnitreeG1ArchivePath(resolved) {
-				return fmt.Errorf("Unitree firmware archive symlink %q escapes the extraction folder", header.Name)
+				return fmt.Errorf("archive symlink %q escapes the extraction folder", header.Name)
 			}
+			if err := makeUnitreeG1ArchiveDirs(root, filepath.Dir(destination)); err != nil {
+				return err
+			}
+			symbolicLinks = append(symbolicLinks, unitreeG1ArchiveLink{name: destination, target: header.Linkname})
 		case tar.TypeLink:
-			if !safeUnitreeG1ArchivePath(header.Linkname) {
-				return fmt.Errorf("Unitree firmware archive hard link %q escapes the extraction folder", header.Name)
+			cleanTarget, target, err := unitreeG1ArchiveDestination(root, header.Linkname)
+			if err != nil {
+				return fmt.Errorf("archive hard link %q: %w", header.Name, err)
 			}
-		default:
-			return fmt.Errorf("Unitree firmware archive contains unsupported entry type %d at %q", header.Typeflag, header.Name)
+			if seen[cleanTarget] != 'f' {
+				return fmt.Errorf("archive hard link %q must target a prior regular file", header.Name)
+			}
+			if err := makeUnitreeG1ArchiveDirs(root, filepath.Dir(destination)); err != nil {
+				return err
+			}
+			hardLinks = append(hardLinks, unitreeG1ArchiveLink{name: destination, target: target})
 		}
 	}
+
+	// Regular files are fully materialized before any links are created. This
+	// prevents a later archive entry from writing through an extracted symlink.
+	for _, link := range hardLinks {
+		info, err := os.Lstat(link.target)
+		if err != nil || !info.Mode().IsRegular() {
+			return fmt.Errorf("archive hard link target %q is not a regular extracted file", link.target)
+		}
+		if err := os.Link(link.target, link.name); err != nil {
+			return fmt.Errorf("creating archive hard link %q: %w", link.name, err)
+		}
+	}
+	for _, link := range symbolicLinks {
+		if _, err := os.Lstat(link.name); err == nil || !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("archive symlink destination %q already exists", link.name)
+		}
+		if err := os.Symlink(link.target, link.name); err != nil {
+			return fmt.Errorf("creating archive symlink %q: %w", link.name, err)
+		}
+	}
+
+	sort.Slice(directories, func(i, j int) bool {
+		return strings.Count(directories[i].path, string(filepath.Separator)) > strings.Count(directories[j].path, string(filepath.Separator))
+	})
+	for _, directory := range directories {
+		if err := os.Chmod(directory.path, directory.mode); err != nil {
+			return fmt.Errorf("setting archive directory mode for %q: %w", directory.path, err)
+		}
+	}
+	return nil
+}
+
+type unitreeG1ContextReader struct {
+	ctx    context.Context
+	reader io.Reader
+}
+
+func (r *unitreeG1ContextReader) Read(buffer []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.reader.Read(buffer)
+}
+
+func unitreeG1ArchiveDestination(root, name string) (cleanName, destination string, err error) {
+	if !safeUnitreeG1ArchivePath(name) {
+		return "", "", fmt.Errorf("archive contains unsafe path %q", name)
+	}
+	cleanName = path.Clean(name)
+	destination = filepath.Join(root, filepath.FromSlash(cleanName))
+	relative, err := filepath.Rel(root, destination)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", "", fmt.Errorf("archive path %q escapes the extraction folder", name)
+	}
+	return cleanName, destination, nil
+}
+
+func unitreeG1SymlinkAncestor(cleanName string, seen map[string]byte) (string, bool) {
+	for parent := path.Dir(cleanName); parent != "." && parent != "/"; parent = path.Dir(parent) {
+		if seen[parent] == 's' {
+			return parent, true
+		}
+	}
+	return "", false
+}
+
+func makeUnitreeG1ArchiveDirs(root, directory string) error {
+	relative, err := filepath.Rel(root, directory)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("archive directory %q escapes the extraction folder", directory)
+	}
+	current := root
+	if relative == "." {
+		return nil
+	}
+	for _, component := range strings.Split(relative, string(filepath.Separator)) {
+		current = filepath.Join(current, component)
+		info, err := os.Lstat(current)
+		switch {
+		case errors.Is(err, os.ErrNotExist):
+			if err := os.Mkdir(current, 0o700); err != nil {
+				return fmt.Errorf("creating archive directory %q: %w", current, err)
+			}
+		case err != nil:
+			return err
+		case !info.IsDir():
+			return fmt.Errorf("archive path component %q is not a real directory", current)
+		}
+	}
+	return nil
 }
 
 func safeUnitreeG1ArchivePath(name string) bool {
@@ -426,6 +786,14 @@ func findUnitreeG1FlashScript(root string) (string, error) {
 }
 
 func runUnitreeG1FirmwareScript(ctx context.Context, script string) error {
+	// SECURITY: This draft-only lab path intentionally runs operator-selected,
+	// unverified Unitree firmware as root because no authenticated publisher
+	// artifacts exist yet. The UI fingerprints both artifacts, requires typed
+	// risk acceptance, extracts without following archive links, shows the exact
+	// script hash/working directory/command, and requires a second confirmation.
+	// Production enablement must replace this exception with Wendy-controlled,
+	// signed or manifest-pinned artifacts; a locally calculated hash alone does
+	// not establish authenticity.
 	cmd := exec.CommandContext(ctx, "sudo", "./flash_nx_module.sh")
 	cmd.Dir = filepath.Dir(script)
 	cmd.Stdin = os.Stdin

--- a/go/internal/cli/commands/os_install_unitree_g1_linux.go
+++ b/go/internal/cli/commands/os_install_unitree_g1_linux.go
@@ -47,8 +47,8 @@ type unitreeG1Fingerprints struct {
 }
 
 func installUnitreeG1(ctx context.Context, opts unitreeG1InstallOptions) error {
-	if runtime.GOARCH != "amd64" {
-		return fmt.Errorf("Unitree G1 flashing currently requires an Ubuntu x86-64 host; this host is linux/%s", runtime.GOARCH)
+	if err := validateUnitreeG1Host(runtime.GOOS, runtime.GOARCH); err != nil {
+		return err
 	}
 	if !isInteractiveTerminal() {
 		return fmt.Errorf("the experimental Unitree G1 installer currently requires an interactive terminal")
@@ -61,6 +61,7 @@ func installUnitreeG1(ctx context.Context, opts unitreeG1InstallOptions) error {
 
 	fmt.Println()
 	fmt.Println(tui.Header("Install Unitree G1 PC2 · JetPack " + version))
+	fmt.Println("Host requirement: " + unitreeG1HostRequirement + ".")
 	fmt.Println(tui.WarningMessage("Experimental hardware flow: this erases a replacement NVMe and updates PC2 module firmware. It never flashes the G1 motion-control computer."))
 	fmt.Println("The original G1 NVMe must be removed and preserved before continuing.")
 	fmt.Println("Historical lab package source: " + unitreeG1HistoricalSource)

--- a/go/internal/cli/commands/os_install_unitree_g1_linux.go
+++ b/go/internal/cli/commands/os_install_unitree_g1_linux.go
@@ -63,6 +63,13 @@ func installUnitreeG1(ctx context.Context, opts unitreeG1InstallOptions) error {
 	fmt.Println("The original G1 NVMe must be removed and preserved before continuing.")
 	fmt.Println("Official source: " + unitreeG1OfficialGuide)
 	fmt.Println()
+	fmt.Println(tui.Header("Required two-stage order"))
+	fmt.Println("  Stage 1 of 2 — NVMe system image")
+	fmt.Println("    Write g1-nx-j6.2.img.bz2 to the replacement NVMe, then install it in PC2.")
+	fmt.Println("  Stage 2 of 2 — Orin NX module firmware")
+	fmt.Println("    Put PC2 in APX recovery mode, then run the matching firmware package over USB-C.")
+	fmt.Println(tui.WarningMessage("Complete Stage 1 first. Do not flash the module firmware before the matching JetPack 6.2 NVMe is installed."))
+	fmt.Println()
 
 	packages, fingerprints, err := resolveOfficialUnitreeG1Packages(ctx)
 	if err != nil {
@@ -81,7 +88,8 @@ func installUnitreeG1(ctx context.Context, opts unitreeG1InstallOptions) error {
 	}
 
 	fmt.Println()
-	fmt.Println(tui.Header("Review destructive write"))
+	fmt.Println(tui.Header("Stage 1 of 2 · Flash replacement NVMe"))
+	fmt.Println("This writes the JetPack 6.2 system image. The PC2 module firmware is flashed afterward.")
 	fmt.Printf("  Model:  %s\n", target.Name)
 	if target.Serial != "" {
 		fmt.Printf("  Serial: %s\n", target.Serial)
@@ -133,7 +141,7 @@ func installUnitreeG1(ctx context.Context, opts unitreeG1InstallOptions) error {
 	}
 
 	fmt.Println()
-	fmt.Println(tui.Header("Put G1 PC2 into recovery mode"))
+	fmt.Println(tui.Header("Prepare Stage 2 of 2 · Put G1 PC2 into recovery mode"))
 	fmt.Println("  1. Hold PC2 PWR and REC together for about 2 seconds.")
 	fmt.Println("  2. Release PWR while continuing to hold REC for another 2 seconds.")
 	fmt.Println("  3. Release REC.")
@@ -168,7 +176,7 @@ func installUnitreeG1(ctx context.Context, opts unitreeG1InstallOptions) error {
 	}
 
 	fmt.Println()
-	fmt.Println(tui.Header("Flashing matching Unitree PC2 module firmware"))
+	fmt.Println(tui.Header("Stage 2 of 2 · Flash matching Unitree PC2 module firmware"))
 	fmt.Printf("  Archive:   sha256:%s\n", fingerprints.Firmware)
 	fmt.Printf("  Script:    %s\n", strings.TrimPrefix(script, workspace+string(filepath.Separator)))
 	fmt.Printf("  Script:    sha256:%s\n", scriptHash)

--- a/go/internal/cli/commands/os_install_unitree_g1_linux.go
+++ b/go/internal/cli/commands/os_install_unitree_g1_linux.go
@@ -28,19 +28,18 @@ const (
 	unitreeG1Version           = "6.2"
 	unitreeG1ImageName         = "g1-nx-j6.2.img.bz2"
 	unitreeG1FirmwareName      = "Jetpack_6.2_nx.tar.bz2"
-	unitreeG1MinDriveBytes     = int64(900_000_000_000)
 	unitreeG1MaxArchiveEntries = 1_000_000
 	unitreeG1MaxExtractedSize  = int64(200 << 30)
 )
 
-type unitreeG1Packages struct {
-	Image    string
-	Firmware string
+type unitreeG1ResolvedArtifact struct {
+	Path   string
+	SHA256 string
 }
 
-type unitreeG1Fingerprints struct {
-	Image    string
-	Firmware string
+type unitreeG1Packages struct {
+	Image    unitreeG1ResolvedArtifact
+	Firmware unitreeG1ResolvedArtifact
 }
 
 func installUnitreeG1(ctx context.Context, opts unitreeG1InstallOptions) error {
@@ -72,7 +71,7 @@ func installUnitreeG1(ctx context.Context, opts unitreeG1InstallOptions) error {
 	fmt.Println(tui.WarningMessage("Complete Stage 1 first. Do not flash the module firmware before the matching JetPack 6.2 NVMe is installed."))
 	fmt.Println()
 
-	packages, fingerprints, err := resolveOfficialUnitreeG1Packages(ctx)
+	packages, err := resolveOfficialUnitreeG1Packages(ctx)
 	if err != nil {
 		return err
 	}
@@ -97,10 +96,10 @@ func installUnitreeG1(ctx context.Context, opts unitreeG1InstallOptions) error {
 	}
 	fmt.Printf("  Device: %s\n", target.DevicePath)
 	fmt.Printf("  Size:   %s\n", target.Size)
-	fmt.Printf("  Image:  %s\n", filepath.Base(packages.Image))
-	fmt.Printf("          sha256:%s\n", fingerprints.Image)
-	fmt.Printf("  PC2:    %s\n", filepath.Base(packages.Firmware))
-	fmt.Printf("          sha256:%s\n", fingerprints.Firmware)
+	fmt.Printf("  Image:  %s\n", filepath.Base(packages.Image.Path))
+	fmt.Printf("          sha256:%s\n", packages.Image.SHA256)
+	fmt.Printf("  PC2:    %s\n", filepath.Base(packages.Firmware.Path))
+	fmt.Printf("          sha256:%s\n", packages.Firmware.SHA256)
 
 	if !opts.Force {
 		fmt.Println()
@@ -112,11 +111,11 @@ func installUnitreeG1(ctx context.Context, opts unitreeG1InstallOptions) error {
 			return ErrUserCancelled
 		}
 	}
-	if err := recheckUnitreeG1Artifact(packages.Image, fingerprints.Image, "before the destructive write"); err != nil {
+	if err := recheckUnitreeG1Artifact(packages.Image.Path, packages.Image.SHA256, "before the destructive write"); err != nil {
 		return err
 	}
 
-	stream, err := streamBzip2Image(packages.Image)
+	stream, err := streamBzip2Image(packages.Image.Path)
 	if err != nil {
 		return err
 	}
@@ -162,11 +161,11 @@ func installUnitreeG1(ctx context.Context, opts unitreeG1InstallOptions) error {
 		return err
 	}
 	fmt.Println(tui.SuccessMessage("Detected " + dev.Describe() + " in APX recovery mode."))
-	if err := recheckUnitreeG1Artifact(packages.Firmware, fingerprints.Firmware, "before extraction and privileged execution"); err != nil {
+	if err := recheckUnitreeG1Artifact(packages.Firmware.Path, packages.Firmware.SHA256, "before extraction and privileged execution"); err != nil {
 		return err
 	}
 
-	workspace, script, err := extractUnitreeG1Firmware(ctx, packages.Firmware)
+	workspace, script, err := extractUnitreeG1Firmware(ctx, packages.Firmware.Path)
 	if err != nil {
 		return err
 	}
@@ -178,7 +177,7 @@ func installUnitreeG1(ctx context.Context, opts unitreeG1InstallOptions) error {
 
 	fmt.Println()
 	fmt.Println(tui.Header("Stage 2 of 2 · Flash matching Unitree PC2 module firmware"))
-	fmt.Printf("  Archive:   sha256:%s\n", fingerprints.Firmware)
+	fmt.Printf("  Archive:   sha256:%s\n", packages.Firmware.SHA256)
 	fmt.Printf("  Script:    %s\n", strings.TrimPrefix(script, workspace+string(filepath.Separator)))
 	fmt.Printf("  Script:    sha256:%s\n", scriptHash)
 	fmt.Printf("  Directory: %s\n", filepath.Dir(script))
@@ -315,7 +314,7 @@ func validateUnitreeG1Drive(target drive) error {
 	if !target.MediaFixed {
 		return fmt.Errorf("%s does not look like a fixed SSD; select the replacement NVMe enclosure, not an SD card or USB stick", target.DevicePath)
 	}
-	if target.SizeBytes < unitreeG1MinDriveBytes {
+	if !unitreeG1DriveMeetsMinimumCapacity(target.SizeBytes) {
 		return fmt.Errorf("%s is %s; the verified G1 procedure requires a replacement NVMe of at least 1 TB", target.DevicePath, target.Size)
 	}
 	return nil

--- a/go/internal/cli/commands/os_install_unitree_g1_linux.go
+++ b/go/internal/cli/commands/os_install_unitree_g1_linux.go
@@ -1,0 +1,438 @@
+//go:build linux
+
+package commands
+
+import (
+	"archive/tar"
+	"compress/bzip2"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/rcm"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+)
+
+const (
+	unitreeG1Version          = "6.2"
+	unitreeG1ImageName        = "g1-nx-j6.2.img.bz2"
+	unitreeG1FirmwareName     = "Jetpack_6.2_nx.tar.bz2"
+	unitreeG1MinDriveBytes    = int64(900_000_000_000)
+	unitreeG1HistoricalSource = "https://drive.google.com/drive/folders/1ho17ectOxi7FbaRFdpAbP4tet8BJWjbm"
+)
+
+type unitreeG1Packages struct {
+	Directory string
+	Image     string
+	Firmware  string
+}
+
+func installUnitreeG1(ctx context.Context, opts unitreeG1InstallOptions) error {
+	if runtime.GOARCH != "amd64" {
+		return fmt.Errorf("Unitree G1 flashing currently requires an Ubuntu x86-64 host; this host is linux/%s", runtime.GOARCH)
+	}
+	if !isInteractiveTerminal() {
+		return fmt.Errorf("the experimental Unitree G1 installer currently requires an interactive terminal")
+	}
+
+	version, err := selectUnitreeG1Version(opts.Version)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println()
+	fmt.Println(tui.Header("Install Unitree G1 PC2 · JetPack " + version))
+	fmt.Println(tui.WarningMessage("Experimental hardware flow: this erases a replacement NVMe and updates PC2 module firmware. It never flashes the G1 motion-control computer."))
+	fmt.Println("The original G1 NVMe must be removed and preserved before continuing.")
+	fmt.Println("Historical lab package source: " + unitreeG1HistoricalSource)
+	fmt.Println()
+
+	packageDir, err := tui.PromptTextWithDefault(
+		"Unitree package folder",
+		fmt.Sprintf("must contain %s and %s", unitreeG1ImageName, unitreeG1FirmwareName),
+		".",
+		func(value string) error {
+			_, err := resolveUnitreeG1Packages(value)
+			return err
+		},
+	)
+	if err != nil {
+		if errors.Is(err, tui.ErrCancelled) {
+			return ErrUserCancelled
+		}
+		return err
+	}
+	packages, err := resolveUnitreeG1Packages(packageDir)
+	if err != nil {
+		return err
+	}
+
+	if err := preAuthElevation(); err != nil {
+		return err
+	}
+	target, err := selectUnitreeG1Drive(ctx, opts.Drive)
+	if err != nil {
+		return err
+	}
+	if err := validateUnitreeG1Drive(target); err != nil {
+		return err
+	}
+
+	fmt.Println()
+	fmt.Println(tui.Header("Review destructive write"))
+	fmt.Printf("  Model:  %s\n", target.Name)
+	if target.Serial != "" {
+		fmt.Printf("  Serial: %s\n", target.Serial)
+	}
+	fmt.Printf("  Device: %s\n", target.DevicePath)
+	fmt.Printf("  Size:   %s\n", target.Size)
+	fmt.Printf("  Image:  %s\n", filepath.Base(packages.Image))
+	fmt.Printf("  PC2:    %s\n", filepath.Base(packages.Firmware))
+
+	if !opts.Force {
+		fmt.Println()
+		confirmed, err := tui.Confirm("Erase this replacement NVMe and write the Unitree G1 image?")
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			return ErrUserCancelled
+		}
+	}
+
+	stream, err := streamBzip2Image(packages.Image)
+	if err != nil {
+		return err
+	}
+	defer stream.Close()
+	if err := writeUnitreeG1Image(stream, target); err != nil {
+		return err
+	}
+	ejectDisk(target)
+
+	fmt.Println()
+	fmt.Println(tui.SuccessMessage("The Unitree G1 image was written to the replacement NVMe."))
+	fmt.Println("  1. Power off the G1.")
+	fmt.Println("  2. Remove the replacement NVMe from its USB enclosure.")
+	fmt.Println("  3. Install it securely in PC2; keep the original NVMe unchanged.")
+	fmt.Println("  4. Power on the G1 and wait for all three power indicators to stay steady.")
+	fmt.Println()
+	ready, err := tui.Confirm("Is the replacement NVMe installed and the G1 ready for PC2 recovery mode?")
+	if err != nil {
+		return err
+	}
+	if !ready {
+		return ErrUserCancelled
+	}
+
+	fmt.Println()
+	fmt.Println(tui.Header("Put G1 PC2 into recovery mode"))
+	fmt.Println("  1. Hold PC2 PWR and REC together for about 2 seconds.")
+	fmt.Println("  2. Release PWR while continuing to hold REC for another 2 seconds.")
+	fmt.Println("  3. Release REC.")
+	fmt.Println("  4. Connect this host to PC2's dedicated USB-C flashing port with a data cable.")
+	fmt.Println("  5. Keep the G1 powered and USB connected until the firmware script reports success.")
+	fmt.Println()
+	ready, err = tui.Confirm("Start scanning for the G1's Orin NX in APX recovery mode?")
+	if err != nil {
+		return err
+	}
+	if !ready {
+		return ErrUserCancelled
+	}
+
+	dev, err := pickUnitreeG1RecoveryDevice()
+	if err != nil {
+		return err
+	}
+	fmt.Println(tui.SuccessMessage("Detected " + dev.Describe() + " in APX recovery mode."))
+
+	workspace, script, err := extractUnitreeG1Firmware(ctx, packages.Firmware)
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(workspace)
+
+	fmt.Println()
+	fmt.Println(tui.Header("Flashing matching Unitree PC2 module firmware"))
+	fmt.Println(tui.WarningMessage("Do not power off the G1 or disconnect USB until flash_nx_module.sh reports success."))
+	if err := runUnitreeG1FirmwareScript(ctx, script); err != nil {
+		return err
+	}
+
+	fmt.Println()
+	fmt.Println(tui.SuccessMessage("Unitree G1 PC2 image and module firmware completed."))
+	fmt.Println("Power off the G1, disconnect recovery USB, then boot normally and allow several minutes for first boot.")
+	fmt.Println("Verify with: ping 192.168.123.164 && ssh unitree@192.168.123.164")
+	return nil
+}
+
+func selectUnitreeG1Version(requested string) (string, error) {
+	if requested != "" && requested != unitreeG1Version {
+		return "", fmt.Errorf("Unitree G1 version %q is unavailable; this experimental installer supports %s", requested, unitreeG1Version)
+	}
+	if requested != "" || !isInteractiveTerminal() {
+		return unitreeG1Version, nil
+	}
+	return pickFromItems("Select an installation", []tui.PickerItem{
+		{
+			Name:        "Unitree G1 JetPack 6.2",
+			Description: "Ubuntu 22.04 · Jetson Linux R36.4.3 · PC2 Orin NX",
+			Section:     "Unitree G1",
+			Value:       unitreeG1Version,
+		},
+	})
+}
+
+func resolveUnitreeG1Packages(dir string) (unitreeG1Packages, error) {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return unitreeG1Packages{}, fmt.Errorf("package folder is required")
+	}
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return unitreeG1Packages{}, fmt.Errorf("resolving package folder: %w", err)
+	}
+	result := unitreeG1Packages{
+		Directory: abs,
+		Image:     filepath.Join(abs, unitreeG1ImageName),
+		Firmware:  filepath.Join(abs, unitreeG1FirmwareName),
+	}
+	for _, path := range []string{result.Image, result.Firmware} {
+		info, err := os.Lstat(path)
+		if err != nil {
+			return unitreeG1Packages{}, fmt.Errorf("required package %s: %w", filepath.Base(path), err)
+		}
+		if !info.Mode().IsRegular() {
+			return unitreeG1Packages{}, fmt.Errorf("required package %s must be a regular file, not a directory or symlink", filepath.Base(path))
+		}
+		if info.Size() == 0 {
+			return unitreeG1Packages{}, fmt.Errorf("required package %s is empty", filepath.Base(path))
+		}
+	}
+	return result, nil
+}
+
+func selectUnitreeG1Drive(ctx context.Context, requested string) (drive, error) {
+	if requested == "" {
+		fmt.Println()
+		return pickExternalDrive(ctx)
+	}
+	drives, err := listAllDrives()
+	if err != nil {
+		return drive{}, fmt.Errorf("listing drives: %w", err)
+	}
+	for _, candidate := range drives {
+		if candidate.DevicePath == requested {
+			return candidate, nil
+		}
+	}
+	return drive{}, fmt.Errorf("replacement drive %s was not found among external drives", requested)
+}
+
+func validateUnitreeG1Drive(target drive) error {
+	if !target.IsRemovable {
+		return fmt.Errorf("%s is not an external drive; attach the replacement NVMe through a USB enclosure", target.DevicePath)
+	}
+	if !target.MediaFixed {
+		return fmt.Errorf("%s does not look like a fixed SSD; select the replacement NVMe enclosure, not an SD card or USB stick", target.DevicePath)
+	}
+	if target.SizeBytes < unitreeG1MinDriveBytes {
+		return fmt.Errorf("%s is %s; the verified G1 procedure requires a replacement NVMe of at least 1 TB", target.DevicePath, target.Size)
+	}
+	return nil
+}
+
+type bzip2ImageReadCloser struct {
+	io.Reader
+	file *os.File
+}
+
+func (r *bzip2ImageReadCloser) Close() error { return r.file.Close() }
+
+func streamBzip2Image(path string) (*imageStream, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening G1 image: %w", err)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return nil, fmt.Errorf("stat G1 image: %w", err)
+	}
+	var magic [3]byte
+	if _, err := io.ReadFull(file, magic[:]); err != nil || string(magic[:]) != "BZh" {
+		file.Close()
+		return nil, fmt.Errorf("%s is not a bzip2 image", filepath.Base(path))
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		file.Close()
+		return nil, err
+	}
+	counter := &countingReader{r: file}
+	return &imageStream{
+		ReadCloser:     &bzip2ImageReadCloser{Reader: bzip2.NewReader(counter), file: file},
+		compressedRead: counter.n.Load,
+		compressedSize: info.Size(),
+	}, nil
+}
+
+func writeUnitreeG1Image(stream *imageStream, target drive) error {
+	progress := tui.NewProgress("Writing Unitree G1 image to " + target.DevicePath + "...")
+	program := tui.NewProgressProgram(progress)
+	go func() {
+		err := writeImageToDisk(stream, 0, target, func(written int64) {
+			if msg, ok := stream.writeProgressMsg(written); ok {
+				program.Send(msg)
+			}
+		})
+		program.Send(tui.ProgressDoneMsg{Err: err})
+	}()
+	final, err := program.Run()
+	if err != nil {
+		return fmt.Errorf("progress TUI: %w", err)
+	}
+	if err := final.(tui.ProgressModel).Err(); err != nil {
+		return fmt.Errorf("writing Unitree G1 image: %w", err)
+	}
+	return nil
+}
+
+func pickUnitreeG1RecoveryDevice() (rcm.RecoveryDevice, error) {
+	dev, err := pickUnixRecoveryDevice(recoveryWaitHints{
+		label:       "Unitree G1 PC2 Orin NX",
+		cablingLine: "the data cable is connected to PC2's dedicated USB-C flashing port",
+		buttonLine:  "hold PWR + REC 2s, release PWR while holding REC 2s more, then release REC",
+	}, func(candidate rcm.RecoveryDevice) bool { return candidate.IsOrinNX() })
+	if err != nil {
+		return rcm.RecoveryDevice{}, err
+	}
+	all, scanErr := rcm.ListRecoveryDevices()
+	if scanErr != nil {
+		return rcm.RecoveryDevice{}, scanErr
+	}
+	if len(all) != 1 {
+		return rcm.RecoveryDevice{}, fmt.Errorf("the Unitree vendor flash script cannot target a USB path safely; disconnect every other Jetson in recovery mode and retry")
+	}
+	if !all[0].IsOrinNX() || all[0].PathKey != dev.PathKey {
+		return rcm.RecoveryDevice{}, fmt.Errorf("the only connected recovery device is not the selected G1 Orin NX")
+	}
+	return dev, nil
+}
+
+func extractUnitreeG1Firmware(ctx context.Context, archive string) (workspace, script string, err error) {
+	if err := validateUnitreeG1Archive(archive); err != nil {
+		return "", "", err
+	}
+	workspace, err = os.MkdirTemp("", "wendy-unitree-g1-")
+	if err != nil {
+		return "", "", err
+	}
+	cmd := exec.CommandContext(ctx, "tar", "--bzip2", "--extract", "--file", archive, "--directory", workspace, "--no-same-owner", "--no-same-permissions")
+	if output, extractErr := cmd.CombinedOutput(); extractErr != nil {
+		os.RemoveAll(workspace)
+		return "", "", fmt.Errorf("extracting Unitree firmware archive: %w: %s", extractErr, strings.TrimSpace(string(output)))
+	}
+	script, err = findUnitreeG1FlashScript(workspace)
+	if err != nil {
+		os.RemoveAll(workspace)
+		return "", "", err
+	}
+	return workspace, script, nil
+}
+
+func validateUnitreeG1Archive(archive string) error {
+	file, err := os.Open(archive)
+	if err != nil {
+		return fmt.Errorf("opening Unitree firmware archive: %w", err)
+	}
+	defer file.Close()
+	return validateUnitreeG1Tar(bzip2.NewReader(file))
+}
+
+func validateUnitreeG1Tar(source io.Reader) error {
+	reader := tar.NewReader(source)
+	for {
+		header, err := reader.Next()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("reading Unitree firmware archive: %w", err)
+		}
+		if !safeUnitreeG1ArchivePath(header.Name) {
+			return fmt.Errorf("Unitree firmware archive contains unsafe path %q", header.Name)
+		}
+		switch header.Typeflag {
+		case tar.TypeReg, tar.TypeRegA, tar.TypeDir:
+		case tar.TypeSymlink:
+			if path.IsAbs(header.Linkname) {
+				return fmt.Errorf("Unitree firmware archive symlink %q has an absolute target", header.Name)
+			}
+			resolved := path.Join(path.Dir(header.Name), header.Linkname)
+			if !safeUnitreeG1ArchivePath(resolved) {
+				return fmt.Errorf("Unitree firmware archive symlink %q escapes the extraction folder", header.Name)
+			}
+		case tar.TypeLink:
+			if !safeUnitreeG1ArchivePath(header.Linkname) {
+				return fmt.Errorf("Unitree firmware archive hard link %q escapes the extraction folder", header.Name)
+			}
+		default:
+			return fmt.Errorf("Unitree firmware archive contains unsupported entry type %d at %q", header.Typeflag, header.Name)
+		}
+	}
+}
+
+func safeUnitreeG1ArchivePath(name string) bool {
+	if name == "" || path.IsAbs(name) {
+		return false
+	}
+	clean := path.Clean(name)
+	return clean != ".." && !strings.HasPrefix(clean, "../")
+}
+
+func findUnitreeG1FlashScript(root string) (string, error) {
+	var matches []string
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.Name() == "flash_nx_module.sh" && filepath.Base(filepath.Dir(path)) == "Linux_for_Tegra" {
+			info, err := os.Lstat(path)
+			if err != nil {
+				return err
+			}
+			if !info.Mode().IsRegular() {
+				return fmt.Errorf("flash_nx_module.sh must be a regular file")
+			}
+			matches = append(matches, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(matches) != 1 {
+		return "", fmt.Errorf("expected exactly one Linux_for_Tegra/flash_nx_module.sh in Unitree firmware archive, found %d", len(matches))
+	}
+	return matches[0], nil
+}
+
+func runUnitreeG1FirmwareScript(ctx context.Context, script string) error {
+	cmd := exec.CommandContext(ctx, "sudo", "./flash_nx_module.sh")
+	cmd.Dir = filepath.Dir(script)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("Unitree flash_nx_module.sh failed: %w", err)
+	}
+	return nil
+}

--- a/go/internal/cli/commands/os_install_unitree_g1_linux_test.go
+++ b/go/internal/cli/commands/os_install_unitree_g1_linux_test.go
@@ -177,6 +177,7 @@ func TestValidateUnitreeG1Drive(t *testing.T) {
 		{"internal", func(d *drive) { d.IsRemovable = false }, "not an external drive"},
 		{"removable media", func(d *drive) { d.MediaFixed = false }, "does not look like a fixed SSD"},
 		{"undersized", func(d *drive) { d.SizeBytes = 512_000_000_000; d.Size = "512 GB" }, "at least 1 TB"},
+		{"just under one terabyte", func(d *drive) { d.SizeBytes = 999_999_999_999; d.Size = "999 GB" }, "at least 1 TB"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/go/internal/cli/commands/os_install_unitree_g1_linux_test.go
+++ b/go/internal/cli/commands/os_install_unitree_g1_linux_test.go
@@ -5,6 +5,7 @@ package commands
 import (
 	"archive/tar"
 	"bytes"
+	"context"
 	"encoding/base64"
 	"io"
 	"os"
@@ -96,22 +97,166 @@ func TestSafeUnitreeG1ArchivePath(t *testing.T) {
 	}
 }
 
-func TestValidateUnitreeG1ArchiveRejectsAbsoluteSymlink(t *testing.T) {
+func TestExtractUnitreeG1Tar(t *testing.T) {
 	var archive bytes.Buffer
 	tarWriter := tar.NewWriter(&archive)
-	if err := tarWriter.WriteHeader(&tar.Header{
-		Name:     "Jetpack_6.2_nx/Linux_for_Tegra/unsafe",
+	const scriptName = "Jetpack_6.2_nx/Linux_for_Tegra/flash_nx_module.sh"
+	writeUnitreeG1TarEntry(t, tarWriter, tar.Header{Name: "Jetpack_6.2_nx/Linux_for_Tegra", Typeflag: tar.TypeDir, Mode: 0o755}, nil)
+	writeUnitreeG1TarEntry(t, tarWriter, tar.Header{Name: scriptName, Typeflag: tar.TypeReg, Mode: 0o755}, []byte("#!/bin/sh\n"))
+	writeUnitreeG1TarEntry(t, tarWriter, tar.Header{
+		Name:     "Jetpack_6.2_nx/Linux_for_Tegra/flash-hardlink.sh",
+		Typeflag: tar.TypeLink,
+		Linkname: scriptName,
+	}, nil)
+	writeUnitreeG1TarEntry(t, tarWriter, tar.Header{
+		Name:     "Jetpack_6.2_nx/Linux_for_Tegra/flash-symlink.sh",
 		Typeflag: tar.TypeSymlink,
-		Linkname: "/etc/passwd",
-	}); err != nil {
-		t.Fatal(err)
-	}
+		Linkname: "flash_nx_module.sh",
+	}, nil)
 	if err := tarWriter.Close(); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := validateUnitreeG1Tar(bytes.NewReader(archive.Bytes())); err == nil || !strings.Contains(err.Error(), "absolute target") {
-		t.Fatalf("absolute symlink error = %v", err)
+	root := t.TempDir()
+	if err := extractUnitreeG1Tar(context.Background(), bytes.NewReader(archive.Bytes()), root); err != nil {
+		t.Fatal(err)
+	}
+	script := filepath.Join(root, filepath.FromSlash(scriptName))
+	data, err := os.ReadFile(script)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "#!/bin/sh\n" {
+		t.Fatalf("script contents = %q", data)
+	}
+	hardInfo, err := os.Stat(filepath.Join(filepath.Dir(script), "flash-hardlink.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	scriptInfo, err := os.Stat(script)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(scriptInfo, hardInfo) {
+		t.Fatal("hard link does not reference the extracted script")
+	}
+	linkTarget, err := os.Readlink(filepath.Join(filepath.Dir(script), "flash-symlink.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if linkTarget != "flash_nx_module.sh" {
+		t.Fatalf("symlink target = %q", linkTarget)
+	}
+}
+
+func TestExtractUnitreeG1TarRejectsUnsafeLinks(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []tar.Header
+		want    string
+	}{
+		{
+			name: "absolute symlink",
+			entries: []tar.Header{{
+				Name:     "Jetpack_6.2_nx/Linux_for_Tegra/unsafe",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "/etc/passwd",
+			}},
+			want: "absolute target",
+		},
+		{
+			name: "hardlink without prior regular target",
+			entries: []tar.Header{{
+				Name:     "Jetpack_6.2_nx/Linux_for_Tegra/unsafe",
+				Typeflag: tar.TypeLink,
+				Linkname: "Jetpack_6.2_nx/Linux_for_Tegra/missing",
+			}},
+			want: "prior regular file",
+		},
+		{
+			name: "write through archive symlink",
+			entries: []tar.Header{
+				{Name: "bundle/link", Typeflag: tar.TypeSymlink, Linkname: "real"},
+				{Name: "bundle/link/payload", Typeflag: tar.TypeReg, Mode: 0o600},
+			},
+			want: "would write through symlink",
+		},
+		{
+			name: "regular file traversal",
+			entries: []tar.Header{{
+				Name:     "../../outside",
+				Typeflag: tar.TypeReg,
+				Mode:     0o600,
+			}},
+			want: "unsafe path",
+		},
+		{
+			name: "special file",
+			entries: []tar.Header{{
+				Name:     "Jetpack_6.2_nx/dev/mem",
+				Typeflag: tar.TypeChar,
+			}},
+			want: "unsupported entry type",
+		},
+		{
+			name: "duplicate regular file",
+			entries: []tar.Header{
+				{Name: "duplicate", Typeflag: tar.TypeReg, Mode: 0o600},
+				{Name: "duplicate", Typeflag: tar.TypeReg, Mode: 0o600},
+			},
+			want: "duplicate path",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var archive bytes.Buffer
+			writer := tar.NewWriter(&archive)
+			for _, header := range tc.entries {
+				data := []byte(nil)
+				if header.Typeflag == tar.TypeReg {
+					data = []byte("x")
+				}
+				writeUnitreeG1TarEntry(t, writer, header, data)
+			}
+			if err := writer.Close(); err != nil {
+				t.Fatal(err)
+			}
+			err := extractUnitreeG1Tar(context.Background(), bytes.NewReader(archive.Bytes()), t.TempDir())
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v; want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractUnitreeG1TarRejectsSymlinkRoot(t *testing.T) {
+	parent := t.TempDir()
+	realRoot := filepath.Join(parent, "real")
+	if err := os.Mkdir(realRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	symlinkRoot := filepath.Join(parent, "link")
+	if err := os.Symlink(realRoot, symlinkRoot); err != nil {
+		t.Fatal(err)
+	}
+	err := extractUnitreeG1Tar(context.Background(), bytes.NewReader(nil), symlinkRoot)
+	if err == nil || !strings.Contains(err.Error(), "real directory") {
+		t.Fatalf("error = %v; want real-directory rejection", err)
+	}
+}
+
+func writeUnitreeG1TarEntry(t *testing.T, writer *tar.Writer, header tar.Header, data []byte) {
+	t.Helper()
+	if header.Typeflag == tar.TypeReg || header.Typeflag == tar.TypeRegA {
+		header.Size = int64(len(data))
+	}
+	if err := writer.WriteHeader(&header); err != nil {
+		t.Fatal(err)
+	}
+	if len(data) > 0 {
+		if _, err := writer.Write(data); err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 
@@ -131,6 +276,32 @@ func TestFindUnitreeG1FlashScript(t *testing.T) {
 	}
 	if got != want {
 		t.Fatalf("script = %q; want %q", got, want)
+	}
+}
+
+func TestHashUnitreeG1File(t *testing.T) {
+	artifact := filepath.Join(t.TempDir(), "artifact")
+	if err := os.WriteFile(artifact, []byte("unitree-g1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	digest, err := hashUnitreeG1File(artifact, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want = "a3cc1c668e3bab252d11494e9181920dde49e94f62f92f60185f420d21d24a46"
+	if digest != want {
+		t.Fatalf("digest = %q; want %q", digest, want)
+	}
+}
+
+func TestValidateUnitreeG1TrustPhrase(t *testing.T) {
+	if err := validateUnitreeG1TrustPhrase(unitreeG1TrustPhrase); err != nil {
+		t.Fatalf("exact phrase rejected: %v", err)
+	}
+	for _, value := range []string{"", "unverified unitree lab flash", unitreeG1TrustPhrase + " "} {
+		if err := validateUnitreeG1TrustPhrase(value); err == nil {
+			t.Fatalf("phrase %q was accepted", value)
+		}
 	}
 }
 

--- a/go/internal/cli/commands/os_install_unitree_g1_linux_test.go
+++ b/go/internal/cli/commands/os_install_unitree_g1_linux_test.go
@@ -1,0 +1,168 @@
+//go:build linux
+
+package commands
+
+import (
+	"archive/tar"
+	"bytes"
+	"encoding/base64"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveUnitreeG1PackagesRequiresExactPair(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, unitreeG1ImageName), []byte("image"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolveUnitreeG1Packages(dir); err == nil || !strings.Contains(err.Error(), unitreeG1FirmwareName) {
+		t.Fatalf("missing firmware error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, unitreeG1FirmwareName), []byte("firmware"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveUnitreeG1Packages(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Image != filepath.Join(dir, unitreeG1ImageName) || got.Firmware != filepath.Join(dir, unitreeG1FirmwareName) {
+		t.Fatalf("resolved packages = %+v", got)
+	}
+}
+
+func TestResolveUnitreeG1PackagesRejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	if err := os.WriteFile(target, []byte("image"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(dir, unitreeG1ImageName)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, unitreeG1FirmwareName), []byte("firmware"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolveUnitreeG1Packages(dir); err == nil || !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("symlink error = %v", err)
+	}
+}
+
+func TestValidateUnitreeG1Drive(t *testing.T) {
+	valid := drive{
+		DevicePath:  "/dev/sdz",
+		Name:        "Crucial P310",
+		Size:        "1.0 TB",
+		SizeBytes:   1_000_000_000_000,
+		IsRemovable: true,
+		MediaFixed:  true,
+	}
+	if err := validateUnitreeG1Drive(valid); err != nil {
+		t.Fatalf("valid drive rejected: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		edit func(*drive)
+		want string
+	}{
+		{"internal", func(d *drive) { d.IsRemovable = false }, "not an external drive"},
+		{"removable media", func(d *drive) { d.MediaFixed = false }, "does not look like a fixed SSD"},
+		{"undersized", func(d *drive) { d.SizeBytes = 512_000_000_000; d.Size = "512 GB" }, "at least 1 TB"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			candidate := valid
+			tc.edit(&candidate)
+			if err := validateUnitreeG1Drive(candidate); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v; want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestSafeUnitreeG1ArchivePath(t *testing.T) {
+	for _, name := range []string{"Jetpack_6.2_nx/Linux_for_Tegra/flash_nx_module.sh", "dir/file"} {
+		if !safeUnitreeG1ArchivePath(name) {
+			t.Errorf("safe path rejected: %q", name)
+		}
+	}
+	for _, name := range []string{"", "/etc/passwd", "../escape", "dir/../../escape"} {
+		if safeUnitreeG1ArchivePath(name) {
+			t.Errorf("unsafe path accepted: %q", name)
+		}
+	}
+}
+
+func TestValidateUnitreeG1ArchiveRejectsAbsoluteSymlink(t *testing.T) {
+	var archive bytes.Buffer
+	tarWriter := tar.NewWriter(&archive)
+	if err := tarWriter.WriteHeader(&tar.Header{
+		Name:     "Jetpack_6.2_nx/Linux_for_Tegra/unsafe",
+		Typeflag: tar.TypeSymlink,
+		Linkname: "/etc/passwd",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := validateUnitreeG1Tar(bytes.NewReader(archive.Bytes())); err == nil || !strings.Contains(err.Error(), "absolute target") {
+		t.Fatalf("absolute symlink error = %v", err)
+	}
+}
+
+func TestFindUnitreeG1FlashScript(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "Jetpack_6.2_nx", "Linux_for_Tegra")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(dir, "flash_nx_module.sh")
+	if err := os.WriteFile(want, []byte("#!/bin/sh\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	got, err := findUnitreeG1FlashScript(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("script = %q; want %q", got, want)
+	}
+}
+
+func TestStreamBzip2Image(t *testing.T) {
+	encoded := "QlpoOTFBWSZTWWNwbZ0AAAeZgAACIAAioxYAIAAiDINAgGmmgibKNXCXcF4u5IpwoSDG4Ns6"
+	compressed, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	image := filepath.Join(t.TempDir(), unitreeG1ImageName)
+	if err := os.WriteFile(image, compressed, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stream, err := streamBzip2Image(image)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stream.Close()
+	data, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "unitree-g1-image" {
+		t.Fatalf("decompressed = %q", data)
+	}
+}
+
+func TestSelectUnitreeG1VersionRejectsUnknown(t *testing.T) {
+	if got, err := selectUnitreeG1Version(unitreeG1Version); err != nil || got != unitreeG1Version {
+		t.Fatalf("version = %q, err = %v", got, err)
+	}
+	if _, err := selectUnitreeG1Version("5.1.1"); err == nil {
+		t.Fatal("expected unsupported version error")
+	}
+}

--- a/go/internal/cli/commands/os_install_unitree_g1_linux_test.go
+++ b/go/internal/cli/commands/os_install_unitree_g1_linux_test.go
@@ -6,47 +6,152 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
+	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
 
-func TestResolveUnitreeG1PackagesRequiresExactPair(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, unitreeG1ImageName), []byte("image"), 0o600); err != nil {
+func TestResumeUnitreeG1Artifact(t *testing.T) {
+	content := bytes.Repeat([]byte("unitree-g1-official-artifact"), 1024)
+	digest := sha256.Sum256(content)
+	const offset = 117
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.Header.Get("Range"), fmt.Sprintf("bytes=%d-", offset); got != want {
+			t.Errorf("Range = %q, want %q", got, want)
+		}
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", offset, len(content)-1, len(content)))
+		w.Header().Set("Content-Length", fmt.Sprint(len(content)-offset))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(content[offset:])
+	}))
+	defer server.Close()
+
+	artifact := unitreeG1Artifact{
+		Name:   "artifact.bz2",
+		URL:    server.URL,
+		Size:   int64(len(content)),
+		SHA256: hex.EncodeToString(digest[:]),
+	}
+	partial := filepath.Join(t.TempDir(), artifact.Name+".partial")
+	if err := os.WriteFile(partial, content[:offset], 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := resolveUnitreeG1Packages(dir); err == nil || !strings.Contains(err.Error(), unitreeG1FirmwareName) {
-		t.Fatalf("missing firmware error = %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, unitreeG1FirmwareName), []byte("firmware"), 0o600); err != nil {
+	var downloaded, total int64
+	if err := resumeUnitreeG1Artifact(context.Background(), server.Client(), artifact, partial, func(got, size int64) {
+		downloaded, total = got, size
+	}); err != nil {
 		t.Fatal(err)
 	}
-	got, err := resolveUnitreeG1Packages(dir)
+	got, err := os.ReadFile(partial)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Image != filepath.Join(dir, unitreeG1ImageName) || got.Firmware != filepath.Join(dir, unitreeG1FirmwareName) {
-		t.Fatalf("resolved packages = %+v", got)
+	if !bytes.Equal(got, content) {
+		t.Fatal("resumed artifact does not match source bytes")
+	}
+	if downloaded != int64(len(content)) || total != int64(len(content)) {
+		t.Fatalf("progress = %d/%d, want %d/%d", downloaded, total, len(content), len(content))
 	}
 }
 
-func TestResolveUnitreeG1PackagesRejectsSymlink(t *testing.T) {
+func TestResumeUnitreeG1ArtifactRestartsWhenRangeIsIgnored(t *testing.T) {
+	content := bytes.Repeat([]byte("official"), 512)
+	digest := sha256.Sum256(content)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Range") == "" {
+			t.Error("resume request did not include Range")
+		}
+		w.Header().Set("Content-Length", fmt.Sprint(len(content)))
+		_, _ = w.Write(content)
+	}))
+	defer server.Close()
+
+	artifact := unitreeG1Artifact{
+		Name:   "artifact.bz2",
+		URL:    server.URL,
+		Size:   int64(len(content)),
+		SHA256: hex.EncodeToString(digest[:]),
+	}
+	partial := filepath.Join(t.TempDir(), artifact.Name+".partial")
+	if err := os.WriteFile(partial, []byte("stale partial bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := resumeUnitreeG1Artifact(context.Background(), server.Client(), artifact, partial, nil); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(partial)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Fatal("range-ignoring server response was not restarted from byte zero")
+	}
+}
+
+func TestValidateUnitreeG1ArtifactMetadata(t *testing.T) {
+	valid := unitreeG1Artifact{Name: "artifact.bz2", URL: "https://example.com/artifact", Size: 1, SHA256: strings.Repeat("a", 64)}
+	if err := validateUnitreeG1ArtifactMetadata(valid); err != nil {
+		t.Fatalf("valid metadata rejected: %v", err)
+	}
+	for _, edit := range []func(*unitreeG1Artifact){
+		func(a *unitreeG1Artifact) { a.Name = "../artifact.bz2" },
+		func(a *unitreeG1Artifact) { a.URL = "" },
+		func(a *unitreeG1Artifact) { a.Size = 0 },
+		func(a *unitreeG1Artifact) { a.SHA256 = "not-a-digest" },
+	} {
+		candidate := valid
+		edit(&candidate)
+		if err := validateUnitreeG1ArtifactMetadata(candidate); err == nil {
+			t.Fatalf("invalid metadata accepted: %+v", candidate)
+		}
+	}
+}
+
+func TestOfficialUnitreeG1ArtifactMetadata(t *testing.T) {
+	wantNames := map[string]bool{
+		unitreeG1ImageName:    false,
+		unitreeG1FirmwareName: false,
+	}
+	for _, artifact := range unitreeG1OfficialArtifacts {
+		if err := validateUnitreeG1ArtifactMetadata(artifact); err != nil {
+			t.Fatalf("official metadata for %s: %v", artifact.Name, err)
+		}
+		seen, expected := wantNames[artifact.Name]
+		if !expected {
+			t.Fatalf("unexpected official artifact %q", artifact.Name)
+		}
+		if seen {
+			t.Fatalf("duplicate official artifact %q", artifact.Name)
+		}
+		wantNames[artifact.Name] = true
+	}
+	for name, seen := range wantNames {
+		if !seen {
+			t.Errorf("official artifact %q is missing", name)
+		}
+	}
+}
+
+func TestUnitreeG1PartialSizeRejectsSymlink(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "target")
-	if err := os.WriteFile(target, []byte("image"), 0o600); err != nil {
+	if err := os.WriteFile(target, []byte("partial"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Symlink(target, filepath.Join(dir, unitreeG1ImageName)); err != nil {
+	link := filepath.Join(dir, "artifact.partial")
+	if err := os.Symlink(target, link); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, unitreeG1FirmwareName), []byte("firmware"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := resolveUnitreeG1Packages(dir); err == nil || !strings.Contains(err.Error(), "regular file") {
+	if _, err := unitreeG1PartialSize(link, 100); err == nil || !strings.Contains(err.Error(), "regular file") {
 		t.Fatalf("symlink error = %v", err)
 	}
 }
@@ -291,17 +396,6 @@ func TestHashUnitreeG1File(t *testing.T) {
 	const want = "a3cc1c668e3bab252d11494e9181920dde49e94f62f92f60185f420d21d24a46"
 	if digest != want {
 		t.Fatalf("digest = %q; want %q", digest, want)
-	}
-}
-
-func TestValidateUnitreeG1TrustPhrase(t *testing.T) {
-	if err := validateUnitreeG1TrustPhrase(unitreeG1TrustPhrase); err != nil {
-		t.Fatalf("exact phrase rejected: %v", err)
-	}
-	for _, value := range []string{"", "unverified unitree lab flash", unitreeG1TrustPhrase + " "} {
-		if err := validateUnitreeG1TrustPhrase(value); err == nil {
-			t.Fatalf("phrase %q was accepted", value)
-		}
 	}
 }
 

--- a/go/internal/cli/commands/os_install_unitree_g1_other.go
+++ b/go/internal/cli/commands/os_install_unitree_g1_other.go
@@ -4,10 +4,9 @@ package commands
 
 import (
 	"context"
-	"fmt"
 	"runtime"
 )
 
 func installUnitreeG1(_ context.Context, _ unitreeG1InstallOptions) error {
-	return fmt.Errorf("Unitree G1 flashing currently requires an Ubuntu x86-64 host; this host is %s/%s", runtime.GOOS, runtime.GOARCH)
+	return validateUnitreeG1Host(runtime.GOOS, runtime.GOARCH)
 }

--- a/go/internal/cli/commands/os_install_unitree_g1_other.go
+++ b/go/internal/cli/commands/os_install_unitree_g1_other.go
@@ -1,0 +1,13 @@
+//go:build darwin || windows
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+)
+
+func installUnitreeG1(_ context.Context, _ unitreeG1InstallOptions) error {
+	return fmt.Errorf("Unitree G1 flashing currently requires an Ubuntu x86-64 host; this host is %s/%s", runtime.GOOS, runtime.GOARCH)
+}

--- a/go/internal/cli/commands/os_install_unitree_g1_shared.go
+++ b/go/internal/cli/commands/os_install_unitree_g1_shared.go
@@ -1,0 +1,7 @@
+package commands
+
+const unitreeG1MinDriveBytes = int64(1_000_000_000_000)
+
+func unitreeG1DriveMeetsMinimumCapacity(sizeBytes int64) bool {
+	return sizeBytes >= unitreeG1MinDriveBytes
+}

--- a/go/internal/cli/commands/os_install_unitree_g1_shared_test.go
+++ b/go/internal/cli/commands/os_install_unitree_g1_shared_test.go
@@ -1,0 +1,22 @@
+package commands
+
+import "testing"
+
+func TestUnitreeG1DriveMeetsMinimumCapacity(t *testing.T) {
+	tests := []struct {
+		name string
+		size int64
+		want bool
+	}{
+		{name: "one byte below one terabyte", size: 999_999_999_999, want: false},
+		{name: "one terabyte", size: 1_000_000_000_000, want: true},
+		{name: "larger drive", size: 2_000_000_000_000, want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := unitreeG1DriveMeetsMinimumCapacity(tc.size); got != tc.want {
+				t.Fatalf("unitreeG1DriveMeetsMinimumCapacity(%d) = %v, want %v", tc.size, got, tc.want)
+			}
+		})
+	}
+}

--- a/go/internal/cli/tegraflash/rcm/recovery.go
+++ b/go/internal/cli/tegraflash/rcm/recovery.go
@@ -40,6 +40,13 @@ func (r RecoveryDevice) IsOrinAGX() bool {
 	return r.Product == uint16(ProductOrinAGX32) || r.Product == uint16(ProductOrinAGX64)
 }
 
+// IsOrinNX reports whether the device is an Orin NX module. Unlike the Orin
+// Nano devkit path, vendor robot carriers such as the Unitree G1 use an NX
+// module and must be matched explicitly before invoking their flash tooling.
+func (r RecoveryDevice) IsOrinNX() bool {
+	return r.Product == uint16(ProductOrinNX16) || r.Product == uint16(ProductOrinNX8)
+}
+
 // IsOrinNano reports whether the device is an Orin Nano module.
 func (r RecoveryDevice) IsOrinNano() bool {
 	return r.Product == uint16(ProductOrinNano8) || r.Product == uint16(ProductOrinNano4)

--- a/go/internal/cli/tegraflash/rcm/recovery_test.go
+++ b/go/internal/cli/tegraflash/rcm/recovery_test.go
@@ -29,8 +29,9 @@ func TestT234FamilyRecoveryPIDs(t *testing.T) {
 		if d.IsThor() {
 			t.Errorf("PID 0x%04x misclassified as Thor", tc.pid)
 		}
-		if d.IsOrinAGX() != tc.agx || d.IsOrinNano() != tc.nano {
-			t.Errorf("PID 0x%04x: IsOrinAGX=%v IsOrinNano=%v, want %v/%v", tc.pid, d.IsOrinAGX(), d.IsOrinNano(), tc.agx, tc.nano)
+		wantNX := tc.pid == ProductOrinNX16 || tc.pid == ProductOrinNX8
+		if d.IsOrinAGX() != tc.agx || d.IsOrinNX() != wantNX || d.IsOrinNano() != tc.nano {
+			t.Errorf("PID 0x%04x: IsOrinAGX=%v IsOrinNX=%v IsOrinNano=%v, want %v/%v/%v", tc.pid, d.IsOrinAGX(), d.IsOrinNX(), d.IsOrinNano(), tc.agx, wantNX, tc.nano)
 		}
 		if got := d.Describe(); !strings.Contains(got, tc.module) {
 			t.Errorf("Describe() for PID 0x%04x = %q, want module %q", tc.pid, got, tc.module)


### PR DESCRIPTION
## Summary

- add **Unitree G1** as the first target under **Robots** in the normal `wendy install` picker
- guide an operator through downloading the paired JetPack 6.2 artifacts, choosing a replacement NVMe, reviewing the destructive write, installing the NVMe in PC2, entering recovery mode, and running the matching Orin NX firmware script
- download the exact package pair linked by [NVIDIA's official G1 JetPack 6 flashing guide](https://nvlabs.github.io/GR00T-WholeBodyControl/references/jetpack6.html), rather than requiring a local package directory or a Wendy-hosted copy
- cache completed packages under `~/.cache/wendy/os-images/unitree-g1/6.2/` and resume interrupted `.partial` downloads with HTTP range requests
- require exact byte lengths and source-pinned SHA-256 values before either artifact can be used:
  - `g1-nx-j6.2.img.bz2`: `8902fba85a2fbd05893deec10b43d8116661762a718e479bade1ae685e123b3d`
  - `Jetpack_6.2_nx.tar.bz2`: `1ce5da305006a070aa00593561dd432d2c60fcb69dc4c25cb5ee13dbbd74e2fc`
- show Linux drive model/path/size in the picker and serial in the final review
- re-hash each artifact immediately before its destructive or privileged flash stage
- validate the target drive, APX device, and vendor archive before either flash stage
- extract the firmware archive in-process with no writes through links, then show the exact script hash, working directory, and privileged command before a second confirmation
- document the guided flow and official upstream source

Related documentation work: #1510.

## Draft status — DO NOT MERGE

This remains intentionally draft for the first complete lab walkthrough on the G1. The source, downloader, integrity checks, archive constraints, and guided flow have automated coverage, but the complete rootfs + PC2 firmware procedure has not yet been executed end-to-end through this command on the lab robot.

The source is now the exact pair linked by NVIDIA's official G1 JetPack 6 guide. Wendy does not mirror or silently update those files. Their exact sizes and SHA-256 values are pinned in reviewed CLI source; if the linked bytes change, the installer refuses to flash until the source and new hashes are deliberately reviewed.

## Verified package parity with the previous G1 process

The automatic CLI source has been cross-checked against the two-package process previously used for the lab G1:

- the current NVIDIA guide and the earlier runbook use the same Google Drive folder ID: `1ho17ectOxi7FbaRFdpAbP4tet8BJWjbm`
- both use the same exact filenames:
  - `g1-nx-j6.2.img.bz2` — compressed full-disk image written to the replacement P310 NVMe
  - `Jetpack_6.2_nx.tar.bz2` — host-side Orin NX firmware package used through recovery/APX mode
- the freshly downloaded official-source files match the historical MD5 values recorded for that earlier pair:
  - image: `a7b6fae1247c1ba83fafd61a9c46f7a7`
  - firmware: `4971d36f8fe17d121dcabc98afc1556d`
- structural inspection confirms that the image decompresses to a partitioned disk image and that the firmware archive contains `Jetpack_6.2_nx/Linux_for_Tegra` and its NVIDIA bootloader stack

The MD5 values are recorded only as historical parity evidence. The CLI's actual safety gate uses the stronger pinned SHA-256 values above, exact byte lengths, and a full re-hash before each destructive or privileged stage.

## Required flashing order shown in the CLI

1. **Stage 1 of 2 — NVMe system image:** write `g1-nx-j6.2.img.bz2` to the replacement P310/NVMe.
2. Install that replacement NVMe securely in PC2 while preserving the original drive.
3. **Stage 2 of 2 — Orin NX module firmware:** put PC2 into APX recovery mode and use `Jetpack_6.2_nx.tar.bz2` from the Ubuntu host over the recovery USB-C connection.

The CLI shows this order before downloading, labels both flash stages, and does not expose the firmware execution step until the NVMe image write has completed and the operator confirms that the replacement NVMe is installed. The documentation carries the same warning: do not flash the module firmware before the matching JetPack 6.2 NVMe is installed.

## Safety boundaries

- the picker states that G1 flashing requires Ubuntu Linux on an Intel/AMD x86-64 PC; Windows, macOS (including Apple Silicon), and ARM Linux are rejected before any destructive step
- the CLI downloads only the two built-in official-source URLs; there is no operator-supplied package directory
- cached files are reused only after exact-size and full SHA-256 verification
- interrupted downloads resume safely, reject symlinks/non-regular cache entries, verify range responses, and fall back to a clean byte-zero write if a server ignores the range request
- a changed, truncated, or corrupted upstream artifact is rejected before any destructive action
- only a fixed external SSD of at least 1 TB is accepted for the destructive image write
- the final review identifies the drive by model, serial (when reported), path, and size
- both artifact hashes are rechecked immediately before their respective destructive/privileged stages
- the original G1 NVMe must be removed and preserved
- the recovery stage accepts only an Orin NX and refuses to run while another recovery-mode Jetson is attached
- the firmware archive is extracted by a constrained Go implementation that rejects absolute/traversal and duplicate paths, special files, writes through symlinks, forward hard links, more than 1,000,000 entries, and more than 200 GiB of expanded regular-file data
- regular files are materialized before validated in-tree hard links and symlinks are created
- the single expected regular `Linux_for_Tegra/flash_nx_module.sh` is fingerprinted and its exact temporary directory plus `sudo ./flash_nx_module.sh` command are displayed before a second confirmation
- the flow targets PC2 only; it does not flash the motion-control computer or issue joint commands

## Automated verification

- complete official downloads checked against the pinned byte lengths and SHA-256 values
- downloader tests cover partial-download resume, range-ignoring server fallback, built-in metadata, malformed metadata, and symlink rejection
- `go test ./...`
- `go vet ./...`
- `gofmt` and `git diff --check`
- Linux container tests for the G1 downloader and installer helpers
- portable boundary coverage proves 999,999,999,999 bytes is rejected and the exact decimal 1 TB threshold (1,000,000,000,000 bytes) is accepted
- each resolved artifact now carries its path and SHA-256 together, preventing a path from being paired with the other package's fingerprint
- manual picker check on macOS: Unitree G1 appears first under Robots and safely rejects the unsupported host
- all 14 GitHub checks passed on the current final picker-label cleanup commit `de756eb8e`, including native Linux test/vet, CodeQL, security, docs, and integration review

## Lab G1 verification checklist

- [ ] Run `wendy install` from an Ubuntu x86-64 host and select **Robots → Unitree G1 → JetPack 6.2**
- [ ] Confirm both official-source downloads start without asking for a package folder
- [ ] Interrupt one download, rerun the command, and confirm it resumes from the existing `.partial` file
- [ ] Confirm completed packages are cached and a second run fully verifies and reuses them
- [ ] Confirm a deliberately changed cached file is rejected and replaced before any destructive action
- [ ] Confirm the replacement P310/NVMe is identifiable in the picker and final review, and no internal host drive is offered
- [ ] Complete the destructive image write and verify the replacement NVMe boots when installed in PC2
- [ ] Confirm the displayed PWR/REC and PC2 USB-C instructions match the physical G1
- [ ] Confirm APX discovery identifies the PC2 module as Orin NX and the official archive passes the constrained extractor; record any rejected archive entry verbatim
- [ ] Review and record the displayed `flash_nx_module.sh` SHA-256, temporary working directory, and exact sudo command before approving it
- [ ] Confirm the vendor script completes successfully
- [ ] Boot normally, allow first-boot setup to finish, then verify `ping 192.168.123.164` and SSH using the documented Unitree credentials
- [ ] Update wording, checks, or hardware assumptions discovered during the walkthrough before marking ready for review
