### PR TITLE
Add ESP32-S3-AUDIO-Board realtime voice assistant example

### DIFF
--- a/Examples/ESP32-Audio-Board/.gitignore
+++ b/Examples/ESP32-Audio-Board/.gitignore
@@ -1,0 +1,12 @@
+# ESP-IDF build artifacts
+build/
+managed_components/
+dependencies.lock
+sdkconfig
+sdkconfig.old
+
+# Editor/tooling caches
+.cache/
+
+# Secrets (WiFi + OpenAI API key) — copy main/secrets.h.example instead
+main/secrets.h

--- a/Examples/ESP32-Audio-Board/CMakeLists.txt
+++ b/Examples/ESP32-Audio-Board/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Top-level project CMake for the ESP32-S3-AUDIO-Board realtime voice demo.
+cmake_minimum_required(VERSION 3.16)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(esp32-s3-audio-board-voice-assistant)

--- a/Examples/ESP32-Audio-Board/README.md
+++ b/Examples/ESP32-Audio-Board/README.md
@@ -1,0 +1,154 @@
+# ESP32-S3-AUDIO-Board — realtime voice assistant
+
+A native ESP-IDF firmware for Waveshare's [ESP32-S3-AUDIO-Board](https://docs.waveshare.com/ESP32-S3-AUDIO-Board)
+that streams microphone audio to OpenAI's Realtime API and plays the spoken
+response through the on-board speaker — the same speech-to-speech experience
+as the [`VoiceAssistant`](../VoiceAssistant) WendyOS example, running
+standalone on the ESP32 instead of on a Linux device. It uses the GA Realtime
+WebSocket interface, `gpt-realtime-2.1`, semantic voice activity detection,
+and 16 kHz mono PCM16 audio in both directions.
+
+Interruption/barge-in is enabled: speak over the assistant and it stops and
+truncates the unheard part of its reply. **This board has no dedicated echo-
+cancellation chip**, so with barge-in enabled the speaker's own output can
+leak into the mic and occasionally trigger a false interruption — there's no
+way around that on this hardware without adding an external AEC front end.
+The assistant can also change its own speaker volume, look up the weather
+anywhere via the free Open-Meteo API, and answer questions that need current
+information (news, scores, prices) via OpenAI web search.
+
+## Hardware
+
+- Waveshare ESP32-S3-AUDIO-Board (ESP32-S3R8: octal 8 MB PSRAM, 16 MB flash)
+- On-board ES7210 digital mic array + ES8311 codec + speaker amp — no extra
+  wiring needed
+- A speaker connected to the board's speaker header
+- WiFi with internet access
+
+The I2C/I2S pin map used here (`main/board_audio.h`) comes from Waveshare's
+own demo firmware, not the product docs page (which doesn't list GPIOs) —
+see `main/board_audio.c` for details and the reasoning behind each codec
+config field.
+
+## 1. Install ESP-IDF
+
+This targets `esp32s3` on ESP-IDF 5.1+ (developed and verified against
+5.5.1, matching Waveshare's own demo). Any full (non-preview) ESP-IDF
+install works:
+
+```sh
+. /path/to/esp-idf/export.sh
+```
+
+## 2. Supply WiFi and OpenAI credentials
+
+```sh
+cp main/secrets.h.example main/secrets.h
+```
+
+Edit `main/secrets.h` with your WiFi SSID/password and an OpenAI API key
+from https://platform.openai.com/api-keys. `secrets.h` is gitignored — it
+never gets committed or flashed anywhere but this one device.
+
+## 3. Build and flash
+
+```sh
+idf.py set-target esp32s3
+idf.py build
+idf.py -p /dev/cu.usbserial-XXXX flash monitor
+```
+
+When the log says `Ready - listening for your voice.`, speak normally.
+Semantic VAD ends the turn automatically and the reply plays through the
+speaker. Press `Ctrl-]` to exit the monitor.
+
+## Volume and other tools
+
+Just ask it: "set the volume to 30 percent", "turn it up", "how loud are
+you?", "what's the weather in Tokyo?", "what's in the news today?". These
+are Realtime function tools — volume goes straight to the ES8311's own
+volume register (no network involved), weather calls the free, keyless
+[Open-Meteo](https://open-meteo.com) API, and anything else that needs live
+information calls OpenAI's Responses API (`gpt-5-mini` by default) with its
+built-in web-search tool enabled, using the same `OPENAI_API_KEY`. Each web
+search bills one Responses API call on top of the Realtime session.
+
+## Configuration
+
+There's no environment-variable injection on a flashed device, so
+model/voice/instructions live as `#define`s at the top of
+`main/realtime_client.c`:
+
+| Constant | Default | Purpose |
+| --- | --- | --- |
+| `REALTIME_MODEL` | `gpt-realtime-2.1` | Realtime model |
+| `ASSISTANT_VOICE` | `marin` | Assistant voice |
+| `ASSISTANT_INSTRUCTIONS` | concise voice assistant | System instructions |
+| `BOARD_AUDIO_SAMPLE_RATE` (`board_audio.h`) | `16000` | PCM sample rate in Hz for both directions |
+| `WEB_SEARCH_MODEL` (`tools.c`) | `gpt-5-mini` | Responses API model used for web searches |
+
+## How it works
+
+`board_audio_read()` pulls 100 ms mono PCM16 chunks straight off the ES7210
+mic (`main/board_audio.c`, built on `esp_codec_dev`). A dedicated FreeRTOS
+task base64-encodes each chunk into `input_audio_buffer.append` events over
+one authenticated WebSocket (`esp_websocket_client`, TLS via ESP-IDF's cert
+bundle). OpenAI's semantic VAD creates each response; returned
+`response.output_audio.delta` chunks are base64-decoded and queued to a
+playback task that writes them straight to the ES8311 speaker — no temporary
+files, no resampling (mic, speaker, and the Realtime session all run at the
+board's native 16 kHz).
+
+Barge-in works by tracking how much of the current reply has actually played
+(via `esp_timer_get_time()`) so that when `input_audio_buffer.speech_started`
+arrives mid-reply, the firmware can drop the queued-but-unplayed audio and
+send `conversation.item.truncate` with an accurate `audio_end_ms`, mirroring
+`VoiceAssistant`'s approach. One simplification versus that app: playback is
+considered "done" immediately at `response.done` rather than delayed until
+the last queued chunk's exact deadline — the only user-visible effect is
+that speech starting in the last ~100-300 ms tail of a reply won't trigger an
+explicit truncate (the tail just finishes playing, which is inaudible).
+
+Tool calling drives everything beyond conversation (`main/tools.c`): the
+session registers `set_volume`, `adjust_volume`, `get_volume`, `get_weather`,
+and `web_search` function tools. Each `function_call` item is handled on its
+own short-lived FreeRTOS task so a slow HTTP request (weather/search) never
+blocks the WebSocket receive loop or barge-in detection. The result goes back
+as `function_call_output` followed by `response.create` — unless the user is
+already talking again.
+
+This follows OpenAI's current [Realtime WebSocket
+guide](https://developers.openai.com/api/docs/guides/realtime-websocket) and
+[Realtime conversation event
+flow](https://developers.openai.com/api/docs/guides/realtime-conversations).
+
+The API key is baked into the flashed firmware, which is appropriate here
+because the device is a trusted, single-purpose client you control — not a
+browser or mobile app. Don't reuse this pattern in code that ships to
+end-user devices you don't control.
+
+## Local checks
+
+A few pure-C helpers (WMO weather-code lookup, citation stripping) have no
+ESP-IDF dependency and can be tested off-target:
+
+```sh
+cd test
+./run_tests.sh
+```
+
+Everything else — audio, WiFi, the actual Realtime session, barge-in — is
+hardware-in-the-loop and hasn't been verified against real silicon yet.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `main/board_audio.c/.h` | I2C/I2S/ES7210/ES8311 bring-up, mono 16 kHz read/write, volume |
+| `main/wifi_connect.c/.h` | Blocking WiFi station connect |
+| `main/realtime_client.c/.h` | WebSocket session, mic/playback tasks, barge-in, tool-call dispatch |
+| `main/tools.c/.h` | Function-tool specs + execution (volume, weather, web search) |
+| `main/weather_codes.c/.h` | WMO weather-code → spoken text (host-testable) |
+| `main/text_utils.c/.h` | Web-search citation stripping (host-testable) |
+| `main/secrets.h.example` | Copy to `secrets.h` (gitignored) and fill in credentials |
+| `test/` | Host-buildable unit tests for the pure-C helpers |

--- a/Examples/ESP32-Audio-Board/main/CMakeLists.txt
+++ b/Examples/ESP32-Audio-Board/main/CMakeLists.txt
@@ -1,0 +1,26 @@
+idf_component_register(
+    SRCS
+        "main.c"
+        "board_audio.c"
+        "wifi_connect.c"
+        "realtime_client.c"
+        "tools.c"
+        "weather_codes.c"
+        "text_utils.c"
+    INCLUDE_DIRS "."
+    REQUIRES
+        esp_wifi
+        esp_netif
+        esp_event
+        nvs_flash
+        json
+        esp_http_client
+        esp-tls
+        mbedtls
+        esp_codec_dev
+        esp_websocket_client
+        esp_driver_gpio
+        esp_driver_i2c
+        esp_driver_i2s
+        esp_timer
+)

--- a/Examples/ESP32-Audio-Board/main/board_audio.c
+++ b/Examples/ESP32-Audio-Board/main/board_audio.c
@@ -1,0 +1,262 @@
+// I2C/I2S/codec bring-up for the ESP32-S3-AUDIO-Board's ES7210 (mic) and
+// ES8311 (speaker) codecs. Ported from Waveshare's own demo firmware
+// (ESP32-S3-AUDIO-Board-Demo.zip, main/hardeware_driver/bsp_board.c) for the
+// verified pin map, then simplified to a single mono 16 kHz PCM16 stream in
+// each direction (the demo drives a raw 4-mic array for on-chip wake-word
+// detection, which this app doesn't need) and rewritten against the current
+// esp_codec_dev 1.6.x API, which reshaped the ES7210/ES8311 config structs
+// since the demo (mic selection moved from a `mic_selected` codec field to
+// `esp_codec_dev_sample_info_t.channel_mask`; PA/clock config moved into
+// shared `audio_hw_*_cfg_t` sub-structs).
+
+#include "board_audio.h"
+
+#include "driver/gpio.h"
+#include "driver/i2c_master.h"
+#include "driver/i2s_std.h"
+#include "esp_codec_dev.h"
+#include "esp_codec_dev_defaults.h"
+#include "esp_log.h"
+
+static const char *TAG = "board_audio";
+
+static i2c_master_bus_handle_t s_i2c_bus;
+static i2s_chan_handle_t s_i2s_tx;
+static i2s_chan_handle_t s_i2s_rx;
+static esp_codec_dev_handle_t s_mic_dev;
+static esp_codec_dev_handle_t s_speaker_dev;
+
+static esp_err_t init_i2c(void) {
+    i2c_master_bus_config_t bus_cfg = {
+        .i2c_port = I2C_NUM_0,
+        .sda_io_num = BOARD_AUDIO_I2C_SDA,
+        .scl_io_num = BOARD_AUDIO_I2C_SCL,
+        .clk_source = I2C_CLK_SRC_DEFAULT,
+        .glitch_ignore_cnt = 7,
+        .flags.enable_internal_pullup = true,
+    };
+    return i2c_new_master_bus(&bus_cfg, &s_i2c_bus);
+}
+
+static esp_err_t init_i2s(void) {
+    i2s_chan_config_t chan_cfg =
+        I2S_CHANNEL_DEFAULT_CONFIG(I2S_NUM_1, I2S_ROLE_MASTER);
+    esp_err_t err = i2s_new_channel(&chan_cfg, &s_i2s_tx, &s_i2s_rx);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    // Physical bus: 32-bit stereo Philips slots at the board's native
+    // 16 kHz — this is the verified working configuration from Waveshare's
+    // demo. esp_codec_dev handles the conversion down to the mono 16-bit
+    // application format we request per-codec below.
+    i2s_std_config_t std_cfg = {
+        .clk_cfg = I2S_STD_CLK_DEFAULT_CONFIG(BOARD_AUDIO_SAMPLE_RATE),
+        .slot_cfg =
+            I2S_STD_PHILIPS_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_32BIT,
+                                                 I2S_SLOT_MODE_STEREO),
+        .gpio_cfg =
+            {
+                .mclk = BOARD_AUDIO_I2S_MCLK,
+                .bclk = BOARD_AUDIO_I2S_BCLK,
+                .ws = BOARD_AUDIO_I2S_WS,
+                .dout = BOARD_AUDIO_I2S_DOUT,
+                .din = BOARD_AUDIO_I2S_DIN,
+            },
+    };
+
+    err = i2s_channel_init_std_mode(s_i2s_tx, &std_cfg);
+    if (err != ESP_OK) {
+        return err;
+    }
+    err = i2s_channel_init_std_mode(s_i2s_rx, &std_cfg);
+    if (err != ESP_OK) {
+        return err;
+    }
+    err = i2s_channel_enable(s_i2s_tx);
+    if (err != ESP_OK) {
+        return err;
+    }
+    return i2s_channel_enable(s_i2s_rx);
+}
+
+static esp_err_t init_mic(void) {
+    audio_codec_i2s_cfg_t i2s_cfg = {
+        .port = I2S_NUM_1,
+        .rx_handle = s_i2s_rx,
+        .tx_handle = NULL,
+    };
+    const audio_codec_data_if_t *data_if = audio_codec_new_i2s_data(&i2s_cfg);
+    if (!data_if) {
+        ESP_LOGE(TAG, "audio_codec_new_i2s_data (mic) failed");
+        return ESP_FAIL;
+    }
+
+    audio_codec_i2c_cfg_t i2c_cfg = {
+        .port = I2C_NUM_0,
+        .addr = ES7210_CODEC_DEFAULT_ADDR,
+        .bus_handle = s_i2c_bus,
+    };
+    const audio_codec_ctrl_if_t *ctrl_if = audio_codec_new_i2c_ctrl(&i2c_cfg);
+    if (!ctrl_if) {
+        ESP_LOGE(TAG, "audio_codec_new_i2c_ctrl (ES7210) failed");
+        return ESP_FAIL;
+    }
+
+    es7210_codec_cfg_t es7210_cfg = {
+        .ctrl_if = ctrl_if,
+        .master_mode = false, // ESP32 I2S is the bus master
+        .mic_selected = ES7210_SEL_MIC1, // single mono mic; no beamforming needed
+        .mclk_src = ES7210_MCLK_FROM_PAD, // ES7210 uses the shared external MCLK
+    };
+    const audio_codec_if_t *codec_if = es7210_codec_new(&es7210_cfg);
+    if (!codec_if) {
+        ESP_LOGE(TAG, "es7210_codec_new failed");
+        return ESP_FAIL;
+    }
+
+    esp_codec_dev_cfg_t dev_cfg = {
+        .dev_type = ESP_CODEC_DEV_TYPE_IN,
+        .codec_if = codec_if,
+        .data_if = data_if,
+    };
+    s_mic_dev = esp_codec_dev_new(&dev_cfg);
+    if (!s_mic_dev) {
+        ESP_LOGE(TAG, "esp_codec_dev_new (mic) failed");
+        return ESP_FAIL;
+    }
+
+    esp_codec_dev_sample_info_t fs = {
+        .bits_per_sample = 16,
+        .channel = 1,
+        .sample_rate = BOARD_AUDIO_SAMPLE_RATE,
+    };
+    int ret = esp_codec_dev_open(s_mic_dev, &fs);
+    if (ret != ESP_CODEC_DEV_OK) {
+        ESP_LOGE(TAG, "esp_codec_dev_open (mic) failed: %d", ret);
+        return ESP_FAIL;
+    }
+    return ESP_OK;
+}
+
+static esp_err_t init_speaker(void) {
+    audio_codec_i2s_cfg_t i2s_cfg = {
+        .port = I2S_NUM_1,
+        .rx_handle = NULL,
+        .tx_handle = s_i2s_tx,
+    };
+    const audio_codec_data_if_t *data_if = audio_codec_new_i2s_data(&i2s_cfg);
+    if (!data_if) {
+        ESP_LOGE(TAG, "audio_codec_new_i2s_data (speaker) failed");
+        return ESP_FAIL;
+    }
+
+    audio_codec_i2c_cfg_t i2c_cfg = {
+        .port = I2C_NUM_0,
+        .addr = ES8311_CODEC_DEFAULT_ADDR,
+        .bus_handle = s_i2c_bus,
+    };
+    const audio_codec_ctrl_if_t *ctrl_if = audio_codec_new_i2c_ctrl(&i2c_cfg);
+    if (!ctrl_if) {
+        ESP_LOGE(TAG, "audio_codec_new_i2c_ctrl (ES8311) failed");
+        return ESP_FAIL;
+    }
+
+    const audio_codec_gpio_if_t *gpio_if = audio_codec_new_gpio();
+    if (!gpio_if) {
+        ESP_LOGE(TAG, "audio_codec_new_gpio failed");
+        return ESP_FAIL;
+    }
+
+    es8311_codec_cfg_t es8311_cfg = {
+        .ctrl_if = ctrl_if,
+        .gpio_if = gpio_if,
+        .codec_mode = ESP_CODEC_DEV_WORK_MODE_DAC, // speaker output only
+        .pa_pin = -1, // no ESP32 GPIO gates the amp; ES8311 drives its own
+                      // PA-enable pin internally over I2C
+        .master_mode = false,
+        // Waveshare's verified demo runs ES8311 with use_mclk=false (clock
+        // derived from BCLK) even though MCLK is physically wired to it.
+        .use_mclk = false,
+    };
+    const audio_codec_if_t *codec_if = es8311_codec_new(&es8311_cfg);
+    if (!codec_if) {
+        ESP_LOGE(TAG, "es8311_codec_new failed");
+        return ESP_FAIL;
+    }
+
+    esp_codec_dev_cfg_t dev_cfg = {
+        .dev_type = ESP_CODEC_DEV_TYPE_OUT,
+        .codec_if = codec_if,
+        .data_if = data_if,
+    };
+    s_speaker_dev = esp_codec_dev_new(&dev_cfg);
+    if (!s_speaker_dev) {
+        ESP_LOGE(TAG, "esp_codec_dev_new (speaker) failed");
+        return ESP_FAIL;
+    }
+
+    esp_codec_dev_sample_info_t fs = {
+        .bits_per_sample = 16,
+        .channel = 1,
+        .sample_rate = BOARD_AUDIO_SAMPLE_RATE,
+    };
+    int ret = esp_codec_dev_open(s_speaker_dev, &fs);
+    if (ret != ESP_CODEC_DEV_OK) {
+        ESP_LOGE(TAG, "esp_codec_dev_open (speaker) failed: %d", ret);
+        return ESP_FAIL;
+    }
+    return ESP_OK;
+}
+
+esp_err_t board_audio_init(void) {
+    esp_err_t err = init_i2c();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "I2C init failed: %s", esp_err_to_name(err));
+        return err;
+    }
+    err = init_i2s();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "I2S init failed: %s", esp_err_to_name(err));
+        return err;
+    }
+    err = init_mic();
+    if (err != ESP_OK) {
+        return err;
+    }
+    err = init_speaker();
+    if (err != ESP_OK) {
+        return err;
+    }
+    ESP_LOGI(TAG, "Audio ready: mono PCM16 @ %d Hz", BOARD_AUDIO_SAMPLE_RATE);
+    return ESP_OK;
+}
+
+esp_err_t board_audio_read(int16_t *buffer, size_t frames, size_t *frames_read) {
+    int ret = esp_codec_dev_read(s_mic_dev, buffer, (int)(frames * sizeof(int16_t)));
+    if (ret != ESP_CODEC_DEV_OK) {
+        *frames_read = 0;
+        return ESP_FAIL;
+    }
+    *frames_read = frames;
+    return ESP_OK;
+}
+
+esp_err_t board_audio_write(const int16_t *buffer, size_t frames) {
+    int ret = esp_codec_dev_write(s_speaker_dev, (void *)buffer,
+                                   (int)(frames * sizeof(int16_t)));
+    return ret == ESP_CODEC_DEV_OK ? ESP_OK : ESP_FAIL;
+}
+
+esp_err_t board_audio_set_volume(int percent) {
+    if (percent < 0 || percent > 100) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    int ret = esp_codec_dev_set_out_vol(s_speaker_dev, percent);
+    return ret == ESP_CODEC_DEV_OK ? ESP_OK : ESP_FAIL;
+}
+
+esp_err_t board_audio_get_volume(int *percent) {
+    int ret = esp_codec_dev_get_out_vol(s_speaker_dev, percent);
+    return ret == ESP_CODEC_DEV_OK ? ESP_OK : ESP_FAIL;
+}

--- a/Examples/ESP32-Audio-Board/main/board_audio.h
+++ b/Examples/ESP32-Audio-Board/main/board_audio.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Pin map verified against Waveshare's own ESP32-S3-AUDIO-Board demo firmware
+// (bsp_board.h in ESP32-S3-AUDIO-Board-Demo.zip) — the product docs page does
+// not list GPIOs, so this is the authoritative source.
+#define BOARD_AUDIO_I2C_SDA GPIO_NUM_11
+#define BOARD_AUDIO_I2C_SCL GPIO_NUM_10
+#define BOARD_AUDIO_I2S_MCLK GPIO_NUM_12
+#define BOARD_AUDIO_I2S_BCLK GPIO_NUM_13
+#define BOARD_AUDIO_I2S_WS GPIO_NUM_14
+#define BOARD_AUDIO_I2S_DIN GPIO_NUM_15  // from ES7210 mic ADC
+#define BOARD_AUDIO_I2S_DOUT GPIO_NUM_16 // to ES8311 speaker DAC
+
+#define BOARD_AUDIO_SAMPLE_RATE 16000
+
+// Brings up the I2C control bus, the shared full-duplex I2S bus, and the
+// ES7210 (mic-in) / ES8311 (speaker-out) codecs as mono 16-bit PCM at
+// BOARD_AUDIO_SAMPLE_RATE. Fatal on failure — audio is this app's whole job.
+esp_err_t board_audio_init(void);
+
+// Blocking read of `frames` mono PCM16 samples from the mic. Returns the
+// number of samples actually read in *frames_read (may be less on error).
+esp_err_t board_audio_read(int16_t *buffer, size_t frames, size_t *frames_read);
+
+// Blocking write of `frames` mono PCM16 samples to the speaker.
+esp_err_t board_audio_write(const int16_t *buffer, size_t frames);
+
+// Speaker volume as a 0-100 percentage (ES8311's own volume register).
+esp_err_t board_audio_set_volume(int percent);
+esp_err_t board_audio_get_volume(int *percent);
+
+#ifdef __cplusplus
+}
+#endif

--- a/Examples/ESP32-Audio-Board/main/idf_component.yml
+++ b/Examples/ESP32-Audio-Board/main/idf_component.yml
@@ -1,0 +1,4 @@
+dependencies:
+  idf: ">=5.1"
+  espressif/esp_codec_dev: "^1.6.2"
+  espressif/esp_websocket_client: "^1.8.0"

--- a/Examples/ESP32-Audio-Board/main/main.c
+++ b/Examples/ESP32-Audio-Board/main/main.c
@@ -1,0 +1,23 @@
+#include "esp_log.h"
+#include "nvs_flash.h"
+
+#include "board_audio.h"
+#include "realtime_client.h"
+#include "wifi_connect.h"
+
+static const char *TAG = "main";
+
+void app_main(void) {
+    esp_err_t ret = nvs_flash_init();
+    if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+        ESP_ERROR_CHECK(nvs_flash_erase());
+        ret = nvs_flash_init();
+    }
+    ESP_ERROR_CHECK(ret);
+
+    ESP_ERROR_CHECK(board_audio_init());
+    ESP_ERROR_CHECK(wifi_connect());
+    ESP_ERROR_CHECK(realtime_client_start());
+
+    ESP_LOGI(TAG, "Voice assistant running. Speak naturally.");
+}

--- a/Examples/ESP32-Audio-Board/main/realtime_client.c
+++ b/Examples/ESP32-Audio-Board/main/realtime_client.c
@@ -1,0 +1,540 @@
+// OpenAI Realtime WebSocket session: connects, negotiates the session,
+// pumps mic audio in, plays speaker audio out, and dispatches function-tool
+// calls. Mirrors VoiceAssistant's app.py, adapted to FreeRTOS tasks instead
+// of asyncio coroutines.
+
+#include "realtime_client.h"
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "board_audio.h"
+#include "cJSON.h"
+#include "esp_crt_bundle.h"
+#include "esp_log.h"
+#include "esp_timer.h"
+#include "esp_websocket_client.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/queue.h"
+#include "freertos/semphr.h"
+#include "freertos/task.h"
+#include "mbedtls/base64.h"
+#include "secrets.h"
+#include "tools.h"
+
+static const char *TAG = "realtime";
+
+#define REALTIME_MODEL "gpt-realtime-2.1"
+#define ASSISTANT_VOICE "marin"
+#define ASSISTANT_INSTRUCTIONS                                               \
+    "You are a friendly voice assistant running on an ESP32 microcontroller. "\
+    "Be conversational, helpful, and concise. Reply in the language the "    \
+    "user speaks. You can change your own speaker volume, look up the "      \
+    "current weather and forecast anywhere, and search the web for "        \
+    "up-to-date information with the provided tools."
+
+#define MIC_CHUNK_MS 100
+#define MIC_CHUNK_FRAMES (BOARD_AUDIO_SAMPLE_RATE * MIC_CHUNK_MS / 1000)
+#define PLAYBACK_QUEUE_LEN 32
+#define RX_MAX_BYTES (64 * 1024)
+
+typedef struct {
+    int16_t *pcm;
+    size_t frames;
+} playback_chunk_t;
+
+static esp_websocket_client_handle_t s_client;
+static SemaphoreHandle_t s_send_mutex;
+static QueueHandle_t s_playback_queue;
+static char s_ws_headers[128];
+
+// Incoming-message reassembly (esp_websocket_client delivers large text
+// frames across multiple WEBSOCKET_EVENT_DATA callbacks).
+static uint8_t *s_rx_buf;
+static size_t s_rx_len;
+static size_t s_rx_cap;
+
+// Playback/barge-in bookkeeping. Only ever touched from the WebSocket
+// client's own event-dispatch task, so no locking is needed here.
+static bool s_assistant_speaking;
+static bool s_user_speaking;
+static char *s_current_item_id;
+static int s_current_content_index;
+static char *s_interrupted_item_id;
+static int64_t s_playback_started_at_us;
+static double s_playback_audio_seconds;
+static int64_t s_playback_deadline_us;
+
+// Accumulates response.output_audio_transcript.delta for one log line per
+// reply, instead of interleaved partial logs.
+static char *s_transcript_buf;
+static size_t s_transcript_len;
+static size_t s_transcript_cap;
+
+static void set_str(char **dst, const char *src) {
+    free(*dst);
+    *dst = src ? strdup(src) : NULL;
+}
+
+// ---------------------------------------------------------------------------
+// Outbound sends
+// ---------------------------------------------------------------------------
+
+// Takes ownership of `msg` (always deletes it). Safe to call concurrently
+// from the mic task, tool-call tasks, and the WebSocket event callback.
+static void send_json(cJSON *msg) {
+    char *text = cJSON_PrintUnformatted(msg);
+    cJSON_Delete(msg);
+    if (!text) {
+        return;
+    }
+    if (s_client && esp_websocket_client_is_connected(s_client)) {
+        xSemaphoreTake(s_send_mutex, portMAX_DELAY);
+        esp_websocket_client_send_text(s_client, text, (int)strlen(text),
+                                        pdMS_TO_TICKS(2000));
+        xSemaphoreGive(s_send_mutex);
+    }
+    free(text);
+}
+
+static void send_session_update(void) {
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddStringToObject(root, "type", "session.update");
+
+    cJSON *session = cJSON_CreateObject();
+    cJSON_AddStringToObject(session, "type", "realtime");
+    cJSON_AddStringToObject(session, "model", REALTIME_MODEL);
+    cJSON *modalities = cJSON_CreateArray();
+    cJSON_AddItemToArray(modalities, cJSON_CreateString("audio"));
+    cJSON_AddItemToObject(session, "output_modalities", modalities);
+    cJSON_AddStringToObject(session, "instructions", ASSISTANT_INSTRUCTIONS);
+    cJSON_AddItemToObject(session, "tools", tools_build_specs());
+    cJSON_AddStringToObject(session, "tool_choice", "auto");
+
+    cJSON *audio = cJSON_CreateObject();
+
+    cJSON *input = cJSON_CreateObject();
+    cJSON *input_format = cJSON_CreateObject();
+    cJSON_AddStringToObject(input_format, "type", "audio/pcm");
+    cJSON_AddNumberToObject(input_format, "rate", BOARD_AUDIO_SAMPLE_RATE);
+    cJSON_AddItemToObject(input, "format", input_format);
+    cJSON *turn_detection = cJSON_CreateObject();
+    cJSON_AddStringToObject(turn_detection, "type", "semantic_vad");
+    cJSON_AddBoolToObject(turn_detection, "create_response", true);
+    cJSON_AddBoolToObject(turn_detection, "interrupt_response", true);
+    cJSON_AddItemToObject(input, "turn_detection", turn_detection);
+    cJSON_AddItemToObject(audio, "input", input);
+
+    cJSON *output = cJSON_CreateObject();
+    cJSON *output_format = cJSON_CreateObject();
+    cJSON_AddStringToObject(output_format, "type", "audio/pcm");
+    cJSON_AddNumberToObject(output_format, "rate", BOARD_AUDIO_SAMPLE_RATE);
+    cJSON_AddItemToObject(output, "format", output_format);
+    cJSON_AddStringToObject(output, "voice", ASSISTANT_VOICE);
+    cJSON_AddItemToObject(audio, "output", output);
+
+    cJSON_AddItemToObject(session, "audio", audio);
+    cJSON_AddItemToObject(root, "session", session);
+    send_json(root);
+}
+
+// ---------------------------------------------------------------------------
+// Transcript accumulation
+// ---------------------------------------------------------------------------
+
+static void transcript_append(const char *delta) {
+    size_t add_len = strlen(delta);
+    size_t need = s_transcript_len + add_len + 1;
+    if (need > s_transcript_cap) {
+        size_t new_cap = need + need / 2;
+        char *grown = realloc(s_transcript_buf, new_cap);
+        if (!grown) {
+            return;
+        }
+        s_transcript_buf = grown;
+        s_transcript_cap = new_cap;
+    }
+    memcpy(s_transcript_buf + s_transcript_len, delta, add_len);
+    s_transcript_len += add_len;
+    s_transcript_buf[s_transcript_len] = '\0';
+}
+
+static void transcript_reset(void) {
+    s_transcript_len = 0;
+    if (s_transcript_buf) {
+        s_transcript_buf[0] = '\0';
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mic capture + speaker playback tasks
+// ---------------------------------------------------------------------------
+
+static void mic_task(void *arg) {
+    (void)arg;
+    int16_t pcm[MIC_CHUNK_FRAMES];
+    size_t b64_cap = 4 * ((sizeof(pcm) + 2) / 3) + 1;
+    char *b64 = malloc(b64_cap);
+
+    for (;;) {
+        size_t frames_read = 0;
+        if (board_audio_read(pcm, MIC_CHUNK_FRAMES, &frames_read) != ESP_OK ||
+            frames_read == 0) {
+            vTaskDelay(pdMS_TO_TICKS(10));
+            continue;
+        }
+        if (!s_client || !esp_websocket_client_is_connected(s_client)) {
+            continue; // drop mic frames while disconnected
+        }
+        size_t olen = 0;
+        mbedtls_base64_encode((unsigned char *)b64, b64_cap, &olen,
+                               (const unsigned char *)pcm,
+                               frames_read * sizeof(int16_t));
+        b64[olen] = '\0';
+
+        cJSON *msg = cJSON_CreateObject();
+        cJSON_AddStringToObject(msg, "type", "input_audio_buffer.append");
+        cJSON_AddStringToObject(msg, "audio", b64);
+        send_json(msg);
+    }
+}
+
+static void playback_task(void *arg) {
+    (void)arg;
+    playback_chunk_t chunk;
+    for (;;) {
+        if (xQueueReceive(s_playback_queue, &chunk, portMAX_DELAY) == pdTRUE) {
+            board_audio_write(chunk.pcm, chunk.frames);
+            free(chunk.pcm);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Barge-in
+// ---------------------------------------------------------------------------
+
+static void handle_interrupt(void) {
+    int64_t now = esp_timer_get_time();
+    double played_s = s_playback_audio_seconds;
+    if (s_playback_started_at_us > 0) {
+        double elapsed_s = (double)(now - s_playback_started_at_us) / 1e6;
+        if (elapsed_s < played_s) {
+            played_s = elapsed_s;
+        }
+    }
+
+    // Drain queued-but-not-yet-played chunks. Whatever's already in the I2S
+    // DMA buffer still plays out — a small, bounded residual (there's no
+    // AEC chip on this board, so this is the tradeoff of enabling barge-in).
+    playback_chunk_t chunk;
+    while (xQueueReceive(s_playback_queue, &chunk, 0) == pdTRUE) {
+        free(chunk.pcm);
+    }
+    s_assistant_speaking = false;
+
+    if (s_current_item_id && s_client && esp_websocket_client_is_connected(s_client)) {
+        cJSON *msg = cJSON_CreateObject();
+        cJSON_AddStringToObject(msg, "type", "conversation.item.truncate");
+        cJSON_AddStringToObject(msg, "item_id", s_current_item_id);
+        cJSON_AddNumberToObject(msg, "content_index", s_current_content_index);
+        cJSON_AddNumberToObject(msg, "audio_end_ms", (int)(played_s * 1000));
+        send_json(msg);
+    }
+    ESP_LOGI(TAG, "Interrupted - listening...");
+
+    set_str(&s_interrupted_item_id, s_current_item_id);
+    set_str(&s_current_item_id, NULL);
+    s_current_content_index = 0;
+    s_playback_deadline_us = 0;
+    s_playback_started_at_us = 0;
+    s_playback_audio_seconds = 0;
+}
+
+// ---------------------------------------------------------------------------
+// Tool calls
+// ---------------------------------------------------------------------------
+
+typedef struct {
+    char *name;
+    char *arguments_json;
+    char *call_id;
+} tool_call_ctx_t;
+
+static void tool_call_task(void *arg) {
+    tool_call_ctx_t *ctx = (tool_call_ctx_t *)arg;
+
+    cJSON *result = tools_execute(ctx->name, ctx->arguments_json);
+    char *result_text = cJSON_PrintUnformatted(result);
+    cJSON_Delete(result);
+    ESP_LOGI(TAG, "Tool %s(%s) -> %s", ctx->name,
+             ctx->arguments_json ? ctx->arguments_json : "",
+             result_text ? result_text : "(no result)");
+
+    cJSON *msg = cJSON_CreateObject();
+    cJSON_AddStringToObject(msg, "type", "conversation.item.create");
+    cJSON *item = cJSON_CreateObject();
+    cJSON_AddStringToObject(item, "type", "function_call_output");
+    cJSON_AddStringToObject(item, "call_id", ctx->call_id);
+    cJSON_AddStringToObject(item, "output", result_text ? result_text : "{}");
+    cJSON_AddItemToObject(msg, "item", item);
+    send_json(msg);
+    free(result_text);
+
+    // The output is in the conversation; the model's next turn will see it.
+    // Forcing a response now would race semantic VAD's turn taking.
+    if (!s_user_speaking) {
+        cJSON *resp = cJSON_CreateObject();
+        cJSON_AddStringToObject(resp, "type", "response.create");
+        send_json(resp);
+    } else {
+        ESP_LOGI(TAG, "User is speaking; deferring the spoken tool result");
+    }
+
+    free(ctx->name);
+    free(ctx->arguments_json);
+    free(ctx->call_id);
+    free(ctx);
+    vTaskDelete(NULL);
+}
+
+// Runs on its own task so a slow tool call (weather/search HTTP requests)
+// never blocks the WebSocket receive loop or barge-in detection.
+static void dispatch_tool_call(cJSON *item) {
+    cJSON *name_item = cJSON_GetObjectItem(item, "name");
+    cJSON *call_id_item = cJSON_GetObjectItem(item, "call_id");
+    cJSON *args_item = cJSON_GetObjectItem(item, "arguments");
+    if (!cJSON_IsString(name_item) || !cJSON_IsString(call_id_item)) {
+        return;
+    }
+
+    tool_call_ctx_t *ctx = calloc(1, sizeof(tool_call_ctx_t));
+    if (!ctx) {
+        return;
+    }
+    ctx->name = strdup(name_item->valuestring);
+    ctx->arguments_json =
+        strdup(cJSON_IsString(args_item) ? args_item->valuestring : "");
+    ctx->call_id = strdup(call_id_item->valuestring);
+    xTaskCreate(tool_call_task, "tool_call", 8192, ctx, 5, NULL);
+}
+
+// ---------------------------------------------------------------------------
+// Realtime event dispatch
+// ---------------------------------------------------------------------------
+
+static void handle_audio_delta(cJSON *event) {
+    cJSON *item_id_item = cJSON_GetObjectItem(event, "item_id");
+    const char *item_id =
+        cJSON_IsString(item_id_item) ? item_id_item->valuestring : NULL;
+
+    if (item_id && s_interrupted_item_id &&
+        strcmp(item_id, s_interrupted_item_id) == 0) {
+        return; // stale audio for an item we already truncated
+    }
+    if (item_id && (!s_current_item_id || strcmp(item_id, s_current_item_id) != 0)) {
+        set_str(&s_current_item_id, item_id);
+        cJSON *content_index_item = cJSON_GetObjectItem(event, "content_index");
+        s_current_content_index =
+            cJSON_IsNumber(content_index_item) ? content_index_item->valueint : 0;
+        s_playback_started_at_us = 0;
+        s_playback_audio_seconds = 0;
+        s_playback_deadline_us = 0;
+        set_str(&s_interrupted_item_id, NULL);
+    }
+
+    cJSON *delta_item = cJSON_GetObjectItem(event, "delta");
+    if (!cJSON_IsString(delta_item)) {
+        return;
+    }
+    const char *b64 = delta_item->valuestring;
+    size_t b64_len = strlen(b64);
+    size_t max_decoded = b64_len * 3 / 4 + 4;
+    unsigned char *pcm_bytes = malloc(max_decoded);
+    if (!pcm_bytes) {
+        return;
+    }
+    size_t decoded_len = 0;
+    if (mbedtls_base64_decode(pcm_bytes, max_decoded, &decoded_len,
+                               (const unsigned char *)b64, b64_len) != 0) {
+        free(pcm_bytes);
+        return;
+    }
+
+    s_assistant_speaking = true;
+    int64_t now = esp_timer_get_time();
+    if (s_playback_started_at_us == 0) {
+        s_playback_started_at_us = now;
+    }
+    double duration_s = (double)decoded_len / 2.0 / BOARD_AUDIO_SAMPLE_RATE;
+    s_playback_audio_seconds += duration_s;
+    int64_t duration_us = (int64_t)(duration_s * 1e6);
+    s_playback_deadline_us =
+        (now > s_playback_deadline_us ? now : s_playback_deadline_us) + duration_us;
+
+    playback_chunk_t chunk = {.pcm = (int16_t *)pcm_bytes, .frames = decoded_len / 2};
+    if (xQueueSend(s_playback_queue, &chunk, 0) != pdTRUE) {
+        ESP_LOGW(TAG, "Playback queue full; dropping a chunk");
+        free(pcm_bytes);
+    }
+}
+
+static void handle_realtime_event(cJSON *event) {
+    cJSON *type_item = cJSON_GetObjectItem(event, "type");
+    const char *type = cJSON_IsString(type_item) ? type_item->valuestring : "";
+
+    if (strcmp(type, "session.updated") == 0) {
+        ESP_LOGI(TAG, "Ready - listening for your voice.");
+    } else if (strcmp(type, "input_audio_buffer.speech_started") == 0) {
+        s_user_speaking = true;
+        if (s_assistant_speaking) {
+            handle_interrupt();
+        } else {
+            ESP_LOGI(TAG, "Listening...");
+        }
+    } else if (strcmp(type, "input_audio_buffer.speech_stopped") == 0) {
+        s_user_speaking = false;
+        ESP_LOGI(TAG, "Thinking...");
+    } else if (strcmp(type, "response.output_item.done") == 0) {
+        cJSON *item = cJSON_GetObjectItem(event, "item");
+        cJSON *item_type = cJSON_GetObjectItem(item, "type");
+        if (cJSON_IsString(item_type) && strcmp(item_type->valuestring, "function_call") == 0) {
+            dispatch_tool_call(item);
+        }
+    } else if (strcmp(type, "response.output_audio.delta") == 0) {
+        handle_audio_delta(event);
+    } else if (strcmp(type, "response.output_audio_transcript.delta") == 0) {
+        cJSON *delta = cJSON_GetObjectItem(event, "delta");
+        if (cJSON_IsString(delta)) {
+            transcript_append(delta->valuestring);
+        }
+    } else if (strcmp(type, "response.done") == 0) {
+        if (s_transcript_len > 0) {
+            ESP_LOGI(TAG, "Assistant: %s", s_transcript_buf);
+        }
+        transcript_reset();
+        // Simplification vs. VoiceAssistant: that app delays clearing
+        // "assistant speaking" until the last queued chunk's playback
+        // deadline, so a very-late barge-in still gets a truncate message.
+        // Here we clear immediately — the only cost is that speech starting
+        // in the last ~100-300ms tail of a reply won't send a truncate (the
+        // tail just finishes playing), which is inaudible in practice.
+        s_assistant_speaking = false;
+    } else if (strcmp(type, "error") == 0) {
+        cJSON *error = cJSON_GetObjectItem(event, "error");
+        cJSON *message = cJSON_GetObjectItem(error, "message");
+        ESP_LOGW(TAG, "Realtime API error: %s",
+                 cJSON_IsString(message) ? message->valuestring : "unknown");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Incoming-frame reassembly
+// ---------------------------------------------------------------------------
+
+// Appends one fragment at `offset` and grows the buffer to always have room
+// for a trailing NUL. Returns false (and drops the in-progress message) on
+// allocation failure or if the assembled message would exceed RX_MAX_BYTES.
+static bool rx_append(const char *data, size_t len, size_t offset) {
+    size_t need = offset + len;
+    if (need + 1 > RX_MAX_BYTES) {
+        ESP_LOGW(TAG, "Incoming message too large (%u bytes); dropping",
+                 (unsigned)need);
+        s_rx_len = 0;
+        return false;
+    }
+    if (need + 1 > s_rx_cap) {
+        size_t new_cap = (need + 1) + (need + 1) / 2;
+        uint8_t *grown = realloc(s_rx_buf, new_cap);
+        if (!grown) {
+            s_rx_len = 0;
+            return false;
+        }
+        s_rx_buf = grown;
+        s_rx_cap = new_cap;
+    }
+    memcpy(s_rx_buf + offset, data, len);
+    s_rx_len = need;
+    return true;
+}
+
+static void ws_event_handler(void *handler_args, esp_event_base_t base,
+                              int32_t event_id, void *event_data) {
+    (void)handler_args;
+    (void)base;
+    esp_websocket_event_data_t *data = (esp_websocket_event_data_t *)event_data;
+
+    switch (event_id) {
+    case WEBSOCKET_EVENT_CONNECTED:
+        ESP_LOGI(TAG, "WebSocket connected; sending session.update");
+        send_session_update();
+        break;
+    case WEBSOCKET_EVENT_DISCONNECTED:
+        ESP_LOGW(TAG, "WebSocket disconnected; will auto-reconnect");
+        s_assistant_speaking = false;
+        s_user_speaking = false;
+        set_str(&s_current_item_id, NULL);
+        set_str(&s_interrupted_item_id, NULL);
+        s_rx_len = 0;
+        break;
+    case WEBSOCKET_EVENT_DATA:
+        if (data->data_len <= 0 || data->payload_len <= 0) {
+            break;
+        }
+        if (!rx_append(data->data_ptr, data->data_len, data->payload_offset)) {
+            break;
+        }
+        if ((int)s_rx_len == data->payload_len) {
+            s_rx_buf[s_rx_len] = '\0';
+            cJSON *event = cJSON_Parse((const char *)s_rx_buf);
+            if (event) {
+                handle_realtime_event(event);
+                cJSON_Delete(event);
+            } else {
+                ESP_LOGW(TAG, "Failed to parse incoming Realtime event JSON");
+            }
+            s_rx_len = 0;
+        }
+        break;
+    case WEBSOCKET_EVENT_ERROR:
+        ESP_LOGW(TAG, "WebSocket transport error");
+        break;
+    default:
+        break;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+esp_err_t realtime_client_start(void) {
+    s_send_mutex = xSemaphoreCreateMutex();
+    s_playback_queue = xQueueCreate(PLAYBACK_QUEUE_LEN, sizeof(playback_chunk_t));
+    if (!s_send_mutex || !s_playback_queue) {
+        return ESP_ERR_NO_MEM;
+    }
+
+    xTaskCreate(playback_task, "audio_playback", 4096, NULL, 6, NULL);
+    xTaskCreate(mic_task, "audio_mic", 4096, NULL, 6, NULL);
+
+    snprintf(s_ws_headers, sizeof(s_ws_headers), "Authorization: Bearer %s\r\n",
+             OPENAI_API_KEY);
+
+    esp_websocket_client_config_t config = {
+        .uri = "wss://api.openai.com/v1/realtime?model=" REALTIME_MODEL,
+        .headers = s_ws_headers,
+        .buffer_size = 16384,
+        .reconnect_timeout_ms = 2000,
+        .network_timeout_ms = 15000,
+        .crt_bundle_attach = esp_crt_bundle_attach,
+    };
+    s_client = esp_websocket_client_init(&config);
+    if (!s_client) {
+        ESP_LOGE(TAG, "Failed to initialize WebSocket client");
+        return ESP_FAIL;
+    }
+    esp_websocket_register_events(s_client, WEBSOCKET_EVENT_ANY, ws_event_handler, NULL);
+    return esp_websocket_client_start(s_client);
+}

--- a/Examples/ESP32-Audio-Board/main/realtime_client.h
+++ b/Examples/ESP32-Audio-Board/main/realtime_client.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Starts the realtime voice assistant: opens the WebSocket connection to
+// OpenAI's Realtime API and spawns the mic-capture and speaker-playback
+// tasks. Returns once everything is running — the spawned tasks and the
+// WebSocket client's own internal task keep the assistant alive for the
+// rest of the program, reconnecting automatically on drops.
+esp_err_t realtime_client_start(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/Examples/ESP32-Audio-Board/main/secrets.h.example
+++ b/Examples/ESP32-Audio-Board/main/secrets.h.example
@@ -1,0 +1,11 @@
+// Copy this file to secrets.h (gitignored) and fill in your own values.
+//
+//   cp main/secrets.h.example main/secrets.h
+//
+#pragma once
+
+#define WIFI_SSID "your-wifi-ssid"
+#define WIFI_PASSWORD "your-wifi-password"
+
+// Create a key at https://platform.openai.com/api-keys
+#define OPENAI_API_KEY "sk-..."

--- a/Examples/ESP32-Audio-Board/main/text_utils.c
+++ b/Examples/ESP32-Audio-Board/main/text_utils.c
@@ -1,0 +1,148 @@
+#include "text_utils.h"
+
+#include <ctype.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Matches a markdown link "[text](url)" at the start of `s`.
+// require_nonempty mirrors the two different Python regexes this is based
+// on: the citation-group scanner requires `[^\]]+`/`[^)\s]+` (non-empty
+// text and URL), while the leftover standalone-link pass is the more
+// lenient `[^\]]*`/`[^)\s]*` (either may be empty).
+static bool match_markdown_link(const char *s, bool require_nonempty,
+                                 size_t *out_consumed, size_t *out_text_start,
+                                 size_t *out_text_len) {
+    if (s[0] != '[') {
+        return false;
+    }
+    size_t i = 1;
+    while (s[i] != '\0' && s[i] != ']') {
+        i++;
+    }
+    if (s[i] != ']') {
+        return false;
+    }
+    size_t text_len = i - 1;
+    if (require_nonempty && text_len == 0) {
+        return false;
+    }
+    i++; // past ']'
+    if (s[i] != '(') {
+        return false;
+    }
+    i++; // past '('
+    size_t url_start = i;
+    while (s[i] != '\0' && s[i] != ')' && !isspace((unsigned char)s[i])) {
+        i++;
+    }
+    if (s[i] != ')') {
+        return false;
+    }
+    size_t url_len = i - url_start;
+    if (require_nonempty && url_len == 0) {
+        return false;
+    }
+    i++; // past ')'
+
+    *out_consumed = i;
+    *out_text_start = 1;
+    *out_text_len = text_len;
+    return true;
+}
+
+// Matches "\s*\((?:\[...\]\(...\)(?:,\s*)?)+\)" at the start of `s`: a
+// parenthesized run of one-or-more citation links, each optionally followed
+// by a comma and whitespace, with nothing else inside the parens.
+static bool match_citation_group(const char *s, size_t *out_consumed) {
+    size_t i = 0;
+    while (isspace((unsigned char)s[i])) {
+        i++;
+    }
+    if (s[i] != '(') {
+        return false;
+    }
+    i++;
+
+    int link_count = 0;
+    for (;;) {
+        size_t consumed, text_start, text_len;
+        if (!match_markdown_link(s + i, /*require_nonempty=*/true, &consumed,
+                                  &text_start, &text_len)) {
+            break;
+        }
+        i += consumed;
+        link_count++;
+        if (s[i] == ',') {
+            size_t j = i + 1;
+            while (isspace((unsigned char)s[j])) {
+                j++;
+            }
+            i = j;
+        }
+    }
+    if (link_count == 0 || s[i] != ')') {
+        return false;
+    }
+    i++;
+    *out_consumed = i;
+    return true;
+}
+
+// Both passes only ever remove or shorten text, so an output buffer the
+// same size as the input is always a safe upper bound — no growth needed.
+static char *strip_citation_groups(const char *input) {
+    size_t len = strlen(input);
+    char *out = malloc(len + 1);
+    if (!out) {
+        return NULL;
+    }
+    size_t oi = 0;
+    size_t i = 0;
+    while (input[i] != '\0') {
+        size_t consumed;
+        if (match_citation_group(input + i, &consumed)) {
+            i += consumed;
+            continue;
+        }
+        out[oi++] = input[i++];
+    }
+    out[oi] = '\0';
+    return out;
+}
+
+static char *replace_standalone_links(const char *input) {
+    size_t len = strlen(input);
+    char *out = malloc(len + 1);
+    if (!out) {
+        return NULL;
+    }
+    size_t oi = 0;
+    size_t i = 0;
+    while (input[i] != '\0') {
+        size_t consumed, text_start, text_len;
+        if (match_markdown_link(input + i, /*require_nonempty=*/false,
+                                 &consumed, &text_start, &text_len)) {
+            memcpy(out + oi, input + i + text_start, text_len);
+            oi += text_len;
+            i += consumed;
+            continue;
+        }
+        out[oi++] = input[i++];
+    }
+    out[oi] = '\0';
+    return out;
+}
+
+char *strip_citations(const char *input) {
+    if (!input) {
+        return NULL;
+    }
+    char *stage1 = strip_citation_groups(input);
+    if (!stage1) {
+        return NULL;
+    }
+    char *stage2 = replace_standalone_links(stage1);
+    free(stage1);
+    return stage2;
+}

--- a/Examples/ESP32-Audio-Board/main/text_utils.h
+++ b/Examples/ESP32-Audio-Board/main/text_utils.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Strips OpenAI web-search citation markup so answers read cleanly when
+// spoken: whole "(...[site](url)...)" citation groups are dropped, and any
+// leftover standalone "[text](url)" is replaced with just "text". A hand-
+// rolled approximation of VoiceAssistant's regex-based strip_citations() in
+// app.py — this embedded build has no regex engine.
+//
+// Returns a newly malloc'd, NUL-terminated string the caller must free.
+// Returns NULL only if `input` is NULL or allocation fails.
+char *strip_citations(const char *input);
+
+#ifdef __cplusplus
+}
+#endif

--- a/Examples/ESP32-Audio-Board/main/tools.c
+++ b/Examples/ESP32-Audio-Board/main/tools.c
@@ -1,0 +1,623 @@
+// Realtime function-tool implementations: volume control (local, via the
+// ES8311 codec), weather (Open-Meteo, keyless), and web search (OpenAI
+// Responses API). Mirrors VoiceAssistant's tool_specs()/execute_tool() in
+// app.py.
+
+#include "tools.h"
+
+#include <ctype.h>
+#include <math.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "board_audio.h"
+#include "esp_crt_bundle.h"
+#include "esp_http_client.h"
+#include "esp_log.h"
+#include "secrets.h"
+#include "text_utils.h"
+#include "weather_codes.h"
+
+static const char *TAG = "tools";
+
+#define GEOCODING_URL "https://geocoding-api.open-meteo.com/v1/search"
+#define FORECAST_URL "https://api.open-meteo.com/v1/forecast"
+#define RESPONSES_URL "https://api.openai.com/v1/responses"
+#define WEB_SEARCH_MODEL "gpt-5-mini"
+
+// ---------------------------------------------------------------------------
+// Tool specs (session.update "tools" array)
+// ---------------------------------------------------------------------------
+
+cJSON *tools_build_specs(void) {
+    cJSON *specs = cJSON_CreateArray();
+
+    cJSON *set_volume = cJSON_CreateObject();
+    cJSON_AddStringToObject(set_volume, "type", "function");
+    cJSON_AddStringToObject(set_volume, "name", "set_volume");
+    cJSON_AddStringToObject(set_volume, "description",
+                             "Set the speaker output volume to an absolute "
+                             "percentage. Use for requests like 'set the "
+                             "volume to 30 percent'.");
+    {
+        cJSON *params = cJSON_CreateObject();
+        cJSON_AddStringToObject(params, "type", "object");
+        cJSON *props = cJSON_CreateObject();
+        cJSON *percent = cJSON_CreateObject();
+        cJSON_AddStringToObject(percent, "type", "integer");
+        cJSON_AddNumberToObject(percent, "minimum", 0);
+        cJSON_AddNumberToObject(percent, "maximum", 100);
+        cJSON_AddItemToObject(props, "percent", percent);
+        cJSON_AddItemToObject(params, "properties", props);
+        cJSON *required = cJSON_CreateArray();
+        cJSON_AddItemToArray(required, cJSON_CreateString("percent"));
+        cJSON_AddItemToObject(params, "required", required);
+        cJSON_AddItemToObject(set_volume, "parameters", params);
+    }
+    cJSON_AddItemToArray(specs, set_volume);
+
+    cJSON *adjust_volume = cJSON_CreateObject();
+    cJSON_AddStringToObject(adjust_volume, "type", "function");
+    cJSON_AddStringToObject(adjust_volume, "name", "adjust_volume");
+    cJSON_AddStringToObject(adjust_volume, "description",
+                             "Nudge the speaker volume up or down. Use for "
+                             "relative requests like 'turn it up a bit' or "
+                             "'quieter please'.");
+    {
+        cJSON *params = cJSON_CreateObject();
+        cJSON_AddStringToObject(params, "type", "object");
+        cJSON *props = cJSON_CreateObject();
+        cJSON *direction = cJSON_CreateObject();
+        cJSON_AddStringToObject(direction, "type", "string");
+        cJSON *direction_enum = cJSON_CreateArray();
+        cJSON_AddItemToArray(direction_enum, cJSON_CreateString("up"));
+        cJSON_AddItemToArray(direction_enum, cJSON_CreateString("down"));
+        cJSON_AddItemToObject(direction, "enum", direction_enum);
+        cJSON_AddItemToObject(props, "direction", direction);
+        cJSON *step = cJSON_CreateObject();
+        cJSON_AddStringToObject(step, "type", "integer");
+        cJSON_AddNumberToObject(step, "minimum", 1);
+        cJSON_AddNumberToObject(step, "maximum", 100);
+        cJSON_AddNumberToObject(step, "default", 10);
+        cJSON_AddItemToObject(props, "step", step);
+        cJSON_AddItemToObject(params, "properties", props);
+        cJSON *required = cJSON_CreateArray();
+        cJSON_AddItemToArray(required, cJSON_CreateString("direction"));
+        cJSON_AddItemToObject(params, "required", required);
+        cJSON_AddItemToObject(adjust_volume, "parameters", params);
+    }
+    cJSON_AddItemToArray(specs, adjust_volume);
+
+    cJSON *get_volume = cJSON_CreateObject();
+    cJSON_AddStringToObject(get_volume, "type", "function");
+    cJSON_AddStringToObject(get_volume, "name", "get_volume");
+    cJSON_AddStringToObject(get_volume, "description",
+                             "Report the current speaker output volume "
+                             "percentage.");
+    {
+        cJSON *params = cJSON_CreateObject();
+        cJSON_AddStringToObject(params, "type", "object");
+        cJSON_AddItemToObject(params, "properties", cJSON_CreateObject());
+        cJSON_AddItemToObject(get_volume, "parameters", params);
+    }
+    cJSON_AddItemToArray(specs, get_volume);
+
+    cJSON *get_weather = cJSON_CreateObject();
+    cJSON_AddStringToObject(get_weather, "type", "function");
+    cJSON_AddStringToObject(get_weather, "name", "get_weather");
+    cJSON_AddStringToObject(get_weather, "description",
+                             "Get the current weather and a 3-day forecast "
+                             "for a named place. Fast and free — always use "
+                             "this for weather questions instead of "
+                             "web_search.");
+    {
+        cJSON *params = cJSON_CreateObject();
+        cJSON_AddStringToObject(params, "type", "object");
+        cJSON *props = cJSON_CreateObject();
+        cJSON *location = cJSON_CreateObject();
+        cJSON_AddStringToObject(location, "type", "string");
+        cJSON_AddStringToObject(location, "description",
+                                 "City or place name, e.g. 'Berlin' or "
+                                 "'Portland, Oregon'");
+        cJSON_AddItemToObject(props, "location", location);
+        cJSON *units = cJSON_CreateObject();
+        cJSON_AddStringToObject(units, "type", "string");
+        cJSON *units_enum = cJSON_CreateArray();
+        cJSON_AddItemToArray(units_enum, cJSON_CreateString("celsius"));
+        cJSON_AddItemToArray(units_enum, cJSON_CreateString("fahrenheit"));
+        cJSON_AddItemToObject(units, "enum", units_enum);
+        cJSON_AddItemToObject(props, "units", units);
+        cJSON_AddItemToObject(params, "properties", props);
+        cJSON *required = cJSON_CreateArray();
+        cJSON_AddItemToArray(required, cJSON_CreateString("location"));
+        cJSON_AddItemToObject(params, "required", required);
+        cJSON_AddItemToObject(get_weather, "parameters", params);
+    }
+    cJSON_AddItemToArray(specs, get_weather);
+
+    cJSON *web_search = cJSON_CreateObject();
+    cJSON_AddStringToObject(web_search, "type", "function");
+    cJSON_AddStringToObject(web_search, "name", "web_search");
+    cJSON_AddStringToObject(web_search, "description",
+                             "Search the live web for current information: "
+                             "news, sports scores, prices, or facts you are "
+                             "not sure about. Slower and costs money — "
+                             "never use it for weather (use get_weather) or "
+                             "for things you already know.");
+    {
+        cJSON *params = cJSON_CreateObject();
+        cJSON_AddStringToObject(params, "type", "object");
+        cJSON *props = cJSON_CreateObject();
+        cJSON *query = cJSON_CreateObject();
+        cJSON_AddStringToObject(query, "type", "string");
+        cJSON_AddStringToObject(query, "description", "A concise search query");
+        cJSON_AddItemToObject(props, "query", query);
+        cJSON_AddItemToObject(params, "properties", props);
+        cJSON *required = cJSON_CreateArray();
+        cJSON_AddItemToArray(required, cJSON_CreateString("query"));
+        cJSON_AddItemToObject(params, "required", required);
+        cJSON_AddItemToObject(web_search, "parameters", params);
+    }
+    cJSON_AddItemToArray(specs, web_search);
+
+    return specs;
+}
+
+// ---------------------------------------------------------------------------
+// HTTPS helpers
+// ---------------------------------------------------------------------------
+
+typedef struct {
+    char *buf;
+    size_t len;
+    size_t cap;
+} http_body_t;
+
+static esp_err_t http_event_handler(esp_http_client_event_t *evt) {
+    if (evt->event_id != HTTP_EVENT_ON_DATA) {
+        return ESP_OK;
+    }
+    http_body_t *body = (http_body_t *)evt->user_data;
+    size_t need = body->len + evt->data_len + 1;
+    if (need > body->cap) {
+        size_t new_cap = need + need / 2;
+        char *grown = realloc(body->buf, new_cap);
+        if (!grown) {
+            return ESP_FAIL;
+        }
+        body->buf = grown;
+        body->cap = new_cap;
+    }
+    memcpy(body->buf + body->len, evt->data, evt->data_len);
+    body->len += evt->data_len;
+    body->buf[body->len] = '\0';
+    return ESP_OK;
+}
+
+// GET when post_body is NULL, POST with a JSON body (and Authorization
+// header) otherwise. Returns a malloc'd response body the caller frees, or
+// NULL on any transport/HTTP-status failure.
+static char *http_request(const char *url, const char *auth_header,
+                           const char *post_body) {
+    http_body_t body = {0};
+    esp_http_client_config_t config = {
+        .url = url,
+        .method = post_body ? HTTP_METHOD_POST : HTTP_METHOD_GET,
+        .event_handler = http_event_handler,
+        .user_data = &body,
+        .crt_bundle_attach = esp_crt_bundle_attach,
+        .timeout_ms = post_body ? 45000 : 15000,
+    };
+    esp_http_client_handle_t client = esp_http_client_init(&config);
+    if (!client) {
+        return NULL;
+    }
+    if (auth_header) {
+        esp_http_client_set_header(client, "Authorization", auth_header);
+    }
+    if (post_body) {
+        esp_http_client_set_header(client, "Content-Type", "application/json");
+        esp_http_client_set_post_field(client, post_body, strlen(post_body));
+    }
+
+    esp_err_t err = esp_http_client_perform(client);
+    int status = esp_http_client_get_status_code(client);
+    esp_http_client_cleanup(client);
+
+    if (err != ESP_OK || status < 200 || status >= 300) {
+        ESP_LOGW(TAG, "HTTP request to %s failed: err=%s status=%d", url,
+                 esp_err_to_name(err), status);
+        free(body.buf);
+        return NULL;
+    }
+    return body.buf ? body.buf : strdup("");
+}
+
+// Percent-encodes a query-string value (RFC 3986 unreserved chars pass
+// through; everything else, including spaces, becomes %XX).
+static char *percent_encode(const char *s) {
+    size_t len = strlen(s);
+    char *out = malloc(len * 3 + 1);
+    if (!out) {
+        return NULL;
+    }
+    size_t oi = 0;
+    for (size_t i = 0; i < len; i++) {
+        unsigned char c = (unsigned char)s[i];
+        if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~') {
+            out[oi++] = (char)c;
+        } else {
+            oi += snprintf(out + oi, 4, "%%%02X", c);
+        }
+    }
+    out[oi] = '\0';
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// Volume tools (local, no network)
+// ---------------------------------------------------------------------------
+
+static cJSON *do_set_volume(cJSON *args) {
+    cJSON *percent_item = cJSON_GetObjectItem(args, "percent");
+    if (!cJSON_IsNumber(percent_item)) {
+        cJSON *err = cJSON_CreateObject();
+        cJSON_AddStringToObject(err, "error", "percent is required");
+        return err;
+    }
+    int percent = percent_item->valueint;
+    if (percent < 0) percent = 0;
+    if (percent > 100) percent = 100;
+    if (board_audio_set_volume(percent) != ESP_OK) {
+        cJSON *err = cJSON_CreateObject();
+        cJSON_AddStringToObject(err, "error", "failed to set volume");
+        return err;
+    }
+    cJSON *result = cJSON_CreateObject();
+    cJSON_AddNumberToObject(result, "volume_percent", percent);
+    return result;
+}
+
+static cJSON *do_get_volume(void) {
+    int percent = 0;
+    if (board_audio_get_volume(&percent) != ESP_OK) {
+        cJSON *err = cJSON_CreateObject();
+        cJSON_AddStringToObject(err, "error", "failed to read volume");
+        return err;
+    }
+    cJSON *result = cJSON_CreateObject();
+    cJSON_AddNumberToObject(result, "volume_percent", percent);
+    return result;
+}
+
+static cJSON *do_adjust_volume(cJSON *args) {
+    cJSON *direction_item = cJSON_GetObjectItem(args, "direction");
+    const char *direction =
+        cJSON_IsString(direction_item) ? direction_item->valuestring : NULL;
+    if (!direction || (strcmp(direction, "up") != 0 && strcmp(direction, "down") != 0)) {
+        cJSON *err = cJSON_CreateObject();
+        cJSON_AddStringToObject(err, "error",
+                                 "direction must be 'up' or 'down'");
+        return err;
+    }
+    cJSON *step_item = cJSON_GetObjectItem(args, "step");
+    int step = cJSON_IsNumber(step_item) ? step_item->valueint : 10;
+
+    int current = 0;
+    if (board_audio_get_volume(&current) != ESP_OK) {
+        cJSON *err = cJSON_CreateObject();
+        cJSON_AddStringToObject(err, "error", "failed to read volume");
+        return err;
+    }
+    int target = current + (strcmp(direction, "up") == 0 ? step : -step);
+    if (target < 0) target = 0;
+    if (target > 100) target = 100;
+    if (board_audio_set_volume(target) != ESP_OK) {
+        cJSON *err = cJSON_CreateObject();
+        cJSON_AddStringToObject(err, "error", "failed to set volume");
+        return err;
+    }
+    cJSON *result = cJSON_CreateObject();
+    cJSON_AddNumberToObject(result, "volume_percent", target);
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// get_weather (Open-Meteo, keyless)
+// ---------------------------------------------------------------------------
+
+static double num_or(cJSON *obj, const char *key, double fallback) {
+    cJSON *item = cJSON_GetObjectItem(obj, key);
+    return cJSON_IsNumber(item) ? item->valuedouble : fallback;
+}
+
+static cJSON *do_get_weather(cJSON *args) {
+    cJSON *location_item = cJSON_GetObjectItem(args, "location");
+    const char *location =
+        cJSON_IsString(location_item) ? location_item->valuestring : NULL;
+    if (!location || strlen(location) == 0) {
+        cJSON *err = cJSON_CreateObject();
+        cJSON_AddStringToObject(err, "error", "location is required");
+        return err;
+    }
+    cJSON *units_item = cJSON_GetObjectItem(args, "units");
+    const char *units =
+        cJSON_IsString(units_item) ? units_item->valuestring : "celsius";
+    bool fahrenheit = strcmp(units, "fahrenheit") == 0;
+
+    char *encoded_location = percent_encode(location);
+    if (!encoded_location) {
+        cJSON *err = cJSON_CreateObject();
+        cJSON_AddStringToObject(err, "error", "out of memory");
+        return err;
+    }
+    char geocode_url[512];
+    snprintf(geocode_url, sizeof(geocode_url),
+              "%s?name=%s&count=1&language=en&format=json", GEOCODING_URL,
+              encoded_location);
+    free(encoded_location);
+
+    char *geocode_body = http_request(geocode_url, NULL, NULL);
+    if (!geocode_body) {
+        cJSON *err = cJSON_CreateObject();
+        cJSON_AddStringToObject(err, "error", "weather lookup failed (network)");
+        return err;
+    }
+    cJSON *geocode_json = cJSON_Parse(geocode_body);
+    free(geocode_body);
+    if (!geocode_json) {
+        cJSON *err = cJSON_CreateObject();
+        cJSON_AddStringToObject(err, "error", "weather lookup returned invalid JSON");
+        return err;
+    }
+    cJSON *results = cJSON_GetObjectItem(geocode_json, "results");
+    cJSON *place = (cJSON_IsArray(results) && cJSON_GetArraySize(results) > 0)
+                       ? cJSON_GetArrayItem(results, 0)
+                       : NULL;
+    if (!place) {
+        cJSON *err = cJSON_CreateObject();
+        char msg[160];
+        snprintf(msg, sizeof(msg), "no location found matching '%s'", location);
+        cJSON_AddStringToObject(err, "error", msg);
+        cJSON_Delete(geocode_json);
+        return err;
+    }
+
+    double lat = num_or(place, "latitude", 0);
+    double lon = num_or(place, "longitude", 0);
+    const char *name_parts[3];
+    int name_part_count = 0;
+    const char *candidates[3] = {
+        cJSON_GetStringValue(cJSON_GetObjectItem(place, "name")),
+        cJSON_GetStringValue(cJSON_GetObjectItem(place, "admin1")),
+        cJSON_GetStringValue(cJSON_GetObjectItem(place, "country")),
+    };
+    for (int i = 0; i < 3; i++) {
+        if (!candidates[i] || strlen(candidates[i]) == 0) {
+            continue;
+        }
+        bool dup = false;
+        for (int j = 0; j < name_part_count; j++) {
+            if (strcmp(name_parts[j], candidates[i]) == 0) {
+                dup = true;
+                break;
+            }
+        }
+        if (!dup) {
+            name_parts[name_part_count++] = candidates[i];
+        }
+    }
+    char location_label[192] = {0};
+    for (int i = 0; i < name_part_count; i++) {
+        if (i > 0) strlcat(location_label, ", ", sizeof(location_label));
+        strlcat(location_label, name_parts[i], sizeof(location_label));
+    }
+    cJSON_Delete(geocode_json);
+
+    char forecast_url[512];
+    snprintf(forecast_url, sizeof(forecast_url),
+              "%s?latitude=%.6f&longitude=%.6f"
+              "&current=temperature_2m,apparent_temperature,relative_humidity_2m,"
+              "weather_code,wind_speed_10m,is_day"
+              "&daily=weather_code,temperature_2m_max,temperature_2m_min,"
+              "precipitation_probability_max"
+              "&forecast_days=3&timezone=auto%s",
+              FORECAST_URL, lat, lon,
+              fahrenheit ? "&temperature_unit=fahrenheit&wind_speed_unit=mph" : "");
+
+    char *forecast_body = http_request(forecast_url, NULL, NULL);
+    if (!forecast_body) {
+        cJSON *err = cJSON_CreateObject();
+        cJSON_AddStringToObject(err, "error", "forecast lookup failed (network)");
+        return err;
+    }
+    cJSON *forecast_json = cJSON_Parse(forecast_body);
+    free(forecast_body);
+    if (!forecast_json) {
+        cJSON *err = cJSON_CreateObject();
+        cJSON_AddStringToObject(err, "error", "forecast lookup returned invalid JSON");
+        return err;
+    }
+
+    cJSON *current = cJSON_GetObjectItem(forecast_json, "current");
+    cJSON *daily = cJSON_GetObjectItem(forecast_json, "daily");
+
+    cJSON *result = cJSON_CreateObject();
+    cJSON_AddStringToObject(result, "location", location_label);
+    cJSON_AddStringToObject(result, "units", units);
+
+    cJSON *current_out = cJSON_CreateObject();
+    cJSON_AddNumberToObject(current_out, "temperature", num_or(current, "temperature_2m", NAN));
+    cJSON_AddNumberToObject(current_out, "feels_like", num_or(current, "apparent_temperature", NAN));
+    cJSON_AddNumberToObject(current_out, "humidity_percent", num_or(current, "relative_humidity_2m", NAN));
+    cJSON_AddNumberToObject(current_out, "wind_speed", num_or(current, "wind_speed_10m", NAN));
+    cJSON *wcode_item = cJSON_GetObjectItem(current, "weather_code");
+    cJSON_AddStringToObject(
+        current_out, "conditions",
+        describe_weather_code(cJSON_IsNumber(wcode_item) ? wcode_item->valueint : 0,
+                               cJSON_IsNumber(wcode_item)));
+    cJSON_AddItemToObject(result, "current", current_out);
+
+    cJSON *daily_out = cJSON_CreateArray();
+    cJSON *times = cJSON_GetObjectItem(daily, "time");
+    int day_count = cJSON_IsArray(times) ? cJSON_GetArraySize(times) : 0;
+    cJSON *daily_codes = cJSON_GetObjectItem(daily, "weather_code");
+    cJSON *daily_highs = cJSON_GetObjectItem(daily, "temperature_2m_max");
+    cJSON *daily_lows = cJSON_GetObjectItem(daily, "temperature_2m_min");
+    cJSON *daily_precip = cJSON_GetObjectItem(daily, "precipitation_probability_max");
+    for (int i = 0; i < day_count; i++) {
+        cJSON *day = cJSON_CreateObject();
+        cJSON *time_item = cJSON_GetArrayItem(times, i);
+        cJSON_AddStringToObject(day, "date",
+                                 cJSON_IsString(time_item) ? time_item->valuestring : "");
+        cJSON *high_item = cJSON_GetArrayItem(daily_highs, i);
+        cJSON *low_item = cJSON_GetArrayItem(daily_lows, i);
+        cJSON_AddNumberToObject(day, "high", cJSON_IsNumber(high_item) ? high_item->valuedouble : NAN);
+        cJSON_AddNumberToObject(day, "low", cJSON_IsNumber(low_item) ? low_item->valuedouble : NAN);
+        cJSON *code_item = cJSON_GetArrayItem(daily_codes, i);
+        cJSON_AddStringToObject(
+            day, "conditions",
+            describe_weather_code(cJSON_IsNumber(code_item) ? code_item->valueint : 0,
+                                   cJSON_IsNumber(code_item)));
+        cJSON *precip_item = cJSON_GetArrayItem(daily_precip, i);
+        cJSON_AddNumberToObject(day, "precipitation_chance_percent",
+                                 cJSON_IsNumber(precip_item) ? precip_item->valuedouble : NAN);
+        cJSON_AddItemToArray(daily_out, day);
+    }
+    cJSON_AddItemToObject(result, "daily", daily_out);
+
+    cJSON_Delete(forecast_json);
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// web_search (OpenAI Responses API, built-in web_search tool)
+// ---------------------------------------------------------------------------
+
+static cJSON *do_web_search(cJSON *args) {
+    cJSON *query_item = cJSON_GetObjectItem(args, "query");
+    const char *query = cJSON_IsString(query_item) ? query_item->valuestring : NULL;
+    if (!query || strlen(query) == 0) {
+        cJSON *err = cJSON_CreateObject();
+        cJSON_AddStringToObject(err, "error", "query is required");
+        return err;
+    }
+
+    cJSON *body_json = cJSON_CreateObject();
+    cJSON_AddStringToObject(body_json, "model", WEB_SEARCH_MODEL);
+    cJSON_AddStringToObject(body_json, "input", query);
+    cJSON_AddStringToObject(
+        body_json, "instructions",
+        "You are a silent search backend for a voice assistant; the "
+        "assistant has already acknowledged the user. Reply with 1-3 short "
+        "spoken-style sentences of concrete facts, current as of today. "
+        "Start directly with the facts — no greetings, acknowledgements, or "
+        "lead-ins like 'Got it' or 'Here's what's going on'. No markdown or "
+        "URLs. Never ask clarifying questions — this is a one-shot search, "
+        "so pick the most likely interpretation of the query, search, and "
+        "answer.");
+    cJSON *tools = cJSON_CreateArray();
+    cJSON *web_search_tool = cJSON_CreateObject();
+    cJSON_AddStringToObject(web_search_tool, "type", "web_search");
+    cJSON_AddItemToArray(tools, web_search_tool);
+    cJSON_AddItemToObject(body_json, "tools", tools);
+    cJSON *reasoning = cJSON_CreateObject();
+    cJSON_AddStringToObject(reasoning, "effort", "low");
+    cJSON_AddItemToObject(body_json, "reasoning", reasoning);
+
+    char *body_text = cJSON_PrintUnformatted(body_json);
+    cJSON_Delete(body_json);
+    if (!body_text) {
+        cJSON *err = cJSON_CreateObject();
+        cJSON_AddStringToObject(err, "error", "out of memory");
+        return err;
+    }
+
+    char auth_header[64];
+    snprintf(auth_header, sizeof(auth_header), "Bearer %s", OPENAI_API_KEY);
+    char *response_body = http_request(RESPONSES_URL, auth_header, body_text);
+    free(body_text);
+    if (!response_body) {
+        cJSON *err = cJSON_CreateObject();
+        cJSON_AddStringToObject(err, "error", "web search failed (network)");
+        return err;
+    }
+
+    cJSON *response_json = cJSON_Parse(response_body);
+    free(response_body);
+    if (!response_json) {
+        cJSON *err = cJSON_CreateObject();
+        cJSON_AddStringToObject(err, "error", "web search returned invalid JSON");
+        return err;
+    }
+
+    // Concatenate output_text content, mirroring VoiceAssistant's
+    // extract_output_text().
+    char answer[2048] = {0};
+    cJSON *output = cJSON_GetObjectItem(response_json, "output");
+    if (cJSON_IsArray(output)) {
+        cJSON *item;
+        cJSON_ArrayForEach(item, output) {
+            cJSON *type_item = cJSON_GetObjectItem(item, "type");
+            if (!cJSON_IsString(type_item) || strcmp(type_item->valuestring, "message") != 0) {
+                continue;
+            }
+            cJSON *content = cJSON_GetObjectItem(item, "content");
+            cJSON *content_item;
+            cJSON_ArrayForEach(content_item, content) {
+                cJSON *ctype = cJSON_GetObjectItem(content_item, "type");
+                cJSON *text = cJSON_GetObjectItem(content_item, "text");
+                if (cJSON_IsString(ctype) && strcmp(ctype->valuestring, "output_text") == 0 &&
+                    cJSON_IsString(text)) {
+                    strlcat(answer, text->valuestring, sizeof(answer));
+                }
+            }
+        }
+    }
+    cJSON_Delete(response_json);
+
+    char *clean_answer = strip_citations(answer);
+    cJSON *result = cJSON_CreateObject();
+    if (!clean_answer || strlen(clean_answer) == 0) {
+        cJSON_AddStringToObject(result, "error", "web search returned no answer");
+    } else {
+        cJSON_AddStringToObject(result, "answer", clean_answer);
+    }
+    free(clean_answer);
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+cJSON *tools_execute(const char *name, const char *arguments_json) {
+    cJSON *args = NULL;
+    if (arguments_json && strlen(arguments_json) > 0) {
+        args = cJSON_Parse(arguments_json);
+    }
+    if (!args) {
+        args = cJSON_CreateObject();
+    }
+
+    cJSON *result;
+    if (strcmp(name, "set_volume") == 0) {
+        result = do_set_volume(args);
+    } else if (strcmp(name, "adjust_volume") == 0) {
+        result = do_adjust_volume(args);
+    } else if (strcmp(name, "get_volume") == 0) {
+        result = do_get_volume();
+    } else if (strcmp(name, "get_weather") == 0) {
+        result = do_get_weather(args);
+    } else if (strcmp(name, "web_search") == 0) {
+        result = do_web_search(args);
+    } else {
+        result = cJSON_CreateObject();
+        char msg[64];
+        snprintf(msg, sizeof(msg), "unknown tool: %s", name);
+        cJSON_AddStringToObject(result, "error", msg);
+    }
+    cJSON_Delete(args);
+    return result;
+}

--- a/Examples/ESP32-Audio-Board/main/tools.h
+++ b/Examples/ESP32-Audio-Board/main/tools.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "cJSON.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Builds the "tools" array for the Realtime session.update payload:
+// set_volume, adjust_volume, get_volume, get_weather, web_search. Mirrors
+// VoiceAssistant's tool_specs() in app.py. Caller owns the returned array.
+cJSON *tools_build_specs(void);
+
+// Executes one tool call by name with its JSON-encoded arguments string.
+// Always returns a JSON object (never NULL) — failures are encoded as
+// {"error": "..."} rather than propagated, since a Realtime function tool
+// must answer, not crash the session. Caller owns the returned object.
+cJSON *tools_execute(const char *name, const char *arguments_json);
+
+#ifdef __cplusplus
+}
+#endif

--- a/Examples/ESP32-Audio-Board/main/weather_codes.c
+++ b/Examples/ESP32-Audio-Board/main/weather_codes.c
@@ -1,0 +1,52 @@
+#include "weather_codes.h"
+
+#include <stddef.h>
+
+typedef struct {
+    int code;
+    const char *description;
+} weather_code_entry_t;
+
+// Mirrors VoiceAssistant's _WMO_WEATHER_CODES table (app.py) exactly.
+static const weather_code_entry_t kWeatherCodes[] = {
+    {0, "clear sky"},
+    {1, "mainly clear"},
+    {2, "partly cloudy"},
+    {3, "overcast"},
+    {45, "fog"},
+    {48, "depositing rime fog"},
+    {51, "light drizzle"},
+    {53, "moderate drizzle"},
+    {55, "dense drizzle"},
+    {56, "light freezing drizzle"},
+    {57, "dense freezing drizzle"},
+    {61, "light rain"},
+    {63, "moderate rain"},
+    {65, "heavy rain"},
+    {66, "light freezing rain"},
+    {67, "heavy freezing rain"},
+    {71, "light snow"},
+    {73, "moderate snow"},
+    {75, "heavy snow"},
+    {77, "snow grains"},
+    {80, "light rain showers"},
+    {81, "moderate rain showers"},
+    {82, "violent rain showers"},
+    {85, "light snow showers"},
+    {86, "heavy snow showers"},
+    {95, "thunderstorm"},
+    {96, "thunderstorm with light hail"},
+    {99, "thunderstorm with heavy hail"},
+};
+#define kWeatherCodesCount (sizeof(kWeatherCodes) / sizeof(kWeatherCodes[0]))
+
+const char *describe_weather_code(int code, bool has_code) {
+    if (has_code) {
+        for (size_t i = 0; i < kWeatherCodesCount; i++) {
+            if (kWeatherCodes[i].code == code) {
+                return kWeatherCodes[i].description;
+            }
+        }
+    }
+    return "unknown conditions";
+}

--- a/Examples/ESP32-Audio-Board/main/weather_codes.h
+++ b/Examples/ESP32-Audio-Board/main/weather_codes.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Spoken-friendly text for a WMO weather interpretation code, as reported by
+// Open-Meteo. Pass has_code=false when the code is missing/unknown so it
+// doesn't get mistaken for the (also valid) code 0 ("clear sky").
+// Pure C, no ESP-IDF dependency — host-testable, mirrors VoiceAssistant's
+// describe_weather_code() in app.py.
+const char *describe_weather_code(int code, bool has_code);
+
+#ifdef __cplusplus
+}
+#endif

--- a/Examples/ESP32-Audio-Board/main/wifi_connect.c
+++ b/Examples/ESP32-Audio-Board/main/wifi_connect.c
@@ -1,0 +1,76 @@
+#include "wifi_connect.h"
+
+#include <string.h>
+
+#include "esp_event.h"
+#include "esp_log.h"
+#include "esp_netif.h"
+#include "esp_wifi.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include "secrets.h"
+
+static const char *TAG = "wifi_connect";
+
+#define WIFI_CONNECTED_BIT BIT0
+#define WIFI_FAIL_BIT BIT1
+#define MAX_RETRIES 10
+
+static EventGroupHandle_t s_event_group;
+static int s_retry_count;
+
+static void event_handler(void *arg, esp_event_base_t event_base,
+                           int32_t event_id, void *event_data) {
+    if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
+        esp_wifi_connect();
+    } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
+        if (s_retry_count < MAX_RETRIES) {
+            esp_wifi_connect();
+            s_retry_count++;
+            ESP_LOGW(TAG, "Reconnecting to WiFi (%d/%d)", s_retry_count, MAX_RETRIES);
+        } else {
+            xEventGroupSetBits(s_event_group, WIFI_FAIL_BIT);
+        }
+    } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
+        ip_event_got_ip_t *event = (ip_event_got_ip_t *)event_data;
+        ESP_LOGI(TAG, "Got IP: " IPSTR, IP2STR(&event->ip_info.ip));
+        s_retry_count = 0;
+        xEventGroupSetBits(s_event_group, WIFI_CONNECTED_BIT);
+    }
+}
+
+esp_err_t wifi_connect(void) {
+    s_event_group = xEventGroupCreate();
+
+    ESP_ERROR_CHECK(esp_netif_init());
+    ESP_ERROR_CHECK(esp_event_loop_create_default());
+    esp_netif_create_default_wifi_sta();
+
+    wifi_init_config_t init_cfg = WIFI_INIT_CONFIG_DEFAULT();
+    ESP_ERROR_CHECK(esp_wifi_init(&init_cfg));
+
+    ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, ESP_EVENT_ANY_ID,
+                                                &event_handler, NULL));
+    ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_STA_GOT_IP,
+                                                &event_handler, NULL));
+
+    wifi_config_t wifi_cfg = {0};
+    strlcpy((char *)wifi_cfg.sta.ssid, WIFI_SSID, sizeof(wifi_cfg.sta.ssid));
+    strlcpy((char *)wifi_cfg.sta.password, WIFI_PASSWORD, sizeof(wifi_cfg.sta.password));
+    wifi_cfg.sta.threshold.authmode = WIFI_AUTH_WPA2_PSK;
+
+    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
+    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_cfg));
+    ESP_ERROR_CHECK(esp_wifi_start());
+
+    ESP_LOGI(TAG, "Connecting to WiFi SSID '%s'...", WIFI_SSID);
+    EventBits_t bits = xEventGroupWaitBits(s_event_group,
+                                           WIFI_CONNECTED_BIT | WIFI_FAIL_BIT,
+                                           pdFALSE, pdFALSE, portMAX_DELAY);
+
+    if (bits & WIFI_CONNECTED_BIT) {
+        return ESP_OK;
+    }
+    ESP_LOGE(TAG, "Failed to connect to WiFi after %d retries", MAX_RETRIES);
+    return ESP_FAIL;
+}

--- a/Examples/ESP32-Audio-Board/main/wifi_connect.h
+++ b/Examples/ESP32-Audio-Board/main/wifi_connect.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Blocking WiFi station connect using WIFI_SSID/WIFI_PASSWORD from
+// secrets.h. Retries with backoff; returns ESP_OK once an IP address is
+// obtained, or ESP_FAIL after repeated failures.
+esp_err_t wifi_connect(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/Examples/ESP32-Audio-Board/partitions.csv
+++ b/Examples/ESP32-Audio-Board/partitions.csv
@@ -1,0 +1,4 @@
+# Name,     Type, SubType, Offset,   Size, Flags
+nvs,        data, nvs,     0x9000,   0x6000,
+phy_init,   data, phy,     0xf000,   0x1000,
+factory,    app,  factory, 0x10000,  4M,

--- a/Examples/ESP32-Audio-Board/sdkconfig.defaults
+++ b/Examples/ESP32-Audio-Board/sdkconfig.defaults
@@ -1,0 +1,36 @@
+# Defaults for the ESP32-S3-AUDIO-Board (ESP32-S3R8: octal 8 MB PSRAM, 16 MB flash).
+# Verified against Waveshare's own demo firmware's sdkconfig for this exact board.
+
+# --- Partition table: custom CSV sized for the 16 MB flash ---
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
+CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"
+CONFIG_PARTITION_TABLE_OFFSET=0x8000
+
+# --- Flash: 16 MB, 80 MHz (matches the octal PSRAM speed below) ---
+CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y
+CONFIG_ESPTOOLPY_FLASHSIZE="16MB"
+CONFIG_ESPTOOLPY_FLASHFREQ_80M=y
+CONFIG_ESPTOOLPY_FLASHFREQ="80m"
+
+# --- Octal PSRAM (S3R8 module) ---
+CONFIG_SPIRAM=y
+CONFIG_SPIRAM_MODE_OCT=y
+CONFIG_SPIRAM_SPEED_80M=y
+CONFIG_SPIRAM_CLK_IO=30
+CONFIG_SPIRAM_CS_IO=26
+CONFIG_SPIRAM_USE_MALLOC=y
+CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP=y
+
+# --- mbedTLS: dynamic buffers keep the WebSocket/HTTPS TLS sessions off the
+#     static heap so WiFi buffers and audio DMA don't get starved. ---
+CONFIG_MBEDTLS_DYNAMIC_BUFFER=y
+CONFIG_MBEDTLS_DYNAMIC_FREE_CONFIG_DATA=y
+CONFIG_MBEDTLS_DYNAMIC_FREE_CA_CERT=y
+CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=y
+
+# --- Console over UART (on-board USB-UART bridge) ---
+CONFIG_ESP_CONSOLE_UART_DEFAULT=y
+
+# --- Main task needs headroom for WiFi/TLS/WebSocket setup at boot ---
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192

--- a/Examples/ESP32-Audio-Board/test/run_tests.sh
+++ b/Examples/ESP32-Audio-Board/test/run_tests.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Builds and runs the host-buildable unit tests with the system C compiler —
+# no ESP-IDF toolchain needed, since these files have zero ESP-IDF dependency.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+CC="${CC:-cc}"
+"$CC" -std=c11 -Wall -Wextra -O0 -g \
+    test_main.c \
+    ../main/text_utils.c \
+    ../main/weather_codes.c \
+    -o /tmp/esp32_audio_board_tests
+
+/tmp/esp32_audio_board_tests

--- a/Examples/ESP32-Audio-Board/test/test_main.c
+++ b/Examples/ESP32-Audio-Board/test/test_main.c
@@ -1,0 +1,92 @@
+// Host-buildable tests for the pure-C helpers that have no ESP-IDF
+// dependency. Run via ./run_tests.sh — no target hardware or toolchain
+// needed. Everything else in this project (audio, WiFi, the Realtime
+// session, barge-in) is hardware-in-the-loop and isn't covered here.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../main/text_utils.h"
+#include "../main/weather_codes.h"
+
+static int failures = 0;
+
+#define EXPECT_STR_EQ(actual, expected)                                      \
+    do {                                                                     \
+        const char *_a = (actual);                                          \
+        const char *_e = (expected);                                        \
+        if (strcmp(_a, _e) != 0) {                                          \
+            printf("FAIL %s:%d: expected \"%s\", got \"%s\"\n", __FILE__,    \
+                   __LINE__, _e, _a);                                       \
+            failures++;                                                     \
+        } else {                                                            \
+            printf("PASS %s:%d\n", __FILE__, __LINE__);                     \
+        }                                                                    \
+    } while (0)
+
+static void test_weather_codes(void) {
+    EXPECT_STR_EQ(describe_weather_code(0, true), "clear sky");
+    EXPECT_STR_EQ(describe_weather_code(63, true), "moderate rain");
+    EXPECT_STR_EQ(describe_weather_code(95, true), "thunderstorm");
+    EXPECT_STR_EQ(describe_weather_code(999, true), "unknown conditions");
+    // A missing code must not be confused with the (also valid) code 0.
+    EXPECT_STR_EQ(describe_weather_code(0, false), "unknown conditions");
+}
+
+static void test_strip_citations(void) {
+    char *r;
+
+    r = strip_citations("The sky is blue.");
+    EXPECT_STR_EQ(r, "The sky is blue.");
+    free(r);
+
+    // A single-citation group is dropped entirely, including its leading
+    // whitespace -- there is deliberately no space left before the period.
+    r = strip_citations("It rained today ([weather.com](https://weather.com)).");
+    EXPECT_STR_EQ(r, "It rained today.");
+    free(r);
+
+    // Multiple links inside one parenthetical, comma-separated.
+    r = strip_citations(
+        "Score was 3-1 ([espn](https://espn.com), [bbc](https://bbc.com)).");
+    EXPECT_STR_EQ(r, "Score was 3-1.");
+    free(r);
+
+    // A citation group in the middle of a sentence: only the ONE leading
+    // space before the parens is consumed, so the surrounding text still
+    // reads naturally with a single space.
+    r = strip_citations(
+        "Sunshine tomorrow ([source](https://x.com)) according to reports.");
+    EXPECT_STR_EQ(r, "Sunshine tomorrow according to reports.");
+    free(r);
+
+    // A standalone markdown link (not wrapped in citation parens) keeps
+    // its surrounding text and is replaced with just its inner text.
+    r = strip_citations("See [this article](https://example.com) for more.");
+    EXPECT_STR_EQ(r, "See this article for more.");
+    free(r);
+
+    r = strip_citations("");
+    EXPECT_STR_EQ(r, "");
+    free(r);
+
+    if (strip_citations(NULL) != NULL) {
+        printf("FAIL: strip_citations(NULL) should return NULL\n");
+        failures++;
+    } else {
+        printf("PASS: strip_citations(NULL) returns NULL\n");
+    }
+}
+
+int main(void) {
+    test_weather_codes();
+    test_strip_citations();
+
+    if (failures == 0) {
+        printf("\nAll tests passed.\n");
+        return 0;
+    }
+    printf("\n%d test(s) failed.\n", failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary
- Native ESP-IDF firmware for Waveshare's ESP32-S3-AUDIO-Board that streams mic audio to OpenAI's Realtime API and plays the spoken response through the on-board speaker — the same speech-to-speech behavior as the `VoiceAssistant` WendyOS example, running standalone on the ESP32 instead of on a Linux device.
- Full-duplex barge-in enabled, plus tool-call parity with `VoiceAssistant`: local volume control (ES8311), weather (Open-Meteo), and web search (OpenAI Responses API).
- I2C/I2S pin map and codec init are ported from Waveshare's own demo firmware (`ESP32-S3-AUDIO-Board-Demo.zip`), since the product docs page lists no GPIOs.

## Status
- Build-verified clean against ESP-IDF 5.5.1 (`esp32s3` target, 73% flash free).
- Host-buildable pure-C unit tests (`test/run_tests.sh`) pass — WMO weather-code lookup and web-search citation stripping.
- **Hardware-unverified** — no physical board was available to test audio, WiFi, or the live Realtime session end-to-end.

## Test plan
- [ ] Flash to real ESP32-S3-AUDIO-Board hardware and confirm mic capture / speaker playback
- [ ] Verify barge-in behavior given the board has no dedicated AEC chip
- [ ] Confirm volume/weather/web_search tool calls work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bg7dBCYroFW55WHFjULyeU