### PR TITLE
Build host authorization: require a person to build, authenticate the push hop

### DIFF
--- a/Proto/wendy/agent/services/v2/build_service.proto
+++ b/Proto/wendy/agent/services/v2/build_service.proto
@@ -7,10 +7,19 @@ option go_package = "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2;agent
 // WendyBuildService lets a CLI delegate a container image build to this device,
 // so a developer's laptop does not have to be the machine that builds.
 //
-// BuildImage is remote code execution by design — that is the feature — so two
-// things are non-negotiable here: the device must be explicitly opted in as a
-// builder (see builder_enabled), and every field of a BuildSpec is re-validated
-// on the server rather than trusted from the client, even an in-org one.
+// BuildImage is remote code execution by design — that is the feature — so
+// three things are non-negotiable here: the device must be explicitly opted in
+// as a builder (see builder_enabled); every field of a BuildSpec is re-validated
+// on the server rather than trusted from the client, even an in-org one; and the
+// caller must be a *person*.
+//
+// That last one means a user certificate, or the local admin socket, whose
+// filesystem permissions are themselves the credential. A device certificate is
+// refused, and so is the unauthenticated pre-provisioning plaintext port.
+// SetBuildHostEnabled below already makes the same demand; if BuildImage did
+// not, the opt-in gate would admit the very certificate type its own toggle
+// rejects, leaving a compromised device in the org with code execution on the
+// build host.
 service WendyBuildService {
   rpc GetBuildCapabilities(GetBuildCapabilitiesRequest) returns (GetBuildCapabilitiesResponse);
   rpc BuildImage(stream BuildImageRequest) returns (stream BuildImageProgress);

--- a/go/internal/agent/services/build_push_proxy.go
+++ b/go/internal/agent/services/build_push_proxy.go
@@ -2,12 +2,20 @@ package services
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/subtle"
 	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
-	"io"
 	"net"
+	"net/http"
+	"net/http/httputil"
+	"os"
+	"path/filepath"
 	"regexp"
 	"sync"
+	"time"
 
 	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
 	"google.golang.org/grpc/codes"
@@ -34,10 +42,16 @@ type PeerDialer interface {
 // cannot distinguish an unreachable peer from a rejected certificate, which are
 // the two causes with entirely different fixes.
 type pushProxy struct {
-	addr    string
-	ln      net.Listener
-	stop    func()
-	assetID int32
+	addr string
+	ln   net.Listener
+	stop func()
+	// credential is this build's loopback password. The listener is on
+	// 127.0.0.1, which is not a boundary on a shared build host: every local
+	// user can reach it, and without a credential any of them could push an
+	// arbitrary image to the target device using the agent's mesh identity and
+	// client certificate, for as long as a build runs.
+	credential string
+	assetID    int32
 	// dial opens the outbound hop. A field so tests can relay over plain TCP;
 	// production dials the mesh peer and wraps the result in TLS. It must be set
 	// before serve, which is when the first reader of it can exist.
@@ -119,21 +133,35 @@ func startPushProxy(ctx context.Context, dialer PeerDialer, target *agentpbv2.Pu
 	return p, nil
 }
 
-// newPushProxy binds the loopback listener but accepts nothing yet.
+// pushProxyUser is the username half of the loopback credential. Only the
+// password carries entropy; the username exists because the registry credential
+// format has a slot for one.
+const pushProxyUser = "wendy-build"
+
+// newPushProxy binds the loopback listener and mints this build's credential,
+// but serves nothing yet.
 //
 // Construction is split from serve so that a caller replacing dial — a test
 // relaying over plain TCP — writes the field before any goroutine that reads it
-// exists. Overwriting it after the accept loop is running is a data race.
+// exists. Overwriting it after the server is running is a data race.
 func newPushProxy(dialer PeerDialer, target *agentpbv2.PushTarget, tlsCfg *tls.Config) (*pushProxy, error) {
+	credential, err := newPushCredential()
+	if err != nil {
+		return nil, err
+	}
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return nil, fmt.Errorf("starting push proxy: %w", err)
 	}
 	return &pushProxy{
-		addr:    ln.Addr().String(),
-		ln:      ln,
-		stop:    func() { _ = ln.Close() },
-		assetID: target.GetAssetId(),
+		addr: ln.Addr().String(),
+		ln:   ln,
+		// Serving replaces this with the server's own shutdown. Set here so a
+		// proxy that is constructed and never served is still closable, rather
+		// than leaking the listener through a nil func.
+		stop:       func() { _ = ln.Close() },
+		credential: credential,
+		assetID:    target.GetAssetId(),
 		dial: func(ctx context.Context) (net.Conn, error) {
 			raw, _, derr := dialer.DialDevice(ctx, target.GetAssetId(), uint16(target.GetRegistryPort()))
 			if derr != nil {
@@ -145,52 +173,118 @@ func newPushProxy(dialer PeerDialer, target *agentpbv2.PushTarget, tlsCfg *tls.C
 	}, nil
 }
 
-// serve accepts loopback connections until stop closes the listener.
+// newPushCredential mints the per-build password for the loopback hop.
+func newPushCredential() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generating the push credential: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+// authorized reports whether r carries this build's credential.
+//
+// Constant-time comparison because the attacker this gate exists for is local
+// and can retry as fast as loopback allows.
+func (p *pushProxy) authorized(r *http.Request) bool {
+	user, pass, ok := r.BasicAuth()
+	if !ok {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(user), []byte(pushProxyUser)) == 1 &&
+		subtle.ConstantTimeCompare([]byte(pass), []byte(p.credential)) == 1
+}
+
+// serve runs the loopback registry endpoint until stop shuts it down.
+//
+// This is an HTTP reverse proxy rather than the byte relay it replaces, because
+// a byte relay cannot tell one local connection from another: it forwards
+// whatever arrives, using credentials the caller does not have. Speaking HTTP is
+// what makes the credential check possible.
 func (p *pushProxy) serve(ctx context.Context) {
-	go func() {
-		for {
-			local, acceptErr := p.ln.Accept()
-			if acceptErr != nil {
-				return // listener closed by stop()
+	rp := &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			// The transport always dials the mesh peer regardless of this host,
+			// so it serves only to produce a well-formed request. The inbound
+			// Host is preserved: the target's registry names images from its own
+			// listen address, and the byte relay this replaces forwarded the
+			// header untouched.
+			pr.Out.URL.Scheme = "https"
+			pr.Out.URL.Host = pr.In.Host
+			pr.Out.Host = pr.In.Host
+			// The loopback credential is ours, not the registry's. The registry
+			// authenticates us by client certificate.
+			pr.Out.Header.Del("Authorization")
+		},
+		Transport: &http.Transport{
+			DialTLSContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return p.dial(ctx)
+			},
+			// Registry pushes are HTTP/1.1 with sized bodies; the byte relay this
+			// replaces never negotiated h2, so do not start now.
+			ForceAttemptHTTP2:     false,
+			MaxIdleConnsPerHost:   8,
+			ResponseHeaderTimeout: 0,
+		},
+		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {
+			// Same reason the byte relay recorded its dial failure: buildkit
+			// would otherwise see only a broken loopback connection, which
+			// cannot distinguish an unreachable peer from a rejected certificate.
+			p.recordError(fmt.Errorf("reaching device %d's registry over the mesh: %w", p.assetID, err))
+			w.WriteHeader(http.StatusBadGateway)
+		},
+	}
+
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !p.authorized(r) {
+				// The challenge is what makes this work with an ordinary
+				// registry client: containerd's authorizer retries with the
+				// credentials it holds for this host once it sees one.
+				w.Header().Set("WWW-Authenticate", `Basic realm="wendy build push"`)
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
 			}
-			go p.proxyOne(ctx, local)
-		}
-	}()
+			rp.ServeHTTP(w, r)
+		}),
+		BaseContext: func(net.Listener) context.Context { return ctx },
+		// A layer push can legitimately take minutes; a read/write deadline here
+		// would abort large uploads rather than protect anything.
+		ReadHeaderTimeout: 30 * time.Second,
+	}
+	p.stop = func() { _ = srv.Close() }
+
+	go func() { _ = srv.Serve(p.ln) }()
 }
 
-func (p *pushProxy) proxyOne(ctx context.Context, local net.Conn) {
-	defer local.Close()
-	remote, err := p.dial(ctx)
+// dockerConfigWithPushAuth writes a docker config.json holding the loopback
+// credential and returns its directory, for DOCKER_CONFIG.
+//
+// A file rather than anything on the command line, deliberately: buildctl's
+// argv is world-readable through /proc/<pid>/cmdline, so a credential passed as
+// an argument — or embedded in the image reference — would be readable by the
+// very local user this gate exists to stop. /proc/<pid>/environ is restricted to
+// the process owner, and the file itself is 0600 in a 0700 directory.
+func dockerConfigWithPushAuth(dir, registryHost, credential string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("creating the push credential directory: %w", err)
+	}
+	type authEntry struct {
+		Auth string `json:"auth"`
+	}
+	cfg := struct {
+		Auths map[string]authEntry `json:"auths"`
+	}{
+		Auths: map[string]authEntry{
+			registryHost: {Auth: base64.StdEncoding.EncodeToString([]byte(pushProxyUser + ":" + credential))},
+		},
+	}
+	data, err := json.Marshal(cfg)
 	if err != nil {
-		p.recordError(fmt.Errorf("reaching device %d's registry over the mesh: %w", p.assetID, err))
-		return
+		return fmt.Errorf("encoding the push credential: %w", err)
 	}
-	defer remote.Close()
-	relayConns(local, remote)
-}
-
-// relayConns splices two connections until BOTH directions finish, signalling
-// end-of-stream to the far side with a half-close where the transport supports
-// one. This mirrors mesh.relayBytes, and the "both" matters: returning after
-// only the first direction completes tears down a socket that still has unread
-// data, which TCP signals as RST rather than FIN — reaching the peer as
-// "connection reset by peer" rather than a clean end of response.
-func relayConns(a, b net.Conn) {
-	done := make(chan struct{}, 2)
-	cp := func(dst, src net.Conn) {
-		_, _ = io.Copy(dst, src)
-		type closeWriter interface{ CloseWrite() error }
-		if cw, ok := dst.(closeWriter); ok {
-			_ = cw.CloseWrite()
-		} else {
-			// No half-close available: closing outright is the only way to stop
-			// the opposite copy blocking forever and leaking its goroutine.
-			_ = dst.Close()
-		}
-		done <- struct{}{}
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), data, 0o600); err != nil {
+		return fmt.Errorf("writing the push credential: %w", err)
 	}
-	go cp(b, a)
-	go cp(a, b)
-	<-done
-	<-done
+	return nil
 }

--- a/go/internal/agent/services/build_push_proxy_test.go
+++ b/go/internal/agent/services/build_push_proxy_test.go
@@ -3,11 +3,17 @@ package services
 import (
 	"context"
 	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
-	"time"
 
 	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
 )
@@ -47,70 +53,194 @@ func TestPushProxy_SurfacesDialFailure(t *testing.T) {
 	}
 	defer proxy.stop()
 
-	conn, err := net.Dial("tcp", proxy.addr)
-	if err != nil {
-		t.Fatalf("dialing the proxy: %v", err)
+	req, _ := http.NewRequest(http.MethodHead, "http://"+proxy.addr+"/v2/", nil)
+	req.SetBasicAuth(pushProxyUser, proxy.credential)
+	resp, err := http.DefaultClient.Do(req)
+	if err == nil {
+		resp.Body.Close()
 	}
-	// Drive one request through so the proxy attempts its outbound dial.
-	conn.SetDeadline(time.Now().Add(5 * time.Second))
-	conn.Write([]byte("HEAD /v2/ HTTP/1.1\r\nHost: x\r\n\r\n"))
-	io.Copy(io.Discard, conn)
-	conn.Close()
 
 	if got := proxy.firstError(); got == nil {
 		t.Fatal("the proxy must record why the outbound dial failed, not discard it")
 	}
 }
 
-// A client that finishes sending and half-closes must still receive the whole
-// response. Tearing both connections down as soon as ONE direction finishes
-// truncates the reply, which reaches the client as "connection reset by peer" —
-// the failure buildkit hit on every concurrent push connection.
-func TestPushProxy_DeliversResponseAfterClientHalfClose(t *testing.T) {
-	const reply = "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n"
+// proxyToBackend wires a proxy whose outbound hop is a plain-TCP test backend.
+// The mesh dial and TLS wrapping are orthogonal to what these tests check.
+func proxyToBackend(t *testing.T, handler http.Handler) *pushProxy {
+	t.Helper()
+	backend := httptest.NewServer(handler)
+	t.Cleanup(backend.Close)
 
-	backend, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	defer backend.Close()
-	go func() {
-		c, aerr := backend.Accept()
-		if aerr != nil {
-			return
-		}
-		defer c.Close()
-		io.Copy(io.Discard, c) // read until the client half-closes
-		c.Write([]byte(reply))
-	}()
-
-	proxy, err := newPushProxy(stubPeerDialer{addr: backend.Addr().String()}, testTarget(), nil)
+	proxy, err := newPushProxy(stubPeerDialer{addr: backend.Listener.Addr().String()}, testTarget(), nil)
 	if err != nil {
 		t.Fatalf("newPushProxy: %v", err)
 	}
-	defer proxy.stop()
-	// Plain TCP for the backend hop; the TLS wrapping is orthogonal to relaying.
-	// Set before serve, so no accepting goroutine can be reading dial yet.
+	// Wrapped rather than passed directly: serve replaces stop, and t.Cleanup
+	// would otherwise capture the pre-serve value.
+	t.Cleanup(func() { proxy.stop() })
+	// Set before serve, so no goroutine can be reading dial yet.
 	proxy.dial = func(ctx context.Context) (net.Conn, error) {
-		return net.Dial("tcp", backend.Addr().String())
+		return net.Dial("tcp", backend.Listener.Addr().String())
 	}
 	proxy.serve(context.Background())
+	return proxy
+}
 
-	conn, err := net.Dial("tcp", proxy.addr)
-	if err != nil {
-		t.Fatalf("dialing proxy: %v", err)
-	}
-	defer conn.Close()
-	conn.SetDeadline(time.Now().Add(10 * time.Second))
-	conn.Write([]byte("HEAD /v2/x/blobs/sha256:deadbeef HTTP/1.1\r\nHost: x\r\n\r\n"))
-	conn.(*net.TCPConn).CloseWrite()
+// The whole point of WDY-2371: loopback is not a boundary on a shared build
+// host, so an unauthenticated local process must not be able to push through
+// this proxy using the agent's mesh identity and certificate.
+func TestPushProxy_RefusesUnauthenticatedLocalCaller(t *testing.T) {
+	var reached bool
+	proxy := proxyToBackend(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
 
-	got, err := io.ReadAll(conn)
+	resp, err := http.Get("http://" + proxy.addr + "/v2/evil/blobs/uploads/")
 	if err != nil {
-		t.Fatalf("reading response through the proxy: %v", err)
+		t.Fatalf("requesting through the proxy: %v", err)
 	}
-	if string(got) != reply {
-		t.Fatalf("response truncated through the proxy:\n got: %q\nwant: %q", got, reply)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 for a caller with no credential", resp.StatusCode)
+	}
+	if reached {
+		t.Fatal("an unauthenticated request reached the target device's registry")
+	}
+	// containerd's authorizer only retries with credentials once it sees a
+	// challenge, so without this header a legitimate push never authenticates.
+	if got := resp.Header.Get("WWW-Authenticate"); !strings.HasPrefix(got, "Basic ") {
+		t.Fatalf("WWW-Authenticate = %q, want a Basic challenge", got)
+	}
+}
+
+func TestPushProxy_RefusesWrongCredential(t *testing.T) {
+	proxy := proxyToBackend(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("a request with the wrong credential reached the registry")
+	}))
+
+	req, _ := http.NewRequest(http.MethodGet, "http://"+proxy.addr+"/v2/", nil)
+	req.SetBasicAuth(pushProxyUser, "not-the-credential")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("requesting through the proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 for a wrong credential", resp.StatusCode)
+	}
+}
+
+// Each build mints its own credential, so one leaked from a previous build is
+// not a standing key to the next one.
+func TestPushProxy_CredentialIsPerBuild(t *testing.T) {
+	first, err := newPushProxy(stubPeerDialer{}, testTarget(), nil)
+	if err != nil {
+		t.Fatalf("newPushProxy: %v", err)
+	}
+	defer first.ln.Close()
+	second, err := newPushProxy(stubPeerDialer{}, testTarget(), nil)
+	if err != nil {
+		t.Fatalf("newPushProxy: %v", err)
+	}
+	defer second.ln.Close()
+
+	if first.credential == "" {
+		t.Fatal("a proxy must mint a credential")
+	}
+	if first.credential == second.credential {
+		t.Fatal("two builds must not share a push credential")
+	}
+}
+
+// The authenticated path must reach the registry with the body and method
+// intact — and without the loopback credential, which is ours and means nothing
+// to the target (it authenticates us by client certificate).
+func TestPushProxy_ForwardsAuthenticatedRequestWithoutTheCredential(t *testing.T) {
+	var (
+		gotAuth   string
+		gotMethod string
+		gotPath   string
+		gotBody   string
+	)
+	proxy := proxyToBackend(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte("done"))
+	}))
+
+	req, _ := http.NewRequest(http.MethodPut,
+		"http://"+proxy.addr+"/v2/myapp/blobs/uploads/abc", strings.NewReader("layer-bytes"))
+	req.SetBasicAuth(pushProxyUser, proxy.credential)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("requesting through the proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status = %d, want 201 forwarded from the registry", resp.StatusCode)
+	}
+	if string(body) != "done" {
+		t.Fatalf("response body = %q, want the registry's %q", body, "done")
+	}
+	if gotAuth != "" {
+		t.Fatalf("the loopback credential was forwarded to the registry: %q", gotAuth)
+	}
+	if gotMethod != http.MethodPut || gotPath != "/v2/myapp/blobs/uploads/abc" {
+		t.Fatalf("request reached the registry as %s %s, want PUT /v2/myapp/blobs/uploads/abc", gotMethod, gotPath)
+	}
+	if gotBody != "layer-bytes" {
+		t.Fatalf("body reached the registry as %q, want %q", gotBody, "layer-bytes")
+	}
+}
+
+// buildctl must be able to find the credential, and must find it in a file
+// rather than anywhere argv-visible.
+func TestDockerConfigWithPushAuth_WritesUsableCredential(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "auth")
+	if err := dockerConfigWithPushAuth(dir, "127.0.0.1:41000", "s3cret"); err != nil {
+		t.Fatalf("dockerConfigWithPushAuth: %v", err)
+	}
+
+	path := filepath.Join(dir, "config.json")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat config.json: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("config.json mode = %o, want 0600 — it holds a credential", perm)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading config.json: %v", err)
+	}
+	var parsed struct {
+		Auths map[string]struct {
+			Auth string `json:"auth"`
+		} `json:"auths"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("config.json is not valid docker config: %v", err)
+	}
+	entry, ok := parsed.Auths["127.0.0.1:41000"]
+	if !ok {
+		t.Fatalf("no auth entry for the proxy address, got %v", parsed.Auths)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(entry.Auth)
+	if err != nil {
+		t.Fatalf("auth entry is not base64: %v", err)
+	}
+	if string(decoded) != pushProxyUser+":s3cret" {
+		t.Fatalf("auth entry decodes to %q, want %q", decoded, pushProxyUser+":s3cret")
 	}
 }
 

--- a/go/internal/agent/services/build_service.go
+++ b/go/internal/agent/services/build_service.go
@@ -213,7 +213,7 @@ func (s *BuildService) builderEnabled() bool {
 // comment in build_service.proto: without that split the opt-in gate would be
 // decorative, because anything able to call BuildImage could call this first.
 func (s *BuildService) SetBuildHostEnabled(ctx context.Context, req *agentpbv2.SetBuildHostEnabledRequest) (*agentpbv2.SetBuildHostEnabledResponse, error) {
-	actor, err := userIdentityFromContext(ctx)
+	actor, err := userIdentityFromContext(ctx, "changing the builder role")
 	if err != nil {
 		return nil, err
 	}
@@ -243,32 +243,53 @@ func (s *BuildService) SetBuildHostEnabled(ctx context.Context, req *agentpbv2.S
 	return &agentpbv2.SetBuildHostEnabledResponse{Enabled: req.GetEnabled()}, nil
 }
 
+// onLocalAdminSocket reports whether the caller arrived over the agent's local
+// unix socket rather than a network listener.
+//
+// That socket carries no TLS, so it has no certificate to inspect — but it is
+// not therefore untrusted: access to it IS the credential. It lives at 0660
+// under a root-owned directory that oci.applyAdmin bind-mounts only into
+// containers holding the admin entitlement, so reaching it already means
+// full-agent authority.
+//
+// The distinction matters because "no TLS" alone does not imply the local
+// socket. The pre-provisioning plaintext TCP server on the agent port also has
+// no TLS and is reachable by anyone on the LAN, and registerAllServices puts
+// this service on both. The listener's network is what separates them.
+func onLocalAdminSocket(p *peer.Peer) bool {
+	return p != nil && p.Addr != nil && p.Addr.Network() == "unix"
+}
+
 // userIdentityFromContext admits only a caller presenting a wendy USER
 // certificate, and returns that identity so the caller can name it in an audit
 // log. Mirrors MeshService.assetIdentityFromContext, which makes the opposite
 // demand: mesh dials are device-to-device, this is human-to-device.
+//
+// action names the operation being gated, so the refusal tells the caller what
+// they were denied rather than naming whichever RPC happened to define the
+// helper.
 //
 // Org equality is deliberately left to the server's mTLS interceptors here.
 // Unlike MeshDial — which must reject cross-org callers even when
 // WENDY_MTLS_ORG_ENFORCEMENT is off — this device has no independent notion of
 // which org "owns" it beyond the certificate chain that already admitted the
 // connection.
-func userIdentityFromContext(ctx context.Context) (certs.WendyIdentity, error) {
+func userIdentityFromContext(ctx context.Context, action string) (certs.WendyIdentity, error) {
 	p, ok := peer.FromContext(ctx)
 	if !ok {
-		return certs.WendyIdentity{}, status.Error(codes.PermissionDenied, "changing the builder role requires mTLS")
+		return certs.WendyIdentity{}, status.Errorf(codes.PermissionDenied, "%s requires mTLS", action)
 	}
 	tlsInfo, ok := p.AuthInfo.(credentials.TLSInfo)
 	if !ok || len(tlsInfo.State.PeerCertificates) == 0 {
-		return certs.WendyIdentity{}, status.Error(codes.PermissionDenied, "changing the builder role requires a client certificate")
+		return certs.WendyIdentity{}, status.Errorf(codes.PermissionDenied, "%s requires a client certificate", action)
 	}
 	ident, found, err := certs.IdentityFromCert(tlsInfo.State.PeerCertificates[0])
 	if err != nil || !found {
 		return certs.WendyIdentity{}, status.Error(codes.PermissionDenied, "client certificate carries no wendy identity")
 	}
 	if ident.EntityType != "user" {
-		return certs.WendyIdentity{}, status.Error(codes.PermissionDenied,
-			"changing the builder role requires a user certificate; a device certificate cannot opt this host in")
+		return certs.WendyIdentity{}, status.Errorf(codes.PermissionDenied,
+			"%s requires a user certificate; a device certificate is not accepted", action)
 	}
 	return ident, nil
 }
@@ -326,7 +347,45 @@ func buildkitSocketPresent(addr string) bool {
 	return err == nil
 }
 
+// authorizeBuildSubmission decides whether this caller may submit a build.
+//
+// BuildImage executes client-supplied instructions under buildkitd, so this is
+// the boundary that decides who gets code execution on the build host.
+// registerAllServices puts this service on three listeners, which are not
+// equally trusted:
+//
+//   - The mTLS TCP server — a developer's CLI presenting a user certificate.
+//     This covers the cloud tunnel too: the broker relays bytes, so the CLI's
+//     own certificate is what terminates at the agent (see connectCloudAsset).
+//     Allowed.
+//   - The local unix socket — an on-device container holding the admin
+//     entitlement. No TLS, but reaching the socket is already full-agent
+//     authority. Allowed; see onLocalAdminSocket.
+//   - The pre-provisioning plaintext TCP server — anyone on the LAN, no
+//     credential whatsoever. Refused. It only runs before provisioning, when a
+//     build host has nothing to build with, so this closes a hole rather than
+//     removing a capability.
+//
+// A DEVICE certificate is refused everywhere. Builds are submitted by people;
+// nothing in the design has one device build for another. SetBuildHostEnabled
+// already makes exactly this demand, and without the same demand here the gate
+// it protects would admit the certificate type it rejects — leaving a
+// compromised device in the org with arbitrary code execution on the build
+// host, which is the whole thing the opt-in was meant to prevent.
+func authorizeBuildSubmission(ctx context.Context) error {
+	if p, ok := peer.FromContext(ctx); ok && onLocalAdminSocket(p) {
+		return nil
+	}
+	_, err := userIdentityFromContext(ctx, "submitting a build")
+	return err
+}
+
 func (s *BuildService) BuildImage(stream agentpbv2.WendyBuildService_BuildImageServer) error {
+	// Before the opt-in check, so an unauthorized caller cannot use this RPC to
+	// probe whether a device is a build host.
+	if err := authorizeBuildSubmission(stream.Context()); err != nil {
+		return err
+	}
 	if !s.builderEnabled() {
 		return status.Error(codes.FailedPrecondition,
 			"this device is not configured as a build host; run `wendy device build-host enable --device <this device>` to allow remote builds")

--- a/go/internal/agent/services/build_service.go
+++ b/go/internal/agent/services/build_service.go
@@ -63,6 +63,11 @@ var validPlatformRe = regexp.MustCompile(`^[a-z0-9]+/[a-z0-9]+(/[a-z0-9]+)?$`)
 // defaultBuildStateDir holds reassembled build contexts, one directory per app.
 const defaultBuildStateDir = "/var/lib/wendy/buildctx"
 
+// dockerConfigDirSuffix names the per-build credential directory beside the
+// context directory. A sibling rather than a child: anything inside the context
+// directory is build input, and the credential must not end up in the image.
+const dockerConfigDirSuffix = ".auth"
+
 // ChunkSource reads previously staged chunks back in order. It is the same
 // content store WendyContainerService.WriteChunks writes into.
 type ChunkSource interface {
@@ -470,12 +475,22 @@ func (s *BuildService) BuildImage(stream agentpbv2.WendyBuildService_BuildImageS
 	}
 	defer proxy.stop()
 
+	// The credential goes in a file, not in args: buildctl's argv is world
+	// readable through /proc/<pid>/cmdline, so anything secret there would be
+	// readable by the local user this gate exists to stop. See
+	// dockerConfigWithPushAuth.
+	authDir := dir + dockerConfigDirSuffix
+	if err := dockerConfigWithPushAuth(authDir, proxy.addr, proxy.credential); err != nil {
+		return status.Errorf(codes.Internal, "%v", err)
+	}
+	defer os.RemoveAll(authDir)
+
 	args, err := buildctlArgs(dir, df.GetDockerfile(), spec.GetPlatform(), proxy.addr+"/"+target.GetRepository(), df.GetBuildArgs())
 	if err != nil {
 		return err
 	}
 
-	buildErr := s.runBuildctl(ctx, stream, args)
+	buildErr := s.runBuildctl(ctx, stream, args, authDir)
 	// A failed outbound push shows up to buildctl only as a reset loopback
 	// connection, so its error says "exit status 1" and nothing useful. When the
 	// proxy knows the real reason, report THAT — and as Unavailable, which the
@@ -537,9 +552,15 @@ func (s *BuildService) reassembleContext(ctx context.Context, m *agentpbv2.Chunk
 
 // runBuildctl streams buildctl's plain-mode output back as log lines and
 // finishes with the result event.
-func (s *BuildService) runBuildctl(ctx context.Context, stream agentpbv2.WendyBuildService_BuildImageServer, args []string) error {
+//
+// dockerConfigDir holds the loopback push credential. buildctl reads it into
+// the auth provider it attaches to the build session, which is how buildkitd
+// answers the proxy's 401 challenge.
+func (s *BuildService) runBuildctl(ctx context.Context, stream agentpbv2.WendyBuildService_BuildImageServer, args []string, dockerConfigDir string) error {
 	cmd := buildctlCommandContext(ctx, "buildctl", args...)
-	cmd.Env = append(os.Environ(), "BUILDKIT_HOST="+s.buildkitAddress)
+	cmd.Env = append(os.Environ(),
+		"BUILDKIT_HOST="+s.buildkitAddress,
+		"DOCKER_CONFIG="+dockerConfigDir)
 	if s.logger != nil {
 		// Build-arg VALUES can carry secrets, so the command line is never logged raw.
 		s.logger.Info("remote build starting", zap.Strings("args", redactBuildctlArgs(args)))

--- a/go/internal/agent/services/build_service_test.go
+++ b/go/internal/agent/services/build_service_test.go
@@ -883,7 +883,7 @@ func TestRunBuildctl_FailsAndReapsOnOversizedLogLine(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
-	err := (&BuildService{}).runBuildctl(ctx, &stubBuildStream{}, nil)
+	err := (&BuildService{}).runBuildctl(ctx, &stubBuildStream{}, nil, t.TempDir())
 	if status.Code(err) != codes.Internal || !strings.Contains(err.Error(), "reading buildctl output") {
 		t.Fatalf("got %v, want an Internal scanner error instead of a hang or truncated success", err)
 	}

--- a/go/internal/agent/services/build_service_test.go
+++ b/go/internal/agent/services/build_service_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"io"
+	"net"
 	"net/url"
 	"os"
 	"os/exec"
@@ -727,6 +728,85 @@ func (s staticChunkSource) OpenChunkStream(context.Context, [][32]byte) io.Reade
 	return bytes.NewReader(s.data)
 }
 
+// buildSpecForAuthTest is a spec that would get well past the authorization
+// check if it were allowed to, so a PermissionDenied can only have come from
+// the gate rather than from a malformed request.
+func buildSpecForAuthTest() *agentpbv2.BuildSpec {
+	return &agentpbv2.BuildSpec{
+		AppId:      "app",
+		Platform:   "linux/arm64",
+		PushTarget: &agentpbv2.PushTarget{AssetId: 214, RegistryPort: 5000, Repository: "app:latest"},
+		Context:    &agentpbv2.ChunkManifest{ChunkHashes: [][]byte{make([]byte, 32)}},
+		Definition: &agentpbv2.BuildSpec_DockerfileBuild{
+			DockerfileBuild: &agentpbv2.DockerfileBuild{Dockerfile: "Dockerfile"},
+		},
+	}
+}
+
+// A device certificate must not be able to submit a build. SetBuildHostEnabled
+// already refuses one; if BuildImage did not, the gate would admit the very
+// certificate type its own opt-in rejects, and any compromised device in the
+// org would have code execution on the build host.
+func TestBuildImage_RefusesDeviceCertificate(t *testing.T) {
+	svc := enabledService(t)
+	err := svc.BuildImage(&stubBuildStream{
+		ctx:  ctxWithURN("urn:wendy:org:2:asset:345"),
+		spec: buildSpecForAuthTest(),
+	})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("got %v, want PermissionDenied for a device certificate", err)
+	}
+}
+
+// The pre-provisioning plaintext TCP server carries no credential at all, and
+// registerAllServices puts this service on it.
+func TestBuildImage_RefusesPlaintextTCPCaller(t *testing.T) {
+	plaintext := peer.NewContext(context.Background(), &peer.Peer{
+		Addr: &net.TCPAddr{IP: net.IPv4(10, 0, 0, 9), Port: 50051},
+	})
+	err := enabledService(t).BuildImage(&stubBuildStream{ctx: plaintext, spec: buildSpecForAuthTest()})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("got %v, want PermissionDenied for an unauthenticated LAN caller", err)
+	}
+}
+
+// The local unix socket has no TLS, but reaching it means holding the admin
+// entitlement, which is already full-agent authority. It must not be lumped in
+// with the plaintext TCP server just because neither has a certificate.
+func TestBuildImage_AllowsLocalAdminSocket(t *testing.T) {
+	local := peer.NewContext(context.Background(), &peer.Peer{
+		Addr: &net.UnixAddr{Name: "/var/lib/wendy/agent.sock", Net: "unix"},
+	})
+	// Reaches the push-credential step, which is well past authorization: the
+	// service has no PushTLS, so it fails there rather than at the gate.
+	err := enabledService(t).BuildImage(&stubBuildStream{ctx: local, spec: buildSpecForAuthTest()})
+	if status.Code(err) == codes.PermissionDenied {
+		t.Fatalf("the local admin socket must not be refused: %v", err)
+	}
+}
+
+// A user certificate is the ordinary case, on the LAN and through the cloud
+// tunnel alike — the broker relays bytes, so the CLI's own cert terminates here.
+func TestBuildImage_AllowsUserCertificate(t *testing.T) {
+	err := enabledService(t).BuildImage(&stubBuildStream{spec: buildSpecForAuthTest()})
+	if status.Code(err) == codes.PermissionDenied {
+		t.Fatalf("a user certificate must be able to submit a build: %v", err)
+	}
+}
+
+// Authorization runs before the opt-in check, so an unauthorized caller cannot
+// use this RPC to discover whether a device is a build host.
+func TestBuildImage_AuthorizesBeforeDisclosingBuilderRole(t *testing.T) {
+	notABuilder := NewBuildService(zap.NewNop(), BuildServiceOptions{ConfigPath: t.TempDir()})
+	err := notABuilder.BuildImage(&stubBuildStream{
+		ctx:  ctxWithURN("urn:wendy:org:2:asset:345"),
+		spec: buildSpecForAuthTest(),
+	})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("got %v, want PermissionDenied — an unauthorized caller must not learn the builder role's state", err)
+	}
+}
+
 // stubBuildStream is a fake BuildImage server stream for unit tests.
 type stubBuildStream struct {
 	agentpbv2.WendyBuildService_BuildImageServer
@@ -734,9 +814,41 @@ type stubBuildStream struct {
 	extra []*agentpbv2.BuildImageRequest
 	sent  []*agentpbv2.BuildImageProgress
 	recvd bool
+	// ctx overrides the caller identity. Zero value means an ordinary developer
+	// with a user certificate, which is what every test that is not about
+	// authorization wants.
+	ctx context.Context
 }
 
-func (s *stubBuildStream) Context() context.Context { return context.Background() }
+func (s *stubBuildStream) Context() context.Context {
+	if s.ctx != nil {
+		return s.ctx
+	}
+	return userCtx()
+}
+
+// userCtx is a context carrying a wendy USER certificate — the identity a
+// developer's CLI presents, on the LAN path and through the cloud tunnel alike.
+func userCtx() context.Context {
+	return ctxWithURN("urn:wendy:org:2:user:alice")
+}
+
+// ctxWithURN builds a gRPC context whose mTLS peer leaf carries urn. Unlike
+// ctxWithIdentity it takes no *testing.T, so it can be used in struct literals
+// and package-level helpers.
+func ctxWithURN(urn string) context.Context {
+	uri, err := url.Parse(urn)
+	if err != nil {
+		panic("test urn does not parse: " + urn)
+	}
+	leaf := &x509.Certificate{URIs: []*url.URL{uri}}
+	return peer.NewContext(context.Background(), &peer.Peer{
+		Addr: &net.TCPAddr{IP: net.IPv4(10, 0, 0, 2), Port: 4242},
+		AuthInfo: credentials.TLSInfo{
+			State: tls.ConnectionState{PeerCertificates: []*x509.Certificate{leaf}},
+		},
+	})
+}
 
 func (s *stubBuildStream) Recv() (*agentpbv2.BuildImageRequest, error) {
 	if s.recvd {

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/build-host.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/build-host.md
@@ -23,7 +23,18 @@ Enabling takes effect on the next build. There is no agent restart.
 certificate. Without that split the opt-in would be decorative: anything able to
 call `BuildImage` could call `enable` first and let itself in.
 
-Cross-organisation callers are rejected before the command is reached, by the
+Submitting a build makes the same demand. A device certificate cannot build even
+on a host that has opted in — nothing in the design has one device build for
+another, and allowing it would leave a single compromised device with code
+execution on every build host in the organisation. The unauthenticated port the
+agent serves before provisioning does not accept builds either.
+
+The one caller without a certificate is an on-device container holding the
+**admin entitlement**, which reaches the agent over a local unix socket. There
+the socket's own permissions are the credential, and that entitlement already
+carries full agent authority.
+
+Cross-organisation callers are rejected before any of this is reached, by the
 agent's mTLS organisation check.
 
 ## `status`

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
@@ -251,6 +251,13 @@ other people's instructions:
   concurrently. Two people building one app id would otherwise share a context
   directory, and the second build's extraction would replace sources the first
   was still compiling.
+- **Delivery is scoped to one build.** While a build runs, the agent exposes a
+  loopback endpoint that BuildKit pushes through, and that endpoint holds the
+  credentials for reaching the target device. It requires a password minted for
+  that build alone, so other processes on the build host cannot use it to push
+  something of their own to your device. The password is passed to BuildKit in a
+  `0600` file rather than on a command line, where any local user could read it
+  out of `/proc`.
 
 ### Errors
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
@@ -233,10 +233,15 @@ other people's instructions:
 
 - **Anyone in your organisation can build on it.** A remote build executes the
   Dockerfile it was handed, which is the feature — but it means the builder role
-  grants code execution on that device to every holder of a valid organisation
-  certificate. Cross-organisation callers are rejected by the agent's mTLS
-  organisation check. Enable the role on machines you would already trust that
-  way, not on a robot in the field.
+  grants code execution on that device to every *person* in your organisation.
+  Enable it on machines you would already trust that way, not on a robot in the
+  field.
+
+  Three things sit outside that grant. Cross-organisation callers are rejected by
+  the agent's mTLS organisation check. **Devices** are rejected too — submitting a
+  build requires a user certificate, so one compromised device cannot conscript
+  its peers into building for it. And the unauthenticated port the agent serves
+  before provisioning does not accept builds at all.
 - **Build contexts land on its disk.** Sources are reassembled under
   `/var/lib/wendy/buildctx/<app>` (mode `0700`, root-owned) and are kept between
   builds so BuildKit's local-source cache stays warm. They are cleared and

--- a/go/proto/gen/agentpb/v2/build_service_grpc.pb.go
+++ b/go/proto/gen/agentpb/v2/build_service_grpc.pb.go
@@ -31,10 +31,19 @@ const (
 // WendyBuildService lets a CLI delegate a container image build to this device,
 // so a developer's laptop does not have to be the machine that builds.
 //
-// BuildImage is remote code execution by design — that is the feature — so two
-// things are non-negotiable here: the device must be explicitly opted in as a
-// builder (see builder_enabled), and every field of a BuildSpec is re-validated
-// on the server rather than trusted from the client, even an in-org one.
+// BuildImage is remote code execution by design — that is the feature — so
+// three things are non-negotiable here: the device must be explicitly opted in
+// as a builder (see builder_enabled); every field of a BuildSpec is re-validated
+// on the server rather than trusted from the client, even an in-org one; and the
+// caller must be a *person*.
+//
+// That last one means a user certificate, or the local admin socket, whose
+// filesystem permissions are themselves the credential. A device certificate is
+// refused, and so is the unauthenticated pre-provisioning plaintext port.
+// SetBuildHostEnabled below already makes the same demand; if BuildImage did
+// not, the opt-in gate would admit the very certificate type its own toggle
+// rejects, leaving a compromised device in the org with code execution on the
+// build host.
 type WendyBuildServiceClient interface {
 	GetBuildCapabilities(ctx context.Context, in *GetBuildCapabilitiesRequest, opts ...grpc.CallOption) (*GetBuildCapabilitiesResponse, error)
 	BuildImage(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[BuildImageRequest, BuildImageProgress], error)
@@ -100,10 +109,19 @@ func (c *wendyBuildServiceClient) SetBuildHostEnabled(ctx context.Context, in *S
 // WendyBuildService lets a CLI delegate a container image build to this device,
 // so a developer's laptop does not have to be the machine that builds.
 //
-// BuildImage is remote code execution by design — that is the feature — so two
-// things are non-negotiable here: the device must be explicitly opted in as a
-// builder (see builder_enabled), and every field of a BuildSpec is re-validated
-// on the server rather than trusted from the client, even an in-org one.
+// BuildImage is remote code execution by design — that is the feature — so
+// three things are non-negotiable here: the device must be explicitly opted in
+// as a builder (see builder_enabled); every field of a BuildSpec is re-validated
+// on the server rather than trusted from the client, even an in-org one; and the
+// caller must be a *person*.
+//
+// That last one means a user certificate, or the local admin socket, whose
+// filesystem permissions are themselves the credential. A device certificate is
+// refused, and so is the unauthenticated pre-provisioning plaintext port.
+// SetBuildHostEnabled below already makes the same demand; if BuildImage did
+// not, the opt-in gate would admit the very certificate type its own toggle
+// rejects, leaving a compromised device in the org with code execution on the
+// build host.
 type WendyBuildServiceServer interface {
 	GetBuildCapabilities(context.Context, *GetBuildCapabilitiesRequest) (*GetBuildCapabilitiesResponse, error)
 	BuildImage(grpc.BidiStreamingServer[BuildImageRequest, BuildImageProgress]) error


### PR DESCRIPTION
Closes the two HIGH findings from #1636's security review. Both are about the same thing from opposite ends: a build host holds credentials its callers do not, and neither end of that was checking who it was talking to.

Stacked on `jo/remote-build-host` (#1636); retarget to `main` once that merges.

## WDY-2370 — a build must be submitted by a person

`BuildImage` executes client-supplied instructions under buildkitd, gated only on the builder opt-in marker. Any org certificate could submit a build, **including a device certificate** — so one compromised device had arbitrary code execution on every opted-in build host in the org.

`SetBuildHostEnabled` already refused device certs, reasoning that without it the gate would be decorative since anything able to call `BuildImage` could call `enable` first. But the gate it protected then admitted the very certificate type it rejected.

**The prerequisite the issue called out is settled.** The cloud tunnel is TLS passthrough: `connectCloudAsset` presents `auth.Certificates[0]` — the developer's own certificate — and the broker only relays bytes, so the agent sees a user cert on the cloud path exactly as on the LAN path. Tightening this does not break `wendy cloud run --build-host`.

`registerAllServices` puts this service on three listeners, which are not equally trusted:

| Listener | Caller | |
|---|---|---|
| mTLS TCP | a developer's CLI, LAN or cloud tunnel | allowed, user certs only |
| local unix socket | an admin-entitled container | allowed |
| plaintext TCP (pre-provisioning) | anyone on the LAN | refused |

The unix socket carries no TLS, but reaching it *is* the credential: `0660` under a root-owned directory that `oci.applyAdmin` mounts only into entitled containers. So "no TLS" could not be the test — the plaintext port shares that property — and the listener's network is what separates them. The plaintext port only runs before provisioning, when a build host has nothing to build with, so refusing it closes a hole rather than removing a capability.

Authorization runs *before* the opt-in check, so an unauthorized caller cannot use this RPC to probe whether a device is a build host.

## WDY-2371 — the loopback push hop is authenticated

The push proxy accepted any local connection. For the length of a build, any process on the build host could find the ephemeral port and push an arbitrary image to the target device using the agent's mesh reachability and client certificate — a confused deputy handing out credentials the caller does not have. On the motivating deployment, a shared DGX Spark with ordinary local users, that is a real path into someone else's robot. The asset pin added in #1636 does not help here: it authenticates the far end of the hop, not whoever connected to loopback.

Each build now mints a random password and the proxy requires it.

That meant making the proxy **HTTP-aware**. A byte relay cannot tell one local connection from another because there is nothing to inspect; it is now an `httputil.ReverseProxy` that challenges with `401` + `WWW-Authenticate: Basic`, which is what makes an ordinary registry client authenticate — containerd's authorizer retries with the credentials it holds once it sees a challenge. The credential is stripped before forwarding, since the registry authenticates us by client certificate and has no use for it.

**Why the credential lives in a file.** It reaches buildctl through `DOCKER_CONFIG`, `0600` inside a `0700` directory. The simpler design — a nonce in the image reference — fails for a specific reason: buildctl's argv is world-readable through `/proc/<pid>/cmdline`, so the secret would be readable by exactly the local user this gate exists to stop. `/proc/<pid>/environ` is restricted to the process owner.

Preserved from the byte relay: the inbound `Host` header passes through untouched (the target's registry names images from its own listen address), HTTP/2 is not attempted, and outbound failures are still recorded so a delivery failure reports why rather than surfacing as a reset socket.

`relayConns` and its half-close regression test go with it — that bug was a property of splicing two sockets by hand, which no longer happens. Response delivery is covered instead by a test driving a real request through to a real backend, asserting body, method, path, and that the credential was stripped.

## Not done here

WDY-2372 (build-context retention and an aggregate concurrency budget) and WDY-2373 (Swift E2E coverage) are still open.

## Tests

`go test ./internal/agent/services ./internal/cli/commands` — pass, including `-race` on the services package. 12 new tests: the three-listener authorization matrix, and the proxy's unauthenticated/wrong-credential/per-build-credential/forwarding behaviour against a real HTTP client and server.

**One thing this cannot verify:** that buildkitd honours `DOCKER_CONFIG` credentials for a loopback registry. The auth flow is exercised end to end against a real `net/http` client and server, but the hardware run from #1636 (build on a Spark, deliver to a device) should be repeated before merge, since this changes that exact path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6vUHgSXqd1kErEnbnkgae
