### PR TITLE
Add an ipc entitlement so apps can share a socket without sharing a volume

### DIFF
--- a/Proto/wendy/agent/services/v1/wendy_agent_v1_container_service.proto
+++ b/Proto/wendy/agent/services/v1/wendy_agent_v1_container_service.proto
@@ -163,6 +163,8 @@ message CreateContainerProgress {
     int32 total_layers = 3;
     int64 layer_size = 4;
     bool reused_snapshot = 5;
+    // A non-fatal deploy warning that the CLI should show directly to the user.
+    string warning = 6;
 }
 
 message CreateContainerProgressResponse {

--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -282,9 +282,12 @@ func main() {
 
 	notificationSender := services.NewCloudNotificationSender(logger, provisioningSvc)
 	systemAPISocketManager := services.NewAppSystemAPISocketManager(ctx, logger, notificationSender)
+	serviceSocketManager := services.NewServiceSocketManager(logger)
 	if ctrdClient != nil {
 		ctrdClient.SetAppSystemAPISocketProvider(systemAPISocketManager)
 		ctrdClient.RestoreAppSystemAPISockets(ctx)
+		ctrdClient.SetServiceSocketProvider(serviceSocketManager)
+		ctrdClient.RestoreServiceSockets(ctx)
 	}
 
 	go timesyncMgr.RunDirect(ctx)

--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -282,12 +282,12 @@ func main() {
 
 	notificationSender := services.NewCloudNotificationSender(logger, provisioningSvc)
 	systemAPISocketManager := services.NewAppSystemAPISocketManager(ctx, logger, notificationSender)
-	serviceSocketManager := services.NewServiceSocketManager(logger)
+	ipcSocketManager := services.NewIPCSocketManager(logger)
 	if ctrdClient != nil {
 		ctrdClient.SetAppSystemAPISocketProvider(systemAPISocketManager)
 		ctrdClient.RestoreAppSystemAPISockets(ctx)
-		ctrdClient.SetServiceSocketProvider(serviceSocketManager)
-		ctrdClient.RestoreServiceSockets(ctx)
+		ctrdClient.SetIPCSocketProvider(ipcSocketManager)
+		ctrdClient.RestoreIPCSockets(ctx)
 	}
 
 	go timesyncMgr.RunDirect(ctx)

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -71,6 +71,7 @@ type AppSystemAPISocketProvider interface {
 // reason as restartSuppressor above, and so tests can inject a recorder.
 type IPCSocketProvider interface {
 	Ensure(name, role, appID, serviceName string) (string, error)
+	MissingProviderWarning(name string) string
 	PrepareProvider(name, appID, serviceName string) error
 	Release(name, appID, serviceName string)
 	ReleaseApp(appID string)
@@ -235,6 +236,31 @@ func ipcEntitlements(ents []appconfig.Entitlement) []appconfig.Entitlement {
 		out = append(out, e)
 	}
 	return out
+}
+
+func validateUniqueIPCEntitlements(ents []appconfig.Entitlement) error {
+	seen := make(map[string]struct{}, len(ents))
+	for _, e := range ents {
+		if _, ok := seen[e.Name]; ok {
+			return fmt.Errorf("duplicate ipc entitlement for name %q; declare each ipc name at most once per container", e.Name)
+		}
+		seen[e.Name] = struct{}{}
+	}
+	return nil
+}
+
+func containerIdentityFromLabels(containerID string, labels map[string]string) (appID, serviceName string, err error) {
+	appID = labels[labelKeyAppID]
+	if err := appconfig.ValidateAppID(appID); err != nil {
+		return "", "", fmt.Errorf("invalid app ID label on container %q: %w", containerID, err)
+	}
+	serviceName = labels[labelKeyServiceName]
+	if serviceName != "" {
+		if err := appconfig.ValidateServiceName(serviceName); err != nil {
+			return "", "", fmt.Errorf("invalid service name label on container %q: %w", containerID, err)
+		}
+	}
+	return appID, serviceName, nil
 }
 
 // releaseIPCSockets drops every IPC claim a container holds. Safe to
@@ -1125,12 +1151,12 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 		resumeRestarts := c.suppressRestarts(containerName)
 		defer resumeRestarts()
 
-		oldHadSystemAPI := false
-		var oldEntitlements []appconfig.Entitlement
-		if labels, labelErr := existing.Labels(ctx); labelErr == nil {
-			oldEntitlements = parseEntitlementsFromAnnotations(labels)
-			oldHadSystemAPI = entitlementsContain(oldEntitlements, appconfig.EntitlementNotifications)
+		labels, labelErr := existing.Labels(ctx)
+		if labelErr != nil {
+			return fmt.Errorf("loading existing container labels for socket cleanup for %q: %w", containerName, labelErr)
 		}
+		oldEntitlements := parseEntitlementsFromAnnotations(labels)
+		oldHadSystemAPI := entitlementsContain(oldEntitlements, appconfig.EntitlementNotifications)
 		c.logger.Info("Removing existing container", zap.String("container_name", containerName))
 		// Kill the old task's whole process group — not just init — and wait
 		// for it to exit. A surviving process keeps devices/ports the new
@@ -1366,6 +1392,9 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 	var ipcSocketDirs map[string]string
 	ipcRefsOwned := ipcEntitlements(appCfg.Entitlements)
 	if len(ipcRefsOwned) > 0 {
+		if err := validateUniqueIPCEntitlements(ipcRefsOwned); err != nil {
+			return err
+		}
 		if c.ipcSocketProvider == nil {
 			return fmt.Errorf("ipc entitlement unavailable: ipc socket manager is not configured")
 		}
@@ -1381,6 +1410,11 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 				return fmt.Errorf("preparing ipc socket %q: %w", e.Name, ensureErr)
 			}
 			ipcSocketDirs[e.Name] = dir
+			if e.Role == appconfig.IPCRoleConsume {
+				if warning := c.ipcSocketProvider.MissingProviderWarning(e.Name); warning != "" {
+					report(&agentpb.CreateContainerProgress{Warning: warning})
+				}
+			}
 		}
 	}
 
@@ -3631,19 +3665,20 @@ func (c *Client) deleteOne(ctx context.Context, ctr containerd.Container, wantIm
 	// the same reason as stopOne above: the cache is only best-effort warmed
 	// at boot, and a miss there must not silently skip CNI DEL / DNS release
 	// / mesh teardown for a container that is actually isolated.
-	appID, svcName, parseErr := ParseContainerName(ctr.ID())
-	var entitlements []appconfig.Entitlement
-	isolation := c.getIsolation(appID)
-	needsBridge := false
-	if parseErr == nil {
-		if labels, lerr := ctr.Labels(ctx); lerr == nil {
-			entitlements = parseEntitlementsFromAnnotations(labels)
-			if iso, ok := labels[labelKeyIsolation]; ok {
-				isolation = iso
-			}
-		}
-		needsBridge = needsCNIBridgeWiring(isolation, svcName, entitlements)
+	labels, labelsErr := ctr.Labels(ctx)
+	if labelsErr != nil {
+		return "", fmt.Errorf("loading labels for container %q before delete: %w", ctr.ID(), labelsErr)
 	}
+	appID, svcName, identityErr := containerIdentityFromLabels(ctr.ID(), labels)
+	if identityErr != nil {
+		return "", identityErr
+	}
+	entitlements := parseEntitlementsFromAnnotations(labels)
+	isolation := c.getIsolation(appID)
+	if iso, ok := labels[labelKeyIsolation]; ok {
+		isolation = iso
+	}
+	needsBridge := needsCNIBridgeWiring(isolation, svcName, entitlements)
 	if needsBridge {
 		if needsGatewayDNS(isolation, entitlements) {
 			c.releaseMeshDNS(ctr.ID(), appID)
@@ -3698,9 +3733,7 @@ func (c *Client) deleteOne(ctx context.Context, ctr containerd.Container, wantIm
 	// Released here rather than in stopOne for the same reason — a stopped
 	// container keeps its bind mount and is expected to reclaim its socket on
 	// the next start.
-	if parseErr == nil {
-		c.releaseIPCSockets(entitlements, appID, svcName)
-	}
+	c.releaseIPCSockets(entitlements, appID, svcName)
 	c.logger.Info("Container deleted", zap.String("container_id", ctr.ID()))
 	return imgName, nil
 }

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -63,6 +63,19 @@ type AppSystemAPISocketProvider interface {
 	ReleaseApp(appID string)
 }
 
+// ServiceSocketProvider is the narrow capability the client needs from
+// services.ServiceSocketManager to honour the `service` entitlement: claim a
+// name for a container and get the host directory to mount, clear a stale
+// socket before a provider's task starts, and drop claims at teardown.
+// Declared here — rather than importing the concrete type — for the same
+// reason as restartSuppressor above, and so tests can inject a recorder.
+type ServiceSocketProvider interface {
+	Ensure(name, role, appID, serviceName string) (string, error)
+	PrepareProvider(name, appID, serviceName string) error
+	Release(name, appID, serviceName string)
+	ReleaseApp(appID string)
+}
+
 // restartSuppressor is the narrow capability the client needs from the
 // container-restart monitor: pause automatic restarts for a container name
 // while a replace or stop operation holds the handle, so the monitor's
@@ -84,6 +97,7 @@ type Client struct {
 	mu                      sync.Mutex
 	proxyManager            *dbusproxy.Manager // nil if xdg-dbus-proxy is not available
 	systemAPISocketProvider AppSystemAPISocketProvider
+	serviceSocketProvider   ServiceSocketProvider
 
 	// appServices caches the services map for multi-service apps, keyed by appID.
 	// Populated on CreateContainerWithProgress; used by resolveStopOrder.
@@ -193,6 +207,94 @@ func (c *Client) SetMeshDNS(d *mesh.DNSServer) {
 // SetAppSystemAPISocketProvider injects the manager for private app System API sockets.
 func (c *Client) SetAppSystemAPISocketProvider(provider AppSystemAPISocketProvider) {
 	c.systemAPISocketProvider = provider
+}
+
+// SetServiceSocketProvider injects the manager for app-provided service sockets.
+// Called once from main.go at agent startup, before the Client is exposed to
+// concurrent callers (same single-threaded-startup contract as SetMeshDNS).
+func (c *Client) SetServiceSocketProvider(provider ServiceSocketProvider) {
+	c.serviceSocketProvider = provider
+}
+
+// serviceEntitlements returns the `service` entitlements in ents that name a
+// valid service and a valid role. Malformed entries are dropped rather than
+// erroring: the same list is read back from container labels, which are
+// external state the agent must not trust (SOC2-CC6, NIST-SI-10).
+func serviceEntitlements(ents []appconfig.Entitlement) []appconfig.Entitlement {
+	var out []appconfig.Entitlement
+	for _, e := range ents {
+		if e.Type != appconfig.EntitlementService {
+			continue
+		}
+		if appconfig.ValidateServiceSocketName(e.Name) != nil {
+			continue
+		}
+		if e.Role != appconfig.ServiceRoleProvide && e.Role != appconfig.ServiceRoleConsume {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// releaseServiceSockets drops every service claim a container holds. Safe to
+// call for a container with no service entitlements (it does nothing) and safe
+// to call twice — Release is a no-op for an owner that is already gone.
+func (c *Client) releaseServiceSockets(ents []appconfig.Entitlement, appID, serviceName string) {
+	if c.serviceSocketProvider == nil {
+		return
+	}
+	for _, e := range serviceEntitlements(ents) {
+		c.serviceSocketProvider.Release(e.Name, appID, serviceName)
+	}
+}
+
+// RestoreServiceSockets reconstructs service-name claims from trusted,
+// persisted container labels after an agent restart, so a provider does not
+// lose its name to a later app and a still-deployed consumer's directory is not
+// swept as unused. Stopped containers count too: they retain the bind mount and
+// may be started again. It deliberately never touches the sockets themselves —
+// a provider that survived the agent restart is still serving on its.
+func (c *Client) RestoreServiceSockets(ctx context.Context) {
+	if c.serviceSocketProvider == nil {
+		return
+	}
+	ctx = c.withNamespace(ctx)
+	ctrs, err := c.client.Containers(ctx, fmt.Sprintf("labels.%q", labelKeyAppID))
+	if err != nil {
+		c.logger.Warn("restore service sockets: listing containers failed", zap.Error(err))
+		return
+	}
+	labelSets := make([]map[string]string, 0, len(ctrs))
+	for _, ctr := range ctrs {
+		info, err := ctr.Info(ctx)
+		if err != nil {
+			c.logger.Warn("restore service socket: reading container failed", zap.String("id", ctr.ID()), zap.Error(err))
+			continue
+		}
+		labelSets = append(labelSets, info.Labels)
+	}
+	// Providers first, then consumers. Containerd returns containers in no
+	// meaningful order, and restoring a consumer before its provider would emit
+	// a spurious "no provider on this device" warning at every agent start.
+	for _, role := range []string{appconfig.ServiceRoleProvide, appconfig.ServiceRoleConsume} {
+		for _, labels := range labelSets {
+			appID := labels[labelKeyAppID]
+			serviceName := labels[labelKeyServiceName]
+			if appconfig.ValidateAppID(appID) != nil || (serviceName != "" && appconfig.ValidateServiceName(serviceName) != nil) {
+				continue
+			}
+			for _, e := range serviceEntitlements(parseEntitlementsFromAnnotations(labels)) {
+				if e.Role != role {
+					continue
+				}
+				if _, err := c.serviceSocketProvider.Ensure(e.Name, e.Role, appID, serviceName); err != nil {
+					c.logger.Warn("restore service socket failed",
+						zap.String(logfields.AppID, appID), zap.String("service", e.Name), zap.Error(err))
+				}
+			}
+		}
+	}
 }
 
 type appSystemAPIOwner struct {
@@ -1024,8 +1126,10 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 		defer resumeRestarts()
 
 		oldHadSystemAPI := false
+		var oldEntitlements []appconfig.Entitlement
 		if labels, labelErr := existing.Labels(ctx); labelErr == nil {
-			oldHadSystemAPI = entitlementsContain(parseEntitlementsFromAnnotations(labels), appconfig.EntitlementNotifications)
+			oldEntitlements = parseEntitlementsFromAnnotations(labels)
+			oldHadSystemAPI = entitlementsContain(oldEntitlements, appconfig.EntitlementNotifications)
 		}
 		c.logger.Info("Removing existing container", zap.String("container_name", containerName))
 		// Kill the old task's whole process group — not just init — and wait
@@ -1072,6 +1176,11 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 		if oldHadSystemAPI && c.systemAPISocketProvider != nil {
 			c.systemAPISocketProvider.Release(appID, serviceName)
 		}
+		// Release the replaced container's service claims so a redeploy that
+		// drops (or renames) a "provide" entitlement frees the name. Claims the
+		// new spec still declares are re-Ensured below under the same owner key,
+		// and the directory survives the gap whenever a consumer still holds it.
+		c.releaseServiceSockets(oldEntitlements, appID, serviceName)
 		// Stop old D-Bus proxy if any.
 		if c.proxyManager != nil {
 			_ = c.proxyManager.Stop(containerName)
@@ -1250,9 +1359,35 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 		}()
 	}
 
+	// Claim each declared service name before the spec is built. Failure is
+	// fatal, not best-effort: a provider whose name is already taken must not
+	// start believing it owns the socket, and a consumer must not start with a
+	// silently absent mount it will then poll forever.
+	var serviceSocketDirs map[string]string
+	serviceRefsOwned := serviceEntitlements(appCfg.Entitlements)
+	if len(serviceRefsOwned) > 0 {
+		if c.serviceSocketProvider == nil {
+			return fmt.Errorf("service entitlement unavailable: service socket manager is not configured")
+		}
+		serviceSocketDirs = make(map[string]string, len(serviceRefsOwned))
+		defer func() {
+			for _, e := range serviceRefsOwned {
+				c.serviceSocketProvider.Release(e.Name, appID, serviceName)
+			}
+		}()
+		for _, e := range serviceRefsOwned {
+			dir, ensureErr := c.serviceSocketProvider.Ensure(e.Name, e.Role, appID, serviceName)
+			if ensureErr != nil {
+				return fmt.Errorf("preparing service socket %q: %w", e.Name, ensureErr)
+			}
+			serviceSocketDirs[e.Name] = dir
+		}
+	}
+
 	opts := localoci.ApplyOptions{
 		DBusProxySocketDir: dbusProxySocketDir,
 		SystemAPISocketDir: systemAPISocketDir,
+		ServiceSocketDirs:  serviceSocketDirs,
 	}
 	// Pass a shallow copy of appCfg with AppID and ServiceName set to the
 	// derived (validated) values. This ensures ApplyEntitlements always receives
@@ -1467,6 +1602,7 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 	// Container created successfully; keep its external socket resources running.
 	dbusProxyStarted = false
 	systemAPIRefOwned = false
+	serviceRefsOwned = nil
 
 	report(&agentpb.CreateContainerProgress{Phase: agentpb.CreateContainerProgress_COMPLETE})
 
@@ -1606,6 +1742,28 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 	} else {
 		c.logger.Warn("mesh: could not load container spec to recreate resolv.conf before start",
 			zap.String("app_name", appName), zap.Error(serr))
+	}
+
+	// Clear a stale service socket BEFORE the task is created, so the provider's
+	// first bind() in the new run always lands on an empty directory. This is
+	// the platform owning the "provider died without cleanup" failure: without
+	// it the previous run's socket file is still there, the provider's bind
+	// fails with EADDRINUSE, and consumers are left with a socket that opens but
+	// refuses connections. Fail-closed — a provider that cannot get a clean
+	// directory must not start and pretend to serve.
+	if c.serviceSocketProvider != nil {
+		var startEntitlements []appconfig.Entitlement
+		if labels, lerr := container.Labels(ctx); lerr == nil {
+			startEntitlements = parseEntitlementsFromAnnotations(labels)
+		}
+		for _, e := range serviceEntitlements(startEntitlements) {
+			if e.Role != appconfig.ServiceRoleProvide {
+				continue
+			}
+			if err := c.serviceSocketProvider.PrepareProvider(e.Name, appID, serviceName); err != nil {
+				return nil, fmt.Errorf("preparing service socket %q for %q: %w", e.Name, appName, err)
+			}
+		}
 	}
 
 	if restartPolicy != nil {
@@ -3533,6 +3691,15 @@ func (c *Client) deleteOne(ctx context.Context, ctr containerd.Container, wantIm
 				zap.Error(proxyErr))
 		}
 	}
+	// Drop this container's service claims only after the container itself is
+	// gone: a claim released while the container still exists would let another
+	// app take the name out from under a provider that is merely stopped.
+	// Released here rather than in stopOne for the same reason — a stopped
+	// container keeps its bind mount and is expected to reclaim its socket on
+	// the next start.
+	if parseErr == nil {
+		c.releaseServiceSockets(entitlements, appID, svcName)
+	}
 	c.logger.Info("Container deleted", zap.String("container_id", ctr.ID()))
 	return imgName, nil
 }
@@ -3575,6 +3742,12 @@ func (c *Client) DeleteContainer(ctx context.Context, name string, deleteImage b
 	// The system-API socket is per app: only release it once the app is gone.
 	if len(errs) == 0 && wholeApp && c.systemAPISocketProvider != nil {
 		c.systemAPISocketProvider.ReleaseApp(appID)
+	}
+	// Sweep any service claim deleteOne could not attribute (an unparseable
+	// container ID, or labels that failed to load). deleteOne already released
+	// the attributable ones; ReleaseApp is idempotent for those.
+	if len(errs) == 0 && wholeApp && c.serviceSocketProvider != nil {
+		c.serviceSocketProvider.ReleaseApp(appID)
 	}
 	return errors.Join(errs...)
 }

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -1752,10 +1752,11 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 	// refuses connections. Fail-closed — a provider that cannot get a clean
 	// directory must not start and pretend to serve.
 	if c.ipcSocketProvider != nil {
-		var startEntitlements []appconfig.Entitlement
-		if labels, lerr := container.Labels(ctx); lerr == nil {
-			startEntitlements = parseEntitlementsFromAnnotations(labels)
+		labels, lerr := container.Labels(ctx)
+		if lerr != nil {
+			return nil, fmt.Errorf("loading container labels for ipc socket preparation for %q: %w", appName, lerr)
 		}
+		startEntitlements := parseEntitlementsFromAnnotations(labels)
 		for _, e := range ipcEntitlements(startEntitlements) {
 			if e.Role != appconfig.IPCRoleProvide {
 				continue

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -63,13 +63,13 @@ type AppSystemAPISocketProvider interface {
 	ReleaseApp(appID string)
 }
 
-// ServiceSocketProvider is the narrow capability the client needs from
-// services.ServiceSocketManager to honour the `service` entitlement: claim a
+// IPCSocketProvider is the narrow capability the client needs from
+// services.IPCSocketManager to honour the `ipc` entitlement: claim a
 // name for a container and get the host directory to mount, clear a stale
 // socket before a provider's task starts, and drop claims at teardown.
 // Declared here — rather than importing the concrete type — for the same
 // reason as restartSuppressor above, and so tests can inject a recorder.
-type ServiceSocketProvider interface {
+type IPCSocketProvider interface {
 	Ensure(name, role, appID, serviceName string) (string, error)
 	PrepareProvider(name, appID, serviceName string) error
 	Release(name, appID, serviceName string)
@@ -97,7 +97,7 @@ type Client struct {
 	mu                      sync.Mutex
 	proxyManager            *dbusproxy.Manager // nil if xdg-dbus-proxy is not available
 	systemAPISocketProvider AppSystemAPISocketProvider
-	serviceSocketProvider   ServiceSocketProvider
+	ipcSocketProvider       IPCSocketProvider
 
 	// appServices caches the services map for multi-service apps, keyed by appID.
 	// Populated on CreateContainerWithProgress; used by resolveStopOrder.
@@ -209,27 +209,27 @@ func (c *Client) SetAppSystemAPISocketProvider(provider AppSystemAPISocketProvid
 	c.systemAPISocketProvider = provider
 }
 
-// SetServiceSocketProvider injects the manager for app-provided service sockets.
+// SetIPCSocketProvider injects the manager for app-provided IPC sockets.
 // Called once from main.go at agent startup, before the Client is exposed to
 // concurrent callers (same single-threaded-startup contract as SetMeshDNS).
-func (c *Client) SetServiceSocketProvider(provider ServiceSocketProvider) {
-	c.serviceSocketProvider = provider
+func (c *Client) SetIPCSocketProvider(provider IPCSocketProvider) {
+	c.ipcSocketProvider = provider
 }
 
-// serviceEntitlements returns the `service` entitlements in ents that name a
-// valid service and a valid role. Malformed entries are dropped rather than
+// ipcEntitlements returns the `ipc` entitlements in ents that name a valid
+// IPC service and a valid role. Malformed entries are dropped rather than
 // erroring: the same list is read back from container labels, which are
 // external state the agent must not trust (SOC2-CC6, NIST-SI-10).
-func serviceEntitlements(ents []appconfig.Entitlement) []appconfig.Entitlement {
+func ipcEntitlements(ents []appconfig.Entitlement) []appconfig.Entitlement {
 	var out []appconfig.Entitlement
 	for _, e := range ents {
-		if e.Type != appconfig.EntitlementService {
+		if e.Type != appconfig.EntitlementIPC {
 			continue
 		}
-		if appconfig.ValidateServiceSocketName(e.Name) != nil {
+		if appconfig.ValidateIPCName(e.Name) != nil {
 			continue
 		}
-		if e.Role != appconfig.ServiceRoleProvide && e.Role != appconfig.ServiceRoleConsume {
+		if e.Role != appconfig.IPCRoleProvide && e.Role != appconfig.IPCRoleConsume {
 			continue
 		}
 		out = append(out, e)
@@ -237,39 +237,39 @@ func serviceEntitlements(ents []appconfig.Entitlement) []appconfig.Entitlement {
 	return out
 }
 
-// releaseServiceSockets drops every service claim a container holds. Safe to
-// call for a container with no service entitlements (it does nothing) and safe
+// releaseIPCSockets drops every IPC claim a container holds. Safe to
+// call for a container with no ipc entitlements (it does nothing) and safe
 // to call twice — Release is a no-op for an owner that is already gone.
-func (c *Client) releaseServiceSockets(ents []appconfig.Entitlement, appID, serviceName string) {
-	if c.serviceSocketProvider == nil {
+func (c *Client) releaseIPCSockets(ents []appconfig.Entitlement, appID, serviceName string) {
+	if c.ipcSocketProvider == nil {
 		return
 	}
-	for _, e := range serviceEntitlements(ents) {
-		c.serviceSocketProvider.Release(e.Name, appID, serviceName)
+	for _, e := range ipcEntitlements(ents) {
+		c.ipcSocketProvider.Release(e.Name, appID, serviceName)
 	}
 }
 
-// RestoreServiceSockets reconstructs service-name claims from trusted,
+// RestoreIPCSockets reconstructs IPC-name claims from trusted,
 // persisted container labels after an agent restart, so a provider does not
 // lose its name to a later app and a still-deployed consumer's directory is not
 // swept as unused. Stopped containers count too: they retain the bind mount and
 // may be started again. It deliberately never touches the sockets themselves —
 // a provider that survived the agent restart is still serving on its.
-func (c *Client) RestoreServiceSockets(ctx context.Context) {
-	if c.serviceSocketProvider == nil {
+func (c *Client) RestoreIPCSockets(ctx context.Context) {
+	if c.ipcSocketProvider == nil {
 		return
 	}
 	ctx = c.withNamespace(ctx)
 	ctrs, err := c.client.Containers(ctx, fmt.Sprintf("labels.%q", labelKeyAppID))
 	if err != nil {
-		c.logger.Warn("restore service sockets: listing containers failed", zap.Error(err))
+		c.logger.Warn("restore ipc sockets: listing containers failed", zap.Error(err))
 		return
 	}
 	labelSets := make([]map[string]string, 0, len(ctrs))
 	for _, ctr := range ctrs {
 		info, err := ctr.Info(ctx)
 		if err != nil {
-			c.logger.Warn("restore service socket: reading container failed", zap.String("id", ctr.ID()), zap.Error(err))
+			c.logger.Warn("restore ipc socket: reading container failed", zap.String("id", ctr.ID()), zap.Error(err))
 			continue
 		}
 		labelSets = append(labelSets, info.Labels)
@@ -277,20 +277,20 @@ func (c *Client) RestoreServiceSockets(ctx context.Context) {
 	// Providers first, then consumers. Containerd returns containers in no
 	// meaningful order, and restoring a consumer before its provider would emit
 	// a spurious "no provider on this device" warning at every agent start.
-	for _, role := range []string{appconfig.ServiceRoleProvide, appconfig.ServiceRoleConsume} {
+	for _, role := range []string{appconfig.IPCRoleProvide, appconfig.IPCRoleConsume} {
 		for _, labels := range labelSets {
 			appID := labels[labelKeyAppID]
 			serviceName := labels[labelKeyServiceName]
 			if appconfig.ValidateAppID(appID) != nil || (serviceName != "" && appconfig.ValidateServiceName(serviceName) != nil) {
 				continue
 			}
-			for _, e := range serviceEntitlements(parseEntitlementsFromAnnotations(labels)) {
+			for _, e := range ipcEntitlements(parseEntitlementsFromAnnotations(labels)) {
 				if e.Role != role {
 					continue
 				}
-				if _, err := c.serviceSocketProvider.Ensure(e.Name, e.Role, appID, serviceName); err != nil {
-					c.logger.Warn("restore service socket failed",
-						zap.String(logfields.AppID, appID), zap.String("service", e.Name), zap.Error(err))
+				if _, err := c.ipcSocketProvider.Ensure(e.Name, e.Role, appID, serviceName); err != nil {
+					c.logger.Warn("restore ipc socket failed",
+						zap.String(logfields.AppID, appID), zap.String("ipc_name", e.Name), zap.Error(err))
 				}
 			}
 		}
@@ -1176,11 +1176,11 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 		if oldHadSystemAPI && c.systemAPISocketProvider != nil {
 			c.systemAPISocketProvider.Release(appID, serviceName)
 		}
-		// Release the replaced container's service claims so a redeploy that
+		// Release the replaced container's IPC claims so a redeploy that
 		// drops (or renames) a "provide" entitlement frees the name. Claims the
 		// new spec still declares are re-Ensured below under the same owner key,
 		// and the directory survives the gap whenever a consumer still holds it.
-		c.releaseServiceSockets(oldEntitlements, appID, serviceName)
+		c.releaseIPCSockets(oldEntitlements, appID, serviceName)
 		// Stop old D-Bus proxy if any.
 		if c.proxyManager != nil {
 			_ = c.proxyManager.Stop(containerName)
@@ -1359,35 +1359,35 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 		}()
 	}
 
-	// Claim each declared service name before the spec is built. Failure is
+	// Claim each declared IPC name before the spec is built. Failure is
 	// fatal, not best-effort: a provider whose name is already taken must not
 	// start believing it owns the socket, and a consumer must not start with a
 	// silently absent mount it will then poll forever.
-	var serviceSocketDirs map[string]string
-	serviceRefsOwned := serviceEntitlements(appCfg.Entitlements)
-	if len(serviceRefsOwned) > 0 {
-		if c.serviceSocketProvider == nil {
-			return fmt.Errorf("service entitlement unavailable: service socket manager is not configured")
+	var ipcSocketDirs map[string]string
+	ipcRefsOwned := ipcEntitlements(appCfg.Entitlements)
+	if len(ipcRefsOwned) > 0 {
+		if c.ipcSocketProvider == nil {
+			return fmt.Errorf("ipc entitlement unavailable: ipc socket manager is not configured")
 		}
-		serviceSocketDirs = make(map[string]string, len(serviceRefsOwned))
+		ipcSocketDirs = make(map[string]string, len(ipcRefsOwned))
 		defer func() {
-			for _, e := range serviceRefsOwned {
-				c.serviceSocketProvider.Release(e.Name, appID, serviceName)
+			for _, e := range ipcRefsOwned {
+				c.ipcSocketProvider.Release(e.Name, appID, serviceName)
 			}
 		}()
-		for _, e := range serviceRefsOwned {
-			dir, ensureErr := c.serviceSocketProvider.Ensure(e.Name, e.Role, appID, serviceName)
+		for _, e := range ipcRefsOwned {
+			dir, ensureErr := c.ipcSocketProvider.Ensure(e.Name, e.Role, appID, serviceName)
 			if ensureErr != nil {
-				return fmt.Errorf("preparing service socket %q: %w", e.Name, ensureErr)
+				return fmt.Errorf("preparing ipc socket %q: %w", e.Name, ensureErr)
 			}
-			serviceSocketDirs[e.Name] = dir
+			ipcSocketDirs[e.Name] = dir
 		}
 	}
 
 	opts := localoci.ApplyOptions{
 		DBusProxySocketDir: dbusProxySocketDir,
 		SystemAPISocketDir: systemAPISocketDir,
-		ServiceSocketDirs:  serviceSocketDirs,
+		IPCSocketDirs:      ipcSocketDirs,
 	}
 	// Pass a shallow copy of appCfg with AppID and ServiceName set to the
 	// derived (validated) values. This ensures ApplyEntitlements always receives
@@ -1602,7 +1602,7 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 	// Container created successfully; keep its external socket resources running.
 	dbusProxyStarted = false
 	systemAPIRefOwned = false
-	serviceRefsOwned = nil
+	ipcRefsOwned = nil
 
 	report(&agentpb.CreateContainerProgress{Phase: agentpb.CreateContainerProgress_COMPLETE})
 
@@ -1744,24 +1744,24 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 			zap.String("app_name", appName), zap.Error(serr))
 	}
 
-	// Clear a stale service socket BEFORE the task is created, so the provider's
+	// Clear a stale IPC socket BEFORE the task is created, so the provider's
 	// first bind() in the new run always lands on an empty directory. This is
 	// the platform owning the "provider died without cleanup" failure: without
 	// it the previous run's socket file is still there, the provider's bind
 	// fails with EADDRINUSE, and consumers are left with a socket that opens but
 	// refuses connections. Fail-closed — a provider that cannot get a clean
 	// directory must not start and pretend to serve.
-	if c.serviceSocketProvider != nil {
+	if c.ipcSocketProvider != nil {
 		var startEntitlements []appconfig.Entitlement
 		if labels, lerr := container.Labels(ctx); lerr == nil {
 			startEntitlements = parseEntitlementsFromAnnotations(labels)
 		}
-		for _, e := range serviceEntitlements(startEntitlements) {
-			if e.Role != appconfig.ServiceRoleProvide {
+		for _, e := range ipcEntitlements(startEntitlements) {
+			if e.Role != appconfig.IPCRoleProvide {
 				continue
 			}
-			if err := c.serviceSocketProvider.PrepareProvider(e.Name, appID, serviceName); err != nil {
-				return nil, fmt.Errorf("preparing service socket %q for %q: %w", e.Name, appName, err)
+			if err := c.ipcSocketProvider.PrepareProvider(e.Name, appID, serviceName); err != nil {
+				return nil, fmt.Errorf("preparing ipc socket %q for %q: %w", e.Name, appName, err)
 			}
 		}
 	}
@@ -3691,14 +3691,14 @@ func (c *Client) deleteOne(ctx context.Context, ctr containerd.Container, wantIm
 				zap.Error(proxyErr))
 		}
 	}
-	// Drop this container's service claims only after the container itself is
+	// Drop this container's IPC claims only after the container itself is
 	// gone: a claim released while the container still exists would let another
 	// app take the name out from under a provider that is merely stopped.
 	// Released here rather than in stopOne for the same reason — a stopped
 	// container keeps its bind mount and is expected to reclaim its socket on
 	// the next start.
 	if parseErr == nil {
-		c.releaseServiceSockets(entitlements, appID, svcName)
+		c.releaseIPCSockets(entitlements, appID, svcName)
 	}
 	c.logger.Info("Container deleted", zap.String("container_id", ctr.ID()))
 	return imgName, nil
@@ -3743,11 +3743,11 @@ func (c *Client) DeleteContainer(ctx context.Context, name string, deleteImage b
 	if len(errs) == 0 && wholeApp && c.systemAPISocketProvider != nil {
 		c.systemAPISocketProvider.ReleaseApp(appID)
 	}
-	// Sweep any service claim deleteOne could not attribute (an unparseable
+	// Sweep any IPC claim deleteOne could not attribute (an unparseable
 	// container ID, or labels that failed to load). deleteOne already released
 	// the attributable ones; ReleaseApp is idempotent for those.
-	if len(errs) == 0 && wholeApp && c.serviceSocketProvider != nil {
-		c.serviceSocketProvider.ReleaseApp(appID)
+	if len(errs) == 0 && wholeApp && c.ipcSocketProvider != nil {
+		c.ipcSocketProvider.ReleaseApp(appID)
 	}
 	return errors.Join(errs...)
 }

--- a/go/internal/agent/containerd/ipc_socket_test.go
+++ b/go/internal/agent/containerd/ipc_socket_test.go
@@ -1,0 +1,80 @@
+package containerd
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/services"
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+// The concrete manager must keep satisfying the narrow interface the client
+// depends on, so a signature change is caught here rather than in main.go.
+var _ ServiceSocketProvider = (*services.ServiceSocketManager)(nil)
+
+// serviceEntitlements is fed from container labels, which are external state.
+// Anything malformed must be dropped rather than reaching the manager, where
+// the name would become a host path component.
+func TestServiceEntitlements_DropsMalformedEntries(t *testing.T) {
+	got := serviceEntitlements([]appconfig.Entitlement{
+		{Type: appconfig.EntitlementService, Name: "world", Role: appconfig.ServiceRoleProvide},
+		{Type: appconfig.EntitlementService, Name: "planner", Role: appconfig.ServiceRoleConsume},
+		{Type: appconfig.EntitlementPersist, Name: "data", Path: "/data"},
+		{Type: appconfig.EntitlementService, Name: "../etc", Role: appconfig.ServiceRoleProvide},
+		{Type: appconfig.EntitlementService, Name: "..", Role: appconfig.ServiceRoleProvide},
+		{Type: appconfig.EntitlementService, Name: "World", Role: appconfig.ServiceRoleProvide},
+		{Type: appconfig.EntitlementService, Name: "", Role: appconfig.ServiceRoleProvide},
+		{Type: appconfig.EntitlementService, Name: "world2", Role: ""},
+		{Type: appconfig.EntitlementService, Name: "world3", Role: "publish"},
+	})
+	want := []appconfig.Entitlement{
+		{Type: appconfig.EntitlementService, Name: "world", Role: appconfig.ServiceRoleProvide},
+		{Type: appconfig.EntitlementService, Name: "planner", Role: appconfig.ServiceRoleConsume},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("serviceEntitlements = %+v, want %+v", got, want)
+	}
+}
+
+func TestServiceEntitlements_NoneWhenAbsent(t *testing.T) {
+	if got := serviceEntitlements(nil); got != nil {
+		t.Errorf("serviceEntitlements(nil) = %+v, want nil", got)
+	}
+	if got := serviceEntitlements([]appconfig.Entitlement{{Type: appconfig.EntitlementGPU}}); got != nil {
+		t.Errorf("serviceEntitlements(gpu) = %+v, want nil", got)
+	}
+}
+
+// Service entitlements must survive the round trip through container labels:
+// the start-time stale-socket cleanup and the delete-time claim release both
+// read them back from labels rather than from the original request.
+func TestServiceEntitlements_SurviveLabelRoundTrip(t *testing.T) {
+	want := []appconfig.Entitlement{
+		{Type: appconfig.EntitlementService, Name: "world", Role: appconfig.ServiceRoleProvide},
+		{Type: appconfig.EntitlementService, Name: "planner", Role: appconfig.ServiceRoleConsume},
+	}
+	labels := wendyLabels("com.example.app", "api", "1", nil, want, "", nil)
+	got := serviceEntitlements(parseEntitlementsFromAnnotations(labels))
+
+	if len(got) != len(want) {
+		t.Fatalf("round-tripped %d service entitlements, want %d: %+v", len(got), len(want), got)
+	}
+	byName := make(map[string]appconfig.Entitlement, len(got))
+	for _, e := range got {
+		byName[e.Name] = e
+	}
+	for _, w := range want {
+		if !reflect.DeepEqual(byName[w.Name], w) {
+			t.Errorf("service %q round-tripped as %+v, want %+v", w.Name, byName[w.Name], w)
+		}
+	}
+}
+
+// A client with no service socket provider wired in (unit tests, or an agent
+// build without one) must not panic on the release paths.
+func TestReleaseServiceSockets_NilProviderIsNoOp(t *testing.T) {
+	c := &Client{}
+	c.releaseServiceSockets([]appconfig.Entitlement{
+		{Type: appconfig.EntitlementService, Name: "world", Role: appconfig.ServiceRoleProvide},
+	}, "com.example.app", "")
+}

--- a/go/internal/agent/containerd/ipc_socket_test.go
+++ b/go/internal/agent/containerd/ipc_socket_test.go
@@ -45,6 +45,32 @@ func TestIPCEntitlements_NoneWhenAbsent(t *testing.T) {
 	}
 }
 
+func TestValidateUniqueIPCEntitlementsRejectsDuplicateName(t *testing.T) {
+	ents := []appconfig.Entitlement{
+		{Type: appconfig.EntitlementIPC, Name: "world", Role: appconfig.IPCRoleProvide},
+		{Type: appconfig.EntitlementIPC, Name: "world", Role: appconfig.IPCRoleConsume},
+	}
+	if err := validateUniqueIPCEntitlements(ents); err == nil {
+		t.Fatal("duplicate ipc names passed the container-boundary validation")
+	}
+}
+
+func TestContainerIdentityFromLabelsUsesServiceLabel(t *testing.T) {
+	// "myapp_someservice" is itself a valid app ID, so ParseContainerName's
+	// single-container fast path cannot recover this service identity. The
+	// persisted labels are unambiguous and must remain authoritative.
+	appID, serviceName, err := containerIdentityFromLabels("myapp_someservice", map[string]string{
+		labelKeyAppID:       "myapp",
+		labelKeyServiceName: "someservice",
+	})
+	if err != nil {
+		t.Fatalf("containerIdentityFromLabels: %v", err)
+	}
+	if appID != "myapp" || serviceName != "someservice" {
+		t.Fatalf("identity = (%q, %q), want (%q, %q)", appID, serviceName, "myapp", "someservice")
+	}
+}
+
 // IPC entitlements must survive the round trip through container labels:
 // the start-time stale-socket cleanup and the delete-time claim release both
 // read them back from labels rather than from the original request.

--- a/go/internal/agent/containerd/ipc_socket_test.go
+++ b/go/internal/agent/containerd/ipc_socket_test.go
@@ -10,54 +10,54 @@ import (
 
 // The concrete manager must keep satisfying the narrow interface the client
 // depends on, so a signature change is caught here rather than in main.go.
-var _ ServiceSocketProvider = (*services.ServiceSocketManager)(nil)
+var _ IPCSocketProvider = (*services.IPCSocketManager)(nil)
 
-// serviceEntitlements is fed from container labels, which are external state.
+// ipcEntitlements is fed from container labels, which are external state.
 // Anything malformed must be dropped rather than reaching the manager, where
 // the name would become a host path component.
-func TestServiceEntitlements_DropsMalformedEntries(t *testing.T) {
-	got := serviceEntitlements([]appconfig.Entitlement{
-		{Type: appconfig.EntitlementService, Name: "world", Role: appconfig.ServiceRoleProvide},
-		{Type: appconfig.EntitlementService, Name: "planner", Role: appconfig.ServiceRoleConsume},
+func TestIPCEntitlements_DropsMalformedEntries(t *testing.T) {
+	got := ipcEntitlements([]appconfig.Entitlement{
+		{Type: appconfig.EntitlementIPC, Name: "world", Role: appconfig.IPCRoleProvide},
+		{Type: appconfig.EntitlementIPC, Name: "planner", Role: appconfig.IPCRoleConsume},
 		{Type: appconfig.EntitlementPersist, Name: "data", Path: "/data"},
-		{Type: appconfig.EntitlementService, Name: "../etc", Role: appconfig.ServiceRoleProvide},
-		{Type: appconfig.EntitlementService, Name: "..", Role: appconfig.ServiceRoleProvide},
-		{Type: appconfig.EntitlementService, Name: "World", Role: appconfig.ServiceRoleProvide},
-		{Type: appconfig.EntitlementService, Name: "", Role: appconfig.ServiceRoleProvide},
-		{Type: appconfig.EntitlementService, Name: "world2", Role: ""},
-		{Type: appconfig.EntitlementService, Name: "world3", Role: "publish"},
+		{Type: appconfig.EntitlementIPC, Name: "../etc", Role: appconfig.IPCRoleProvide},
+		{Type: appconfig.EntitlementIPC, Name: "..", Role: appconfig.IPCRoleProvide},
+		{Type: appconfig.EntitlementIPC, Name: "World", Role: appconfig.IPCRoleProvide},
+		{Type: appconfig.EntitlementIPC, Name: "", Role: appconfig.IPCRoleProvide},
+		{Type: appconfig.EntitlementIPC, Name: "world2", Role: ""},
+		{Type: appconfig.EntitlementIPC, Name: "world3", Role: "publish"},
 	})
 	want := []appconfig.Entitlement{
-		{Type: appconfig.EntitlementService, Name: "world", Role: appconfig.ServiceRoleProvide},
-		{Type: appconfig.EntitlementService, Name: "planner", Role: appconfig.ServiceRoleConsume},
+		{Type: appconfig.EntitlementIPC, Name: "world", Role: appconfig.IPCRoleProvide},
+		{Type: appconfig.EntitlementIPC, Name: "planner", Role: appconfig.IPCRoleConsume},
 	}
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("serviceEntitlements = %+v, want %+v", got, want)
+		t.Fatalf("ipcEntitlements = %+v, want %+v", got, want)
 	}
 }
 
-func TestServiceEntitlements_NoneWhenAbsent(t *testing.T) {
-	if got := serviceEntitlements(nil); got != nil {
-		t.Errorf("serviceEntitlements(nil) = %+v, want nil", got)
+func TestIPCEntitlements_NoneWhenAbsent(t *testing.T) {
+	if got := ipcEntitlements(nil); got != nil {
+		t.Errorf("ipcEntitlements(nil) = %+v, want nil", got)
 	}
-	if got := serviceEntitlements([]appconfig.Entitlement{{Type: appconfig.EntitlementGPU}}); got != nil {
-		t.Errorf("serviceEntitlements(gpu) = %+v, want nil", got)
+	if got := ipcEntitlements([]appconfig.Entitlement{{Type: appconfig.EntitlementGPU}}); got != nil {
+		t.Errorf("ipcEntitlements(gpu) = %+v, want nil", got)
 	}
 }
 
-// Service entitlements must survive the round trip through container labels:
+// IPC entitlements must survive the round trip through container labels:
 // the start-time stale-socket cleanup and the delete-time claim release both
 // read them back from labels rather than from the original request.
-func TestServiceEntitlements_SurviveLabelRoundTrip(t *testing.T) {
+func TestIPCEntitlements_SurviveLabelRoundTrip(t *testing.T) {
 	want := []appconfig.Entitlement{
-		{Type: appconfig.EntitlementService, Name: "world", Role: appconfig.ServiceRoleProvide},
-		{Type: appconfig.EntitlementService, Name: "planner", Role: appconfig.ServiceRoleConsume},
+		{Type: appconfig.EntitlementIPC, Name: "world", Role: appconfig.IPCRoleProvide},
+		{Type: appconfig.EntitlementIPC, Name: "planner", Role: appconfig.IPCRoleConsume},
 	}
 	labels := wendyLabels("com.example.app", "api", "1", nil, want, "", nil)
-	got := serviceEntitlements(parseEntitlementsFromAnnotations(labels))
+	got := ipcEntitlements(parseEntitlementsFromAnnotations(labels))
 
 	if len(got) != len(want) {
-		t.Fatalf("round-tripped %d service entitlements, want %d: %+v", len(got), len(want), got)
+		t.Fatalf("round-tripped %d ipc entitlements, want %d: %+v", len(got), len(want), got)
 	}
 	byName := make(map[string]appconfig.Entitlement, len(got))
 	for _, e := range got {
@@ -65,16 +65,16 @@ func TestServiceEntitlements_SurviveLabelRoundTrip(t *testing.T) {
 	}
 	for _, w := range want {
 		if !reflect.DeepEqual(byName[w.Name], w) {
-			t.Errorf("service %q round-tripped as %+v, want %+v", w.Name, byName[w.Name], w)
+			t.Errorf("ipc name %q round-tripped as %+v, want %+v", w.Name, byName[w.Name], w)
 		}
 	}
 }
 
-// A client with no service socket provider wired in (unit tests, or an agent
+// A client with no ipc socket provider wired in (unit tests, or an agent
 // build without one) must not panic on the release paths.
-func TestReleaseServiceSockets_NilProviderIsNoOp(t *testing.T) {
+func TestReleaseIPCSockets_NilProviderIsNoOp(t *testing.T) {
 	c := &Client{}
-	c.releaseServiceSockets([]appconfig.Entitlement{
-		{Type: appconfig.EntitlementService, Name: "world", Role: appconfig.ServiceRoleProvide},
+	c.releaseIPCSockets([]appconfig.Entitlement{
+		{Type: appconfig.EntitlementIPC, Name: "world", Role: appconfig.IPCRoleProvide},
 	}, "com.example.app", "")
 }

--- a/go/internal/agent/oci/entitlements.go
+++ b/go/internal/agent/oci/entitlements.go
@@ -34,13 +34,13 @@ const (
 	// appSystemAPIGroupGID is reserved by WendyOS for private app System API
 	// sockets, allowing non-root workloads to connect without world access.
 	appSystemAPIGroupGID uint32 = 2000
-	// appServiceGroupGID is reserved by WendyOS for app-provided service sockets
-	// (the `service` entitlement), the analogue of appSystemAPIGroupGID for
-	// agent-provided ones. It owns the per-service directory, which is setgid,
-	// so a socket the provider binds inside it inherits this group without the
-	// app having to know the GID exists. Kept in sync with the agent-side
-	// constant of the same name in internal/agent/services.
-	appServiceGroupGID uint32 = 2001
+	// appIPCGroupGID is reserved by WendyOS for app-provided IPC sockets (the
+	// `ipc` entitlement), the analogue of appSystemAPIGroupGID for
+	// agent-provided ones. It owns the per-name directory, which is setgid, so a
+	// socket the provider binds inside it inherits this group without the app
+	// having to know the GID exists. Kept in sync with the agent-side constant
+	// of the same name in internal/agent/services.
+	appIPCGroupGID uint32 = 2001
 	// v4l2Major is the standard Video4Linux character device major.
 	v4l2Major int64 = 81
 )
@@ -61,12 +61,12 @@ type ApplyOptions struct {
 	// SystemAPISocketDir is the app-specific host directory prepared by
 	// AppSystemAPISocketManager. It contains only the narrow System API socket.
 	SystemAPISocketDir string
-	// ServiceSocketDirs maps a `service` entitlement name to the host directory
-	// ServiceSocketManager prepared for it. Only names present here are mounted:
+	// IPCSocketDirs maps an `ipc` entitlement name to the host directory
+	// IPCSocketManager prepared for it. Only names present here are mounted:
 	// the caller, not this package, decides which claims were granted, so an
 	// entitlement the manager refused (e.g. a name another app already provides)
 	// cannot smuggle a mount in via the app's own config.
-	ServiceSocketDirs map[string]string
+	IPCSocketDirs map[string]string
 }
 
 // ApplyEntitlements modifies an OCI spec in-place based on app config entitlements.
@@ -131,8 +131,8 @@ func ApplyEntitlements(spec *Spec, cfg *appconfig.AppConfig, opts ApplyOptions) 
 			applyAdmin(spec)
 		case appconfig.EntitlementBuild:
 			applyBuild(spec)
-		case appconfig.EntitlementService:
-			applyServiceSocket(spec, ent, opts.ServiceSocketDirs)
+		case appconfig.EntitlementIPC:
+			applyIPCSocket(spec, ent, opts.IPCSocketDirs)
 		}
 	}
 	return nil
@@ -480,16 +480,16 @@ func applyAdmin(spec *Spec) {
 	spec.Process.Env = append(spec.Process.Env, "WENDY_AGENT_SOCKET="+ctrAgentSocketPath)
 }
 
-// ServiceSocketContainerRoot is the in-container parent of every `service`
-// entitlement mount. One directory per service name is bind-mounted beneath it.
-const ServiceSocketContainerRoot = "/run/wendy/services"
+// IPCSocketContainerRoot is the in-container parent of every `ipc` entitlement
+// mount. One directory per IPC name is bind-mounted beneath it.
+const IPCSocketContainerRoot = "/run/wendy/ipc"
 
-// ServiceSocketFilename is the socket inside each service directory. Fixed by
+// IPCSocketFilename is the socket inside each IPC directory. Fixed by
 // the platform so both sides of the entitlement agree on the path without an
 // out-of-band convention.
-const ServiceSocketFilename = "service.sock"
+const IPCSocketFilename = "ipc.sock"
 
-// applyServiceSocket mounts one app-provided service socket directory.
+// applyIPCSocket mounts one app-provided IPC socket directory.
 //
 // This is the same trust-boundary shape as applyAdmin and applySystemAPI —
 // an entitlement-gated bind mount of an agent-owned directory — generalized
@@ -506,9 +506,9 @@ const ServiceSocketFilename = "service.sock"
 // whole point of the entitlement.
 //
 // A name absent from hostDirs is skipped rather than mounted from a guessed
-// path: only claims the ServiceSocketManager actually granted are honoured.
-func applyServiceSocket(spec *Spec, ent appconfig.Entitlement, hostDirs map[string]string) {
-	if appconfig.ValidateServiceSocketName(ent.Name) != nil {
+// path: only claims the IPCSocketManager actually granted are honoured.
+func applyIPCSocket(spec *Spec, ent appconfig.Entitlement, hostDirs map[string]string) {
+	if appconfig.ValidateIPCName(ent.Name) != nil {
 		return
 	}
 	hostDirectory := hostDirs[ent.Name]
@@ -520,32 +520,32 @@ func applyServiceSocket(spec *Spec, ent appconfig.Entitlement, hostDirs map[stri
 	}
 
 	options := []string{"rbind", "nosuid", "noexec", "nodev"}
-	if ent.Role == appconfig.ServiceRoleProvide {
+	if ent.Role == appconfig.IPCRoleProvide {
 		options = append(options, "rw")
 	} else {
 		options = append(options, "ro")
 	}
-	containerDirectory := path.Join(ServiceSocketContainerRoot, ent.Name)
+	containerDirectory := path.Join(IPCSocketContainerRoot, ent.Name)
 	spec.Mounts = append(spec.Mounts, Mount{
 		Destination: containerDirectory,
 		Source:      hostDirectory,
 		Type:        "bind",
 		Options:     options,
 	})
-	// The directory is mode 2770 root:appServiceGroupGID, so without this GID a
+	// The directory is mode 2770 root:appIPCGroupGID, so without this GID a
 	// non-root process cannot even traverse into it. Membership on its own
 	// reaches nothing — the bind mount is what makes the directory visible.
-	spec.Process.User.AdditionalGids = appendUnique(spec.Process.User.AdditionalGids, appServiceGroupGID)
+	spec.Process.User.AdditionalGids = appendUnique(spec.Process.User.AdditionalGids, appIPCGroupGID)
 	spec.Process.Env = append(spec.Process.Env,
-		serviceSocketEnvName(ent.Name)+"="+path.Join(containerDirectory, ServiceSocketFilename))
+		ipcSocketEnvName(ent.Name)+"="+path.Join(containerDirectory, IPCSocketFilename))
 }
 
-// serviceSocketEnvName maps a service name to the environment variable that
-// carries its socket path, e.g. "world-model" → "WENDY_SERVICE_WORLD_MODEL_SOCKET".
-// The name is already restricted to [a-z0-9-] by ValidateServiceSocketName, so
-// upper-casing and replacing hyphens always yields a valid POSIX variable name.
-func serviceSocketEnvName(name string) string {
-	return "WENDY_SERVICE_" + strings.ToUpper(strings.ReplaceAll(name, "-", "_")) + "_SOCKET"
+// ipcSocketEnvName maps an IPC name to the environment variable that carries
+// its socket path, e.g. "world-model" → "WENDY_IPC_WORLD_MODEL_SOCKET". The
+// name is already restricted to [a-z0-9-] by ValidateIPCName, so upper-casing
+// and replacing hyphens always yields a valid POSIX variable name.
+func ipcSocketEnvName(name string) string {
+	return "WENDY_IPC_" + strings.ToUpper(strings.ReplaceAll(name, "-", "_")) + "_SOCKET"
 }
 
 // applyNetwork configures the network namespace.

--- a/go/internal/agent/oci/entitlements.go
+++ b/go/internal/agent/oci/entitlements.go
@@ -34,6 +34,13 @@ const (
 	// appSystemAPIGroupGID is reserved by WendyOS for private app System API
 	// sockets, allowing non-root workloads to connect without world access.
 	appSystemAPIGroupGID uint32 = 2000
+	// appServiceGroupGID is reserved by WendyOS for app-provided service sockets
+	// (the `service` entitlement), the analogue of appSystemAPIGroupGID for
+	// agent-provided ones. It owns the per-service directory, which is setgid,
+	// so a socket the provider binds inside it inherits this group without the
+	// app having to know the GID exists. Kept in sync with the agent-side
+	// constant of the same name in internal/agent/services.
+	appServiceGroupGID uint32 = 2001
 	// v4l2Major is the standard Video4Linux character device major.
 	v4l2Major int64 = 81
 )
@@ -54,6 +61,12 @@ type ApplyOptions struct {
 	// SystemAPISocketDir is the app-specific host directory prepared by
 	// AppSystemAPISocketManager. It contains only the narrow System API socket.
 	SystemAPISocketDir string
+	// ServiceSocketDirs maps a `service` entitlement name to the host directory
+	// ServiceSocketManager prepared for it. Only names present here are mounted:
+	// the caller, not this package, decides which claims were granted, so an
+	// entitlement the manager refused (e.g. a name another app already provides)
+	// cannot smuggle a mount in via the app's own config.
+	ServiceSocketDirs map[string]string
 }
 
 // ApplyEntitlements modifies an OCI spec in-place based on app config entitlements.
@@ -118,6 +131,8 @@ func ApplyEntitlements(spec *Spec, cfg *appconfig.AppConfig, opts ApplyOptions) 
 			applyAdmin(spec)
 		case appconfig.EntitlementBuild:
 			applyBuild(spec)
+		case appconfig.EntitlementService:
+			applyServiceSocket(spec, ent, opts.ServiceSocketDirs)
 		}
 	}
 	return nil
@@ -463,6 +478,74 @@ func applyAdmin(spec *Spec) {
 		Options:     []string{"rbind", "nosuid", "noexec", "ro"},
 	})
 	spec.Process.Env = append(spec.Process.Env, "WENDY_AGENT_SOCKET="+ctrAgentSocketPath)
+}
+
+// ServiceSocketContainerRoot is the in-container parent of every `service`
+// entitlement mount. One directory per service name is bind-mounted beneath it.
+const ServiceSocketContainerRoot = "/run/wendy/services"
+
+// ServiceSocketFilename is the socket inside each service directory. Fixed by
+// the platform so both sides of the entitlement agree on the path without an
+// out-of-band convention.
+const ServiceSocketFilename = "service.sock"
+
+// applyServiceSocket mounts one app-provided service socket directory.
+//
+// This is the same trust-boundary shape as applyAdmin and applySystemAPI —
+// an entitlement-gated bind mount of an agent-owned directory — generalized
+// from agent-provided sockets to app-provided ones. The directory (not the
+// socket inode) is mounted so a provider that recreates its socket is
+// transparent to an already-running consumer, exactly as for the admin socket.
+//
+// The provider gets it read-write because it must bind() the socket there.
+// Consumers get it read-only, which still permits connect(): the kernel's
+// read-only-superblock check (sb_permission) applies to regular files,
+// directories and symlinks, never to sockets. Read-only therefore denies a
+// consumer the ability to unlink or replace the provider's socket — and it
+// grants no access whatsoever to the provider's persist volume, which is the
+// whole point of the entitlement.
+//
+// A name absent from hostDirs is skipped rather than mounted from a guessed
+// path: only claims the ServiceSocketManager actually granted are honoured.
+func applyServiceSocket(spec *Spec, ent appconfig.Entitlement, hostDirs map[string]string) {
+	if appconfig.ValidateServiceSocketName(ent.Name) != nil {
+		return
+	}
+	hostDirectory := hostDirs[ent.Name]
+	if hostDirectory == "" {
+		return
+	}
+	if _, err := os.Stat(hostDirectory); err != nil {
+		return
+	}
+
+	options := []string{"rbind", "nosuid", "noexec", "nodev"}
+	if ent.Role == appconfig.ServiceRoleProvide {
+		options = append(options, "rw")
+	} else {
+		options = append(options, "ro")
+	}
+	containerDirectory := path.Join(ServiceSocketContainerRoot, ent.Name)
+	spec.Mounts = append(spec.Mounts, Mount{
+		Destination: containerDirectory,
+		Source:      hostDirectory,
+		Type:        "bind",
+		Options:     options,
+	})
+	// The directory is mode 2770 root:appServiceGroupGID, so without this GID a
+	// non-root process cannot even traverse into it. Membership on its own
+	// reaches nothing — the bind mount is what makes the directory visible.
+	spec.Process.User.AdditionalGids = appendUnique(spec.Process.User.AdditionalGids, appServiceGroupGID)
+	spec.Process.Env = append(spec.Process.Env,
+		serviceSocketEnvName(ent.Name)+"="+path.Join(containerDirectory, ServiceSocketFilename))
+}
+
+// serviceSocketEnvName maps a service name to the environment variable that
+// carries its socket path, e.g. "world-model" → "WENDY_SERVICE_WORLD_MODEL_SOCKET".
+// The name is already restricted to [a-z0-9-] by ValidateServiceSocketName, so
+// upper-casing and replacing hyphens always yields a valid POSIX variable name.
+func serviceSocketEnvName(name string) string {
+	return "WENDY_SERVICE_" + strings.ToUpper(strings.ReplaceAll(name, "-", "_")) + "_SOCKET"
 }
 
 // applyNetwork configures the network namespace.

--- a/go/internal/agent/oci/entitlements_test.go
+++ b/go/internal/agent/oci/entitlements_test.go
@@ -1966,27 +1966,27 @@ func TestApplyAdmin_NonAdminAppUnchanged(t *testing.T) {
 	}
 }
 
-// TestApplyService_ProviderGetsWritableMount covers the provider side: it must
+// TestApplyIPC_ProviderGetsWritableMount covers the provider side: it must
 // be able to bind() a socket in the directory, so the mount is read-write, and
-// it gets the service group so a non-root provider can traverse the setgid
+// it gets the ipc group so a non-root provider can traverse the setgid
 // directory the manager created.
-func TestApplyService_ProviderGetsWritableMount(t *testing.T) {
+func TestApplyIPC_ProviderGetsWritableMount(t *testing.T) {
 	dir := t.TempDir()
 	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
 	cfg := &appconfig.AppConfig{
 		AppID: "test",
 		Entitlements: []appconfig.Entitlement{
-			{Type: appconfig.EntitlementService, Name: "world", Role: appconfig.ServiceRoleProvide},
+			{Type: appconfig.EntitlementIPC, Name: "world", Role: appconfig.IPCRoleProvide},
 		},
 	}
-	opts := ApplyOptions{ServiceSocketDirs: map[string]string{"world": dir}}
+	opts := ApplyOptions{IPCSocketDirs: map[string]string{"world": dir}}
 	if err := ApplyEntitlements(spec, cfg, opts); err != nil {
 		t.Fatalf("ApplyEntitlements: %v", err)
 	}
 
-	mount, ok := mountForDest(spec, "/run/wendy/services/world")
+	mount, ok := mountForDest(spec, "/run/wendy/ipc/world")
 	if !ok {
-		t.Fatal("provider did not get a service socket mount")
+		t.Fatal("provider did not get an ipc socket mount")
 	}
 	if mount.Source != dir {
 		t.Errorf("mount source = %q, want %q", mount.Source, dir)
@@ -2002,35 +2002,35 @@ func TestApplyService_ProviderGetsWritableMount(t *testing.T) {
 			t.Errorf("provider mount options = %v, missing %q", mount.Options, want)
 		}
 	}
-	if !hasEnv(spec, "WENDY_SERVICE_WORLD_SOCKET=/run/wendy/services/world/service.sock") {
-		t.Error("provider did not get WENDY_SERVICE_WORLD_SOCKET")
+	if !hasEnv(spec, "WENDY_IPC_WORLD_SOCKET=/run/wendy/ipc/world/ipc.sock") {
+		t.Error("provider did not get WENDY_IPC_WORLD_SOCKET")
 	}
-	if !hasGID(spec, appServiceGroupGID) {
-		t.Error("provider did not get the service socket group")
+	if !hasGID(spec, appIPCGroupGID) {
+		t.Error("provider did not get the ipc socket group")
 	}
 }
 
-// TestApplyService_ConsumerGetsReadOnlyMountAndNothingElse is the whole point
+// TestApplyIPC_ConsumerGetsReadOnlyMountAndNothingElse is the whole point
 // of the entitlement: a consumer receives the socket directory and no access to
 // the provider's data. Read-only still permits connect() (the kernel's
 // read-only-superblock check exempts sockets) while denying unlink/replace.
-func TestApplyService_ConsumerGetsReadOnlyMountAndNothingElse(t *testing.T) {
+func TestApplyIPC_ConsumerGetsReadOnlyMountAndNothingElse(t *testing.T) {
 	dir := t.TempDir()
 	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
 	cfg := &appconfig.AppConfig{
 		AppID: "consumer",
 		Entitlements: []appconfig.Entitlement{
-			{Type: appconfig.EntitlementService, Name: "world-model", Role: appconfig.ServiceRoleConsume},
+			{Type: appconfig.EntitlementIPC, Name: "world-model", Role: appconfig.IPCRoleConsume},
 		},
 	}
-	opts := ApplyOptions{ServiceSocketDirs: map[string]string{"world-model": dir}}
+	opts := ApplyOptions{IPCSocketDirs: map[string]string{"world-model": dir}}
 	if err := ApplyEntitlements(spec, cfg, opts); err != nil {
 		t.Fatalf("ApplyEntitlements: %v", err)
 	}
 
-	mount, ok := mountForDest(spec, "/run/wendy/services/world-model")
+	mount, ok := mountForDest(spec, "/run/wendy/ipc/world-model")
 	if !ok {
-		t.Fatal("consumer did not get a service socket mount")
+		t.Fatal("consumer did not get an ipc socket mount")
 	}
 	if !slices.Contains(mount.Options, "ro") {
 		t.Errorf("consumer mount options = %v, want ro", mount.Options)
@@ -2039,8 +2039,8 @@ func TestApplyService_ConsumerGetsReadOnlyMountAndNothingElse(t *testing.T) {
 		t.Errorf("consumer mount options = %v, must not be writable", mount.Options)
 	}
 	// Hyphens become underscores so the variable name stays POSIX-portable.
-	if !hasEnv(spec, "WENDY_SERVICE_WORLD_MODEL_SOCKET=/run/wendy/services/world-model/service.sock") {
-		t.Error("consumer did not get WENDY_SERVICE_WORLD_MODEL_SOCKET")
+	if !hasEnv(spec, "WENDY_IPC_WORLD_MODEL_SOCKET=/run/wendy/ipc/world-model/ipc.sock") {
+		t.Error("consumer did not get WENDY_IPC_WORLD_MODEL_SOCKET")
 	}
 	// The over-granting this entitlement exists to avoid: a consumer must not
 	// receive the provider's data volume, agent socket, or System API socket.
@@ -2050,27 +2050,27 @@ func TestApplyService_ConsumerGetsReadOnlyMountAndNothingElse(t *testing.T) {
 		}
 	}
 	if hasGID(spec, appSystemAPIGroupGID) {
-		t.Error("service entitlement must not grant the System API socket group")
+		t.Error("ipc entitlement must not grant the System API socket group")
 	}
 }
 
-func TestApplyService_MultipleNamesGetSeparateMounts(t *testing.T) {
+func TestApplyIPC_MultipleNamesGetSeparateMounts(t *testing.T) {
 	worldDir, plannerDir := t.TempDir(), t.TempDir()
 	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
 	cfg := &appconfig.AppConfig{
 		AppID: "consumer",
 		Entitlements: []appconfig.Entitlement{
-			{Type: appconfig.EntitlementService, Name: "world", Role: appconfig.ServiceRoleConsume},
-			{Type: appconfig.EntitlementService, Name: "planner", Role: appconfig.ServiceRoleConsume},
+			{Type: appconfig.EntitlementIPC, Name: "world", Role: appconfig.IPCRoleConsume},
+			{Type: appconfig.EntitlementIPC, Name: "planner", Role: appconfig.IPCRoleConsume},
 		},
 	}
-	opts := ApplyOptions{ServiceSocketDirs: map[string]string{"world": worldDir, "planner": plannerDir}}
+	opts := ApplyOptions{IPCSocketDirs: map[string]string{"world": worldDir, "planner": plannerDir}}
 	if err := ApplyEntitlements(spec, cfg, opts); err != nil {
 		t.Fatalf("ApplyEntitlements: %v", err)
 	}
 	for dest, want := range map[string]string{
-		"/run/wendy/services/world":   worldDir,
-		"/run/wendy/services/planner": plannerDir,
+		"/run/wendy/ipc/world":   worldDir,
+		"/run/wendy/ipc/planner": plannerDir,
 	} {
 		mount, ok := mountForDest(spec, dest)
 		if !ok {
@@ -2082,80 +2082,80 @@ func TestApplyService_MultipleNamesGetSeparateMounts(t *testing.T) {
 	}
 }
 
-// A name the manager did not grant (absent from ServiceSocketDirs) must not be
+// A name the manager did not grant (absent from IPCSocketDirs) must not be
 // mounted from a guessed path: only claims the agent actually granted count, so
 // an app cannot mount a name another app provides by declaring it in its own
 // wendy.json.
-func TestApplyService_UngrantedNameIsNotMounted(t *testing.T) {
+func TestApplyIPC_UngrantedNameIsNotMounted(t *testing.T) {
 	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
 	cfg := &appconfig.AppConfig{
 		AppID: "squatter",
 		Entitlements: []appconfig.Entitlement{
-			{Type: appconfig.EntitlementService, Name: "world", Role: appconfig.ServiceRoleConsume},
+			{Type: appconfig.EntitlementIPC, Name: "world", Role: appconfig.IPCRoleConsume},
 		},
 	}
 	if err := ApplyEntitlements(spec, cfg, ApplyOptions{}); err != nil {
 		t.Fatalf("ApplyEntitlements: %v", err)
 	}
-	if hasMount(spec, "/run/wendy/services/world") {
-		t.Error("an ungranted service name was mounted")
+	if hasMount(spec, "/run/wendy/ipc/world") {
+		t.Error("an ungranted ipc name was mounted")
 	}
-	if hasGID(spec, appServiceGroupGID) {
-		t.Error("an ungranted service name granted the service socket group")
+	if hasGID(spec, appIPCGroupGID) {
+		t.Error("an ungranted ipc name granted the ipc socket group")
 	}
-	if hasEnv(spec, "WENDY_SERVICE_WORLD_SOCKET=/run/wendy/services/world/service.sock") {
-		t.Error("an ungranted service name injected its socket env var")
+	if hasEnv(spec, "WENDY_IPC_WORLD_SOCKET=/run/wendy/ipc/world/ipc.sock") {
+		t.Error("an ungranted ipc name injected its socket env var")
 	}
 }
 
 // Defence in depth: even if a malformed name reached the OCI layer (labels are
 // external state), it must never become a mount destination.
-func TestApplyService_RejectsMalformedName(t *testing.T) {
+func TestApplyIPC_RejectsMalformedName(t *testing.T) {
 	dir := t.TempDir()
 	for _, name := range []string{"../etc", "..", "a/b", "World", ""} {
 		spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
 		cfg := &appconfig.AppConfig{
 			AppID: "test",
 			Entitlements: []appconfig.Entitlement{
-				{Type: appconfig.EntitlementService, Name: name, Role: appconfig.ServiceRoleProvide},
+				{Type: appconfig.EntitlementIPC, Name: name, Role: appconfig.IPCRoleProvide},
 			},
 		}
-		opts := ApplyOptions{ServiceSocketDirs: map[string]string{name: dir}}
+		opts := ApplyOptions{IPCSocketDirs: map[string]string{name: dir}}
 		if err := ApplyEntitlements(spec, cfg, opts); err != nil {
 			t.Fatalf("ApplyEntitlements(%q): %v", name, err)
 		}
 		for _, m := range spec.Mounts {
-			if strings.HasPrefix(m.Destination, ServiceSocketContainerRoot) {
-				t.Errorf("malformed service name %q produced mount %q", name, m.Destination)
+			if strings.HasPrefix(m.Destination, IPCSocketContainerRoot) {
+				t.Errorf("malformed ipc name %q produced mount %q", name, m.Destination)
 			}
 		}
 	}
 }
 
-func TestApplyService_AbsentWithoutEntitlement(t *testing.T) {
+func TestApplyIPC_AbsentWithoutEntitlement(t *testing.T) {
 	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
 	cfg := &appconfig.AppConfig{
 		AppID:        "test",
 		Entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementPersist, Name: "data", Path: "/data"}},
 	}
-	opts := ApplyOptions{ServiceSocketDirs: map[string]string{"world": t.TempDir()}}
+	opts := ApplyOptions{IPCSocketDirs: map[string]string{"world": t.TempDir()}}
 	if err := ApplyEntitlements(spec, cfg, opts); err != nil {
 		t.Fatalf("ApplyEntitlements: %v", err)
 	}
-	if hasMount(spec, "/run/wendy/services/world") || hasGID(spec, appServiceGroupGID) {
-		t.Error("app without a service entitlement received service socket access")
+	if hasMount(spec, "/run/wendy/ipc/world") || hasGID(spec, appIPCGroupGID) {
+		t.Error("app without an ipc entitlement received ipc socket access")
 	}
 }
 
-func TestServiceSocketEnvName(t *testing.T) {
+func TestIPCSocketEnvName(t *testing.T) {
 	for in, want := range map[string]string{
-		"world":            "WENDY_SERVICE_WORLD_SOCKET",
-		"world-model":      "WENDY_SERVICE_WORLD_MODEL_SOCKET",
-		"a-b-c9":           "WENDY_SERVICE_A_B_C9_SOCKET",
-		"telemetry-bridge": "WENDY_SERVICE_TELEMETRY_BRIDGE_SOCKET",
+		"world":            "WENDY_IPC_WORLD_SOCKET",
+		"world-model":      "WENDY_IPC_WORLD_MODEL_SOCKET",
+		"a-b-c9":           "WENDY_IPC_A_B_C9_SOCKET",
+		"telemetry-bridge": "WENDY_IPC_TELEMETRY_BRIDGE_SOCKET",
 	} {
-		if got := serviceSocketEnvName(in); got != want {
-			t.Errorf("serviceSocketEnvName(%q) = %q, want %q", in, got, want)
+		if got := ipcSocketEnvName(in); got != want {
+			t.Errorf("ipcSocketEnvName(%q) = %q, want %q", in, got, want)
 		}
 	}
 }

--- a/go/internal/agent/oci/entitlements_test.go
+++ b/go/internal/agent/oci/entitlements_test.go
@@ -1966,6 +1966,200 @@ func TestApplyAdmin_NonAdminAppUnchanged(t *testing.T) {
 	}
 }
 
+// TestApplyService_ProviderGetsWritableMount covers the provider side: it must
+// be able to bind() a socket in the directory, so the mount is read-write, and
+// it gets the service group so a non-root provider can traverse the setgid
+// directory the manager created.
+func TestApplyService_ProviderGetsWritableMount(t *testing.T) {
+	dir := t.TempDir()
+	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
+	cfg := &appconfig.AppConfig{
+		AppID: "test",
+		Entitlements: []appconfig.Entitlement{
+			{Type: appconfig.EntitlementService, Name: "world", Role: appconfig.ServiceRoleProvide},
+		},
+	}
+	opts := ApplyOptions{ServiceSocketDirs: map[string]string{"world": dir}}
+	if err := ApplyEntitlements(spec, cfg, opts); err != nil {
+		t.Fatalf("ApplyEntitlements: %v", err)
+	}
+
+	mount, ok := mountForDest(spec, "/run/wendy/services/world")
+	if !ok {
+		t.Fatal("provider did not get a service socket mount")
+	}
+	if mount.Source != dir {
+		t.Errorf("mount source = %q, want %q", mount.Source, dir)
+	}
+	if !slices.Contains(mount.Options, "rw") {
+		t.Errorf("provider mount options = %v, want rw (the provider must bind the socket)", mount.Options)
+	}
+	if slices.Contains(mount.Options, "ro") {
+		t.Errorf("provider mount options = %v, must not be read-only", mount.Options)
+	}
+	for _, want := range []string{"nosuid", "noexec", "nodev"} {
+		if !slices.Contains(mount.Options, want) {
+			t.Errorf("provider mount options = %v, missing %q", mount.Options, want)
+		}
+	}
+	if !hasEnv(spec, "WENDY_SERVICE_WORLD_SOCKET=/run/wendy/services/world/service.sock") {
+		t.Error("provider did not get WENDY_SERVICE_WORLD_SOCKET")
+	}
+	if !hasGID(spec, appServiceGroupGID) {
+		t.Error("provider did not get the service socket group")
+	}
+}
+
+// TestApplyService_ConsumerGetsReadOnlyMountAndNothingElse is the whole point
+// of the entitlement: a consumer receives the socket directory and no access to
+// the provider's data. Read-only still permits connect() (the kernel's
+// read-only-superblock check exempts sockets) while denying unlink/replace.
+func TestApplyService_ConsumerGetsReadOnlyMountAndNothingElse(t *testing.T) {
+	dir := t.TempDir()
+	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
+	cfg := &appconfig.AppConfig{
+		AppID: "consumer",
+		Entitlements: []appconfig.Entitlement{
+			{Type: appconfig.EntitlementService, Name: "world-model", Role: appconfig.ServiceRoleConsume},
+		},
+	}
+	opts := ApplyOptions{ServiceSocketDirs: map[string]string{"world-model": dir}}
+	if err := ApplyEntitlements(spec, cfg, opts); err != nil {
+		t.Fatalf("ApplyEntitlements: %v", err)
+	}
+
+	mount, ok := mountForDest(spec, "/run/wendy/services/world-model")
+	if !ok {
+		t.Fatal("consumer did not get a service socket mount")
+	}
+	if !slices.Contains(mount.Options, "ro") {
+		t.Errorf("consumer mount options = %v, want ro", mount.Options)
+	}
+	if slices.Contains(mount.Options, "rw") {
+		t.Errorf("consumer mount options = %v, must not be writable", mount.Options)
+	}
+	// Hyphens become underscores so the variable name stays POSIX-portable.
+	if !hasEnv(spec, "WENDY_SERVICE_WORLD_MODEL_SOCKET=/run/wendy/services/world-model/service.sock") {
+		t.Error("consumer did not get WENDY_SERVICE_WORLD_MODEL_SOCKET")
+	}
+	// The over-granting this entitlement exists to avoid: a consumer must not
+	// receive the provider's data volume, agent socket, or System API socket.
+	for _, dest := range []string{"/data", "/run/wendy/agent", "/run/wendy/system"} {
+		if hasMount(spec, dest) {
+			t.Errorf("consumer received unrelated mount %q", dest)
+		}
+	}
+	if hasGID(spec, appSystemAPIGroupGID) {
+		t.Error("service entitlement must not grant the System API socket group")
+	}
+}
+
+func TestApplyService_MultipleNamesGetSeparateMounts(t *testing.T) {
+	worldDir, plannerDir := t.TempDir(), t.TempDir()
+	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
+	cfg := &appconfig.AppConfig{
+		AppID: "consumer",
+		Entitlements: []appconfig.Entitlement{
+			{Type: appconfig.EntitlementService, Name: "world", Role: appconfig.ServiceRoleConsume},
+			{Type: appconfig.EntitlementService, Name: "planner", Role: appconfig.ServiceRoleConsume},
+		},
+	}
+	opts := ApplyOptions{ServiceSocketDirs: map[string]string{"world": worldDir, "planner": plannerDir}}
+	if err := ApplyEntitlements(spec, cfg, opts); err != nil {
+		t.Fatalf("ApplyEntitlements: %v", err)
+	}
+	for dest, want := range map[string]string{
+		"/run/wendy/services/world":   worldDir,
+		"/run/wendy/services/planner": plannerDir,
+	} {
+		mount, ok := mountForDest(spec, dest)
+		if !ok {
+			t.Fatalf("missing mount %q", dest)
+		}
+		if mount.Source != want {
+			t.Errorf("%s source = %q, want %q", dest, mount.Source, want)
+		}
+	}
+}
+
+// A name the manager did not grant (absent from ServiceSocketDirs) must not be
+// mounted from a guessed path: only claims the agent actually granted count, so
+// an app cannot mount a name another app provides by declaring it in its own
+// wendy.json.
+func TestApplyService_UngrantedNameIsNotMounted(t *testing.T) {
+	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
+	cfg := &appconfig.AppConfig{
+		AppID: "squatter",
+		Entitlements: []appconfig.Entitlement{
+			{Type: appconfig.EntitlementService, Name: "world", Role: appconfig.ServiceRoleConsume},
+		},
+	}
+	if err := ApplyEntitlements(spec, cfg, ApplyOptions{}); err != nil {
+		t.Fatalf("ApplyEntitlements: %v", err)
+	}
+	if hasMount(spec, "/run/wendy/services/world") {
+		t.Error("an ungranted service name was mounted")
+	}
+	if hasGID(spec, appServiceGroupGID) {
+		t.Error("an ungranted service name granted the service socket group")
+	}
+	if hasEnv(spec, "WENDY_SERVICE_WORLD_SOCKET=/run/wendy/services/world/service.sock") {
+		t.Error("an ungranted service name injected its socket env var")
+	}
+}
+
+// Defence in depth: even if a malformed name reached the OCI layer (labels are
+// external state), it must never become a mount destination.
+func TestApplyService_RejectsMalformedName(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"../etc", "..", "a/b", "World", ""} {
+		spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
+		cfg := &appconfig.AppConfig{
+			AppID: "test",
+			Entitlements: []appconfig.Entitlement{
+				{Type: appconfig.EntitlementService, Name: name, Role: appconfig.ServiceRoleProvide},
+			},
+		}
+		opts := ApplyOptions{ServiceSocketDirs: map[string]string{name: dir}}
+		if err := ApplyEntitlements(spec, cfg, opts); err != nil {
+			t.Fatalf("ApplyEntitlements(%q): %v", name, err)
+		}
+		for _, m := range spec.Mounts {
+			if strings.HasPrefix(m.Destination, ServiceSocketContainerRoot) {
+				t.Errorf("malformed service name %q produced mount %q", name, m.Destination)
+			}
+		}
+	}
+}
+
+func TestApplyService_AbsentWithoutEntitlement(t *testing.T) {
+	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
+	cfg := &appconfig.AppConfig{
+		AppID:        "test",
+		Entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementPersist, Name: "data", Path: "/data"}},
+	}
+	opts := ApplyOptions{ServiceSocketDirs: map[string]string{"world": t.TempDir()}}
+	if err := ApplyEntitlements(spec, cfg, opts); err != nil {
+		t.Fatalf("ApplyEntitlements: %v", err)
+	}
+	if hasMount(spec, "/run/wendy/services/world") || hasGID(spec, appServiceGroupGID) {
+		t.Error("app without a service entitlement received service socket access")
+	}
+}
+
+func TestServiceSocketEnvName(t *testing.T) {
+	for in, want := range map[string]string{
+		"world":            "WENDY_SERVICE_WORLD_SOCKET",
+		"world-model":      "WENDY_SERVICE_WORLD_MODEL_SOCKET",
+		"a-b-c9":           "WENDY_SERVICE_A_B_C9_SOCKET",
+		"telemetry-bridge": "WENDY_SERVICE_TELEMETRY_BRIDGE_SOCKET",
+	} {
+		if got := serviceSocketEnvName(in); got != want {
+			t.Errorf("serviceSocketEnvName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
 func seccompDenies(spec *Spec, syscall string) bool {
 	if spec.Linux == nil || spec.Linux.Seccomp == nil {
 		return false

--- a/go/internal/agent/services/container_service_test.go
+++ b/go/internal/agent/services/container_service_test.go
@@ -37,6 +37,7 @@ type mockContainerdClient struct {
 	writtenData           []byte
 	createErr             error
 	progressPhases        []agentpb.CreateContainerProgress_Phase
+	progressUpdates       []*agentpb.CreateContainerProgress
 	startOutputCh         chan ContainerOutput
 	startErr              error
 	statsResult           []*agentpb.ContainerStats
@@ -112,6 +113,9 @@ func (m *mockContainerdClient) CreateContainer(_ context.Context, req *agentpb.C
 }
 func (m *mockContainerdClient) CreateContainerWithProgress(ctx context.Context, req *agentpb.CreateContainerRequest, appCfg *appconfig.AppConfig, onProgress ProgressFunc) error {
 	if onProgress != nil {
+		for _, progress := range m.progressUpdates {
+			onProgress(progress)
+		}
 		for _, phase := range m.progressPhases {
 			onProgress(&agentpb.CreateContainerProgress{Phase: phase})
 		}
@@ -560,6 +564,28 @@ func TestCreateContainerWithProgress(t *testing.T) {
 	}
 	if !gotCompleted {
 		t.Error("did not receive Completed response")
+	}
+}
+
+func TestCreateContainerWithProgressForwardsWarning(t *testing.T) {
+	want := `ipc consumer "world" has no provider on this device`
+	mock := &mockContainerdClient{progressUpdates: []*agentpb.CreateContainerProgress{{Warning: want}}}
+	client, cleanup := startContainerServer(t, mock)
+	defer cleanup()
+
+	stream, err := client.CreateContainerWithProgress(context.Background(), &agentpb.CreateContainerRequest{
+		ImageName: "test-image:latest",
+		AppName:   "test-app",
+	})
+	if err != nil {
+		t.Fatalf("CreateContainerWithProgress: %v", err)
+	}
+	resp, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("recv warning: %v", err)
+	}
+	if got := resp.GetProgress().GetWarning(); got != want {
+		t.Fatalf("warning = %q, want %q", got, want)
 	}
 }
 

--- a/go/internal/agent/services/ipc_socket_manager.go
+++ b/go/internal/agent/services/ipc_socket_manager.go
@@ -142,6 +142,29 @@ func (m *IPCSocketManager) Ensure(name, role, appID, serviceName string) (string
 	return directory, nil
 }
 
+// MissingProviderWarning returns a user-facing warning when name currently has
+// no provider. The containerd client sends this over the create-progress stream
+// so the CLI can surface the condition directly instead of leaving it only in
+// agent logs. An empty result means a provider exists.
+func (m *IPCSocketManager) MissingProviderWarning(name string) string {
+	if appconfig.ValidateIPCName(name) != nil {
+		return ""
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry := m.entries[name]
+	if entry != nil && entry.provider != "" {
+		return ""
+	}
+	provided := m.providedNamesLocked()
+	if len(provided) == 0 {
+		return fmt.Sprintf("ipc consumer %q has no provider on this device; no ipc providers are currently deployed", name)
+	}
+	return fmt.Sprintf("ipc consumer %q has no provider on this device; currently provided ipc names: %s",
+		name, strings.Join(provided, ", "))
+}
+
 // PrepareProvider removes a stale socket left behind by a previous run of the
 // provider, and must be called before the provider's task starts. A provider
 // that dies without cleanup otherwise leaves a socket file that consumers can

--- a/go/internal/agent/services/ipc_socket_manager.go
+++ b/go/internal/agent/services/ipc_socket_manager.go
@@ -14,44 +14,45 @@ import (
 )
 
 const (
-	// ServiceSocketFilename is the single socket the agent exposes inside each
-	// service directory. It is fixed rather than app-chosen so both sides of the
+	// IPCSocketFilename is the single socket the agent exposes inside each
+	// IPC directory. It is fixed rather than app-chosen so both sides of the
 	// entitlement agree on the path without any out-of-band convention — the
 	// "discovery by convention" failure the shared-persist workaround had.
-	ServiceSocketFilename = "service.sock"
+	IPCSocketFilename = "ipc.sock"
 
-	// appServiceGroupGID is reserved by WendyOS for app-provided service
-	// sockets, the direct analogue of appSystemAPIGroupGID (2000) for
-	// agent-provided ones. Membership is granted only alongside a service
-	// bind mount, so the GID alone reaches nothing.
-	appServiceGroupGID = 2001
+	// appIPCGroupGID is reserved by WendyOS for app-provided IPC sockets, the
+	// direct analogue of appSystemAPIGroupGID (2000) for agent-provided ones.
+	// Membership is granted only alongside an IPC bind mount, so the GID alone
+	// reaches nothing.
+	appIPCGroupGID = 2001
 
-	// serviceDirMode is setgid + rwx for owner and group, nothing for others.
+	// ipcDirMode is setgid + rwx for owner and group, nothing for others.
 	// setgid matters: a socket the provider binds inside the directory inherits
-	// group appServiceGroupGID automatically, so a non-root provider does not
+	// group appIPCGroupGID automatically, so a non-root provider does not
 	// have to know the GID exists.
-	serviceDirMode = os.FileMode(0o770) | os.ModeSetgid
+	ipcDirMode = os.FileMode(0o770) | os.ModeSetgid
 
-	// serviceRootMode keeps the root traversable (containers only ever receive a
+	// ipcRootMode keeps the root traversable (containers only ever receive a
 	// bind mount of one child) but not listable by anyone but root.
-	serviceRootMode = os.FileMode(0o711)
+	ipcRootMode = os.FileMode(0o711)
 )
 
-// ServiceSocketRootPath is disk-backed, not on /run, for the same reason as
+// IPCSocketRootPath is disk-backed, not on /run, for the same reason as
 // AdminAgentSocketHostPath: a container's bind mount pins the directory inode,
 // and tmpfs is wiped (fresh inode) on every boot, which would strand a
 // long-lived consumer on an orphaned pre-reboot inode. Behind a var so tests
 // can redirect it into a tempdir.
-var ServiceSocketRootPath = "/var/lib/wendy/services"
+var IPCSocketRootPath = "/var/lib/wendy/ipc"
 
-// serviceSocketEntry is the agent's record of one service name.
+// ipcSocketEntry is the agent's record of one IPC name.
 //
-// owners is keyed by container (appID + serviceName) so a multi-service app
+// owners is keyed by container (appID + serviceName — the app's service name
+// from the top-level `services` map, not the IPC name) so a multi-service app
 // counts once per service container, mirroring AppSystemAPISocketManager. The
 // directory outlives every individual container in owners and is removed only
 // when the last one is deleted — removing it earlier would replace the inode
 // that still-deployed consumers have bind-mounted.
-type serviceSocketEntry struct {
+type ipcSocketEntry struct {
 	// provider is the owner key of the container that declared role "provide",
 	// or "" when only consumers are deployed. It is the anti-hijack record: a
 	// second app cannot claim a name that is already provided.
@@ -59,7 +60,7 @@ type serviceSocketEntry struct {
 	owners   map[string]string // owner key → role
 }
 
-// ServiceSocketManager owns the host side of the `service` entitlement: the
+// IPCSocketManager owns the host side of the `ipc` entitlement: the
 // per-name directory, its ownership and permissions, which app is allowed to
 // provide each name, and removal of a stale socket before a provider starts.
 //
@@ -69,52 +70,52 @@ type serviceSocketEntry struct {
 // provider's persist volume. The provider's identity for a name is
 // first-claim-wins and is held until the providing container is deleted, so a
 // later app cannot take over a name that is already being served.
-type ServiceSocketManager struct {
+type IPCSocketManager struct {
 	logger  *zap.Logger
 	mu      sync.Mutex
-	entries map[string]*serviceSocketEntry
+	entries map[string]*ipcSocketEntry
 }
 
-func NewServiceSocketManager(logger *zap.Logger) *ServiceSocketManager {
-	return &ServiceSocketManager{
+func NewIPCSocketManager(logger *zap.Logger) *IPCSocketManager {
+	return &IPCSocketManager{
 		logger:  logger,
-		entries: make(map[string]*serviceSocketEntry),
+		entries: make(map[string]*ipcSocketEntry),
 	}
 }
 
-// Ensure registers one container as an owner of a service name and returns the
+// Ensure registers one container as an owner of an IPC name and returns the
 // host directory to bind-mount for it. It is idempotent for the same container,
 // so a redeploy or an agent-restart restore can call it again safely.
 //
 // It never creates, removes, or touches the socket itself: that is
 // PrepareProvider's job, and keeping it out of Ensure is what makes Ensure safe
 // to call from the restore path against a provider that is already serving.
-func (m *ServiceSocketManager) Ensure(name, role, appID, serviceName string) (string, error) {
-	if role != appconfig.ServiceRoleProvide && role != appconfig.ServiceRoleConsume {
-		return "", fmt.Errorf("service role must be %q or %q, got %q",
-			appconfig.ServiceRoleProvide, appconfig.ServiceRoleConsume, role)
+func (m *IPCSocketManager) Ensure(name, role, appID, serviceName string) (string, error) {
+	if role != appconfig.IPCRoleProvide && role != appconfig.IPCRoleConsume {
+		return "", fmt.Errorf("ipc role must be %q or %q, got %q",
+			appconfig.IPCRoleProvide, appconfig.IPCRoleConsume, role)
 	}
-	owner, err := serviceSocketOwner(name, appID, serviceName)
+	owner, err := ipcSocketOwner(name, appID, serviceName)
 	if err != nil {
 		return "", err
 	}
-	directory := filepath.Join(ServiceSocketRootPath, name)
+	directory := filepath.Join(IPCSocketRootPath, name)
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	entry := m.entries[name]
 	if entry == nil {
-		entry = &serviceSocketEntry{owners: make(map[string]string)}
+		entry = &ipcSocketEntry{owners: make(map[string]string)}
 		m.entries[name] = entry
 	}
-	if role == appconfig.ServiceRoleProvide && entry.provider != "" && entry.provider != owner {
+	if role == appconfig.IPCRoleProvide && entry.provider != "" && entry.provider != owner {
 		return "", fmt.Errorf(
-			"service %q is already provided by %s on this device; only one app may provide a service name (remove the other app first)",
+			"ipc service %q is already provided by %s on this device; only one app may provide an ipc name (remove the other app first)",
 			name, entry.provider)
 	}
 
-	if err := m.prepareServiceDirectory(directory); err != nil {
+	if err := m.prepareIPCDirectory(directory); err != nil {
 		// Roll the registration back so a failed create does not leave a phantom
 		// owner (or a phantom provider claim) blocking the name.
 		if len(entry.owners) == 0 {
@@ -124,19 +125,19 @@ func (m *ServiceSocketManager) Ensure(name, role, appID, serviceName string) (st
 	}
 
 	entry.owners[owner] = role
-	if role == appconfig.ServiceRoleProvide {
+	if role == appconfig.IPCRoleProvide {
 		entry.provider = owner
 	}
-	if role == appconfig.ServiceRoleConsume && entry.provider == "" {
+	if role == appconfig.IPCRoleConsume && entry.provider == "" {
 		// A typo in the name is otherwise indistinguishable from "the provider
 		// is not deployed yet" — the second thing the hardware spike called out.
 		// Say so at deploy time, with the names that do exist, instead of
 		// leaving the app to hand-roll a retry against a path that will never
 		// appear.
-		m.logger.Warn("service consumer has no provider on this device",
-			zap.String("service", name),
+		m.logger.Warn("ipc consumer has no provider on this device",
+			zap.String("ipc_name", name),
 			zap.String("app_id", appID),
-			zap.Strings("provided_services", m.providedNamesLocked()))
+			zap.Strings("provided_ipc_names", m.providedNamesLocked()))
 	}
 	return directory, nil
 }
@@ -148,9 +149,9 @@ func (m *ServiceSocketManager) Ensure(name, role, appID, serviceName string) (st
 // (EADDRINUSE) — the platform owns that here so no app has to `rm -f` on boot.
 //
 // It is a no-op for a name this container does not provide, so callers can
-// invoke it for every service entitlement on a container without branching.
-func (m *ServiceSocketManager) PrepareProvider(name, appID, serviceName string) error {
-	owner, err := serviceSocketOwner(name, appID, serviceName)
+// invoke it for every ipc entitlement on a container without branching.
+func (m *IPCSocketManager) PrepareProvider(name, appID, serviceName string) error {
+	owner, err := ipcSocketOwner(name, appID, serviceName)
 	if err != nil {
 		return err
 	}
@@ -162,7 +163,7 @@ func (m *ServiceSocketManager) PrepareProvider(name, appID, serviceName string) 
 		return nil
 	}
 
-	socketPath := filepath.Join(ServiceSocketRootPath, name, ServiceSocketFilename)
+	socketPath := filepath.Join(IPCSocketRootPath, name, IPCSocketFilename)
 	// Lstat, not Stat: a symlink planted in the directory must be removed as the
 	// link it is, never followed to a target outside the directory.
 	fi, err := os.Lstat(socketPath)
@@ -170,23 +171,23 @@ func (m *ServiceSocketManager) PrepareProvider(name, appID, serviceName string) 
 		if os.IsNotExist(err) {
 			return nil
 		}
-		return fmt.Errorf("inspecting stale service socket for %q: %w", name, err)
+		return fmt.Errorf("inspecting stale ipc socket for %q: %w", name, err)
 	}
 	if err := os.Remove(socketPath); err != nil {
-		return fmt.Errorf("removing stale service socket for %q: %w", name, err)
+		return fmt.Errorf("removing stale ipc socket for %q: %w", name, err)
 	}
-	m.logger.Info("removed stale service socket before provider start",
-		zap.String("service", name),
+	m.logger.Info("removed stale ipc socket before provider start",
+		zap.String("ipc_name", name),
 		zap.String("app_id", appID),
 		zap.String("mode", fi.Mode().String()))
 	return nil
 }
 
-// Release drops one container's ownership of a service name. The directory (and
+// Release drops one container's ownership of an IPC name. The directory (and
 // any socket in it) is removed only once no provider and no consumer remain, so
 // a provider restart never invalidates a deployed consumer's bind mount.
-func (m *ServiceSocketManager) Release(name, appID, serviceName string) {
-	owner, err := serviceSocketOwner(name, appID, serviceName)
+func (m *IPCSocketManager) Release(name, appID, serviceName string) {
+	owner, err := ipcSocketOwner(name, appID, serviceName)
 	if err != nil {
 		// A malformed identity cannot have been registered by Ensure, so there
 		// is nothing to release.
@@ -197,14 +198,14 @@ func (m *ServiceSocketManager) Release(name, appID, serviceName string) {
 	m.releaseOwnerLocked(name, owner)
 }
 
-// ReleaseApp drops every ownership held by an app, across all service names. It
+// ReleaseApp drops every ownership held by an app, across all IPC names. It
 // is the whole-app teardown counterpart of Release, used once containerd
 // confirms the app has no remaining containers.
-func (m *ServiceSocketManager) ReleaseApp(appID string) {
+func (m *IPCSocketManager) ReleaseApp(appID string) {
 	if appconfig.ValidateAppID(appID) != nil {
 		return
 	}
-	prefix := serviceOwnerPrefix(appID)
+	prefix := ipcOwnerPrefix(appID)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	for name, entry := range m.entries {
@@ -216,7 +217,7 @@ func (m *ServiceSocketManager) ReleaseApp(appID string) {
 	}
 }
 
-func (m *ServiceSocketManager) releaseOwnerLocked(name, owner string) {
+func (m *IPCSocketManager) releaseOwnerLocked(name, owner string) {
 	entry := m.entries[name]
 	if entry == nil {
 		return
@@ -232,15 +233,15 @@ func (m *ServiceSocketManager) releaseOwnerLocked(name, owner string) {
 		return
 	}
 	delete(m.entries, name)
-	if err := os.RemoveAll(filepath.Join(ServiceSocketRootPath, name)); err != nil {
-		m.logger.Warn("cannot remove unused service socket directory",
-			zap.String("service", name), zap.Error(err))
+	if err := os.RemoveAll(filepath.Join(IPCSocketRootPath, name)); err != nil {
+		m.logger.Warn("cannot remove unused ipc socket directory",
+			zap.String("ipc_name", name), zap.Error(err))
 	}
 }
 
-// providedNamesLocked returns the sorted set of names that currently have a
+// providedNamesLocked returns the sorted set of IPC names that currently have a
 // provider. Caller must hold m.mu.
-func (m *ServiceSocketManager) providedNamesLocked() []string {
+func (m *IPCSocketManager) providedNamesLocked() []string {
 	names := make([]string, 0, len(m.entries))
 	for name, entry := range m.entries {
 		if entry.provider != "" {
@@ -251,12 +252,13 @@ func (m *ServiceSocketManager) providedNamesLocked() []string {
 	return names
 }
 
-// serviceSocketOwner re-validates every identity that reaches the manager and
-// returns the owner key. The agent must not trust a name, app ID, or service
-// name that arrived over RPC or was read back from container labels (SOC2-CC6,
-// NIST-SI-10) — the service name in particular becomes a host path component.
-func serviceSocketOwner(name, appID, serviceName string) (string, error) {
-	if err := appconfig.ValidateServiceSocketName(name); err != nil {
+// ipcSocketOwner re-validates every identity that reaches the manager and
+// returns the owner key. The agent must not trust an IPC name, app ID, or app
+// service name that arrived over RPC or was read back from container labels
+// (SOC2-CC6, NIST-SI-10) — the IPC name in particular becomes a host path
+// component.
+func ipcSocketOwner(name, appID, serviceName string) (string, error) {
+	if err := appconfig.ValidateIPCName(name); err != nil {
 		return "", err
 	}
 	if err := appconfig.ValidateAppID(appID); err != nil {
@@ -267,47 +269,47 @@ func serviceSocketOwner(name, appID, serviceName string) (string, error) {
 			return "", fmt.Errorf("invalid service name: %w", err)
 		}
 	}
-	return serviceOwnerPrefix(appID) + serviceName, nil
+	return ipcOwnerPrefix(appID) + serviceName, nil
 }
 
-func serviceOwnerPrefix(appID string) string { return appID + "/" }
+func ipcOwnerPrefix(appID string) string { return appID + "/" }
 
-// prepareServiceDirectory creates (or re-asserts) the host directory for one
-// service name. Permissions are re-applied on every call rather than only at
+// prepareIPCDirectory creates (or re-asserts) the host directory for one IPC
+// name. Permissions are re-applied on every call rather than only at
 // creation: MkdirAll is a no-op for an existing directory, so a directory left
 // behind by an older agent build would otherwise keep its old mode forever.
-func (m *ServiceSocketManager) prepareServiceDirectory(directory string) error {
-	if err := os.MkdirAll(ServiceSocketRootPath, serviceRootMode); err != nil {
-		return fmt.Errorf("create service socket root: %w", err)
+func (m *IPCSocketManager) prepareIPCDirectory(directory string) error {
+	if err := os.MkdirAll(IPCSocketRootPath, ipcRootMode); err != nil {
+		return fmt.Errorf("create ipc socket root: %w", err)
 	}
-	if err := os.Chmod(ServiceSocketRootPath, serviceRootMode); err != nil {
-		return fmt.Errorf("set service socket root permissions: %w", err)
+	if err := os.Chmod(IPCSocketRootPath, ipcRootMode); err != nil {
+		return fmt.Errorf("set ipc socket root permissions: %w", err)
 	}
 	if err := os.MkdirAll(directory, 0o770); err != nil {
-		return fmt.Errorf("create service socket directory: %w", err)
+		return fmt.Errorf("create ipc socket directory: %w", err)
 	}
 	// Chmod after MkdirAll: MkdirAll's mode is masked by the process umask and
 	// cannot set the setgid bit at all.
-	if err := os.Chmod(directory, serviceDirMode); err != nil {
-		return fmt.Errorf("set service socket directory permissions: %w", err)
+	if err := os.Chmod(directory, ipcDirMode); err != nil {
+		return fmt.Errorf("set ipc socket directory permissions: %w", err)
 	}
 	// Chown before the setgid verification below: on some filesystems chown
 	// clears setgid, so the check has to see the final state.
 	if os.Geteuid() == 0 {
-		if err := os.Chown(directory, 0, appServiceGroupGID); err != nil {
-			return fmt.Errorf("set service socket directory ownership: %w", err)
+		if err := os.Chown(directory, 0, appIPCGroupGID); err != nil {
+			return fmt.Errorf("set ipc socket directory ownership: %w", err)
 		}
-		if err := os.Chmod(directory, serviceDirMode); err != nil {
-			return fmt.Errorf("re-set service socket directory permissions after chown: %w", err)
+		if err := os.Chmod(directory, ipcDirMode); err != nil {
+			return fmt.Errorf("re-set ipc socket directory permissions after chown: %w", err)
 		}
 	}
 	// A chmod that silently drops setgid (some filesystems and non-Linux hosts
 	// do exactly that, without erroring) degrades non-root providers quietly:
-	// their socket would land in their own primary group instead of the service
+	// their socket would land in their own primary group instead of the ipc
 	// group, and non-root consumers could not reach it. Warn rather than fail —
 	// a root-run provider and consumer pair still works.
 	if fi, err := os.Stat(directory); err == nil && fi.Mode()&os.ModeSetgid == 0 {
-		m.logger.Warn("service socket directory did not retain the setgid bit; a non-root provider's socket will not inherit the service group",
+		m.logger.Warn("ipc socket directory did not retain the setgid bit; a non-root provider's socket will not inherit the ipc group",
 			zap.String("directory", directory),
 			zap.String("mode", fi.Mode().String()))
 	}

--- a/go/internal/agent/services/ipc_socket_manager.go
+++ b/go/internal/agent/services/ipc_socket_manager.go
@@ -1,0 +1,315 @@
+package services
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"go.uber.org/zap"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+const (
+	// ServiceSocketFilename is the single socket the agent exposes inside each
+	// service directory. It is fixed rather than app-chosen so both sides of the
+	// entitlement agree on the path without any out-of-band convention — the
+	// "discovery by convention" failure the shared-persist workaround had.
+	ServiceSocketFilename = "service.sock"
+
+	// appServiceGroupGID is reserved by WendyOS for app-provided service
+	// sockets, the direct analogue of appSystemAPIGroupGID (2000) for
+	// agent-provided ones. Membership is granted only alongside a service
+	// bind mount, so the GID alone reaches nothing.
+	appServiceGroupGID = 2001
+
+	// serviceDirMode is setgid + rwx for owner and group, nothing for others.
+	// setgid matters: a socket the provider binds inside the directory inherits
+	// group appServiceGroupGID automatically, so a non-root provider does not
+	// have to know the GID exists.
+	serviceDirMode = os.FileMode(0o770) | os.ModeSetgid
+
+	// serviceRootMode keeps the root traversable (containers only ever receive a
+	// bind mount of one child) but not listable by anyone but root.
+	serviceRootMode = os.FileMode(0o711)
+)
+
+// ServiceSocketRootPath is disk-backed, not on /run, for the same reason as
+// AdminAgentSocketHostPath: a container's bind mount pins the directory inode,
+// and tmpfs is wiped (fresh inode) on every boot, which would strand a
+// long-lived consumer on an orphaned pre-reboot inode. Behind a var so tests
+// can redirect it into a tempdir.
+var ServiceSocketRootPath = "/var/lib/wendy/services"
+
+// serviceSocketEntry is the agent's record of one service name.
+//
+// owners is keyed by container (appID + serviceName) so a multi-service app
+// counts once per service container, mirroring AppSystemAPISocketManager. The
+// directory outlives every individual container in owners and is removed only
+// when the last one is deleted — removing it earlier would replace the inode
+// that still-deployed consumers have bind-mounted.
+type serviceSocketEntry struct {
+	// provider is the owner key of the container that declared role "provide",
+	// or "" when only consumers are deployed. It is the anti-hijack record: a
+	// second app cannot claim a name that is already provided.
+	provider string
+	owners   map[string]string // owner key → role
+}
+
+// ServiceSocketManager owns the host side of the `service` entitlement: the
+// per-name directory, its ownership and permissions, which app is allowed to
+// provide each name, and removal of a stale socket before a provider starts.
+//
+// SECURITY: the bind mount is the entire trust boundary, exactly as for the
+// `admin` and `notifications` entitlements. A consumer receives one directory
+// containing one socket and nothing else — in particular, none of the
+// provider's persist volume. The provider's identity for a name is
+// first-claim-wins and is held until the providing container is deleted, so a
+// later app cannot take over a name that is already being served.
+type ServiceSocketManager struct {
+	logger  *zap.Logger
+	mu      sync.Mutex
+	entries map[string]*serviceSocketEntry
+}
+
+func NewServiceSocketManager(logger *zap.Logger) *ServiceSocketManager {
+	return &ServiceSocketManager{
+		logger:  logger,
+		entries: make(map[string]*serviceSocketEntry),
+	}
+}
+
+// Ensure registers one container as an owner of a service name and returns the
+// host directory to bind-mount for it. It is idempotent for the same container,
+// so a redeploy or an agent-restart restore can call it again safely.
+//
+// It never creates, removes, or touches the socket itself: that is
+// PrepareProvider's job, and keeping it out of Ensure is what makes Ensure safe
+// to call from the restore path against a provider that is already serving.
+func (m *ServiceSocketManager) Ensure(name, role, appID, serviceName string) (string, error) {
+	if role != appconfig.ServiceRoleProvide && role != appconfig.ServiceRoleConsume {
+		return "", fmt.Errorf("service role must be %q or %q, got %q",
+			appconfig.ServiceRoleProvide, appconfig.ServiceRoleConsume, role)
+	}
+	owner, err := serviceSocketOwner(name, appID, serviceName)
+	if err != nil {
+		return "", err
+	}
+	directory := filepath.Join(ServiceSocketRootPath, name)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry := m.entries[name]
+	if entry == nil {
+		entry = &serviceSocketEntry{owners: make(map[string]string)}
+		m.entries[name] = entry
+	}
+	if role == appconfig.ServiceRoleProvide && entry.provider != "" && entry.provider != owner {
+		return "", fmt.Errorf(
+			"service %q is already provided by %s on this device; only one app may provide a service name (remove the other app first)",
+			name, entry.provider)
+	}
+
+	if err := m.prepareServiceDirectory(directory); err != nil {
+		// Roll the registration back so a failed create does not leave a phantom
+		// owner (or a phantom provider claim) blocking the name.
+		if len(entry.owners) == 0 {
+			delete(m.entries, name)
+		}
+		return "", err
+	}
+
+	entry.owners[owner] = role
+	if role == appconfig.ServiceRoleProvide {
+		entry.provider = owner
+	}
+	if role == appconfig.ServiceRoleConsume && entry.provider == "" {
+		// A typo in the name is otherwise indistinguishable from "the provider
+		// is not deployed yet" — the second thing the hardware spike called out.
+		// Say so at deploy time, with the names that do exist, instead of
+		// leaving the app to hand-roll a retry against a path that will never
+		// appear.
+		m.logger.Warn("service consumer has no provider on this device",
+			zap.String("service", name),
+			zap.String("app_id", appID),
+			zap.Strings("provided_services", m.providedNamesLocked()))
+	}
+	return directory, nil
+}
+
+// PrepareProvider removes a stale socket left behind by a previous run of the
+// provider, and must be called before the provider's task starts. A provider
+// that dies without cleanup otherwise leaves a socket file that consumers can
+// open but not connect to, and that the provider itself cannot rebind
+// (EADDRINUSE) — the platform owns that here so no app has to `rm -f` on boot.
+//
+// It is a no-op for a name this container does not provide, so callers can
+// invoke it for every service entitlement on a container without branching.
+func (m *ServiceSocketManager) PrepareProvider(name, appID, serviceName string) error {
+	owner, err := serviceSocketOwner(name, appID, serviceName)
+	if err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	entry := m.entries[name]
+	if entry == nil || entry.provider != owner {
+		return nil
+	}
+
+	socketPath := filepath.Join(ServiceSocketRootPath, name, ServiceSocketFilename)
+	// Lstat, not Stat: a symlink planted in the directory must be removed as the
+	// link it is, never followed to a target outside the directory.
+	fi, err := os.Lstat(socketPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("inspecting stale service socket for %q: %w", name, err)
+	}
+	if err := os.Remove(socketPath); err != nil {
+		return fmt.Errorf("removing stale service socket for %q: %w", name, err)
+	}
+	m.logger.Info("removed stale service socket before provider start",
+		zap.String("service", name),
+		zap.String("app_id", appID),
+		zap.String("mode", fi.Mode().String()))
+	return nil
+}
+
+// Release drops one container's ownership of a service name. The directory (and
+// any socket in it) is removed only once no provider and no consumer remain, so
+// a provider restart never invalidates a deployed consumer's bind mount.
+func (m *ServiceSocketManager) Release(name, appID, serviceName string) {
+	owner, err := serviceSocketOwner(name, appID, serviceName)
+	if err != nil {
+		// A malformed identity cannot have been registered by Ensure, so there
+		// is nothing to release.
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.releaseOwnerLocked(name, owner)
+}
+
+// ReleaseApp drops every ownership held by an app, across all service names. It
+// is the whole-app teardown counterpart of Release, used once containerd
+// confirms the app has no remaining containers.
+func (m *ServiceSocketManager) ReleaseApp(appID string) {
+	if appconfig.ValidateAppID(appID) != nil {
+		return
+	}
+	prefix := serviceOwnerPrefix(appID)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for name, entry := range m.entries {
+		for owner := range entry.owners {
+			if strings.HasPrefix(owner, prefix) {
+				m.releaseOwnerLocked(name, owner)
+			}
+		}
+	}
+}
+
+func (m *ServiceSocketManager) releaseOwnerLocked(name, owner string) {
+	entry := m.entries[name]
+	if entry == nil {
+		return
+	}
+	if _, ok := entry.owners[owner]; !ok {
+		return
+	}
+	delete(entry.owners, owner)
+	if entry.provider == owner {
+		entry.provider = ""
+	}
+	if len(entry.owners) != 0 {
+		return
+	}
+	delete(m.entries, name)
+	if err := os.RemoveAll(filepath.Join(ServiceSocketRootPath, name)); err != nil {
+		m.logger.Warn("cannot remove unused service socket directory",
+			zap.String("service", name), zap.Error(err))
+	}
+}
+
+// providedNamesLocked returns the sorted set of names that currently have a
+// provider. Caller must hold m.mu.
+func (m *ServiceSocketManager) providedNamesLocked() []string {
+	names := make([]string, 0, len(m.entries))
+	for name, entry := range m.entries {
+		if entry.provider != "" {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// serviceSocketOwner re-validates every identity that reaches the manager and
+// returns the owner key. The agent must not trust a name, app ID, or service
+// name that arrived over RPC or was read back from container labels (SOC2-CC6,
+// NIST-SI-10) — the service name in particular becomes a host path component.
+func serviceSocketOwner(name, appID, serviceName string) (string, error) {
+	if err := appconfig.ValidateServiceSocketName(name); err != nil {
+		return "", err
+	}
+	if err := appconfig.ValidateAppID(appID); err != nil {
+		return "", fmt.Errorf("invalid app ID: %w", err)
+	}
+	if serviceName != "" {
+		if err := appconfig.ValidateServiceName(serviceName); err != nil {
+			return "", fmt.Errorf("invalid service name: %w", err)
+		}
+	}
+	return serviceOwnerPrefix(appID) + serviceName, nil
+}
+
+func serviceOwnerPrefix(appID string) string { return appID + "/" }
+
+// prepareServiceDirectory creates (or re-asserts) the host directory for one
+// service name. Permissions are re-applied on every call rather than only at
+// creation: MkdirAll is a no-op for an existing directory, so a directory left
+// behind by an older agent build would otherwise keep its old mode forever.
+func (m *ServiceSocketManager) prepareServiceDirectory(directory string) error {
+	if err := os.MkdirAll(ServiceSocketRootPath, serviceRootMode); err != nil {
+		return fmt.Errorf("create service socket root: %w", err)
+	}
+	if err := os.Chmod(ServiceSocketRootPath, serviceRootMode); err != nil {
+		return fmt.Errorf("set service socket root permissions: %w", err)
+	}
+	if err := os.MkdirAll(directory, 0o770); err != nil {
+		return fmt.Errorf("create service socket directory: %w", err)
+	}
+	// Chmod after MkdirAll: MkdirAll's mode is masked by the process umask and
+	// cannot set the setgid bit at all.
+	if err := os.Chmod(directory, serviceDirMode); err != nil {
+		return fmt.Errorf("set service socket directory permissions: %w", err)
+	}
+	// Chown before the setgid verification below: on some filesystems chown
+	// clears setgid, so the check has to see the final state.
+	if os.Geteuid() == 0 {
+		if err := os.Chown(directory, 0, appServiceGroupGID); err != nil {
+			return fmt.Errorf("set service socket directory ownership: %w", err)
+		}
+		if err := os.Chmod(directory, serviceDirMode); err != nil {
+			return fmt.Errorf("re-set service socket directory permissions after chown: %w", err)
+		}
+	}
+	// A chmod that silently drops setgid (some filesystems and non-Linux hosts
+	// do exactly that, without erroring) degrades non-root providers quietly:
+	// their socket would land in their own primary group instead of the service
+	// group, and non-root consumers could not reach it. Warn rather than fail —
+	// a root-run provider and consumer pair still works.
+	if fi, err := os.Stat(directory); err == nil && fi.Mode()&os.ModeSetgid == 0 {
+		m.logger.Warn("service socket directory did not retain the setgid bit; a non-root provider's socket will not inherit the service group",
+			zap.String("directory", directory),
+			zap.String("mode", fi.Mode().String()))
+	}
+	return nil
+}

--- a/go/internal/agent/services/ipc_socket_manager_test.go
+++ b/go/internal/agent/services/ipc_socket_manager_test.go
@@ -1,0 +1,326 @@
+package services
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+func newTestServiceSocketManager(t *testing.T) *ServiceSocketManager {
+	t.Helper()
+	// os.MkdirTemp("/tmp", …) rather than t.TempDir(): a unix socket path is
+	// capped at 108 bytes and macOS t.TempDir() paths are long enough to blow
+	// past it once the service directory and socket name are appended.
+	root, err := os.MkdirTemp("/tmp", "wendy-svc-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := ServiceSocketRootPath
+	ServiceSocketRootPath = root
+	t.Cleanup(func() {
+		ServiceSocketRootPath = original
+		_ = os.RemoveAll(root)
+	})
+	return NewServiceSocketManager(zap.NewNop())
+}
+
+func TestServiceSocketManager_EnsureCreatesSetgidDirectory(t *testing.T) {
+	m := newTestServiceSocketManager(t)
+
+	dir, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.provider", "")
+	if err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	if want := filepath.Join(ServiceSocketRootPath, "world"); dir != want {
+		t.Errorf("directory = %q, want %q", dir, want)
+	}
+
+	// setgid is what makes a socket the provider binds inherit the service
+	// group automatically, so a non-root provider never has to know the GID.
+	if serviceDirMode&os.ModeSetgid == 0 {
+		t.Error("serviceDirMode does not request the setgid bit")
+	}
+
+	fi, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat service directory: %v", err)
+	}
+	// macOS silently drops setgid when the caller is not root and not a member
+	// of the directory's group, so only assert the on-disk bit where the agent
+	// actually runs.
+	if runtime.GOOS == "linux" && fi.Mode()&os.ModeSetgid == 0 {
+		t.Errorf("service directory mode = %v, want the setgid bit set", fi.Mode())
+	}
+	if perm := fi.Mode().Perm(); perm != 0o770 {
+		t.Errorf("service directory perm = %04o, want 0770 (no access for others)", perm)
+	}
+
+	// The root must not be world-listable: a container only ever receives a
+	// bind mount of one child, never the root.
+	rootInfo, err := os.Stat(ServiceSocketRootPath)
+	if err != nil {
+		t.Fatalf("stat service root: %v", err)
+	}
+	if perm := rootInfo.Mode().Perm(); perm != 0o711 {
+		t.Errorf("service root perm = %04o, want 0711", perm)
+	}
+}
+
+func TestServiceSocketManager_EnsureIsIdempotentForSameOwner(t *testing.T) {
+	m := newTestServiceSocketManager(t)
+	first, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.provider", "")
+	if err != nil {
+		t.Fatalf("first Ensure: %v", err)
+	}
+	second, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.provider", "")
+	if err != nil {
+		t.Fatalf("second Ensure: %v", err)
+	}
+	if first != second {
+		t.Errorf("Ensure returned %q then %q; want a stable directory", first, second)
+	}
+}
+
+// Only one app may provide a name: otherwise a second app could stand up its
+// own socket on the name a consumer already trusts and intercept its traffic.
+func TestServiceSocketManager_RejectsSecondProvider(t *testing.T) {
+	m := newTestServiceSocketManager(t)
+	if _, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.provider", ""); err != nil {
+		t.Fatalf("first provider Ensure: %v", err)
+	}
+	if _, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.impostor", ""); err == nil {
+		t.Fatal("a second app claimed an already-provided service name")
+	}
+	// A consumer of the same name is still fine — that is the whole feature.
+	if _, err := m.Ensure("world", appconfig.ServiceRoleConsume, "com.example.impostor", ""); err != nil {
+		t.Fatalf("consumer Ensure after provider conflict: %v", err)
+	}
+}
+
+// A name freed by removing its provider becomes claimable again.
+func TestServiceSocketManager_ProviderNameIsReclaimableAfterRelease(t *testing.T) {
+	m := newTestServiceSocketManager(t)
+	if _, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.provider", ""); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	m.Release("world", "com.example.provider", "")
+	if _, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.other", ""); err != nil {
+		t.Fatalf("Ensure after release: %v", err)
+	}
+}
+
+// The stale-socket problem the hardware spike hit: a provider that dies without
+// cleanup leaves a socket file that refuses connections and that the provider
+// cannot rebind. The platform clears it before the provider's task starts.
+func TestServiceSocketManager_PrepareProviderRemovesStaleSocket(t *testing.T) {
+	m := newTestServiceSocketManager(t)
+	dir, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.provider", "")
+	if err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	socketPath := filepath.Join(dir, ServiceSocketFilename)
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	// Close without unlinking, exactly as a crashed provider leaves things.
+	if unixListener, ok := listener.(*net.UnixListener); ok {
+		unixListener.SetUnlinkOnClose(false)
+	}
+	if err := listener.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+	if _, err := os.Lstat(socketPath); err != nil {
+		t.Fatalf("test setup: expected a stale socket at %q: %v", socketPath, err)
+	}
+
+	if err := m.PrepareProvider("world", "com.example.provider", ""); err != nil {
+		t.Fatalf("PrepareProvider: %v", err)
+	}
+	if _, err := os.Lstat(socketPath); !os.IsNotExist(err) {
+		t.Errorf("stale socket still present after PrepareProvider (err=%v)", err)
+	}
+	// The directory itself must survive: consumers have it bind-mounted, and
+	// replacing its inode would strand them.
+	if _, err := os.Stat(dir); err != nil {
+		t.Errorf("service directory removed by PrepareProvider: %v", err)
+	}
+}
+
+// PrepareProvider must not let one app clear the socket of a name another app
+// provides.
+func TestServiceSocketManager_PrepareProviderIgnoresNonProvider(t *testing.T) {
+	m := newTestServiceSocketManager(t)
+	dir, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.provider", "")
+	if err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	if _, err := m.Ensure("world", appconfig.ServiceRoleConsume, "com.example.consumer", ""); err != nil {
+		t.Fatalf("consumer Ensure: %v", err)
+	}
+	socketPath := filepath.Join(dir, ServiceSocketFilename)
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+
+	if err := m.PrepareProvider("world", "com.example.consumer", ""); err != nil {
+		t.Fatalf("PrepareProvider: %v", err)
+	}
+	if _, err := os.Lstat(socketPath); err != nil {
+		t.Errorf("a consumer removed the provider's live socket: %v", err)
+	}
+
+	// And it is a harmless no-op for a name nobody registered.
+	if err := m.PrepareProvider("unknown", "com.example.consumer", ""); err != nil {
+		t.Errorf("PrepareProvider for an unregistered name = %v, want nil", err)
+	}
+}
+
+// The directory outlives every individual container that references it:
+// removing it while a consumer still has it bind-mounted would replace the
+// inode the consumer is pinned to.
+func TestServiceSocketManager_DirectoryOutlivesProviderWhileConsumersRemain(t *testing.T) {
+	m := newTestServiceSocketManager(t)
+	dir, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.provider", "")
+	if err != nil {
+		t.Fatalf("provider Ensure: %v", err)
+	}
+	if _, err := m.Ensure("world", appconfig.ServiceRoleConsume, "com.example.consumer", ""); err != nil {
+		t.Fatalf("consumer Ensure: %v", err)
+	}
+	before, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+
+	m.Release("world", "com.example.provider", "")
+	after, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("directory removed while a consumer still holds it: %v", err)
+	}
+	if !os.SameFile(before, after) {
+		t.Error("directory inode changed while a consumer still holds it")
+	}
+
+	m.Release("world", "com.example.consumer", "")
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("directory survived the last owner (err=%v)", err)
+	}
+}
+
+func TestServiceSocketManager_ReleaseAppDropsEveryClaim(t *testing.T) {
+	m := newTestServiceSocketManager(t)
+	worldDir, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.app", "talker")
+	if err != nil {
+		t.Fatalf("Ensure world: %v", err)
+	}
+	plannerDir, err := m.Ensure("planner", appconfig.ServiceRoleConsume, "com.example.app", "listener")
+	if err != nil {
+		t.Fatalf("Ensure planner: %v", err)
+	}
+
+	m.ReleaseApp("com.example.app")
+	for _, dir := range []string{worldDir, plannerDir} {
+		if _, err := os.Stat(dir); !os.IsNotExist(err) {
+			t.Errorf("%q survived ReleaseApp (err=%v)", dir, err)
+		}
+	}
+	// Idempotent: a second sweep after deleteOne already released is a no-op.
+	m.ReleaseApp("com.example.app")
+
+	// The name is claimable again by a different app.
+	if _, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.other", ""); err != nil {
+		t.Fatalf("Ensure after ReleaseApp: %v", err)
+	}
+}
+
+// Multi-service apps count once per service container, so one service exiting
+// does not tear the directory out from under its siblings.
+func TestServiceSocketManager_RefcountsPerServiceContainer(t *testing.T) {
+	m := newTestServiceSocketManager(t)
+	dir, err := m.Ensure("world", appconfig.ServiceRoleConsume, "com.example.app", "alpha")
+	if err != nil {
+		t.Fatalf("Ensure alpha: %v", err)
+	}
+	if _, err := m.Ensure("world", appconfig.ServiceRoleConsume, "com.example.app", "beta"); err != nil {
+		t.Fatalf("Ensure beta: %v", err)
+	}
+
+	m.Release("world", "com.example.app", "alpha")
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("directory removed while sibling service beta still holds it: %v", err)
+	}
+	m.Release("world", "com.example.app", "beta")
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("directory survived the last sibling (err=%v)", err)
+	}
+}
+
+// Identities that reach the manager are re-validated: the service name becomes
+// a host path component, so a traversal attempt must never create a directory
+// outside the root.
+func TestServiceSocketManager_RejectsMalformedIdentities(t *testing.T) {
+	m := newTestServiceSocketManager(t)
+	cases := []struct {
+		desc                     string
+		name, role, appID, svcNm string
+	}{
+		{"traversal name", "../etc", appconfig.ServiceRoleProvide, "com.example.app", ""},
+		{"dot dot name", "..", appconfig.ServiceRoleProvide, "com.example.app", ""},
+		{"slash name", "a/b", appconfig.ServiceRoleProvide, "com.example.app", ""},
+		{"empty name", "", appconfig.ServiceRoleProvide, "com.example.app", ""},
+		{"uppercase name", "World", appconfig.ServiceRoleProvide, "com.example.app", ""},
+		{"unknown role", "world", "publish", "com.example.app", ""},
+		{"empty role", "world", "", "com.example.app", ""},
+		{"empty app id", "world", appconfig.ServiceRoleProvide, "", ""},
+		{"dotted app id", "world", appconfig.ServiceRoleProvide, "..", ""},
+		{"bad service name", "world", appconfig.ServiceRoleProvide, "com.example.app", "Bad_Name"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			if _, err := m.Ensure(tc.name, tc.role, tc.appID, tc.svcNm); err == nil {
+				t.Fatalf("Ensure(%q, %q, %q, %q) = nil error, want a rejection", tc.name, tc.role, tc.appID, tc.svcNm)
+			}
+		})
+	}
+
+	entries, err := os.ReadDir(ServiceSocketRootPath)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("read service root: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("rejected claims created %d directories: %v", len(entries), entries)
+	}
+}
+
+// A failed directory creation must not leave a phantom provider claim blocking
+// the name for the app that retries.
+func TestServiceSocketManager_FailedEnsureLeavesNoClaim(t *testing.T) {
+	m := newTestServiceSocketManager(t)
+	// A regular file where the service directory should go makes MkdirAll fail.
+	if err := os.MkdirAll(ServiceSocketRootPath, 0o711); err != nil {
+		t.Fatal(err)
+	}
+	blocker := filepath.Join(ServiceSocketRootPath, "world")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.provider", ""); err == nil {
+		t.Fatal("Ensure succeeded despite a file blocking the directory")
+	}
+
+	if err := os.Remove(blocker); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.other", ""); err != nil {
+		t.Fatalf("a failed Ensure left the name claimed: %v", err)
+	}
+}

--- a/go/internal/agent/services/ipc_socket_manager_test.go
+++ b/go/internal/agent/services/ipc_socket_manager_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"go.uber.org/zap"
@@ -84,6 +85,31 @@ func TestIPCSocketManager_EnsureIsIdempotentForSameOwner(t *testing.T) {
 	}
 	if first != second {
 		t.Errorf("Ensure returned %q then %q; want a stable directory", first, second)
+	}
+}
+
+func TestIPCSocketManager_MissingProviderWarning(t *testing.T) {
+	m := newTestIPCSocketManager(t)
+	if _, err := m.Ensure("planner", appconfig.IPCRoleProvide, "com.example.planner", ""); err != nil {
+		t.Fatalf("Ensure planner provider: %v", err)
+	}
+	if _, err := m.Ensure("world", appconfig.IPCRoleConsume, "com.example.consumer", ""); err != nil {
+		t.Fatalf("Ensure world consumer: %v", err)
+	}
+
+	warning := m.MissingProviderWarning("world")
+	if !strings.Contains(warning, `ipc consumer "world" has no provider`) {
+		t.Fatalf("warning = %q, want missing-provider context", warning)
+	}
+	if !strings.Contains(warning, "planner") {
+		t.Fatalf("warning = %q, want available provider name", warning)
+	}
+
+	if _, err := m.Ensure("world", appconfig.IPCRoleProvide, "com.example.provider", ""); err != nil {
+		t.Fatalf("Ensure world provider: %v", err)
+	}
+	if warning := m.MissingProviderWarning("world"); warning != "" {
+		t.Fatalf("warning with provider present = %q, want empty", warning)
 	}
 }
 

--- a/go/internal/agent/services/ipc_socket_manager_test.go
+++ b/go/internal/agent/services/ipc_socket_manager_test.go
@@ -12,73 +12,73 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
 )
 
-func newTestServiceSocketManager(t *testing.T) *ServiceSocketManager {
+func newTestIPCSocketManager(t *testing.T) *IPCSocketManager {
 	t.Helper()
 	// os.MkdirTemp("/tmp", …) rather than t.TempDir(): a unix socket path is
 	// capped at 108 bytes and macOS t.TempDir() paths are long enough to blow
-	// past it once the service directory and socket name are appended.
+	// past it once the IPC directory and socket name are appended.
 	root, err := os.MkdirTemp("/tmp", "wendy-svc-")
 	if err != nil {
 		t.Fatal(err)
 	}
-	original := ServiceSocketRootPath
-	ServiceSocketRootPath = root
+	original := IPCSocketRootPath
+	IPCSocketRootPath = root
 	t.Cleanup(func() {
-		ServiceSocketRootPath = original
+		IPCSocketRootPath = original
 		_ = os.RemoveAll(root)
 	})
-	return NewServiceSocketManager(zap.NewNop())
+	return NewIPCSocketManager(zap.NewNop())
 }
 
-func TestServiceSocketManager_EnsureCreatesSetgidDirectory(t *testing.T) {
-	m := newTestServiceSocketManager(t)
+func TestIPCSocketManager_EnsureCreatesSetgidDirectory(t *testing.T) {
+	m := newTestIPCSocketManager(t)
 
-	dir, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.provider", "")
+	dir, err := m.Ensure("world", appconfig.IPCRoleProvide, "com.example.provider", "")
 	if err != nil {
 		t.Fatalf("Ensure: %v", err)
 	}
-	if want := filepath.Join(ServiceSocketRootPath, "world"); dir != want {
+	if want := filepath.Join(IPCSocketRootPath, "world"); dir != want {
 		t.Errorf("directory = %q, want %q", dir, want)
 	}
 
-	// setgid is what makes a socket the provider binds inherit the service
+	// setgid is what makes a socket the provider binds inherit the ipc
 	// group automatically, so a non-root provider never has to know the GID.
-	if serviceDirMode&os.ModeSetgid == 0 {
-		t.Error("serviceDirMode does not request the setgid bit")
+	if ipcDirMode&os.ModeSetgid == 0 {
+		t.Error("ipcDirMode does not request the setgid bit")
 	}
 
 	fi, err := os.Stat(dir)
 	if err != nil {
-		t.Fatalf("stat service directory: %v", err)
+		t.Fatalf("stat ipc directory: %v", err)
 	}
 	// macOS silently drops setgid when the caller is not root and not a member
 	// of the directory's group, so only assert the on-disk bit where the agent
 	// actually runs.
 	if runtime.GOOS == "linux" && fi.Mode()&os.ModeSetgid == 0 {
-		t.Errorf("service directory mode = %v, want the setgid bit set", fi.Mode())
+		t.Errorf("ipc directory mode = %v, want the setgid bit set", fi.Mode())
 	}
 	if perm := fi.Mode().Perm(); perm != 0o770 {
-		t.Errorf("service directory perm = %04o, want 0770 (no access for others)", perm)
+		t.Errorf("ipc directory perm = %04o, want 0770 (no access for others)", perm)
 	}
 
 	// The root must not be world-listable: a container only ever receives a
 	// bind mount of one child, never the root.
-	rootInfo, err := os.Stat(ServiceSocketRootPath)
+	rootInfo, err := os.Stat(IPCSocketRootPath)
 	if err != nil {
-		t.Fatalf("stat service root: %v", err)
+		t.Fatalf("stat ipc root: %v", err)
 	}
 	if perm := rootInfo.Mode().Perm(); perm != 0o711 {
-		t.Errorf("service root perm = %04o, want 0711", perm)
+		t.Errorf("ipc root perm = %04o, want 0711", perm)
 	}
 }
 
-func TestServiceSocketManager_EnsureIsIdempotentForSameOwner(t *testing.T) {
-	m := newTestServiceSocketManager(t)
-	first, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.provider", "")
+func TestIPCSocketManager_EnsureIsIdempotentForSameOwner(t *testing.T) {
+	m := newTestIPCSocketManager(t)
+	first, err := m.Ensure("world", appconfig.IPCRoleProvide, "com.example.provider", "")
 	if err != nil {
 		t.Fatalf("first Ensure: %v", err)
 	}
-	second, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.provider", "")
+	second, err := m.Ensure("world", appconfig.IPCRoleProvide, "com.example.provider", "")
 	if err != nil {
 		t.Fatalf("second Ensure: %v", err)
 	}
@@ -89,28 +89,28 @@ func TestServiceSocketManager_EnsureIsIdempotentForSameOwner(t *testing.T) {
 
 // Only one app may provide a name: otherwise a second app could stand up its
 // own socket on the name a consumer already trusts and intercept its traffic.
-func TestServiceSocketManager_RejectsSecondProvider(t *testing.T) {
-	m := newTestServiceSocketManager(t)
-	if _, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.provider", ""); err != nil {
+func TestIPCSocketManager_RejectsSecondProvider(t *testing.T) {
+	m := newTestIPCSocketManager(t)
+	if _, err := m.Ensure("world", appconfig.IPCRoleProvide, "com.example.provider", ""); err != nil {
 		t.Fatalf("first provider Ensure: %v", err)
 	}
-	if _, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.impostor", ""); err == nil {
-		t.Fatal("a second app claimed an already-provided service name")
+	if _, err := m.Ensure("world", appconfig.IPCRoleProvide, "com.example.impostor", ""); err == nil {
+		t.Fatal("a second app claimed an already-provided ipc name")
 	}
 	// A consumer of the same name is still fine — that is the whole feature.
-	if _, err := m.Ensure("world", appconfig.ServiceRoleConsume, "com.example.impostor", ""); err != nil {
+	if _, err := m.Ensure("world", appconfig.IPCRoleConsume, "com.example.impostor", ""); err != nil {
 		t.Fatalf("consumer Ensure after provider conflict: %v", err)
 	}
 }
 
 // A name freed by removing its provider becomes claimable again.
-func TestServiceSocketManager_ProviderNameIsReclaimableAfterRelease(t *testing.T) {
-	m := newTestServiceSocketManager(t)
-	if _, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.provider", ""); err != nil {
+func TestIPCSocketManager_ProviderNameIsReclaimableAfterRelease(t *testing.T) {
+	m := newTestIPCSocketManager(t)
+	if _, err := m.Ensure("world", appconfig.IPCRoleProvide, "com.example.provider", ""); err != nil {
 		t.Fatalf("Ensure: %v", err)
 	}
 	m.Release("world", "com.example.provider", "")
-	if _, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.other", ""); err != nil {
+	if _, err := m.Ensure("world", appconfig.IPCRoleProvide, "com.example.other", ""); err != nil {
 		t.Fatalf("Ensure after release: %v", err)
 	}
 }
@@ -118,13 +118,13 @@ func TestServiceSocketManager_ProviderNameIsReclaimableAfterRelease(t *testing.T
 // The stale-socket problem the hardware spike hit: a provider that dies without
 // cleanup leaves a socket file that refuses connections and that the provider
 // cannot rebind. The platform clears it before the provider's task starts.
-func TestServiceSocketManager_PrepareProviderRemovesStaleSocket(t *testing.T) {
-	m := newTestServiceSocketManager(t)
-	dir, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.provider", "")
+func TestIPCSocketManager_PrepareProviderRemovesStaleSocket(t *testing.T) {
+	m := newTestIPCSocketManager(t)
+	dir, err := m.Ensure("world", appconfig.IPCRoleProvide, "com.example.provider", "")
 	if err != nil {
 		t.Fatalf("Ensure: %v", err)
 	}
-	socketPath := filepath.Join(dir, ServiceSocketFilename)
+	socketPath := filepath.Join(dir, IPCSocketFilename)
 	listener, err := net.Listen("unix", socketPath)
 	if err != nil {
 		t.Fatalf("listen: %v", err)
@@ -149,22 +149,22 @@ func TestServiceSocketManager_PrepareProviderRemovesStaleSocket(t *testing.T) {
 	// The directory itself must survive: consumers have it bind-mounted, and
 	// replacing its inode would strand them.
 	if _, err := os.Stat(dir); err != nil {
-		t.Errorf("service directory removed by PrepareProvider: %v", err)
+		t.Errorf("ipc directory removed by PrepareProvider: %v", err)
 	}
 }
 
 // PrepareProvider must not let one app clear the socket of a name another app
 // provides.
-func TestServiceSocketManager_PrepareProviderIgnoresNonProvider(t *testing.T) {
-	m := newTestServiceSocketManager(t)
-	dir, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.provider", "")
+func TestIPCSocketManager_PrepareProviderIgnoresNonProvider(t *testing.T) {
+	m := newTestIPCSocketManager(t)
+	dir, err := m.Ensure("world", appconfig.IPCRoleProvide, "com.example.provider", "")
 	if err != nil {
 		t.Fatalf("Ensure: %v", err)
 	}
-	if _, err := m.Ensure("world", appconfig.ServiceRoleConsume, "com.example.consumer", ""); err != nil {
+	if _, err := m.Ensure("world", appconfig.IPCRoleConsume, "com.example.consumer", ""); err != nil {
 		t.Fatalf("consumer Ensure: %v", err)
 	}
-	socketPath := filepath.Join(dir, ServiceSocketFilename)
+	socketPath := filepath.Join(dir, IPCSocketFilename)
 	listener, err := net.Listen("unix", socketPath)
 	if err != nil {
 		t.Fatalf("listen: %v", err)
@@ -187,13 +187,13 @@ func TestServiceSocketManager_PrepareProviderIgnoresNonProvider(t *testing.T) {
 // The directory outlives every individual container that references it:
 // removing it while a consumer still has it bind-mounted would replace the
 // inode the consumer is pinned to.
-func TestServiceSocketManager_DirectoryOutlivesProviderWhileConsumersRemain(t *testing.T) {
-	m := newTestServiceSocketManager(t)
-	dir, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.provider", "")
+func TestIPCSocketManager_DirectoryOutlivesProviderWhileConsumersRemain(t *testing.T) {
+	m := newTestIPCSocketManager(t)
+	dir, err := m.Ensure("world", appconfig.IPCRoleProvide, "com.example.provider", "")
 	if err != nil {
 		t.Fatalf("provider Ensure: %v", err)
 	}
-	if _, err := m.Ensure("world", appconfig.ServiceRoleConsume, "com.example.consumer", ""); err != nil {
+	if _, err := m.Ensure("world", appconfig.IPCRoleConsume, "com.example.consumer", ""); err != nil {
 		t.Fatalf("consumer Ensure: %v", err)
 	}
 	before, err := os.Stat(dir)
@@ -216,13 +216,13 @@ func TestServiceSocketManager_DirectoryOutlivesProviderWhileConsumersRemain(t *t
 	}
 }
 
-func TestServiceSocketManager_ReleaseAppDropsEveryClaim(t *testing.T) {
-	m := newTestServiceSocketManager(t)
-	worldDir, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.app", "talker")
+func TestIPCSocketManager_ReleaseAppDropsEveryClaim(t *testing.T) {
+	m := newTestIPCSocketManager(t)
+	worldDir, err := m.Ensure("world", appconfig.IPCRoleProvide, "com.example.app", "talker")
 	if err != nil {
 		t.Fatalf("Ensure world: %v", err)
 	}
-	plannerDir, err := m.Ensure("planner", appconfig.ServiceRoleConsume, "com.example.app", "listener")
+	plannerDir, err := m.Ensure("planner", appconfig.IPCRoleConsume, "com.example.app", "listener")
 	if err != nil {
 		t.Fatalf("Ensure planner: %v", err)
 	}
@@ -237,20 +237,20 @@ func TestServiceSocketManager_ReleaseAppDropsEveryClaim(t *testing.T) {
 	m.ReleaseApp("com.example.app")
 
 	// The name is claimable again by a different app.
-	if _, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.other", ""); err != nil {
+	if _, err := m.Ensure("world", appconfig.IPCRoleProvide, "com.example.other", ""); err != nil {
 		t.Fatalf("Ensure after ReleaseApp: %v", err)
 	}
 }
 
 // Multi-service apps count once per service container, so one service exiting
 // does not tear the directory out from under its siblings.
-func TestServiceSocketManager_RefcountsPerServiceContainer(t *testing.T) {
-	m := newTestServiceSocketManager(t)
-	dir, err := m.Ensure("world", appconfig.ServiceRoleConsume, "com.example.app", "alpha")
+func TestIPCSocketManager_RefcountsPerServiceContainer(t *testing.T) {
+	m := newTestIPCSocketManager(t)
+	dir, err := m.Ensure("world", appconfig.IPCRoleConsume, "com.example.app", "alpha")
 	if err != nil {
 		t.Fatalf("Ensure alpha: %v", err)
 	}
-	if _, err := m.Ensure("world", appconfig.ServiceRoleConsume, "com.example.app", "beta"); err != nil {
+	if _, err := m.Ensure("world", appconfig.IPCRoleConsume, "com.example.app", "beta"); err != nil {
 		t.Fatalf("Ensure beta: %v", err)
 	}
 
@@ -264,25 +264,25 @@ func TestServiceSocketManager_RefcountsPerServiceContainer(t *testing.T) {
 	}
 }
 
-// Identities that reach the manager are re-validated: the service name becomes
+// Identities that reach the manager are re-validated: the ipc name becomes
 // a host path component, so a traversal attempt must never create a directory
 // outside the root.
-func TestServiceSocketManager_RejectsMalformedIdentities(t *testing.T) {
-	m := newTestServiceSocketManager(t)
+func TestIPCSocketManager_RejectsMalformedIdentities(t *testing.T) {
+	m := newTestIPCSocketManager(t)
 	cases := []struct {
 		desc                     string
 		name, role, appID, svcNm string
 	}{
-		{"traversal name", "../etc", appconfig.ServiceRoleProvide, "com.example.app", ""},
-		{"dot dot name", "..", appconfig.ServiceRoleProvide, "com.example.app", ""},
-		{"slash name", "a/b", appconfig.ServiceRoleProvide, "com.example.app", ""},
-		{"empty name", "", appconfig.ServiceRoleProvide, "com.example.app", ""},
-		{"uppercase name", "World", appconfig.ServiceRoleProvide, "com.example.app", ""},
+		{"traversal name", "../etc", appconfig.IPCRoleProvide, "com.example.app", ""},
+		{"dot dot name", "..", appconfig.IPCRoleProvide, "com.example.app", ""},
+		{"slash name", "a/b", appconfig.IPCRoleProvide, "com.example.app", ""},
+		{"empty name", "", appconfig.IPCRoleProvide, "com.example.app", ""},
+		{"uppercase name", "World", appconfig.IPCRoleProvide, "com.example.app", ""},
 		{"unknown role", "world", "publish", "com.example.app", ""},
 		{"empty role", "world", "", "com.example.app", ""},
-		{"empty app id", "world", appconfig.ServiceRoleProvide, "", ""},
-		{"dotted app id", "world", appconfig.ServiceRoleProvide, "..", ""},
-		{"bad service name", "world", appconfig.ServiceRoleProvide, "com.example.app", "Bad_Name"},
+		{"empty app id", "world", appconfig.IPCRoleProvide, "", ""},
+		{"dotted app id", "world", appconfig.IPCRoleProvide, "..", ""},
+		{"bad app service name", "world", appconfig.IPCRoleProvide, "com.example.app", "Bad_Name"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -292,9 +292,9 @@ func TestServiceSocketManager_RejectsMalformedIdentities(t *testing.T) {
 		})
 	}
 
-	entries, err := os.ReadDir(ServiceSocketRootPath)
+	entries, err := os.ReadDir(IPCSocketRootPath)
 	if err != nil && !os.IsNotExist(err) {
-		t.Fatalf("read service root: %v", err)
+		t.Fatalf("read ipc root: %v", err)
 	}
 	if len(entries) != 0 {
 		t.Errorf("rejected claims created %d directories: %v", len(entries), entries)
@@ -303,24 +303,24 @@ func TestServiceSocketManager_RejectsMalformedIdentities(t *testing.T) {
 
 // A failed directory creation must not leave a phantom provider claim blocking
 // the name for the app that retries.
-func TestServiceSocketManager_FailedEnsureLeavesNoClaim(t *testing.T) {
-	m := newTestServiceSocketManager(t)
-	// A regular file where the service directory should go makes MkdirAll fail.
-	if err := os.MkdirAll(ServiceSocketRootPath, 0o711); err != nil {
+func TestIPCSocketManager_FailedEnsureLeavesNoClaim(t *testing.T) {
+	m := newTestIPCSocketManager(t)
+	// A regular file where the ipc directory should go makes MkdirAll fail.
+	if err := os.MkdirAll(IPCSocketRootPath, 0o711); err != nil {
 		t.Fatal(err)
 	}
-	blocker := filepath.Join(ServiceSocketRootPath, "world")
+	blocker := filepath.Join(IPCSocketRootPath, "world")
 	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.provider", ""); err == nil {
+	if _, err := m.Ensure("world", appconfig.IPCRoleProvide, "com.example.provider", ""); err == nil {
 		t.Fatal("Ensure succeeded despite a file blocking the directory")
 	}
 
 	if err := os.Remove(blocker); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := m.Ensure("world", appconfig.ServiceRoleProvide, "com.example.other", ""); err != nil {
+	if _, err := m.Ensure("world", appconfig.IPCRoleProvide, "com.example.other", ""); err != nil {
 		t.Fatalf("a failed Ensure left the name claimed: %v", err)
 	}
 }

--- a/go/internal/cli/assets/docs/apps/wendy.json.md
+++ b/go/internal/cli/assets/docs/apps/wendy.json.md
@@ -287,7 +287,7 @@ IP networking access.
 | `"host-admin"` | Host networking **plus** `CAP_NET_ADMIN` — allows reconfiguring interfaces, routes, and netfilter. Only request this if your app genuinely manages the network; it is a high-privilege capability. |
 | `"none"` | Networking fully disabled — no namespace connectivity of any kind. |
 | `"bridge"` | Isolated network namespace with a private IP, outbound internet via NAT, and working DNS — but **no** host/LAN-published ports. Use this for apps that need to reach the internet without exposing anything locally. Cross-device access to a bridge app is via a `mesh` entitlement, not this one. |
-| `"mesh"` | Isolated network namespace chained into the wendy-mesh CNI, with a route to a `serviceCIDR` (required for this mode — a valid CIDR string) so the app can reach other meshed devices/services. Optionally set `ports` (host→container mappings) so mesh peers can dial in. |
+| `"mesh"` | Isolated network namespace chained into the wendy-mesh CNI, with a route to a `serviceCIDR` (required for this mode — a valid CIDR string) so the app can reach other meshed devices/services. Optionally set `ports` (host→container mappings) so mesh peers can dial in. **Cross-device only** — for app-to-app access on the *same* device, use the [`service`](#service) entitlement. |
 
 > **Security note:** `CAP_NET_ADMIN` (host network reconfiguration) is granted only by `"host-admin"`, never by plain `"host"`. Apps that previously relied on `CAP_NET_ADMIN` under `"host"` must switch to `"host-admin"`.
 
@@ -531,6 +531,42 @@ Grants the container the wendy-agent's **full gRPC over a local unix socket** (`
 An app with `admin` can start, stop, and delete apps and read all device data locally. The socket is bind-mounted **only** into containers that declare `admin` — that mount is the entire trust boundary — and it is never reachable off-device (a unix socket, not TCP). At most one `admin` per app.
 
 > **Security:** `admin` is a privileged, deliberate grant equivalent to local device control. Grant it only to fully-trusted first-party apps (e.g. the WendyOS shell). Requires an agent build that serves the local socket.
+
+### `service`
+
+Lets one app expose a unix socket to another app on the same device, without either app gaining access to the other's data.
+
+```json
+{ "type": "service", "name": "world", "role": "provide" }
+```
+
+```json
+{ "type": "service", "name": "world", "role": "consume" }
+```
+
+| Field | Description |
+|-------|-------------|
+| `name` | The service name. Both sides use the same one. Lowercase RFC 1123 label (`^[a-z]([a-z0-9-]{0,55}[a-z0-9])?$`). Unrelated to `persist` volume names and to the top-level `services` map. |
+| `role` | `"provide"` binds the socket and owns the service; `"consume"` may only connect to it. |
+
+The agent owns the socket path and its lifecycle. It bind-mounts a per-name directory at `/run/wendy/services/<name>` — **read-write** for the provider (which must `bind()` there) and **read-only** for consumers — and injects `WENDY_SERVICE_<NAME>_SOCKET` pointing at `/run/wendy/services/<name>/service.sock` (hyphens in the name become underscores in the variable). The directory, not the socket inode, is mounted, so a provider that recreates its socket is transparent to an already-running consumer.
+
+A read-only mount still permits `connect()` — the kernel's read-only-superblock check applies to regular files, directories, and symlinks, never to sockets — so read-only denies a consumer only the ability to unlink or replace the provider's socket.
+
+The agent also handles the lifecycle problems apps would otherwise each solve badly:
+
+| Problem | What the agent does |
+|---|---|
+| Stale socket after an unclean provider exit | Removes any leftover socket before the provider's task starts, so `bind()` never hits `EADDRINUSE` and consumers never find a socket that refuses connections |
+| Name typo vs. provider not deployed | Warns at deploy time when a consumer's name has no provider on the device, and lists the names that do |
+| Directory lifetime | The per-name host directory under `/var/lib/wendy/services` is reference-counted across every provider and consumer container (stopped ones included) and removed only after the last is deleted, so a provider restart never strands a consumer's bind mount |
+| Traversal | Both sides get supplementary GID `2001`; the directory is `2770 root:2001` and setgid, so a socket the provider binds inherits the group without the app knowing the GID exists |
+
+> **Why not a shared `persist` volume?** Two apps *can* share a socket today by sharing a `persist` name — but that grants the entire data volume. An app that only needs to *call* a service should not also get read/write on that service's database. `service` grants the socket and nothing else.
+
+> **Security:** at most one app may `provide` a given name on a device, first claim wins, held until the providing container is deleted. A later app cannot take over a name a consumer already trusts. Claims are restored from container labels after an agent restart.
+
+> **Known limitation — non-root providers.** The socket's *mode* is set by whoever calls `bind()`. With a default umask a provider creates it `0755`, which a **non-root** consumer cannot `connect()` to (connect requires write permission on the socket inode). Until socket activation lands, a non-root provider must create the socket group-accessible — `umask(0o007)` before binding, or `chmod(path, 0o660)` after. Providers and consumers that both run as root (the current WendyOS default) are unaffected.
 
 ---
 

--- a/go/internal/cli/assets/docs/apps/wendy.json.md
+++ b/go/internal/cli/assets/docs/apps/wendy.json.md
@@ -287,7 +287,7 @@ IP networking access.
 | `"host-admin"` | Host networking **plus** `CAP_NET_ADMIN` — allows reconfiguring interfaces, routes, and netfilter. Only request this if your app genuinely manages the network; it is a high-privilege capability. |
 | `"none"` | Networking fully disabled — no namespace connectivity of any kind. |
 | `"bridge"` | Isolated network namespace with a private IP, outbound internet via NAT, and working DNS — but **no** host/LAN-published ports. Use this for apps that need to reach the internet without exposing anything locally. Cross-device access to a bridge app is via a `mesh` entitlement, not this one. |
-| `"mesh"` | Isolated network namespace chained into the wendy-mesh CNI, with a route to a `serviceCIDR` (required for this mode — a valid CIDR string) so the app can reach other meshed devices/services. Optionally set `ports` (host→container mappings) so mesh peers can dial in. **Cross-device only** — for app-to-app access on the *same* device, use the [`service`](#service) entitlement. |
+| `"mesh"` | Isolated network namespace chained into the wendy-mesh CNI, with a route to a `serviceCIDR` (required for this mode — a valid CIDR string) so the app can reach other meshed devices/services. Optionally set `ports` (host→container mappings) so mesh peers can dial in. **Cross-device only** — for app-to-app access on the *same* device, use the [`ipc`](#ipc) entitlement. |
 
 > **Security note:** `CAP_NET_ADMIN` (host network reconfiguration) is granted only by `"host-admin"`, never by plain `"host"`. Apps that previously relied on `CAP_NET_ADMIN` under `"host"` must switch to `"host-admin"`.
 
@@ -532,24 +532,24 @@ An app with `admin` can start, stop, and delete apps and read all device data lo
 
 > **Security:** `admin` is a privileged, deliberate grant equivalent to local device control. Grant it only to fully-trusted first-party apps (e.g. the WendyOS shell). Requires an agent build that serves the local socket.
 
-### `service`
+### `ipc`
 
 Lets one app expose a unix socket to another app on the same device, without either app gaining access to the other's data.
 
 ```json
-{ "type": "service", "name": "world", "role": "provide" }
+{ "type": "ipc", "name": "world", "role": "provide" }
 ```
 
 ```json
-{ "type": "service", "name": "world", "role": "consume" }
+{ "type": "ipc", "name": "world", "role": "consume" }
 ```
 
 | Field | Description |
 |-------|-------------|
-| `name` | The service name. Both sides use the same one. Lowercase RFC 1123 label (`^[a-z]([a-z0-9-]{0,55}[a-z0-9])?$`). Unrelated to `persist` volume names and to the top-level `services` map. |
+| `name` | The IPC service name. Both sides use the same one. Lowercase RFC 1123 label (`^[a-z]([a-z0-9-]{0,55}[a-z0-9])?$`). Unrelated to `persist` volume names, to the top-level `services` map, and to `serviceName`. |
 | `role` | `"provide"` binds the socket and owns the service; `"consume"` may only connect to it. |
 
-The agent owns the socket path and its lifecycle. It bind-mounts a per-name directory at `/run/wendy/services/<name>` — **read-write** for the provider (which must `bind()` there) and **read-only** for consumers — and injects `WENDY_SERVICE_<NAME>_SOCKET` pointing at `/run/wendy/services/<name>/service.sock` (hyphens in the name become underscores in the variable). The directory, not the socket inode, is mounted, so a provider that recreates its socket is transparent to an already-running consumer.
+The agent owns the socket path and its lifecycle. It bind-mounts a per-name directory at `/run/wendy/ipc/<name>` — **read-write** for the provider (which must `bind()` there) and **read-only** for consumers — and injects `WENDY_IPC_<NAME>_SOCKET` pointing at `/run/wendy/ipc/<name>/ipc.sock` (hyphens in the name become underscores in the variable). The directory, not the socket inode, is mounted, so a provider that recreates its socket is transparent to an already-running consumer.
 
 A read-only mount still permits `connect()` — the kernel's read-only-superblock check applies to regular files, directories, and symlinks, never to sockets — so read-only denies a consumer only the ability to unlink or replace the provider's socket.
 
@@ -559,10 +559,10 @@ The agent also handles the lifecycle problems apps would otherwise each solve ba
 |---|---|
 | Stale socket after an unclean provider exit | Removes any leftover socket before the provider's task starts, so `bind()` never hits `EADDRINUSE` and consumers never find a socket that refuses connections |
 | Name typo vs. provider not deployed | Warns at deploy time when a consumer's name has no provider on the device, and lists the names that do |
-| Directory lifetime | The per-name host directory under `/var/lib/wendy/services` is reference-counted across every provider and consumer container (stopped ones included) and removed only after the last is deleted, so a provider restart never strands a consumer's bind mount |
+| Directory lifetime | The per-name host directory under `/var/lib/wendy/ipc` is reference-counted across every provider and consumer container (stopped ones included) and removed only after the last is deleted, so a provider restart never strands a consumer's bind mount |
 | Traversal | Both sides get supplementary GID `2001`; the directory is `2770 root:2001` and setgid, so a socket the provider binds inherits the group without the app knowing the GID exists |
 
-> **Why not a shared `persist` volume?** Two apps *can* share a socket today by sharing a `persist` name — but that grants the entire data volume. An app that only needs to *call* a service should not also get read/write on that service's database. `service` grants the socket and nothing else.
+> **Why not a shared `persist` volume?** Two apps *can* share a socket today by sharing a `persist` name — but that grants the entire data volume. An app that only needs to *call* a service should not also get read/write on that service's database. `ipc` grants the socket and nothing else.
 
 > **Security:** at most one app may `provide` a given name on a device, first claim wins, held until the providing container is deleted. A later app cannot take over a name a consumer already trusts. Claims are restored from container labels after an agent restart.
 

--- a/go/internal/cli/assets/docs/device/entitlements.md
+++ b/go/internal/cli/assets/docs/device/entitlements.md
@@ -258,6 +258,8 @@ The persist entitlement allows the container to persist data across restarts. Da
 
 Volumes are identified by name only (not by app ID), so multiple apps can share data by using the same volume name. This is useful for sharing caches or data between apps.
 
+> **Sharing a socket, not data?** Use the [`service`](#service) entitlement instead. A shared `persist` name grants the *entire* volume — an app that only needs to call another app's service would also get read/write on that service's database.
+
 ### Recommended Shared Volume Names
 
 | Name | Path | Description |
@@ -273,6 +275,40 @@ Example for a Python ML app:
     "path": "/app/.cache/huggingface"
 }
 ```
+
+## Service
+
+The service entitlement lets one app expose a unix socket to another app **on the same device**. It is the same mechanism `admin` and `notifications` already use — an entitlement-gated bind mount of an agent-owned socket directory — generalized from agent-provided sockets to app-provided ones.
+
+The provider:
+
+```json
+{ "type": "service", "name": "world", "role": "provide" }
+```
+
+The consumer:
+
+```json
+{ "type": "service", "name": "world", "role": "consume" }
+```
+
+| Boundary | Value |
+|---|---|
+| Mount | `/run/wendy/services/<name>` — read-write for `provide`, read-only for `consume` |
+| Injected environment | `WENDY_SERVICE_<NAME>_SOCKET=/run/wendy/services/<name>/service.sock` (hyphens become underscores) |
+| Supplementary group | GID `2001`, so non-root apps can traverse the directory without world access |
+| Stable host directory | `/var/lib/wendy/services/<name>`, mode `2770 root:2001` |
+| Providers per name | One per device, first claim wins, held until that container is deleted |
+
+Both sides read the socket path from the environment rather than hardcoding it, so a typo cannot silently produce two apps talking past each other. A consumer whose name has no provider on the device is warned about at deploy time, with the names that do exist — the failure mode that a shared-volume socket makes indistinguishable from "the provider hasn't started yet".
+
+The agent removes a leftover socket before the provider's task starts, so a provider that died without cleaning up does not leave a socket that consumers can open but not connect to, and does not have to `rm -f` its own socket on boot.
+
+**This is not cross-device.** For a container on one device to reach a service on another, use the [`network` entitlement's `mesh` mode](../apps/wendy.json.md#network), which addresses peers by cloud asset ID over a service CIDR. `service` is device-local IPC only.
+
+> **Not a shared volume.** Two apps can already share a unix socket by sharing a `persist` name, but that grants the whole data volume. `service` grants the socket and nothing else — a consumer gets no access to the provider's storage.
+
+> **Non-root providers (current limitation).** The socket's permissions come from whoever calls `bind()`. With a default umask that is `0755`, which a **non-root** consumer cannot connect to. Until socket activation lands, a non-root provider should `umask(0o007)` before binding or `chmod` the socket to `0660` after. Root-run providers and consumers — the current WendyOS default — need no change.
 
 ## Build
 

--- a/go/internal/cli/assets/docs/device/entitlements.md
+++ b/go/internal/cli/assets/docs/device/entitlements.md
@@ -258,7 +258,7 @@ The persist entitlement allows the container to persist data across restarts. Da
 
 Volumes are identified by name only (not by app ID), so multiple apps can share data by using the same volume name. This is useful for sharing caches or data between apps.
 
-> **Sharing a socket, not data?** Use the [`service`](#service) entitlement instead. A shared `persist` name grants the *entire* volume — an app that only needs to call another app's service would also get read/write on that service's database.
+> **Sharing a socket, not data?** Use the [`ipc`](#ipc) entitlement instead. A shared `persist` name grants the *entire* volume — an app that only needs to call another app's service would also get read/write on that service's database.
 
 ### Recommended Shared Volume Names
 
@@ -276,37 +276,38 @@ Example for a Python ML app:
 }
 ```
 
-## Service
+## IPC
 
-The service entitlement lets one app expose a unix socket to another app **on the same device**. It is the same mechanism `admin` and `notifications` already use — an entitlement-gated bind mount of an agent-owned socket directory — generalized from agent-provided sockets to app-provided ones.
+The ipc entitlement lets one app expose a unix socket to another app **on the same device**. It is the same mechanism `admin` and `notifications` already use — an entitlement-gated bind mount of an agent-owned socket directory — generalized from agent-provided sockets to app-provided ones.
 
 The provider:
 
 ```json
-{ "type": "service", "name": "world", "role": "provide" }
+{ "type": "ipc", "name": "world", "role": "provide" }
 ```
 
 The consumer:
 
 ```json
-{ "type": "service", "name": "world", "role": "consume" }
+{ "type": "ipc", "name": "world", "role": "consume" }
 ```
 
 | Boundary | Value |
 |---|---|
-| Mount | `/run/wendy/services/<name>` — read-write for `provide`, read-only for `consume` |
-| Injected environment | `WENDY_SERVICE_<NAME>_SOCKET=/run/wendy/services/<name>/service.sock` (hyphens become underscores) |
+| Mount | `/run/wendy/ipc/<name>` — read-write for `provide`, read-only for `consume` |
+| Injected environment | `WENDY_IPC_<NAME>_SOCKET=/run/wendy/ipc/<name>/ipc.sock` (hyphens become underscores) |
 | Supplementary group | GID `2001`, so non-root apps can traverse the directory without world access |
-| Stable host directory | `/var/lib/wendy/services/<name>`, mode `2770 root:2001` |
+| Stable host directory | `/var/lib/wendy/ipc/<name>`, mode `2770 root:2001` |
 | Providers per name | One per device, first claim wins, held until that container is deleted |
+| Name | Shared by both sides. Unrelated to `persist` volume names, to the top-level `services` map, and to `serviceName`. |
 
 Both sides read the socket path from the environment rather than hardcoding it, so a typo cannot silently produce two apps talking past each other. A consumer whose name has no provider on the device is warned about at deploy time, with the names that do exist — the failure mode that a shared-volume socket makes indistinguishable from "the provider hasn't started yet".
 
 The agent removes a leftover socket before the provider's task starts, so a provider that died without cleaning up does not leave a socket that consumers can open but not connect to, and does not have to `rm -f` its own socket on boot.
 
-**This is not cross-device.** For a container on one device to reach a service on another, use the [`network` entitlement's `mesh` mode](../apps/wendy.json.md#network), which addresses peers by cloud asset ID over a service CIDR. `service` is device-local IPC only.
+**This is not cross-device.** For a container on one device to reach a service on another, use the [`network` entitlement's `mesh` mode](../apps/wendy.json.md#network), which addresses peers by cloud asset ID over a service CIDR. `ipc` is device-local only.
 
-> **Not a shared volume.** Two apps can already share a unix socket by sharing a `persist` name, but that grants the whole data volume. `service` grants the socket and nothing else — a consumer gets no access to the provider's storage.
+> **Not a shared volume.** Two apps can already share a unix socket by sharing a `persist` name, but that grants the whole data volume. `ipc` grants the socket and nothing else — a consumer gets no access to the provider's storage.
 
 > **Non-root providers (current limitation).** The socket's permissions come from whoever calls `bind()`. With a default umask that is `0755`, which a **non-root** consumer cannot connect to. Until socket activation lands, a non-root provider should `umask(0o007)` before binding or `chmod` the socket to `0660` after. Root-run providers and consumers — the current WendyOS default — need no change.
 

--- a/go/internal/cli/assets/skills/wendy/references/wendy.json.md
+++ b/go/internal/cli/assets/skills/wendy/references/wendy.json.md
@@ -233,6 +233,26 @@ Runs a container image builder (BuildKit) inside the app container.
 
 Grants `CAP_SYS_ADMIN` and un-denies the `unshare` / `clone(CLONE_NEWUSER)` syscalls a nested builder needs (the kernel-module and `kexec` denials are kept). **Privileged-equivalent: a container→host escape surface.** Used so a device can build apps for itself (see the `claude-on-device` example). Grant only to fully-trusted, first-party apps. At most one per app; takes no parameters (`{"type":"build"}`).
 
+### Service Entitlement
+
+Exposes a unix socket from one app to another **on the same device**, without either app gaining access to the other's data.
+
+```json
+{ "type": "service", "name": "world", "role": "provide" }
+```
+
+```json
+{ "type": "service", "name": "world", "role": "consume" }
+```
+
+`name` is a lowercase RFC 1123 label shared by both sides (unrelated to `persist` volume names and to the top-level `services` map). `role` is `"provide"` (binds the socket) or `"consume"` (may only connect).
+
+The agent bind-mounts `/run/wendy/services/<name>` — read-write for the provider, read-only for consumers — and injects `WENDY_SERVICE_<NAME>_SOCKET=/run/wendy/services/<name>/service.sock` (hyphens become underscores). Read it from the environment rather than hardcoding the path. The agent also clears a stale socket before the provider starts, refcounts the directory so a provider restart cannot strand a consumer, and allows only one provider per name per device.
+
+Use this instead of sharing a `persist` volume to reach another app's socket: a shared volume grants the whole data directory, this grants the socket and nothing else. For **cross-device** service access use the `network` entitlement's `mesh` mode instead — `service` is device-local only.
+
+> **Non-root providers:** the socket's mode comes from whoever calls `bind()`; a default umask yields `0755`, which a non-root consumer cannot connect to. A non-root provider should `umask(0o007)` before binding or `chmod` the socket to `0660`. Root-run apps need no change.
+
 ## Common Configurations
 
 ### Web Server with Camera

--- a/go/internal/cli/assets/skills/wendy/references/wendy.json.md
+++ b/go/internal/cli/assets/skills/wendy/references/wendy.json.md
@@ -233,23 +233,23 @@ Runs a container image builder (BuildKit) inside the app container.
 
 Grants `CAP_SYS_ADMIN` and un-denies the `unshare` / `clone(CLONE_NEWUSER)` syscalls a nested builder needs (the kernel-module and `kexec` denials are kept). **Privileged-equivalent: a container→host escape surface.** Used so a device can build apps for itself (see the `claude-on-device` example). Grant only to fully-trusted, first-party apps. At most one per app; takes no parameters (`{"type":"build"}`).
 
-### Service Entitlement
+### IPC Entitlement
 
 Exposes a unix socket from one app to another **on the same device**, without either app gaining access to the other's data.
 
 ```json
-{ "type": "service", "name": "world", "role": "provide" }
+{ "type": "ipc", "name": "world", "role": "provide" }
 ```
 
 ```json
-{ "type": "service", "name": "world", "role": "consume" }
+{ "type": "ipc", "name": "world", "role": "consume" }
 ```
 
-`name` is a lowercase RFC 1123 label shared by both sides (unrelated to `persist` volume names and to the top-level `services` map). `role` is `"provide"` (binds the socket) or `"consume"` (may only connect).
+`name` is a lowercase RFC 1123 label shared by both sides (unrelated to `persist` volume names, to the top-level `services` map, and to `serviceName`). `role` is `"provide"` (binds the socket) or `"consume"` (may only connect).
 
-The agent bind-mounts `/run/wendy/services/<name>` — read-write for the provider, read-only for consumers — and injects `WENDY_SERVICE_<NAME>_SOCKET=/run/wendy/services/<name>/service.sock` (hyphens become underscores). Read it from the environment rather than hardcoding the path. The agent also clears a stale socket before the provider starts, refcounts the directory so a provider restart cannot strand a consumer, and allows only one provider per name per device.
+The agent bind-mounts `/run/wendy/ipc/<name>` — read-write for the provider, read-only for consumers — and injects `WENDY_IPC_<NAME>_SOCKET=/run/wendy/ipc/<name>/ipc.sock` (hyphens become underscores). Read it from the environment rather than hardcoding the path. The agent also clears a stale socket before the provider starts, refcounts the directory so a provider restart cannot strand a consumer, and allows only one provider per name per device.
 
-Use this instead of sharing a `persist` volume to reach another app's socket: a shared volume grants the whole data directory, this grants the socket and nothing else. For **cross-device** service access use the `network` entitlement's `mesh` mode instead — `service` is device-local only.
+Use this instead of sharing a `persist` volume to reach another app's socket: a shared volume grants the whole data directory, this grants the socket and nothing else. For **cross-device** service access use the `network` entitlement's `mesh` mode instead — `ipc` is device-local only.
 
 > **Non-root providers:** the socket's mode comes from whoever calls `bind()`; a default umask yields `0755`, which a non-root consumer cannot connect to. A non-root provider should `umask(0o007)` before binding or `chmod` the socket to `0660`. Root-run apps need no change.
 

--- a/go/internal/cli/commands/project.go
+++ b/go/internal/cli/commands/project.go
@@ -29,7 +29,7 @@ var entitlementDescriptions = map[string]string{
 	appconfig.EntitlementGPIO:      "Access GPIO pins",
 	appconfig.EntitlementSPI:       "Access SPI bus devices (displays, sensors, flash - may require GPIO access)",
 	appconfig.EntitlementInput:     "Access Linux input devices (game controllers, barcode scanners, keyboards)",
-	appconfig.EntitlementService:   "Expose a unix socket to another app on the device, or connect to one",
+	appconfig.EntitlementIPC:       "Expose a unix socket to another app on the device, or connect to one",
 }
 
 // frameworkDescriptions mirrors entitlementDescriptions for the "frameworks"
@@ -579,12 +579,12 @@ func promptEntitlementFields(ent *appconfig.Entitlement) error {
 		}
 		ent.Pins = pins
 
-	case appconfig.EntitlementService:
+	case appconfig.EntitlementIPC:
 		name, err := tui.PromptText(
-			"Service name",
-			"both apps use this same name — unrelated to persist volumes",
+			"IPC name",
+			"both apps use this same name — unrelated to persist volumes and the services map",
 			func(v string) error {
-				return appconfig.ValidateServiceSocketName(strings.TrimSpace(v))
+				return appconfig.ValidateIPCName(strings.TrimSpace(v))
 			},
 		)
 		if err != nil {
@@ -594,11 +594,11 @@ func promptEntitlementFields(ent *appconfig.Entitlement) error {
 
 		role, err := tui.PromptTextWithDefault(
 			"Role",
-			fmt.Sprintf("%q binds the socket, %q only connects to it", appconfig.ServiceRoleProvide, appconfig.ServiceRoleConsume),
-			appconfig.ServiceRoleConsume,
+			fmt.Sprintf("%q binds the socket, %q only connects to it", appconfig.IPCRoleProvide, appconfig.IPCRoleConsume),
+			appconfig.IPCRoleConsume,
 			func(v string) error {
-				if !slices.Contains(appconfig.ValidServiceRoles, strings.TrimSpace(v)) {
-					return fmt.Errorf("role must be %q or %q", appconfig.ServiceRoleProvide, appconfig.ServiceRoleConsume)
+				if !slices.Contains(appconfig.ValidIPCRoles, strings.TrimSpace(v)) {
+					return fmt.Errorf("role must be %q or %q", appconfig.IPCRoleProvide, appconfig.IPCRoleConsume)
 				}
 				return nil
 			},

--- a/go/internal/cli/commands/project.go
+++ b/go/internal/cli/commands/project.go
@@ -29,6 +29,7 @@ var entitlementDescriptions = map[string]string{
 	appconfig.EntitlementGPIO:      "Access GPIO pins",
 	appconfig.EntitlementSPI:       "Access SPI bus devices (displays, sensors, flash - may require GPIO access)",
 	appconfig.EntitlementInput:     "Access Linux input devices (game controllers, barcode scanners, keyboards)",
+	appconfig.EntitlementService:   "Expose a unix socket to another app on the device, or connect to one",
 }
 
 // frameworkDescriptions mirrors entitlementDescriptions for the "frameworks"
@@ -577,6 +578,35 @@ func promptEntitlementFields(ent *appconfig.Entitlement) error {
 			return err
 		}
 		ent.Pins = pins
+
+	case appconfig.EntitlementService:
+		name, err := tui.PromptText(
+			"Service name",
+			"both apps use this same name — unrelated to persist volumes",
+			func(v string) error {
+				return appconfig.ValidateServiceSocketName(strings.TrimSpace(v))
+			},
+		)
+		if err != nil {
+			return err
+		}
+		ent.Name = strings.TrimSpace(name)
+
+		role, err := tui.PromptTextWithDefault(
+			"Role",
+			fmt.Sprintf("%q binds the socket, %q only connects to it", appconfig.ServiceRoleProvide, appconfig.ServiceRoleConsume),
+			appconfig.ServiceRoleConsume,
+			func(v string) error {
+				if !slices.Contains(appconfig.ValidServiceRoles, strings.TrimSpace(v)) {
+					return fmt.Errorf("role must be %q or %q", appconfig.ServiceRoleProvide, appconfig.ServiceRoleConsume)
+				}
+				return nil
+			},
+		)
+		if err != nil {
+			return err
+		}
+		ent.Role = strings.TrimSpace(role)
 	}
 
 	return nil

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -293,6 +294,9 @@ func createContainerWithProgressPlain(stream agentpb.WendyContainerService_Creat
 
 		switch r := resp.GetResponseType().(type) {
 		case *agentpb.CreateContainerProgressResponse_Progress:
+			if warning := r.Progress.GetWarning(); warning != "" {
+				cliNotice("Warning: %s", warning)
+			}
 			switch r.Progress.GetPhase() {
 			case agentpb.CreateContainerProgress_UNPACKING, agentpb.CreateContainerProgress_APPLYING_LAYER:
 				if detail := unpackProgressDetail(r.Progress); detail != "" {
@@ -348,11 +352,20 @@ func createContainerWithProgressTUI(cancel context.CancelFunc, stream agentpb.We
 	prog := tui.NewProgressProgram(tui.NewProgress("Pulling image on device...").WithoutErrorView())
 
 	var (
-		createErr error
-		done      = make(chan struct{})
-		creating  = make(chan struct{}, 1)
-		completed bool
+		createErr  error
+		done       = make(chan struct{})
+		creating   = make(chan struct{}, 1)
+		completed  bool
+		warningsMu sync.Mutex
+		warnings   []string
 	)
+	defer func() {
+		warningsMu.Lock()
+		defer warningsMu.Unlock()
+		for _, warning := range warnings {
+			cliNotice("Warning: %s", warning)
+		}
+	}()
 
 	go func() {
 		defer close(done)
@@ -378,6 +391,11 @@ func createContainerWithProgressTUI(cancel context.CancelFunc, stream agentpb.We
 
 			switch r := resp.GetResponseType().(type) {
 			case *agentpb.CreateContainerProgressResponse_Progress:
+				if warning := r.Progress.GetWarning(); warning != "" {
+					warningsMu.Lock()
+					warnings = append(warnings, warning)
+					warningsMu.Unlock()
+				}
 				switch r.Progress.GetPhase() {
 				case agentpb.CreateContainerProgress_UNPACKING, agentpb.CreateContainerProgress_APPLYING_LAYER:
 					prog.Send(tui.ProgressUpdateMsg{

--- a/go/internal/shared/appconfig/annotation.go
+++ b/go/internal/shared/appconfig/annotation.go
@@ -31,6 +31,7 @@ const EntitlementAnnotationKeyPrefix = "sh.wendy/entitlement."
 //	gpio(pins=[17,18])       → "pins=17,18"
 //	mcp(port=8080)           → "port=8080"
 //	network(host,[8080:80])  → "mode=host,ports=8080:80"
+//	ipc(world,provide)       → "name=world,role=provide"
 func EntitlementAnnotationValue(e Entitlement) string {
 	var parts []string
 	if e.Mode != "" {
@@ -44,6 +45,9 @@ func EntitlementAnnotationValue(e Entitlement) string {
 	}
 	if e.Device != "" {
 		parts = append(parts, "device="+e.Device)
+	}
+	if e.Role != "" {
+		parts = append(parts, "role="+e.Role)
 	}
 	if e.Port != 0 {
 		parts = append(parts, "port="+strconv.Itoa(e.Port))
@@ -94,6 +98,8 @@ func ParseEntitlementAnnotation(entType, value string) Entitlement {
 			ent.Path = val
 		case "device":
 			ent.Device = val
+		case "role":
+			ent.Role = val
 		case "port":
 			if n, err := strconv.Atoi(val); err == nil {
 				ent.Port = n

--- a/go/internal/shared/appconfig/annotation_test.go
+++ b/go/internal/shared/appconfig/annotation_test.go
@@ -166,6 +166,8 @@ func TestEntitlementAnnotationRoundTrip(t *testing.T) {
 		{Type: EntitlementI2C, Device: "i2c-1"},
 		{Type: EntitlementSerial, Device: "ttyUSB0"},
 		{Type: EntitlementNetwork, Mode: "mesh", ServiceCIDR: "10.99.0.0/16"},
+		{Type: EntitlementIPC, Name: "world", Role: IPCRoleProvide},
+		{Type: EntitlementIPC, Name: "world-model", Role: IPCRoleConsume},
 	}
 
 	for _, want := range entitlements {

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -64,7 +64,24 @@ const (
 	// declares the app's primary HTTP port so clients (wendy run, remote
 	// management apps) can discover and open it. See entitlements.md.
 	EntitlementHTTP = "http"
+	// EntitlementIPC lets one app expose a unix socket to another app on the
+	// same device without either app gaining access to the other's data. It
+	// generalizes the agent-owned socket mounts already used by `admin` and
+	// `notifications` from agent-provided sockets to app-provided ones. See
+	// entitlements.md.
+	EntitlementIPC = "ipc"
 )
+
+// IPC entitlement roles. A "provide" app owns the socket and binds it; a
+// "consume" app receives the same socket read-only and may only connect.
+const (
+	IPCRoleProvide = "provide"
+	IPCRoleConsume = "consume"
+)
+
+// ValidIPCRoles is the set of accepted `role` values for the ipc
+// entitlement, in the order they are offered to users.
+var ValidIPCRoles = []string{IPCRoleProvide, IPCRoleConsume}
 
 // ValidEntitlementTypes is the set of all recognized entitlement type strings.
 var ValidEntitlementTypes = []string{
@@ -87,6 +104,7 @@ var ValidEntitlementTypes = []string{
 	EntitlementAdmin,
 	EntitlementBuild,
 	EntitlementHTTP,
+	EntitlementIPC,
 }
 
 // FrameworkROS2 is the "ros2" key under wendy.json's "frameworks" object.
@@ -123,6 +141,7 @@ var allowedKeys = map[string][]string{
 	EntitlementAdmin:         {"type"},
 	EntitlementBuild:         {"type"},
 	EntitlementHTTP:          {"type", "port"},
+	EntitlementIPC:           {"type", "name", "role"},
 }
 
 // Platform constants identify the target hardware family.
@@ -363,6 +382,14 @@ type Entitlement struct {
 	// The agent derives the gateway from the bridge subnet separately; this
 	// field only carries the service CIDR policy.
 	ServiceCIDR string `json:"serviceCIDR,omitempty"` // Network (mesh mode)
+
+	// Role is the ipc entitlement's side of the socket: "provide" (this app
+	// binds it) or "consume" (this app may only connect to it). It shares the
+	// Name field with persist, but the two namespaces are unrelated: a persist
+	// name selects a data volume, an ipc name selects an agent-owned socket
+	// directory that carries no data. Unrelated to ServiceName / the top-level
+	// services map, which identify containers within one app.
+	Role string `json:"role,omitempty"` // IPC
 }
 
 // DeprecatedEntitlementReplacement reports the preferred replacement for a deprecated entitlement type.
@@ -466,7 +493,35 @@ func validateEntitlements(entitlements []Entitlement, prefix string) error {
 			if e.Port < 1 || e.Port > 65535 {
 				return fmt.Errorf("%s[%d]: http port must be between 1 and 65535, got %d", prefix, i, e.Port)
 			}
+		case EntitlementIPC:
+			if e.Name == "" {
+				return fmt.Errorf("%s[%d]: ipc entitlement requires a name", prefix, i)
+			}
+			if err := ValidateIPCName(e.Name); err != nil {
+				return fmt.Errorf("%s[%d]: %w", prefix, i, err)
+			}
+			if e.Role == "" {
+				return fmt.Errorf("%s[%d]: ipc entitlement requires a role (%q or %q)", prefix, i, IPCRoleProvide, IPCRoleConsume)
+			}
+			if !slices.Contains(ValidIPCRoles, e.Role) {
+				return fmt.Errorf("%s[%d]: ipc role must be %q or %q, got %q", prefix, i, IPCRoleProvide, IPCRoleConsume, e.Role)
+			}
 		}
+	}
+
+	// One entitlement list may not name the same ipc service twice: two entries for
+	// the same name would produce two bind mounts on the same destination, and a
+	// provide+consume pair on one container is a self-connection that the socket
+	// already allows without a second entitlement.
+	seenIPCNames := make(map[string]int, len(entitlements))
+	for i, e := range entitlements {
+		if e.Type != EntitlementIPC {
+			continue
+		}
+		if first, ok := seenIPCNames[e.Name]; ok {
+			return fmt.Errorf("%s[%d]: duplicate ipc entitlement for name %q (already declared at %s[%d]); declare each ipc name at most once per container", prefix, i, e.Name, prefix, first)
+		}
+		seenIPCNames[e.Name] = i
 	}
 
 	mcpCount := 0
@@ -561,6 +616,28 @@ func ValidateServiceName(name string) error {
 	}
 	if !serviceNamePattern.MatchString(name) {
 		return fmt.Errorf("serviceName %q is invalid: must start with a lowercase letter, contain only lowercase letters, digits, or hyphens, end with a letter or digit, and be at most 57 chars (RFC 1123)", name)
+	}
+	return nil
+}
+
+// ValidateIPCName reports whether name is a well-formed ipc entitlement
+// name. The name becomes a directory component on the host
+// (/var/lib/wendy/ipc/<name>), a bind-mount destination inside the
+// container (/run/wendy/ipc/<name>), and part of an injected environment
+// variable name, so it is held to the same RFC 1123 DNS-label rule as
+// serviceName: no dots (so it can never traverse), no separators, no case
+// ambiguity. Unlike appID — which permits dots and is therefore hashed before
+// use as a path — a name that passes this check is safe to use verbatim, which
+// keeps `ls /var/lib/wendy/ipc` a readable list of what is registered.
+func ValidateIPCName(name string) error {
+	if name == "" {
+		return fmt.Errorf("ipc name is required")
+	}
+	if len(name) > 57 {
+		return fmt.Errorf("ipc name too long: %d chars (max 57)", len(name))
+	}
+	if !serviceNamePattern.MatchString(name) {
+		return fmt.Errorf("ipc name %q is invalid: must start with a lowercase letter, contain only lowercase letters, digits, or hyphens, end with a letter or digit, and be at most 57 chars (RFC 1123)", name)
 	}
 	return nil
 }

--- a/go/internal/shared/appconfig/appconfig_test.go
+++ b/go/internal/shared/appconfig/appconfig_test.go
@@ -2293,6 +2293,115 @@ func TestValidateJSON_BuildEntitlementRejectsExtraKeys(t *testing.T) {
 	}
 }
 
+func TestValidate_IPCEntitlement(t *testing.T) {
+	valid := []struct {
+		name string
+		role string
+	}{
+		{"world", IPCRoleProvide},
+		{"world", IPCRoleConsume},
+		{"world-model", IPCRoleProvide},
+		{"a", IPCRoleConsume},
+		{"svc9", IPCRoleProvide},
+	}
+	for _, tc := range valid {
+		t.Run("valid/"+tc.name+"/"+tc.role, func(t *testing.T) {
+			cfg := &AppConfig{
+				AppID:        "com.example.app",
+				Entitlements: []Entitlement{{Type: EntitlementIPC, Name: tc.name, Role: tc.role}},
+			}
+			if err := cfg.Validate(); err != nil {
+				t.Errorf("Validate() unexpected error: %v", err)
+			}
+		})
+	}
+
+	invalid := []struct {
+		desc string
+		ent  Entitlement
+	}{
+		{"missing name", Entitlement{Type: EntitlementIPC, Role: IPCRoleProvide}},
+		{"missing role", Entitlement{Type: EntitlementIPC, Name: "world"}},
+		{"unknown role", Entitlement{Type: EntitlementIPC, Name: "world", Role: "publish"}},
+		{"uppercase name", Entitlement{Type: EntitlementIPC, Name: "World", Role: IPCRoleProvide}},
+		{"dotted name", Entitlement{Type: EntitlementIPC, Name: "com.example", Role: IPCRoleProvide}},
+		{"traversal name", Entitlement{Type: EntitlementIPC, Name: "../etc", Role: IPCRoleProvide}},
+		{"dot dot name", Entitlement{Type: EntitlementIPC, Name: "..", Role: IPCRoleProvide}},
+		{"slash name", Entitlement{Type: EntitlementIPC, Name: "a/b", Role: IPCRoleProvide}},
+		{"leading digit", Entitlement{Type: EntitlementIPC, Name: "1world", Role: IPCRoleProvide}},
+		{"trailing hyphen", Entitlement{Type: EntitlementIPC, Name: "world-", Role: IPCRoleProvide}},
+	}
+	for _, tc := range invalid {
+		t.Run("invalid/"+tc.desc, func(t *testing.T) {
+			cfg := &AppConfig{AppID: "com.example.app", Entitlements: []Entitlement{tc.ent}}
+			if err := cfg.Validate(); err == nil {
+				t.Errorf("Validate() accepted %+v, want an error", tc.ent)
+			}
+		})
+	}
+}
+
+// A single container may not declare the same ipc name twice: two entries
+// would produce two bind mounts on one destination, and provide+consume on the
+// same container is a self-connection the socket already permits.
+func TestValidate_IPCEntitlementRejectsDuplicateName(t *testing.T) {
+	for _, roles := range [][2]string{
+		{IPCRoleProvide, IPCRoleConsume},
+		{IPCRoleProvide, IPCRoleProvide},
+		{IPCRoleConsume, IPCRoleConsume},
+	} {
+		cfg := &AppConfig{
+			AppID: "com.example.app",
+			Entitlements: []Entitlement{
+				{Type: EntitlementIPC, Name: "world", Role: roles[0]},
+				{Type: EntitlementIPC, Name: "world", Role: roles[1]},
+			},
+		}
+		if err := cfg.Validate(); err == nil {
+			t.Errorf("Validate() accepted duplicate ipc name with roles %v, want an error", roles)
+		}
+	}
+
+	// Distinct names on one container are fine — an app may consume several.
+	cfg := &AppConfig{
+		AppID: "com.example.app",
+		Entitlements: []Entitlement{
+			{Type: EntitlementIPC, Name: "world", Role: IPCRoleConsume},
+			{Type: EntitlementIPC, Name: "planner", Role: IPCRoleConsume},
+			{Type: EntitlementIPC, Name: "telemetry", Role: IPCRoleProvide},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Validate() rejected distinct ipc names: %v", err)
+	}
+}
+
+func TestValidateJSON_IPCEntitlementRejectsExtraKeys(t *testing.T) {
+	warnings := ValidateJSON([]byte(`{"appId":"test","entitlements":[{"type":"ipc","name":"world","role":"provide","path":"/data"}]}`))
+	if len(warnings) == 0 {
+		t.Fatal("expected a warning for an unknown key on the ipc entitlement")
+	}
+}
+
+func TestValidateJSON_IPCEntitlement(t *testing.T) {
+	warnings := ValidateJSON([]byte(`{"appId":"test","entitlements":[{"type":"ipc","name":"world","role":"consume"}]}`))
+	if len(warnings) != 0 {
+		t.Fatalf("expected ipc entitlement to validate, got warnings: %v", warnings)
+	}
+}
+
+func TestValidateIPCName(t *testing.T) {
+	if err := ValidateIPCName(""); err == nil {
+		t.Error("ValidateIPCName(\"\") = nil, want an error")
+	}
+	if err := ValidateIPCName(strings.Repeat("a", 58)); err == nil {
+		t.Error("ValidateIPCName(58 chars) = nil, want an error")
+	}
+	if err := ValidateIPCName(strings.Repeat("a", 57)); err != nil {
+		t.Errorf("ValidateIPCName(57 chars) = %v, want nil", err)
+	}
+}
+
 // TestAppConfig_TopLevelEnv covers WDY-2040: a single-container app declares
 // env at the top level, which is the only place it can.
 func TestAppConfig_TopLevelEnv(t *testing.T) {

--- a/go/internal/shared/appconfig/schema_test.go
+++ b/go/internal/shared/appconfig/schema_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"reflect"
+	"regexp"
 	"testing"
 )
 
@@ -210,6 +211,91 @@ func TestSchemaJSON_HTTPEntitlement(t *testing.T) {
 	if got := int(port["maximum"].(float64)); got != 65535 {
 		t.Errorf("http port maximum = %d, want 65535", got)
 	}
+}
+
+// TestSchemaJSON_IPCEntitlement is a sync guard between the schema branch
+// editors validate against and the Go rules the agent enforces: the role enum
+// must match ValidIPCRoles and the name pattern must accept exactly what
+// ValidateIPCName accepts.
+func TestSchemaJSON_IPCEntitlement(t *testing.T) {
+	var schema map[string]any
+	if err := json.Unmarshal([]byte(SchemaJSON), &schema); err != nil {
+		t.Fatalf("schema is not valid JSON: %v", err)
+	}
+
+	branch := entitlementBranch(t, schema, "ipc")
+	if additional, ok := branch["additionalProperties"].(bool); !ok || additional {
+		t.Errorf("ipc entitlement additionalProperties = %v, want false", branch["additionalProperties"])
+	}
+
+	required, _ := branch["required"].([]any)
+	requiredSet := make(map[string]bool, len(required))
+	for _, key := range required {
+		if name, ok := key.(string); ok {
+			requiredSet[name] = true
+		}
+	}
+	for _, key := range []string{"type", "name", "role"} {
+		if !requiredSet[key] {
+			t.Errorf("ipc entitlement does not require %q", key)
+		}
+	}
+
+	props := schemaProps(t, branch)
+	role, ok := props["role"].(map[string]any)
+	if !ok {
+		t.Fatal("ipc entitlement missing role property")
+	}
+	roleEnum, _ := role["enum"].([]any)
+	if len(roleEnum) != len(ValidIPCRoles) {
+		t.Fatalf("schema role enum = %v, want %v", roleEnum, ValidIPCRoles)
+	}
+	for i, want := range ValidIPCRoles {
+		if roleEnum[i] != want {
+			t.Errorf("schema role enum[%d] = %v, want %q", i, roleEnum[i], want)
+		}
+	}
+
+	name, ok := props["name"].(map[string]any)
+	if !ok {
+		t.Fatal("ipc entitlement missing name property")
+	}
+	pattern, _ := name["pattern"].(string)
+	if pattern == "" {
+		t.Fatal("ipc entitlement name has no pattern")
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		t.Fatalf("ipc name pattern does not compile: %v", err)
+	}
+	for _, candidate := range []string{"world", "world-model", "a", "svc9", "World", "1world", "world-", "com.example", "../etc", ""} {
+		schemaOK := re.MatchString(candidate)
+		goOK := ValidateIPCName(candidate) == nil
+		if schemaOK != goOK {
+			t.Errorf("ipc name %q: schema pattern accepts=%v, ValidateIPCName accepts=%v", candidate, schemaOK, goOK)
+		}
+	}
+}
+
+// entitlementBranch returns the $defs.entitlement oneOf branch whose type const
+// is entType.
+func entitlementBranch(t *testing.T, schema map[string]any, entType string) map[string]any {
+	t.Helper()
+	entitlement := defOf(t, schema, "entitlement")
+	branches, ok := entitlement["oneOf"].([]any)
+	if !ok {
+		t.Fatal("$defs.entitlement missing oneOf")
+	}
+	for _, raw := range branches {
+		branch, _ := raw.(map[string]any)
+		props, _ := branch["properties"].(map[string]any)
+		typeProp, _ := props["type"].(map[string]any)
+		if typeProp["const"] == entType {
+			return branch
+		}
+	}
+	t.Fatalf("$defs.entitlement.oneOf missing %q branch", entType)
+	return nil
 }
 
 func TestSchemaJSON_DeclaresROS2ExampleKeys(t *testing.T) {

--- a/go/internal/shared/appconfig/wendy.schema.json
+++ b/go/internal/shared/appconfig/wendy.schema.json
@@ -339,6 +339,26 @@
           "required": ["type"],
           "additionalProperties": false,
           "description": "Run a container image builder (BuildKit) inside the app container. Privileged-equivalent: grants CAP_SYS_ADMIN and the namespace syscalls a nested builder needs — a container→host escape surface. Grant only to fully-trusted first-party apps. At most one per app."
+        },
+        {
+          "properties": {
+            "type": { "const": "ipc" },
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 57,
+              "pattern": "^[a-z]([a-z0-9-]{0,55}[a-z0-9])?$",
+              "description": "Name of the device-local IPC service. Both sides must use the same name. Unrelated to the persist volume namespace and to the top-level \"services\" map."
+            },
+            "role": {
+              "type": "string",
+              "enum": ["provide", "consume"],
+              "description": "\"provide\" binds the socket and owns the service; \"consume\" may only connect to it."
+            }
+          },
+          "required": ["type", "name", "role"],
+          "additionalProperties": false,
+          "description": "Expose or connect to another app on the same device over a unix socket. The agent owns the socket path, its directory, and cleanup: it mounts /run/wendy/ipc/<name> (read-write to the provider, read-only to consumers) and injects WENDY_IPC_<NAME>_SOCKET. Consumers get the socket and nothing else — no access to the provider's persist volume. At most one provider per name per device."
         }
       ]
     },

--- a/go/proto/gen/agentpb/wendy_agent_v1_container_service.pb.go
+++ b/go/proto/gen/agentpb/wendy_agent_v1_container_service.pb.go
@@ -991,8 +991,10 @@ type CreateContainerProgress struct {
 	TotalLayers    int32                         `protobuf:"varint,3,opt,name=total_layers,json=totalLayers,proto3" json:"total_layers,omitempty"`
 	LayerSize      int64                         `protobuf:"varint,4,opt,name=layer_size,json=layerSize,proto3" json:"layer_size,omitempty"`
 	ReusedSnapshot bool                          `protobuf:"varint,5,opt,name=reused_snapshot,json=reusedSnapshot,proto3" json:"reused_snapshot,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// A non-fatal deploy warning that the CLI should show directly to the user.
+	Warning       string `protobuf:"bytes,6,opt,name=warning,proto3" json:"warning,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *CreateContainerProgress) Reset() {
@@ -1058,6 +1060,13 @@ func (x *CreateContainerProgress) GetReusedSnapshot() bool {
 		return x.ReusedSnapshot
 	}
 	return false
+}
+
+func (x *CreateContainerProgress) GetWarning() string {
+	if x != nil {
+		return x.Warning
+	}
+	return ""
 }
 
 type CreateContainerProgressResponse struct {
@@ -3077,7 +3086,7 @@ const file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDes
 	"\tuser_args\x18\a \x03(\tR\buserArgs\x12\x10\n" +
 	"\x03env\x18\b \x03(\tR\x03envB\x11\n" +
 	"\x0f_restart_policy\"\x19\n" +
-	"\x17CreateContainerResponse\"\xdc\x02\n" +
+	"\x17CreateContainerResponse\"\xf6\x02\n" +
 	"\x17CreateContainerProgress\x12L\n" +
 	"\x05phase\x18\x01 \x01(\x0e26.wendy.agent.services.v1.CreateContainerProgress.PhaseR\x05phase\x12\x1f\n" +
 	"\vlayer_index\x18\x02 \x01(\x05R\n" +
@@ -3085,7 +3094,8 @@ const file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDes
 	"\ftotal_layers\x18\x03 \x01(\x05R\vtotalLayers\x12\x1d\n" +
 	"\n" +
 	"layer_size\x18\x04 \x01(\x03R\tlayerSize\x12'\n" +
-	"\x0freused_snapshot\x18\x05 \x01(\bR\x0ereusedSnapshot\"g\n" +
+	"\x0freused_snapshot\x18\x05 \x01(\bR\x0ereusedSnapshot\x12\x18\n" +
+	"\awarning\x18\x06 \x01(\tR\awarning\"g\n" +
 	"\x05Phase\x12\x15\n" +
 	"\x11PHASE_UNSPECIFIED\x10\x00\x12\r\n" +
 	"\tUNPACKING\x10\x01\x12\x12\n" +

--- a/specs/2026-08-09-ipc-entitlement-design.md
+++ b/specs/2026-08-09-ipc-entitlement-design.md
@@ -1,4 +1,4 @@
-# `service` entitlement: app-to-app unix sockets without sharing a data volume
+# `ipc` entitlement: app-to-app unix sockets without sharing a data volume
 
 Date: 2026-08-09
 Status: Proposed
@@ -64,24 +64,24 @@ the mount's inode survives reboot. This design reuses all of it.
 ### 1. `wendy.json`
 
 ```json
-{ "type": "service", "name": "world", "role": "provide" }
-{ "type": "service", "name": "world", "role": "consume" }
+{ "type": "ipc", "name": "world", "role": "provide" }
+{ "type": "ipc", "name": "world", "role": "consume" }
 ```
 
 - `name` — lowercase RFC 1123 label, validated by
-  `appconfig.ValidateServiceSocketName` with the same pattern as `serviceName`.
+  `appconfig.ValidateIPCName` with the same pattern as `serviceName`.
   Unlike `appID` (which permits dots and is therefore hashed before use as a
   path), a name that passes is safe to use verbatim as a directory component, so
-  `ls /var/lib/wendy/services` stays a readable list of what is registered.
+  `ls /var/lib/wendy/ipc` stays a readable list of what is registered.
 - `role` — `provide` or `consume`.
 - At most one entitlement per name per container (two entries would produce two
   bind mounts on one destination).
 
-### 2. Agent: `services.ServiceSocketManager`
+### 2. Agent: `services.IPCSocketManager`
 
 Modelled directly on `AppSystemAPISocketManager`.
 
-- Host directory `/var/lib/wendy/services/<name>`, mode `2770`, owner
+- Host directory `/var/lib/wendy/ipc/<name>`, mode `2770`, owner
   `root:2001`. Disk-backed for the same reason as `AdminAgentSocketHostPath`:
   the bind mount pins the inode and tmpfs is wiped on reboot.
 - `Ensure(name, role, appID, serviceName)` registers a container as an owner and
@@ -100,10 +100,10 @@ Modelled directly on `AppSystemAPISocketManager`.
 
 ### 3. Agent: OCI spec
 
-`applyServiceSocket` mounts `/run/wendy/services/<name>` with
+`applyIPCSocket` mounts `/run/wendy/ipc/<name>` with
 `rbind,nosuid,noexec,nodev` plus `rw` for `provide` and `ro` for `consume`, adds
 supplementary GID 2001, and injects
-`WENDY_SERVICE_<NAME>_SOCKET=/run/wendy/services/<name>/service.sock`.
+`WENDY_IPC_<NAME>_SOCKET=/run/wendy/ipc/<name>/ipc.sock`.
 
 A read-only mount still permits `connect()`: the kernel's read-only-superblock
 check (`sb_permission`) returns `EROFS` only for `S_ISREG`/`S_ISDIR`/`S_ISLNK`,
@@ -111,7 +111,7 @@ never for sockets. Read-only therefore denies a consumer exactly the right
 thing — unlinking or replacing the provider's socket — while allowing the
 connection.
 
-Only names present in `ApplyOptions.ServiceSocketDirs` are mounted, so an app
+Only names present in `ApplyOptions.IPCSocketDirs` are mounted, so an app
 cannot mount a name the manager refused by declaring it in its own `wendy.json`.
 
 ### 4. Agent: lifecycle wiring
@@ -123,7 +123,7 @@ cannot mount a name the manager refused by declaring it in its own `wendy.json`.
 | `StartContainer` | `PrepareProvider` for each provided name before the task is created. Fail-closed. |
 | `deleteOne` | Release claims *after* the container is gone — a claim released while a merely-stopped container exists would let another app take the name. |
 | `DeleteContainer` (whole app) | `ReleaseApp` sweeps claims `deleteOne` could not attribute. |
-| Agent start | `RestoreServiceSockets` rebuilds claims from container labels, never touching sockets. |
+| Agent start | `RestoreIPCSockets` rebuilds claims from container labels, never touching sockets. |
 
 Stopped containers keep their claim: they retain the bind mount and are expected
 to reclaim their socket on the next start. This matches `notifications`.
@@ -152,7 +152,7 @@ cannot fix its *mode*.
 Root-run providers and consumers — the current WendyOS default, and what the
 hardware spike exercised — are unaffected. For non-root, the provider must
 `umask(0o007)` before binding or `chmod` the socket to `0660`. This is
-documented on both doc surfaces rather than left implicit.
+documented on all three doc surfaces rather than left implicit.
 
 The clean fix is **socket activation**: the agent binds and listens, with a mode
 and owner it fully controls, and passes the listening fd into the container. That
@@ -162,13 +162,14 @@ connect before the provider is up, and the kernel queues it). It is deliberately
 (`--preserve-fds` / `LISTEN_FDS`) that is a substantial change on its own and
 should not be entangled with the entitlement's schema and lifecycle.
 
-### Naming
+## Naming
 
-`service` collides conceptually with two existing `wendy.json` concepts: the
-top-level `services` map (containers within one app) and `serviceName`. Internal
-identifiers are spelled unambiguously (`ServiceSocketManager`,
-`ValidateServiceSocketName`, `serviceSocketEnvName`) but the user-facing keyword
-is worth a second look before merge. `socket` or `ipc` would not collide.
+This was first drafted as a `service` entitlement. That collides conceptually
+with two existing `wendy.json` concepts — the top-level `services` map
+(containers within one app) and `serviceName` — and since the keyword is public
+API it was cheaper to settle before it landed. Renamed to `ipc`, which does not
+collide with anything in the schema and says what the mechanism is. The `role`
+values stay `provide`/`consume`: those read fine and collide with nothing.
 
 ## Testing
 
@@ -192,4 +193,4 @@ is worth a second look before merge. `socket` or `ipc` would not collide.
 - Cross-device service access — that is `network` mode `mesh`.
 - Any wire protocol over the socket. The platform provides the socket; what
   flows through it is the apps' business.
-- Multiple sockets per service name.
+- Multiple sockets per IPC name.

--- a/specs/2026-08-09-ipc-entitlement-design.md
+++ b/specs/2026-08-09-ipc-entitlement-design.md
@@ -1,0 +1,195 @@
+# `service` entitlement: app-to-app unix sockets without sharing a data volume
+
+Date: 2026-08-09
+Status: Proposed
+
+## Problem
+
+Two apps on one device can already share a unix socket — by declaring the same
+`persist` name. That works, and it over-grants badly: `persist` mounts the whole
+volume, so an app that only needs to *call* a service also gets read/write on
+that service's database. There is no way to express "may connect to this
+service" without also saying "may rewrite its data".
+
+A hardware spike on an AGX Orin confirmed both halves: two distinct `appId`s
+sharing a `persist` `name` do see the same mount, a unix socket created by one
+is connectable by the other, and each app has to hand-roll everything around it.
+The spike surfaced four problems the platform should own rather than each app:
+
+1. **Stale sockets.** The provider had to `rm -f` its socket on boot. A provider
+   that dies without cleanup leaves a socket file consumers can open but not
+   connect to, and that the provider itself cannot rebind (`EADDRINUSE`).
+2. **Discovery by convention.** Both sides hardcode the path. A typo in the
+   shared namespace is indistinguishable from "provider not running".
+3. **Permissions.** Two non-root apps sharing a volume need uid/gid coordination
+   that nothing manages.
+4. **Cold-start ordering.** Consumers must hand-roll bounded retry.
+
+## Why not `network` mode `mesh`
+
+`mesh` is a *cross-device* mode and does not cover this. Its design goal is "let
+a container on device A reach a service on device B"
+(`specs/2026-07-02-mesh-data-plane-design.md:8-16`); addressing is by cloud asset
+ID mapped to a VIP in the service CIDR (`go/internal/agent/mesh/vip.go:26-34`);
+transport is LAN-direct mTLS gRPC or cloud-broker relay
+(`go/internal/agent/services/mesh_dialer.go:152-175`); and `discoverOnLAN`
+deliberately discards loopback addresses
+(`go/internal/agent/services/mesh_dialer.go:211-236`). Service-name discovery is
+explicitly out of scope for v1 (`specs/2026-07-02-mesh-data-plane-design.md:161-163`).
+The only same-board mechanism that exists today is `/etc/hosts` generation for
+services *within one isolated multi-service app*
+(`go/internal/agent/containerd/client.go:1330-1352`) — not across apps.
+
+## Existing precedent
+
+WendyOS already has exactly this pattern for *agent*-provided sockets, and it is
+the code path this design generalizes rather than replacing:
+
+- `admin` — `applyAdmin` (`go/internal/agent/oci/entitlements.go`) bind-mounts
+  the *parent directory* of the agent control socket read-only and injects
+  `WENDY_AGENT_SOCKET`. Its docs say "the entitlement-gated socket mount is the
+  entire trust boundary".
+- `notifications` — `AppSystemAPISocketManager` owns a per-app directory under
+  `/var/lib/wendy/app-system` with mode `0750 root:2000`, `applySystemAPI`
+  mounts it read-only, injects `WENDY_SYSTEM_SOCKET`, and adds GID 2000 so
+  non-root apps can connect. Ownership is refcounted per service container and
+  restored from container labels after an agent restart.
+
+Both mount a **directory**, never the socket inode, so socket recreation is
+transparent to a running container; both live on `/var/lib` rather than tmpfs so
+the mount's inode survives reboot. This design reuses all of it.
+
+## Design
+
+### 1. `wendy.json`
+
+```json
+{ "type": "service", "name": "world", "role": "provide" }
+{ "type": "service", "name": "world", "role": "consume" }
+```
+
+- `name` — lowercase RFC 1123 label, validated by
+  `appconfig.ValidateServiceSocketName` with the same pattern as `serviceName`.
+  Unlike `appID` (which permits dots and is therefore hashed before use as a
+  path), a name that passes is safe to use verbatim as a directory component, so
+  `ls /var/lib/wendy/services` stays a readable list of what is registered.
+- `role` — `provide` or `consume`.
+- At most one entitlement per name per container (two entries would produce two
+  bind mounts on one destination).
+
+### 2. Agent: `services.ServiceSocketManager`
+
+Modelled directly on `AppSystemAPISocketManager`.
+
+- Host directory `/var/lib/wendy/services/<name>`, mode `2770`, owner
+  `root:2001`. Disk-backed for the same reason as `AdminAgentSocketHostPath`:
+  the bind mount pins the inode and tmpfs is wiped on reboot.
+- `Ensure(name, role, appID, serviceName)` registers a container as an owner and
+  returns the directory. **First claim wins for `provide`**: a second app cannot
+  take a name a consumer already trusts. Never touches the socket, so the
+  agent-restart restore path can call it against a live provider.
+- `PrepareProvider(name, appID, serviceName)` removes a stale socket, called
+  from `StartContainer` before `container.NewTask` so the provider's first
+  `bind()` always lands on an empty directory. No-op for a container that does
+  not provide the name.
+- `Release` / `ReleaseApp` drop claims. The directory is removed only once **no**
+  provider and **no** consumer remains — removing it while a consumer still has
+  it mounted would replace the inode the consumer is pinned to.
+- Every identity is re-validated at the manager boundary; labels and RPC input
+  are untrusted (SOC2-CC6, NIST-SI-10) and the name becomes a host path.
+
+### 3. Agent: OCI spec
+
+`applyServiceSocket` mounts `/run/wendy/services/<name>` with
+`rbind,nosuid,noexec,nodev` plus `rw` for `provide` and `ro` for `consume`, adds
+supplementary GID 2001, and injects
+`WENDY_SERVICE_<NAME>_SOCKET=/run/wendy/services/<name>/service.sock`.
+
+A read-only mount still permits `connect()`: the kernel's read-only-superblock
+check (`sb_permission`) returns `EROFS` only for `S_ISREG`/`S_ISDIR`/`S_ISLNK`,
+never for sockets. Read-only therefore denies a consumer exactly the right
+thing — unlinking or replacing the provider's socket — while allowing the
+connection.
+
+Only names present in `ApplyOptions.ServiceSocketDirs` are mounted, so an app
+cannot mount a name the manager refused by declaring it in its own `wendy.json`.
+
+### 4. Agent: lifecycle wiring
+
+| Point | Action |
+|---|---|
+| `CreateContainerWithProgress` | `Ensure` every declared name; **fail-closed** — a provider must not start believing it owns a socket it doesn't, and a consumer must not start with a silently absent mount. Rolled back on any later create failure. |
+| Replace path | Release the replaced container's claims so a redeploy that drops a `provide` frees the name. |
+| `StartContainer` | `PrepareProvider` for each provided name before the task is created. Fail-closed. |
+| `deleteOne` | Release claims *after* the container is gone — a claim released while a merely-stopped container exists would let another app take the name. |
+| `DeleteContainer` (whole app) | `ReleaseApp` sweeps claims `deleteOne` could not attribute. |
+| Agent start | `RestoreServiceSockets` rebuilds claims from container labels, never touching sockets. |
+
+Stopped containers keep their claim: they retain the bind mount and are expected
+to reclaim their socket on the next start. This matches `notifications`.
+
+## How this addresses the spike's four problems
+
+1. **Stale sockets** — owned by the platform (`PrepareProvider`).
+2. **Discovery** — the path is injected as an env var and is identical on both
+   sides; a consumer whose name has no provider is warned at deploy time, with
+   the names that do exist.
+3. **Permissions** — the setgid `2770 root:2001` directory plus supplementary
+   GID 2001 handles *traversal* for both sides. It does **not** fully solve the
+   socket's own mode; see below.
+4. **Cold-start ordering** — **not** addressed; see below.
+
+## Known limitations
+
+### Non-root socket mode
+
+`connect()` on a unix socket requires write permission on the socket inode, and
+the socket's mode is set by whoever calls `bind()`. With a default umask that is
+`0755`, so a **non-root** consumer connecting to a **non-root** provider's socket
+gets `EACCES`. The setgid directory fixes the socket's *group* automatically but
+cannot fix its *mode*.
+
+Root-run providers and consumers — the current WendyOS default, and what the
+hardware spike exercised — are unaffected. For non-root, the provider must
+`umask(0o007)` before binding or `chmod` the socket to `0660`. This is
+documented on both doc surfaces rather than left implicit.
+
+The clean fix is **socket activation**: the agent binds and listens, with a mode
+and owner it fully controls, and passes the listening fd into the container. That
+removes both this limitation and the cold-start ordering problem (a consumer can
+connect before the provider is up, and the kernel queues it). It is deliberately
+**deferred**: passing an fd into a containerd-managed task needs runtime plumbing
+(`--preserve-fds` / `LISTEN_FDS`) that is a substantial change on its own and
+should not be entangled with the entitlement's schema and lifecycle.
+
+### Naming
+
+`service` collides conceptually with two existing `wendy.json` concepts: the
+top-level `services` map (containers within one app) and `serviceName`. Internal
+identifiers are spelled unambiguously (`ServiceSocketManager`,
+`ValidateServiceSocketName`, `serviceSocketEnvName`) but the user-facing keyword
+is worth a second look before merge. `socket` or `ipc` would not collide.
+
+## Testing
+
+- `appconfig`: name/role validation, traversal rejection, duplicate-name
+  rejection, unknown-key rejection, schema↔Go sync guard on the role enum and
+  name pattern, annotation round-trip.
+- `oci`: provider gets `rw`, consumer gets `ro`, both get the env var and GID,
+  multiple names get separate mounts, an ungranted or malformed name is never
+  mounted, a consumer receives no unrelated mount.
+- `services`: directory mode and ownership, provider-conflict rejection, stale
+  socket removal, non-provider cannot clear a live socket, directory survives a
+  provider release while consumers remain, refcounting across sibling service
+  containers, malformed identities create nothing on disk, a failed `Ensure`
+  leaves no phantom claim.
+- `containerd`: label round-trip of name+role, malformed label entries dropped,
+  nil-provider no-op.
+
+## Out of scope
+
+- Socket activation (see above).
+- Cross-device service access — that is `network` mode `mesh`.
+- Any wire protocol over the socket. The platform provides the socket; what
+  flows through it is the apps' business.
+- Multiple sockets per service name.

--- a/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/wendy_agent_v1_container_service.pb.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/wendy_agent_v1_container_service.pb.swift
@@ -320,6 +320,9 @@ public nonisolated struct Wendy_Agent_Services_V1_CreateContainerProgress: Senda
 
   public var reusedSnapshot: Bool = false
 
+  /// A non-fatal deploy warning that the CLI should show directly to the user.
+  public var warning: String = String()
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public nonisolated enum Phase: SwiftProtobuf.Enum, Swift.CaseIterable {
@@ -1632,7 +1635,7 @@ nonisolated extension Wendy_Agent_Services_V1_CreateContainerResponse: SwiftProt
 
 nonisolated extension Wendy_Agent_Services_V1_CreateContainerProgress: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".CreateContainerProgress"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}phase\0\u{3}layer_index\0\u{3}total_layers\0\u{3}layer_size\0\u{3}reused_snapshot\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}phase\0\u{3}layer_index\0\u{3}total_layers\0\u{3}layer_size\0\u{3}reused_snapshot\0\u{1}warning\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1645,6 +1648,7 @@ nonisolated extension Wendy_Agent_Services_V1_CreateContainerProgress: SwiftProt
       case 3: try { try decoder.decodeSingularInt32Field(value: &self.totalLayers) }()
       case 4: try { try decoder.decodeSingularInt64Field(value: &self.layerSize) }()
       case 5: try { try decoder.decodeSingularBoolField(value: &self.reusedSnapshot) }()
+      case 6: try { try decoder.decodeSingularStringField(value: &self.warning) }()
       default: break
       }
     }
@@ -1666,6 +1670,9 @@ nonisolated extension Wendy_Agent_Services_V1_CreateContainerProgress: SwiftProt
     if self.reusedSnapshot != false {
       try visitor.visitSingularBoolField(value: self.reusedSnapshot, fieldNumber: 5)
     }
+    if !self.warning.isEmpty {
+      try visitor.visitSingularStringField(value: self.warning, fieldNumber: 6)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -1675,6 +1682,7 @@ nonisolated extension Wendy_Agent_Services_V1_CreateContainerProgress: SwiftProt
     if lhs.totalLayers != rhs.totalLayers {return false}
     if lhs.layerSize != rhs.layerSize {return false}
     if lhs.reusedSnapshot != rhs.reusedSnapshot {return false}
+    if lhs.warning != rhs.warning {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }


### PR DESCRIPTION
Two apps on one device can share a unix socket today — by declaring the same `persist` name. That works, and it over-grants badly: `persist` mounts the whole volume, so an app that only needs to *call* a service also gets read/write on that service's database. There is no way to express "may connect to this service" without also saying "may rewrite its data".

This is not an ergonomics PR. The gap is over-granting.

**This is not new machinery.** WendyOS already has exactly this pattern for sockets the *agent* serves, and it just isn't available to apps:

- `admin` bind-mounts the parent directory of the agent control socket — its docs say *"the entitlement-gated socket mount is the entire trust boundary"*.
- `notifications` gives each app a private System API socket directory, `root:2000`, with a matching supplementary GID and label-based restore after agent restart.

Both mount a **directory**, never the socket inode, so socket recreation is transparent to a running container; both live on `/var/lib` rather than tmpfs so the mount's inode survives reboot. This PR generalizes that code path from agent-provided sockets to app-provided ones.

```json
{ "type": "ipc", "name": "world", "role": "provide" }
{ "type": "ipc", "name": "world", "role": "consume" }
```

The agent bind-mounts `/run/wendy/ipc/<name>` read-write for the provider and read-only for consumers, and injects `WENDY_IPC_<NAME>_SOCKET`. A read-only mount still permits `connect()` — the kernel's read-only-superblock check applies to regular files, directories and symlinks, never to sockets — so it denies a consumer exactly the right thing (unlinking or replacing the provider's socket) and grants no access at all to the provider's data volume.

**On the keyword.** This was drafted as a `service` entitlement and deliberately renamed. `wendy.json` already uses "service" for something else: the top-level `services` map and `serviceName` identify containers *within one app*. An entitlement whose `name` lived in a third, unrelated namespace under the same word would be a standing source of confusion, and the keyword is public API, so it was cheaper to settle before it landed. `ipc` collides with nothing and says what the mechanism is. The `role` values stay `provide`/`consume`. Each doc surface states the namespace distinction explicitly rather than relying on the keyword alone, and `serviceName` is untouched throughout the agent code — it remains the app's own service name and is the second half of an IPC owner key.

**Why not `mesh`?** `mesh` is cross-device by design: it addresses peers by cloud asset ID mapped to a VIP in the service CIDR, transported LAN-direct over mTLS gRPC or relayed through the cloud broker, and its dialer deliberately discards loopback addresses. Service-name discovery is explicitly out of scope for mesh v1. `mesh` cannot express "the app next to me on this board". The mesh docs row now says so and points here.

**What the platform now owns**, instead of every app re-solving it (each of these is a problem an AGX Orin spike hit with the shared-volume workaround):

| Problem | Handled by |
|---|---|
| Provider dies without cleanup, leaving a socket that opens but refuses connections and that the provider can't rebind | Agent removes any stale socket before the provider's task is created |
| A typo in the name is indistinguishable from "provider not running" | Path comes from an injected env var, identical on both sides; a consumer with no provider is warned at deploy time with the names that do exist |
| uid/gid coordination between two apps sharing a volume | Setgid `2770 root:2001` directory + supplementary GID 2001 |
| Socket hijacking | One provider per name per device, first claim wins, held until that container is deleted, restored from container labels after agent restart |
| Provider restart stranding a consumer's bind mount | Directory refcounted across every provider and consumer container (stopped ones included), removed only after the last is deleted |

Create and start are fail-closed: a provider must not start believing it owns a socket it doesn't, and a consumer must not start with a silently absent mount it will then poll forever.

### Deferred, on purpose

**Socket activation is not in this PR.** With it, the agent would bind and listen — with a mode and owner it fully controls — and pass the fd into the container. That removes two things this PR does not fix:

1. **Non-root socket mode.** `connect()` needs write permission on the socket inode, and the mode is set by whoever calls `bind()`. With a default umask that's `0755`, so a non-root consumer cannot reach a non-root provider's socket. The setgid directory fixes the socket's *group* automatically but not its *mode*. Root-run providers and consumers — the current WendyOS default — are unaffected. Documented on all three doc surfaces with the workaround (`umask(0o007)` before binding, or `chmod 0660` after), and the agent warns if setgid fails to stick, so the degradation is never silent.
2. **Cold-start ordering.** Consumers still need bounded retry. Socket activation would let a consumer connect before the provider is up, with the kernel queueing the connection.

Deferred because passing a listening fd into a containerd-managed task needs `--preserve-fds`/`LISTEN_FDS` runtime plumbing that is a substantial change on its own and shouldn't be entangled with this entitlement's schema and lifecycle.

### Testing

`gofmt -s`, `go vet`, and `go test ./...` clean apart from the pre-existing macOS-only `TestMDNSStreamBackend` failure in `internal/shared/discovery`, which reproduces identically on unmodified `main` and is in a package this branch does not touch. Race suite green on all touched packages. ~40 new cases across `appconfig`, `oci`, `services`, and `containerd` — validation and traversal rejection, schema↔Go sync guard, provider-rw/consumer-ro/env/GID, ungranted and malformed names never mounted, directory mode and ownership, provider-conflict rejection, stale-socket removal, a consumer being unable to clear a live socket, directory survival across provider release, sibling-service refcounting, and failed-`Ensure` leaving no phantom claim.

**Not verified on hardware** — all testing is unit-level on macOS, and the setgid assertion is Linux-gated because macOS drops setgid for non-root callers. The shared-volume mechanism this replaces was proven on an AGX Orin; this entitlement's mount behaviour has not yet run on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9eGDX6KWUzSHhFgAnGRzd
