### PR TITLE
fix(agent): keep a device rename in the mDNS advertisement across reboots

### DIFF
--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -140,6 +140,16 @@ func main() {
 
 	configpartition.Apply(logger, configPath)
 
+	// Restore the mDNS advertisement for a device renamed via
+	// 'wendy device rename'. The boot-time identity units — and
+	// configpartition.Apply just above, when the config partition carries a
+	// device name — re-derive the name/displayname TXT records from
+	// /etc/wendyos/device-name, reverting the rename. Ordered last so the
+	// operator's explicit choice wins, matching generate-hostname.sh's
+	// precedence for the hostname itself. A no-op on a device that was never
+	// renamed.
+	services.ReassertHostnameAdvertisement(logger)
+
 	// Time sync: apply config-partition floor immediately, then start
 	// background Roughtime + multicast sync.
 	timesyncMgr := timesync.NewManager(logger, configPath)

--- a/go/internal/agent/configpartition/apply.go
+++ b/go/internal/agent/configpartition/apply.go
@@ -306,8 +306,12 @@ func applyDeviceName(logger *zap.Logger, name string) error {
 		logger.Info("Hostname updated", zap.String("hostname", "wendyos-"+name))
 	}
 
-	// update-mdns-uuid.sh is a first-boot placeholder replacer and is a no-op
-	// on a running device. Update the avahi service file directly instead.
+	// update-mdns-uuid.sh runs at boot, before the agent, so it cannot publish a
+	// name applied here at runtime. Update the avahi service file directly
+	// instead. (It is no longer the one-shot placeholder replacer it once was —
+	// it now re-derives name/displayname from device-name on every boot, which is
+	// why services.ReassertHostnameAdvertisement re-applies an explicit rename
+	// over the top of it at startup.)
 	updateAvahiDeviceName(logger, name, env)
 
 	return nil

--- a/go/internal/agent/services/hostname.go
+++ b/go/internal/agent/services/hostname.go
@@ -138,8 +138,9 @@ func updateAvahiHostname(logger *zap.Logger, hostname string) {
 	// Unconditional restart, unlike the re-assert path: here the hostname itself
 	// just changed, so avahi must re-read gethostname() even when the TXT records
 	// happen to be unchanged.
-	restartAvahiDaemon(logger)
-	logger.Info("Restarted avahi-daemon with new hostname", zap.String("hostname", hostname))
+	if restartAvahiDaemon(logger) {
+		logger.Info("Restarted avahi-daemon with new hostname", zap.String("hostname", hostname))
+	}
 }
 
 // ReassertHostnameAdvertisement re-publishes the mDNS TXT records for a hostname
@@ -158,14 +159,14 @@ func updateAvahiHostname(logger *zap.Logger, hostname string) {
 // already agree, it touches nothing and leaves avahi-daemon alone — this runs on
 // every agent start, and a needless restart would drop the advertisement.
 func ReassertHostnameAdvertisement(logger *zap.Logger) {
-	reassertHostnameAdvertisement(logger, explicitHostnamePath, avahiServiceFile, func() {
-		restartAvahiDaemon(logger)
+	reassertHostnameAdvertisement(logger, explicitHostnamePath, avahiServiceFile, func() bool {
+		return restartAvahiDaemon(logger)
 	})
 }
 
 // reassertHostnameAdvertisement is the testable core of
 // ReassertHostnameAdvertisement, with the paths and the avahi restart injected.
-func reassertHostnameAdvertisement(logger *zap.Logger, hostnamePath, serviceFile string, restartAvahi func()) {
+func reassertHostnameAdvertisement(logger *zap.Logger, hostnamePath, serviceFile string, restartAvahi func() bool) {
 	data, err := os.ReadFile(hostnamePath)
 	if err != nil {
 		// A missing file is the normal "never renamed" case, not a problem.
@@ -201,9 +202,10 @@ func reassertHostnameAdvertisement(logger *zap.Logger, hostnamePath, serviceFile
 		logger.Warn("Could not write avahi service file", zap.String("path", serviceFile), zap.Error(err))
 		return
 	}
-	restartAvahi()
-	logger.Info("Re-applied renamed hostname to the mDNS advertisement",
-		zap.String("hostname", hostname))
+	if restartAvahi() {
+		logger.Info("Re-applied renamed hostname to the mDNS advertisement",
+			zap.String("hostname", hostname))
+	}
 }
 
 // avahiContentForHostname returns the avahi service file content with the
@@ -219,12 +221,14 @@ func avahiContentForHostname(content, hostname string) string {
 // restartAvahiDaemon restarts avahi-daemon so it re-reads both the service file
 // and gethostname(). A full restart is required: --reload (SIGHUP) only
 // refreshes service files, leaving the %h-based records stale.
-func restartAvahiDaemon(logger *zap.Logger) {
+func restartAvahiDaemon(logger *zap.Logger) bool {
 	restart := exec.Command("/usr/bin/systemctl", "restart", "avahi-daemon")
 	restart.Env = systemPathEnv()
 	if out, err := restart.CombinedOutput(); err != nil {
 		logger.Warn("systemctl restart avahi-daemon failed", zap.Error(err), zap.String("output", string(out)))
+		return false
 	}
+	return true
 }
 
 // replaceAvahiTXTRecord replaces the value in a <txt-record>key=...</txt-record> line.

--- a/go/internal/agent/services/hostname.go
+++ b/go/internal/agent/services/hostname.go
@@ -19,6 +19,13 @@ const explicitHostnamePath = "/etc/wendy-agent/hostname"
 // maxHostnameLen is the RFC 1035 limit for a single DNS label.
 const maxHostnameLen = 63
 
+// avahiServiceFile is the mDNS advertisement the agent edits at runtime. Unlike
+// explicitHostnamePath it is NOT persistent: it lives on the rootfs, so it is
+// per-OTA-slot, and wendyos-identity.service rewrites its name/displayname TXT
+// records from /etc/wendyos/device-name on every boot. See
+// ReassertHostnameAdvertisement.
+const avahiServiceFile = "/etc/avahi/services/wendyos-mdns.service"
+
 // validHostname reports whether name is a valid DNS label suitable for use as a
 // literal hostname: 1–63 characters, starting with a lowercase letter, followed
 // by lowercase letters, digits, or hyphens, and not ending in a hyphen.
@@ -116,32 +123,108 @@ func updateEtcHosts(logger *zap.Logger, hostname string) {
 // avoid an import cycle (configpartition imports this package). Keep the avahi
 // service-file format in sync between them.
 func updateAvahiHostname(logger *zap.Logger, hostname string) {
-	const serviceFile = "/etc/avahi/services/wendyos-mdns.service"
-
-	data, err := os.ReadFile(serviceFile)
+	data, err := os.ReadFile(avahiServiceFile)
 	if err != nil {
-		logger.Warn("Could not read avahi service file", zap.String("path", serviceFile), zap.Error(err))
+		logger.Warn("Could not read avahi service file", zap.String("path", avahiServiceFile), zap.Error(err))
 		return
 	}
 
-	content := replaceAvahiTXTRecord(string(data), "name", hostname)
-	content = replaceAvahiTXTRecord(content, "displayname", avahiDisplayName(hostname))
-	content = replaceAvahiTXTRecord(content, "fqdn", "sh.wendy."+hostname)
+	content := avahiContentForHostname(string(data), hostname)
+	if err := os.WriteFile(avahiServiceFile, []byte(content), 0o644); err != nil {
+		logger.Warn("Could not write avahi service file", zap.String("path", avahiServiceFile), zap.Error(err))
+		return
+	}
+
+	// Unconditional restart, unlike the re-assert path: here the hostname itself
+	// just changed, so avahi must re-read gethostname() even when the TXT records
+	// happen to be unchanged.
+	restartAvahiDaemon(logger)
+	logger.Info("Restarted avahi-daemon with new hostname", zap.String("hostname", hostname))
+}
+
+// ReassertHostnameAdvertisement re-publishes the mDNS TXT records for a hostname
+// previously set via SetHostname ('wendy device rename'). Call it once at agent
+// startup, after the boot-time identity units have run.
+//
+// A rename persists the hostname itself (explicitHostnamePath is bind-mounted to
+// /data and generate-hostname.sh prefers it), but the advertisement carrying the
+// name/displayname TXT records is rootfs state that gets reverted underneath us
+// two ways: wendyos-identity.service re-derives those records from
+// /etc/wendyos/device-name on every boot, and an A/B OTA brings back a fresh
+// service file from the new slot. Either way the device goes on resolving as
+// <name>.local while 'wendy device list' shows the pre-rename name again.
+//
+// Best-effort and quiet by design: with no rename in effect, or when the records
+// already agree, it touches nothing and leaves avahi-daemon alone — this runs on
+// every agent start, and a needless restart would drop the advertisement.
+func ReassertHostnameAdvertisement(logger *zap.Logger) {
+	reassertHostnameAdvertisement(logger, explicitHostnamePath, avahiServiceFile, func() {
+		restartAvahiDaemon(logger)
+	})
+}
+
+// reassertHostnameAdvertisement is the testable core of
+// ReassertHostnameAdvertisement, with the paths and the avahi restart injected.
+func reassertHostnameAdvertisement(logger *zap.Logger, hostnamePath, serviceFile string, restartAvahi func()) {
+	data, err := os.ReadFile(hostnamePath)
+	if err != nil {
+		// A missing file is the normal "never renamed" case, not a problem.
+		if !os.IsNotExist(err) {
+			logger.Warn("Could not read persisted hostname", zap.String("path", hostnamePath), zap.Error(err))
+		}
+		return
+	}
+
+	hostname := strings.TrimSpace(string(data))
+	if !validHostname(hostname) {
+		logger.Warn("Ignoring invalid persisted hostname; leaving the mDNS advertisement as-is",
+			zap.String("path", hostnamePath), zap.String("hostname", hostname))
+		return
+	}
+
+	service, err := os.ReadFile(serviceFile)
+	if err != nil {
+		// Absent on a non-WendyOS host (e.g. the Linux desktop install), where
+		// there is no avahi service file to keep in sync.
+		if !os.IsNotExist(err) {
+			logger.Warn("Could not read avahi service file", zap.String("path", serviceFile), zap.Error(err))
+		}
+		return
+	}
+
+	content := avahiContentForHostname(string(service), hostname)
+	if content == string(service) {
+		return // already advertising the renamed device
+	}
 
 	if err := os.WriteFile(serviceFile, []byte(content), 0o644); err != nil {
 		logger.Warn("Could not write avahi service file", zap.String("path", serviceFile), zap.Error(err))
 		return
 	}
+	restartAvahi()
+	logger.Info("Re-applied renamed hostname to the mDNS advertisement",
+		zap.String("hostname", hostname))
+}
 
-	// A full restart (not --reload) is required so avahi re-reads gethostname()
-	// and re-publishes the %h-based records under the new hostname.
+// avahiContentForHostname returns the avahi service file content with the
+// hostname-derived TXT records set. Only those records are rewritten, so the
+// port and the tls/assetid/orgid records owned by UpdateAvahiForProvisioning
+// survive untouched.
+func avahiContentForHostname(content, hostname string) string {
+	content = replaceAvahiTXTRecord(content, "name", hostname)
+	content = replaceAvahiTXTRecord(content, "displayname", avahiDisplayName(hostname))
+	return replaceAvahiTXTRecord(content, "fqdn", "sh.wendy."+hostname)
+}
+
+// restartAvahiDaemon restarts avahi-daemon so it re-reads both the service file
+// and gethostname(). A full restart is required: --reload (SIGHUP) only
+// refreshes service files, leaving the %h-based records stale.
+func restartAvahiDaemon(logger *zap.Logger) {
 	restart := exec.Command("/usr/bin/systemctl", "restart", "avahi-daemon")
 	restart.Env = systemPathEnv()
 	if out, err := restart.CombinedOutput(); err != nil {
 		logger.Warn("systemctl restart avahi-daemon failed", zap.Error(err), zap.String("output", string(out)))
-		return
 	}
-	logger.Info("Restarted avahi-daemon with new hostname", zap.String("hostname", hostname))
 }
 
 // replaceAvahiTXTRecord replaces the value in a <txt-record>key=...</txt-record> line.

--- a/go/internal/agent/services/hostname_reassert_test.go
+++ b/go/internal/agent/services/hostname_reassert_test.go
@@ -1,0 +1,172 @@
+package services
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// avahiFixture is the shipped wendyos-mdns.service template after the boot-time
+// publisher (update-mdns-uuid.sh) has filled in the generated device name — i.e.
+// exactly the state a renamed device comes back in after a reboot.
+const avahiFixture = `<?xml version="1.0" standalone='no'?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+  <name replace-wildcards="yes">%h</name>
+  <service protocol="any">
+    <type>_wendyos._udp</type>
+    <port>50052</port>
+    <txt-record>id=3f2b1a7c</txt-record>
+    <txt-record>name=brave-dolphin</txt-record>
+    <txt-record>displayname=Brave Dolphin</txt-record>
+    <txt-record>tls=true</txt-record>
+  </service>
+</service-group>
+`
+
+// reassertFixture writes the explicit-hostname and avahi service files into a
+// temp dir and returns their paths. An empty hostname means "no rename in
+// effect": the file is not created at all.
+func reassertFixture(t *testing.T, hostname, serviceContent string) (hostnamePath, servicePath string) {
+	t.Helper()
+	dir := t.TempDir()
+	hostnamePath = filepath.Join(dir, "hostname")
+	servicePath = filepath.Join(dir, "wendyos-mdns.service")
+
+	if hostname != "" {
+		if err := os.WriteFile(hostnamePath, []byte(hostname+"\n"), 0o644); err != nil {
+			t.Fatalf("writing hostname fixture: %v", err)
+		}
+	}
+	if serviceContent != "" {
+		if err := os.WriteFile(servicePath, []byte(serviceContent), 0o644); err != nil {
+			t.Fatalf("writing avahi fixture: %v", err)
+		}
+	}
+	return hostnamePath, servicePath
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	return string(data)
+}
+
+// A rename must survive a reboot. The hostname itself does (it is persisted to
+// /etc/wendy-agent and generate-hostname.sh prefers it), but the avahi service
+// file lives on the rootfs and is rewritten from /etc/wendyos/device-name by
+// wendyos-identity.service on every boot — reverting the name/displayname TXT
+// records that 'wendy device list' displays. Re-asserting at startup fixes it.
+func TestReassertHostnameAdvertisementRestoresRevertedRecords(t *testing.T) {
+	hostnamePath, servicePath := reassertFixture(t, "kitchen-pi", avahiFixture)
+
+	restarts := 0
+	reassertHostnameAdvertisement(zap.NewNop(), hostnamePath, servicePath, func() { restarts++ })
+
+	got := readFile(t, servicePath)
+	if !strings.Contains(got, "<txt-record>name=kitchen-pi</txt-record>") {
+		t.Errorf("name TXT record not restored:\n%s", got)
+	}
+	if !strings.Contains(got, "<txt-record>displayname=Kitchen Pi</txt-record>") {
+		t.Errorf("displayname TXT record not restored:\n%s", got)
+	}
+	// Records the agent owns elsewhere must survive untouched.
+	if !strings.Contains(got, "<txt-record>tls=true</txt-record>") {
+		t.Errorf("tls TXT record was clobbered:\n%s", got)
+	}
+	if !strings.Contains(got, "<port>50052</port>") {
+		t.Errorf("port was clobbered:\n%s", got)
+	}
+	if restarts != 1 {
+		t.Errorf("avahi restarts = %d, want 1", restarts)
+	}
+}
+
+// The common case is a device that was never renamed. Doing nothing matters:
+// this runs on every agent start, and a needless avahi-daemon restart would
+// drop the device's mDNS advertisement for no reason.
+func TestReassertHostnameAdvertisementNoExplicitHostname(t *testing.T) {
+	_, servicePath := reassertFixture(t, "", avahiFixture)
+	hostnamePath := filepath.Join(t.TempDir(), "absent")
+
+	restarts := 0
+	reassertHostnameAdvertisement(zap.NewNop(), hostnamePath, servicePath, func() { restarts++ })
+
+	if got := readFile(t, servicePath); got != avahiFixture {
+		t.Errorf("service file modified with no rename in effect:\n%s", got)
+	}
+	if restarts != 0 {
+		t.Errorf("avahi restarts = %d, want 0", restarts)
+	}
+}
+
+// Second and later boots after a rename: the records already agree, so this is
+// a no-op — again, no avahi restart.
+func TestReassertHostnameAdvertisementAlreadyCurrent(t *testing.T) {
+	current := strings.NewReplacer(
+		"name=brave-dolphin", "name=kitchen-pi",
+		"displayname=Brave Dolphin", "displayname=Kitchen Pi",
+	).Replace(avahiFixture)
+	hostnamePath, servicePath := reassertFixture(t, "kitchen-pi", current)
+
+	restarts := 0
+	reassertHostnameAdvertisement(zap.NewNop(), hostnamePath, servicePath, func() { restarts++ })
+
+	if got := readFile(t, servicePath); got != current {
+		t.Errorf("service file rewritten when already current:\n%s", got)
+	}
+	if restarts != 0 {
+		t.Errorf("avahi restarts = %d, want 0", restarts)
+	}
+}
+
+// A corrupt persisted hostname must not be advertised. Leaving the boot-time
+// device-name in place is the safe outcome.
+func TestReassertHostnameAdvertisementInvalidHostname(t *testing.T) {
+	for _, invalid := range []string{"Kitchen Pi", "-leading", "trailing-", "1digit", "under_score", ""} {
+		t.Run(invalid, func(t *testing.T) {
+			dir := t.TempDir()
+			hostnamePath := filepath.Join(dir, "hostname")
+			servicePath := filepath.Join(dir, "wendyos-mdns.service")
+			if err := os.WriteFile(hostnamePath, []byte(invalid+"\n"), 0o644); err != nil {
+				t.Fatalf("writing hostname fixture: %v", err)
+			}
+			if err := os.WriteFile(servicePath, []byte(avahiFixture), 0o644); err != nil {
+				t.Fatalf("writing avahi fixture: %v", err)
+			}
+
+			restarts := 0
+			reassertHostnameAdvertisement(zap.NewNop(), hostnamePath, servicePath, func() { restarts++ })
+
+			if got := readFile(t, servicePath); got != avahiFixture {
+				t.Errorf("service file modified for invalid hostname %q:\n%s", invalid, got)
+			}
+			if restarts != 0 {
+				t.Errorf("avahi restarts = %d, want 0", restarts)
+			}
+		})
+	}
+}
+
+// A non-WendyOS host (the Linux desktop install) has no avahi service file.
+// That is not an error worth failing startup over.
+func TestReassertHostnameAdvertisementMissingServiceFile(t *testing.T) {
+	dir := t.TempDir()
+	hostnamePath := filepath.Join(dir, "hostname")
+	if err := os.WriteFile(hostnamePath, []byte("kitchen-pi\n"), 0o644); err != nil {
+		t.Fatalf("writing hostname fixture: %v", err)
+	}
+
+	restarts := 0
+	reassertHostnameAdvertisement(zap.NewNop(), hostnamePath, filepath.Join(dir, "absent.service"), func() { restarts++ })
+
+	if restarts != 0 {
+		t.Errorf("avahi restarts = %d, want 0", restarts)
+	}
+}

--- a/go/internal/agent/services/hostname_reassert_test.go
+++ b/go/internal/agent/services/hostname_reassert_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 // avahiFixture is the shipped wendyos-mdns.service template after the boot-time
@@ -67,7 +69,10 @@ func TestReassertHostnameAdvertisementRestoresRevertedRecords(t *testing.T) {
 	hostnamePath, servicePath := reassertFixture(t, "kitchen-pi", avahiFixture)
 
 	restarts := 0
-	reassertHostnameAdvertisement(zap.NewNop(), hostnamePath, servicePath, func() { restarts++ })
+	reassertHostnameAdvertisement(zap.NewNop(), hostnamePath, servicePath, func() bool {
+		restarts++
+		return true
+	})
 
 	got := readFile(t, servicePath)
 	if !strings.Contains(got, "<txt-record>name=kitchen-pi</txt-record>") {
@@ -96,7 +101,10 @@ func TestReassertHostnameAdvertisementNoExplicitHostname(t *testing.T) {
 	hostnamePath := filepath.Join(t.TempDir(), "absent")
 
 	restarts := 0
-	reassertHostnameAdvertisement(zap.NewNop(), hostnamePath, servicePath, func() { restarts++ })
+	reassertHostnameAdvertisement(zap.NewNop(), hostnamePath, servicePath, func() bool {
+		restarts++
+		return true
+	})
 
 	if got := readFile(t, servicePath); got != avahiFixture {
 		t.Errorf("service file modified with no rename in effect:\n%s", got)
@@ -116,7 +124,10 @@ func TestReassertHostnameAdvertisementAlreadyCurrent(t *testing.T) {
 	hostnamePath, servicePath := reassertFixture(t, "kitchen-pi", current)
 
 	restarts := 0
-	reassertHostnameAdvertisement(zap.NewNop(), hostnamePath, servicePath, func() { restarts++ })
+	reassertHostnameAdvertisement(zap.NewNop(), hostnamePath, servicePath, func() bool {
+		restarts++
+		return true
+	})
 
 	if got := readFile(t, servicePath); got != current {
 		t.Errorf("service file rewritten when already current:\n%s", got)
@@ -142,7 +153,10 @@ func TestReassertHostnameAdvertisementInvalidHostname(t *testing.T) {
 			}
 
 			restarts := 0
-			reassertHostnameAdvertisement(zap.NewNop(), hostnamePath, servicePath, func() { restarts++ })
+			reassertHostnameAdvertisement(zap.NewNop(), hostnamePath, servicePath, func() bool {
+				restarts++
+				return true
+			})
 
 			if got := readFile(t, servicePath); got != avahiFixture {
 				t.Errorf("service file modified for invalid hostname %q:\n%s", invalid, got)
@@ -164,9 +178,23 @@ func TestReassertHostnameAdvertisementMissingServiceFile(t *testing.T) {
 	}
 
 	restarts := 0
-	reassertHostnameAdvertisement(zap.NewNop(), hostnamePath, filepath.Join(dir, "absent.service"), func() { restarts++ })
+	reassertHostnameAdvertisement(zap.NewNop(), hostnamePath, filepath.Join(dir, "absent.service"), func() bool {
+		restarts++
+		return true
+	})
 
 	if restarts != 0 {
 		t.Errorf("avahi restarts = %d, want 0", restarts)
+	}
+}
+
+func TestReassertHostnameAdvertisementDoesNotLogSuccessWhenRestartFails(t *testing.T) {
+	hostnamePath, servicePath := reassertFixture(t, "kitchen-pi", avahiFixture)
+	core, logs := observer.New(zapcore.InfoLevel)
+
+	reassertHostnameAdvertisement(zap.New(core), hostnamePath, servicePath, func() bool { return false })
+
+	if got := logs.FilterMessage("Re-applied renamed hostname to the mDNS advertisement").Len(); got != 0 {
+		t.Errorf("success logs = %d, want 0", got)
 	}
 }

--- a/go/internal/cli/assets/docs/wendyos/networking/mdns.md
+++ b/go/internal/cli/assets/docs/wendyos/networking/mdns.md
@@ -21,16 +21,27 @@ The Avahi service definition is installed at `/etc/avahi/services/wendyos-mdns.s
 </service-group>
 ```
 
-The placeholder tokens (`WENDY_DEVICE_ID` etc.) are replaced at boot by `update-mdns-uuid.sh` (see below).
+The placeholder tokens (`WENDY_DEVICE_ID` etc.) are replaced during boot. On
+later boots, the same updater replaces the current TXT record values again; it
+is not limited to the original placeholders (see below).
 
 - **Service type**: `_wendyos._udp`
 - **Port**: `50051` pre-provisioning; updated to `50052` (mTLS) automatically once the device enrolls
 - **Instance name**: The device hostname (`%h` expands to the current hostname as set by Avahi)
-- **TXT records**: `id`, `name`, `displayname` (placeholder tokens replaced at boot by `update-mdns-uuid.sh`)
+- **TXT records**: `id`, `name`, `displayname`, plus provisioning records such as `tls`, `assetid`, and `orgid` when applicable
 
-## Dynamic UUID Injection
+Provisioning updates the port and may add `tls`, `assetid`, and `orgid`. Some
+service templates also contain an optional `fqdn` record. The agent preserves
+these records when it updates the hostname-derived TXT values.
 
-At boot, `update-mdns-uuid.sh` (from `recipes-core/wendyos-identity/`):
+## Boot-time mDNS Identity Update
+
+On every boot, `wendyos-identity.service` runs `update-mdns-uuid.sh` from
+`recipes-core/wendyos-identity/`. The script reads
+`/etc/wendyos/device-uuid` and `/etc/wendyos/device-name`, derives the title-case
+display name, and replaces the current `id`, `name`, and `displayname` values in
+the Avahi service file. Matching records by key makes this update idempotent; it
+is not a one-time placeholder replacement. The equivalent data flow is:
 
 ```bash
 UUID=$(cat /etc/wendyos/device-uuid)
@@ -38,14 +49,27 @@ DEVICE_NAME=$(cat /etc/wendyos/device-name 2>/dev/null || echo "unknown-device")
 DISPLAY_NAME=$(echo "$DEVICE_NAME" | sed 's/-/ /g' | \
     awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) tolower(substr($i,2));}1')
 
-sed -i "s|WENDY_DEVICE_ID|$UUID|g"           "$SERVICE_FILE"
-sed -i "s|WENDY_DEVICE_NAME|$DEVICE_NAME|g"  "$SERVICE_FILE"
-sed -i "s|WENDY_DISPLAY_NAME|$DISPLAY_NAME|g" "$SERVICE_FILE"
+# Replace the value of each matching <txt-record>key=...</txt-record> entry.
+set_txt id "$UUID"
+set_txt name "$DEVICE_NAME"
+set_txt displayname "$DISPLAY_NAME"
 ```
 
 The `displayname` field converts the hyphen-separated device name to Title Case (e.g. `my-device` becomes `My Device`).
 
-If UUID or device-name files are not yet present, the script retries for up to 10 seconds to handle ordering races. After patching the file it calls `avahi-daemon --reload` if the daemon is already running.
+If UUID or device-name files are not yet present, the script retries for up to
+10 seconds to handle ordering races. After updating the file it calls
+`avahi-daemon --reload` if the daemon is already running.
+
+`wendy device rename` persists the operator-selected hostname in
+`/etc/wendy-agent/hostname` and updates the Avahi records at rename time; it
+does not overwrite the generated `/etc/wendyos/device-name`. Consequently, the
+boot-time identity update above can replace `name` and `displayname` with the
+generated device name. At agent startup, after `wendyos-identity.service` and
+`avahi-daemon.service`, `ReassertHostnameAdvertisement` compares the service
+file with the persisted explicit hostname and restores the hostname-derived TXT
+records when needed. It restarts Avahi only when it changes the service file.
+The same re-assertion repairs a fresh service file after an A/B OTA slot switch.
 
 ## Hostname Generation
 
@@ -60,6 +84,14 @@ Avahi broadcasts the device hostname as `<hostname>.local`. The hostname is set 
 4. Legacy fallbacks: RPi serial from `/proc/cpuinfo`, first 16 chars of `/etc/machine-id`, first MAC address, random hex
 
 The hostname is written to `/etc/hostname` using a direct write (not `hostnamectl`, to avoid EBUSY issues with bind mounts) and also added to `/etc/hosts` as `127.0.1.1 <hostname> <hostname>.local`.
+
+> **Rename persistence:** The hostname itself remains stable across reboots and
+> OTA updates because `/etc/wendy-agent/hostname` is backed by `/data` and has
+> highest precedence above. The Avahi `name` and `displayname` TXT records are
+> separate rootfs state and can be re-derived from `/etc/wendyos/device-name`
+> during boot. The agent re-asserts those records from the persistent explicit
+> hostname at startup and does nothing on devices that have never been renamed
+> or whose records are already current.
 
 A hostname override can be applied by creating `/etc/wendyos-hostname-override`.
 
@@ -129,7 +161,7 @@ type MDNSService struct {
     Hostname     string
     IPAddress    string        // link-local IPv6 includes %zone suffix
     Port         int
-    TXTRecords   map[string]string   // "id", "name", "displayname"
+    TXTRecords   map[string]string   // all advertised TXT records
 }
 ```
 
@@ -140,5 +172,6 @@ type MDNSService struct {
 | `id` | Device UUID (from `/etc/wendyos/device-uuid`) | `550e8400-e29b-41d4-a716-446655440000` |
 | `name` | Slug device name (from `/etc/wendyos/device-name`) | `my-device` |
 | `displayname` | Title-cased device name | `My Device` |
+| `fqdn` | Optional reverse-DNS name derived from the hostname when present in the service template | `sh.wendy.my-device` |
 | `wendyosdevice` | Device UUID (preferred over `id` when present) | `769dc651-4eb2-49f3-b9f6-3e473f15694a` |
 | `tls` | `"true"` when the device is provisioned and requires mTLS (port 50052) | `true` |

--- a/go/internal/cli/assets/docs/wendyos/services/README.md
+++ b/go/internal/cli/assets/docs/wendyos/services/README.md
@@ -13,7 +13,7 @@ WendyOS is a Yocto-based Linux distribution managed entirely by systemd. This do
 | `wendyos-hostname.service` | `recipes-connectivity/avahi` | Derives `hostname` from the persistent device name and sets it before Avahi starts |
 | `gadget-setup.service` | `recipes-core/gadget-setup` | Configures the USB gadget composite device (NCM or ECM network + ACM serial console) using Linux configfs |
 | `wendyos-usbgadget-unbind.service` | `recipes-core/gadget-setup` | Tears down the USB gadget on shutdown |
-| `wendyos-agent.service` | `recipes-core/wendyos-agent` | Runs the `wendy-agent` binary; provides device management, gRPC API, WiFi control, and container orchestration |
+| `wendyos-agent.service` | `recipes-core/wendyos-agent` | Runs the `wendy-agent` binary; provides device management, gRPC API, WiFi control, and container orchestration. Ordered after the boot-time identity publisher and Avahi so an explicit rename can be re-asserted without a race. |
 | `wendyos-agent-updater.service` | `recipes-core/wendyos-agent` | One-shot agent self-update (downloads from GitHub releases). Also stopped during `UpdateOS` to prevent cgroup SIGTERM propagation to the in-flight OTA (wendyos-update) process |
 | `wendyos-agent-updater.timer` | `recipes-core/wendyos-agent` | Triggers the updater 5 min after boot, then daily at 03:00 with a random 30-min jitter. Stopped for the duration of any `UpdateOS` call so the updater cannot interrupt an in-flight OTA (wendyos-update) operation; re-started when the call returns |
 | `containerd.service` | upstream (meta-virtualization) | Container runtime; `wendy-agent` requires it before starting |
@@ -62,8 +62,10 @@ local-fs.target
 wendyos-uuid-generate.service
 wendyos-device-name-generate.service
       |
-      +-- wendyos-hostname.service --> avahi-daemon.service
-      +-- wendyos-identity.service
+      +-- wendyos-hostname.service --> avahi-daemon.service --+
+      +-- wendyos-identity.service ---------------------------+
+                                                               |
+                                                     wendyos-agent.service
 ```
 
 ## systemd target dependencies
@@ -83,6 +85,7 @@ wendyos-device-name-generate.service
 3. `gadget-setup.service` runs before `systemd-networkd` so the `usb0` interface exists when networkd starts.
 4. `containerd.service` must be running and `/var/lib/containerd` must be bind-mounted before `wendyos-agent.service` starts.
 5. EEPROM services (RPi 5 only) run after `multi-user.target` and use a flag file (`/var/lib/wendyos/eeprom-updated`, `/var/lib/wendyos/eeprom-nvme-updated`) to guarantee they execute at most once.
+6. `wendyos-agent.service` runs after `wendyos-identity.service` and `avahi-daemon.service`. This ensures `ReassertHostnameAdvertisement`, which restores an explicit `wendy device rename` hostname over boot-time TXT records, runs after the publisher instead of racing it. These are ordering-only dependencies; packaged Linux installs that do not provide the WendyOS units continue to start normally.
 
 ## Checking service status
 

--- a/go/internal/cli/assets/docs/wendyos/services/configuration-files.md
+++ b/go/internal/cli/assets/docs/wendyos/services/configuration-files.md
@@ -17,7 +17,7 @@ All files under `/etc/wendyos/` are bind-mounted from `/data/etc/wendyos/` by `w
 
 | Path | Description |
 |------|-------------|
-| `/etc/wendy-agent/hostname` | Literal hostname set by `wendy device rename`. Takes precedence over `/etc/wendyos/device-name` in hostname generation. |
+| `/etc/wendy-agent/hostname` | Literal hostname set by `wendy device rename`. Backed by `/data`, it survives reboots and OTA updates and takes precedence over `/etc/wendyos/device-name` in hostname generation. At agent startup, `ReassertHostnameAdvertisement` also uses it to restore hostname-derived Avahi TXT records that were replaced during boot or by a fresh OTA slot. |
 | `/etc/default/wendy-agent` | Shell-format environment file sourced by both `wendyos-agent.service` and `wendyos-agent-updater.sh`. Supports `WENDYOS_AGENT_GITHUB_REPO`, `WENDYOS_AGENT_VERSION`. Not created by default; create it to override release channel. |
 | `/var/lib/wendy-agent/` | Runtime state directory for the agent (current-version file, working data). |
 | `/usr/local/bin/wendy-agent` | Agent binary. Installed at build time; overwritten in-place by `wendyos-agent-updater.service`. |

--- a/packaging/linux/systemd/wendy-agent.service
+++ b/packaging/linux/systemd/wendy-agent.service
@@ -1,6 +1,12 @@
 [Unit]
 Description=Wendy Agent
 After=network-online.target dbus.service containerd.service time-sync.target
+# wendyos-identity.service rewrites the mDNS name/displayname TXT records from
+# the generated device-name on every boot. The agent re-asserts an explicit
+# 'wendy device rename' hostname over that (ReassertHostnameAdvertisement), so
+# it must run after it rather than race it. Ordering-only: both units are absent
+# on a non-WendyOS host, where systemd simply ignores the line.
+After=wendyos-identity.service avahi-daemon.service
 Wants=network-online.target time-sync.target
 Requires=containerd.service
 


### PR DESCRIPTION
## The bug

`wendy device rename` does not stick across a reboot. The device keeps resolving as `<new>.local`, but `wendy device list` shows the pre-rename name again.

A rename sets the hostname *and* rewrites the `name`/`displayname` TXT records in the avahi service file (`hostname.go`). Only the first half is persistent:

| What | Persists? | Why |
|---|---|---|
| Hostname | ✅ | `/etc/wendy-agent/hostname` is bind-mounted to `/data` (`setup-etc-binds.sh` Phase 3), and `generate-hostname.sh` prefers it verbatim. |
| avahi TXT `name` / `displayname` | ❌ | The service file is **rootfs** state. |

Two things revert it:

1. `wendyos-identity.service` (`WantedBy=multi-user.target`, so every boot) re-derives both records from `/etc/wendyos/device-name`, which a rename never writes.
2. An A/B OTA brings back a fresh service file from the new slot.

The CLI shows the reverted value because `lanDeviceFromService` (`discovery/mdns.go:45`) lets the `displayname` TXT record win over the hostname.

## The fix

`ReassertHostnameAdvertisement` re-applies the records at agent startup from the persisted hostname.

It is deliberately quiet. With no rename in effect, or when the records already agree, it touches nothing and does **not** restart `avahi-daemon` — this runs on every agent start, and a needless restart would drop the device's advertisement.

Ordered after `configpartition.Apply`, so an explicit rename outranks a config-partition device name — matching the precedence `generate-hostname.sh` already gives it for the hostname.

Also pinned the unit ordering: `wendy-agent.service` gains `After=wendyos-identity.service avahi-daemon.service`, so the re-assert follows the boot-time publisher instead of racing it. Ordering-only, and ignored on hosts where those units don't exist (the Linux desktop install).

Fixed a stale comment in `configpartition/apply.go` while I was in it: it claimed `update-mdns-uuid.sh` is "a first-boot placeholder replacer and a no-op on a running device". That stopped being true when the script was rewritten to idempotent value-replacement, and the agent was reasoning from the old behavior.

## Tests

`hostname_reassert_test.go` — restores reverted records; no-ops with no rename; no-ops (and no avahi restart) when already current; ignores an invalid persisted hostname; tolerates an absent service file. The avahi restart is injected, so nothing shells out.

```
ok  github.com/wendylabsinc/wendy/go/internal/agent/services
ok  github.com/wendylabsinc/wendy/go/internal/agent/configpartition
```

`go vet` clean on the touched packages. (`GOOS=linux go build ./...` fails in the `gousb` cgo dep — pre-existing on `main`, unrelated.)

## Companion PR

WendyOS-Builder#224 is the root fix: it teaches `update-mdns-uuid.sh` to prefer the explicit hostname, so the revert stops happening at the source. This PR complements it — it covers the OTA slot reset, and reaches already-deployed devices with an agent update alone, without waiting for an OS image.

## Not verified

No hardware reboot test. The reasoning is from boot ordering and the persistence map in `setup-etc-binds.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)