### PR TITLE
fix(cli): never let a stranded buildx process wedge every build

### DIFF
--- a/go/internal/cli/commands/buildxstore.go
+++ b/go/internal/cli/commands/buildxstore.go
@@ -1,0 +1,187 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// buildx serializes every access to its builder store — `buildx build`,
+// inspect, create, rm, ls — behind one exclusive flock on
+// <docker-config>/buildx/.lock, and it takes that lock with no timeout and no
+// output. So a single wedged buildx process anywhere on the machine silently
+// blocks every build in every wendy process, for as long as it lives.
+//
+// The way one gets wedged: a builder whose stored endpoint names a docker
+// context that is no longer running (a `desktop-linux` builder on a machine now
+// using orbstack). `docker buildx rm` on it dials a daemon that will never
+// answer, holding the store lock the whole time. Orphan that process — the
+// wendy that started it is gone — and nothing will ever release the lock.
+//
+// groupCommandContext and dockerControlTimeout stop wendy from creating such a
+// process. This file handles the ones that already exist: it refuses to block
+// on the lock indefinitely, reclaims the store when the holder is provably
+// stranded work, and otherwise fails with an error that names the lock and its
+// holder instead of hanging.
+
+// buildxStoreLockWait bounds how long to wait for a lock another process
+// legitimately holds. Real buildx store transactions are sub-second; this is
+// generous enough to cover a concurrent build's bookkeeping and short enough
+// that a wedged holder surfaces as an error while the user is still watching.
+// A var so tests need not wait it out.
+var buildxStoreLockWait = 20 * time.Second
+
+// procInfo is the subset of a process listing this file reasons about.
+type procInfo struct {
+	PID     int
+	PPID    int
+	PGID    int
+	Command string
+}
+
+// listOwnProcesses and killGroupByPGID are vars so the reaping policy can be
+// tested without real processes; the defaults are the platform implementations.
+var (
+	listOwnProcesses = psOwnProcesses
+	killGroupByPGID  = killProcessGroupByPGID
+)
+
+// dockerConfigDir is the directory docker keeps its client state in, which is
+// also where buildx keeps the builder store.
+func dockerConfigDir() (string, error) {
+	if dir := os.Getenv("DOCKER_CONFIG"); dir != "" {
+		return dir, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("finding home directory: %w", err)
+	}
+	return filepath.Join(home, ".docker"), nil
+}
+
+// buildxStoreLockPath returns the path of buildx's builder-store lock.
+func buildxStoreLockPath() (string, error) {
+	dir, err := dockerConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "buildx", ".lock"), nil
+}
+
+// orphanedBuildxProcesses returns the processes that can only be stranded
+// buildx work: a buildx command whose parent has exited. Both conditions are
+// required. A buildx process with a live parent is somebody's build — possibly
+// a concurrent wendy, possibly a plain `docker buildx` the user is running —
+// and killing it would turn this safeguard into the very failure it exists to
+// prevent. Orphaned non-buildx processes are none of our business, and self is
+// excluded so a wendy re-parented to init never targets itself.
+func orphanedBuildxProcesses(procs []procInfo, self int) []procInfo {
+	var out []procInfo
+	for _, p := range procs {
+		if p.PID == self || p.PID <= 1 || p.PPID != 1 {
+			continue
+		}
+		if !strings.Contains(p.Command, "buildx") {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// reapOrphanedBuildx kills the process group of every stranded buildx process,
+// reporting each one, and returns how many it signalled.
+func reapOrphanedBuildx(w io.Writer) int {
+	procs, err := listOwnProcesses()
+	if err != nil {
+		return 0
+	}
+	orphans := orphanedBuildxProcesses(procs, os.Getpid())
+	killed := 0
+	for _, p := range orphans {
+		pgid := p.PGID
+		if pgid <= 1 {
+			pgid = p.PID
+		}
+		if err := killGroupByPGID(pgid); err != nil {
+			continue
+		}
+		killed++
+		fmt.Fprintf(w, "[buildx] reclaimed the builder store from a stranded process (pid %d: %s)\n", p.PID, p.Command)
+	}
+	return killed
+}
+
+// ensureBuildxStoreUsable returns once buildx's builder store can be entered,
+// or with an error explaining why it cannot. It never blocks indefinitely.
+//
+// The probe takes and immediately drops the same lock buildx takes, so it
+// answers "would buildx block right now" without changing anything.
+func ensureBuildxStoreUsable(ctx context.Context, w io.Writer) error {
+	path, err := buildxStoreLockPath()
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(path); err != nil {
+		// No store: buildx has never run here, so nothing can be holding it.
+		return nil
+	}
+
+	free, err := buildxStoreLockFree(path)
+	if err != nil || free {
+		// A probe that cannot run is not evidence of a problem; let the real
+		// buildx call produce the diagnostic.
+		return nil
+	}
+
+	// Held. Before waiting on it, see whether the holder is stranded work.
+	if reapOrphanedBuildx(w) > 0 {
+		if free, err := buildxStoreLockFree(path); err == nil && free {
+			return nil
+		}
+	}
+
+	// Someone may legitimately be mid-transaction; give them a bounded window.
+	fmt.Fprintln(w, "[buildx] waiting for Docker's builder store lock (another buildx command is running)...")
+	deadline := time.Now().Add(buildxStoreLockWait)
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(200 * time.Millisecond):
+		}
+		if free, err := buildxStoreLockFree(path); err == nil && free {
+			return nil
+		}
+	}
+
+	return fmt.Errorf(
+		"Docker's buildx builder store is locked by another process and did not release it within %s.\n"+
+			"Every buildx command (including this build) blocks on %s until it does.\n"+
+			"Find the holder with:  lsof %s\n"+
+			"If it is a stray `docker buildx` process, killing it releases the lock.",
+		buildxStoreLockWait, path, path)
+}
+
+// buildxStoreLockFree reports whether the store lock can be taken right now. It
+// releases the lock immediately: this is a liveness probe, not an acquisition —
+// buildx itself must be free to take it a moment later.
+func buildxStoreLockFree(path string) (bool, error) {
+	f, err := os.OpenFile(path, os.O_RDWR, 0o644)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+	locked, err := tryLockFile(f)
+	if err != nil {
+		return false, err
+	}
+	if locked {
+		_ = unlockFile(f)
+	}
+	return locked, nil
+}

--- a/go/internal/cli/commands/buildxstore_test.go
+++ b/go/internal/cli/commands/buildxstore_test.go
@@ -1,0 +1,166 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func writeBuildxStore(t *testing.T) string {
+	t.Helper()
+	cfg := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cfg, "buildx"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	lock := filepath.Join(cfg, "buildx", ".lock")
+	if err := os.WriteFile(lock, nil, 0o644); err != nil {
+		t.Fatalf("write lock: %v", err)
+	}
+	t.Setenv("DOCKER_CONFIG", cfg)
+	return lock
+}
+
+// holdLock takes the same advisory lock buildx takes. flock is per open file
+// description, so a second Open in this very process contends exactly as
+// another process would — no helper binary needed.
+func holdLock(t *testing.T, path string) (release func()) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_RDWR, 0o644)
+	if err != nil {
+		t.Fatalf("open lock: %v", err)
+	}
+	locked, err := tryLockFile(f)
+	if err != nil || !locked {
+		f.Close()
+		t.Fatalf("could not take the lock for the test: locked=%v err=%v", locked, err)
+	}
+	release = sync.OnceFunc(func() {
+		_ = unlockFile(f)
+		_ = f.Close()
+	})
+	t.Cleanup(release)
+	return release
+}
+
+func TestBuildxStoreLockPathHonoursDockerConfig(t *testing.T) {
+	want := writeBuildxStore(t)
+	got, err := buildxStoreLockPath()
+	if err != nil {
+		t.Fatalf("buildxStoreLockPath: %v", err)
+	}
+	if got != want {
+		t.Fatalf("lock path = %q, want %q", got, want)
+	}
+}
+
+func TestEnsureBuildxStoreUsableFreeLock(t *testing.T) {
+	writeBuildxStore(t)
+	var out bytes.Buffer
+	if err := ensureBuildxStoreUsable(context.Background(), &out); err != nil {
+		t.Fatalf("free lock should be usable, got %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("a free lock must be silent, got %q", out.String())
+	}
+}
+
+// buildx has never run here; there is nothing to be blocked by.
+func TestEnsureBuildxStoreUsableNoStore(t *testing.T) {
+	t.Setenv("DOCKER_CONFIG", t.TempDir())
+	if err := ensureBuildxStoreUsable(context.Background(), &bytes.Buffer{}); err != nil {
+		t.Fatalf("missing store should be usable, got %v", err)
+	}
+}
+
+// The point of the preflight: a held lock produces a bounded, explained failure
+// instead of the silent forever-block `docker buildx` gives on its own.
+func TestEnsureBuildxStoreUsableHeldLockFailsWithGuidance(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("flock semantics differ on Windows")
+	}
+	lockPath := writeBuildxStore(t)
+	holdLock(t, lockPath)
+
+	oldWait, oldList := buildxStoreLockWait, listOwnProcesses
+	buildxStoreLockWait = 150 * time.Millisecond
+	listOwnProcesses = func() ([]procInfo, error) { return nil, nil }
+	t.Cleanup(func() { buildxStoreLockWait, listOwnProcesses = oldWait, oldList })
+
+	var out bytes.Buffer
+	start := time.Now()
+	err := ensureBuildxStoreUsable(context.Background(), &out)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error while the store lock is held")
+	}
+	if elapsed > 10*time.Second {
+		t.Fatalf("waited %s; the preflight must be bounded", elapsed)
+	}
+	if !strings.Contains(err.Error(), lockPath) {
+		t.Fatalf("error must name the lock file so the user can find the holder, got %q", err)
+	}
+}
+
+func TestOrphanedBuildxProcessesSelectsOnlyStrandedBuildx(t *testing.T) {
+	self := os.Getpid()
+	procs := []procInfo{
+		{PID: 100, PPID: 1, PGID: 100, Command: "docker-buildx buildx rm wendy-mtls"},
+		{PID: 101, PPID: 1, PGID: 101, Command: "docker buildx rm wendy-mtls"},
+		// Parented to a live process: someone is still driving it.
+		{PID: 102, PPID: self, PGID: 102, Command: "docker buildx build ."},
+		// Orphaned, but nothing to do with buildx.
+		{PID: 103, PPID: 1, PGID: 103, Command: "/usr/sbin/cupsd -l"},
+		// Our own process must never be a candidate.
+		{PID: self, PPID: 1, PGID: self, Command: "wendy run --device woof.local"},
+	}
+
+	got := orphanedBuildxProcesses(procs, self)
+	var pids []int
+	for _, p := range got {
+		pids = append(pids, p.PID)
+	}
+	if len(pids) != 2 || pids[0] != 100 || pids[1] != 101 {
+		t.Fatalf("candidates = %v, want [100 101]", pids)
+	}
+}
+
+// A held lock that a reap can clear must let the build proceed, not fail.
+func TestEnsureBuildxStoreUsableReclaimsAfterReap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("flock semantics differ on Windows")
+	}
+	lockPath := writeBuildxStore(t)
+	release := holdLock(t, lockPath)
+
+	oldList, oldKill := listOwnProcesses, killGroupByPGID
+	t.Cleanup(func() { listOwnProcesses, killGroupByPGID = oldList, oldKill })
+
+	listOwnProcesses = func() ([]procInfo, error) {
+		return []procInfo{{PID: 4242, PPID: 1, PGID: 4242, Command: "docker buildx rm wendy-mtls"}}, nil
+	}
+	killed := 0
+	killGroupByPGID = func(int) error {
+		killed++
+		// Killing the (simulated) holder releases the lock.
+		release()
+		return nil
+	}
+
+	var out bytes.Buffer
+	if err := ensureBuildxStoreUsable(context.Background(), &out); err != nil {
+		t.Fatalf("expected the store to be reclaimed, got %v", err)
+	}
+	if killed != 1 {
+		t.Fatalf("killed %d groups, want 1", killed)
+	}
+	if !strings.Contains(out.String(), "buildx") {
+		t.Fatalf("reclaiming must be reported to the user, got %q", out.String())
+	}
+}

--- a/go/internal/cli/commands/buildxstore_unix.go
+++ b/go/internal/cli/commands/buildxstore_unix.go
@@ -1,0 +1,55 @@
+//go:build !windows
+
+package commands
+
+import (
+	"context"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// psListTimeout bounds the process listing. It is only ever reached on the
+// already-degraded path, and a hung `ps` must not become a second way to stall
+// a build.
+const psListTimeout = 5 * time.Second
+
+// psOwnProcesses lists this user's processes. `ps -x` (without -A) is the
+// portable spelling for "processes owned by me" on both macOS and Linux, which
+// keeps the reaper from ever considering another user's processes.
+func psOwnProcesses() ([]procInfo, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), psListTimeout)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "ps", "-xo", "pid=,ppid=,pgid=,command=").Output()
+	if err != nil {
+		return nil, err
+	}
+	var procs []procInfo
+	for line := range strings.Lines(string(out)) {
+		// pid, ppid and pgid are fixed-width numeric columns; the command is
+		// the rest of the line and may contain spaces, so split only 4 ways.
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) < 4 {
+			continue
+		}
+		pid, err1 := strconv.Atoi(fields[0])
+		ppid, err2 := strconv.Atoi(fields[1])
+		pgid, err3 := strconv.Atoi(fields[2])
+		if err1 != nil || err2 != nil || err3 != nil {
+			continue
+		}
+		command := strings.TrimSpace(strings.Join(fields[3:], " "))
+		procs = append(procs, procInfo{PID: pid, PPID: ppid, PGID: pgid, Command: command})
+	}
+	return procs, nil
+}
+
+// killProcessGroupByPGID SIGKILLs a whole process group. The group is the unit
+// that matters: a stranded `docker buildx rm` is two processes (the CLI and the
+// plugin it exec'd) and killing only one leaves the lock held.
+func killProcessGroupByPGID(pgid int) error {
+	return syscall.Kill(-pgid, syscall.SIGKILL)
+}

--- a/go/internal/cli/commands/buildxstore_windows.go
+++ b/go/internal/cli/commands/buildxstore_windows.go
@@ -1,0 +1,15 @@
+package commands
+
+import "errors"
+
+// Windows has neither the process-group semantics the reaper relies on nor the
+// stranded-plugin failure it exists for. Reporting "unsupported" makes
+// reapOrphanedBuildx a no-op, leaving the bounded wait and the actionable error
+// as the behavior there.
+func psOwnProcesses() ([]procInfo, error) {
+	return nil, errors.New("process listing is not supported on Windows")
+}
+
+func killProcessGroupByPGID(int) error {
+	return errors.New("process groups are not supported on Windows")
+}

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -1060,7 +1060,7 @@ var windowsDockerRuntimes = []dockerRuntime{
 var (
 	dockerLookPathFn    = exec.LookPath
 	dockerStatFn        = os.Stat
-	dockerVersionOKFn   = func(ctx context.Context) bool { return exec.CommandContext(ctx, "docker", "version").Run() == nil }
+	dockerVersionOKFn   = func(ctx context.Context) bool { return runDockerControl(ctx, "version") == nil }
 	dockerOpenRuntimeFn = func(ctx context.Context, appPath string) error {
 		return exec.CommandContext(ctx, "open", "-a", appPath).Run()
 	}
@@ -1272,6 +1272,12 @@ func ensureBuildxBuilder(ctx context.Context, registryAddr string, useMTLS bool,
 	if err := ensureDockerDaemon(ctx); err != nil {
 		return "", "", err
 	}
+	// Everything below enters buildx's builder store, which serializes every
+	// access behind one lock taken with no timeout. Check the store can be
+	// entered rather than issue a command that blocks on it with no output.
+	if err := ensureBuildxStoreUsable(ctx, w); err != nil {
+		return "", "", err
+	}
 	// Use separate builders for mTLS and plaintext so switching between
 	// provisioned and unprovisioned devices doesn't recreate builders.
 	const containerCertDir = "/etc/buildkit/certs"
@@ -1303,9 +1309,9 @@ func ensureBuildxBuilder(ctx context.Context, registryAddr string, useMTLS bool,
 	// the alias to the real IPv6 address.
 	if ipv6IP != "" {
 		containerName := "buildx_buildkit_" + builderName + "0"
-		hostsCmd := exec.CommandContext(ctx, "docker", "exec", containerName, "sh", "-c",
+		out, cmdErr := combinedDockerControl(ctx, "exec", containerName, "sh", "-c",
 			fmt.Sprintf("if grep -q ' wendy-registry' /etc/hosts; then sed -i 's/^[^#]* wendy-registry$/%s wendy-registry/' /etc/hosts; else printf '\\n%s wendy-registry\\n' >> /etc/hosts; fi", ipv6IP, ipv6IP))
-		if out, cmdErr := hostsCmd.CombinedOutput(); cmdErr != nil {
+		if cmdErr != nil {
 			return "", "", fmt.Errorf("adding hosts entry to builder: %s: %w", string(out), cmdErr)
 		}
 	}
@@ -1340,31 +1346,34 @@ func ensureOCIExportBuilder(ctx context.Context, w io.Writer) (string, error) {
 	// plugin load, no buildkit gRPC handshake). On any miss we fall through to the
 	// full robust path below.
 	containerName := "buildx_buildkit_" + builderName + "0"
-	if out, err := exec.CommandContext(ctx, "docker", "inspect", "-f", "{{.State.Running}}", containerName).Output(); err == nil && strings.TrimSpace(string(out)) == "true" {
+	if out, err := outputDockerControl(ctx, "inspect", "-f", "{{.State.Running}}", containerName); err == nil && strings.TrimSpace(string(out)) == "true" {
 		return builderName, nil
 	}
 
 	if err := ensureDockerDaemon(ctx); err != nil {
 		return "", err
 	}
+	// Everything below enters buildx's builder store. Check it can be entered
+	// before issuing a command that would otherwise block on it with no output.
+	if err := ensureBuildxStoreUsable(ctx, w); err != nil {
+		return "", err
+	}
 
-	exists := exec.CommandContext(ctx, "docker", "buildx", "inspect", builderName).Run() == nil
+	exists := runDockerControl(ctx, "buildx", "inspect", builderName) == nil
 	if !exists {
 		fmt.Fprintf(w, "[buildx] creating OCI-export builder %q\n", builderName)
-		cmd := exec.CommandContext(ctx, "docker", "buildx", "create",
+		if out, err := combinedDockerControl(ctx, "buildx", "create",
 			"--name", builderName,
 			"--driver", "docker-container",
 			"--driver-opt", "network=host",
-		)
-		if out, err := cmd.CombinedOutput(); err != nil {
+		); err != nil {
 			return "", fmt.Errorf("creating buildx builder %q: %s: %w", builderName, string(out), err)
 		}
 	}
 
 	// Ensure the builder is running. This is cheap when it is already up and,
 	// crucially, performs no config injection or container restart.
-	bootstrapCmd := exec.CommandContext(ctx, "docker", "buildx", "inspect", "--bootstrap", "--builder", builderName)
-	if out, err := bootstrapCmd.CombinedOutput(); err != nil {
+	if out, err := combinedDockerBootstrap(ctx, "buildx", "inspect", "--bootstrap", "--builder", builderName); err != nil {
 		return "", fmt.Errorf("bootstrapping builder %q: %s: %w", builderName, string(out), err)
 	}
 	return builderName, nil
@@ -1392,9 +1401,15 @@ func buildkitRegistryConfig(registryAddr string, plainHTTP bool, keypair *[2]str
 // removeBuilder removes a buildx builder, falling back to deleting the
 // instance file directly when `docker buildx rm` fails (e.g. because the
 // stored config contains IPv6 brackets that the host TOML parser rejects).
+//
+// The rm is deadline-bounded because failure here is not always a returned
+// error: a builder whose stored endpoint names a docker context that no longer
+// runs makes `docker buildx rm` block forever — while holding the buildx store
+// lock, which stalls every build on the machine until that process is killed.
+// Timing out and taking the fallback path is strictly better than waiting: the
+// fallback removes the same state without talking to the dead endpoint at all.
 func removeBuilder(ctx context.Context, name string) {
-	rmCmd := exec.CommandContext(ctx, "docker", "buildx", "rm", name)
-	if rmCmd.Run() == nil {
+	if runDockerControl(ctx, "buildx", "rm", name) == nil {
 		return
 	}
 	// Fallback: remove the instance file and kill the container directly.
@@ -1403,7 +1418,7 @@ func removeBuilder(ctx context.Context, name string) {
 		os.Remove(filepath.Join(home, ".docker", "buildx", "instances", name))
 		os.Remove(filepath.Join(home, ".docker", "buildx", "activity", name))
 	}
-	exec.CommandContext(ctx, "docker", "rm", "-f", "buildx_buildkit_"+name+"0").Run()
+	_ = runDockerControl(ctx, "rm", "-f", "buildx_buildkit_"+name+"0")
 }
 
 // ensurePlaintextBuilder ensures the "wendy" buildx builder exists with plain
@@ -1423,8 +1438,7 @@ func ensurePlaintextBuilder(ctx context.Context, configDir, registryAddr string,
 	appliedConfig, _ := os.ReadFile(appliedPath)
 	configChanged := string(appliedConfig) != fullConfig
 
-	cmd := exec.CommandContext(ctx, "docker", "buildx", "inspect", builderName)
-	builderExists := cmd.Run() == nil
+	builderExists := runDockerControl(ctx, "buildx", "inspect", builderName) == nil
 
 	if builderExists && configChanged {
 		removeBuilder(ctx, builderName)
@@ -1432,12 +1446,11 @@ func ensurePlaintextBuilder(ctx context.Context, configDir, registryAddr string,
 	}
 
 	if !builderExists {
-		cmd = exec.CommandContext(ctx, "docker", "buildx", "create",
+		if out, err := combinedDockerControl(ctx, "buildx", "create",
 			"--name", builderName,
 			"--driver", "docker-container",
 			"--driver-opt", "network=host",
-		)
-		if out, err := cmd.CombinedOutput(); err != nil {
+		); err != nil {
 			return "", fmt.Errorf("creating buildx builder %q: %s: %w", builderName, string(out), err)
 		}
 		configChanged = true // always inject config into a newly created builder
@@ -1450,8 +1463,8 @@ func ensurePlaintextBuilder(ctx context.Context, configDir, registryAddr string,
 
 	// Read the config currently applied inside the running container (if any).
 	var liveContainerConfig string
-	if out, err := exec.CommandContext(ctx, "docker", "exec", containerName,
-		"cat", "/etc/buildkit/buildkitd.toml").Output(); err == nil {
+	if out, err := outputDockerControl(ctx, "exec", containerName,
+		"cat", "/etc/buildkit/buildkitd.toml"); err == nil {
 		liveContainerConfig = string(out)
 	}
 
@@ -1462,8 +1475,7 @@ func ensurePlaintextBuilder(ctx context.Context, configDir, registryAddr string,
 		_ = os.WriteFile(appliedPath, []byte(fullConfig), 0o644)
 	} else {
 		// Builder exists with correct config — just ensure it's running.
-		bootstrapCmd := exec.CommandContext(ctx, "docker", "buildx", "inspect", "--bootstrap", "--builder", builderName)
-		if out, err := bootstrapCmd.CombinedOutput(); err != nil {
+		if out, err := combinedDockerBootstrap(ctx, "buildx", "inspect", "--bootstrap", "--builder", builderName); err != nil {
 			return "", fmt.Errorf("bootstrapping builder: %s: %w", string(out), err)
 		}
 	}
@@ -1536,8 +1548,7 @@ func ensureMTLSBuilder(ctx context.Context, configDir, registryAddr, containerCe
 	appliedConfig, _ := os.ReadFile(appliedPath)
 	configChanged := string(appliedConfig) != appliedState
 
-	cmd := exec.CommandContext(ctx, "docker", "buildx", "inspect", builderName)
-	builderExists := cmd.Run() == nil
+	builderExists := runDockerControl(ctx, "buildx", "inspect", builderName) == nil
 
 	if builderExists && configChanged {
 		removeBuilder(ctx, builderName)
@@ -1545,12 +1556,11 @@ func ensureMTLSBuilder(ctx context.Context, configDir, registryAddr, containerCe
 	}
 
 	if !builderExists {
-		cmd = exec.CommandContext(ctx, "docker", "buildx", "create",
+		if out, err := combinedDockerControl(ctx, "buildx", "create",
 			"--name", builderName,
 			"--driver", "docker-container",
 			"--driver-opt", "network=host",
-		)
-		if out, err := cmd.CombinedOutput(); err != nil {
+		); err != nil {
 			return "", fmt.Errorf("creating buildx builder %q: %s: %w", builderName, string(out), err)
 		}
 		configChanged = true // always inject certs and config into a newly created builder
@@ -1568,8 +1578,7 @@ func ensureMTLSBuilder(ctx context.Context, configDir, registryAddr, containerCe
 		_ = os.WriteFile(appliedPath, []byte(appliedState), 0o600)
 	} else {
 		// Builder exists with correct config — just ensure it's running.
-		bootstrapCmd := exec.CommandContext(ctx, "docker", "buildx", "inspect", "--bootstrap", "--builder", builderName)
-		if out, err := bootstrapCmd.CombinedOutput(); err != nil {
+		if out, err := combinedDockerBootstrap(ctx, "buildx", "inspect", "--bootstrap", "--builder", builderName); err != nil {
 			return "", fmt.Errorf("bootstrapping builder: %s: %w", string(out), err)
 		}
 	}
@@ -1582,8 +1591,7 @@ func ensureMTLSBuilder(ctx context.Context, configDir, registryAddr, containerCe
 // with the device registry.
 func copyCertsToBuilder(ctx context.Context, builderName, hostCertDir, containerCertDir string) error {
 	// Bootstrap the builder to ensure the container is running.
-	cmd := exec.CommandContext(ctx, "docker", "buildx", "inspect", "--bootstrap", "--builder", builderName)
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := combinedDockerBootstrap(ctx, "buildx", "inspect", "--bootstrap", "--builder", builderName); err != nil {
 		return fmt.Errorf("bootstrapping builder: %s: %w", string(out), err)
 	}
 
@@ -1591,8 +1599,7 @@ func copyCertsToBuilder(ctx context.Context, builderName, hostCertDir, container
 	containerName := "buildx_buildkit_" + builderName + "0"
 
 	// Copy cert files into the running container.
-	cmd = exec.CommandContext(ctx, "docker", "cp", hostCertDir+"/.", containerName+":"+containerCertDir)
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := combinedDockerControl(ctx, "cp", hostCertDir+"/.", containerName+":"+containerCertDir); err != nil {
 		return fmt.Errorf("docker cp certs: %s: %w", string(out), err)
 	}
 
@@ -1604,8 +1611,7 @@ func copyCertsToBuilder(ctx context.Context, builderName, hostCertDir, container
 // configuration takes effect.
 func updateBuilderConfig(ctx context.Context, builderName, config string, w io.Writer) error {
 	fmt.Fprintf(w, "[buildx] bootstrapping builder %q\n", builderName)
-	bootstrapCmd := exec.CommandContext(ctx, "docker", "buildx", "inspect", "--bootstrap", "--builder", builderName)
-	if out, err := bootstrapCmd.CombinedOutput(); err != nil {
+	if out, err := combinedDockerBootstrap(ctx, "buildx", "inspect", "--bootstrap", "--builder", builderName); err != nil {
 		return fmt.Errorf("bootstrapping builder: %s: %w", string(out), err)
 	}
 	fmt.Fprintf(w, "[buildx] bootstrap done\n")
@@ -1627,8 +1633,7 @@ func updateBuilderConfig(ctx context.Context, builderName, config string, w io.W
 	tmp.Close()
 
 	fmt.Fprintf(w, "[buildx] copying config into container %q\n", containerName)
-	cmd := exec.CommandContext(ctx, "docker", "cp", tmp.Name(), containerName+":"+containerConfigPath)
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := combinedDockerControl(ctx, "cp", tmp.Name(), containerName+":"+containerConfigPath); err != nil {
 		return fmt.Errorf("docker cp config: %s: %w", string(out), err)
 	}
 
@@ -1637,9 +1642,9 @@ func updateBuilderConfig(ctx context.Context, builderName, config string, w io.W
 	// is a macOS binary that does not exist on Linux and causes "signal: killed"
 	// errors when pulling public base images (e.g. python:3.11-slim).
 	fmt.Fprintf(w, "[buildx] injecting clean docker config into container %q\n", containerName)
-	injectCmd := exec.CommandContext(ctx, "docker", "exec", containerName,
+	out, err := combinedDockerControl(ctx, "exec", containerName,
 		"sh", "-c", `mkdir -p /root/.docker && printf '{"auths":{}}' > /root/.docker/config.json`)
-	if out, err := injectCmd.CombinedOutput(); err != nil {
+	if err != nil {
 		// Non-fatal: log the error but proceed. The credential helper may still
 		// fail for private images, but public images will work without credentials.
 		fmt.Fprintf(w, "[buildx] warning: could not inject docker config: %s\n", string(out))
@@ -1648,14 +1653,12 @@ func updateBuilderConfig(ctx context.Context, builderName, config string, w io.W
 	}
 
 	fmt.Fprintf(w, "[buildx] restarting container %q\n", containerName)
-	cmd = exec.CommandContext(ctx, "docker", "restart", containerName)
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := combinedDockerControl(ctx, "restart", containerName); err != nil {
 		return fmt.Errorf("restarting builder: %s: %w", string(out), err)
 	}
 	fmt.Fprintf(w, "[buildx] container restarted, waiting for buildkitd\n")
 
-	bootstrapAfterRestart := exec.CommandContext(ctx, "docker", "buildx", "inspect", "--bootstrap", "--builder", builderName)
-	if out, err := bootstrapAfterRestart.CombinedOutput(); err != nil {
+	if out, err := combinedDockerBootstrap(ctx, "buildx", "inspect", "--bootstrap", "--builder", builderName); err != nil {
 		return fmt.Errorf("waiting for builder after restart: %s: %w", string(out), err)
 	}
 	fmt.Fprintf(w, "[buildx] builder ready\n")
@@ -1890,7 +1893,7 @@ func buildAndPushImage(ctx context.Context, dir, registryAddr, registryImage, pl
 	var lastErr error
 	for attempt := 1; attempt <= maxBuildPushAttempts; attempt++ {
 		capture := &capturingWriter{w: streamOutput}
-		cmd := exec.CommandContext(ctx, "docker", args...)
+		cmd := dockerCommand(ctx, args...)
 		cmd.Dir = dir
 		cmd.Stdout = capture
 		cmd.Stderr = capture
@@ -3330,7 +3333,7 @@ func buildSwiftDockerImage(ctx context.Context, dir, product, arch, buildConfig 
 
 	// Build the Docker image with a sanitised name.
 	imageName := sanitizeDockerImageName(product) + ":latest"
-	dockerCmd := exec.CommandContext(ctx, "docker", "build", "-t", imageName, ".")
+	dockerCmd := dockerCommand(ctx, "build", "-t", imageName, ".")
 	dockerCmd.Dir = tmpDir
 	dockerCmd.Stdout = os.Stdout
 	dockerCmd.Stderr = os.Stderr

--- a/go/internal/cli/commands/dockerexec.go
+++ b/go/internal/cli/commands/dockerexec.go
@@ -1,0 +1,96 @@
+package commands
+
+import (
+	"context"
+	"os/exec"
+	"time"
+)
+
+// A `docker buildx ...` invocation is not one process: the docker CLI execs the
+// docker-buildx plugin as a child of its own. Killing the `docker` pid — which
+// is all exec.CommandContext does by default — leaves that plugin running, and
+// a stranded buildx plugin keeps the exclusive flock it holds on
+// <docker-config>/buildx/.lock. Every later buildx command on the machine, in
+// any wendy process, then blocks on that lock forever with no output: the
+// symptom that reads as "two parallel builds deadlocked".
+//
+// groupCommandContext puts the invocation in its own process group and kills
+// the whole group on cancellation, so the plugin is reaped along with the CLI.
+func groupCommandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, name, args...)
+	setProcessGroup(cmd)
+	cmd.Cancel = func() error { return killProcessGroup(cmd) }
+	// The killed group can still hold the write end of a pipe this process is
+	// reading (buildkit's progress stream is inherited by the plugin), and Wait
+	// blocks on those copies until they close. WaitDelay bounds that so a
+	// cancelled build cannot wedge its caller.
+	cmd.WaitDelay = dockerKillGrace
+	return cmd
+}
+
+// dockerKillGrace is how long Wait may spend draining inherited pipes after the
+// process group has been killed.
+const dockerKillGrace = 5 * time.Second
+
+// dockerControlTimeout bounds a docker/buildx *control-plane* call — inspect,
+// create, rm, cp, restart, version. Against a healthy daemon these return in
+// well under a second; against an unhealthy one they can block indefinitely,
+// because neither the docker CLI nor buildx applies a timeout of its own. The
+// case that motivated this: a builder whose stored endpoint names a docker
+// context that no longer runs (a `desktop-linux` builder on a machine since
+// moved to orbstack). `docker buildx rm` on it dials a dead daemon forever
+// while holding the builder-store lock, taking every future build with it.
+//
+// Calls with a legitimately unbounded runtime — the build itself — use
+// groupCommandContext directly and are bounded by the caller's own context.
+const dockerControlTimeout = 90 * time.Second
+
+// dockerBootstrapTimeout bounds `buildx inspect --bootstrap`, which is a
+// control-plane call that legitimately takes minutes the first time: it starts
+// the builder container, pulling the buildkit image if the machine has never
+// had one. It is still bounded, because a bootstrap against a dead endpoint
+// hangs exactly like an rm does.
+const dockerBootstrapTimeout = 10 * time.Minute
+
+// dockerCommand is a docker invocation that cannot outlive this process. Use it
+// for long-running calls (the build); the caller's context governs the deadline.
+func dockerCommand(ctx context.Context, args ...string) *exec.Cmd {
+	return groupCommandContext(ctx, "docker", args...)
+}
+
+// dockerControlCommand is dockerCommand with dockerControlTimeout applied. The
+// returned stop func releases the timer and must be called, conventionally via
+// defer, exactly as with context.WithTimeout's cancel.
+func dockerControlCommand(ctx context.Context, args ...string) (*exec.Cmd, func()) {
+	cctx, cancel := context.WithTimeout(ctx, dockerControlTimeout)
+	return dockerCommand(cctx, args...), cancel
+}
+
+// runDockerControl, outputDockerControl and combinedDockerControl are the
+// deadline-and-cleanup-managed forms of the three ways this package runs a
+// docker control call. Call sites use these rather than building a command by
+// hand so no control call can be added without a deadline.
+func runDockerControl(ctx context.Context, args ...string) error {
+	cmd, stop := dockerControlCommand(ctx, args...)
+	defer stop()
+	return cmd.Run()
+}
+
+func outputDockerControl(ctx context.Context, args ...string) ([]byte, error) {
+	cmd, stop := dockerControlCommand(ctx, args...)
+	defer stop()
+	return cmd.Output()
+}
+
+func combinedDockerControl(ctx context.Context, args ...string) ([]byte, error) {
+	cmd, stop := dockerControlCommand(ctx, args...)
+	defer stop()
+	return cmd.CombinedOutput()
+}
+
+// combinedDockerBootstrap is combinedDockerControl on the bootstrap budget.
+func combinedDockerBootstrap(ctx context.Context, args ...string) ([]byte, error) {
+	cctx, cancel := context.WithTimeout(ctx, dockerBootstrapTimeout)
+	defer cancel()
+	return dockerCommand(cctx, args...).CombinedOutput()
+}

--- a/go/internal/cli/commands/dockerexec_test.go
+++ b/go/internal/cli/commands/dockerexec_test.go
@@ -2,108 +2,9 @@ package commands
 
 import (
 	"context"
-	"fmt"
-	"os"
-	"path/filepath"
-	"runtime"
-	"strconv"
 	"strings"
-	"syscall"
 	"testing"
-	"time"
 )
-
-// waitGone polls until pid is no longer a live process, or the deadline
-// expires. Signal 0 is the portable "does this pid exist" probe.
-func waitGone(t *testing.T, pid int, within time.Duration) bool {
-	t.Helper()
-	deadline := time.Now().Add(within)
-	for time.Now().Before(deadline) {
-		if err := syscall.Kill(pid, 0); err != nil {
-			return true
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	return false
-}
-
-// A `docker buildx ...` invocation is two processes: the docker CLI and the
-// docker-buildx plugin it execs. Killing only the CLI leaves the plugin holding
-// buildx's store lock, which is the whole reason this helper exists.
-func TestGroupCommandContextKillsGrandchildren(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("process groups are POSIX-only; Windows falls back to killing the direct child")
-	}
-	dir := t.TempDir()
-	pidFile := filepath.Join(dir, "grandchild.pid")
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// The inner `sh` stands in for the buildx plugin: a grandchild that
-	// survives a kill aimed at the direct child alone.
-	script := fmt.Sprintf(`sh -c 'while true; do sleep 0.05; done' & echo $! > %q; wait`, pidFile)
-	cmd := groupCommandContext(ctx, "sh", "-c", script)
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("start: %v", err)
-	}
-
-	var grandchild int
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		b, err := os.ReadFile(pidFile)
-		if err == nil {
-			if pid, convErr := strconv.Atoi(strings.TrimSpace(string(b))); convErr == nil && pid > 0 {
-				grandchild = pid
-				break
-			}
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	if grandchild == 0 {
-		t.Fatal("grandchild never reported its pid")
-	}
-
-	cancel()
-	_ = cmd.Wait()
-
-	if !waitGone(t, grandchild, 5*time.Second) {
-		_ = syscall.Kill(grandchild, syscall.SIGKILL)
-		t.Fatalf("grandchild %d survived cancellation; it would keep holding the buildx store lock", grandchild)
-	}
-}
-
-// Wait must not block on a pipe the killed group left open. Without WaitDelay a
-// cancelled build can hang in Wait forever holding everything downstream of it.
-func TestGroupCommandContextWaitReturnsAfterCancel(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("process groups are POSIX-only")
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	cmd := groupCommandContext(ctx, "sh", "-c", `sh -c 'while true; do sleep 0.05; done' & wait`)
-	out, err := cmd.StdoutPipe()
-	if err != nil {
-		t.Fatalf("stdout pipe: %v", err)
-	}
-	defer out.Close()
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("start: %v", err)
-	}
-	cancel()
-
-	done := make(chan struct{})
-	go func() {
-		_ = cmd.Wait()
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(30 * time.Second):
-		t.Fatal("Wait did not return after cancellation")
-	}
-}
 
 func TestDockerControlCommandAppliesDeadline(t *testing.T) {
 	cmd, stop := dockerControlCommand(context.Background(), "buildx", "rm", "wendy-mtls")
@@ -120,25 +21,5 @@ func TestDockerControlCommandAppliesDeadline(t *testing.T) {
 		if cmd.Args[i] != want[i] {
 			t.Fatalf("args = %v, want %v", cmd.Args, want)
 		}
-	}
-}
-
-// A control-plane call must fail on its own deadline rather than block
-// forever the way `docker buildx rm` against a dead docker context does.
-func TestControlCommandTimesOutInsteadOfHanging(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("process groups are POSIX-only")
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-	defer cancel()
-
-	cmd := groupCommandContext(ctx, "sh", "-c", "sleep 120")
-	start := time.Now()
-	err := cmd.Run()
-	if err == nil {
-		t.Fatal("expected the command to be killed by its deadline")
-	}
-	if elapsed := time.Since(start); elapsed > 30*time.Second {
-		t.Fatalf("command took %s to die; the deadline is not being enforced", elapsed)
 	}
 }

--- a/go/internal/cli/commands/dockerexec_test.go
+++ b/go/internal/cli/commands/dockerexec_test.go
@@ -1,0 +1,144 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// waitGone polls until pid is no longer a live process, or the deadline
+// expires. Signal 0 is the portable "does this pid exist" probe.
+func waitGone(t *testing.T, pid int, within time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pid, 0); err != nil {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}
+
+// A `docker buildx ...` invocation is two processes: the docker CLI and the
+// docker-buildx plugin it execs. Killing only the CLI leaves the plugin holding
+// buildx's store lock, which is the whole reason this helper exists.
+func TestGroupCommandContextKillsGrandchildren(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process groups are POSIX-only; Windows falls back to killing the direct child")
+	}
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "grandchild.pid")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// The inner `sh` stands in for the buildx plugin: a grandchild that
+	// survives a kill aimed at the direct child alone.
+	script := fmt.Sprintf(`sh -c 'while true; do sleep 0.05; done' & echo $! > %q; wait`, pidFile)
+	cmd := groupCommandContext(ctx, "sh", "-c", script)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	var grandchild int
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		b, err := os.ReadFile(pidFile)
+		if err == nil {
+			if pid, convErr := strconv.Atoi(strings.TrimSpace(string(b))); convErr == nil && pid > 0 {
+				grandchild = pid
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if grandchild == 0 {
+		t.Fatal("grandchild never reported its pid")
+	}
+
+	cancel()
+	_ = cmd.Wait()
+
+	if !waitGone(t, grandchild, 5*time.Second) {
+		_ = syscall.Kill(grandchild, syscall.SIGKILL)
+		t.Fatalf("grandchild %d survived cancellation; it would keep holding the buildx store lock", grandchild)
+	}
+}
+
+// Wait must not block on a pipe the killed group left open. Without WaitDelay a
+// cancelled build can hang in Wait forever holding everything downstream of it.
+func TestGroupCommandContextWaitReturnsAfterCancel(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process groups are POSIX-only")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := groupCommandContext(ctx, "sh", "-c", `sh -c 'while true; do sleep 0.05; done' & wait`)
+	out, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	defer out.Close()
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("Wait did not return after cancellation")
+	}
+}
+
+func TestDockerControlCommandAppliesDeadline(t *testing.T) {
+	cmd, stop := dockerControlCommand(context.Background(), "buildx", "rm", "wendy-mtls")
+	defer stop()
+
+	if got := cmd.Args[0]; !strings.HasSuffix(got, "docker") {
+		t.Fatalf("expected a docker invocation, got %q", got)
+	}
+	want := []string{"docker", "buildx", "rm", "wendy-mtls"}
+	if len(cmd.Args) != len(want) {
+		t.Fatalf("args = %v, want %v", cmd.Args, want)
+	}
+	for i := 1; i < len(want); i++ {
+		if cmd.Args[i] != want[i] {
+			t.Fatalf("args = %v, want %v", cmd.Args, want)
+		}
+	}
+}
+
+// A control-plane call must fail on its own deadline rather than block
+// forever the way `docker buildx rm` against a dead docker context does.
+func TestControlCommandTimesOutInsteadOfHanging(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process groups are POSIX-only")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	cmd := groupCommandContext(ctx, "sh", "-c", "sleep 120")
+	start := time.Now()
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected the command to be killed by its deadline")
+	}
+	if elapsed := time.Since(start); elapsed > 30*time.Second {
+		t.Fatalf("command took %s to die; the deadline is not being enforced", elapsed)
+	}
+}

--- a/go/internal/cli/commands/dockerexec_unix.go
+++ b/go/internal/cli/commands/dockerexec_unix.go
@@ -1,0 +1,32 @@
+//go:build !windows
+
+package commands
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setProcessGroup puts the child in a new process group of its own, so the
+// plugin processes it execs share a group id we can signal as a unit.
+func setProcessGroup(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+// killProcessGroup SIGKILLs the child's whole process group. A negative pid is
+// what makes this reach the docker-buildx plugin the docker CLI exec'd; killing
+// cmd.Process alone is exactly the gap that strands lock holders. It falls back
+// to the single process when the group signal fails (the child may have died
+// between Start and here, leaving nothing to signal).
+func killProcessGroup(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+		return cmd.Process.Kill()
+	}
+	return nil
+}

--- a/go/internal/cli/commands/dockerexec_unix_test.go
+++ b/go/internal/cli/commands/dockerexec_unix_test.go
@@ -1,0 +1,126 @@
+//go:build !windows
+
+// The reaper these tests exercise is POSIX-only: it relies on process groups
+// and on signalling a negative pid, neither of which exists on Windows, where
+// killProcessGroup deliberately falls back to killing the direct child. The
+// tests live behind a build tag rather than a runtime skip because
+// syscall.Kill is not defined on Windows at all, so a runtime skip would still
+// fail to compile there — and CI cross-compiles this package's test binary for
+// windows/amd64.
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// waitGone polls until pid is no longer a live process, or the deadline
+// expires. Signal 0 is the portable "does this pid exist" probe.
+func waitGone(t *testing.T, pid int, within time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pid, 0); err != nil {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}
+
+// A `docker buildx ...` invocation is two processes: the docker CLI and the
+// docker-buildx plugin it execs. Killing only the CLI leaves the plugin holding
+// buildx's store lock, which is the whole reason this helper exists.
+func TestGroupCommandContextKillsGrandchildren(t *testing.T) {
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "grandchild.pid")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// The inner `sh` stands in for the buildx plugin: a grandchild that
+	// survives a kill aimed at the direct child alone.
+	script := fmt.Sprintf(`sh -c 'while true; do sleep 0.05; done' & echo $! > %q; wait`, pidFile)
+	cmd := groupCommandContext(ctx, "sh", "-c", script)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	var grandchild int
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		b, err := os.ReadFile(pidFile)
+		if err == nil {
+			if pid, convErr := strconv.Atoi(strings.TrimSpace(string(b))); convErr == nil && pid > 0 {
+				grandchild = pid
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if grandchild == 0 {
+		t.Fatal("grandchild never reported its pid")
+	}
+
+	cancel()
+	_ = cmd.Wait()
+
+	if !waitGone(t, grandchild, 5*time.Second) {
+		_ = syscall.Kill(grandchild, syscall.SIGKILL)
+		t.Fatalf("grandchild %d survived cancellation; it would keep holding the buildx store lock", grandchild)
+	}
+}
+
+// Wait must not block on a pipe the killed group left open. Without WaitDelay a
+// cancelled build can hang in Wait forever holding everything downstream of it.
+func TestGroupCommandContextWaitReturnsAfterCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := groupCommandContext(ctx, "sh", "-c", `sh -c 'while true; do sleep 0.05; done' & wait`)
+	out, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	defer out.Close()
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("Wait did not return after cancellation")
+	}
+}
+
+// A control-plane call must fail on its own deadline rather than block
+// forever the way `docker buildx rm` against a dead docker context does.
+func TestControlCommandTimesOutInsteadOfHanging(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	cmd := groupCommandContext(ctx, "sh", "-c", "sleep 120")
+	start := time.Now()
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected the command to be killed by its deadline")
+	}
+	if elapsed := time.Since(start); elapsed > 30*time.Second {
+		t.Fatalf("command took %s to die; the deadline is not being enforced", elapsed)
+	}
+}

--- a/go/internal/cli/commands/dockerexec_windows.go
+++ b/go/internal/cli/commands/dockerexec_windows.go
@@ -1,0 +1,16 @@
+package commands
+
+import "os/exec"
+
+// Windows has no process groups in the POSIX sense, and docker's plugin model
+// there does not produce the stranded-grandchild case this guards against on
+// Unix. Killing the child directly is the same behavior exec.CommandContext
+// would have applied on its own.
+func setProcessGroup(*exec.Cmd) {}
+
+func killProcessGroup(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	return cmd.Process.Kill()
+}

--- a/go/internal/cli/commands/ocilayers.go
+++ b/go/internal/cli/commands/ocilayers.go
@@ -1039,7 +1039,7 @@ func buildImageWithBuildxOCIExport(ctx context.Context, cwd, dockerfile, platfor
 	submark("  build: setup (cache/env)")
 
 	fmt.Fprintf(stderr, "[buildx] starting OCI export: docker %s\n", strings.Join(redactBuildArgsForLog(args), " "))
-	cmd := exec.CommandContext(ctx, "docker", args...)
+	cmd := dockerCommand(ctx, args...)
 	cmd.Dir = cwd
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr


### PR DESCRIPTION
## The bug

Two parallel `wendy run`s deadlock with no output at all — neither build makes progress, and nothing is printed.

The cause is in neither build. buildx serializes **every** access to its builder store — `build`, `inspect`, `create`, `rm`, `ls` — behind one exclusive flock on `<docker-config>/buildx/.lock`, taken with no timeout and no output. So a single wedged buildx process anywhere on the machine silently blocks every build in every wendy process, for as long as it lives.

How one gets wedged: a builder whose stored endpoint names a docker context that no longer runs — a `desktop-linux` builder on a machine since moved to orbstack — makes `docker buildx rm` dial a daemon that will never answer, holding the store lock throughout. `removeBuilder` ran that rm with no deadline. And `docker buildx …` is *two* processes (the CLI plus the docker-buildx plugin it execs), so `exec.CommandContext`'s kill — which targets only the direct child — could not reap the plugin. When the wendy that started it exited, the plugin was left orphaned on init, holding the lock forever.

Observed on a dev machine: an orphaned `buildx rm` at 15 minutes, with `buildx build`, `buildx inspect` and `buildx ls` all stacked behind it. `docker ps` and `docker version` returned instantly throughout — the daemon was never the problem.

## The fix

Three layers, so this cannot recur:

- **No orphans.** Every docker invocation runs in its own process group and is killed as a group, so cancelling a build reaps the plugin too. `WaitDelay` keeps a cancelled build from wedging its caller on an inherited pipe.
- **Deadlines on every control-plane call** (inspect, create, rm, cp, restart, version; bootstrap gets a longer budget since it may pull the buildkit image). `removeBuilder` timing out into its *existing* fallback — delete the instance file, force-remove the container — is strictly better than waiting, because the fallback never talks to the dead endpoint at all.
- **Preflight store probe.** Before entering the store, check whether it can be entered. Turns a silent forever-block into either a reclaim or a bounded error naming the lock file and how to find the holder. It reclaims **only** from processes that are provably stranded work: a buildx command whose parent has exited. A buildx process with a live parent is somebody's build and is never touched.

## Verification

- Confirmed against a live build that buildx holds the store lock only for short transactions, **not** for a build's duration — so the preflight cannot false-positive on a legitimate concurrent build. This was the main design risk.
- `go test ./internal/cli/commands` passes (full package, 17s); `gofmt` and `go vet` clean; `git diff --check` clean.
- New tests: grandchild reaping on cancel, `Wait` returning after cancel, deadline enforcement, the reclaim-vs-leave-alone policy, and the bounded-error path.

Windows keeps its existing behavior — it has neither the process-group semantics the reaper needs nor the stranded-plugin failure mode; it gets the bounded wait and the actionable error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bc2et8saTHasGjMv2FSaTv