### PR TITLE
fix(run): reuse chunk-diff's built image for the registry-push fallback

### DIFF
--- a/go/internal/cli/commands/ocipush.go
+++ b/go/internal/cli/commands/ocipush.go
@@ -1,0 +1,163 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+// ociLayoutManifestForPlatform opens dir as an OCI image layout and returns
+// the v1.Image for the manifest pickOCIDescriptor would choose for platform —
+// the newest manifest matching os/arch, skipping buildx's unknown/unknown
+// attestation entries. Matching that selection exactly matters: it must be
+// the same manifest deployByChunkDiff just read and diffed against the
+// device (readOCILayoutDirLayers uses the identical pickOCIDescriptor call),
+// or a registry-push fallback that reuses this layout could push a different
+// image than the one the user just saw diffed.
+func ociLayoutManifestForPlatform(dir, platform string) (v1.Image, error) {
+	idx, err := layout.ImageIndexFromPath(dir)
+	if err != nil {
+		return nil, fmt.Errorf("opening OCI layout %s: %w", dir, err)
+	}
+	im, err := idx.IndexManifest()
+	if err != nil {
+		return nil, fmt.Errorf("reading OCI layout index: %w", err)
+	}
+
+	descs := make([]ociDescriptor, len(im.Manifests))
+	for i, m := range im.Manifests {
+		d := ociDescriptor{MediaType: string(m.MediaType), Digest: m.Digest.String()}
+		if m.Platform != nil {
+			d.Platform = &struct {
+				Architecture string `json:"architecture"`
+				OS           string `json:"os"`
+			}{Architecture: m.Platform.Architecture, OS: m.Platform.OS}
+		}
+		descs[i] = d
+	}
+
+	wantOS, wantArch := parseOCIPlatform(platform)
+	chosen := pickOCIDescriptor(descs, wantOS, wantArch)
+	if chosen == nil {
+		return nil, fmt.Errorf("no image manifest for platform %s in OCI layout %s", platform, dir)
+	}
+	hash, err := v1.NewHash(chosen.Digest)
+	if err != nil {
+		return nil, fmt.Errorf("invalid manifest digest %q: %w", chosen.Digest, err)
+	}
+	img, err := idx.Image(hash)
+	if err != nil {
+		return nil, fmt.Errorf("reading image %s from OCI layout: %w", hash, err)
+	}
+	return img, nil
+}
+
+// registryPushTransport builds the http.RoundTripper pushOCILayoutToRegistry
+// uses to reach the device registry at registryAddr, mirroring
+// buildkitRegistryConfig's per-mode posture: plain HTTP for an
+// unprovisioned device, or an mTLS handshake for a provisioned one.
+//
+// The mTLS case deliberately does NOT construct its own tls.Config — it
+// reuses this package's existing tlsClientDialer (docker.go), the same
+// helper resolveRegistryForSwiftAgent's cloud-tunnel path uses, so the
+// device registry's certificate gets the exact same Wendy-CA chain
+// validation (wendyRegistryServerVerifier) as every other mTLS path in this
+// CLI, instead of a second, independently-reviewed TLS trust decision living
+// here. insecureHTTP tells the caller to parse the registry reference with
+// name.Insecure (plain http://, no TLS at all) rather than use this
+// transport.
+func registryPushTransport(registryAddr string, useMTLS bool) (transport http.RoundTripper, insecureHTTP bool, err error) {
+	if !useMTLS {
+		return http.DefaultTransport, true, nil
+	}
+
+	certInfo := loadCLICert()
+	if certInfo == nil || certInfo.PemCertificate == "" || !certInfo.HasPrivateKey() {
+		return nil, false, fmt.Errorf("mTLS connection but no CLI certificates available")
+	}
+	keyPEM, err := certInfo.PrivateKeyPEM()
+	if err != nil {
+		return nil, false, fmt.Errorf("loading client key: %w", err)
+	}
+
+	rawDial := func(dialCtx context.Context) (net.Conn, error) {
+		var d net.Dialer
+		return d.DialContext(dialCtx, "tcp", registryAddr)
+	}
+	tlsDial, err := tlsClientDialer(certInfo.PemCertificate, keyPEM, certInfo.PemCertificateChain, rawDial)
+	if err != nil {
+		return nil, false, fmt.Errorf("preparing mTLS dialer for device registry: %w", err)
+	}
+
+	return &http.Transport{
+		DialTLSContext: func(dialCtx context.Context, _, _ string) (net.Conn, error) {
+			return tlsDial(dialCtx)
+		},
+	}, false, nil
+}
+
+// pushOCILayoutToRegistry pushes the manifest ociLayoutManifestForPlatform
+// selects straight to registryAddr/repo:latest using go-containerregistry,
+// without invoking docker or buildx. It exists so the registry-push fallback
+// can reuse an OCI-layout image the chunk-diff deploy already built instead
+// of re-running an entire buildx build a second time: buildx itself can't
+// share the result between the two call sites because they use different
+// output types ("type=oci" for the layout export vs "type=image,push=true"
+// for a registry push), but the underlying image content is identical given
+// the same Dockerfile, build-args, and platform — so a raw registry push of
+// the already-built manifest is equivalent to rebuilding and pushing it,
+// without paying for the rebuild.
+func pushOCILayoutToRegistry(ctx context.Context, layoutDir, platform, registryAddr, repo string, useMTLS bool) error {
+	img, err := ociLayoutManifestForPlatform(layoutDir, platform)
+	if err != nil {
+		return err
+	}
+
+	transport, insecureHTTP, err := registryPushTransport(registryAddr, useMTLS)
+	if err != nil {
+		return err
+	}
+
+	var nameOpts []name.Option
+	if insecureHTTP {
+		nameOpts = append(nameOpts, name.Insecure)
+	}
+	ref, err := name.ParseReference(fmt.Sprintf("%s/%s:latest", registryAddr, repo), nameOpts...)
+	if err != nil {
+		return fmt.Errorf("parsing registry reference: %w", err)
+	}
+
+	// Retry transient registry/push failures for the same reason
+	// buildAndPushImage does (WDY-1690): images push to the device registry
+	// through one shared tunnel that can briefly collapse under concurrent
+	// load, surfacing as timeouts/connection resets rather than a genuine
+	// push failure.
+	var lastErr error
+	for attempt := 1; attempt <= maxBuildPushAttempts; attempt++ {
+		lastErr = remote.Write(ref, img,
+			remote.WithContext(ctx),
+			remote.WithTransport(transport),
+			remote.WithAuth(authn.Anonymous),
+		)
+		if lastErr == nil {
+			return nil
+		}
+		if !shouldRetryPush(ctx.Err(), attempt, lastErr.Error(), nil) {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("pushing OCI layout to registry: %w", lastErr)
+		case <-time.After(buildPushRetryBackoff(attempt)):
+		}
+	}
+	return fmt.Errorf("pushing OCI layout to registry: %w", lastErr)
+}

--- a/go/internal/cli/commands/ocipush_test.go
+++ b/go/internal/cli/commands/ocipush_test.go
@@ -1,0 +1,138 @@
+package commands
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+// TestOciLayoutManifestForPlatform_PicksNewestForPlatform verifies
+// ociLayoutManifestForPlatform selects the SAME manifest pickOCIDescriptor
+// would (last entry matching the requested platform, skipping the
+// unknown/unknown attestation entry) — it must never disagree with the
+// chunk-diff read path (readOCILayoutDirLayers) about which manifest is "the
+// image", or a registry-push fallback could push different content than what
+// was just diffed against the device.
+func TestOciLayoutManifestForPlatform_PicksNewestForPlatform(t *testing.T) {
+	dir := t.TempDir()
+
+	oldManifest, oldEntries := imageManifestBytes(t, "arm64", []byte("old layer"))
+	newManifest, newEntries := imageManifestBytes(t, "arm64", []byte("new layer"))
+	for name, data := range oldEntries {
+		writeOCILayoutDir(t, dir, map[string][]byte{name: data})
+	}
+	for name, data := range newEntries {
+		writeOCILayoutDir(t, dir, map[string][]byte{name: data})
+	}
+	writeOCILayoutDir(t, dir, map[string][]byte{"oci-layout": []byte(`{"imageLayoutVersion":"1.0.0"}`)})
+
+	oldDigest := "sha256:" + sha256Hex(oldManifest)
+	newDigest := "sha256:" + sha256Hex(newManifest)
+	oldEntry := `{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"` + oldDigest + `","size":` + strconv.Itoa(len(oldManifest)) + `,"platform":{"architecture":"arm64","os":"linux"}}`
+	newEntry := `{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"` + newDigest + `","size":` + strconv.Itoa(len(newManifest)) + `,"platform":{"architecture":"arm64","os":"linux"}}`
+	writeLayoutIndex(t, dir, oldEntry, newEntry)
+
+	img, err := ociLayoutManifestForPlatform(dir, "linux/arm64")
+	if err != nil {
+		t.Fatalf("ociLayoutManifestForPlatform: %v", err)
+	}
+	gotDigest, err := img.Digest()
+	if err != nil {
+		t.Fatalf("img.Digest: %v", err)
+	}
+	if gotDigest.String() != newDigest {
+		t.Fatalf("got manifest %s, want the newest (last) entry %s", gotDigest.String(), newDigest)
+	}
+}
+
+// TestOciLayoutManifestForPlatform_NoDeployableManifest verifies a layout
+// containing only a buildx attestation manifest (platform "unknown/unknown")
+// is correctly reported as having no deployable image, matching
+// pickOCIDescriptor's own "never a deployable image" rule for that platform.
+func TestOciLayoutManifestForPlatform_NoDeployableManifest(t *testing.T) {
+	dir := t.TempDir()
+	digest := writeBlob(t, dir, []byte(`{"schemaVersion":2}`))
+	entry := `{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"` + digest + `","size":1,"platform":{"architecture":"unknown","os":"unknown"}}`
+	writeLayoutIndex(t, dir, entry)
+	writeOCILayoutDir(t, dir, map[string][]byte{"oci-layout": []byte(`{"imageLayoutVersion":"1.0.0"}`)})
+
+	if _, err := ociLayoutManifestForPlatform(dir, "linux/arm64"); err == nil {
+		t.Fatal("want an error for a layout with only an attestation manifest, got nil")
+	}
+}
+
+// TestRegistryPushWouldUseDocker pins registryPushWouldUseDocker's precedence
+// against the same builder-selection order buildAndPushImageForAgent applies
+// (explicit --builder wins outright; otherwise Docker unless the macOS Apple
+// Container auto-attempt would run first) — this is what gates whether the
+// chunk-diff deploy's OCI layout is safe to reuse for the registry-push
+// fallback (it was only ever built with Docker/buildx).
+func TestRegistryPushWouldUseDocker(t *testing.T) {
+	if !registryPushWouldUseDocker("docker") {
+		t.Error(`registryPushWouldUseDocker("docker") = false, want true`)
+	}
+	if registryPushWouldUseDocker("apple-container") {
+		t.Error(`registryPushWouldUseDocker("apple-container") = true, want false`)
+	}
+	if registryPushWouldUseDocker("not-a-real-builder") {
+		t.Error(`registryPushWouldUseDocker("not-a-real-builder") = true, want false (invalid builder)`)
+	}
+	// The empty (default) builder's outcome is host-dependent — it mirrors
+	// buildAndPushImageForAgent's own precedence exactly, so assert against
+	// that same helper rather than a fixed boolean.
+	if got, want := registryPushWouldUseDocker(""), !shouldAutoAttemptAppleContainerBuilder(); got != want {
+		t.Errorf(`registryPushWouldUseDocker("") = %v, want %v`, got, want)
+	}
+}
+
+// TestPushOCILayoutToRegistry_PlaintextRoundTrip pushes a locally-built OCI
+// layout directory straight to an in-memory registry via
+// pushOCILayoutToRegistry (no docker/buildx invoked) and fetches the result
+// back to confirm it landed as the exact same manifest — this is the
+// mechanism the registry-push fallback uses to skip a second, redundant
+// buildx build when the chunk-diff deploy already built this image.
+func TestPushOCILayoutToRegistry_PlaintextRoundTrip(t *testing.T) {
+	srv := httptest.NewServer(registry.New())
+	defer srv.Close()
+	registryAddr := strings.TrimPrefix(srv.URL, "http://")
+
+	dir := t.TempDir()
+	layerData := []byte("wendy chunk-diff reuse test layer")
+	entries := minimalOCILayoutEntries(t, layerData, "application/vnd.oci.image.layer.v1.tar", layerData)
+	writeOCILayoutDir(t, dir, entries)
+
+	img, err := ociLayoutManifestForPlatform(dir, "linux/amd64")
+	if err != nil {
+		t.Fatalf("ociLayoutManifestForPlatform: %v", err)
+	}
+	wantDigest, err := img.Digest()
+	if err != nil {
+		t.Fatalf("img.Digest: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := pushOCILayoutToRegistry(ctx, dir, "linux/amd64", registryAddr, "wendy/reuse-test", false); err != nil {
+		t.Fatalf("pushOCILayoutToRegistry: %v", err)
+	}
+
+	ref, err := name.ParseReference(registryAddr+"/wendy/reuse-test:latest", name.Insecure)
+	if err != nil {
+		t.Fatalf("name.ParseReference: %v", err)
+	}
+	pulled, err := remote.Get(ref, remote.WithTransport(http.DefaultTransport))
+	if err != nil {
+		t.Fatalf("remote.Get after push: %v", err)
+	}
+	if pulled.Digest.String() != wantDigest.String() {
+		t.Fatalf("pushed manifest digest = %s, want %s", pulled.Digest.String(), wantDigest.String())
+	}
+}

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -1631,8 +1631,11 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 	//
 	// --chunking gates this path: "off" skips it entirely (registry push only),
 	// while "force" uses it with no registry-push fallback on failure.
+	var ociHint *ociReuseHint
 	if !isDarwinAgent && !opts.deploy && opts.chunking != chunkingOff {
-		if diffIDs, err := deployByChunkDiff(ctx, conn, cwd, appCfg, platform, opts.dockerfile, buildArgs, deployEnv, opts); err == nil {
+		diffIDs, hint, err := deployByChunkDiff(ctx, conn, cwd, appCfg, platform, opts.dockerfile, buildArgs, deployEnv, opts)
+		ociHint = hint
+		if err == nil {
 			if hashErr == nil {
 				// Record the layer diff IDs we deployed so the next run's fast path
 				// can verify the device still holds this content before skipping the
@@ -1677,18 +1680,44 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 	// Build and push the Docker image directly to the device's registry.
 	regPort := registryPort(agentOS)
 	repo := strings.ToLower(appCfg.AppID)
-	// Single-service build: no concurrency, so keep the shared local cache dir
-	// (empty cache key) for cross-run cache reuse.
-	buildTitle := fmt.Sprintf("Building and pushing image for %s...", tui.Value(platform))
-	if err := runBuildWithProgress(ctx, buildTitle, dumpRawUnlessRegistryUnavailable, func(stream, logw io.Writer) error {
-		return buildAndPushImageForAgent(ctx, conn, regPort, agentOS, opts.builder, cwd, repo, platform, opts.dockerfile, buildArgs, "", stream, logw)
-	}); err != nil {
-		if isRegistryUnavailable(err) {
-			// Return the friendly error bare (matching the Swift path above) —
-			// the "building and pushing image" prefix adds nothing to it.
-			return err
+
+	// The chunk-diff attempt above may have already built this exact image
+	// (same Dockerfile, build-args, and platform) to a local OCI layout
+	// directory before failing for a reason unrelated to the build itself
+	// (e.g. the device not supporting chunk-diff). Reuse that content — a
+	// direct registry push, no buildx involved — instead of paying for a
+	// second full build of identical content. This is what used to show up
+	// as a second "Building and pushing image..." buildx run that re-did
+	// everything the first build already did, including any non-cacheable
+	// steps (e.g. a Swift compile) that BuildKit's own layer cache can't
+	// carry across the two builds' separate builder instances. Purely an
+	// optimization: any failure here (stale layout, registry unreachable,
+	// unsupported builder combination, ...) falls straight through to the
+	// normal rebuild below exactly as if this block were absent.
+	pushed := false
+	if ociHint != nil && registryPushWouldUseDocker(opts.builder) {
+		if err := tryPushExistingOCILayout(ctx, conn, regPort, ociHint, repo, conn.IsMTLS); err == nil {
+			cliSuccess("Reused already-built image for the registry push (skipped a redundant rebuild)")
+			pushed = true
+		} else if opts.debug {
+			cliLogln("Reusing the already-built image failed (%v); rebuilding instead.", err)
 		}
-		return fmt.Errorf("building and pushing image: %w", err)
+	}
+
+	if !pushed {
+		// Single-service build: no concurrency, so keep the shared local cache dir
+		// (empty cache key) for cross-run cache reuse.
+		buildTitle := fmt.Sprintf("Building and pushing image for %s...", tui.Value(platform))
+		if err := runBuildWithProgress(ctx, buildTitle, dumpRawUnlessRegistryUnavailable, func(stream, logw io.Writer) error {
+			return buildAndPushImageForAgent(ctx, conn, regPort, agentOS, opts.builder, cwd, repo, platform, opts.dockerfile, buildArgs, "", stream, logw)
+		}); err != nil {
+			if isRegistryUnavailable(err) {
+				// Return the friendly error bare (matching the Swift path above) —
+				// the "building and pushing image" prefix adds nothing to it.
+				return err
+			}
+			return fmt.Errorf("building and pushing image: %w", err)
+		}
 	}
 
 	// The agent pulls from localhost:<regPort>.
@@ -1710,6 +1739,50 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 	}
 
 	return startAndStreamContainer(ctx, conn, appCfg, createReq, opts)
+}
+
+// registryPushWouldUseDocker reports whether the registry-push fallback in
+// runWithAgent would end up building with the Docker builder — mirroring,
+// without any side effects, the precedence buildAndPushImageForAgent applies:
+// an explicit --builder wins outright, otherwise the macOS Apple Container
+// auto-attempt (shouldAutoAttemptAppleContainerBuilder) is tried before
+// Docker. The chunk-diff deploy's reusable OCI layout (ociReuseHint) was only
+// ever built with Docker/buildx (chunkExportPlan), so reusing it for the
+// fallback is only valid when this also resolves to Docker — otherwise the
+// fallback may legitimately want a different builder and reuse must not
+// short-circuit that choice.
+func registryPushWouldUseDocker(builder string) bool {
+	if imageBuilderWasExplicit(builder) {
+		normalized, err := normalizeImageBuilder(builder)
+		return err == nil && normalized == imageBuilderDocker
+	}
+	return !shouldAutoAttemptAppleContainerBuilder()
+}
+
+// tryPushExistingOCILayout pushes the image hint already points at straight
+// to the device's registry, without invoking docker/buildx again. It is the
+// registry-push fallback's fast path when the preceding chunk-diff attempt
+// already built this exact image (see ociReuseHint's doc comment for why the
+// content is guaranteed identical). Any error here should be treated as
+// "reuse didn't work" by the caller, which then falls back to the normal
+// rebuild — this function never leaves the deploy worse off than skipping it
+// entirely would have.
+func tryPushExistingOCILayout(ctx context.Context, conn *grpcclient.AgentConnection, regPort int, hint *ociReuseHint, repo string, useMTLS bool) error {
+	registryAddr, cleanup, dialErr, err := resolveRegistryForAgent(ctx, conn, regPort)
+	if err != nil {
+		return fmt.Errorf("resolving device registry: %w", err)
+	}
+	defer cleanup()
+
+	if err := pushOCILayoutToRegistry(ctx, hint.layoutDir, hint.platform, registryAddr, repo, useMTLS); err != nil {
+		if dialErr != nil {
+			if de := dialErr(); isDialRefused(de) {
+				return fmt.Errorf("device registry unreachable: %w", de)
+			}
+		}
+		return err
+	}
+	return nil
 }
 
 // validateEnvFlag checks --env entries are KEY=VALUE with a POSIX-portable
@@ -2314,14 +2387,32 @@ func shouldDumpChunkDiffBuildLog(chunking string) func(error) bool {
 // instead of requiring the caller to set it by hand.
 const imageSignaturePathEnv = "WENDY_IMAGE_SIGNATURE_PATH"
 
+// ociReuseHint carries the on-disk location of the OCI-layout image the
+// chunk-diff deploy just built, so a registry-push fallback triggered by a
+// LATER failure (e.g. the device rejecting chunk-diff entirely) can push that
+// exact content straight to the registry via pushOCILayoutToRegistry instead
+// of re-running buildx from scratch — the two builds are otherwise given the
+// same Dockerfile, build-args, and platform, so the content would be
+// identical anyway. Non-nil only when the "dir" export plan was used (see
+// chunkExportPlan) and the build succeeded and was read back successfully:
+// nil for the "tar" export plan (whose temp directory is removed before the
+// caller could reuse it) and whenever the build/read itself failed.
+type ociReuseHint struct {
+	layoutDir string
+	platform  string
+}
+
 // deployByChunkDiff builds the image to a local OCI layout tar, diffs the
 // layers against what the device already has via content-defined chunking, and
 // calls RunContainer with the resulting layer headers. On success it returns the
 // uncompressed layer diff IDs it deployed, so the caller can record them in the
 // deploy fingerprint and later verify the device still holds this content before
-// skipping a rebuild (WDY-1824).
-func deployByChunkDiff(ctx context.Context, conn *grpcclient.AgentConnection, cwd string, appCfg *appconfig.AppConfig, platform, dockerfile string, buildArgs map[string]string, deployEnv []string, opts runOptions) ([]string, error) {
+// skipping a rebuild (WDY-1824). It also returns an *ociReuseHint (see its doc
+// comment) so a caller that has to fall back to a registry push after a
+// failure here can reuse the image already built rather than rebuilding it.
+func deployByChunkDiff(ctx context.Context, conn *grpcclient.AgentConnection, cwd string, appCfg *appconfig.AppConfig, platform, dockerfile string, buildArgs map[string]string, deployEnv []string, opts runOptions) ([]string, *ociReuseHint, error) {
 	mark := phaseTimer()
+	var hint *ociReuseHint
 
 	buildTitle := fmt.Sprintf("Building image (OCI layout) for %s...", tui.Value(platform))
 	runBuild := func(build func(stream, logw io.Writer) error) error {
@@ -2360,7 +2451,7 @@ func deployByChunkDiff(ctx context.Context, conn *grpcclient.AgentConnection, cw
 	if exportMode == "dir" {
 		releaseLayout, err := lockOCILayoutDir(ctx, layoutDir)
 		if err != nil {
-			return nil, err
+			return nil, hint, err
 		}
 		defer releaseLayout()
 		build := func(stream, logw io.Writer) error {
@@ -2394,7 +2485,7 @@ func deployByChunkDiff(ctx context.Context, conn *grpcclient.AgentConnection, cw
 			mark("build (native layers)")
 		} else {
 			if err := runBuild(build); err != nil {
-				return nil, err
+				return nil, hint, err
 			}
 			mark("build (oci export)")
 		}
@@ -2406,14 +2497,14 @@ func deployByChunkDiff(ctx context.Context, conn *grpcclient.AgentConnection, cw
 			// removes state.json, so the native path stays off until re-adoption.
 			cliLogln("OCI layout cache unreadable (%v); rebuilding it from scratch", err)
 			if rmErr := os.RemoveAll(layoutDir); rmErr != nil {
-				return nil, fmt.Errorf("resetting OCI layout cache %s: %w", layoutDir, rmErr)
+				return nil, hint, fmt.Errorf("resetting OCI layout cache %s: %w", layoutDir, rmErr)
 			}
 			nativeDone = false
 			if err := runBuild(build); err != nil {
-				return nil, err
+				return nil, hint, err
 			}
 			if layers, imageConfig, err = readOCILayoutDirLayers(layoutDir, platform); err != nil {
-				return nil, err
+				return nil, hint, err
 			}
 		}
 		if nativeEligible && !nativeDone {
@@ -2422,10 +2513,14 @@ func deployByChunkDiff(ctx context.Context, conn *grpcclient.AgentConnection, cw
 			// layers' file sets) so every following iteration can skip buildx.
 			if adopted, adoptErr := adoptNativeLayers(layoutDir, platform, cwd, sf, depsHash); adoptErr == nil && adopted {
 				if layers, imageConfig, err = readOCILayoutDirLayers(layoutDir, platform); err != nil {
-					return nil, err
+					return nil, hint, err
 				}
 			}
 		}
+		// The layout directory now holds a known-good, freshly built image —
+		// record it so a chunk-diff failure below can fall back to reusing it
+		// (see ociReuseHint) instead of a redundant second buildx build.
+		hint = &ociReuseHint{layoutDir: layoutDir, platform: platform}
 		// Prune blobs superseded by this build once the deploy is done with them.
 		// Best-effort: reachable blobs are never touched, so a failed GC only
 		// leaves garbage for the next run to collect.
@@ -2433,19 +2528,19 @@ func deployByChunkDiff(ctx context.Context, conn *grpcclient.AgentConnection, cw
 	} else {
 		tmp, err := os.MkdirTemp("", "wendy-oci-*")
 		if err != nil {
-			return nil, err
+			return nil, hint, err
 		}
 		defer os.RemoveAll(tmp)
 		ociTar := filepath.Join(tmp, "image.tar")
 		if err := runBuild(func(stream, logw io.Writer) error {
 			return buildImageToOCILayout(ctx, cwd, dockerfile, platform, buildArgs, opts.builder, ociTar, stream, logw)
 		}); err != nil {
-			return nil, err
+			return nil, hint, err
 		}
 		mark("build (oci export)")
 		layers, imageConfig, err = readOCILayoutLayers(ociTar, platform)
 		if err != nil {
-			return nil, err
+			return nil, hint, err
 		}
 	}
 	mark("read+decompress layers")
@@ -2453,17 +2548,17 @@ func deployByChunkDiff(ctx context.Context, conn *grpcclient.AgentConnection, cw
 	cliLogln("Diffing %s layer(s) against device...", tui.Value(fmt.Sprintf("%d", len(layers))))
 	headers, err := pushLayersByChunks(ctx, conn.ContainerService, layers)
 	if err != nil {
-		return nil, err
+		return nil, hint, err
 	}
 	mark("chunk+query+write")
 
 	appConfigData, err := json.Marshal(appCfg)
 	if err != nil {
-		return nil, err
+		return nil, hint, err
 	}
 	imageSignature, err := readOptionalSignature(os.Getenv(imageSignaturePathEnv))
 	if err != nil {
-		return nil, fmt.Errorf("reading image signature from %s: %w", imageSignaturePathEnv, err)
+		return nil, hint, fmt.Errorf("reading image signature from %s: %w", imageSignaturePathEnv, err)
 	}
 	imageName := strings.ToLower(appCfg.AppID) + ":latest"
 	// Carry the post-start agent-hook metadata so the agent runs the in-container
@@ -2481,14 +2576,14 @@ func deployByChunkDiff(ctx context.Context, conn *grpcclient.AgentConnection, cw
 		Env:            deployEnv,
 	})
 	if err != nil {
-		return nil, err
+		return nil, hint, err
 	}
 	if err := streamRunContainer(ctx, conn, stream, appCfg, opts); err != nil {
 		mark("runcontainer (assemble+create+start[+readiness])")
-		return nil, err
+		return nil, hint, err
 	}
 	mark("runcontainer (assemble+create+start[+readiness])")
-	return layerDiffIDs(headers), nil
+	return layerDiffIDs(headers), hint, nil
 }
 
 // layerDiffIDs extracts the ordered uncompressed diff IDs from the reassembly


### PR DESCRIPTION
When `wendy run` fell back from chunk-diff transfer to a registry push, it
rebuilt the image instead of reusing the one chunk-diff had already built.
This threads the built image through to the push path, so the fallback costs
a push rather than a second build.

mTLS pushes reuse the existing `tlsClientDialer` / `wendyRegistryServerVerifier`
helpers for Wendy-CA-verified TLS rather than a hand-rolled `tls.Config`.

## Testing
- `go build ./...`
- `go test ./go/internal/cli/commands/...` — passes (new `ocipush_test.go` included)
- Not exercised end-to-end against a device.

Rebased onto `main` (2026-08-10), no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4JpbQ7PDaPGGKzua2MHS6
