### PR TITLE
Lower Stagefiles into a typed IR, and key builds off it

### DIFF
--- a/go/internal/stagefile/cachekey/cachekey.go
+++ b/go/internal/stagefile/cachekey/cachekey.go
@@ -1,0 +1,371 @@
+// Package cachekey computes stable content-addressed keys for ir nodes.
+//
+// A key covers a node's semantic dependency closure: its recipe and
+// version, its declared parameters, the digests of any input files it
+// reads, and — recursively — the keys of the nodes it runs on. It does not
+// cover the node's position in the source file, the text of any rendered
+// command, or any unrelated sibling stage.
+//
+// That is the difference between this and a Docker layer ID, and the
+// property it buys is this one: two projects that declare the same
+// operations, in the same order, on the same base converge on the same key —
+// no matter what else their Stagefiles contain, what their stages are named,
+// or which file they live in.
+//
+// It is not a key over the resulting filesystem. Two builds that reach an
+// identical rootfs by different routes still key differently: reordering two
+// independent installs, or splitting one apt install into two, changes the op
+// sequence and therefore the key. Those are missed cache hits, never wrong
+// hits — the direction a cache is allowed to be wrong in.
+package cachekey
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/wendylabsinc/wendy/go/internal/stagefile/ir"
+)
+
+// keyFormatVersion prefixes every key. Bumping it invalidates every cached
+// node everywhere; it exists for changes to the keying scheme itself, as
+// distinct from ir.Recipe.Version which scopes an invalidation to one
+// recipe.
+// Version 2 added the target platform and the npm manifest digest to the
+// key, and moved copy-destination normalization ahead of it; all three
+// change every key they touch, so they were folded into one bump before the
+// format shipped.
+// Version 3 extended the model to the rest of the DSL — the stage's
+// args/env/workdir/platform, fetches and their extraction, apt repositories,
+// cmake, uv, pip indexes, and the copy/build/npm fields that had no ir
+// representation before. Everything it adds is a build input that was
+// previously invisible to the key, so it is one bump rather than one per
+// field.
+const keyFormatVersion = 3
+
+// Inputs supplies the externally-resolved facts a key depends on: base
+// image digests (from the lockfile) and build-context path digests.
+//
+// Files maps a context-relative path to a digest of its content. For a
+// directory that must be a digest over the whole tree — names, modes, and
+// contents — because a copy of a directory depends on all of it. Computing
+// these belongs to the caller; stage 3 supplies them from the build
+// context, and stage 1 only ever receives them from tests. Key treats a
+// missing entry as an error rather than hashing an empty string, so a
+// caller that forgets a path cannot silently produce a key that collides
+// across different content.
+//
+// Platform is the target platform the build is compiled for ("linux/arm64"
+// and so on). It is part of the key rather than part of the graph because
+// the graph describes what to build and the platform describes what machine
+// the result runs on: the same node built for two architectures produces two
+// different rootfs. It cannot be inferred from the base image digest either
+// — a multi-arch base resolves to one index digest shared by every
+// architecture — so without this field an arm64 build and an amd64 build of
+// the same Stagefile would key identically and poison each other across a
+// shared cache.
+//
+// There is no production caller of this field yet — Platform is hashed, but
+// nothing today wires it to a real value. Whoever adds the first production
+// caller MUST pass exactly the platform string given to codegen.Generate for
+// the same build; an empty Platform is only correct when the build
+// genuinely does not pin an architecture. Getting this wrong is silent:
+// lock.CraneResolver (lock/resolve.go) calls crane.Digest(ref) with no
+// platform, so it stores an architecture-ambiguous multi-arch index digest —
+// the image digest folded into the rest of the key cannot disambiguate
+// architecture on its own. Platform is the only field that can, so a
+// caller that passes an empty or mismatched platform here lets two
+// different architectures collide on one cache key.
+type Inputs struct {
+	Images   map[string]string
+	Files    map[string]string
+	Platform string
+}
+
+// keyState is the per-call recursion state for one top-level Key call. It
+// must never outlive that call or be shared across two calls with different
+// Inputs: memo is only valid for the exact (graph, Inputs) pair it was built
+// against, and a memo entry computed under one Inputs served to another
+// would be a wrong cache key served with high confidence — the worst kind of
+// bug this package can have. Key constructs a fresh keyState on every call
+// for exactly this reason; nothing here is package-level or reused.
+type keyState struct {
+	// ancestors is the set of node indices currently on the recursion
+	// stack, for O(1) cycle detection. path is the same stack in visit
+	// order, kept only so a detected cycle can be reported by the route
+	// that reached it rather than by the single index where it closed.
+	ancestors map[int]bool
+	path      []int
+	// memo caches each node's finished key by index, so a diamond-shaped
+	// closure (two nodes sharing a common ancestor) computes that ancestor's
+	// key once per Key call instead of once per path that reaches it. An
+	// entry is written only after write() returns successfully — never
+	// before recursing into a node — so the memo can't paper over the cycle
+	// guard above: a node still on the stack has no memo entry yet.
+	memo map[int]string
+}
+
+// Key returns the "sha256:<hex>" key of node idx in g.
+//
+// Key is exported and, per package doc, may be called against a hand-built
+// Graph rather than only ir.Lower's output — Lower itself only ever
+// produces a DAG, but a caller assembling a Graph by hand can wire up a
+// cycle. keyPath guards against that with the set of node indices currently
+// on the recursion stack (ancestors), not a global visited set: a DAG may
+// legitimately reach the same node from two different paths (e.g. two
+// stages copying from the same base), and that must not be mistaken for a
+// cycle.
+func Key(g *ir.Graph, idx int, in Inputs) (string, error) {
+	st := &keyState{ancestors: map[int]bool{}, memo: map[int]string{}}
+	return keyPath(g, idx, in, st)
+}
+
+func keyPath(g *ir.Graph, idx int, in Inputs, st *keyState) (string, error) {
+	if idx < 0 || idx >= len(g.Nodes) {
+		return "", fmt.Errorf("cachekey: node index %d out of range", idx)
+	}
+	if st.ancestors[idx] {
+		return "", fmt.Errorf("cachekey: cycle detected: %s", cyclePath(st.path, idx))
+	}
+	if k, ok := st.memo[idx]; ok {
+		return k, nil
+	}
+	st.ancestors[idx] = true
+	st.path = append(st.path, idx)
+	defer func() {
+		delete(st.ancestors, idx)
+		st.path = st.path[:len(st.path)-1]
+	}()
+
+	h := sha256.New()
+	e := enc{h: h}
+	e.tag("stagefile-key")
+	e.int(keyFormatVersion)
+	// Platform is folded in here, alongside the format version, rather than
+	// into any individual node: it applies uniformly to the whole build, and
+	// every node's key must differ between architectures.
+	e.str(in.Platform)
+	if err := write(e, g, idx, in, st); err != nil {
+		return "", err
+	}
+	key := "sha256:" + hex.EncodeToString(h.Sum(nil))
+	// Recorded only now, after write has fully succeeded: a partially
+	// computed or errored node must never be memoized, and a node still
+	// mid-recursion (an ancestor of itself) is caught above before this
+	// point is ever reached.
+	st.memo[idx] = key
+	return key, nil
+}
+
+// cyclePath renders the full recursion route from the top-level Key call
+// down to the repeated node, not the minimal repeating loop within it: a
+// call starting at the cycle prints just the loop (e.g. "2 -> 4 -> 2"), but
+// a call starting two hops earlier prints the leading nodes too (e.g.
+// "0 -> 1 -> 3 -> 4 -> 3"). The extra leading nodes are deliberate — they
+// show a caller debugging a hand-built graph how it got there, not just
+// where it closed.
+func cyclePath(path []int, idx int) string {
+	parts := make([]string, 0, len(path)+1)
+	for _, p := range path {
+		parts = append(parts, strconv.Itoa(p))
+	}
+	parts = append(parts, strconv.Itoa(idx))
+	return strings.Join(parts, " -> ")
+}
+
+func write(e enc, g *ir.Graph, idx int, in Inputs, st *keyState) error {
+	n := g.Nodes[idx]
+
+	// Inputs are folded in by key, not by index — an index is a position in
+	// this particular file and must never reach the hash.
+	e.tag("inputs")
+	e.int(len(n.Inputs))
+	for _, dep := range n.Inputs {
+		sub, err := keyPath(g, dep, in, st)
+		if err != nil {
+			return err
+		}
+		e.str(sub)
+	}
+
+	e.tag(string(n.Kind))
+	switch n.Kind {
+	case ir.OpImage:
+		if n.Image == nil {
+			return fmt.Errorf("cachekey: node %d has kind %q but nil Image payload", idx, n.Kind)
+		}
+		if !n.Image.Unpinned {
+			digest, ok := in.Images[n.Image.Ref]
+			if !ok {
+				return fmt.Errorf("cachekey: no resolved digest for image %q", n.Image.Ref)
+			}
+			// The ref itself is excluded on purpose: two tags pointing at the
+			// same digest are the same rootfs and must share a key.
+			e.str(digest)
+		} else {
+			// An unpinned image has no digest anywhere — that is what
+			// `pin: false` means. The ref is all there is to hash, so the key
+			// covers which image was named and cannot cover what it
+			// contained: a locally-loaded image rebuilt under the same tag
+			// keys identically. That is a real limitation of `pin: false`,
+			// not of this package, and it is why the ref is hashed under its
+			// own tag rather than in the same position a digest would take —
+			// so an unpinned node can never collide with a pinned one whose
+			// digest happens to equal the ref string.
+			e.tag("unpinned")
+			e.str(n.Image.Ref)
+		}
+		e.str(n.Image.Platform)
+		e.kv(n.Image.Args)
+		e.kv(n.Image.Env)
+		e.str(n.Image.Workdir)
+	case ir.OpFetch:
+		if n.Fetch == nil {
+			return fmt.Errorf("cachekey: node %d has kind %q but nil Fetch payload", idx, n.Kind)
+		}
+		// The checksum is what makes a fetch keyable at all: it pins the
+		// bytes, so two builds fetching the same content from the same URL
+		// share a key even across a re-lock. The URL is hashed alongside it
+		// because the same bytes reached from a different URL is a different
+		// declaration, and Dest/Mode/Owner because they decide where the
+		// bytes land and how they are owned.
+		e.str(n.Fetch.URL)
+		e.str(n.Fetch.Checksum)
+		e.str(n.Fetch.Dest)
+		e.str(n.Fetch.Mode)
+		e.str(n.Fetch.Owner)
+	case ir.OpCopy:
+		if n.Copy == nil {
+			return fmt.Errorf("cachekey: node %d has kind %q but nil Copy payload", idx, n.Kind)
+		}
+		e.bool(n.Copy.FromLocal)
+		e.strs(n.Copy.Paths)
+		e.str(n.Copy.Dest)
+		e.str(n.Copy.Owner)
+		e.str(n.Copy.Mode)
+		if n.Copy.FromLocal {
+			for _, p := range n.Copy.Paths {
+				d, ok := in.Files[p]
+				if !ok {
+					return fmt.Errorf("cachekey: no digest for context path %q", p)
+				}
+				e.str(d)
+			}
+		}
+	case ir.OpExec:
+		if n.Exec == nil {
+			return fmt.Errorf("cachekey: node %d has kind %q but nil Exec payload", idx, n.Kind)
+		}
+		if err := writeExec(e, n.Exec, in); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("cachekey: unhandled node kind %q", n.Kind)
+	}
+	return nil
+}
+
+func writeExec(e enc, x *ir.ExecOp, in Inputs) error {
+	e.str(x.Recipe.Name)
+	e.int(x.Recipe.Version)
+	switch {
+	case x.Apt != nil:
+		e.strs(x.Apt.Packages)
+		e.bool(x.Apt.Recommends)
+		// A declared repository changes which packages the install can even
+		// resolve, so it is as much a build input as the package list. The
+		// key is hashed by URL and digest rather than by fetching it: the
+		// digest is the content, and it is mandatory in the spec.
+		e.int(len(x.Apt.Repositories))
+		for _, r := range x.Apt.Repositories {
+			e.str(r.Name)
+			e.str(r.URL)
+			e.strs(r.Suites)
+			e.strs(r.Components)
+			e.str(r.KeyURL)
+			e.str(r.KeySHA256)
+			e.str(r.KeyFormat)
+		}
+	case x.Apk != nil:
+		e.strs(x.Apk.Packages)
+		e.bool(x.Apk.Cache)
+		e.strs(x.Apk.Repositories)
+	case x.CMake != nil:
+		// Commit is hashed even though cmakeCacheID deliberately excludes it:
+		// the cache id decides what may share a build tree, while the key
+		// decides what may reuse a finished rootfs. A different commit is a
+		// different rootfs.
+		e.str(x.CMake.Repository)
+		e.str(x.CMake.Commit)
+		e.str(x.CMake.Prefix)
+		e.str(x.CMake.BuildType)
+		e.kv(x.CMake.Defines)
+		e.int(x.CMake.Jobs)
+		e.str(x.CMake.Root)
+	case x.Pip != nil:
+		e.str(x.Pip.Requirements)
+		e.strs(x.Pip.Packages)
+		// The index set is hashed because the same package name resolves to
+		// different wheels from different indexes — which is the entire point
+		// of a cuda: group, where ir.Lower has already substituted the GPU
+		// profile's index here.
+		e.str(x.Pip.Index)
+		e.strs(x.Pip.ExtraIndex)
+		if x.Pip.Requirements != "" {
+			d, ok := in.Files[x.Pip.Requirements]
+			if !ok {
+				return fmt.Errorf("cachekey: no digest for %q", x.Pip.Requirements)
+			}
+			e.str(d)
+		}
+	case x.Npm != nil:
+		e.str(x.Npm.Manager)
+		e.str(x.Npm.Manifest)
+		e.str(x.Npm.Lockfile)
+		e.bool(x.Npm.Production)
+		// The manifest is hashed exactly like the lockfile, and for the same
+		// reason: the install reads both, so an edit to either changes the
+		// resulting filesystem. A key that covered only the lockfile would
+		// serve a stale rootfs for any change to package.json's scripts,
+		// engines, or dependency ranges that left the lockfile untouched.
+		for _, f := range []string{x.Npm.Manifest, x.Npm.Lockfile} {
+			d, ok := in.Files[f]
+			if !ok {
+				return fmt.Errorf("cachekey: no digest for %q", f)
+			}
+			e.str(d)
+		}
+	case x.Uv != nil:
+		e.strs(x.Uv.Extras)
+		e.bool(x.Uv.Dev)
+		e.strs(x.Uv.Files)
+		// pyproject.toml and uv.lock are hashed for the same reason npm's
+		// pair is: `uv sync --frozen` reads both, and neither the Dockerfile
+		// nor the image lockfile varies with their contents, so without this
+		// a dependency edit would change nothing the key can see.
+		for _, f := range x.Uv.Files {
+			d, ok := in.Files[f]
+			if !ok {
+				return fmt.Errorf("cachekey: no digest for %q", f)
+			}
+			e.str(d)
+		}
+	case x.Extract != nil:
+		e.str(x.Extract.Archive)
+		e.str(x.Extract.Dest)
+		e.str(x.Extract.Format)
+	case x.CUDACollect != nil:
+		e.str(x.CUDACollect.LibDir)
+		e.str(x.CUDACollect.ConfPath)
+	case x.Build != nil:
+		e.str(x.Build.Lang)
+		e.str(x.Build.Profile)
+		e.str(x.Build.Product)
+		e.str(x.Build.Script)
+	default:
+		return fmt.Errorf("cachekey: exec node has no params")
+	}
+	return nil
+}

--- a/go/internal/stagefile/cachekey/cachekey_test.go
+++ b/go/internal/stagefile/cachekey/cachekey_test.go
@@ -1,0 +1,556 @@
+package cachekey
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/stagefile/ir"
+	"github.com/wendylabsinc/wendy/go/internal/stagefile/spec"
+)
+
+func mustLower(t *testing.T, f *spec.File) *ir.Graph {
+	t.Helper()
+	g, err := ir.Lower(f, ir.Options{})
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	return g
+}
+
+func pipStage(name, from, reqs string, aptPkgs []string) spec.Stage {
+	s := spec.Stage{Name: name, From: from, Install: &spec.Install{
+		Pip: []spec.PipInstall{{Requirements: reqs}},
+	}}
+	if aptPkgs != nil {
+		s.Install.Apt = &spec.AptInstall{Packages: aptPkgs}
+	}
+	return s
+}
+
+func testInputs() Inputs {
+	return Inputs{
+		Images: map[string]string{"python:3.12-slim": "sha256:aaa", "debian:12": "sha256:bbb"},
+		Files:  map[string]string{"requirements.txt": "sha256:reqs1"},
+	}
+}
+
+// The core property: the same pip install on the same base yields the same
+// key across two unrelated Stagefiles.
+func TestKeyIsStableAcrossUnrelatedFiles(t *testing.T) {
+	a := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{
+		pipStage("deps", "python:3.12-slim", "requirements.txt", nil),
+	}})
+	b := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{
+		{Name: "unrelated", From: "debian:12"},
+		pipStage("otherName", "python:3.12-slim", "requirements.txt", nil),
+	}})
+
+	ka, err := Key(a, a.Stages[0].Final, testInputs())
+	if err != nil {
+		t.Fatalf("Key(a): %v", err)
+	}
+	kb, err := Key(b, b.Stages[1].Final, testInputs())
+	if err != nil {
+		t.Fatalf("Key(b): %v", err)
+	}
+	if ka != kb {
+		t.Fatalf("keys differ across unrelated files:\n a=%s\n b=%s", ka, kb)
+	}
+	if !strings.HasPrefix(ka, "sha256:") {
+		t.Fatalf("key %q lacks sha256: prefix", ka)
+	}
+}
+
+// The soundness property: a different dependency closure must key
+// differently, even with identical pip params.
+func TestKeyDiffersWhenClosureDiffers(t *testing.T) {
+	a := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{
+		pipStage("deps", "python:3.12-slim", "requirements.txt", []string{"foo"}),
+	}})
+	b := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{
+		pipStage("deps", "python:3.12-slim", "requirements.txt", []string{"bar"}),
+	}})
+
+	ka, _ := Key(a, a.Stages[0].Final, testInputs())
+	kb, _ := Key(b, b.Stages[0].Final, testInputs())
+	if ka == kb {
+		t.Fatal("pip keyed identically over different apt closures — cache is unsound")
+	}
+}
+
+func TestKeyDiffersWhenInputFileChanges(t *testing.T) {
+	g := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{
+		pipStage("deps", "python:3.12-slim", "requirements.txt", nil),
+	}})
+
+	in1 := testInputs()
+	k1, _ := Key(g, g.Stages[0].Final, in1)
+
+	in2 := testInputs()
+	in2.Files["requirements.txt"] = "sha256:reqs2"
+	k2, _ := Key(g, g.Stages[0].Final, in2)
+
+	if k1 == k2 {
+		t.Fatal("key ignored requirements.txt content")
+	}
+}
+
+func TestKeyDiffersWhenBaseDigestChanges(t *testing.T) {
+	g := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{
+		pipStage("deps", "python:3.12-slim", "requirements.txt", nil),
+	}})
+
+	k1, _ := Key(g, g.Stages[0].Final, testInputs())
+	in2 := testInputs()
+	in2.Images["python:3.12-slim"] = "sha256:ccc"
+	k2, _ := Key(g, g.Stages[0].Final, in2)
+
+	if k1 == k2 {
+		t.Fatal("key ignored the base image digest")
+	}
+}
+
+func TestKeyErrorsOnMissingImageDigest(t *testing.T) {
+	g := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{
+		{Name: "app", From: "alpine:3.20"},
+	}})
+	if _, err := Key(g, 0, testInputs()); err == nil {
+		t.Fatal("Key succeeded with no resolved digest for alpine:3.20")
+	}
+}
+
+func TestKeyErrorsOnMissingFileDigest(t *testing.T) {
+	g := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{
+		pipStage("deps", "python:3.12-slim", "absent.txt", nil),
+	}})
+	if _, err := Key(g, g.Stages[0].Final, testInputs()); err == nil {
+		t.Fatal("Key succeeded with no digest for absent.txt")
+	}
+}
+
+// Entrypoint and user are image config, not filesystem content; changing
+// them must not invalidate a built node.
+func TestKeyIgnoresEntrypointAndUser(t *testing.T) {
+	base := pipStage("deps", "python:3.12-slim", "requirements.txt", nil)
+	a := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{base}})
+
+	withCfg := base
+	withCfg.Entrypoint = &spec.Entrypoint{Exec: []string{"python3", "x.py"}}
+	withCfg.User = "1000"
+	b := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{withCfg}})
+
+	ka, _ := Key(a, a.Stages[0].Final, testInputs())
+	kb, _ := Key(b, b.Stages[0].Final, testInputs())
+	if ka != kb {
+		t.Fatal("entrypoint/user changed the filesystem key")
+	}
+}
+
+func copyStage(name, from, srcStage string, paths []string, dest string) spec.Stage {
+	return spec.Stage{Name: name, From: from, Copy: []spec.CopyEntry{
+		{From: srcStage, Paths: paths, Dest: dest},
+	}}
+}
+
+// TestKeyChangesWithCrossStageCopy covers the OpCopy branch for a
+// stage-to-stage copy (FromLocal == false), which no existing test
+// exercises: it must react both to its own declared paths and to the
+// content produced by the stage it copies from, and it must do so via the
+// source stage's key, never its index.
+func TestKeyChangesWithCrossStageCopy(t *testing.T) {
+	build := func(basePkgs []string, copyPaths []string) *ir.Graph {
+		return mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{
+			{Name: "base", From: "debian:12", Install: &spec.Install{
+				Apt: &spec.AptInstall{Packages: basePkgs},
+			}},
+			copyStage("app", "debian:12", "base", copyPaths, "dest.txt"),
+		}})
+	}
+	in := testInputs()
+
+	g1 := build([]string{"curl"}, []string{"a.txt"})
+	k1, err := Key(g1, g1.Stages[1].Final, in)
+	if err != nil {
+		t.Fatalf("Key: %v", err)
+	}
+
+	// Different declared source paths must change the key even though a
+	// cross-stage copy looks up no per-file digest (that lookup only
+	// applies to FromLocal copies).
+	g2 := build([]string{"curl"}, []string{"b.txt"})
+	k2, err := Key(g2, g2.Stages[1].Final, in)
+	if err != nil {
+		t.Fatalf("Key: %v", err)
+	}
+	if k1 == k2 {
+		t.Fatal("changing the copy's source paths did not change the key")
+	}
+
+	// Changing the source stage's own content must change the copy's key,
+	// because a dependency is folded in by its key, not its index.
+	g3 := build([]string{"wget"}, []string{"a.txt"})
+	k3, err := Key(g3, g3.Stages[1].Final, in)
+	if err != nil {
+		t.Fatalf("Key: %v", err)
+	}
+	if k1 == k3 {
+		t.Fatal("changing the source stage's content did not change the dependent copy's key")
+	}
+}
+
+// TestKeyConvergesOnEquivalentCopyDests pins the payoff of resolving
+// CopyOp.Dest at lower time: two spellings of the same copy are one build
+// and must be one cache entry. An omitted dest means "the path itself", and
+// BuildKit requires a multi-source dest to end in "/", so "/app" and "/app/"
+// describe the same destination.
+func TestKeyConvergesOnEquivalentCopyDests(t *testing.T) {
+	in := testInputs()
+	in.Files["app.py"] = "sha256:app"
+	in.Files["b.py"] = "sha256:b"
+
+	keyOf := func(t *testing.T, entry spec.CopyEntry) string {
+		t.Helper()
+		g := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{
+			{Name: "app", From: "python:3.12-slim", Copy: []spec.CopyEntry{entry}},
+		}})
+		k, err := Key(g, g.Stages[0].Final, in)
+		if err != nil {
+			t.Fatalf("Key: %v", err)
+		}
+		return k
+	}
+
+	implicit := keyOf(t, spec.CopyEntry{From: "local", Paths: []string{"app.py"}})
+	explicit := keyOf(t, spec.CopyEntry{From: "local", Paths: []string{"app.py"}, Dest: "app.py"})
+	if implicit != explicit {
+		t.Error("an omitted dest and the equivalent explicit dest keyed differently")
+	}
+
+	noSlash := keyOf(t, spec.CopyEntry{From: "local", Paths: []string{"app.py", "b.py"}, Dest: "/app"})
+	slash := keyOf(t, spec.CopyEntry{From: "local", Paths: []string{"app.py", "b.py"}, Dest: "/app/"})
+	if noSlash != slash {
+		t.Error("a multi-path dest keyed differently with and without its required trailing slash")
+	}
+
+	// The normalization must not flatten genuinely different destinations.
+	if other := keyOf(t, spec.CopyEntry{From: "local", Paths: []string{"app.py"}, Dest: "/srv/app.py"}); other == implicit {
+		t.Error("two different destinations collapsed onto one key")
+	}
+}
+
+func npmStage(name, from, manager string) spec.Stage {
+	return spec.Stage{Name: name, From: from, Install: &spec.Install{
+		Npm: &spec.NpmInstall{Manager: manager},
+	}}
+}
+
+// TestKeyDiffersForNpmManagerAndLockfile covers the Npm branch of
+// writeExec, which no existing test exercises: both the resolved manager
+// name and the lockfile's content digest must participate in the key.
+func TestKeyDiffersForNpmManagerAndLockfile(t *testing.T) {
+	inputsFor := func(manager, lockDigest string) Inputs {
+		in := testInputs()
+		in.Files["package.json"] = "sha256:pkgjson1"
+		in.Files[spec.NpmLockfile(manager)] = lockDigest
+		return in
+	}
+
+	gNpm := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{
+		npmStage("deps", "python:3.12-slim", "npm"),
+	}})
+	gPnpm := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{
+		npmStage("deps", "python:3.12-slim", "pnpm"),
+	}})
+
+	kNpm, err := Key(gNpm, gNpm.Stages[0].Final, inputsFor("npm", "sha256:lock1"))
+	if err != nil {
+		t.Fatalf("Key: %v", err)
+	}
+	kPnpm, err := Key(gPnpm, gPnpm.Stages[0].Final, inputsFor("pnpm", "sha256:lock1"))
+	if err != nil {
+		t.Fatalf("Key: %v", err)
+	}
+	if kNpm == kPnpm {
+		t.Fatal("switching npm manager (npm -> pnpm) did not change the key")
+	}
+
+	kNpmOtherLock, err := Key(gNpm, gNpm.Stages[0].Final, inputsFor("npm", "sha256:lock2"))
+	if err != nil {
+		t.Fatalf("Key: %v", err)
+	}
+	if kNpm == kNpmOtherLock {
+		t.Fatal("changing the lockfile digest did not change the key")
+	}
+}
+
+// TestKeyDiffersForNpmManifest is the regression test for a key that
+// covered the lockfile but not package.json. The install reads both — and
+// codegen COPYs both — so editing scripts, engines, or a dependency range
+// without regenerating the lockfile changes the built filesystem. A key
+// blind to that serves a stale rootfs from a shared cache.
+func TestKeyDiffersForNpmManifest(t *testing.T) {
+	g := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{
+		npmStage("deps", "python:3.12-slim", "npm"),
+	}})
+
+	inputs := func(manifestDigest string) Inputs {
+		in := testInputs()
+		in.Files["package.json"] = manifestDigest
+		in.Files["package-lock.json"] = "sha256:lock1"
+		return in
+	}
+
+	k1, err := Key(g, g.Stages[0].Final, inputs("sha256:pkgjson1"))
+	if err != nil {
+		t.Fatalf("Key: %v", err)
+	}
+	k2, err := Key(g, g.Stages[0].Final, inputs("sha256:pkgjson2"))
+	if err != nil {
+		t.Fatalf("Key: %v", err)
+	}
+	if k1 == k2 {
+		t.Fatal("editing package.json did not change the key — a stale rootfs would be served")
+	}
+}
+
+// A manifest digest the caller forgot to supply must be an error, never a
+// silently-hashed empty string: the latter collides across every possible
+// package.json.
+func TestKeyErrorsOnMissingNpmManifestDigest(t *testing.T) {
+	g := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{
+		npmStage("deps", "python:3.12-slim", "npm"),
+	}})
+	in := testInputs()
+	in.Files["package-lock.json"] = "sha256:lock1"
+
+	if _, err := Key(g, g.Stages[0].Final, in); err == nil {
+		t.Fatal("Key succeeded with no digest for package.json")
+	}
+}
+
+// TestKeyDiffersByPlatform guards against cross-architecture poisoning of a
+// shared cache. A multi-arch base image resolves to one index digest for
+// every architecture, so nothing else in the key distinguishes an arm64
+// build from an amd64 one.
+func TestKeyDiffersByPlatform(t *testing.T) {
+	g := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{
+		pipStage("deps", "python:3.12-slim", "requirements.txt", nil),
+	}})
+
+	arm := testInputs()
+	arm.Platform = "linux/arm64"
+	amd := testInputs()
+	amd.Platform = "linux/amd64"
+
+	kArm, err := Key(g, g.Stages[0].Final, arm)
+	if err != nil {
+		t.Fatalf("Key: %v", err)
+	}
+	kAmd, err := Key(g, g.Stages[0].Final, amd)
+	if err != nil {
+		t.Fatalf("Key: %v", err)
+	}
+	if kArm == kAmd {
+		t.Fatal("arm64 and amd64 builds of the same Stagefile share a key — a shared cache would serve the wrong architecture's rootfs")
+	}
+
+	// An unset platform is a legitimate caller state (nothing has been
+	// resolved yet) and must still key deterministically rather than
+	// varying run to run.
+	empty1, err := Key(g, g.Stages[0].Final, testInputs())
+	if err != nil {
+		t.Fatalf("Key: %v", err)
+	}
+	empty2, err := Key(g, g.Stages[0].Final, testInputs())
+	if err != nil {
+		t.Fatalf("Key: %v", err)
+	}
+	if empty1 != empty2 {
+		t.Fatal("an empty Platform keyed non-deterministically")
+	}
+	if empty1 == kArm {
+		t.Fatal("an empty Platform keyed the same as linux/arm64")
+	}
+}
+
+func buildStage(name, from, lang, profile string) spec.Stage {
+	return spec.Stage{Name: name, From: from, Build: &spec.Build{Lang: lang, Profile: profile}}
+}
+
+// TestKeyDiffersForBuildLangAndProfile covers the Build branch of
+// writeExec, which no existing test exercises: both Lang and Profile must
+// participate in the key, since a debug build is a different artifact from
+// a release build of the same language.
+func TestKeyDiffersForBuildLangAndProfile(t *testing.T) {
+	in := testInputs()
+
+	gGoRelease := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{
+		buildStage("app", "debian:12", "go", "release"),
+	}})
+	gRustRelease := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{
+		buildStage("app", "debian:12", "rust", "release"),
+	}})
+	gGoDebug := mustLower(t, &spec.File{Version: 1, Stages: []spec.Stage{
+		buildStage("app", "debian:12", "go", "debug"),
+	}})
+
+	kGoRelease, err := Key(gGoRelease, gGoRelease.Stages[0].Final, in)
+	if err != nil {
+		t.Fatalf("Key: %v", err)
+	}
+	kRustRelease, err := Key(gRustRelease, gRustRelease.Stages[0].Final, in)
+	if err != nil {
+		t.Fatalf("Key: %v", err)
+	}
+	if kGoRelease == kRustRelease {
+		t.Fatal("changing build.lang did not change the key")
+	}
+
+	kGoDebug, err := Key(gGoDebug, gGoDebug.Stages[0].Final, in)
+	if err != nil {
+		t.Fatalf("Key: %v", err)
+	}
+	if kGoRelease == kGoDebug {
+		t.Fatal("changing build.profile did not change the key")
+	}
+}
+
+// TestKeyErrorsOnCycle guards the fix for hand-built graphs: Lower never
+// produces a cycle, but Key is exported and must return an error rather
+// than recursing forever when a caller wires one up directly. The call is
+// bounded by a timeout so a regression back to unbounded recursion fails
+// the test instead of hanging the run (a real stack overflow would abort
+// the process outright, but a slower infinite loop should still be caught
+// deterministically rather than left to the CI job timeout).
+func TestKeyErrorsOnCycle(t *testing.T) {
+	g := &ir.Graph{Nodes: []ir.Node{
+		{Kind: ir.OpImage, Inputs: []int{1}, Image: &ir.ImageOp{Ref: "a"}},
+		{Kind: ir.OpImage, Inputs: []int{0}, Image: &ir.ImageOp{Ref: "b"}},
+	}}
+
+	type result struct {
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		_, err := Key(g, 0, testInputs())
+		done <- result{err: err}
+	}()
+
+	select {
+	case r := <-done:
+		if r.err == nil {
+			t.Fatal("Key succeeded on a graph with a dependency cycle")
+		}
+		// The error must name the actual route back to the repeated node
+		// (e.g. "0 -> 1 -> 0"), not just the index where the cycle closed,
+		// so a caller debugging a hand-built graph can see the whole loop.
+		if !strings.Contains(r.err.Error(), "0 -> 1 -> 0") {
+			t.Fatalf("cycle error %q does not name the cycle path", r.err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Key did not return on a cyclic graph (unbounded recursion)")
+	}
+}
+
+// TestKeyErrorsOnCycleReportsLongerPath covers a cycle that closes several
+// nodes deep rather than immediately, e.g. "2 -> 4 -> 2", to guard against a
+// path implementation that only ever reports the last two nodes.
+func TestKeyErrorsOnCycleReportsLongerPath(t *testing.T) {
+	g := &ir.Graph{Nodes: []ir.Node{
+		{Kind: ir.OpImage, Image: &ir.ImageOp{Ref: "a"}},
+		{Kind: ir.OpImage, Image: &ir.ImageOp{Ref: "b"}},
+		{Kind: ir.OpImage, Inputs: []int{4}, Image: &ir.ImageOp{Ref: "c"}},
+		{Kind: ir.OpImage, Image: &ir.ImageOp{Ref: "d"}},
+		{Kind: ir.OpImage, Inputs: []int{2}, Image: &ir.ImageOp{Ref: "e"}},
+	}}
+
+	_, err := Key(g, 2, testInputs())
+	if err == nil {
+		t.Fatal("Key succeeded on a graph with a dependency cycle")
+	}
+	if !strings.Contains(err.Error(), "2 -> 4 -> 2") {
+		t.Fatalf("cycle error %q does not name the cycle path", err)
+	}
+}
+
+// TestKeyMemoizesSharedAncestorCorrectly covers a diamond-shaped closure:
+// two nodes (1 and 2) share a common ancestor (0), and a fourth node (3)
+// depends on both. Within one Key call, node 0's key is computed once and
+// reused for both branches. That reuse must not paper over the ancestor's
+// actual contribution — changing it must still change every key downstream
+// of it, on both branches and at the join.
+func TestKeyMemoizesSharedAncestorCorrectly(t *testing.T) {
+	build := func() *ir.Graph {
+		return &ir.Graph{Nodes: []ir.Node{
+			{Kind: ir.OpImage, Image: &ir.ImageOp{Ref: "debian:12"}},
+			{Kind: ir.OpExec, Inputs: []int{0}, Exec: &ir.ExecOp{
+				Recipe: ir.RecipeApt, Apt: &ir.AptParams{Packages: []string{"curl"}},
+			}},
+			{Kind: ir.OpExec, Inputs: []int{0}, Exec: &ir.ExecOp{
+				Recipe: ir.RecipeApt, Apt: &ir.AptParams{Packages: []string{"git"}},
+			}},
+			{Kind: ir.OpExec, Inputs: []int{1, 2}, Exec: &ir.ExecOp{
+				Recipe: ir.RecipeBuild, Build: &ir.BuildParams{Lang: "go", Profile: "release"},
+			}},
+		}}
+	}
+
+	in1 := Inputs{Images: map[string]string{"debian:12": "sha256:aaa"}}
+	in2 := Inputs{Images: map[string]string{"debian:12": "sha256:bbb"}}
+
+	g1, g2 := build(), build()
+
+	k1Branch1, err := Key(g1, 1, in1)
+	if err != nil {
+		t.Fatalf("Key(branch1, in1): %v", err)
+	}
+	k1Branch2, err := Key(g1, 2, in1)
+	if err != nil {
+		t.Fatalf("Key(branch2, in1): %v", err)
+	}
+	k1Join, err := Key(g1, 3, in1)
+	if err != nil {
+		t.Fatalf("Key(join, in1): %v", err)
+	}
+
+	k2Branch1, err := Key(g2, 1, in2)
+	if err != nil {
+		t.Fatalf("Key(branch1, in2): %v", err)
+	}
+	k2Branch2, err := Key(g2, 2, in2)
+	if err != nil {
+		t.Fatalf("Key(branch2, in2): %v", err)
+	}
+	k2Join, err := Key(g2, 3, in2)
+	if err != nil {
+		t.Fatalf("Key(join, in2): %v", err)
+	}
+
+	if k1Branch1 == k2Branch1 {
+		t.Fatal("changing the shared ancestor's digest did not change branch 1's key")
+	}
+	if k1Branch2 == k2Branch2 {
+		t.Fatal("changing the shared ancestor's digest did not change branch 2's key")
+	}
+	// This is the assertion that actually exercises memoization: computing
+	// the join node visits node 0 twice in one Key call (once via node 1,
+	// once via node 2). If the memo returned a stale or wrong cached value
+	// on the second visit, the join's key could fail to reflect the
+	// ancestor's change even though both branches individually reflect it.
+	if k1Join == k2Join {
+		t.Fatal("changing the shared ancestor's digest did not change the join node's key — memoization served a stale value")
+	}
+}
+
+// TestKeyErrorsOnNilPayload guards the fix for malformed hand-built nodes:
+// a Kind whose matching payload pointer is nil must error, not panic.
+func TestKeyErrorsOnNilPayload(t *testing.T) {
+	g := &ir.Graph{Nodes: []ir.Node{
+		{Kind: ir.OpExec, Exec: nil},
+	}}
+	if _, err := Key(g, 0, testInputs()); err == nil {
+		t.Fatal("Key succeeded on a node with a nil Exec payload")
+	}
+}

--- a/go/internal/stagefile/cachekey/canonical.go
+++ b/go/internal/stagefile/cachekey/canonical.go
@@ -1,0 +1,86 @@
+package cachekey
+
+import (
+	"encoding/binary"
+	"hash"
+	"sort"
+)
+
+// enc writes a self-delimiting, order-explicit byte stream into a hash.
+//
+// Three properties make the stream unambiguous, so that no two distinct
+// values can produce the same bytes:
+//
+//   - Every string is length-prefixed, so a boundary between adjacent
+//     strings can never be misread ("ab"+"c" and "a"+"bc" differ).
+//   - Every slice is count-prefixed, so a slice cannot be confused with its
+//     flattened elements.
+//   - Field order is fixed by the call order in cachekey.go, and the arms
+//     that could otherwise collide are separated by an explicit tag() —
+//     "stagefile-key" at the start of a key, "inputs" before the dependency
+//     list, and the node kind before the payload, which is what keeps two
+//     different kinds from encoding alike. Payload fields themselves are
+//     untagged; their position within a known kind identifies them.
+//
+// This is deliberately more verbose than gob or JSON: both of those can
+// change their output when a struct's fields are reordered or a field is
+// added, which would silently invalidate every cached node in the fleet
+// during an ordinary refactor. Here, any change to the encoding is a
+// visible edit to this file or to the call order in cachekey.go.
+type enc struct{ h hash.Hash }
+
+func (e enc) tag(name string) {
+	e.str(name)
+}
+
+func (e enc) str(s string) {
+	var n [8]byte
+	binary.BigEndian.PutUint64(n[:], uint64(len(s)))
+	e.h.Write(n[:])
+	e.h.Write([]byte(s))
+}
+
+func (e enc) int(i int) {
+	var n [8]byte
+	binary.BigEndian.PutUint64(n[:], uint64(i))
+	e.h.Write(n[:])
+}
+
+func (e enc) bool(b bool) {
+	if b {
+		e.int(1)
+		return
+	}
+	e.int(0)
+}
+
+// strs encodes a slice in its given order. Order is significant for package
+// lists: apt resolves differently depending on order in rare cases, and
+// pretending otherwise would key two genuinely different rootfs alike.
+func (e enc) strs(ss []string) {
+	e.int(len(ss))
+	for _, s := range ss {
+		e.str(s)
+	}
+}
+
+// kv encodes a map in sorted key order.
+//
+// Sorting is what makes a map hashable at all — Go's iteration order is
+// randomized per run, so encoding in range order would give the same map a
+// different key on every process. It is also correct rather than merely
+// convenient: the only consumers of these maps (ENV, ARG, cmake -D flags)
+// are themselves emitted sorted by key, so two maps that differ only in
+// declaration order really do produce identical output.
+func (e enc) kv(m map[string]string) {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	e.int(len(keys))
+	for _, k := range keys {
+		e.str(k)
+		e.str(m[k])
+	}
+}

--- a/go/internal/stagefile/cachekey/coverage_test.go
+++ b/go/internal/stagefile/cachekey/coverage_test.go
@@ -1,0 +1,277 @@
+package cachekey
+
+import (
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/stagefile/ir"
+)
+
+// Every field keyedPayloadFields pins must be able to change a key on its
+// own. A field that is listed, wired through Lower and codegen, but never
+// actually hashed is the exact defect the field guard exists to catch — and
+// the guard cannot catch it, because listing a field is not the same as
+// hashing it. These tests close that gap: each case mutates one field of an
+// otherwise identical node and asserts the key moves.
+//
+// The graphs here are hand-built rather than lowered, so that one field can
+// be varied in isolation — a spec-level edit often changes two at once.
+
+func keyOf(t *testing.T, n ir.Node, in Inputs) string {
+	t.Helper()
+	g := &ir.Graph{Nodes: []ir.Node{n}}
+	k, err := Key(g, 0, in)
+	if err != nil {
+		t.Fatalf("Key: %v", err)
+	}
+	return k
+}
+
+func imageInputs() Inputs {
+	return Inputs{Images: map[string]string{"debian:12": "sha256:aaa", "other:1": "sha256:bbb"}}
+}
+
+func TestImageFieldsChangeTheKey(t *testing.T) {
+	base := ir.Node{Kind: ir.OpImage, Image: &ir.ImageOp{Ref: "debian:12"}}
+	baseKey := keyOf(t, base, imageInputs())
+
+	cases := []struct {
+		name string
+		op   ir.ImageOp
+	}{
+		{"platform", ir.ImageOp{Ref: "debian:12", Platform: "linux/arm64"}},
+		{"args", ir.ImageOp{Ref: "debian:12", Args: map[string]string{"V": "1"}}},
+		{"env", ir.ImageOp{Ref: "debian:12", Env: map[string]string{"MODE": "prod"}}},
+		{"workdir", ir.ImageOp{Ref: "debian:12", Workdir: "/srv"}},
+		{"unpinned", ir.ImageOp{Ref: "debian:12", Unpinned: true}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			op := tc.op
+			if got := keyOf(t, ir.Node{Kind: ir.OpImage, Image: &op}, imageInputs()); got == baseKey {
+				t.Fatalf("changing %s did not change the key", tc.name)
+			}
+		})
+	}
+}
+
+// An env map's key must not depend on Go's randomized map iteration order,
+// and two maps that differ only in declaration order are one build.
+func TestImageEnvKeyIsOrderIndependent(t *testing.T) {
+	a := ir.ImageOp{Ref: "debian:12", Env: map[string]string{"A": "1", "B": "2", "C": "3"}}
+	b := ir.ImageOp{Ref: "debian:12", Env: map[string]string{"C": "3", "B": "2", "A": "1"}}
+	for range 8 {
+		ka := keyOf(t, ir.Node{Kind: ir.OpImage, Image: &a}, imageInputs())
+		kb := keyOf(t, ir.Node{Kind: ir.OpImage, Image: &b}, imageInputs())
+		if ka != kb {
+			t.Fatalf("same env keyed differently across map orderings:\n %s\n %s", ka, kb)
+		}
+	}
+}
+
+// An unpinned image keys off its ref, so two different unpinned refs differ —
+// but it cannot collide with a pinned node whose digest happens to equal a
+// ref string, which is what the separate "unpinned" tag buys.
+func TestUnpinnedImageKeysOffItsRef(t *testing.T) {
+	in := imageInputs()
+	a := keyOf(t, ir.Node{Kind: ir.OpImage, Image: &ir.ImageOp{Ref: "local/a:dev", Unpinned: true}}, in)
+	b := keyOf(t, ir.Node{Kind: ir.OpImage, Image: &ir.ImageOp{Ref: "local/b:dev", Unpinned: true}}, in)
+	if a == b {
+		t.Fatal("two different unpinned refs keyed identically")
+	}
+
+	collide := Inputs{Images: map[string]string{"x": "local/a:dev"}}
+	pinned := keyOf(t, ir.Node{Kind: ir.OpImage, Image: &ir.ImageOp{Ref: "x"}}, collide)
+	unpinned := keyOf(t, ir.Node{Kind: ir.OpImage, Image: &ir.ImageOp{Ref: "local/a:dev", Unpinned: true}}, collide)
+	if pinned == unpinned {
+		t.Fatal("a pinned node whose digest equals an unpinned node's ref collided with it")
+	}
+}
+
+func TestFetchFieldsChangeTheKey(t *testing.T) {
+	base := ir.FetchOp{URL: "https://example.test/x.bin", Dest: "/x.bin", Checksum: "sha256:aaa"}
+	baseKey := keyOf(t, ir.Node{Kind: ir.OpFetch, Fetch: &base}, Inputs{})
+
+	cases := []struct {
+		name string
+		op   ir.FetchOp
+	}{
+		{"url", ir.FetchOp{URL: "https://example.test/y.bin", Dest: "/x.bin", Checksum: "sha256:aaa"}},
+		{"dest", ir.FetchOp{URL: "https://example.test/x.bin", Dest: "/y.bin", Checksum: "sha256:aaa"}},
+		{"checksum", ir.FetchOp{URL: "https://example.test/x.bin", Dest: "/x.bin", Checksum: "sha256:bbb"}},
+		{"mode", ir.FetchOp{URL: "https://example.test/x.bin", Dest: "/x.bin", Checksum: "sha256:aaa", Mode: "0755"}},
+		{"owner", ir.FetchOp{URL: "https://example.test/x.bin", Dest: "/x.bin", Checksum: "sha256:aaa", Owner: "1000:1000"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			op := tc.op
+			if got := keyOf(t, ir.Node{Kind: ir.OpFetch, Fetch: &op}, Inputs{}); got == baseKey {
+				t.Fatalf("changing %s did not change the key", tc.name)
+			}
+		})
+	}
+}
+
+func TestCopyOwnerAndModeChangeTheKey(t *testing.T) {
+	in := Inputs{Files: map[string]string{"app.py": "sha256:app"}}
+	base := ir.CopyOp{FromLocal: true, Paths: []string{"app.py"}, Dest: "app.py"}
+	baseKey := keyOf(t, ir.Node{Kind: ir.OpCopy, Copy: &base}, in)
+
+	owner := base
+	owner.Owner = "1000:1000"
+	if keyOf(t, ir.Node{Kind: ir.OpCopy, Copy: &owner}, in) == baseKey {
+		t.Error("changing copy owner did not change the key")
+	}
+	mode := base
+	mode.Mode = "0755"
+	if keyOf(t, ir.Node{Kind: ir.OpCopy, Copy: &mode}, in) == baseKey {
+		t.Error("changing copy mode did not change the key")
+	}
+}
+
+func execKey(t *testing.T, x ir.ExecOp, in Inputs) string {
+	t.Helper()
+	return keyOf(t, ir.Node{Kind: ir.OpExec, Exec: &x}, in)
+}
+
+func TestExecPayloadFieldsChangeTheKey(t *testing.T) {
+	uvFiles := []string{"pyproject.toml", "uv.lock"}
+	in := Inputs{Files: map[string]string{
+		"requirements.txt":  "sha256:reqs",
+		"package.json":      "sha256:pkg",
+		"package-lock.json": "sha256:lock",
+		"pyproject.toml":    "sha256:pyproject",
+		"uv.lock":           "sha256:uvlock",
+	}}
+
+	cases := []struct {
+		name string
+		a, b ir.ExecOp
+	}{
+		{
+			"apt repositories",
+			ir.ExecOp{Recipe: ir.RecipeApt, Apt: &ir.AptParams{Packages: []string{"curl"}}},
+			ir.ExecOp{Recipe: ir.RecipeApt, Apt: &ir.AptParams{Packages: []string{"curl"}, Repositories: []ir.AptRepository{{
+				Name: "ros2", URL: "http://packages.ros.org/ros2/ubuntu",
+				Suites: []string{"jammy"}, Components: []string{"main"},
+				KeyURL: "https://example.test/ros.key", KeySHA256: "abc",
+			}}}},
+		},
+		{
+			"apt repository key digest",
+			ir.ExecOp{Recipe: ir.RecipeApt, Apt: &ir.AptParams{Repositories: []ir.AptRepository{{Name: "r", KeySHA256: "abc"}}}},
+			ir.ExecOp{Recipe: ir.RecipeApt, Apt: &ir.AptParams{Repositories: []ir.AptRepository{{Name: "r", KeySHA256: "def"}}}},
+		},
+		{
+			"apk cache",
+			ir.ExecOp{Recipe: ir.RecipeApk, Apk: &ir.ApkParams{Packages: []string{"musl-dev"}}},
+			ir.ExecOp{Recipe: ir.RecipeApk, Apk: &ir.ApkParams{Packages: []string{"musl-dev"}, Cache: true}},
+		},
+		{
+			"apk repositories",
+			ir.ExecOp{Recipe: ir.RecipeApk, Apk: &ir.ApkParams{Packages: []string{"musl-dev"}}},
+			ir.ExecOp{Recipe: ir.RecipeApk, Apk: &ir.ApkParams{Packages: []string{"musl-dev"}, Repositories: []string{"https://example.test/edge"}}},
+		},
+		{
+			"cmake commit",
+			ir.ExecOp{Recipe: ir.RecipeCMake, CMake: &ir.CMakeParams{Repository: "r", Commit: "a1", Root: "/tmp/x"}},
+			ir.ExecOp{Recipe: ir.RecipeCMake, CMake: &ir.CMakeParams{Repository: "r", Commit: "b2", Root: "/tmp/x"}},
+		},
+		{
+			"cmake defines",
+			ir.ExecOp{Recipe: ir.RecipeCMake, CMake: &ir.CMakeParams{Repository: "r", Commit: "a1", Root: "/tmp/x"}},
+			ir.ExecOp{Recipe: ir.RecipeCMake, CMake: &ir.CMakeParams{Repository: "r", Commit: "a1", Root: "/tmp/x", Defines: map[string]string{"T": "OFF"}}},
+		},
+		{
+			"cmake jobs",
+			ir.ExecOp{Recipe: ir.RecipeCMake, CMake: &ir.CMakeParams{Repository: "r", Commit: "a1", Root: "/tmp/x"}},
+			ir.ExecOp{Recipe: ir.RecipeCMake, CMake: &ir.CMakeParams{Repository: "r", Commit: "a1", Root: "/tmp/x", Jobs: 4}},
+		},
+		{
+			"cmake root",
+			ir.ExecOp{Recipe: ir.RecipeCMake, CMake: &ir.CMakeParams{Repository: "r", Commit: "a1", Root: "/tmp/x"}},
+			ir.ExecOp{Recipe: ir.RecipeCMake, CMake: &ir.CMakeParams{Repository: "r", Commit: "a1", Root: "/tmp/y"}},
+		},
+		{
+			"pip index",
+			ir.ExecOp{Recipe: ir.RecipePip, Pip: &ir.PipParams{Packages: []string{"torch"}}},
+			ir.ExecOp{Recipe: ir.RecipePip, Pip: &ir.PipParams{Packages: []string{"torch"}, Index: "https://pypi.jetson.example/simple"}},
+		},
+		{
+			"pip extra index",
+			ir.ExecOp{Recipe: ir.RecipePip, Pip: &ir.PipParams{Packages: []string{"torch"}}},
+			ir.ExecOp{Recipe: ir.RecipePip, Pip: &ir.PipParams{Packages: []string{"torch"}, ExtraIndex: []string{"https://extra.example/simple"}}},
+		},
+		{
+			"npm production",
+			ir.ExecOp{Recipe: ir.RecipeNpm, Npm: &ir.NpmParams{Manager: "npm", Manifest: "package.json", Lockfile: "package-lock.json"}},
+			ir.ExecOp{Recipe: ir.RecipeNpm, Npm: &ir.NpmParams{Manager: "npm", Manifest: "package.json", Lockfile: "package-lock.json", Production: true}},
+		},
+		{
+			"uv dev",
+			ir.ExecOp{Recipe: ir.RecipeUv, Uv: &ir.UvParams{Files: uvFiles}},
+			ir.ExecOp{Recipe: ir.RecipeUv, Uv: &ir.UvParams{Files: uvFiles, Dev: true}},
+		},
+		{
+			"uv extras",
+			ir.ExecOp{Recipe: ir.RecipeUv, Uv: &ir.UvParams{Files: uvFiles}},
+			ir.ExecOp{Recipe: ir.RecipeUv, Uv: &ir.UvParams{Files: uvFiles, Extras: []string{"gpu"}}},
+		},
+		{
+			"extract format",
+			ir.ExecOp{Recipe: ir.RecipeExtract, Extract: &ir.ExtractParams{Archive: "/tmp/a.tar.gz", Dest: "/m", Format: "tar.gz"}},
+			ir.ExecOp{Recipe: ir.RecipeExtract, Extract: &ir.ExtractParams{Archive: "/tmp/a.tar.gz", Dest: "/m", Format: "zip"}},
+		},
+		{
+			"cuda collect libdir",
+			ir.ExecOp{Recipe: ir.RecipeCUDACollect, CUDACollect: &ir.CUDACollectParams{LibDir: "/opt/a", ConfPath: "/etc/c"}},
+			ir.ExecOp{Recipe: ir.RecipeCUDACollect, CUDACollect: &ir.CUDACollectParams{LibDir: "/opt/b", ConfPath: "/etc/c"}},
+		},
+		{
+			"build product",
+			ir.ExecOp{Recipe: ir.RecipeBuild, Build: &ir.BuildParams{Lang: "swift", Profile: "release"}},
+			ir.ExecOp{Recipe: ir.RecipeBuild, Build: &ir.BuildParams{Lang: "swift", Profile: "release", Product: "Server"}},
+		},
+		{
+			"build script",
+			ir.ExecOp{Recipe: ir.RecipeBuild, Build: &ir.BuildParams{Lang: "npm", Script: "build"}},
+			ir.ExecOp{Recipe: ir.RecipeBuild, Build: &ir.BuildParams{Lang: "npm", Script: "bundle"}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if execKey(t, tc.a, in) == execKey(t, tc.b, in) {
+				t.Fatalf("changing %s did not change the key", tc.name)
+			}
+		})
+	}
+}
+
+// uv reads pyproject.toml and uv.lock, and neither the Dockerfile nor the
+// image lockfile varies with their contents — so if the key did not hash
+// them, editing a dependency would change nothing any cache could see. This
+// is the same defect npm's package.json had.
+func TestUvHashesItsLockFiles(t *testing.T) {
+	x := ir.ExecOp{Recipe: ir.RecipeUv, Uv: &ir.UvParams{Files: []string{"pyproject.toml", "uv.lock"}}}
+	base := Inputs{Files: map[string]string{"pyproject.toml": "sha256:a", "uv.lock": "sha256:b"}}
+	edited := Inputs{Files: map[string]string{"pyproject.toml": "sha256:a", "uv.lock": "sha256:CHANGED"}}
+	if execKey(t, x, base) == execKey(t, x, edited) {
+		t.Fatal("editing uv.lock did not change the key")
+	}
+}
+
+func TestUvRefusesAMissingFileDigest(t *testing.T) {
+	g := &ir.Graph{Nodes: []ir.Node{{Kind: ir.OpExec, Exec: &ir.ExecOp{
+		Recipe: ir.RecipeUv, Uv: &ir.UvParams{Files: []string{"pyproject.toml", "uv.lock"}},
+	}}}}
+	if _, err := Key(g, 0, Inputs{Files: map[string]string{"pyproject.toml": "sha256:a"}}); err == nil {
+		t.Fatal("Key succeeded with no digest for uv.lock")
+	}
+}
+
+func TestKeyRefusesANilFetchPayload(t *testing.T) {
+	g := &ir.Graph{Nodes: []ir.Node{{Kind: ir.OpFetch}}}
+	if _, err := Key(g, 0, Inputs{}); err == nil {
+		t.Fatal("Key succeeded on a fetch node with a nil payload")
+	}
+}

--- a/go/internal/stagefile/cachekey/fields_test.go
+++ b/go/internal/stagefile/cachekey/fields_test.go
@@ -1,0 +1,117 @@
+package cachekey
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/stagefile/ir"
+)
+
+// keyedPayloadFields pins the exported fields of every ir payload the key
+// covers. It is the guard for a defect this branch actually shipped: npm's
+// package.json was copied into the image and allowlisted as a build input,
+// but never hashed, so editing it produced an identical key and a different
+// rootfs. Nothing failed, because adding a field to an ir payload and wiring
+// it through Lower and codegen changes the filesystem without touching any
+// test that looks at keys.
+//
+// Listing a field here is not the same as hashing it. Stage-level config
+// (ir.Stage.Entrypoint, ir.Stage.User) is deliberately outside the key and
+// deliberately outside this list; ir.ImageOp.Ref is listed but intentionally
+// excluded from the hash, because two tags resolving to one digest are one
+// rootfs. The list's job is to force the question to be asked.
+var keyedPayloadFields = map[string][]string{
+	"AptParams":     {"Packages", "Recommends", "Repositories"},
+	"AptRepository": {"Name", "URL", "Suites", "Components", "KeyURL", "KeySHA256", "KeyFormat"},
+	"ApkParams":     {"Packages", "Cache", "Repositories"},
+	"CMakeParams":   {"Repository", "Commit", "Prefix", "BuildType", "Defines", "Jobs", "Root"},
+	"PipParams":     {"Requirements", "Packages", "Index", "ExtraIndex"},
+	"NpmParams":     {"Manager", "Manifest", "Lockfile", "Production"},
+	"UvParams":      {"Extras", "Dev", "Files"},
+	"ExtractParams": {"Archive", "Dest", "Format"},
+	// LibDir and ConfPath are both hashed. They come from the pinned GPU
+	// profile rather than the Stagefile, so in practice they change only
+	// when the profile does — but they are paths the built rootfs actually
+	// contains, so they belong in the key rather than being excluded as
+	// rendering detail.
+	"CUDACollectParams": {"LibDir", "ConfPath"},
+	"BuildParams":       {"Lang", "Profile", "Product", "Script"},
+	"CopyOp":            {"FromLocal", "Paths", "Dest", "Owner", "Mode"},
+	"FetchOp":           {"URL", "Dest", "Checksum", "Mode", "Owner"},
+	// Ref is listed but hashed only for an unpinned image: for a pinned one
+	// the resolved digest stands in for it, because two tags resolving to
+	// one digest are one rootfs. Unpinned itself is hashed by selecting
+	// between those two encodings.
+	"ImageOp": {"Ref", "Unpinned", "Platform", "Args", "Env", "Workdir"},
+	"ExecOp": {"Recipe", "Apt", "Apk", "CMake", "Pip", "Npm", "Uv",
+		"Extract", "CUDACollect", "Build"},
+	"Recipe": {"Name", "Version"},
+}
+
+// TestIRPayloadFieldsAreAccountedFor fails whenever an ir payload gains or
+// loses an exported field.
+//
+// If this test is failing, do not just update the list. First decide whether
+// the new field changes the filesystem the node produces:
+//
+//   - If it does, it belongs in the cache key. Hash it in cachekey.go
+//     (writeExec or write), add a test asserting two Inputs differing only in
+//     that field key differently, bump keyFormatVersion or the relevant
+//     ir.Recipe.Version, and re-harvest the golden corpus. Then add the field
+//     here.
+//   - If it does not — it is image config, or a rendering hint with no effect
+//     on the resulting rootfs — add it here with a comment saying why it is
+//     excluded, the way ir.Stage.Entrypoint and ir.Stage.User are.
+//
+// Skipping that decision is how a key silently stops covering a build input.
+func TestIRPayloadFieldsAreAccountedFor(t *testing.T) {
+	payloads := []any{
+		ir.AptParams{},
+		ir.AptRepository{},
+		ir.ApkParams{},
+		ir.CMakeParams{},
+		ir.PipParams{},
+		ir.NpmParams{},
+		ir.UvParams{},
+		ir.ExtractParams{},
+		ir.CUDACollectParams{},
+		ir.BuildParams{},
+		ir.CopyOp{},
+		ir.FetchOp{},
+		ir.ImageOp{},
+		ir.ExecOp{},
+		ir.Recipe{},
+	}
+
+	seen := map[string]bool{}
+	for _, p := range payloads {
+		typ := reflect.TypeOf(p)
+		name := typ.Name()
+		seen[name] = true
+
+		want, ok := keyedPayloadFields[name]
+		if !ok {
+			t.Errorf("ir.%s has no entry in keyedPayloadFields — decide which of its fields belong in the cache key, then add it", name)
+			continue
+		}
+
+		var got []string
+		for i := range typ.NumField() {
+			if f := typ.Field(i); f.IsExported() {
+				got = append(got, f.Name)
+			}
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("ir.%s exported fields changed:\n got  %v\n want %v\n"+
+				"A new field here changes the built filesystem but not the cache key until you hash it.\n"+
+				"Decide whether it belongs in the key (see this test's doc comment), then update keyedPayloadFields.",
+				name, got, want)
+		}
+	}
+
+	for name := range keyedPayloadFields {
+		if !seen[name] {
+			t.Errorf("keyedPayloadFields pins ir.%s, but no such payload is checked — was it renamed or removed?", name)
+		}
+	}
+}

--- a/go/internal/stagefile/cachekey/golden_keys_test.go
+++ b/go/internal/stagefile/cachekey/golden_keys_test.go
@@ -1,0 +1,109 @@
+package cachekey
+
+import (
+	"os"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/stagefile/ir"
+	"github.com/wendylabsinc/wendy/go/internal/stagefile/spec"
+)
+
+// TestGoldenKeys pins the key of every node in every shipped fixture
+// Stagefile. These strings are a wire format, not an implementation detail:
+// changing one invalidates that node for every cache tier, in every org,
+// permanently. A diff here is only ever correct alongside a bump to
+// ir.Recipe.Version (scoped) or keyFormatVersion (global), and both belong
+// in their own reviewed commit.
+//
+// Between them the fixtures must reach all five recipes and both copy
+// flavors. example.stagefile.yaml covers image, apt, pip, and copy;
+// npmbuild.stagefile.yaml covers npm, apk, and build. A recipe with no
+// frozen key is a recipe whose params can gain or lose a field with no test
+// noticing — which is precisely how npm's package.json digest went missing.
+func TestGoldenKeys(t *testing.T) {
+	cases := []struct {
+		fixture string
+		in      Inputs
+		want    []string
+	}{
+		{
+			fixture: "example.stagefile.yaml",
+			in: Inputs{
+				Images: map[string]string{"python:3.12-slim": "sha256:abc123"},
+				Files: map[string]string{
+					"requirements.txt": "sha256:fixedreqs",
+					"app.py":           "sha256:fixedapp",
+				},
+				Platform: "linux/arm64",
+			},
+			want: []string{
+				"sha256:af5065361d0fbbce9bde07caaa4e5b8dc4abd129d4b2e4198b5da3135da97e29",
+				"sha256:0806cb7cf175b910d3733d8e742c49a4a55016ed1a27e55ded858652cccbffa3",
+				"sha256:e10a7f44181cced429e4074448ab357b40da887e28192372140e1df7fb366577",
+				"sha256:af5065361d0fbbce9bde07caaa4e5b8dc4abd129d4b2e4198b5da3135da97e29",
+				"sha256:525549c50c0b2be4880210488a402871c4304f2cc7612af0da4cae7040b3038c",
+				"sha256:d3e106c5ad74ba127b59a645eb527e2068ab2805857f8170091095ce423ce5db",
+			},
+		},
+		{
+			fixture: "npmbuild.stagefile.yaml",
+			in: Inputs{
+				Images: map[string]string{
+					"node:20-slim":  "sha256:node20",
+					"rust:1-alpine": "sha256:rust1",
+				},
+				Files: map[string]string{
+					"package.json":      "sha256:fixedpkgjson",
+					"package-lock.json": "sha256:fixedpkglock",
+					"src":               "sha256:fixedsrc",
+					"tsconfig.json":     "sha256:fixedtsconfig",
+				},
+				Platform: "linux/arm64",
+			},
+			want: []string{
+				"sha256:f14948db391fcdca5457255da7bc9897eaab4735cf836091016bee120d5b7dfd",
+				"sha256:e11cefc5aad3445de1d11cc2775c4dd63cf41d4293fe4c75f60bc119634744b0",
+				"sha256:f33cd53c4a9c8d74c46dfa68a3134ef7989187aa7587fcc013256d8532aa51bd",
+				"sha256:2b9ec32b97be9f52d128dc676795b2fe7e47b2ecd06766e3320adeb47a1f20aa",
+				"sha256:43bda82d75a3ff1a5e2cc3a6ce0b848baf643571ff01360b4abd4affc5937d6e",
+				"sha256:1243a24800c4125e5dac389edd627c041e914da4284fa3ebd67231c6336779ea",
+				"sha256:f14948db391fcdca5457255da7bc9897eaab4735cf836091016bee120d5b7dfd",
+				"sha256:8fb7b638047b032559ab0684813075444aee9ae4a80ea2f2e83a1a76564576f3",
+				"sha256:2a0a243246b5aa580a2405193ea6f6e063920fccc8eb3eddf8f9365a323232fa",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.fixture, func(t *testing.T) {
+			data, err := os.ReadFile("../testdata/" + tc.fixture)
+			if err != nil {
+				t.Fatal(err)
+			}
+			f, err := spec.Parse(data)
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			// Lowered at the same platform the Inputs name: the graph now
+			// carries the per-stage resolution of it, so lowering at one
+			// platform and keying at another would freeze a combination no
+			// real build can produce.
+			g, err := ir.Lower(f, ir.Options{Platform: tc.in.Platform})
+			if err != nil {
+				t.Fatalf("Lower: %v", err)
+			}
+			if len(g.Nodes) != len(tc.want) {
+				t.Fatalf("fixture lowered to %d nodes, corpus pins %d — update both together", len(g.Nodes), len(tc.want))
+			}
+			for i := range g.Nodes {
+				got, err := Key(g, i, tc.in)
+				if err != nil {
+					t.Fatalf("Key(node %d): %v", i, err)
+				}
+				if got != tc.want[i] {
+					t.Errorf("node %d (%s) key drift:\n got  %s\n want %s", i, g.Nodes[i].Kind, got, tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/go/internal/stagefile/ir/ir.go
+++ b/go/internal/stagefile/ir/ir.go
@@ -1,0 +1,287 @@
+// Package ir is the typed intermediate representation between a parsed
+// Stagefile and any backend that renders it. A Graph is a flat,
+// topologically ordered list of Nodes whose edges are indices into that
+// list — never pointers, because Node must serialize deterministically for
+// cache-key computation (see package cachekey).
+//
+// Two rules hold everywhere in this package:
+//
+//  1. No node carries a rendered shell string. Nodes carry typed recipe
+//     parameters; rendering and quoting belong to a backend.
+//  2. No node payload aliases a spec type. spec grows fields as DSL coverage
+//     gaps close; if ir aliased those types, a new spec field would silently
+//     change cache keys fleet-wide. Every field crosses the boundary through
+//     Lower, by hand, on purpose.
+package ir
+
+// OpKind is the closed set of node operations. Adding a kind is a
+// deliberate extension of the model, not a convenience.
+type OpKind string
+
+const (
+	OpImage OpKind = "image"
+	OpExec  OpKind = "exec"
+	OpCopy  OpKind = "copy"
+	OpFetch OpKind = "fetch"
+)
+
+// Recipe identifies a typed exec operation and the version of its
+// compilation rules. Version participates in the cache key: bumping it
+// invalidates every node using that recipe, everywhere. Treat a bump as a
+// migration, not a refactor.
+type Recipe struct {
+	Name    string
+	Version int
+}
+
+var (
+	RecipeApt         = Recipe{Name: "apt", Version: 1}
+	RecipeApk         = Recipe{Name: "apk", Version: 1}
+	RecipeCMake       = Recipe{Name: "cmake", Version: 1}
+	RecipePip         = Recipe{Name: "pip", Version: 1}
+	RecipeNpm         = Recipe{Name: "npm", Version: 1}
+	RecipeUv          = Recipe{Name: "uv", Version: 1}
+	RecipeExtract     = Recipe{Name: "extract", Version: 1}
+	RecipeCUDACollect = Recipe{Name: "cuda-collect", Version: 1}
+	RecipeBuild       = Recipe{Name: "build", Version: 1}
+)
+
+// Graph is a lowered Stagefile.
+type Graph struct {
+	Nodes  []Node
+	Stages []Stage
+}
+
+// Stage names a build stage and points at the node holding its final state.
+type Stage struct {
+	Name  string
+	Final int
+	// Healthcheck, Entrypoint, Cmd, and User are stage-level image config
+	// rather than filesystem operations, so they hang off the stage, not
+	// off a node. They never enter a cache key: changing an entrypoint does
+	// not invalidate a built filesystem.
+	//
+	// Everything that DOES change the filesystem — the base image, the
+	// stage's env/args/workdir, its target platform — lives on the stage's
+	// ImageOp instead, where the key covers it and every later node in the
+	// stage inherits it through the input chain.
+	Healthcheck *Healthcheck
+	Entrypoint  []string
+	Cmd         []string
+	User        string
+}
+
+// Healthcheck is the container health probe, exec form only.
+type Healthcheck struct {
+	Exec        []string
+	Interval    string
+	Timeout     string
+	StartPeriod string
+	Retries     int
+}
+
+// Node is one operation. Exactly one of Image/Exec/Copy/Fetch is non-nil,
+// matching Kind.
+type Node struct {
+	Kind   OpKind
+	Inputs []int
+	Image  *ImageOp
+	Exec   *ExecOp
+	Copy   *CopyOp
+	Fetch  *FetchOp
+}
+
+// ImageOp is a stage's initial state: the base image by its original
+// reference, plus the build-time settings every later operation in the
+// stage runs under. The resolved digest is supplied separately at key time
+// and at render time, so the graph itself stays independent of any
+// particular lockfile state.
+//
+// Args, Env, and Workdir live here rather than on Stage because they are
+// not image config — they change what every install and build in the stage
+// does, so they must reach the cache key. Hanging them off the stage's
+// first node is what gets them there: every later node lists it as an
+// ancestor, so its key propagates down the whole stage.
+type ImageOp struct {
+	Ref string
+	// Unpinned marks the `pin: false` images that exist solely in a local
+	// daemon store and have no registry digest to pin against.
+	//
+	// The field is negated so that the zero value is the pinned, safe one.
+	// A hand-built graph — which cachekey explicitly supports — that forgot
+	// to set a positive Pinned field would key off the image's tag instead
+	// of its digest, silently narrowing what the key covers. Forgetting this
+	// field costs nothing instead.
+	Unpinned bool
+	// Platform is the resolved platform for this stage: the build's target
+	// platform, or "$BUILDPLATFORM" for a `platform: build` stage, or "" to
+	// let the builder decide. It is hashed because a stage pinned to the
+	// build platform produces different bytes than the same stage built for
+	// the target.
+	Platform string
+	Args     map[string]string
+	Env      map[string]string
+	Workdir  string
+}
+
+// ExecOp is a typed operation. Exactly one params pointer is non-nil, and
+// it must correspond to Recipe.
+type ExecOp struct {
+	Recipe      Recipe
+	Apt         *AptParams
+	Apk         *ApkParams
+	CMake       *CMakeParams
+	Pip         *PipParams
+	Npm         *NpmParams
+	Uv          *UvParams
+	Extract     *ExtractParams
+	CUDACollect *CUDACollectParams
+	Build       *BuildParams
+}
+
+// AptParams installs Debian/Ubuntu packages, optionally from extra
+// repositories set up first.
+type AptParams struct {
+	Packages     []string
+	Recommends   bool
+	Repositories []AptRepository
+}
+
+// AptRepository is one extra apt source, with its signing key pinned by
+// digest. KeyFormat is "armored" or "" (binary), already defaulted.
+type AptRepository struct {
+	Name       string
+	URL        string
+	Suites     []string
+	Components []string
+	KeyURL     string
+	// KeySHA256 is the bare hex digest, "sha256:" prefix already stripped
+	// at lower time so no backend has to decide whether to strip it.
+	KeySHA256 string
+	KeyFormat string
+}
+
+// ApkParams installs Alpine packages. Alpine has no Recommends concept, so
+// this is a separate type from AptParams rather than a shared one: Cache
+// opts in to keeping /var/cache/apk in the layer.
+type ApkParams struct {
+	Packages     []string
+	Cache        bool
+	Repositories []string
+}
+
+// CMakeParams builds and installs one commit-pinned CMake project. Prefix
+// and BuildType are defaulted at lower time, so a backend never has to know
+// what "unset" means.
+//
+// Root is the scratch directory this install checks out and builds under,
+// resolved from the install's position in its stage. It is resolved here for
+// the same reason ExtractParams.Archive is: it depends on where the install
+// sits among its siblings, and a backend that recounted that position could
+// disagree with the one the key hashed.
+type CMakeParams struct {
+	Repository string
+	Commit     string
+	Prefix     string
+	BuildType  string
+	Defines    map[string]string
+	Jobs       int
+	Root       string
+}
+
+// PipParams installs from a requirements file, an explicit list, or both.
+//
+// Index is the group's effective index, already resolved: a group that
+// declared cuda: carries the GPU profile's index here, not a flag saying to
+// go look one up. That resolution is what lets the cache key cover which
+// index the wheels came from without the key having to know about GPUs.
+type PipParams struct {
+	Requirements string
+	Packages     []string
+	Index        string
+	ExtraIndex   []string
+}
+
+// NpmParams records the resolved manager, the manifest it reads, and the
+// lockfile that pins its resolution — all resolved at lower time so no
+// backend re-derives them and drifts.
+//
+// Manifest is named explicitly rather than assumed to be "package.json" by
+// each backend, because it is a build input in its own right: the install
+// reads scripts, engines, and dependency ranges from it, so editing it
+// without touching the lockfile still changes the resulting filesystem and
+// must therefore change the cache key.
+type NpmParams struct {
+	Manager    string
+	Manifest   string
+	Lockfile   string
+	Production bool
+}
+
+// UvParams syncs from pyproject.toml + uv.lock. Files names them explicitly,
+// for the same reason NpmParams.Manifest does: they are build inputs, and a
+// key that did not cover them would serve a stale rootfs after a dependency
+// edit.
+type UvParams struct {
+	Extras []string
+	Dev    bool
+	Files  []string
+}
+
+// ExtractParams unpacks an archive a Fetch node staged. Archive is the
+// staging path that fetch wrote, resolved at lower time so the two nodes
+// cannot disagree about the filename.
+type ExtractParams struct {
+	Archive string
+	Dest    string
+	Format  string
+}
+
+// CUDACollectParams links the CUDA runtime wheels' shared objects into one
+// directory and registers it with the dynamic loader. Both paths are
+// resolved from the pinned GPU profile at lower time.
+type CUDACollectParams struct {
+	LibDir   string
+	ConfPath string
+}
+
+// BuildParams is a language compile step with its profile resolved.
+type BuildParams struct {
+	Lang    string
+	Profile string
+	Product string
+	Script  string
+}
+
+// FetchOp downloads one URL into the stage. Checksum is mandatory and fully
+// resolved at lower time ("sha256:<hex>"): the Stagefile's own pin, or
+// failing that the one recorded in the lockfile. An unpinned fetch is not
+// representable.
+//
+// Dest is where the bytes land — the declared destination, or the staging
+// path when the download is extracted later in the stage.
+type FetchOp struct {
+	URL      string
+	Dest     string
+	Checksum string
+	Mode     string
+	Owner    string
+}
+
+// CopyOp promotes paths into the stage this node belongs to. When FromLocal
+// is set the source is the build context and Inputs holds only the base;
+// otherwise Inputs is [base, sourceStageFinalNode].
+//
+// Dest is the final destination, fully resolved at lower time: defaulted to
+// the single source path when the spec omits it, and suffixed with "/" when
+// more than one path is copied. Resolving it here rather than in a backend
+// is what makes `copy: {paths: [app.py]}` and
+// `copy: {paths: [app.py], dest: app.py}` — the same build — reach the same
+// cache key.
+type CopyOp struct {
+	FromLocal bool
+	Paths     []string
+	Dest      string
+	Owner     string
+	Mode      string
+}

--- a/go/internal/stagefile/ir/lower.go
+++ b/go/internal/stagefile/ir/lower.go
@@ -1,0 +1,474 @@
+package ir
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/wendylabsinc/wendy/go/internal/stagefile/gpu"
+	"github.com/wendylabsinc/wendy/go/internal/stagefile/spec"
+)
+
+// supportedLangs mirrors the languages codegen can render. Lower rejects
+// anything else here so an unsupported language fails at lowering rather
+// than surfacing from a backend deep in the pipeline.
+var supportedLangs = map[string]bool{
+	"rust": true, "go": true, "swift": true,
+	"npm": true, "yarn": true, "pnpm": true,
+}
+
+// Options carries the build-time facts a Stagefile does not contain but
+// lowering must resolve against.
+//
+// All three are pinned inputs, not ambient state. Downloads and CUDAProfile
+// come from the lockfile, and Platform is the architecture the caller is
+// building for. They are resolved here, at lower time, rather than in a
+// backend so that everything the cache key hashes is the same value the
+// Dockerfile renders — a backend that re-derived any of them could drift
+// from the key while still producing a Dockerfile that builds.
+type Options struct {
+	// Platform is the target platform (e.g. "linux/arm64"), or "" to let
+	// the builder decide.
+	Platform string
+	// Downloads maps a download URL to the sha256 resolved for it, for
+	// downloads that declared none of their own.
+	Downloads map[string]string
+	// CUDAProfile is the GPU profile resolved for Platform. Required if any
+	// stage declares cuda:.
+	CUDAProfile *gpu.Profile
+}
+
+// Lower converts a validated spec.File into a Graph.
+//
+// Node order within a stage matches the order a backend must emit, and that
+// ordering is load-bearing in three places:
+//
+//   - Fetches come first. A download is the largest and most stable thing in
+//     a stage; behind the installs, a bumped pip package would re-fetch every
+//     model.
+//   - Extraction comes after the installs, because it is the only position
+//     where `extract: zip` can rely on unzip having been declared in
+//     install.apt.packages.
+//   - Copy comes after every install and before build, so that editing app
+//     source never reruns an install. Reversing install and copy was a real
+//     defect once already (see codegen/golden_test.go).
+func Lower(f *spec.File, opts Options) (*Graph, error) {
+	g := &Graph{}
+	stageFinal := map[string]int{}
+
+	for _, s := range f.Stages {
+		if s.CUDA && opts.CUDAProfile == nil {
+			return nil, fmt.Errorf("stage %q declares cuda: but no GPU target was resolved for this build", s.Name)
+		}
+
+		platform := opts.Platform
+		if s.Platform == "build" {
+			platform = "$BUILDPLATFORM"
+		}
+
+		cur := g.add(Node{Kind: OpImage, Image: &ImageOp{
+			Ref: s.From,
+			// An absent pin: means pinned; `pin: false` is the visible
+			// deviation. Resolving the tri-state pointer here means no
+			// backend has to know that nil means true.
+			Unpinned: s.Pin != nil && !*s.Pin,
+			Platform: platform,
+			// Cloned, like every other spec-owned value below: a caller
+			// that patches its spec.File in place and lowers again must not
+			// silently corrupt this graph — and now that a graph is hashed
+			// into a cache key, corrupting it means corrupting the key too.
+			Args:    maps.Clone(s.Args),
+			Env:     stageEnv(&s, opts.CUDAProfile),
+			Workdir: s.Workdir,
+		}})
+
+		fetches, err := fetchNodes(s.Download, opts.Downloads)
+		if err != nil {
+			return nil, fmt.Errorf("stage %q: %w", s.Name, err)
+		}
+		for _, fo := range fetches {
+			cur = g.add(Node{Kind: OpFetch, Inputs: []int{cur}, Fetch: fo})
+		}
+
+		install := s.Install
+		if install == nil {
+			// An absent install: lowers as an empty one rather than being
+			// skipped, because pipNodes is also where a GPU stage's CUDA
+			// runtime is spliced in, and that stage needs the runtime
+			// whether or not it declares any install of its own — the
+			// collection below imports it. With no fields set, nothing else
+			// here emits a node.
+			install = &spec.Install{}
+		}
+		if install.Apt != nil {
+			cur = g.add(execNode(cur, &ExecOp{Recipe: RecipeApt, Apt: aptParams(install.Apt)}))
+		}
+		if install.Apk != nil {
+			cur = g.add(execNode(cur, &ExecOp{Recipe: RecipeApk, Apk: &ApkParams{
+				Packages:     slices.Clone(install.Apk.Packages),
+				Cache:        install.Apk.Cache,
+				Repositories: slices.Clone(install.Apk.Repositories),
+			}}))
+		}
+		for i, c := range install.CMake {
+			cur = g.add(execNode(cur, &ExecOp{Recipe: RecipeCMake, CMake: cmakeParams(i, c)}))
+		}
+		for _, p := range pipParams(install.Pip, s.CUDA, opts.CUDAProfile) {
+			cur = g.add(execNode(cur, &ExecOp{Recipe: RecipePip, Pip: p}))
+		}
+		if install.Npm != nil {
+			manager := install.Npm.Manager
+			if manager == "" {
+				manager = "npm"
+			}
+			cur = g.add(execNode(cur, &ExecOp{Recipe: RecipeNpm, Npm: &NpmParams{
+				Manager: manager,
+				// spec.NpmManifest is the file every supported manager reads
+				// alongside its lockfile; it is the single source of truth
+				// dockerignore also reads, so backends and the cache key
+				// agree with the build context on one value.
+				Manifest: spec.NpmManifest,
+				// Derived from the defaulted manager, not the raw spec
+				// value: NpmLockfile("") and NpmLockfile("npm") agree today,
+				// but deriving the two fields of one params struct from two
+				// different values is how they drift apart later.
+				Lockfile:   spec.NpmLockfile(manager),
+				Production: install.Npm.Production,
+			}}))
+		}
+		if install.Uv != nil {
+			cur = g.add(execNode(cur, &ExecOp{Recipe: RecipeUv, Uv: &UvParams{
+				Extras: slices.Clone(install.Uv.Extras),
+				Dev:    install.Uv.Dev,
+				Files:  slices.Clone(spec.UvLocalFiles),
+			}}))
+		}
+
+		for i, d := range s.Download {
+			if d.Extract == "" {
+				continue
+			}
+			cur = g.add(execNode(cur, &ExecOp{Recipe: RecipeExtract, Extract: &ExtractParams{
+				Archive: downloadStagingPath(i, d.Extract),
+				Dest:    d.Dest,
+				Format:  d.Extract,
+			}}))
+		}
+
+		// Collection runs after every install (it reads what they produced)
+		// and before copy: (so editing app source never reruns it).
+		if s.CUDA {
+			cur = g.add(execNode(cur, &ExecOp{Recipe: RecipeCUDACollect, CUDACollect: &CUDACollectParams{
+				LibDir:   opts.CUDAProfile.LibDir,
+				ConfPath: CUDAConfPath,
+			}}))
+		}
+
+		for _, c := range s.Copy {
+			dest, err := copyDest(c)
+			if err != nil {
+				return nil, fmt.Errorf("stage %q: %w", s.Name, err)
+			}
+			n := Node{Kind: OpCopy, Inputs: []int{cur}, Copy: &CopyOp{
+				Paths: slices.Clone(c.Paths),
+				Dest:  dest,
+				Owner: c.Owner,
+				Mode:  c.Mode,
+			}}
+			if c.From == "local" {
+				n.Copy.FromLocal = true
+			} else {
+				src, ok := stageFinal[c.From]
+				if !ok {
+					return nil, fmt.Errorf("stage %q: copy from unknown stage %q", s.Name, c.From)
+				}
+				n.Inputs = append(n.Inputs, src)
+			}
+			cur = g.add(n)
+		}
+
+		if s.Build != nil {
+			if !supportedLangs[s.Build.Lang] {
+				return nil, fmt.Errorf("stage %q: unsupported build.lang %q (supported: go, rust, swift, npm, yarn, pnpm)", s.Name, s.Build.Lang)
+			}
+			profile := s.Build.Profile
+			if profile == "" {
+				profile = "release"
+			}
+			script := s.Build.Script
+			if script == "" {
+				script = "build"
+			}
+			cur = g.add(execNode(cur, &ExecOp{Recipe: RecipeBuild, Build: &BuildParams{
+				Lang:    s.Build.Lang,
+				Profile: profile,
+				Product: s.Build.Product,
+				Script:  script,
+			}}))
+		}
+
+		st := Stage{Name: s.Name, Final: cur, User: stageUser(&s)}
+		if s.Healthcheck != nil {
+			st.Healthcheck = &Healthcheck{
+				Exec:        slices.Clone(s.Healthcheck.Exec),
+				Interval:    s.Healthcheck.Interval,
+				Timeout:     s.Healthcheck.Timeout,
+				StartPeriod: s.Healthcheck.StartPeriod,
+				Retries:     s.Healthcheck.Retries,
+			}
+		}
+		if s.Entrypoint != nil {
+			// Cloned for the same reason as CopyOp.Paths above: codegen
+			// distinguishes a nil Entrypoint (no ENTRYPOINT line) from a
+			// non-nil one, so slices.Clone's nil-preserving behavior matters
+			// here, not just the defensive copy.
+			st.Entrypoint = entrypointArgv(s.Entrypoint)
+		}
+		st.Cmd = slices.Clone(s.Cmd)
+		g.Stages = append(g.Stages, st)
+		stageFinal[s.Name] = cur
+	}
+	return g, nil
+}
+
+// CUDAConfPath is where a CUDA stage registers its collected library
+// directory with the dynamic loader. The 000- prefix puts it first among
+// ld.so.conf.d entries.
+const CUDAConfPath = "/etc/ld.so.conf.d/000-stagefile-cuda.conf"
+
+// entrypointArgv resolves the entrypoint to the exact argv a backend
+// renders, wrapper included.
+//
+// A source: entrypoint becomes a bash source-then-exec wrapper here rather
+// than in a backend: the wrapper is part of what the image runs, so two
+// backends resolving it separately is two chances to disagree about what
+// the container's PID 1 actually is. The declared argv is passed through
+// untouched as "$@", so no Exec argument is ever parsed by the shell.
+func entrypointArgv(e *spec.Entrypoint) []string {
+	if e.Source == "" {
+		return slices.Clone(e.Exec)
+	}
+	inner := "source " + shellQuoteForWrapper(e.Source) + ` && exec "$@"`
+	return append([]string{"/bin/bash", "-c", inner, "bash"}, e.Exec...)
+}
+
+// shellQuoteForWrapper single-quotes s for the one place ir itself has to
+// build a shell fragment: the source-then-exec entrypoint wrapper, whose
+// argv is part of the image config rather than a rendered RUN line. Every
+// other shell rendering belongs to a backend.
+func shellQuoteForWrapper(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
+}
+
+// stageUser resolves the final user, including the reason a GPU stage is
+// exempt from the non-root default.
+//
+// CUDA's memory manager opens /dev/nvmap, which is root-only on a Jetson. A
+// GPU stage that took the non-root default would build clean and then fail
+// on the device at the first allocation, so the declaration that the stage
+// uses the GPU is also the declaration that it needs root. An explicit
+// user: still wins. An empty result means "no explicit user", which a
+// backend resolves to its own default.
+func stageUser(s *spec.Stage) string {
+	if s.User != "" {
+		return s.User
+	}
+	if s.CUDA {
+		return "root"
+	}
+	return ""
+}
+
+// stageEnv returns the env map for s: the Stagefile's own, plus the loader
+// path a CUDA stage needs.
+//
+// ld.so.conf alone is not enough. A Jetson's CDI injection puts the host's
+// CUDA directories on the container's loader path in a position that beats
+// ld.so.conf.d, so the collected directory has to be on LD_LIBRARY_PATH to
+// win. spec's validateCUDA refuses a Stagefile that sets the variable
+// itself, so there is nothing here to merge with.
+func stageEnv(s *spec.Stage, cudaProfile *gpu.Profile) map[string]string {
+	if !s.CUDA || cudaProfile == nil {
+		return maps.Clone(s.Env)
+	}
+	env := make(map[string]string, len(s.Env)+1)
+	maps.Copy(env, s.Env)
+	env[spec.LDLibraryPath] = cudaProfile.LibDir
+	return env
+}
+
+func aptParams(a *spec.AptInstall) *AptParams {
+	p := &AptParams{
+		Packages:   slices.Clone(a.Packages),
+		Recommends: a.Recommends,
+	}
+	for _, r := range a.Repositories {
+		p.Repositories = append(p.Repositories, AptRepository{
+			Name:       r.Name,
+			URL:        r.URL,
+			Suites:     slices.Clone(r.Suites),
+			Components: slices.Clone(r.Components),
+			KeyURL:     r.Key.URL,
+			// Stripped here so every backend renders the same digest text
+			// and the key hashes one spelling of it, whichever the
+			// Stagefile used.
+			KeySHA256: strings.TrimPrefix(r.Key.SHA256, "sha256:"),
+			KeyFormat: r.Key.Format,
+		})
+	}
+	return p
+}
+
+func cmakeParams(i int, c spec.CMakeInstall) *CMakeParams {
+	prefix := c.Prefix
+	if prefix == "" {
+		prefix = "/usr/local"
+	}
+	buildType := c.BuildType
+	if buildType == "" {
+		buildType = "Release"
+	}
+	return &CMakeParams{
+		Repository: c.Repository,
+		Commit:     c.Commit,
+		Prefix:     prefix,
+		BuildType:  buildType,
+		Defines:    maps.Clone(c.Defines),
+		Jobs:       c.Jobs,
+		Root:       fmt.Sprintf("/tmp/stagefile-cmake-%d", i),
+	}
+}
+
+// pipParams lowers the stage's pip groups, splicing in the CUDA runtime
+// group a GPU stage needs.
+//
+// The runtime lands directly after the last group that asked for the GPU
+// index, and before any ordinary PyPI group. That position is not cosmetic:
+// the runtime changes only when the profile does, while app dependencies
+// change constantly, and a later group's edit must not invalidate the layer
+// holding several hundred megabytes of CUDA libraries.
+func pipParams(groups []spec.PipInstall, stageCUDA bool, cudaProfile *gpu.Profile) []*PipParams {
+	runtimeAfter := -1
+	for i, g := range groups {
+		if g.CUDA {
+			runtimeAfter = i
+		}
+	}
+
+	var out []*PipParams
+	appendRuntime := func() {
+		if !stageCUDA || cudaProfile == nil {
+			return
+		}
+		// A separate group from the wheels above, with no index, so it
+		// resolves from PyPI. Folding the two together would make the vendor
+		// index primary and PyPI an extra index, and pip would then be free
+		// to satisfy either package from either source — resolving torch
+		// from PyPI, which is the wrong-architecture wheel this whole
+		// feature exists to avoid.
+		out = append(out, &PipParams{Packages: slices.Clone(cudaProfile.Runtime)})
+	}
+
+	for i, g := range groups {
+		index := g.Index
+		if g.CUDA && cudaProfile != nil {
+			index = cudaProfile.Index
+		}
+		out = append(out, &PipParams{
+			Requirements: g.Requirements,
+			Packages:     slices.Clone(g.Packages),
+			Index:        index,
+			ExtraIndex:   slices.Clone(g.ExtraIndex),
+		})
+		if i == runtimeAfter {
+			appendRuntime()
+		}
+	}
+	if runtimeAfter == -1 {
+		// A GPU stage that installs no GPU wheels of its own still gets the
+		// runtime — it may be loading CUDA through something apt or cmake
+		// installed.
+		appendRuntime()
+	}
+	return out
+}
+
+// downloadStagingPath is where an archive lands before it is unpacked. It is
+// keyed to the download's index within its stage, so identical source always
+// compiles to identical bytes — nothing here is random or time-derived.
+func downloadStagingPath(i int, extract string) string {
+	return fmt.Sprintf("/tmp/stagefile-download-%d.%s", i, extract)
+}
+
+func fetchNodes(entries []spec.Download, resolved map[string]string) ([]*FetchOp, error) {
+	var out []*FetchOp
+	for i, d := range entries {
+		checksum, err := downloadChecksum(d, resolved)
+		if err != nil {
+			return nil, err
+		}
+		dest := d.Dest
+		if d.Extract != "" {
+			dest = downloadStagingPath(i, d.Extract)
+		}
+		out = append(out, &FetchOp{
+			URL:      d.URL,
+			Dest:     dest,
+			Checksum: checksum,
+			Mode:     d.Mode,
+			Owner:    d.Owner,
+		})
+	}
+	return out, nil
+}
+
+// downloadChecksum returns the sha256 to pin d with: the one written in the
+// Stagefile, or failing that the one resolved into the lockfile. An
+// unpinned download is not representable in the output, so a download with
+// neither is an error rather than a plain fetch.
+func downloadChecksum(d spec.Download, resolved map[string]string) (string, error) {
+	digest := d.SHA256
+	if digest == "" {
+		digest = resolved[d.URL]
+	}
+	if digest == "" {
+		return "", fmt.Errorf("download %q: no resolved sha256; run a build with network access to pin it, or write sha256: in the Stagefile", d.URL)
+	}
+	return "sha256:" + strings.TrimPrefix(digest, "sha256:"), nil
+}
+
+// copyDest resolves a copy entry's destination to the single value every
+// backend renders and the cache key hashes.
+//
+// Two normalizations happen here rather than in a backend. Defaulting an
+// omitted dest to the sole source path means `paths: [app.py]` and
+// `paths: [app.py], dest: app.py` are one build with one key instead of two.
+// Appending "/" for a multi-path copy is required by BuildKit — a
+// multi-source COPY whose destination lacks a trailing slash validates fine
+// but hard-fails at docker build — and doing it here means `dest: /app` and
+// `dest: /app/` also converge on one key.
+func copyDest(c spec.CopyEntry) (string, error) {
+	if len(c.Paths) == 0 {
+		// spec.Validate already rejects this, but Lower is reachable with a
+		// hand-built spec.File and must not index into an empty slice.
+		return "", fmt.Errorf("copy from %q: paths must be non-empty", c.From)
+	}
+	dest := c.Dest
+	if dest == "" {
+		dest = c.Paths[0]
+	}
+	if len(c.Paths) > 1 && !strings.HasSuffix(dest, "/") {
+		dest += "/"
+	}
+	return dest, nil
+}
+
+func execNode(base int, e *ExecOp) Node {
+	return Node{Kind: OpExec, Inputs: []int{base}, Exec: e}
+}
+
+func (g *Graph) add(n Node) int {
+	g.Nodes = append(g.Nodes, n)
+	return len(g.Nodes) - 1
+}

--- a/go/internal/stagefile/ir/lower_coverage_test.go
+++ b/go/internal/stagefile/ir/lower_coverage_test.go
@@ -1,0 +1,382 @@
+package ir
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/stagefile/gpu"
+	"github.com/wendylabsinc/wendy/go/internal/stagefile/spec"
+)
+
+// These tests cover the resolution Lower took over from codegen when the IR
+// grew to the whole DSL. Each one pins a decision that used to be made at
+// render time and is now made once, at lower time, so that the Dockerfile and
+// the cache key cannot disagree about it.
+
+func testProfile() *gpu.Profile {
+	return &gpu.Profile{
+		Arch:        "sm_87",
+		Board:       "Orin",
+		CUDAVersion: "12.6",
+		Index:       "https://pypi.jetson.example/simple",
+		Runtime:     []string{"nvidia-cuda-runtime-cu12"},
+		LibDir:      "/opt/stagefile/cuda",
+	}
+}
+
+func execNodesOf(g *Graph) []*ExecOp {
+	var out []*ExecOp
+	for i := range g.Nodes {
+		if g.Nodes[i].Exec != nil {
+			out = append(out, g.Nodes[i].Exec)
+		}
+	}
+	return out
+}
+
+// A cuda: stage resolves everything the GPU implies at lower time: the wheel
+// index for its own group, the separate PyPI runtime group after it, the
+// collect step, the loader path, and root.
+func TestLowerResolvesCUDAStage(t *testing.T) {
+	p := testProfile()
+	g, err := Lower(&spec.File{Version: 1, Stages: []spec.Stage{{
+		Name: "app", From: "ubuntu:22.04", CUDA: true,
+		Install: &spec.Install{Pip: []spec.PipInstall{
+			{Packages: []string{"torch"}, CUDA: true},
+			{Packages: []string{"flask"}},
+		}},
+	}}}, Options{CUDAProfile: p})
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+
+	img := g.Nodes[0].Image
+	if got := img.Env[spec.LDLibraryPath]; got != p.LibDir {
+		t.Errorf("%s = %q, want %q", spec.LDLibraryPath, got, p.LibDir)
+	}
+	if g.Stages[0].User != "root" {
+		t.Errorf("user = %q, want root — a GPU stage needs /dev/nvmap", g.Stages[0].User)
+	}
+
+	var pipGroups []*PipParams
+	var collect *CUDACollectParams
+	for _, x := range execNodesOf(g) {
+		switch {
+		case x.Pip != nil:
+			pipGroups = append(pipGroups, x.Pip)
+		case x.CUDACollect != nil:
+			collect = x.CUDACollect
+		}
+	}
+	if len(pipGroups) != 3 {
+		t.Fatalf("got %d pip groups, want 3 (cuda wheels, runtime, pypi)", len(pipGroups))
+	}
+	if pipGroups[0].Index != p.Index {
+		t.Errorf("cuda group index = %q, want the profile's %q", pipGroups[0].Index, p.Index)
+	}
+	// The runtime lands between the GPU group and the ordinary one, and with
+	// no index, so it resolves from PyPI.
+	if !reflect.DeepEqual(pipGroups[1].Packages, p.Runtime) {
+		t.Errorf("group 1 = %v, want the runtime %v", pipGroups[1].Packages, p.Runtime)
+	}
+	if pipGroups[1].Index != "" {
+		t.Errorf("runtime group index = %q, want empty so it resolves from PyPI", pipGroups[1].Index)
+	}
+	if pipGroups[2].Index != "" {
+		t.Errorf("plain group index = %q, want empty", pipGroups[2].Index)
+	}
+	if collect == nil || collect.LibDir != p.LibDir || collect.ConfPath != CUDAConfPath {
+		t.Fatalf("collect = %+v, want LibDir %q and ConfPath %q", collect, p.LibDir, CUDAConfPath)
+	}
+}
+
+// A GPU stage that installs no GPU wheels of its own still gets the runtime:
+// it may be loading CUDA through something apt or cmake installed.
+func TestLowerCUDAStageWithNoPipStillGetsRuntime(t *testing.T) {
+	p := testProfile()
+	g, err := Lower(&spec.File{Version: 1, Stages: []spec.Stage{
+		{Name: "app", From: "ubuntu:22.04", CUDA: true},
+	}}, Options{CUDAProfile: p})
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	var got []string
+	for _, x := range execNodesOf(g) {
+		if x.Pip != nil {
+			got = x.Pip.Packages
+		}
+	}
+	if !reflect.DeepEqual(got, p.Runtime) {
+		t.Fatalf("runtime group = %v, want %v", got, p.Runtime)
+	}
+}
+
+func TestLowerRejectsCUDAWithoutAProfile(t *testing.T) {
+	_, err := Lower(&spec.File{Version: 1, Stages: []spec.Stage{
+		{Name: "app", From: "ubuntu:22.04", CUDA: true},
+	}}, Options{})
+	if err == nil {
+		t.Fatal("Lower accepted a cuda: stage with no resolved GPU profile")
+	}
+}
+
+// An explicit user: still wins over the GPU default.
+func TestLowerExplicitUserBeatsCUDARoot(t *testing.T) {
+	g, err := Lower(&spec.File{Version: 1, Stages: []spec.Stage{
+		{Name: "app", From: "ubuntu:22.04", CUDA: true, User: "1000"},
+	}}, Options{CUDAProfile: testProfile()})
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	if g.Stages[0].User != "1000" {
+		t.Fatalf("user = %q, want the declared 1000", g.Stages[0].User)
+	}
+}
+
+// A download lowers to two nodes at different points in the stage, and they
+// must agree on the staging path — the reason it is resolved here rather
+// than recomputed by a backend.
+func TestLowerFetchAndExtractAgreeOnStagingPath(t *testing.T) {
+	g, err := Lower(&spec.File{Version: 1, Stages: []spec.Stage{{
+		Name: "app", From: "debian:12",
+		Download: []spec.Download{
+			{URL: "https://example.test/model.tar.gz", SHA256: "abc", Dest: "/models", Extract: "tar.gz"},
+			{URL: "https://example.test/plain.bin", SHA256: "sha256:def", Dest: "/opt/plain.bin", Mode: "0755"},
+		},
+		Install: &spec.Install{Apt: &spec.AptInstall{Packages: []string{"unzip"}}},
+	}}}, Options{})
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+
+	var fetches []*FetchOp
+	var extracts []*ExtractParams
+	fetchIdx, aptIdx, extractIdx := -1, -1, -1
+	for i := range g.Nodes {
+		switch {
+		case g.Nodes[i].Fetch != nil:
+			fetches = append(fetches, g.Nodes[i].Fetch)
+			if fetchIdx == -1 {
+				fetchIdx = i
+			}
+		case g.Nodes[i].Exec != nil && g.Nodes[i].Exec.Apt != nil:
+			aptIdx = i
+		case g.Nodes[i].Exec != nil && g.Nodes[i].Exec.Extract != nil:
+			extracts = append(extracts, g.Nodes[i].Exec.Extract)
+			extractIdx = i
+		}
+	}
+	if len(fetches) != 2 || len(extracts) != 1 {
+		t.Fatalf("got %d fetches and %d extracts, want 2 and 1", len(fetches), len(extracts))
+	}
+	// Fetch before install, extract after: extract may need a tool the
+	// install declared (unzip), and a fetch must not be re-run by an
+	// unrelated package bump.
+	if !(fetchIdx < aptIdx && aptIdx < extractIdx) {
+		t.Fatalf("node order fetch=%d apt=%d extract=%d, want fetch < apt < extract", fetchIdx, aptIdx, extractIdx)
+	}
+	if fetches[0].Dest != extracts[0].Archive {
+		t.Fatalf("fetch dest %q and extract archive %q disagree", fetches[0].Dest, extracts[0].Archive)
+	}
+	if extracts[0].Dest != "/models" {
+		t.Errorf("extract dest = %q, want the declared /models", extracts[0].Dest)
+	}
+	// Both spellings of the checksum normalize to one.
+	if fetches[0].Checksum != "sha256:abc" || fetches[1].Checksum != "sha256:def" {
+		t.Errorf("checksums = %q, %q; want both sha256:-prefixed exactly once", fetches[0].Checksum, fetches[1].Checksum)
+	}
+}
+
+func TestLowerRejectsUnpinnedDownload(t *testing.T) {
+	_, err := Lower(&spec.File{Version: 1, Stages: []spec.Stage{{
+		Name: "app", From: "debian:12",
+		Download: []spec.Download{{URL: "https://example.test/x.bin", Dest: "/x.bin"}},
+	}}}, Options{})
+	if err == nil {
+		t.Fatal("Lower accepted a download with no sha256 in the spec or the lockfile")
+	}
+}
+
+func TestLowerTakesDownloadChecksumFromTheLockfile(t *testing.T) {
+	g, err := Lower(&spec.File{Version: 1, Stages: []spec.Stage{{
+		Name: "app", From: "debian:12",
+		Download: []spec.Download{{URL: "https://example.test/x.bin", Dest: "/x.bin"}},
+	}}}, Options{Downloads: map[string]string{"https://example.test/x.bin": "deadbeef"}})
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	if got := g.Nodes[1].Fetch.Checksum; got != "sha256:deadbeef" {
+		t.Fatalf("checksum = %q, want sha256:deadbeef", got)
+	}
+}
+
+// pin: false is the only way to get an unpinned image, and the zero value of
+// the field must not be it — see ir.ImageOp.Unpinned.
+func TestLowerResolvesPin(t *testing.T) {
+	no := false
+	yes := true
+	for _, tc := range []struct {
+		name         string
+		pin          *bool
+		wantUnpinned bool
+	}{
+		{"absent pin defaults to pinned", nil, false},
+		{"pin: true is pinned", &yes, false},
+		{"pin: false is unpinned", &no, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g, err := Lower(&spec.File{Version: 1, Stages: []spec.Stage{
+				{Name: "app", From: "local/img:dev", Pin: tc.pin},
+			}}, Options{})
+			if err != nil {
+				t.Fatalf("Lower: %v", err)
+			}
+			if got := g.Nodes[0].Image.Unpinned; got != tc.wantUnpinned {
+				t.Fatalf("Unpinned = %v, want %v", got, tc.wantUnpinned)
+			}
+		})
+	}
+}
+
+// platform: build pins a stage to $BUILDPLATFORM regardless of what the build
+// targets, and the resolution lands on the node so the key sees it.
+func TestLowerResolvesStagePlatform(t *testing.T) {
+	g, err := Lower(&spec.File{Version: 1, Stages: []spec.Stage{
+		{Name: "web", From: "node:20-slim", Platform: "build"},
+		{Name: "app", From: "debian:12"},
+	}}, Options{Platform: "linux/arm64"})
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	if got := g.Nodes[g.Stages[0].Final].Image.Platform; got != "$BUILDPLATFORM" {
+		t.Errorf("build-platform stage = %q, want $BUILDPLATFORM", got)
+	}
+	if got := g.Nodes[g.Stages[1].Final].Image.Platform; got != "linux/arm64" {
+		t.Errorf("target stage = %q, want linux/arm64", got)
+	}
+}
+
+// A source: entrypoint is wrapped once, here, so both backends and the image
+// config agree on what PID 1 actually is.
+func TestLowerWrapsSourcedEntrypoint(t *testing.T) {
+	g, err := Lower(&spec.File{Version: 1, Stages: []spec.Stage{{
+		Name: "app", From: "ros:humble",
+		Entrypoint: &spec.Entrypoint{
+			Exec:   []string{"ros2", "run", "demo", "talker"},
+			Source: "/opt/ros/humble/setup.bash",
+		},
+	}}}, Options{})
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	got := g.Stages[0].Entrypoint
+	want := []string{"/bin/bash", "-c",
+		`source '/opt/ros/humble/setup.bash' && exec "$@"`, "bash",
+		"ros2", "run", "demo", "talker"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("entrypoint =\n %q\nwant\n %q", got, want)
+	}
+}
+
+// The declared argv is passed through as "$@" and never parsed by the shell,
+// so a metacharacter in the sourced path cannot escape its quoting.
+func TestLowerQuotesTheSourcedPath(t *testing.T) {
+	g, err := Lower(&spec.File{Version: 1, Stages: []spec.Stage{{
+		Name: "app", From: "debian:12",
+		Entrypoint: &spec.Entrypoint{Exec: []string{"app"}, Source: "/opt/a'; rm -rf /; '"},
+	}}}, Options{})
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	// Every embedded quote is closed and reopened, so the injected `rm -rf /`
+	// stays inside the single-quoted argument to source.
+	inner := g.Stages[0].Entrypoint[2]
+	want := `source '/opt/a'"'"'; rm -rf /; '"'"'' && exec "$@"`
+	if inner != want {
+		t.Fatalf("sourced path was not quoted:\n got  %s\n want %s", inner, want)
+	}
+}
+
+// The apt repository key digest is normalized once so no backend has to
+// decide whether to strip a prefix, and the key hashes one spelling.
+func TestLowerNormalizesAptRepositoryKeyDigest(t *testing.T) {
+	for _, in := range []string{"abc123", "sha256:abc123"} {
+		g, err := Lower(&spec.File{Version: 1, Stages: []spec.Stage{{
+			Name: "app", From: "ubuntu:22.04",
+			Install: &spec.Install{Apt: &spec.AptInstall{
+				Packages: []string{"ros-humble-desktop"},
+				Repositories: []spec.AptRepository{{
+					Name: "ros2", URL: "http://packages.ros.org/ros2/ubuntu",
+					Suites: []string{"jammy"}, Components: []string{"main"},
+					Key: spec.AptRepositoryKey{URL: "https://example.test/ros.key", SHA256: in},
+				}},
+			}},
+		}}}, Options{})
+		if err != nil {
+			t.Fatalf("Lower(%q): %v", in, err)
+		}
+		if got := g.Nodes[1].Exec.Apt.Repositories[0].KeySHA256; got != "abc123" {
+			t.Errorf("KeySHA256 for input %q = %q, want abc123", in, got)
+		}
+	}
+}
+
+// cmake's scratch root is resolved from the install's position in its stage,
+// so two installs in one stage never share a build tree.
+func TestLowerGivesEachCMakeInstallItsOwnRoot(t *testing.T) {
+	g, err := Lower(&spec.File{Version: 1, Stages: []spec.Stage{{
+		Name: "app", From: "ubuntu:22.04",
+		Install: &spec.Install{CMake: []spec.CMakeInstall{
+			{Repository: "https://example.test/a.git", Commit: "a1"},
+			{Repository: "https://example.test/b.git", Commit: "b2"},
+		}},
+	}}}, Options{})
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	var roots []string
+	for _, x := range execNodesOf(g) {
+		if x.CMake != nil {
+			roots = append(roots, x.CMake.Root)
+			// Defaults are resolved here, not left for a backend.
+			if x.CMake.Prefix != "/usr/local" || x.CMake.BuildType != "Release" {
+				t.Errorf("defaults not resolved: prefix=%q buildType=%q", x.CMake.Prefix, x.CMake.BuildType)
+			}
+		}
+	}
+	if len(roots) != 2 || roots[0] == roots[1] {
+		t.Fatalf("cmake roots = %v, want two distinct paths", roots)
+	}
+}
+
+// Lower must not alias the maps it copies out of the spec, for the same
+// reason it must not alias the slices: a caller that patches its spec.File in
+// place and lowers again would otherwise corrupt an already-returned graph,
+// and with it the cache key computed from that graph.
+func TestLowerDoesNotAliasSpecMaps(t *testing.T) {
+	env := map[string]string{"MODE": "prod"}
+	args := map[string]string{"VERSION": "1"}
+	defines := map[string]string{"BUILD_TESTS": "OFF"}
+	g, err := Lower(&spec.File{Version: 1, Stages: []spec.Stage{{
+		Name: "app", From: "ubuntu:22.04", Env: env, Args: args,
+		Install: &spec.Install{CMake: []spec.CMakeInstall{
+			{Repository: "https://example.test/a.git", Commit: "a1", Defines: defines},
+		}},
+	}}}, Options{})
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	env["MODE"] = "corrupted"
+	args["VERSION"] = "corrupted"
+	defines["BUILD_TESTS"] = "corrupted"
+
+	if got := g.Nodes[0].Image.Env["MODE"]; got != "prod" {
+		t.Errorf("Env aliased the spec: got %q, want prod", got)
+	}
+	if got := g.Nodes[0].Image.Args["VERSION"]; got != "1" {
+		t.Errorf("Args aliased the spec: got %q, want 1", got)
+	}
+	if got := execNodesOf(g)[0].CMake.Defines["BUILD_TESTS"]; got != "OFF" {
+		t.Errorf("cmake Defines aliased the spec: got %q, want OFF", got)
+	}
+}

--- a/go/internal/stagefile/ir/lower_test.go
+++ b/go/internal/stagefile/ir/lower_test.go
@@ -1,0 +1,317 @@
+package ir
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/stagefile/spec"
+)
+
+func TestLowerSingleStageImageOnly(t *testing.T) {
+	f := &spec.File{
+		Version: 1,
+		Stages:  []spec.Stage{{Name: "app", From: "debian:12"}},
+	}
+	g, err := Lower(f, Options{})
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	if len(g.Nodes) != 1 {
+		t.Fatalf("got %d nodes, want 1", len(g.Nodes))
+	}
+	if g.Nodes[0].Kind != OpImage {
+		t.Fatalf("got kind %q, want %q", g.Nodes[0].Kind, OpImage)
+	}
+	if g.Nodes[0].Image.Ref != "debian:12" {
+		t.Fatalf("got ref %q, want debian:12", g.Nodes[0].Image.Ref)
+	}
+	if len(g.Stages) != 1 || g.Stages[0].Name != "app" || g.Stages[0].Final != 0 {
+		t.Fatalf("got stages %+v, want one stage app→0", g.Stages)
+	}
+}
+
+func TestLowerAptThenPipChainsInputs(t *testing.T) {
+	f := &spec.File{
+		Version: 1,
+		Stages: []spec.Stage{{
+			Name: "deps",
+			From: "python:3.12-slim",
+			Install: &spec.Install{
+				Apt: &spec.AptInstall{Packages: []string{"build-essential"}},
+				Pip: []spec.PipInstall{{Requirements: "requirements.txt"}},
+			},
+		}},
+	}
+	g, err := Lower(f, Options{})
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	if len(g.Nodes) != 3 {
+		t.Fatalf("got %d nodes, want 3 (image, apt, pip)", len(g.Nodes))
+	}
+	if g.Nodes[1].Exec.Recipe != RecipeApt {
+		t.Fatalf("node 1 recipe = %+v, want apt", g.Nodes[1].Exec.Recipe)
+	}
+	if g.Nodes[2].Exec.Recipe != RecipePip {
+		t.Fatalf("node 2 recipe = %+v, want pip", g.Nodes[2].Exec.Recipe)
+	}
+	// The chain must be explicit: pip runs on apt's result.
+	if len(g.Nodes[2].Inputs) != 1 || g.Nodes[2].Inputs[0] != 1 {
+		t.Fatalf("pip inputs = %v, want [1]", g.Nodes[2].Inputs)
+	}
+	if g.Nodes[2].Exec.Pip.Requirements != "requirements.txt" {
+		t.Fatalf("pip requirements = %q", g.Nodes[2].Exec.Pip.Requirements)
+	}
+	if g.Stages[0].Final != 2 {
+		t.Fatalf("stage final = %d, want 2", g.Stages[0].Final)
+	}
+}
+
+func TestLowerCopyFromPriorStageReferencesItsFinalNode(t *testing.T) {
+	f := &spec.File{
+		Version: 1,
+		Stages: []spec.Stage{
+			{Name: "deps", From: "python:3.12-slim",
+				Install: &spec.Install{Apt: &spec.AptInstall{Packages: []string{"gcc"}}}},
+			{Name: "app", From: "python:3.12-slim",
+				Copy: []spec.CopyEntry{{From: "deps", Paths: []string{"/usr/lib"}}}},
+		},
+	}
+	g, err := Lower(f, Options{})
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	depsFinal := g.Stages[0].Final
+	var copyNode *Node
+	for i := range g.Nodes {
+		if g.Nodes[i].Kind == OpCopy {
+			copyNode = &g.Nodes[i]
+		}
+	}
+	if copyNode == nil {
+		t.Fatal("no copy node lowered")
+	}
+	// Inputs[0] is the stage this copy lands on; Inputs[1] is the source stage.
+	if len(copyNode.Inputs) != 2 || copyNode.Inputs[1] != depsFinal {
+		t.Fatalf("copy inputs = %v, want [_, %d]", copyNode.Inputs, depsFinal)
+	}
+	if copyNode.Copy.FromLocal {
+		t.Fatal("copy from a named stage must not be marked FromLocal")
+	}
+}
+
+func TestLowerCopyFromLocalHasNoStageInput(t *testing.T) {
+	f := &spec.File{
+		Version: 1,
+		Stages: []spec.Stage{{
+			Name: "app", From: "debian:12",
+			Copy: []spec.CopyEntry{{From: "local", Paths: []string{"app.py"}}},
+		}},
+	}
+	g, err := Lower(f, Options{})
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	copyNode := g.Nodes[g.Stages[0].Final]
+	if copyNode.Kind != OpCopy || !copyNode.Copy.FromLocal {
+		t.Fatalf("final node = %+v, want a local copy", copyNode)
+	}
+	if len(copyNode.Inputs) != 1 {
+		t.Fatalf("local copy inputs = %v, want exactly the base", copyNode.Inputs)
+	}
+}
+
+// TestLowerResolvesCopyDest pins the contract stated on CopyOp: Dest that
+// reaches a backend or the cache key is always final, never the raw spec
+// value. Leaving it raw made `paths: [app.py]` and
+// `paths: [app.py], dest: app.py` — the same build — key differently.
+func TestLowerResolvesCopyDest(t *testing.T) {
+	cases := []struct {
+		name  string
+		entry spec.CopyEntry
+		want  string
+	}{
+		{"omitted dest defaults to the sole path", spec.CopyEntry{From: "local", Paths: []string{"app.py"}}, "app.py"},
+		{"explicit dest is kept", spec.CopyEntry{From: "local", Paths: []string{"app.py"}, Dest: "/srv/app.py"}, "/srv/app.py"},
+		{"multi-path dest gains a trailing slash", spec.CopyEntry{From: "local", Paths: []string{"a.txt", "b.txt"}, Dest: "/app"}, "/app/"},
+		{"multi-path dest keeps its trailing slash", spec.CopyEntry{From: "local", Paths: []string{"a.txt", "b.txt"}, Dest: "/app/"}, "/app/"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g, err := Lower(&spec.File{Version: 1, Stages: []spec.Stage{
+				{Name: "app", From: "debian:12", Copy: []spec.CopyEntry{tc.entry}},
+			}}, Options{})
+			if err != nil {
+				t.Fatalf("Lower: %v", err)
+			}
+			if got := g.Nodes[g.Stages[0].Final].Copy.Dest; got != tc.want {
+				t.Fatalf("dest = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLowerDoesNotAliasSpecSlices guards against every []string field Lower
+// copies onto a node payload — Apt/Apk/Pip Packages, Copy.Paths, and
+// Stage.Entrypoint — sharing backing memory with the spec.File Lower reads.
+// Aliasing would let a caller that mutates its spec (or re-lowers it after
+// patching an install block in place, the scenario that motivated this
+// test) silently corrupt an already-returned graph — and since the graph is
+// what cachekey hashes, a corrupted graph now means a corrupted cache key.
+func TestLowerDoesNotAliasSpecSlices(t *testing.T) {
+	aptPkgs := []string{"curl"}
+	apkPkgs := []string{"musl-dev"}
+	pipPkgs := []string{"flask"}
+	paths := []string{"app.py"}
+	exec := []string{"python3", "app.py"}
+	f := &spec.File{
+		Version: 1,
+		Stages: []spec.Stage{{
+			Name: "app", From: "debian:12",
+			Install: &spec.Install{
+				Apt: &spec.AptInstall{Packages: aptPkgs},
+				Apk: &spec.ApkInstall{Packages: apkPkgs},
+				Pip: []spec.PipInstall{{Packages: pipPkgs}},
+			},
+			Copy:       []spec.CopyEntry{{From: "local", Paths: paths, Dest: "app.py"}},
+			Entrypoint: &spec.Entrypoint{Exec: exec},
+		}},
+	}
+	g, err := Lower(f, Options{})
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+
+	wantAptPkgs := []string{"curl"}
+	wantApkPkgs := []string{"musl-dev"}
+	wantPipPkgs := []string{"flask"}
+	wantPaths := []string{"app.py"}
+	wantExec := []string{"python3", "app.py"}
+
+	// Mutate the source spec's backing arrays after Lower returns.
+	aptPkgs[0] = "corrupted"
+	apkPkgs[0] = "corrupted"
+	pipPkgs[0] = "corrupted"
+	paths[0] = "corrupted.py"
+	exec[0] = "corrupted"
+
+	var aptNode, apkNode, pipNode *Node
+	for i := range g.Nodes {
+		if g.Nodes[i].Exec == nil {
+			continue
+		}
+		switch g.Nodes[i].Exec.Recipe {
+		case RecipeApt:
+			aptNode = &g.Nodes[i]
+		case RecipeApk:
+			apkNode = &g.Nodes[i]
+		case RecipePip:
+			pipNode = &g.Nodes[i]
+		}
+	}
+	if aptNode == nil || apkNode == nil || pipNode == nil {
+		t.Fatalf("expected apt, apk, and pip exec nodes, got nodes %+v", g.Nodes)
+	}
+	if !reflect.DeepEqual(aptNode.Exec.Apt.Packages, wantAptPkgs) {
+		t.Fatalf("AptParams.Packages changed after mutating the source spec: got %v, want %v", aptNode.Exec.Apt.Packages, wantAptPkgs)
+	}
+	if !reflect.DeepEqual(apkNode.Exec.Apk.Packages, wantApkPkgs) {
+		t.Fatalf("AptParams.Packages (apk) changed after mutating the source spec: got %v, want %v", apkNode.Exec.Apk.Packages, wantApkPkgs)
+	}
+	if !reflect.DeepEqual(pipNode.Exec.Pip.Packages, wantPipPkgs) {
+		t.Fatalf("PipParams.Packages changed after mutating the source spec: got %v, want %v", pipNode.Exec.Pip.Packages, wantPipPkgs)
+	}
+
+	gotCopy := g.Nodes[g.Stages[0].Final].Copy
+	if !reflect.DeepEqual(gotCopy.Paths, wantPaths) {
+		t.Fatalf("Copy.Paths changed after mutating the source spec: got %v, want %v", gotCopy.Paths, wantPaths)
+	}
+	if !reflect.DeepEqual(g.Stages[0].Entrypoint, wantExec) {
+		t.Fatalf("Stage.Entrypoint changed after mutating the source spec: got %v, want %v", g.Stages[0].Entrypoint, wantExec)
+	}
+}
+
+// TestLowerPreservesEntrypointNilness pins the nil-ness codegen relies on
+// (`st.Entrypoint != nil` decides whether an ENTRYPOINT line is emitted at
+// all), across both shapes that must produce it. A stage with no entrypoint
+// declared at all must lower to a nil slice, not an empty non-nil one — and
+// so must a stage whose declared entrypoint.exec is itself nil, which is the
+// shape that actually exercises slices.Clone's nil-preserving behavior: the
+// no-entrypoint case never reaches the clone at all, since Lower only calls
+// it inside `if s.Entrypoint != nil`.
+func TestLowerPreservesEntrypointNilness(t *testing.T) {
+	cases := []struct {
+		name       string
+		entrypoint *spec.Entrypoint
+	}{
+		{"no entrypoint declared", nil},
+		{"entrypoint declared with a nil exec", &spec.Entrypoint{Exec: nil}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g, err := Lower(&spec.File{Version: 1, Stages: []spec.Stage{
+				{Name: "app", From: "debian:12", Entrypoint: tc.entrypoint},
+			}}, Options{})
+			if err != nil {
+				t.Fatalf("Lower: %v", err)
+			}
+			if g.Stages[0].Entrypoint != nil {
+				t.Fatalf("Entrypoint = %#v, want nil", g.Stages[0].Entrypoint)
+			}
+		})
+	}
+}
+
+func TestLowerRejectsCopyWithNoPaths(t *testing.T) {
+	_, err := Lower(&spec.File{Version: 1, Stages: []spec.Stage{
+		{Name: "app", From: "debian:12", Copy: []spec.CopyEntry{{From: "local"}}},
+	}}, Options{})
+	if err == nil {
+		t.Fatal("Lower accepted a copy entry with no paths")
+	}
+}
+
+// TestLowerResolvesNpmManifestAndLockfile pins both npm build inputs on the
+// node. The manifest is named rather than assumed by each backend, and the
+// lockfile is derived from the defaulted manager so the two fields cannot
+// disagree about which manager they describe.
+func TestLowerResolvesNpmManifestAndLockfile(t *testing.T) {
+	for _, tc := range []struct{ manager, wantManager, wantLock string }{
+		{"", "npm", "package-lock.json"},
+		{"npm", "npm", "package-lock.json"},
+		{"yarn", "yarn", "yarn.lock"},
+		{"pnpm", "pnpm", "pnpm-lock.yaml"},
+	} {
+		g, err := Lower(&spec.File{Version: 1, Stages: []spec.Stage{
+			{Name: "app", From: "node:20-slim", Install: &spec.Install{
+				Npm: &spec.NpmInstall{Manager: tc.manager},
+			}},
+		}}, Options{})
+		if err != nil {
+			t.Fatalf("Lower(%q): %v", tc.manager, err)
+		}
+		npm := g.Nodes[g.Stages[0].Final].Exec.Npm
+		if npm.Manager != tc.wantManager {
+			t.Errorf("manager %q: got %q, want %q", tc.manager, npm.Manager, tc.wantManager)
+		}
+		if npm.Manifest != "package.json" {
+			t.Errorf("manager %q: manifest = %q, want package.json", tc.manager, npm.Manifest)
+		}
+		if npm.Lockfile != tc.wantLock {
+			t.Errorf("manager %q: lockfile = %q, want %q", tc.manager, npm.Lockfile, tc.wantLock)
+		}
+	}
+}
+
+func TestLowerRejectsUnknownBuildLang(t *testing.T) {
+	f := &spec.File{
+		Version: 1,
+		Stages: []spec.Stage{{
+			Name: "app", From: "debian:12",
+			Build: &spec.Build{Lang: "cobol"},
+		}},
+	}
+	if _, err := Lower(f, Options{}); err == nil {
+		t.Fatal("Lower accepted an unsupported build.lang")
+	}
+}

--- a/go/internal/stagefile/spec/localfiles.go
+++ b/go/internal/stagefile/spec/localfiles.go
@@ -29,7 +29,7 @@ func (i *Install) LocalFiles() []string {
 		add(p.Requirements)
 	}
 	if i.Npm != nil {
-		add("package.json")
+		add(NpmManifest)
 		add(NpmLockfile(i.Npm.Manager))
 	}
 	if i.Uv != nil {

--- a/go/internal/stagefile/spec/spec.go
+++ b/go/internal/stagefile/spec/spec.go
@@ -237,8 +237,16 @@ type UvInstall struct {
 	Dev    bool     `yaml:"dev,omitempty"`
 }
 
+// NpmManifest is the manifest file npm, yarn, and pnpm all read alongside
+// their lockfile. Both ir.Lower (which records it on the node, so codegen
+// and cachekey share one value) and dockerignore (which allowlists it) use
+// this constant, so the compiled build and the build context can't drift on
+// which file is present. It lives here, next to NpmLockfile, so the
+// manifest and lockfile names are decided in one place.
+const NpmManifest = "package.json"
+
 // NpmLockfile returns the lockfile filename a manager value expects
-// alongside package.json (empty string defaults to "npm"). Both codegen
+// alongside NpmManifest (empty string defaults to "npm"). Both codegen
 // (to COPY and RUN against the right file) and dockerignore (to allowlist
 // it) call this so the two packages can't drift out of sync on which file
 // each manager uses.

--- a/go/internal/stagefile/spec/validate.go
+++ b/go/internal/stagefile/spec/validate.go
@@ -77,6 +77,13 @@ func (f *File) Validate() error {
 		if !isFinal && s.Entrypoint != nil {
 			return fmt.Errorf("stage %q: entrypoint is only allowed on the final stage (%q)", s.Name, finalName)
 		}
+		// An entrypoint with no argv is not a container that starts and does
+		// nothing — it is a broken ENTRYPOINT [] line, and with source: set
+		// it is a bash wrapper that execs nothing. healthcheck.exec already
+		// carries the same guard for the same reason.
+		if s.Entrypoint != nil && len(s.Entrypoint.Exec) == 0 {
+			return fmt.Errorf("stage %q: entrypoint.exec must be non-empty", s.Name)
+		}
 		if !isFinal && s.User != "" {
 			return fmt.Errorf("stage %q: user is only allowed on the final stage (%q)", s.Name, finalName)
 		}
@@ -495,6 +502,13 @@ func validateCopy(entries []CopyEntry, priorNames map[string]bool) error {
 			return fmt.Errorf("copy from %q: paths must be non-empty", e.From)
 		}
 		for _, p := range e.Paths {
+			// An empty entry is not a no-op: ir.Lower defaults an omitted
+			// dest to Paths[0], so `paths: [""]` compiles to a COPY with a
+			// missing source and a blank destination — a Dockerfile that
+			// builds the wrong thing rather than one that fails to build.
+			if p == "" {
+				return fmt.Errorf("copy from %q: a paths entry must not be empty", e.From)
+			}
 			if p == "/" {
 				return fmt.Errorf("copy from %q: copying \"/\" is not allowed; list the specific paths you need", e.From)
 			}

--- a/go/internal/stagefile/spec/validate_test.go
+++ b/go/internal/stagefile/spec/validate_test.go
@@ -398,3 +398,26 @@ func TestValidateRejectsFormFeedInCopyDest(t *testing.T) {
 		t.Fatal("expected an error for a form feed embedded in copy.dest, got nil")
 	}
 }
+
+// An entrypoint with no argv compiles to a broken ENTRYPOINT [] — and with
+// source: set, to a bash wrapper that execs nothing.
+func TestValidateRejectsEmptyEntrypointExec(t *testing.T) {
+	for _, e := range []*Entrypoint{{}, {Exec: []string{}}, {Source: "/opt/setup.bash"}} {
+		f := &File{Version: 1, Stages: []Stage{{Name: "app", From: "debian:12", Entrypoint: e}}}
+		if err := f.Validate(); err == nil {
+			t.Errorf("Validate accepted entrypoint %+v with no exec", e)
+		}
+	}
+}
+
+// paths: [""] passes the cardinality check but compiles to a COPY with a
+// missing source and, via the dest default, a blank destination.
+func TestValidateRejectsEmptyCopyPath(t *testing.T) {
+	f := &File{Version: 1, Stages: []Stage{{
+		Name: "app", From: "debian:12",
+		Copy: []CopyEntry{{From: "local", Paths: []string{""}}},
+	}}}
+	if err := f.Validate(); err == nil {
+		t.Fatal("Validate accepted a copy entry with an empty path")
+	}
+}

--- a/go/internal/stagefile/testdata/npmbuild.stagefile.yaml
+++ b/go/internal/stagefile/testdata/npmbuild.stagefile.yaml
@@ -1,0 +1,41 @@
+# A second corpus fixture, covering the two recipes example.stagefile.yaml
+# does not reach: npm (with its manager defaulted, so the default path is
+# pinned too) and build. Those are exactly the recipes whose params the
+# frozen key corpus otherwise pinned nothing for — which is how a missing
+# package.json digest survived review.
+#
+# It also exercises a multi-path local copy with an explicit dest and two
+# cross-stage copies, so the copy-destination normalization has frozen keys
+# on both sides of it.
+version: 1
+stages:
+  - name: web
+    from: node:20-slim
+    install:
+      npm: {}
+    copy:
+      - from: local
+        paths: [src, tsconfig.json]
+        dest: /app
+
+  - name: server
+    from: rust:1-alpine
+    install:
+      apk:
+        packages: [musl-dev]
+    build:
+      lang: rust
+      profile: debug
+
+  - name: app
+    from: node:20-slim
+    copy:
+      - from: web
+        paths: [/app/dist]
+        dest: /srv/dist
+      - from: server
+        paths: [/target/debug/server]
+        dest: /usr/local/bin/server
+    entrypoint:
+      exec: [/usr/local/bin/server]
+    user: "1000"


### PR DESCRIPTION
Introduces a typed intermediate representation between a parsed Stagefile and
the backends that render it, plus a content-addressed cache key computed from
it. `codegen` becomes one backend among others instead of the only place a
Stagefile's meaning exists.

Three commits, each independently green:

1. **`ir`** — a flat, topologically ordered node graph. No node carries a
   rendered shell string, and no payload aliases a `spec` type. `Lower` is
   where every render-time resolution moves: defaulted copy destinations, npm's
   manifest/lockfile, a `cuda:` group's effective pip index, the CUDA runtime's
   splice position and the root user it implies, download checksums and staging
   paths, cmake scratch roots, and the source-then-exec entrypoint wrapper.
2. **`cachekey`** — keys over a node's semantic dependency closure, not its
   rendered text. Guarded three ways: a reflection test that fails when any ir
   payload gains a field, a per-field test that each field can move a key on
   its own, and a frozen key corpus over two fixtures.
3. **`codegen`** — renders from the graph. Output is byte-identical.

## Relationship to the original branch

The original `jo/stagefile-ir-cachekey` branched on 2026-08-07, and `main` has
since added ~3,900 lines under `go/internal/stagefile` — `cuda:`, `download:`,
`cmake:`, `uv:`, localfiles, pip index/cache scoping. The old IR modelled none
of them, so a literal rebase would have compiled while silently dropping every
one of those features from both the generated Dockerfile and the key.

So this is a **re-authored port, not a rebase**: the IR was extended to cover
main's full spec surface (new `OpFetch` kind; `CMake`/`Uv`/`Extract`/
`CUDACollect` recipes; apt repositories; stage args/env/workdir/platform on the
image node so they reach the key), and codegen was rewritten against today's
771-line renderer rather than the 298-line one the branch forked from. The 18
original commits are collapsed into the 3 above — several were review fixes
whose content is in the final state.

Two design changes fell out of the port:
- `ImageOp.Unpinned` is negated so the zero value is the *pinned* one. As
  `Pinned bool`, a hand-built graph that forgot the field silently keyed off
  the image tag instead of its digest — the existing memoization test caught it.
- `keyFormatVersion` 2 → 3. Everything the new encoding adds was previously
  invisible to the key.

Also fixes two validation gaps the IR exposed, both cases where the compiled
output is wrong rather than absent: an `entrypoint` with no argv, and an empty
`copy.paths` entry.

## Testing
- `go build ./...`
- `go test ./go/internal/stagefile/... ./go/internal/cli/optimize/...` — passes
- Every pre-existing codegen test (goldens, CUDA, cmake, download fixtures,
  cache-mount scope) passes against the IR path unmodified apart from being
  repointed at `GenerateSpec` — that equivalence is the main evidence the port
  is faithful.
- New: 13 lowering tests for the newly-modelled resolution, and per-field key
  tests for every field added to the corpus.
- Each of the 3 commits verified to build and test on its own.
- No on-device build was run; correctness rests on the byte-identical
  Dockerfile output above.

Draft: `jo/stagefile-llb-backend` stacks on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4JpbQ7PDaPGGKzua2MHS6
