### PR TITLE
feat(device top): surface maximum temperature warnings

### DIFF
--- a/go/cmd/wendy-agent/rosbattery.go
+++ b/go/cmd/wendy-agent/rosbattery.go
@@ -43,5 +43,6 @@ func startROS2BatteryMonitor(ctx context.Context, logger *zap.Logger, configPath
 	})
 
 	hoststats.SetFallbackBatterySource(monitor.Battery)
+	hoststats.SetSupplementalThermalSource(monitor.ThermalZones)
 	go monitor.Run(ctx)
 }

--- a/go/internal/agent/hoststats/rosbattery/cache.go
+++ b/go/internal/agent/hoststats/rosbattery/cache.go
@@ -16,13 +16,15 @@ import (
 const StaleAfter = 15 * time.Second
 
 // Cache holds the newest decoded sample and expires it. Safe for concurrent
-// use: the monitor goroutine calls Put while gRPC handlers call Battery.
+// use: the monitor goroutine writes while gRPC handlers read battery and
+// temperature data.
 type Cache struct {
 	now func() time.Time
 
-	mu   sync.RWMutex
-	b    *hoststats.Battery
-	seen time.Time
+	mu    sync.RWMutex
+	b     *hoststats.Battery
+	zones []hoststats.ThermalZone
+	seen  time.Time
 }
 
 // NewCache returns an empty cache reading time from now.
@@ -34,14 +36,30 @@ func NewCache(now func() time.Time) *Cache {
 // the cache, which is how the monitor reports that its writer went away. The
 // sample is copied, so the caller may reuse its buffer.
 func (c *Cache) Put(b *hoststats.Battery) {
+	c.putTelemetry(b, nil)
+}
+
+func (c *Cache) putTelemetry(b *hoststats.Battery, zones []hoststats.ThermalZone) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if b == nil {
-		c.b, c.seen = nil, time.Time{}
+		c.b, c.zones, c.seen = nil, nil, time.Time{}
 		return
 	}
 	cp := *b
-	c.b, c.seen = &cp, c.now()
+	c.b, c.zones, c.seen = &cp, append([]hoststats.ThermalZone(nil), zones...), c.now()
+}
+
+// ThermalZones returns copies of the newest device-specific temperatures, or
+// nil when the cache is empty or stale. They share the battery sample's
+// staleness window because both values come from the same LowState message.
+func (c *Cache) ThermalZones() []hoststats.ThermalZone {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.b == nil || c.now().Sub(c.seen) > StaleAfter {
+		return nil
+	}
+	return append([]hoststats.ThermalZone(nil), c.zones...)
 }
 
 // Battery returns a copy of the newest sample, or nil when the cache is empty

--- a/go/internal/agent/hoststats/rosbattery/cache_test.go
+++ b/go/internal/agent/hoststats/rosbattery/cache_test.go
@@ -85,6 +85,31 @@ func TestCache_PutNilClears(t *testing.T) {
 	if b := c.Battery(); b != nil {
 		t.Errorf("expected nil after Put(nil), got %+v", b)
 	}
+	if zones := c.ThermalZones(); zones != nil {
+		t.Errorf("expected temperatures to clear with the LowState sample, got %+v", zones)
+	}
+}
+
+func TestCache_ThermalZonesAreFreshAndCopied(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(1000, 0)}
+	c := NewCache(clk.now)
+	zones := []hoststats.ThermalZone{{Name: "go2/imu", TempC: 79}}
+	c.putTelemetry(&hoststats.Battery{Percent: 78}, zones)
+
+	zones[0].TempC = 1
+	first := c.ThermalZones()
+	if len(first) != 1 || first[0].TempC != 79 {
+		t.Fatalf("ThermalZones() = %+v, want copied 79C reading", first)
+	}
+	first[0].TempC = 2
+	if second := c.ThermalZones(); second[0].TempC != 79 {
+		t.Fatalf("ThermalZones() returned shared storage: %+v", second)
+	}
+
+	clk.advance(StaleAfter + time.Second)
+	if stale := c.ThermalZones(); stale != nil {
+		t.Fatalf("stale temperatures must disappear, got %+v", stale)
+	}
 }
 
 // Battery must hand back a copy: a caller mutating the result must not corrupt

--- a/go/internal/agent/hoststats/rosbattery/lowstate.go
+++ b/go/internal/agent/hoststats/rosbattery/lowstate.go
@@ -11,7 +11,8 @@ import (
 // advertises over SEDP.
 const TypeLowState = "unitree_go::msg::dds_::LowState_"
 
-// skipMotorState walks one MotorState field by field.
+// readMotorTemperature walks one MotorState field by field and returns its
+// embedded temperature.
 //
 // It must not be skipped as a fixed 48-byte block aligned to 4. CDR aligns per
 // field, not per struct, and MotorState's first member is `uint8 mode` — so the
@@ -20,28 +21,45 @@ const TypeLowState = "unitree_go::msg::dds_::LowState_"
 // 77 and occupies 47 bytes; only the following 19 are 48 each. Forcing
 // 4-alignment at the start inserts three phantom bytes and shifts bms_state —
 // which reads as soc=255 rather than as an error.
-func skipMotorState(d *cdr.Decoder) error {
+func readMotorTemperature(d *cdr.Decoder) (int8, error) {
 	if _, err := d.Uint8(); err != nil { // mode
-		return fmt.Errorf("mode: %w", err)
+		return 0, fmt.Errorf("mode: %w", err)
 	}
 	// q, dq, ddq, tau_est, q_raw, dq_raw, ddq_raw
 	if err := d.SkipBytes(4, 7*4); err != nil {
-		return fmt.Errorf("q..ddq_raw: %w", err)
+		return 0, fmt.Errorf("q..ddq_raw: %w", err)
 	}
-	if _, err := d.Int8(); err != nil { // temperature
-		return fmt.Errorf("temperature: %w", err)
+	temp, err := d.Int8()
+	if err != nil {
+		return 0, fmt.Errorf("temperature: %w", err)
 	}
 	if _, err := d.Uint32(); err != nil { // lost
-		return fmt.Errorf("lost: %w", err)
+		return 0, fmt.Errorf("lost: %w", err)
 	}
 	if err := d.SkipBytes(4, 8); err != nil { // reserve[2]
-		return fmt.Errorf("reserve: %w", err)
+		return 0, fmt.Errorf("reserve: %w", err)
 	}
-	return nil
+	return temp, nil
 }
 
 // lowStateMotors is the fixed motor_state array length.
 const lowStateMotors = 20
+
+var go2MotorNames = []string{
+	"fr-hip", "fr-thigh", "fr-calf",
+	"fl-hip", "fl-thigh", "fl-calf",
+	"rr-hip", "rr-thigh", "rr-calf",
+	"rl-hip", "rl-thigh", "rl-calf",
+}
+
+// LowStateTelemetry is the subset of Unitree LowState that the agent exposes
+// as generic host telemetry. Temperatures are named so the CLI can apply the
+// operational limit appropriate to the sensor class without guessing from a
+// single device-wide maximum.
+type LowStateTelemetry struct {
+	Battery      *hoststats.Battery
+	ThermalZones []hoststats.ThermalZone
+}
 
 // DecodeLowState extracts bms_state from a unitree_go/msg/LowState payload.
 //
@@ -51,6 +69,16 @@ const lowStateMotors = 20
 // therefore walks every remaining field too and asserts it consumed the
 // payload exactly, which is what turns a bad layout assumption into an error.
 func DecodeLowState(payload []byte) (*hoststats.Battery, error) {
+	telemetry, err := DecodeLowStateTelemetry(payload)
+	if err != nil {
+		return nil, err
+	}
+	return telemetry.Battery, nil
+}
+
+// DecodeLowStateTelemetry extracts BMS, IMU, and motor temperatures from a
+// unitree_go/msg/LowState payload in one validated walk of the wire layout.
+func DecodeLowStateTelemetry(payload []byte) (*LowStateTelemetry, error) {
 	d, err := cdr.NewDecoder(payload)
 	if err != nil {
 		return nil, err
@@ -75,14 +103,31 @@ func DecodeLowState(payload []byte) (*hoststats.Battery, error) {
 	if err := d.SkipBytes(4, 13*4); err != nil {
 		return nil, fmt.Errorf("imu_state floats: %w", err)
 	}
-	if _, err := d.Int8(); err != nil {
+	imuTemp, err := d.Int8()
+	if err != nil {
 		return nil, fmt.Errorf("imu_state.temperature: %w", err)
 	}
 
+	var zones []hoststats.ThermalZone
+	if imuTemp > 0 {
+		zones = append(zones, hoststats.ThermalZone{Name: "go2/imu", TempC: float64(imuTemp)})
+	}
 	for i := range lowStateMotors {
-		if err := skipMotorState(d); err != nil {
+		temp, err := readMotorTemperature(d)
+		if err != nil {
 			return nil, fmt.Errorf("motor_state[%d]: %w", i, err)
 		}
+		// LowState reserves 20 MotorState slots, but a Go2 has 12 physical
+		// joints. Continue walking all 20 to validate the wire layout while
+		// exposing only the named physical motors; reserved slots are not
+		// trustworthy temperature sensors.
+		if temp <= 0 || i >= len(go2MotorNames) {
+			continue
+		}
+		zones = append(zones, hoststats.ThermalZone{
+			Name:  "go2/motor/" + go2MotorNames[i],
+			TempC: float64(temp),
+		})
 	}
 
 	// BmsState
@@ -131,7 +176,7 @@ func DecodeLowState(payload []byte) (*hoststats.Battery, error) {
 	}
 	// SecondsRemaining stays 0: BmsState carries no capacity, and the estimate
 	// is never extrapolated.
-	return b, nil
+	return &LowStateTelemetry{Battery: b, ThermalZones: zones}, nil
 }
 
 // skipLowStateTrailer walks every LowState field after bms_state. Nothing here

--- a/go/internal/agent/hoststats/rosbattery/lowstate_test.go
+++ b/go/internal/agent/hoststats/rosbattery/lowstate_test.go
@@ -27,6 +27,10 @@ func (w *lowStateBuilder) arr(align, n int) { w.align(align); w.pad(n) }
 // lowStatePayload builds a complete, correctly-sized LowState whose bms_state
 // carries soc and current, with every other field zeroed.
 func lowStatePayload(soc uint8, current int32) []byte {
+	return lowStatePayloadWithTemperatures(soc, current, 0, nil)
+}
+
+func lowStatePayloadWithTemperatures(soc uint8, current int32, imuTemp int8, motorTemps map[int]int8) []byte {
 	w := &lowStateBuilder{}
 	w.u8(0)
 	w.u8(0)     // head[2]
@@ -39,19 +43,19 @@ func lowStatePayload(soc uint8, current int32) []byte {
 	// IMUState: quaternion[4] + gyroscope[3] + accelerometer[3] + rpy[3]
 	// float32s, then int8 temperature.
 	w.arr(4, 13*4)
-	w.u8(0)
+	w.u8(uint8(imuTemp))
 
 	// MotorState[20]. Note the struct is NOT 4-aligned at its start: its first
 	// member is uint8 mode, so it begins wherever IMUState left off (offset 77,
 	// an odd address). motor_state[0] is therefore 47 bytes and the rest 48.
-	for range 20 {
-		w.u8(0)      // mode
-		w.align(4)   //
-		w.pad(7 * 4) // q..ddq_raw
-		w.u8(0)      // temperature
-		w.align(4)   //
-		w.u32(0)     // lost
-		w.arr(4, 8)  // reserve[2]
+	for i := range 20 {
+		w.u8(0)                    // mode
+		w.align(4)                 //
+		w.pad(7 * 4)               // q..ddq_raw
+		w.u8(uint8(motorTemps[i])) // temperature
+		w.align(4)                 //
+		w.u32(0)                   // lost
+		w.arr(4, 8)                // reserve[2]
 	}
 
 	// BmsState: version_high, version_low, status, soc, current, cycle,
@@ -84,6 +88,62 @@ func lowStatePayload(soc uint8, current int32) []byte {
 	w.u32(0) // crc
 
 	return append([]byte{0x00, 0x01, 0x00, 0x00}, w.b...)
+}
+
+func TestDecodeLowStateTelemetry_Temperatures(t *testing.T) {
+	reading, err := DecodeLowStateTelemetry(lowStatePayloadWithTemperatures(84, -3200, 79, map[int]int8{
+		0:  52,
+		1:  68,
+		9:  61,
+		12: 99, // reserved LowState slot, not a physical Go2 joint
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reading.Battery.Percent != 84 {
+		t.Fatalf("battery percent = %v, want 84", reading.Battery.Percent)
+	}
+	want := map[string]float64{
+		"go2/imu":            79,
+		"go2/motor/fr-hip":   52,
+		"go2/motor/fr-thigh": 68,
+		"go2/motor/rl-hip":   61,
+	}
+	if len(reading.ThermalZones) != len(want) {
+		t.Fatalf("thermal zones = %+v, want %d populated readings", reading.ThermalZones, len(want))
+	}
+	for _, zone := range reading.ThermalZones {
+		if temp, ok := want[zone.Name]; !ok || zone.TempC != temp {
+			t.Errorf("unexpected thermal zone %+v; want %v", zone, want)
+		}
+	}
+}
+
+func TestDecodeLowStateTelemetry_DoesNotExposeReservedMotorSlots(t *testing.T) {
+	reading, err := DecodeLowStateTelemetry(lowStatePayloadWithTemperatures(50, 0, 0, map[int]int8{
+		11: 65,
+		12: 99,
+		19: 98,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reading.ThermalZones) != 1 {
+		t.Fatalf("thermal zones = %+v; reserved motor slots must not be exposed", reading.ThermalZones)
+	}
+	if got := reading.ThermalZones[0]; got.Name != "go2/motor/rl-calf" || got.TempC != 65 {
+		t.Fatalf("physical motor reading = %+v, want rl-calf at 65C", got)
+	}
+}
+
+func TestDecodeLowStateTelemetry_OmitsInvalidZeroTemperatures(t *testing.T) {
+	reading, err := DecodeLowStateTelemetry(lowStatePayload(50, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reading.ThermalZones) != 0 {
+		t.Fatalf("zero temperatures must be omitted, got %+v", reading.ThermalZones)
+	}
 }
 
 func TestDecodeLowState_Discharging(t *testing.T) {

--- a/go/internal/agent/hoststats/rosbattery/monitor.go
+++ b/go/internal/agent/hoststats/rosbattery/monitor.go
@@ -135,6 +135,11 @@ func NewMonitor(cfg Config, cache *Cache, logf func(string, ...any)) *Monitor {
 // Battery returns the newest non-stale reading, or nil.
 func (m *Monitor) Battery() *hoststats.Battery { return m.cache.Battery() }
 
+// ThermalZones returns current device-specific temperatures learned from the
+// same DDS sample as Battery. Standard BatteryState topics add no zones;
+// Unitree LowState adds IMU and motor temperatures.
+func (m *Monitor) ThermalZones() []hoststats.ThermalZone { return m.cache.ThermalZones() }
+
 // Run drives the monitor until ctx is cancelled.
 func (m *Monitor) Run(ctx context.Context) {
 	if !m.cfg.Enabled {
@@ -260,7 +265,7 @@ func (m *Monitor) consume(ctx context.Context, p *rtps.Participant, ep rtps.Endp
 		case <-ctx.Done():
 			return
 		case s := <-p.Samples():
-			b, err := decode(s.Payload)
+			reading, err := decode(s.Payload)
 			if err != nil {
 				// Log once per subscription. A layout mismatch repeats at the
 				// topic's publish rate, which would otherwise flood the log.
@@ -270,7 +275,7 @@ func (m *Monitor) consume(ctx context.Context, p *rtps.Participant, ep rtps.Endp
 				}
 				continue
 			}
-			m.cache.Put(b)
+			m.cache.putTelemetry(reading.Battery, reading.ThermalZones)
 		case <-time.After(StaleAfter):
 			m.logf("ros2 battery: %s silent for %s, rescanning", ep.Topic, StaleAfter)
 			return
@@ -278,14 +283,28 @@ func (m *Monitor) consume(ctx context.Context, p *rtps.Participant, ep rtps.Endp
 	}
 }
 
+type decodedTelemetry struct {
+	Battery      *hoststats.Battery
+	ThermalZones []hoststats.ThermalZone
+}
+
 // decoderFor selects a decoder by DDS type name, or nil when the type is one
 // this package cannot read.
-func decoderFor(typeName string) func([]byte) (*hoststats.Battery, error) {
+func decoderFor(typeName string) func([]byte) (*decodedTelemetry, error) {
 	switch {
 	case strings.Contains(typeName, "BatteryState"):
-		return DecodeBatteryState
+		return func(payload []byte) (*decodedTelemetry, error) {
+			battery, err := DecodeBatteryState(payload)
+			return &decodedTelemetry{Battery: battery}, err
+		}
 	case strings.Contains(typeName, "LowState"):
-		return DecodeLowState
+		return func(payload []byte) (*decodedTelemetry, error) {
+			reading, err := DecodeLowStateTelemetry(payload)
+			if err != nil {
+				return nil, err
+			}
+			return &decodedTelemetry{Battery: reading.Battery, ThermalZones: reading.ThermalZones}, nil
+		}
 	default:
 		return nil
 	}

--- a/go/internal/agent/hoststats/thermal.go
+++ b/go/internal/agent/hoststats/thermal.go
@@ -6,11 +6,17 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 // thermalRoot is the sysfs directory enumerating thermal zones. A package var so
 // tests can point it at a fixture tree.
 var thermalRoot = "/sys/class/thermal"
+
+var (
+	supplementalThermalMu     sync.RWMutex
+	supplementalThermalSource func() []ThermalZone
+)
 
 // ThermalZone is one temperature sensor reading from /sys/class/thermal.
 type ThermalZone struct {
@@ -44,13 +50,44 @@ func SampleThermal() []ThermalZone {
 		}
 		zones = append(zones, ThermalZone{Name: readZoneType(zoneDir, dirName), TempC: tempC})
 	}
+	sortThermalZones(zones)
+	return zones
+}
+
+// SetSupplementalThermalSource registers temperatures that are not exposed by
+// Linux thermal sysfs. A Unitree robot's IMU and motor temperatures, received
+// over DDS, are the motivating case. Pass nil to clear the source.
+//
+// The supplemental source is additive: portable sysfs readings remain present
+// on every host, and a missing or stale device-specific source simply adds
+// nothing.
+func SetSupplementalThermalSource(f func() []ThermalZone) {
+	supplementalThermalMu.Lock()
+	defer supplementalThermalMu.Unlock()
+	supplementalThermalSource = f
+}
+
+// ResolveThermal combines portable Linux thermal zones with any current
+// device-specific readings and sorts the result hottest-first.
+func ResolveThermal() []ThermalZone {
+	zones := SampleThermal()
+	supplementalThermalMu.RLock()
+	source := supplementalThermalSource
+	supplementalThermalMu.RUnlock()
+	if source != nil {
+		zones = append(zones, source()...)
+	}
+	sortThermalZones(zones)
+	return zones
+}
+
+func sortThermalZones(zones []ThermalZone) {
 	sort.SliceStable(zones, func(i, j int) bool {
 		if zones[i].TempC != zones[j].TempC {
 			return zones[i].TempC > zones[j].TempC
 		}
 		return zones[i].Name < zones[j].Name
 	})
-	return zones
 }
 
 // readZoneTemp reads a thermal zone "temp" file (millidegrees Celsius) and

--- a/go/internal/agent/hoststats/thermal_source_test.go
+++ b/go/internal/agent/hoststats/thermal_source_test.go
@@ -1,0 +1,46 @@
+package hoststats
+
+import "testing"
+
+func TestResolveThermalCombinesAndSortsSupplementalSource(t *testing.T) {
+	root := t.TempDir()
+	oldRoot := thermalRoot
+	thermalRoot = root
+	t.Cleanup(func() {
+		thermalRoot = oldRoot
+		SetSupplementalThermalSource(nil)
+	})
+
+	writeZone(t, root, "thermal_zone0", "cpu-thermal", "52000")
+	SetSupplementalThermalSource(func() []ThermalZone {
+		return []ThermalZone{
+			{Name: "go2/motor/front-right-thigh", TempC: 67},
+			{Name: "go2/imu", TempC: 61},
+		}
+	})
+
+	zones := ResolveThermal()
+	if len(zones) != 3 {
+		t.Fatalf("ResolveThermal() returned %d zones, want 3: %+v", len(zones), zones)
+	}
+	if zones[0].Name != "go2/motor/front-right-thigh" || zones[1].Name != "go2/imu" || zones[2].Name != "cpu-thermal" {
+		t.Fatalf("ResolveThermal() not sorted hottest-first: %+v", zones)
+	}
+}
+
+func TestResolveThermalWithoutSupplementalSourcePreservesSysfs(t *testing.T) {
+	root := t.TempDir()
+	oldRoot := thermalRoot
+	thermalRoot = root
+	SetSupplementalThermalSource(nil)
+	t.Cleanup(func() {
+		thermalRoot = oldRoot
+		SetSupplementalThermalSource(nil)
+	})
+
+	writeZone(t, root, "thermal_zone0", "soc-thermal", "49000")
+	zones := ResolveThermal()
+	if len(zones) != 1 || zones[0].Name != "soc-thermal" || zones[0].TempC != 49 {
+		t.Fatalf("ResolveThermal() = %+v, want the existing sysfs zone", zones)
+	}
+}

--- a/go/internal/agent/services/container_service.go
+++ b/go/internal/agent/services/container_service.go
@@ -1229,7 +1229,7 @@ func (s *ContainerService) GetResourceStats(ctx context.Context, _ *agentpb.GetR
 		host.MemAvailableBytes = mem.AvailableBytes
 	}
 	host.Gpus = gpuStatsToProto(hoststats.SampleGPU(ctx))
-	host.ThermalZones = thermalZonesToProto(hoststats.SampleThermal())
+	host.ThermalZones = thermalZonesToProto(hoststats.ResolveThermal())
 	host.Battery = batteryToProto(hoststats.ResolveBattery())
 
 	return &agentpb.GetResourceStatsResponse{

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/top.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/top.md
@@ -1,6 +1,6 @@
 # `wendy device top`
 
-Live CPU, memory, and GPU usage for the device and its containers — an `htop`-style monitor for a WendyOS device.
+Live CPU, memory, GPU, and temperature telemetry for the device and its containers — an `htop`-style monitor for a WendyOS device.
 
 ## Usage
 
@@ -10,7 +10,9 @@ wendy device top [flags]
 
 ## Description
 
-`wendy device top` opens a full-screen, auto-refreshing dashboard showing whole-machine CPU and memory utilization, per-GPU utilization/memory (and temperature/power where reported), and a per-app/per-container table of CPU% and memory. CPU percentages are computed from deltas between refreshes, so the first frame may read low until a second sample is taken.
+`wendy device top` opens a full-screen, auto-refreshing dashboard showing whole-machine CPU and memory utilization, the hottest current device temperature, per-GPU utilization/memory (and temperature/power where reported), and a per-app/per-container table of CPU% and memory. CPU percentages are computed from deltas between refreshes, so the first frame may read low until a second sample is taken.
+
+The temperature header normally shows the maximum reading and its source. A yellow `●` appears when any classified sensor is within 5°C of its operational warning threshold; the circle turns red at or above that threshold. On a Unitree Go2 discovered through LowState telemetry, the agent adds the IMU and 12 physical motor temperatures to the Linux thermal zones and expires them after 15 seconds without a fresh sample. The current operational thresholds are 70°C for Go2 motors and 85°C for the Go2 IMU and host thermal zones. These values were observed and chosen for Woof operations; they are not Unitree or NVIDIA vendor ratings.
 
 Apps are grouped the same way as [`wendy device dashboard`](dashboard.md): multi-service apps show a group header with one subrow per service. Running apps (`●`), stopped apps (`○`), and crash-looping apps (`↻`) have distinct row styling and are counted separately. Resource columns show unavailable values for stopped and crash-looping rows instead of presenting them as active zero-usage workloads. A side panel shows the listening ports of the currently selected running app.
 
@@ -53,6 +55,12 @@ Plain snapshots include a `STATE` column. JSON snapshots have this shape:
     "cpuCount": 8,
     "memUsedBytes": 2147483648,
     "memTotalBytes": 8589934592,
+    "thermalZones": [
+      { "name": "go2/imu", "tempC": 79.0 },
+      { "name": "go2/motor/fr-thigh", "tempC": 66.0 },
+      { "name": "tj-thermal", "tempC": 55.0 }
+    ],
+    "maximumTemperature": { "name": "go2/imu", "tempC": 79.0 },
     "gpus": [
       {
         "index": 0,
@@ -72,6 +80,9 @@ Plain snapshots include a `STATE` column. JSON snapshots have this shape:
 ```
 
 - `host.gpus` is omitted on devices that report no GPU.
+- `host.thermalZones` is omitted when the agent has no readable temperature source.
+- `host.maximumTemperature` is the hottest valid thermal-zone or GPU reading and is omitted when no temperature is available.
+- Go2 IMU and motor temperatures require a device agent with the LowState thermal extension; older agents continue to report host thermal zones only.
 - Each GPU's `tempC` and `powerW` are omitted when the agent doesn't report them.
 - `containers[].state` is `running`, `stopped`, or `crash-loop`.
 - `containers[].cpuPercent` is each container's share of the whole machine (0–100 across all cores).

--- a/go/internal/cli/commands/device_top.go
+++ b/go/internal/cli/commands/device_top.go
@@ -467,6 +467,10 @@ type topModel struct {
 	prev, cur        topSample
 	havePrev         bool
 	cachedContainers []*agentpb.AppContainer
+	// Keep near-equal temperatures from trading places on every sample. The
+	// dashboard preserves this order across refreshes; snapshots remain a
+	// stateless representation of the agent response.
+	displayThermalZones []*agentpb.ThermalZone
 
 	rows      []topRow
 	cursor    int
@@ -705,6 +709,11 @@ func (m topModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.havePrev = true
 		}
 		m.cur = newTopSample(msg.resp, time.Now().UnixNano())
+		if m.cur.host != nil {
+			m.displayThermalZones = stabilizeThermalZoneOrder(m.displayThermalZones, m.cur.host.GetThermalZones())
+		} else {
+			m.displayThermalZones = nil
+		}
 		m.rebuildRows()
 		// Refresh ports for the selected app on every tick so they stay current.
 		sel := m.selectedAppName()
@@ -956,7 +965,13 @@ func (m topModel) View() string {
 			top = append(top, topMeter("GPU", g.GetUtilPercent()/100, val, meterW))
 		}
 
-		if zones := h.GetThermalZones(); len(zones) > 0 {
+		zones := m.displayThermalZones
+		// Some view tests construct a model directly instead of sending a stats
+		// message through Update. Use the sample's order for that initial frame.
+		if zones == nil {
+			zones = h.GetThermalZones()
+		}
+		if len(zones) > 0 {
 			top = append(top, topValDim.Render(" Temp: "+formatThermalZones(zones)))
 		}
 	} else {
@@ -1148,8 +1163,9 @@ func runTopDashboard(ctx context.Context, conn *grpcclient.AgentConnection, inte
 	return err
 }
 
-// formatThermalZones renders thermal zones (already sorted hottest-first by the
-// agent) as a compact one-line summary, e.g. "cpu 49°C  gpu 48°C  soc0 47°C".
+// formatThermalZones renders thermal zones in the supplied order as a compact
+// one-line summary, e.g. "cpu 49°C  gpu 48°C  soc0 47°C". The agent supplies
+// them hottest-first; the live dashboard applies a small ordering hysteresis.
 // Zone names are shortened by trimming the conventional "-thermal"/"-therm"
 // suffix for readability.
 func formatThermalZones(zones []*agentpb.ThermalZone) string {
@@ -1161,6 +1177,55 @@ func formatThermalZones(zones []*agentpb.ThermalZone) string {
 		parts = append(parts, fmt.Sprintf("%s %.0f°C", name, z.GetTempC()))
 	}
 	return strings.Join(parts, "  ")
+}
+
+const thermalOrderHysteresisC = 1.0
+
+// stabilizeThermalZoneOrder keeps the live temperature list hottest-first
+// without allowing insignificant fluctuations to reorder it. Starting with
+// the prior displayed order, a sensor only overtakes the one above it after it
+// becomes more than thermalOrderHysteresisC hotter. Reversing that move needs
+// the same clear lead in the other direction, which prevents oscillation while
+// still surfacing a meaningfully hotter sensor promptly.
+func stabilizeThermalZoneOrder(previous, current []*agentpb.ThermalZone) []*agentpb.ThermalZone {
+	if len(current) == 0 {
+		return nil
+	}
+
+	indicesByName := make(map[string][]int, len(current))
+	for i, zone := range current {
+		indicesByName[zone.GetName()] = append(indicesByName[zone.GetName()], i)
+	}
+
+	ordered := make([]*agentpb.ThermalZone, 0, len(current))
+	used := make([]bool, len(current))
+	for _, zone := range previous {
+		name := zone.GetName()
+		indices := indicesByName[name]
+		if len(indices) > 0 {
+			index := indices[0]
+			indicesByName[name] = indices[1:]
+			ordered = append(ordered, current[index])
+			used[index] = true
+		}
+	}
+	// ResolveThermal sends new sensors hottest-first, so retaining its order
+	// here gives a sensible initial placement before hysteresis is applied.
+	for i, zone := range current {
+		if !used[i] {
+			ordered = append(ordered, zone)
+		}
+	}
+
+	// Insertion-sort from the previous visual order. Unlike a comparator that
+	// embeds hysteresis, this remains deterministic and cannot violate Go's
+	// strict-ordering requirement.
+	for i := 1; i < len(ordered); i++ {
+		for j := i; j > 0 && ordered[j].GetTempC() > ordered[j-1].GetTempC()+thermalOrderHysteresisC; j-- {
+			ordered[j], ordered[j-1] = ordered[j-1], ordered[j]
+		}
+	}
+	return ordered
 }
 
 const (

--- a/go/internal/cli/commands/device_top.go
+++ b/go/internal/cli/commands/device_top.go
@@ -237,12 +237,13 @@ func listAppContainers(ctx context.Context, conn *grpcclient.AgentConnection) ([
 }
 
 type topJSONHost struct {
-	CPUPercent    float64          `json:"cpuPercent"`
-	CPUCount      uint32           `json:"cpuCount"`
-	MemUsedBytes  int64            `json:"memUsedBytes"`
-	MemTotalBytes int64            `json:"memTotalBytes"`
-	GPUs          []topJSONGPU     `json:"gpus,omitempty"`
-	ThermalZones  []topJSONThermal `json:"thermalZones,omitempty"`
+	CPUPercent         float64          `json:"cpuPercent"`
+	CPUCount           uint32           `json:"cpuCount"`
+	MemUsedBytes       int64            `json:"memUsedBytes"`
+	MemTotalBytes      int64            `json:"memTotalBytes"`
+	GPUs               []topJSONGPU     `json:"gpus,omitempty"`
+	ThermalZones       []topJSONThermal `json:"thermalZones,omitempty"`
+	MaximumTemperature *topJSONThermal  `json:"maximumTemperature,omitempty"`
 	// Absent on mains-powered devices. Consumers must read "no battery key" as
 	// "no battery", never as a flat one.
 	Battery *topJSONBattery `json:"battery,omitempty"`
@@ -308,6 +309,9 @@ func buildTopJSON(prev, cur topSample, containers []*agentpb.AppContainer) topJS
 				Name:  z.GetName(),
 				TempC: z.GetTempC(),
 			})
+		}
+		if summary, ok := summarizeTemperature(cur.host); ok {
+			out.Host.MaximumTemperature = &topJSONThermal{Name: summary.Max.Name, TempC: summary.Max.TempC}
 		}
 		if b := cur.host.GetBattery(); b != nil {
 			out.Host.Battery = &topJSONBattery{
@@ -392,6 +396,9 @@ func writeTopPlainSnapshot(w io.Writer, prev, cur topSample, containers []*agent
 			fmt.Fprintf(w, "GPU%d %s: %.0f%%  %s\n", g.GetIndex(), g.GetName(),
 				g.GetUtilPercent(), formatGPUMem(g))
 		}
+		if summary, ok := summarizeTemperature(cur.host); ok {
+			fmt.Fprintf(w, "TEMP MAX: %s\n", formatTemperatureSummary(summary))
+		}
 		if zones := cur.host.GetThermalZones(); len(zones) > 0 {
 			fmt.Fprintf(w, "TEMP: %s\n", formatThermalZones(zones))
 		}
@@ -420,7 +427,7 @@ func newTopCmd() *cobra.Command {
 	var interval time.Duration
 	cmd := &cobra.Command{
 		Use:   "top",
-		Short: "Live CPU, memory, and GPU usage for the device and its containers",
+		Short: "Live CPU, memory, GPU, and temperature for the device and its containers",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			conn, err := connectToAgent(ctx)
@@ -790,11 +797,13 @@ var (
 	topValDim     = lipgloss.NewStyle().Foreground(tui.ColorDim)
 	topHeaderBar  = lipgloss.NewStyle().Bold(true).Background(tui.Emerald500).Foreground(lipgloss.Color("#02160f"))
 	// Bright mint selection bar for strong contrast with the black row text.
-	topSelRow     = lipgloss.NewStyle().Background(lipgloss.Color("#9FE2BF")).Foreground(lipgloss.Color("#000000"))
-	topRunningRow = lipgloss.NewStyle().Foreground(tui.Emerald400)
-	topCrashRow   = lipgloss.NewStyle().Foreground(tui.Red500)
-	topKeyCap     = lipgloss.NewStyle().Foreground(lipgloss.Color("#02160f")).Background(lipgloss.Color("#d0d0d0"))
-	topKeyLabel   = lipgloss.NewStyle().Foreground(lipgloss.Color("#02160f")).Background(tui.Emerald500)
+	topSelRow      = lipgloss.NewStyle().Background(lipgloss.Color("#9FE2BF")).Foreground(lipgloss.Color("#000000"))
+	topRunningRow  = lipgloss.NewStyle().Foreground(tui.Emerald400)
+	topCrashRow    = lipgloss.NewStyle().Foreground(tui.Red500)
+	topThermalNear = lipgloss.NewStyle().Bold(true).Foreground(tui.Amber500)
+	topThermalHot  = lipgloss.NewStyle().Bold(true).Foreground(tui.Red500)
+	topKeyCap      = lipgloss.NewStyle().Foreground(lipgloss.Color("#02160f")).Background(lipgloss.Color("#d0d0d0"))
+	topKeyLabel    = lipgloss.NewStyle().Foreground(lipgloss.Color("#02160f")).Background(tui.Emerald500)
 )
 
 // topMeter renders an htop-style bracketed meter: LABEL[|||||      value].
@@ -903,6 +912,9 @@ func (m topModel) View() string {
 	if m.cur.host != nil {
 		h := m.cur.host
 		meterW := width - 2
+		if summary, ok := summarizeTemperature(h); ok {
+			top = append(top, renderTemperatureHeader(summary))
+		}
 		cpuRatio, cpuVal := 0.0, "—"
 		if m.havePrev {
 			pct := hostCPUPercent(m.prev, m.cur)
@@ -1149,4 +1161,142 @@ func formatThermalZones(zones []*agentpb.ThermalZone) string {
 		parts = append(parts, fmt.Sprintf("%s %.0f°C", name, z.GetTempC()))
 	}
 	return strings.Join(parts, "  ")
+}
+
+const (
+	// These are operational thresholds measured on Woof, not vendor ratings.
+	// Keep the source-specific distinction: Go2 motors have a lower warning
+	// point than the Jetson and Go2 IMU.
+	deviceThermalWarningC = 85.0
+	go2MotorWarningC      = 70.0
+	thermalNearDeltaC     = 5.0
+)
+
+type thermalRisk uint8
+
+const (
+	thermalNormal thermalRisk = iota
+	thermalNear
+	thermalOver
+)
+
+type thermalReading struct {
+	Name  string
+	TempC float64
+}
+
+type temperatureSummary struct {
+	Max            thermalReading
+	Risk           thermalRisk
+	Alert          thermalReading
+	AlertThreshold float64
+}
+
+// summarizeTemperature finds the maximum temperature while separately
+// classifying every reading against its own operational threshold. This is
+// important on a Go2: a 66C motor is near its 70C warning point even when a
+// hotter 79C IMU is still more than 5C below its 85C warning point.
+func summarizeTemperature(host *agentpb.HostStats) (temperatureSummary, bool) {
+	var readings []thermalReading
+	for _, zone := range host.GetThermalZones() {
+		if zone.GetTempC() > 0 {
+			readings = append(readings, thermalReading{Name: zone.GetName(), TempC: zone.GetTempC()})
+		}
+	}
+	for _, gpu := range host.GetGpus() {
+		if gpu.TempC != nil && gpu.GetTempC() > 0 {
+			readings = append(readings, thermalReading{
+				Name:  fmt.Sprintf("gpu/%d", gpu.GetIndex()),
+				TempC: gpu.GetTempC(),
+			})
+		}
+	}
+	if len(readings) == 0 {
+		return temperatureSummary{}, false
+	}
+
+	summary := temperatureSummary{Max: readings[0]}
+	bestMargin := thermalNearDeltaC + 1
+	for _, reading := range readings {
+		if reading.TempC > summary.Max.TempC {
+			summary.Max = reading
+		}
+		threshold, classified := thermalWarningThreshold(reading.Name)
+		if !classified {
+			continue
+		}
+		margin := threshold - reading.TempC
+		risk := thermalNormal
+		switch {
+		case margin <= 0:
+			risk = thermalOver
+		case margin <= thermalNearDeltaC:
+			risk = thermalNear
+		}
+		if risk > summary.Risk || (risk == summary.Risk && risk != thermalNormal && margin < bestMargin) {
+			summary.Risk = risk
+			summary.Alert = reading
+			summary.AlertThreshold = threshold
+			bestMargin = margin
+		}
+	}
+	return summary, true
+}
+
+// thermalWarningThreshold returns an applicable operational warning point.
+// Names under go2/ are emitted by the LowState decoder and therefore form a
+// stable typed seam rather than a heuristic over arbitrary sysfs labels.
+func thermalWarningThreshold(name string) (float64, bool) {
+	name = strings.ToLower(name)
+	switch {
+	case strings.HasPrefix(name, "go2/motor/"):
+		return go2MotorWarningC, true
+	case name == "go2/imu":
+		return deviceThermalWarningC, true
+	case strings.HasPrefix(name, "go2/"):
+		return 0, false
+	default:
+		return deviceThermalWarningC, true
+	}
+}
+
+func formatTemperatureName(name string) string {
+	if name == "go2/imu" {
+		return "Go2 IMU"
+	}
+	if motor, ok := strings.CutPrefix(name, "go2/motor/"); ok {
+		return "Go2 " + strings.ReplaceAll(motor, "-", " ")
+	}
+	return strings.TrimSuffix(strings.TrimSuffix(name, "-thermal"), "-therm")
+}
+
+func formatTemperatureSummary(summary temperatureSummary) string {
+	value := fmt.Sprintf("%.0f°C (%s)", summary.Max.TempC, formatTemperatureName(summary.Max.Name))
+	if summary.Risk == thermalNormal {
+		return value
+	}
+	alert := formatTemperatureName(summary.Alert.Name)
+	if summary.Alert.Name == summary.Max.Name {
+		return fmt.Sprintf("%s, %s %.0f°C warning", value, thermalRiskLabel(summary.Risk), summary.AlertThreshold)
+	}
+	return fmt.Sprintf("%s — %s %.0f°C, %s %.0f°C warning", value, alert, summary.Alert.TempC, thermalRiskLabel(summary.Risk), summary.AlertThreshold)
+}
+
+func thermalRiskLabel(risk thermalRisk) string {
+	if risk == thermalOver {
+		return "at/above"
+	}
+	return "near"
+}
+
+func renderTemperatureHeader(summary temperatureSummary) string {
+	line := " Temp max: " + formatTemperatureSummary(summary)
+	switch summary.Risk {
+	case thermalNear:
+		return " " + topThermalNear.Render("●") + line
+	case thermalOver:
+		return " " + topThermalHot.Render("●") + line
+	default:
+		return topValDim.Render(line)
+	}
 }

--- a/go/internal/cli/commands/device_top_test.go
+++ b/go/internal/cli/commands/device_top_test.go
@@ -48,6 +48,59 @@ func TestFormatThermalZones(t *testing.T) {
 	}
 }
 
+func TestStabilizeThermalZoneOrderUsesHysteresis(t *testing.T) {
+	previous := []*agentpb.ThermalZone{
+		{Name: "go2/motor/fr-hip", TempC: 52},
+		{Name: "go2/motor/fl-hip", TempC: 51},
+		{Name: "go2/motor/rr-hip", TempC: 45},
+	}
+
+	// The agent now reports fl-hip first, but its one-degree lead is visually
+	// insignificant and should not make the dashboard rows trade places.
+	current := []*agentpb.ThermalZone{
+		{Name: "go2/motor/fl-hip", TempC: 52},
+		{Name: "go2/motor/fr-hip", TempC: 51},
+		{Name: "go2/motor/rr-hip", TempC: 45},
+	}
+	stable := stabilizeThermalZoneOrder(previous, current)
+	if got := thermalZoneNames(stable); got != "go2/motor/fr-hip,go2/motor/fl-hip,go2/motor/rr-hip" {
+		t.Fatalf("near-equal readings reordered: %s", got)
+	}
+
+	// A clear lead still promotes the genuinely hotter sensor.
+	current[0].TempC = 54
+	stable = stabilizeThermalZoneOrder(stable, current)
+	if got := thermalZoneNames(stable); got != "go2/motor/fl-hip,go2/motor/fr-hip,go2/motor/rr-hip" {
+		t.Fatalf("meaningfully hotter sensor was not promoted: %s", got)
+	}
+
+	// Crossing back by only one degree does not immediately undo that move.
+	current[0].TempC = 52
+	current[1].TempC = 53
+	stable = stabilizeThermalZoneOrder(stable, current)
+	if got := thermalZoneNames(stable); got != "go2/motor/fl-hip,go2/motor/fr-hip,go2/motor/rr-hip" {
+		t.Fatalf("order oscillated after a small reversal: %s", got)
+	}
+}
+
+func TestStabilizeThermalZoneOrderPreservesDuplicateNames(t *testing.T) {
+	current := []*agentpb.ThermalZone{
+		{Name: "x86_pkg_temp", TempC: 50},
+		{Name: "x86_pkg_temp", TempC: 49},
+	}
+	if got := stabilizeThermalZoneOrder(nil, current); len(got) != len(current) {
+		t.Fatalf("duplicate-named zones were dropped: got %d, want %d", len(got), len(current))
+	}
+}
+
+func thermalZoneNames(zones []*agentpb.ThermalZone) string {
+	names := make([]string, len(zones))
+	for i, zone := range zones {
+		names[i] = zone.GetName()
+	}
+	return strings.Join(names, ",")
+}
+
 func TestSummarizeTemperatureUsesSensorSpecificThreshold(t *testing.T) {
 	host := &agentpb.HostStats{ThermalZones: []*agentpb.ThermalZone{
 		{Name: "go2/imu", TempC: 79},

--- a/go/internal/cli/commands/device_top_test.go
+++ b/go/internal/cli/commands/device_top_test.go
@@ -48,6 +48,76 @@ func TestFormatThermalZones(t *testing.T) {
 	}
 }
 
+func TestSummarizeTemperatureUsesSensorSpecificThreshold(t *testing.T) {
+	host := &agentpb.HostStats{ThermalZones: []*agentpb.ThermalZone{
+		{Name: "go2/imu", TempC: 79},
+		{Name: "go2/motor/fr-thigh", TempC: 66},
+		{Name: "cpu-thermal", TempC: 55},
+	}}
+	summary, ok := summarizeTemperature(host)
+	if !ok {
+		t.Fatal("expected a temperature summary")
+	}
+	if summary.Max.Name != "go2/imu" || summary.Max.TempC != 79 {
+		t.Fatalf("max = %+v, want 79C Go2 IMU", summary.Max)
+	}
+	if summary.Risk != thermalNear {
+		t.Fatalf("risk = %v, want near because a motor is within 5C of 70C", summary.Risk)
+	}
+	if summary.Alert.Name != "go2/motor/fr-thigh" || summary.AlertThreshold != 70 {
+		t.Fatalf("alert = %+v @ %v, want Go2 motor @ 70C", summary.Alert, summary.AlertThreshold)
+	}
+}
+
+func TestSummarizeTemperatureThresholdBoundaries(t *testing.T) {
+	tests := []struct {
+		name string
+		zone *agentpb.ThermalZone
+		want thermalRisk
+	}{
+		{name: "motor below near band", zone: &agentpb.ThermalZone{Name: "go2/motor/fl-calf", TempC: 64.9}, want: thermalNormal},
+		{name: "motor at near edge", zone: &agentpb.ThermalZone{Name: "go2/motor/fl-calf", TempC: 65}, want: thermalNear},
+		{name: "motor at warning", zone: &agentpb.ThermalZone{Name: "go2/motor/fl-calf", TempC: 70}, want: thermalOver},
+		{name: "imu at near edge", zone: &agentpb.ThermalZone{Name: "go2/imu", TempC: 80}, want: thermalNear},
+		{name: "generic zone at near edge", zone: &agentpb.ThermalZone{Name: "cpu-thermal", TempC: 80}, want: thermalNear},
+		{name: "unknown Go2 sensor has no guessed threshold", zone: &agentpb.ThermalZone{Name: "go2/unknown", TempC: 100}, want: thermalNormal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			summary, ok := summarizeTemperature(&agentpb.HostStats{ThermalZones: []*agentpb.ThermalZone{tt.zone}})
+			if !ok || summary.Risk != tt.want {
+				t.Fatalf("summarizeTemperature(%+v) = risk %v, ok %v; want %v", tt.zone, summary.Risk, ok, tt.want)
+			}
+		})
+	}
+}
+
+func TestSummarizeTemperatureIncludesGPUOnlyReading(t *testing.T) {
+	temp := 81.0
+	summary, ok := summarizeTemperature(&agentpb.HostStats{Gpus: []*agentpb.GpuStats{{Index: 2, TempC: &temp}}})
+	if !ok || summary.Max.Name != "gpu/2" || summary.Max.TempC != 81 || summary.Risk != thermalNear {
+		t.Fatalf("GPU-only summary = %+v, ok %v", summary, ok)
+	}
+}
+
+func TestRenderTemperatureHeaderShowsCircleOnlyForAlert(t *testing.T) {
+	normal := renderTemperatureHeader(temperatureSummary{Max: thermalReading{Name: "go2/imu", TempC: 79}})
+	if strings.Contains(normal, "●") {
+		t.Fatalf("normal header unexpectedly has an alert circle: %q", normal)
+	}
+	near := renderTemperatureHeader(temperatureSummary{
+		Max:            thermalReading{Name: "go2/motor/fr-thigh", TempC: 66},
+		Risk:           thermalNear,
+		Alert:          thermalReading{Name: "go2/motor/fr-thigh", TempC: 66},
+		AlertThreshold: 70,
+	})
+	for _, want := range []string{"●", "Temp max", "66°C", "near 70°C warning"} {
+		if !strings.Contains(near, want) {
+			t.Fatalf("near header missing %q: %q", want, near)
+		}
+	}
+}
+
 func TestHostCPUPercent(t *testing.T) {
 	prev := topSample{host: &agentpb.HostStats{CpuTotalJiffies: 1000, CpuIdleJiffies: 800}}
 	cur := topSample{host: &agentpb.HostStats{CpuTotalJiffies: 1100, CpuIdleJiffies: 850}}
@@ -161,6 +231,45 @@ func TestBuildTopJSON(t *testing.T) {
 	}
 }
 
+func TestBuildTopJSONIncludesMaximumTemperatureAdditively(t *testing.T) {
+	temp := 84.0
+	sample := topSample{host: &agentpb.HostStats{
+		ThermalZones: []*agentpb.ThermalZone{{Name: "cpu-thermal", TempC: 72}},
+		Gpus:         []*agentpb.GpuStats{{Index: 0, TempC: &temp}},
+	}}
+	out := buildTopJSON(sample, sample, nil)
+	if out.Host.MaximumTemperature == nil {
+		t.Fatal("expected maximumTemperature")
+	}
+	if out.Host.MaximumTemperature.Name != "gpu/0" || out.Host.MaximumTemperature.TempC != 84 {
+		t.Fatalf("maximumTemperature = %+v, want gpu/0 at 84C", out.Host.MaximumTemperature)
+	}
+	if len(out.Host.ThermalZones) != 1 || out.Host.ThermalZones[0].Name != "cpu-thermal" {
+		t.Fatalf("existing thermalZones changed: %+v", out.Host.ThermalZones)
+	}
+
+	data, err := json.Marshal(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"maximumTemperature":{"name":"gpu/0","tempC":84}`, `"thermalZones":[{"name":"cpu-thermal","tempC":72}]`} {
+		if !strings.Contains(string(data), want) {
+			t.Fatalf("JSON missing additive field %s: %s", want, data)
+		}
+	}
+}
+
+func TestBuildTopJSONOmitsMaximumTemperatureWithoutReading(t *testing.T) {
+	sample := topSample{host: &agentpb.HostStats{}}
+	data, err := json.Marshal(buildTopJSON(sample, sample, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "maximumTemperature") {
+		t.Fatalf("empty host must omit maximumTemperature: %s", data)
+	}
+}
+
 func TestWriteTopPlainSnapshotIncludesStateAndInactiveMetrics(t *testing.T) {
 	containers := []*agentpb.AppContainer{
 		{AppName: "active", RunningState: agentpb.AppRunningState_RUNNING},
@@ -202,6 +311,21 @@ func TestWriteTopPlainSnapshotIncludesStateAndInactiveMetrics(t *testing.T) {
 	}
 }
 
+func TestWriteTopPlainSnapshotIncludesMaximumTemperature(t *testing.T) {
+	sample := topSample{host: &agentpb.HostStats{
+		ThermalZones: []*agentpb.ThermalZone{{Name: "go2/motor/rr-thigh", TempC: 67}},
+	}}
+	var out bytes.Buffer
+	if err := writeTopPlainSnapshot(&out, sample, sample, nil); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"TEMP MAX: 67°C (Go2 rr thigh)", "near 70°C warning"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("plain snapshot missing %q:\n%s", want, out.String())
+		}
+	}
+}
+
 func TestTopViewMakesAllAppStatesExplicit(t *testing.T) {
 	m := topModel{
 		width:  100,
@@ -226,6 +350,28 @@ func TestTopViewMakesAllAppStatesExplicit(t *testing.T) {
 	for _, want := range []string{"1 running", "1 stopped", "1 crash-looping"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("top summary missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestTopViewPutsThermalWarningInHeader(t *testing.T) {
+	m := topModel{
+		width:    100,
+		height:   24,
+		havePrev: true,
+		cur: topSample{host: &agentpb.HostStats{
+			MemTotalBytes: 100,
+			ThermalZones: []*agentpb.ThermalZone{
+				{Name: "go2/imu", TempC: 79},
+				{Name: "go2/motor/fr-thigh", TempC: 66},
+			},
+		}},
+	}
+	view := m.View()
+	firstLine := strings.Split(view, "\n")[0]
+	for _, want := range []string{"●", "Temp max", "79°C", "Go2 fr thigh 66°C", "near 70°C warning"} {
+		if !strings.Contains(firstLine, want) {
+			t.Fatalf("thermal header missing %q:\n%s", want, view)
 		}
 	}
 }


### PR DESCRIPTION
## What changed

- extend the existing pure-Go Unitree LowState monitor to decode Go2 IMU and the 12 physical motor temperatures alongside battery state
- merge fresh Go2 readings with the existing Linux thermal zones and expire DDS-derived values after 15 seconds without a sample
- show the maximum device temperature at the top of the interactive dashboard and in plain snapshot output
- show an amber/yellow circle when any classified sensor is within 5°C of its warning threshold, and red at or above it
- add `host.maximumTemperature` to `device top --json` without changing the existing `thermalZones` field
- document the temperature behavior and operational limits

## Threshold provenance

These are operational thresholds measured and chosen for Woof, not Unitree or NVIDIA vendor ratings:

- Go2 motors: 70°C warning
- Go2 IMU and host/Jetson thermal zones: 85°C warning
- proximity indicator: within 5°C of the applicable threshold

Each sensor is classified independently. A motor near 70°C is therefore visible even when a hotter IMU remains outside its own 85°C proximity band.

## Safety and compatibility

- LowState's eight reserved motor slots are still decoded for wire-layout validation but never exposed as physical temperatures.
- Existing generic devices continue to report Linux thermal zones only.
- Existing JSON consumers retain `thermalZones`; `maximumTemperature` is additive.
- The monitor is read-only and publishes no robot command.

## Validation

- `go test ./go/...`
- `go test -race ./go/internal/agent/hoststats/...`
- `go vet ./go/...`
- Go formatting and `git diff --check`

A locally built CLI live smoke could not complete because Woof's pinned authenticated endpoint did not answer and the CLI correctly refused unauthenticated fallback. The device was not unpinned or modified.

@Joannis, could you review the agent telemetry seam and the operational-threshold presentation?