### PR TITLE
Add read-only camera System API entitlement

### DIFF
--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -280,8 +280,14 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	videoSvc := services.NewVideoService(ctx, logger)
+	defer videoSvc.Shutdown()
+	// Network cameras have to be found before they can be listed, so probe
+	// periodically rather than only when a client asks.
+	videoSvc.StartDiscovery()
+
 	notificationSender := services.NewCloudNotificationSender(logger, provisioningSvc)
-	systemAPISocketManager := services.NewAppSystemAPISocketManager(ctx, logger, notificationSender)
+	systemAPISocketManager := services.NewAppSystemAPISocketManager(ctx, logger, notificationSender, videoSvc)
 	if ctrdClient != nil {
 		ctrdClient.SetAppSystemAPISocketProvider(systemAPISocketManager)
 		ctrdClient.RestoreAppSystemAPISockets(ctx)
@@ -291,12 +297,6 @@ func main() {
 	go timesyncMgr.RunMulticast(ctx)
 
 	startROS2BatteryMonitor(ctx, logger, configPath)
-
-	videoSvc := services.NewVideoService(ctx, logger)
-	defer videoSvc.Shutdown()
-	// Network cameras have to be found before they can be listed, so probe
-	// periodically rather than only when a client asks.
-	videoSvc.StartDiscovery()
 
 	bleDispatcher := bluetooth.NewDispatcher(networkMgr, containerdClient, hwDiscoverer, btManager)
 

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -196,8 +196,29 @@ func (c *Client) SetAppSystemAPISocketProvider(provider AppSystemAPISocketProvid
 }
 
 type appSystemAPIOwner struct {
-	appID       string
-	serviceName string
+	appID        string
+	serviceName  string
+	capabilities []string
+}
+
+func appSystemAPICapabilities(entitlements []appconfig.Entitlement) []string {
+	var camera, notifications bool
+	for _, entitlement := range entitlements {
+		switch entitlement.Type {
+		case appconfig.EntitlementCamera, appconfig.EntitlementVideo:
+			camera = true
+		case appconfig.EntitlementNotifications:
+			notifications = true
+		}
+	}
+	capabilities := make([]string, 0, 2)
+	if camera {
+		capabilities = append(capabilities, services.SystemAPICapabilityCamera)
+	}
+	if notifications {
+		capabilities = append(capabilities, services.SystemAPICapabilityNotifications)
+	}
+	return capabilities
 }
 
 func appSystemAPIOwnersFromLabels(labelSets []map[string]string) []appSystemAPIOwner {
@@ -208,11 +229,35 @@ func appSystemAPIOwnersFromLabels(labelSets []map[string]string) []appSystemAPIO
 		if appconfig.ValidateAppID(appID) != nil || (serviceName != "" && appconfig.ValidateServiceName(serviceName) != nil) {
 			continue
 		}
-		if entitlementsContain(parseEntitlementsFromAnnotations(labels), appconfig.EntitlementNotifications) {
-			owners = append(owners, appSystemAPIOwner{appID: appID, serviceName: serviceName})
+		capabilities := appSystemAPICapabilities(parseEntitlementsFromAnnotations(labels))
+		if len(capabilities) != 0 {
+			owners = append(owners, appSystemAPIOwner{
+				appID: appID, serviceName: serviceName, capabilities: capabilities,
+			})
 		}
 	}
 	return owners
+}
+
+// ensureAppSystemAPISocketForStart recreates the private System API listener
+// required by a persisted container before containerd processes its bind
+// mounts. CreateContainerWithProgress prepares the listener for a new
+// container and RestoreAppSystemAPISockets prepares all listeners at Agent
+// startup, but an explicit start of a persisted container must be independently
+// safe after the runtime directory or listener has disappeared.
+func (c *Client) ensureAppSystemAPISocketForStart(labels map[string]string) error {
+	owners := appSystemAPIOwnersFromLabels([]map[string]string{labels})
+	if len(owners) == 0 {
+		return nil
+	}
+	if c.systemAPISocketProvider == nil {
+		return fmt.Errorf("app System API entitlement unavailable: socket manager is not configured")
+	}
+	owner := owners[0]
+	if _, err := c.systemAPISocketProvider.Ensure(owner.appID, owner.serviceName, owner.capabilities); err != nil {
+		return fmt.Errorf("preparing persisted app System API socket: %w", err)
+	}
+	return nil
 }
 
 // RestoreAppSystemAPISockets reconstructs listeners and ownership from trusted,
@@ -238,7 +283,7 @@ func (c *Client) RestoreAppSystemAPISockets(ctx context.Context) {
 		labelSets = append(labelSets, info.Labels)
 	}
 	for _, owner := range appSystemAPIOwnersFromLabels(labelSets) {
-		if _, err := c.systemAPISocketProvider.Ensure(owner.appID, owner.serviceName, []string{services.SystemAPICapabilityNotifications}); err != nil {
+		if _, err := c.systemAPISocketProvider.Ensure(owner.appID, owner.serviceName, owner.capabilities); err != nil {
 			c.logger.Warn("restore app System API socket failed", zap.String(logfields.AppID, owner.appID), zap.Error(err))
 		}
 	}
@@ -1025,7 +1070,7 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 
 		oldHadSystemAPI := false
 		if labels, labelErr := existing.Labels(ctx); labelErr == nil {
-			oldHadSystemAPI = entitlementsContain(parseEntitlementsFromAnnotations(labels), appconfig.EntitlementNotifications)
+			oldHadSystemAPI = len(appSystemAPICapabilities(parseEntitlementsFromAnnotations(labels))) != 0
 		}
 		c.logger.Info("Removing existing container", zap.String("container_name", containerName))
 		// Kill the old task's whole process group — not just init — and wait
@@ -1230,14 +1275,15 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 
 	var systemAPISocketDir string
 	systemAPIRefOwned := false
-	if appCfg.HasEntitlement(appconfig.EntitlementNotifications) {
+	systemAPICapabilities := appSystemAPICapabilities(appCfg.Entitlements)
+	if len(systemAPICapabilities) != 0 {
 		if c.systemAPISocketProvider == nil {
-			return fmt.Errorf("notifications entitlement unavailable: app System API socket manager is not configured")
+			return fmt.Errorf("app System API entitlement unavailable: socket manager is not configured")
 		}
 		systemAPISocketDir, err = c.systemAPISocketProvider.Ensure(
 			appID,
 			serviceName,
-			[]string{services.SystemAPICapabilityNotifications},
+			systemAPICapabilities,
 		)
 		if err != nil {
 			return fmt.Errorf("preparing app System API socket: %w", err)
@@ -1588,6 +1634,12 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 		// ListBootContainers (e.g. a direct restart of a single container).
 		// c.mu is already held here (muHeld), so use the lock-free core.
 		c.hydrateIsolationLocked(appID, labels)
+		if err := c.ensureAppSystemAPISocketForStart(labels); err != nil {
+			return nil, fmt.Errorf("starting container %q: %w", appName, err)
+		}
+	} else {
+		c.logger.Warn("could not load container labels before start",
+			zap.String("app_name", appName), zap.Error(lerr))
 	}
 
 	// Reboot resilience for meshed containers (C-final-review Fix 1): the
@@ -1911,6 +1963,15 @@ func (c *Client) StartContainerWithStdin(ctx context.Context, appName string, st
 			return nil, fmt.Errorf("app %q has multiple service containers; use the full container name (appID_serviceName) to start a specific service", appName)
 		}
 		container = ctrs[0]
+	}
+
+	if labels, lerr := container.Labels(ctx); lerr == nil {
+		if err := c.ensureAppSystemAPISocketForStart(labels); err != nil {
+			return nil, fmt.Errorf("starting container %q with stdin: %w", appName, err)
+		}
+	} else {
+		c.logger.Warn("could not load container labels before start with stdin",
+			zap.String("app_name", appName), zap.Error(lerr))
 	}
 
 	if restartPolicy != nil {

--- a/go/internal/agent/containerd/helpers.go
+++ b/go/internal/agent/containerd/helpers.go
@@ -303,6 +303,14 @@ func wendyLabels(appName, serviceName, version string, restartPolicy *agentpb.Re
 	}
 
 	for k, v := range appconfig.BuildEntitlementAnnotations(entitlements) {
+		// containerd silently omits labels whose value is empty. Type-only
+		// entitlements (camera, notifications, GPU, and others) therefore need a
+		// non-empty presence marker so restart reconciliation can reconstruct
+		// them from persisted labels. ParseEntitlementAnnotation deliberately
+		// ignores unknown keys, so this round-trips as the original entitlement.
+		if v == "" {
+			v = "present=true"
+		}
 		labels[k] = v
 	}
 

--- a/go/internal/agent/containerd/helpers_test.go
+++ b/go/internal/agent/containerd/helpers_test.go
@@ -389,7 +389,7 @@ func TestWendyLabels_EntitlementsStoredAsKeyValue(t *testing.T) {
 		wantVal string
 	}{
 		{appconfig.EntitlementAnnotationKeyPrefix + appconfig.EntitlementNetwork, "mode=host"},
-		{appconfig.EntitlementAnnotationKeyPrefix + appconfig.EntitlementGPU, ""},
+		{appconfig.EntitlementAnnotationKeyPrefix + appconfig.EntitlementGPU, "present=true"},
 	}
 	for _, tc := range cases {
 		raw, ok := labels[tc.key]
@@ -398,6 +398,29 @@ func TestWendyLabels_EntitlementsStoredAsKeyValue(t *testing.T) {
 		}
 		if raw != tc.wantVal {
 			t.Errorf("%q value = %q; want %q", tc.key, raw, tc.wantVal)
+		}
+	}
+}
+
+func TestWendyLabels_TypeOnlyEntitlementsUseNonEmptyValues(t *testing.T) {
+	entitlements := []appconfig.Entitlement{
+		{Type: appconfig.EntitlementCamera},
+		{Type: appconfig.EntitlementNotifications},
+	}
+	labels := wendyLabels("app", "", "1.0", nil, entitlements, "", nil)
+
+	for _, entitlement := range entitlements {
+		key := appconfig.EntitlementAnnotationKeyPrefix + entitlement.Type
+		raw, ok := labels[key]
+		if !ok {
+			t.Fatalf("missing entitlement label %q", key)
+		}
+		if raw == "" {
+			t.Fatalf("entitlement label %q has an empty value; containerd drops empty-valued labels", key)
+		}
+		got := appconfig.ParseEntitlementAnnotation(entitlement.Type, raw)
+		if got.Type != entitlement.Type {
+			t.Fatalf("parsed entitlement type = %q, want %q", got.Type, entitlement.Type)
 		}
 	}
 }

--- a/go/internal/agent/containerd/system_api_test.go
+++ b/go/internal/agent/containerd/system_api_test.go
@@ -1,17 +1,42 @@
 package containerd
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
+	"github.com/wendylabsinc/wendy/go/internal/agent/services"
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
 )
 
+type recordingAppSystemAPISocketProvider struct {
+	ensures []appSystemAPIOwner
+	err     error
+}
+
+func (p *recordingAppSystemAPISocketProvider) Ensure(appID, serviceName string, capabilities []string) (string, error) {
+	p.ensures = append(p.ensures, appSystemAPIOwner{
+		appID:        appID,
+		serviceName:  serviceName,
+		capabilities: append([]string(nil), capabilities...),
+	})
+	return "/var/lib/wendy/app-system/test", p.err
+}
+
+func (*recordingAppSystemAPISocketProvider) Release(string, string) {}
+func (*recordingAppSystemAPISocketProvider) ReleaseApp(string)      {}
+
 func TestAppSystemAPIOwnersFromLabelsRestoresEntitledMultiServiceContainers(t *testing.T) {
 	notifications := []appconfig.Entitlement{{Type: appconfig.EntitlementNotifications}}
+	camera := []appconfig.Entitlement{{Type: appconfig.EntitlementCamera}}
+	combined := []appconfig.Entitlement{
+		{Type: appconfig.EntitlementCamera},
+		{Type: appconfig.EntitlementNotifications},
+	}
 	labels := []map[string]string{
 		wendyLabels("com.example.app", "api", "1", nil, notifications, "", nil),
-		wendyLabels("com.example.app", "worker", "1", nil, notifications, "", nil),
+		wendyLabels("com.example.app", "worker", "1", nil, camera, "", nil),
+		wendyLabels("com.example.combined", "", "1", nil, combined, "", nil),
 		wendyLabels("com.example.other", "", "1", nil, nil, "", nil),
 		{
 			labelKeyAppID: "../tampered",
@@ -21,10 +46,78 @@ func TestAppSystemAPIOwnersFromLabelsRestoresEntitledMultiServiceContainers(t *t
 
 	got := appSystemAPIOwnersFromLabels(labels)
 	want := []appSystemAPIOwner{
-		{appID: "com.example.app", serviceName: "api"},
-		{appID: "com.example.app", serviceName: "worker"},
+		{
+			appID: "com.example.app", serviceName: "api",
+			capabilities: []string{services.SystemAPICapabilityNotifications},
+		},
+		{
+			appID: "com.example.app", serviceName: "worker",
+			capabilities: []string{services.SystemAPICapabilityCamera},
+		},
+		{
+			appID: "com.example.combined",
+			capabilities: []string{
+				services.SystemAPICapabilityCamera,
+				services.SystemAPICapabilityNotifications,
+			},
+		},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("owners = %+v, want %+v", got, want)
+	}
+}
+
+func TestEnsureAppSystemAPISocketForStartRestoresPersistedCameraOwner(t *testing.T) {
+	provider := &recordingAppSystemAPISocketProvider{}
+	client := &Client{systemAPISocketProvider: provider}
+	labels := wendyLabels(
+		"com.example.camera",
+		"tracker",
+		"1",
+		nil,
+		[]appconfig.Entitlement{{Type: appconfig.EntitlementCamera}},
+		"",
+		nil,
+	)
+
+	if err := client.ensureAppSystemAPISocketForStart(labels); err != nil {
+		t.Fatalf("ensureAppSystemAPISocketForStart() error = %v", err)
+	}
+	want := []appSystemAPIOwner{{
+		appID:        "com.example.camera",
+		serviceName:  "tracker",
+		capabilities: []string{services.SystemAPICapabilityCamera},
+	}}
+	if !reflect.DeepEqual(provider.ensures, want) {
+		t.Fatalf("ensures = %+v, want %+v", provider.ensures, want)
+	}
+}
+
+func TestEnsureAppSystemAPISocketForStartSkipsUnentitledContainer(t *testing.T) {
+	client := &Client{}
+	labels := wendyLabels("com.example.app", "", "1", nil, nil, "", nil)
+
+	if err := client.ensureAppSystemAPISocketForStart(labels); err != nil {
+		t.Fatalf("ensureAppSystemAPISocketForStart() error = %v", err)
+	}
+}
+
+func TestEnsureAppSystemAPISocketForStartFailsClosed(t *testing.T) {
+	wantErr := errors.New("socket unavailable")
+	provider := &recordingAppSystemAPISocketProvider{err: wantErr}
+	client := &Client{systemAPISocketProvider: provider}
+	labels := wendyLabels(
+		"com.example.camera",
+		"",
+		"1",
+		nil,
+		[]appconfig.Entitlement{{Type: appconfig.EntitlementCamera}},
+		"",
+		nil,
+	)
+
+	err := client.ensureAppSystemAPISocketForStart(labels)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("ensureAppSystemAPISocketForStart() error = %v, want wrapped %v", err, wantErr)
 	}
 }

--- a/go/internal/agent/oci/entitlements.go
+++ b/go/internal/agent/oci/entitlements.go
@@ -68,6 +68,7 @@ func ApplyEntitlements(spec *Spec, cfg *appconfig.AppConfig, opts ApplyOptions) 
 	}
 
 	didSetDeviceCapabilities := false
+	needsSystemAPI := false
 	for _, ent := range cfg.Entitlements {
 		switch ent.Type {
 		case appconfig.EntitlementGPU:
@@ -82,6 +83,7 @@ func ApplyEntitlements(spec *Spec, cfg *appconfig.AppConfig, opts ApplyOptions) 
 			}
 		case appconfig.EntitlementVideo, appconfig.EntitlementCamera:
 			applyCamera(spec)
+			needsSystemAPI = true
 			if !didSetDeviceCapabilities {
 				didSetDeviceCapabilities = true
 				SetDeviceCapabilities(spec)
@@ -113,12 +115,15 @@ func ApplyEntitlements(spec *Spec, cfg *appconfig.AppConfig, opts ApplyOptions) 
 				SetDeviceCapabilities(spec)
 			}
 		case appconfig.EntitlementNotifications:
-			applySystemAPI(spec, opts.SystemAPISocketDir)
+			needsSystemAPI = true
 		case appconfig.EntitlementAdmin:
 			applyAdmin(spec)
 		case appconfig.EntitlementBuild:
 			applyBuild(spec)
 		}
+	}
+	if needsSystemAPI {
+		applySystemAPI(spec, opts.SystemAPISocketDir)
 	}
 	return nil
 }

--- a/go/internal/agent/oci/entitlements_test.go
+++ b/go/internal/agent/oci/entitlements_test.go
@@ -1864,6 +1864,68 @@ func TestApplyNotifications_MountsOnlyPrivateSystemSocket(t *testing.T) {
 	}
 }
 
+func TestApplyCamera_MountsPrivateSystemSocketWithoutAdmin(t *testing.T) {
+	dir, err := os.MkdirTemp("/tmp", "wendy-camera-system-oci-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	listener, err := net.Listen("unix", filepath.Join(dir, "system.sock"))
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+
+	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
+	cfg := &appconfig.AppConfig{
+		AppID:        "test",
+		Entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementCamera}},
+	}
+	if err := ApplyEntitlements(spec, cfg, ApplyOptions{SystemAPISocketDir: dir}); err != nil {
+		t.Fatalf("ApplyEntitlements: %v", err)
+	}
+	if !hasMount(spec, "/run/wendy/system") || !hasEnv(spec, "WENDY_SYSTEM_SOCKET=/run/wendy/system/system.sock") {
+		t.Fatal("camera entitlement did not expose the private System API socket")
+	}
+	if hasMount(spec, "/run/wendy/agent") || hasEnv(spec, "WENDY_AGENT_SOCKET=") {
+		t.Fatal("camera entitlement exposed the admin control socket")
+	}
+}
+
+func TestApplyCameraAndNotifications_MountSystemSocketOnce(t *testing.T) {
+	dir, err := os.MkdirTemp("/tmp", "wendy-combined-system-oci-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	listener, err := net.Listen("unix", filepath.Join(dir, "system.sock"))
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+
+	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
+	cfg := &appconfig.AppConfig{
+		AppID: "test",
+		Entitlements: []appconfig.Entitlement{
+			{Type: appconfig.EntitlementCamera},
+			{Type: appconfig.EntitlementNotifications},
+		},
+	}
+	if err := ApplyEntitlements(spec, cfg, ApplyOptions{SystemAPISocketDir: dir}); err != nil {
+		t.Fatalf("ApplyEntitlements: %v", err)
+	}
+	mounts := 0
+	for _, mount := range spec.Mounts {
+		if mount.Destination == "/run/wendy/system" {
+			mounts++
+		}
+	}
+	if mounts != 1 {
+		t.Fatalf("System API mount count = %d, want 1", mounts)
+	}
+}
+
 func TestApplyNotifications_AbsentWithoutEntitlement(t *testing.T) {
 	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
 	cfg := &appconfig.AppConfig{AppID: "test"}

--- a/go/internal/agent/services/app_system_api_camera_test.go
+++ b/go/internal/agent/services/app_system_api_camera_test.go
@@ -1,0 +1,157 @@
+package services
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	systempb "github.com/wendylabsinc/wendy/go/proto/gen/systempb"
+)
+
+type systemAPITestVideoService struct {
+	agentpb.UnimplementedWendyVideoServiceServer
+}
+
+func (s *systemAPITestVideoService) ListVideoDevices(
+	context.Context,
+	*agentpb.ListVideoDevicesRequest,
+) (*agentpb.ListVideoDevicesResponse, error) {
+	return &agentpb.ListVideoDevicesResponse{Devices: []*agentpb.VideoDevice{{
+		Id: 200, Name: "test-ip-camera", Transport: agentpb.VideoTransport_VIDEO_TRANSPORT_IP,
+	}}}, nil
+}
+
+func (s *systemAPITestVideoService) StreamVideo(
+	_ *agentpb.StreamVideoRequest,
+	stream grpc.ServerStreamingServer[agentpb.VideoFrame],
+) error {
+	return stream.Send(&agentpb.VideoFrame{Data: []byte("frame"), TimestampNs: 123})
+}
+
+func TestCameraCapabilityAllowsOnlyReadOnlyVideoRPCs(t *testing.T) {
+	oldRoot := AppSystemAPISocketRootPath
+	root, err := os.MkdirTemp("/tmp", "wendy-system-camera-allow-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	AppSystemAPISocketRootPath = root
+	t.Cleanup(func() {
+		AppSystemAPISocketRootPath = oldRoot
+		_ = os.RemoveAll(root)
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	manager := NewAppSystemAPISocketManager(
+		ctx,
+		zap.NewNop(),
+		&recordingNotificationSender{},
+		&systemAPITestVideoService{},
+	)
+	directory, err := manager.Ensure(
+		"com.example.camera",
+		"viewer",
+		[]string{SystemAPICapabilityCamera},
+	)
+	if err != nil {
+		t.Fatalf("Ensure(camera) error = %v", err)
+	}
+
+	conn, err := grpc.NewClient(
+		"unix://"+filepath.Join(directory, SystemAPISocketFilename),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("dial System API: %v", err)
+	}
+	defer conn.Close()
+	callCtx, callCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer callCancel()
+	video := agentpb.NewWendyVideoServiceClient(conn)
+
+	devices, err := video.ListVideoDevices(callCtx, &agentpb.ListVideoDevicesRequest{})
+	if err != nil {
+		t.Fatalf("ListVideoDevices() error = %v", err)
+	}
+	if len(devices.GetDevices()) != 1 || devices.GetDevices()[0].GetId() != 200 {
+		t.Fatalf("ListVideoDevices() = %+v", devices.GetDevices())
+	}
+	stream, err := video.StreamVideo(callCtx, &agentpb.StreamVideoRequest{DeviceId: 200})
+	if err != nil {
+		t.Fatalf("StreamVideo() error = %v", err)
+	}
+	frame, err := stream.Recv()
+	if err != nil || string(frame.GetData()) != "frame" {
+		t.Fatalf("StreamVideo().Recv() = data %q, err %v", frame.GetData(), err)
+	}
+
+	_, err = video.SetCameraCredentials(callCtx, &agentpb.SetCameraCredentialsRequest{
+		DeviceId: 200, Username: "admin", Password: "must-not-reach-service",
+	})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("SetCameraCredentials() code = %v, want PermissionDenied (err=%v)", status.Code(err), err)
+	}
+	_, err = systempb.NewNotificationServiceClient(conn).Send(
+		callCtx,
+		validSystemNotificationRequest(),
+	)
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("Notification Send() code = %v, want PermissionDenied (err=%v)", status.Code(err), err)
+	}
+}
+
+func TestNotificationsCapabilityCannotReadVideo(t *testing.T) {
+	oldRoot := AppSystemAPISocketRootPath
+	root, err := os.MkdirTemp("/tmp", "wendy-system-camera-deny-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	AppSystemAPISocketRootPath = root
+	t.Cleanup(func() {
+		AppSystemAPISocketRootPath = oldRoot
+		_ = os.RemoveAll(root)
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	manager := NewAppSystemAPISocketManager(
+		ctx,
+		zap.NewNop(),
+		&recordingNotificationSender{},
+		&systemAPITestVideoService{},
+	)
+	directory, err := manager.Ensure(
+		"com.example.notifications",
+		"",
+		[]string{SystemAPICapabilityNotifications},
+	)
+	if err != nil {
+		t.Fatalf("Ensure(notifications) error = %v", err)
+	}
+	conn, err := grpc.NewClient(
+		"unix://"+filepath.Join(directory, SystemAPISocketFilename),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("dial System API: %v", err)
+	}
+	defer conn.Close()
+	callCtx, callCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer callCancel()
+	_, err = agentpb.NewWendyVideoServiceClient(conn).ListVideoDevices(
+		callCtx,
+		&agentpb.ListVideoDevicesRequest{},
+	)
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("ListVideoDevices() code = %v, want PermissionDenied (err=%v)", status.Code(err), err)
+	}
+}

--- a/go/internal/agent/services/app_system_api_socket_manager.go
+++ b/go/internal/agent/services/app_system_api_socket_manager.go
@@ -19,11 +19,13 @@ import (
 
 	"github.com/wendylabsinc/wendy/go/internal/agent/localsocket"
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 	systempb "github.com/wendylabsinc/wendy/go/proto/gen/systempb"
 )
 
 const (
 	SystemAPICapabilityNotifications = "notifications"
+	SystemAPICapabilityCamera        = "camera"
 	SystemAPISocketFilename          = "system.sock"
 	appSystemAPIGroupGID             = 2000
 )
@@ -52,6 +54,7 @@ type AppSystemAPISocketManager struct {
 	ctx                context.Context
 	logger             *zap.Logger
 	notificationSender NotificationSender
+	videoService       agentpb.WendyVideoServiceServer
 	mu                 sync.RWMutex
 	sockets            map[string]*appSystemAPISocket
 }
@@ -60,11 +63,13 @@ func NewAppSystemAPISocketManager(
 	ctx context.Context,
 	logger *zap.Logger,
 	notificationSender NotificationSender,
+	videoService agentpb.WendyVideoServiceServer,
 ) *AppSystemAPISocketManager {
 	manager := &AppSystemAPISocketManager{
 		ctx:                ctx,
 		logger:             logger,
 		notificationSender: notificationSender,
+		videoService:       videoService,
 		sockets:            make(map[string]*appSystemAPISocket),
 	}
 	go func() {
@@ -90,8 +95,11 @@ func (m *AppSystemAPISocketManager) Ensure(appID, serviceName string, capabiliti
 		return "", fmt.Errorf("at least one System API capability is required")
 	}
 	for _, capability := range capabilities {
-		if capability != SystemAPICapabilityNotifications {
+		if capability != SystemAPICapabilityNotifications && capability != SystemAPICapabilityCamera {
 			return "", fmt.Errorf("unsupported System API capability %q", capability)
+		}
+		if capability == SystemAPICapabilityCamera && m.videoService == nil {
+			return "", fmt.Errorf("camera System API capability is unavailable")
 		}
 	}
 
@@ -148,10 +156,14 @@ func (m *AppSystemAPISocketManager) Ensure(appID, serviceName string, capabiliti
 		grpc.MaxRecvMsgSize(16*1024),
 		grpc.MaxConcurrentStreams(16),
 		grpc.UnaryInterceptor(m.authorize(socket)),
+		grpc.StreamInterceptor(m.authorizeStream(socket)),
 		grpc.KeepaliveParams(keepalive.ServerParameters{MaxConnectionIdle: 2 * time.Minute}),
 	)
 	socket.server = server
 	systempb.RegisterNotificationServiceServer(server, NewSystemNotificationService(appID, m.notificationSender))
+	if m.videoService != nil {
+		agentpb.RegisterWendyVideoServiceServer(server, m.videoService)
+	}
 	m.sockets[key] = socket
 
 	go func() {
@@ -238,9 +250,29 @@ func (m *AppSystemAPISocketManager) authorize(socket *appSystemAPISocket) grpc.U
 	}
 }
 
+func (m *AppSystemAPISocketManager) authorizeStream(socket *appSystemAPISocket) grpc.StreamServerInterceptor {
+	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		capability := systemAPICapabilityForMethod(info.FullMethod)
+		if capability == "" {
+			return status.Error(codes.PermissionDenied, "System API method is not authorized")
+		}
+		m.mu.RLock()
+		allowed := socketHasCapability(socket, capability)
+		m.mu.RUnlock()
+		if !allowed {
+			return status.Error(codes.PermissionDenied, "System API capability is not authorized for this app")
+		}
+		return handler(srv, stream)
+	}
+}
+
 func systemAPICapabilityForMethod(method string) string {
-	if method == systempb.NotificationService_Send_FullMethodName {
+	switch method {
+	case systempb.NotificationService_Send_FullMethodName:
 		return SystemAPICapabilityNotifications
+	case agentpb.WendyVideoService_ListVideoDevices_FullMethodName,
+		agentpb.WendyVideoService_StreamVideo_FullMethodName:
+		return SystemAPICapabilityCamera
 	}
 	return ""
 }

--- a/go/internal/agent/services/notification_service_test.go
+++ b/go/internal/agent/services/notification_service_test.go
@@ -676,7 +676,7 @@ func TestAppSystemAPISocketManagerSharesPerAppAndIsolatesIdentity(t *testing.T) 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	sender := &recordingNotificationSender{}
-	manager := NewAppSystemAPISocketManager(ctx, zap.NewNop(), sender)
+	manager := NewAppSystemAPISocketManager(ctx, zap.NewNop(), sender, nil)
 
 	appADir, err := manager.Ensure("com.example.a", "api", []string{SystemAPICapabilityNotifications})
 	if err != nil {
@@ -750,7 +750,7 @@ func TestAppSystemAPISocketManagerRecreatesSocketInStableDirectory(t *testing.T)
 	})
 
 	ctx1, cancel1 := context.WithCancel(context.Background())
-	manager1 := NewAppSystemAPISocketManager(ctx1, zap.NewNop(), &recordingNotificationSender{})
+	manager1 := NewAppSystemAPISocketManager(ctx1, zap.NewNop(), &recordingNotificationSender{}, nil)
 	directory, err := manager1.Ensure("com.example.restart", "", []string{SystemAPICapabilityNotifications})
 	if err != nil {
 		t.Fatalf("first Ensure() error = %v", err)
@@ -764,7 +764,7 @@ func TestAppSystemAPISocketManagerRecreatesSocketInStableDirectory(t *testing.T)
 
 	ctx2, cancel2 := context.WithCancel(context.Background())
 	defer cancel2()
-	manager2 := NewAppSystemAPISocketManager(ctx2, zap.NewNop(), &recordingNotificationSender{})
+	manager2 := NewAppSystemAPISocketManager(ctx2, zap.NewNop(), &recordingNotificationSender{}, nil)
 	restored, err := manager2.Ensure("com.example.restart", "", []string{SystemAPICapabilityNotifications})
 	if err != nil {
 		t.Fatalf("restored Ensure() error = %v", err)

--- a/go/internal/cli/assets/docs/apps/wendy.json.md
+++ b/go/internal/cli/assets/docs/apps/wendy.json.md
@@ -311,7 +311,8 @@ On Raspberry Pi, `/dev/vcio` is bind-mounted only when present on the host; acce
 
 ### `camera`
 
-Camera / V4L2 device access.
+Camera access across local V4L2/CSI devices and IP cameras already authenticated
+by the Wendy agent.
 
 ```json
 { "type": "camera" }
@@ -321,6 +322,16 @@ Camera / V4L2 device access.
 | Field | Description |
 |-------|-------------|
 | `allowlist` | Restrict access to specific device paths. Omit to allow all cameras. |
+
+The agent mounts the app's private System API socket and injects
+`WENDY_SYSTEM_SOCKET=/run/wendy/system/system.sock`. Apps can use the existing
+Wendy video gRPC definitions to call `ListVideoDevices` and `StreamVideo` on
+that socket. This is the path for IP cameras because their stored credentials
+remain inside the agent. Credential changes, camera removal/refresh, and all
+administrative Agent RPCs are denied on the app-facing socket.
+
+> **Security:** `camera` never exposes `WENDY_AGENT_SOCKET`. Use `admin` only
+> when the app genuinely needs full device administration, not to read video.
 
 ### `audio`
 
@@ -491,8 +502,8 @@ app connection.
 
 The agent/daemon mounts `/run/wendy/system` read-only and injects
 `WENDY_SYSTEM_SOCKET=/run/wendy/system/system.sock`. There is one socket per
-app, shared by that app's entitled service containers and by future app-facing
-API capabilities; it is not one socket per capability. The public Swift
+app, shared by that app's camera- and notifications-entitled service containers;
+it is not one socket per capability. The public Swift
 API is `WendyNotification.send(_:)` in WendyKit, so normal apps do not call
 gRPC directly.
 

--- a/go/internal/cli/assets/docs/cloud/requirements.md
+++ b/go/internal/cli/assets/docs/cloud/requirements.md
@@ -243,7 +243,7 @@ The following entitlements are supported:
 | `gpu` | GPU access for ML inference and compute workloads. |
 | `persist` | A named persistent storage volume. The volume persists across application restarts and updates. Two applications on the same device declaring a volume with the same name share that volume. |
 | `audio` | Audio device access for recording or playback. |
-| `camera` | Camera and video device access. |
+| `camera` | Local camera access plus read-only listing and streaming of agent-managed IP cameras. |
 | `bluetooth` | Filtered Bluetooth access via a D-Bus proxy. |
 | `usb` | Raw USB device access. |
 | `i2c` | I2C bus access. Requires a specific device to be named. |

--- a/go/internal/cli/assets/docs/cloud/telemetry.md
+++ b/go/internal/cli/assets/docs/cloud/telemetry.md
@@ -21,7 +21,7 @@ The private app connection variable is conditional on an entitlement:
 
 | Variable | Value | Notes |
 |---|---|---|
-| `WENDY_SYSTEM_SOCKET` | `/run/wendy/system/system.sock` | Injected only with the `notifications` entitlement. Points to the app's private app-facing socket. |
+| `WENDY_SYSTEM_SOCKET` | `/run/wendy/system/system.sock` | Injected with `camera` or `notifications`. The private socket authorizes only the RPC capabilities declared by those entitlements. |
 
 The OpenTelemetry variables are injected **only when the app has the host
 `network` entitlement**, because the agent's local OTLP receiver listens on the

--- a/go/internal/cli/assets/docs/device/entitlements.md
+++ b/go/internal/cli/assets/docs/device/entitlements.md
@@ -16,6 +16,18 @@ Declare them in the `entitlements` array of your `wendy.json`, or add one with `
 
 > **Complete reference:** for every entitlement type, its options, and security notes, see [wendy.json → Entitlements](../apps/wendy.json.md#entitlements-1). This page is a guide to the common ones and how to choose between similar options.
 
+## Camera
+
+Use `{ "type": "camera" }` for local USB/V4L2 and CSI devices and for IP
+cameras already authenticated by the Wendy agent. The entitlement mounts the
+private app System API socket and injects `WENDY_SYSTEM_SOCKET`. On that socket,
+camera-entitled apps may call only `ListVideoDevices` and `StreamVideo` from the
+Wendy video service. Credential changes, camera removal/refresh, and all Agent
+administration methods remain unavailable.
+
+The System API mount is shared with `notifications` when a service declares
+both entitlements. It never exposes `WENDY_AGENT_SOCKET`.
+
 ## Notifications
 
 Use `{ "type": "notifications" }` when an app needs to alert operators through

--- a/go/internal/cli/assets/skills/wendy/SKILL.md
+++ b/go/internal/cli/assets/skills/wendy/SKILL.md
@@ -100,7 +100,7 @@ See `references/wendy.json.md` for detailed entitlement configuration.
 | `network` (host mode) | Web servers, HTTP APIs, incoming connections |
 | `gpu` | ML inference/computer vision (Jetson), board telemetry (Raspberry Pi) |
 | `display` | Present to local monitor as Wayland client |
-| `camera` | Camera access, video capture |
+| `camera` | Local camera access and read-only agent-brokered IP-camera streams |
 | `audio` | Microphone, speakers |
 | `bluetooth` | BLE devices, Bluetooth communication |
 

--- a/go/internal/cli/assets/skills/wendy/references/wendy.json.md
+++ b/go/internal/cli/assets/skills/wendy/references/wendy.json.md
@@ -114,18 +114,26 @@ On NVIDIA Jetson the GL/EGL userspace is injected from the host through CDI; on 
 
 > **Security:** apps **without** `display` never receive `/dev/dri` — the default GPU/display sandbox is unchanged.
 
-### Video Entitlement
+### Camera Entitlement
 
-**Deprecated:** Use `camera` instead. Provides access to video capture devices (USB cameras, CSI cameras).
+Provides local USB/V4L2 and CSI camera access. It also injects the app-private
+`WENDY_SYSTEM_SOCKET`; the agent authorizes only `ListVideoDevices` and
+`StreamVideo` there so apps can consume authenticated IP cameras without the
+full `admin` socket.
 
 ```json
-{ "type": "video" }
+{ "type": "camera" }
 ```
 
 When enabled:
 - Mounts `/dev` to expose all video capture devices
 - Configures device permissions for video capture
 - Enables V4L2 (Video4Linux2) and libcamera interfaces
+- Allows read-only camera listing and streaming through `WENDY_SYSTEM_SOCKET`
+
+The deprecated `{ "type": "video" }` alias has the same runtime behavior.
+Credential changes, camera removal/refresh, and administrative Agent RPCs are
+not authorized by `camera`.
 
 ### Audio Entitlement
 

--- a/go/internal/shared/appconfig/wendy.schema.json
+++ b/go/internal/shared/appconfig/wendy.schema.json
@@ -225,7 +225,7 @@
           },
           "required": ["type"],
           "additionalProperties": false,
-          "description": "Camera/V4L2 device access. Legacy video entitlement keys remain accepted for compatibility."
+          "description": "Camera access across local V4L2/CSI devices and read-only agent-brokered IP-camera streams. Injects WENDY_SYSTEM_SOCKET for ListVideoDevices and StreamVideo. Legacy video entitlement keys remain accepted for compatibility."
         },
         {
           "properties": {

--- a/plugins/wendy-agentic-coding/skills/wendy-entitlements/SKILL.md
+++ b/plugins/wendy-agentic-coding/skills/wendy-entitlements/SKILL.md
@@ -43,7 +43,7 @@ Use this table as the starting point, then verify against the local repo when ch
 | `gpu` | none | none | Jetson: adds NVIDIA device nodes, env vars, CDI wiring. Raspberry Pi: exposes `/dev/vcio` for board telemetry. |
 | `display` | none | none | Grants `/dev/dri` (GPU render nodes) and the WendyOS compositor's Wayland socket; allows the container to present to a locally-attached monitor as a Wayland client. Requires a display-enabled WendyOS image; on headless images the socket is absent so nothing renders. On Jetson, GPU graphics userspace is injected from the host via CDI. At most one per app. |
 | `audio` | none | none | Adds audio group, mounts `/dev/snd`, allows sound devices, and mounts PipeWire/Pulse sockets when present. |
-| `camera` | none | `mode`, `allowlist` | Canonical V4L2/camera entitlement; allows major 81, bind-mounts host `/dev` for live camera hotplug, and bind-mounts `/run/udev` read-only for libcamera CSI enumeration. |
+| `camera` | none | `mode`, `allowlist` | Grants local V4L2/CSI access and the private `WENDY_SYSTEM_SOCKET`, where only read-only `ListVideoDevices`/`StreamVideo` RPCs are authorized for agent-managed IP cameras. |
 | `video` | none | `mode`, `allowlist` | Deprecated compatibility alias for `camera`; prefer `camera` in new configs. |
 | `persist` | `name`, `path` | none | Creates/binds `/var/lib/wendy/volumes/<name>` to the container `path`; volume names are shared across apps. |
 | `bluetooth` | none | `mode` | Uses a filtered `xdg-dbus-proxy` socket for BlueZ. Do not assume unrestricted host D-Bus access. |


### PR DESCRIPTION
## What

- expose read-only camera discovery and streaming through each entitled app private System API socket
- authorize camera and notification capabilities independently on the shared per-app listener
- reconstruct camera capability ownership from persisted container labels
- recreate the listener before normal and stdin-based persisted container starts
- persist type-only entitlements with a non-empty `present=true` value so containerd retains them
- document the camera entitlement and update the Wendy app schema

## Why

A restart of the G1 person-recognition app left its persisted container intact, but the app-scoped camera System API socket was not recreated before `apps start`. The container then timed out connecting to `WENDY_SYSTEM_SOCKET`, even though camera 200 was separately recoverable.

The create path prepared the socket and agent startup restored known owners, but explicit persisted-start paths did not independently ensure the listener before `container.NewTask`. Live validation also found that containerd drops empty-valued labels, so type-only entitlements such as `camera` were absent from persisted metadata until encoded as `present=true`.

Tracks [WDY-2384](https://linear.app/wendylabsinc/issue/WDY-2384) and fixes [WDY-2386](https://linear.app/wendylabsinc/issue/WDY-2386/persisted-app-start-does-not-recreate-camera-system-api-socket).

## Security

- the app-private bind mount remains the caller credential
- camera entitlement permits only `ListVideoDevices` and `StreamVideo`
- camera credential mutation and unrelated notification calls remain denied
- entitled starts fail closed if the private listener cannot be prepared

## Validation

- `go test ./go/...`
- regression coverage for persisted camera-owner recreation, non-empty type-only entitlement labels, unentitled starts, and fail-closed socket setup
- gRPC authorization coverage for camera-only and notification-only apps
- live Parakeet acceptance: installed hash verified, private socket restored, camera 200 online at `10.98.0.50`, clean `apps stop` / `apps start`, advancing authenticated frames, and detector inference at about 7.9 FPS