### PR TITLE
fix(cli): report why an OS update rolled back instead of always blaming healthchecks

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/update.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/update.md
@@ -76,8 +76,13 @@ After the device is back online, `wendy device update` queries the post-reboot c
 
 ```
 Update failed post-reboot healthchecks and was rolled back to WendyOS-0.10.4.
-Reason: wendyos-update commit failed: exit status 4 (health.d/50-containerd.sh exited 1)
+Reason: wendyos-update commit failed: exit status 4 (health hook "50-containerd.sh" failed: exit status 1)
 ```
+
+The first line distinguishes a healthcheck failure from an update that never
+booted (the firmware fell back to the old slot, so `health.d` never ran) and from
+a rollback whose reason the CLI cannot classify. See
+[`wendy os update`](../os/update.md) for all three forms.
 
 On cloud-tunneled (asset) devices the command does not wait for the reboot and does not query the outcome; it prints instructions to reconnect and re-run if needed.
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/update.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/update.md
@@ -70,10 +70,27 @@ The verdict — including any failure reason reported by `wendyos-update commit`
 
 ```
 Update failed post-reboot healthchecks and was rolled back to WendyOS-0.10.4.
-Reason: wendyos-update commit failed: exit status 4 (health.d/50-containerd.sh exited 1)
+Reason: wendyos-update commit failed: exit status 4 (health hook "50-containerd.sh" failed: exit status 1)
 ```
 
 *(the text in parentheses is whatever `wendyos-update commit` itself reported as the failure reason)*
+
+A rollback is not always a healthcheck failure, and the first line says which it
+was. When the new OS never booted — the firmware fell back to the old slot, so
+`health.d` never ran at all — the report names that instead:
+
+```
+The new OS did not boot; the device fell back to WendyOS-0.10.4 and the update was rolled back.
+Reason: wendyos-update commit failed: exit status 1 (pending update wendyos-image-... is marked failed; run rollback)
+```
+
+If the reason is one the CLI cannot classify, it reports the rollback and the
+captured reason without attributing a cause:
+
+```
+Update was rolled back to WendyOS-0.10.4.
+Reason: wendyos-update commit failed: exit status 4 (platform verify: ESRT status 6163)
+```
 
 `wendy os update-status` reports the same record (including the `Reason:` line) after the fact, without re-running the update — useful for diagnosing a commit failure without shell access to the device. In addition to the persisted record, `wendy os update-status` queries the live wendyos-update engine snapshot, which distinguishes a committed nightly from a rolled-back one even when the OS version string is identical across builds.
 

--- a/go/internal/cli/commands/os_cmd.go
+++ b/go/internal/cli/commands/os_cmd.go
@@ -760,7 +760,15 @@ func evaluateOSUpdateOutcome(
 		if rolledBackTo == "" {
 			rolledBackTo = postUpdateOSVersion
 		}
-		fmt.Fprintf(&b, "Update failed post-reboot healthchecks and was rolled back to %s.\n", rolledBackTo)
+		reason := classifyOSRollback(resp.GetServices(), resp.GetNote())
+		switch reason {
+		case rollbackReasonNotBooted:
+			fmt.Fprintf(&b, "The new OS did not boot; the device fell back to %s and the update was rolled back.\n", rolledBackTo)
+		case rollbackReasonHealthchecks:
+			fmt.Fprintf(&b, "Update failed post-reboot healthchecks and was rolled back to %s.\n", rolledBackTo)
+		default:
+			fmt.Fprintf(&b, "Update was rolled back to %s.\n", rolledBackTo)
+		}
 		writeFailedServices(&b, resp.GetServices())
 		// When the updater ran its own health gate (wendyos-update health.d),
 		// there are no per-service results — the reason is carried in the note.
@@ -770,13 +778,22 @@ func evaluateOSUpdateOutcome(
 		if re := resp.GetRollbackError(); re != "" {
 			fmt.Fprintf(&b, "Rollback error: %s\n", re)
 		}
-		return strings.TrimRight(b.String(), "\n"),
-			errors.New("OS update rolled back: critical services failed healthchecks")
+		return strings.TrimRight(b.String(), "\n"), rolledBackError(reason)
 
 	case agentpb.GetOSUpdateStatusResponse_OUTCOME_ROLLBACK_FAILED:
 		var b strings.Builder
-		b.WriteString("Update failed post-reboot healthchecks, and the automatic rollback could not be performed. " +
-			"The device may be in a degraded state.\n")
+		reason := classifyOSRollback(resp.GetServices(), resp.GetNote())
+		switch reason {
+		case rollbackReasonNotBooted:
+			b.WriteString("The new OS did not boot, and the automatic rollback could not be performed. " +
+				"The device may be in a degraded state.\n")
+		case rollbackReasonHealthchecks:
+			b.WriteString("Update failed post-reboot healthchecks, and the automatic rollback could not be performed. " +
+				"The device may be in a degraded state.\n")
+		default:
+			b.WriteString("The update did not stick, and the automatic rollback could not be performed. " +
+				"The device may be in a degraded state.\n")
+		}
 		writeFailedServices(&b, resp.GetServices())
 		// When the updater ran its own health gate (wendyos-update health.d),
 		// there are no per-service results — the reason is carried in the note.
@@ -786,8 +803,7 @@ func evaluateOSUpdateOutcome(
 		if re := resp.GetRollbackError(); re != "" {
 			fmt.Fprintf(&b, "Rollback error: %s\n", re)
 		}
-		return strings.TrimRight(b.String(), "\n"),
-			errors.New("OS update healthchecks failed and automatic rollback did not run")
+		return strings.TrimRight(b.String(), "\n"), rollbackFailedError(reason)
 
 	default: // OUTCOME_COMMIT_FAILED
 		msg := "The update could not be committed: no health verdict was rendered. " +
@@ -878,9 +894,23 @@ func formatOSUpdateStatus(resp *agentpb.GetOSUpdateStatusResponse) string {
 	case agentpb.GetOSUpdateStatusResponse_OUTCOME_COMMITTED:
 		b.WriteString("Last OS update: committed (healthchecks passed).\n")
 	case agentpb.GetOSUpdateStatusResponse_OUTCOME_ROLLED_BACK:
-		b.WriteString("Last OS update: rolled back after failed healthchecks.\n")
+		switch classifyOSRollback(resp.GetServices(), resp.GetNote()) {
+		case rollbackReasonNotBooted:
+			b.WriteString("Last OS update: rolled back — the new OS did not boot.\n")
+		case rollbackReasonHealthchecks:
+			b.WriteString("Last OS update: rolled back after failed healthchecks.\n")
+		default:
+			b.WriteString("Last OS update: rolled back.\n")
+		}
 	case agentpb.GetOSUpdateStatusResponse_OUTCOME_ROLLBACK_FAILED:
-		b.WriteString("Last OS update: healthchecks failed and the rollback could not be performed.\n")
+		switch classifyOSRollback(resp.GetServices(), resp.GetNote()) {
+		case rollbackReasonNotBooted:
+			b.WriteString("Last OS update: the new OS did not boot and the rollback could not be performed.\n")
+		case rollbackReasonHealthchecks:
+			b.WriteString("Last OS update: healthchecks failed and the rollback could not be performed.\n")
+		default:
+			b.WriteString("Last OS update: the update did not stick and the rollback could not be performed.\n")
+		}
 	case agentpb.GetOSUpdateStatusResponse_OUTCOME_COMMIT_FAILED:
 		b.WriteString("Last OS update: the commit did not complete (no health verdict was rendered); it will be retried.\n")
 	default:
@@ -968,6 +998,102 @@ func sortedKeys(m map[string]string) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+// osRollbackReason classifies why an OS update was rolled back. The CLI used to
+// state "critical services failed healthchecks" for every rollback, which is
+// false whenever the update backend runs its own health gate: wendyos-update's
+// boot verifier marks a deployment failed *before* commit when the new slot
+// never booted, so /etc/wendyos-update/health.d never runs at all. Reporting a
+// healthcheck failure then points the reader at the wrong layer entirely
+// (WDY-2200).
+type osRollbackReason int
+
+const (
+	// rollbackReasonUnknown: the record does not say why. The CLI reports the
+	// rollback and the captured reason without naming a cause of its own.
+	rollbackReasonUnknown osRollbackReason = iota
+	// rollbackReasonHealthchecks: a critical service failed, so the agent's own
+	// CheckAll rejected the update. This is a genuine healthcheck failure.
+	rollbackReasonHealthchecks
+	// rollbackReasonNotBooted: the new OS never produced a healthy boot — the
+	// firmware fell back to the old slot, or the deployment was already marked
+	// failed — so no healthcheck was ever reached.
+	rollbackReasonNotBooted
+)
+
+// updaterNeverBootedMarkers are substrings of a wendyos-update commit rejection
+// that mean the new slot never booted. They are matched on the note because the
+// exit code cannot distinguish these cases: the CLI contract's exit 4 covers
+// both platform-verification and health.d failures, while an already-marked-
+// failed deployment exits 1. An unmatched note yields rollbackReasonUnknown,
+// which asserts nothing — the property that matters is that the CLI never claims
+// a healthcheck failure it cannot substantiate.
+//
+// A structured reason field on the agent's status response would remove this
+// matching entirely; until then, matching the note keeps every already-deployed
+// agent honest, because they all report it.
+var updaterNeverBootedMarkers = []string{
+	"is marked failed",  // engine.Commit: pending update <x> is marked failed
+	"firmware fallback", // engine.Commit / VerifyBoot: booted slot != target slot
+	"never swapped",     // engine.Commit: written but never swapped
+}
+
+// updaterHealthcheckMarker matches engine.HookError for the gating health phase,
+// which formats as `health hook "<name>" failed: <err>`. The delegated path
+// reports no per-service results, so without this a genuine
+// /etc/wendyos-update/health.d rejection would fall through to
+// rollbackReasonUnknown and discard the one thing the record does establish.
+const updaterHealthcheckMarker = "health hook"
+
+// classifyOSRollback determines why an update was rolled back. A failed service
+// is decisive: only the agent-run CheckAll path populates service results, and
+// it records only failures it actually observed. The never-booted markers are
+// checked before the health marker because the boot verifier marks a deployment
+// failed before commit ever reaches health.d, so a record carrying both is a
+// never-booted one.
+func classifyOSRollback(services []*agentpb.GetOSUpdateStatusResponse_ServiceResult, note string) osRollbackReason {
+	for _, svc := range services {
+		if svc.GetStatus() == agentpb.GetOSUpdateStatusResponse_ServiceResult_STATUS_FAILED {
+			return rollbackReasonHealthchecks
+		}
+	}
+	lowered := strings.ToLower(note)
+	for _, marker := range updaterNeverBootedMarkers {
+		if strings.Contains(lowered, marker) {
+			return rollbackReasonNotBooted
+		}
+	}
+	if strings.Contains(lowered, updaterHealthcheckMarker) {
+		return rollbackReasonHealthchecks
+	}
+	return rollbackReasonUnknown
+}
+
+// rolledBackError is the exit error for a rolled-back update, worded to match
+// what the record actually supports.
+func rolledBackError(reason osRollbackReason) error {
+	switch reason {
+	case rollbackReasonNotBooted:
+		return errors.New("OS update rolled back: the new OS did not boot")
+	case rollbackReasonHealthchecks:
+		return errors.New("OS update rolled back: critical services failed healthchecks")
+	default:
+		return errors.New("OS update rolled back")
+	}
+}
+
+// rollbackFailedError is the exit error for an update that failed and could not
+// be rolled back.
+func rollbackFailedError(reason osRollbackReason) error {
+	switch reason {
+	case rollbackReasonNotBooted:
+		return errors.New("the new OS did not boot and automatic rollback did not run")
+	case rollbackReasonHealthchecks:
+		return errors.New("OS update healthchecks failed and automatic rollback did not run")
+	default:
+		return errors.New("OS update did not stick and automatic rollback did not run")
+	}
 }
 
 func writeFailedServices(b *strings.Builder, services []*agentpb.GetOSUpdateStatusResponse_ServiceResult) {
@@ -1269,7 +1395,15 @@ func downloadArtifactToTemp(artifactURL string) (string, error) {
 		return "", fmt.Errorf("progress TUI: %w", err)
 	}
 
-	model := finalModel.(tui.ProgressModel)
+	// Comma-ok rather than a bare assertion: a bubbletea program can return a
+	// different final model (e.g. when it is killed), and panicking mid-download
+	// would leave the temp file behind with no diagnosable error.
+	model, ok := finalModel.(tui.ProgressModel)
+	if !ok {
+		tmpFile.Close()
+		os.Remove(tmpFile.Name())
+		return "", fmt.Errorf("progress TUI returned an unexpected model %T", finalModel)
+	}
 	if model.Err() != nil {
 		tmpFile.Close()
 		os.Remove(tmpFile.Name())

--- a/go/internal/cli/commands/os_cmd_test.go
+++ b/go/internal/cli/commands/os_cmd_test.go
@@ -352,16 +352,95 @@ func TestProgressLabel(t *testing.T) {
 	}
 }
 
+// TestClassifyOSRollback pins the boundary between a genuine healthcheck
+// failure and an update that never booted (WDY-2200). Every marker corresponds
+// to a real wendyos-update rejection message; an unrecognised note must stay
+// unknown so the CLI reports no cause rather than the wrong one.
+func TestClassifyOSRollback(t *testing.T) {
+	failed := []*agentpb.GetOSUpdateStatusResponse_ServiceResult{
+		{Unit: "avahi-daemon.service", Status: agentpb.GetOSUpdateStatusResponse_ServiceResult_STATUS_FAILED},
+	}
+	skipped := []*agentpb.GetOSUpdateStatusResponse_ServiceResult{
+		{Unit: "avahi-daemon.service", Status: agentpb.GetOSUpdateStatusResponse_ServiceResult_STATUS_SKIPPED},
+	}
+
+	tests := []struct {
+		name     string
+		services []*agentpb.GetOSUpdateStatusResponse_ServiceResult
+		note     string
+		want     osRollbackReason
+	}{
+		{"a failed service is a healthcheck failure", failed, "", rollbackReasonHealthchecks},
+		{"a failed service wins over a never-booted note", failed,
+			"pending update x is marked failed; run rollback", rollbackReasonHealthchecks},
+		{"skipped services are not failures", skipped, "", rollbackReasonUnknown},
+		{"marked-failed deployment never booted", nil,
+			"wendyos-update commit failed: exit status 1 (pending update x is marked failed; run rollback)", rollbackReasonNotBooted},
+		{"firmware fallback never booted", nil,
+			"running slot A but the update targeted slot 1 (firmware fallback)", rollbackReasonNotBooted},
+		{"written but never swapped never booted", nil,
+			"pending update x was written but never swapped; run rollback or mark-good", rollbackReasonNotBooted},
+		{"marker matching ignores case", nil, "PENDING UPDATE X IS MARKED FAILED", rollbackReasonNotBooted},
+		{"empty record is unknown", nil, "", rollbackReasonUnknown},
+		{"unrecognised rejection is unknown", nil,
+			"wendyos-update commit failed: exit status 3 (something we have never seen)", rollbackReasonUnknown},
+		// engine.HookError formats a gating hook failure as
+		// `health hook "<name>" failed: <err>`. That IS a real healthcheck
+		// rejection even though no per-service results accompany it, so the
+		// delegated path must keep the healthcheck wording rather than degrade
+		// to the neutral one.
+		{"a health.d hook rejection is a healthcheck failure", nil,
+			`wendyos-update commit failed: exit status 4 (health hook "50-containerd.sh" failed: exit status 1)`,
+			rollbackReasonHealthchecks},
+		{"a platform-verify rejection is neither", nil,
+			"wendyos-update commit failed: exit status 4 (platform verify: ESRT status 6163)", rollbackReasonUnknown},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyOSRollback(tc.services, tc.note); got != tc.want {
+				t.Errorf("classifyOSRollback(%v, %q) = %v, want %v", tc.services, tc.note, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestFormatOSUpdateStatus(t *testing.T) {
 	tests := []struct {
-		name         string
-		resp         *agentpb.GetOSUpdateStatusResponse
-		wantContains []string
+		name            string
+		resp            *agentpb.GetOSUpdateStatusResponse
+		wantContains    []string
+		wantNotContains []string
 	}{
 		{
 			name:         "no record",
 			resp:         &agentpb.GetOSUpdateStatusResponse{HasResult: false},
 			wantContains: []string{"No OS update"},
+		},
+		{
+			// WDY-2200: this record is what `wendy os update-status` showed for
+			// days on a stranded Thor, claiming healthchecks failed when
+			// health.d had never run.
+			name: "rolled back because the OS never booted does not blame healthchecks",
+			resp: &agentpb.GetOSUpdateStatusResponse{
+				HasResult:    true,
+				Outcome:      agentpb.GetOSUpdateStatusResponse_OUTCOME_ROLLED_BACK,
+				OldOsVersion: "WendyOS-0.17.0",
+				NewOsVersion: "WendyOS-0.17.0",
+				Note:         "wendyos-update commit failed: exit status 1 (pending update wendyos-image-jetson-agx-thor-devkit-nvme-wendyos-0.18.2 is marked failed; run rollback)",
+			},
+			wantContains:    []string{"did not boot", "is marked failed"},
+			wantNotContains: []string{"healthcheck"},
+		},
+		{
+			name: "rolled back with an unrecognised reason does not blame healthchecks",
+			resp: &agentpb.GetOSUpdateStatusResponse{
+				HasResult: true,
+				Outcome:   agentpb.GetOSUpdateStatusResponse_OUTCOME_ROLLED_BACK,
+				Note:      "wendyos-update commit failed: exit status 3 (something we have never seen)",
+			},
+			wantContains:    []string{"rolled back"},
+			wantNotContains: []string{"healthcheck"},
 		},
 		{
 			name: "commit failed shows the captured reason",
@@ -393,6 +472,11 @@ func TestFormatOSUpdateStatus(t *testing.T) {
 			for _, want := range tc.wantContains {
 				if !strings.Contains(msg, want) {
 					t.Errorf("formatOSUpdateStatus() = %q, missing %q", msg, want)
+				}
+			}
+			for _, unwanted := range tc.wantNotContains {
+				if strings.Contains(strings.ToLower(msg), strings.ToLower(unwanted)) {
+					t.Errorf("formatOSUpdateStatus() = %q, must not mention %q", msg, unwanted)
 				}
 			}
 		})
@@ -588,14 +672,26 @@ func TestEvaluateOSUpdateOutcome(t *testing.T) {
 		RollbackError: "wendyos-update reported nothing to roll back",
 	}
 
+	// A rollback whose commit rejection matches none of the recognised
+	// "never booted" signatures: the CLI cannot tell why, so it must not
+	// invent a cause.
+	unclassifiedRolledBack := &agentpb.GetOSUpdateStatusResponse{
+		HasResult:     true,
+		Outcome:       agentpb.GetOSUpdateStatusResponse_OUTCOME_ROLLED_BACK,
+		OldOsVersion:  "WendyOS-0.10.4",
+		CreatedAtUnix: fresh,
+		Note:          "wendyos-update commit failed: exit status 3 (something we have never seen)",
+	}
+
 	tests := []struct {
-		name         string
-		resp         *agentpb.GetOSUpdateStatusResponse
-		rpcErr       error
-		preVer       string
-		postVer      string
-		wantErr      bool
-		wantContains []string
+		name            string
+		resp            *agentpb.GetOSUpdateStatusResponse
+		rpcErr          error
+		preVer          string
+		postVer         string
+		wantErr         bool
+		wantContains    []string
+		wantNotContains []string
 	}{
 		{
 			name:         "committed is verified success",
@@ -648,6 +744,49 @@ func TestEvaluateOSUpdateOutcome(t *testing.T) {
 				"WendyOS-0.10.4",
 				"is marked failed",
 			},
+		},
+		{
+			// WDY-2200: the boot verifier marks the deployment failed before
+			// commit, so health.d never runs. Blaming healthchecks sent a real
+			// investigation to the wrong layer entirely.
+			name:    "rollback for an OS that never booted does not blame healthchecks",
+			resp:    delegatedRolledBack,
+			preVer:  "WendyOS-0.10.4",
+			postVer: "WendyOS-0.10.4",
+			wantErr: true,
+			wantContains: []string{
+				"did not boot",
+				"WendyOS-0.10.4",
+			},
+			wantNotContains: []string{"healthcheck"},
+		},
+		{
+			name:            "rollback with an unrecognised reason does not blame healthchecks",
+			resp:            unclassifiedRolledBack,
+			preVer:          "WendyOS-0.10.4",
+			postVer:         "WendyOS-0.10.4",
+			wantErr:         true,
+			wantContains:    []string{"rolled back", "something we have never seen"},
+			wantNotContains: []string{"healthcheck"},
+		},
+		{
+			// The agent-run CheckAll path genuinely is a healthcheck failure,
+			// so that wording must survive.
+			name:         "rollback with failed services still reports healthchecks",
+			resp:         rolledBack,
+			preVer:       "WendyOS-0.10.4",
+			postVer:      "WendyOS-0.10.4",
+			wantErr:      true,
+			wantContains: []string{"healthcheck", "avahi-daemon.service"},
+		},
+		{
+			name:            "rollback-failed for an OS that never booted does not blame healthchecks",
+			resp:            rollbackFailedWithNote,
+			preVer:          "WendyOS-0.10.4",
+			postVer:         "WendyOS-0.11.0",
+			wantErr:         true,
+			wantContains:    []string{"did not boot", "nothing to roll back"},
+			wantNotContains: []string{"healthcheck"},
 		},
 		{
 			name:         "rollback failed reports degraded state",
@@ -732,6 +871,18 @@ func TestEvaluateOSUpdateOutcome(t *testing.T) {
 			for _, want := range tc.wantContains {
 				if !strings.Contains(msg, want) {
 					t.Errorf("message %q missing %q", msg, want)
+				}
+			}
+			for _, unwanted := range tc.wantNotContains {
+				if strings.Contains(strings.ToLower(msg), strings.ToLower(unwanted)) {
+					t.Errorf("message %q must not mention %q", msg, unwanted)
+				}
+			}
+			if err != nil {
+				for _, unwanted := range tc.wantNotContains {
+					if strings.Contains(strings.ToLower(err.Error()), strings.ToLower(unwanted)) {
+						t.Errorf("error %q must not mention %q", err, unwanted)
+					}
 				}
 			}
 		})

--- a/specs/2026-08-10-jetson-ota-clean-reboot-design.md
+++ b/specs/2026-08-10-jetson-ota-clean-reboot-design.md
@@ -1,0 +1,232 @@
+# Durable OS-update reboot, an OS-workarounds package, and honest rollback reporting
+
+Date: 2026-08-10
+Status: approved, ready for planning
+Issue: WDY-2200 (follow-up #4 covered by part C)
+
+## Problem
+
+A Jetson running WendyOS 0.16.1 or 0.17.0 cannot update over the air. Every OTA
+installs to the inactive slot, reboots, comes back on the **old** slot, and rolls
+back. Reproduced on `wendystudio-walter.local` (jetson-agx-thor, tegra264) on
+2026-08-10 while updating to a PR-226 0.18.2 image.
+
+The chain, confirmed on that device:
+
+1. Every Thor/Orin image ships `/var/lib/wendyos/update-bootloader`, so
+   `SwapSlot` takes the capsule branch, which **deliberately does not call**
+   `nvbootctrl set-active-boot-slot` (`tegrauefi/swap-slot.go:139`). UEFI
+   processing the staged capsule is the only thing that can move the slot.
+2. `copyFileSync` fsyncs only the capsule file, not the vfat ESP.
+3. The agent reboots with `syscall.Reboot(LINUX_REBOOT_CMD_RESTART)`
+   (`agent/services/reboot_linux.go:8`) — an immediate restart with no userspace
+   sync and no unmount. The capsule never reaches disk.
+4. UEFI finds no capsule, so the boot chain never switches, so the rootfs slot
+   never switches. `verify-boot` correctly detects `running != target`, marks the
+   deployment failed, and the agent rolls back.
+
+Device evidence distinguishing "no capsule processed" from "capsule rejected":
+
+```
+boot verifier: firmware fallback detected running=A target=B
+boot verifier: marking pending deployment failed artifact=...wendyos-0.18.2
+ESRT last_attempt_status=0  last_attempt_version=0   # never even attempted
+fw_version=2556416 (39.2.0, unchanged)
+```
+
+`wendyos-update` fixed its own half in `cb2c7b5` (`unix.Syncfs` of the ESP),
+shipped in 0.18.1. But an OTA is executed by the updater on the **currently
+running** slot, so an affected device uses the broken binary to perform its own
+upgrade and can never deliver its own fix.
+
+The agent is the lever that reaches these devices, because the agent — not
+`wendyos-update` — is what performs the post-install reboot, and the agent runs
+from the *old* slot. So an agent-side durable reboot fixes a stranded device in
+place, with no pinned binary to publish and no SHA to maintain.
+
+The precise limitation: the device must already be running an agent that contains
+the fix. `wendy os update` updates the agent before the OTA, which delivers it on
+any device whose agent is behind — but on a device already running the newest
+agent, that step is a no-op (observed on `wendystudio-walter`: `Agent is up to
+date`). Such a device needs one agent update carrying this change before its next
+OTA can succeed, which `wendy device update` or any later agent bump provides.
+This does not weaken the approach; it only means the fix lands with an agent
+release rather than instantly.
+
+A separate reporting defect made this far more expensive to diagnose than it
+should have been: the CLI reported "critical services failed healthchecks" when
+no healthcheck ever ran.
+
+## Non-goals
+
+- ESRT 6163 treated as recoverable (WDY-2200 follow-up #2) and surfacing an
+  unconfirmed boot chain (#3). Both live in the `wendyos-update` repo.
+- Decoupling the rootfs switch from the capsule (follow-up #1). Also
+  `wendyos-update`, and it needs hardware validation.
+- Any pinned/embedded `wendyos-update` binary. Considered and rejected: a single
+  hardcoded SHA cannot identify "the fixed build" in general (0.18.2's is
+  `20c416ed…83485`; 0.18.1's and every later build differ), and an allowlist
+  needs a new entry per release. Fixing the reboot fixes the cause instead.
+- Remediating devices already stranded today. That is Tom's hardware-validated
+  `fix-jetson-ota.sh`; this change stops new devices from being stranded.
+
+## Part A — `go/internal/agent/osworkarounds/`
+
+A dedicated package for OS-version-gated quirks, isolated so they are easy to
+find and easy to delete. One file per issue; each field documents what it works
+around, why, and its **removal condition**.
+
+```go
+// Set is the set of workarounds that apply to a running OS version.
+type Set struct {
+    // CleanRebootForCapsuleDurability: WendyOS < 0.18.1 ships a wendyos-update
+    // whose SwapSlot fsyncs only the staged capsule file, not the vfat ESP
+    // (WDY-2200), so an immediate reboot loses it and every Jetson OTA rolls
+    // back. The agent compensates by flushing and rebooting cleanly.
+    // Remove when no supported upgrade path starts below 0.18.1.
+    CleanRebootForCapsuleDurability bool
+}
+
+// For returns the workarounds applying to osVersion, which may carry a
+// "WendyOS-" display prefix.
+func For(osVersion string) Set
+```
+
+Files: `osworkarounds.go` (the `Set` type and `For`), `wdy2200.go` (the
+version predicate for this quirk), `osworkarounds_test.go`.
+
+`For` **fails open**: an empty, dev (`version.IsDev`), or unparseable version
+yields the zero `Set`, mirroring `requireReflashableOSVersion`
+(`cli/commands/os_cmd.go:103`) so dev and CI images are never mis-gated. It
+reuses `shared/version.CompareVersions`, which splits on `.` and `-`, so
+`0.17.0-nightly` sorts below `0.18.1` (workaround applies) as intended.
+
+Chosen over a registry or plugin structure because a struct of documented
+booleans is the smallest thing that isolates the knowledge and stays trivially
+testable. The package is agent-internal; the CLI does not consume it.
+
+## Part B — durable reboot
+
+Two layers, fixing different things.
+
+**B1, unconditional.** `rebootSystem()` calls `unix.Sync()` before
+`syscall.Reboot`. This is the underlying defect and is not Jetson-specific: an
+immediate `LINUX_REBOOT_CMD_RESTART` can lose *any* recent write. `sync(2)`
+writes back every mounted filesystem including the vfat ESP, which is on its own
+sufficient to make the capsule durable. Both existing callers benefit — the
+post-update reboot (`agent_service.go:907`) and the gate's rollback reboot
+(`os_update_gate.go:50`).
+
+**B2, version-gated.** On a version where `CleanRebootForCapsuleDurability` is
+set, the post-OS-update reboot syncs (as in B1) and then, instead of restarting
+immediately, goes through `systemctl --no-block reboot` so systemd unmounts the
+ESP. The sync is kept on this path too: it makes the capsule durable even if the
+systemd shutdown is what later hangs. This reproduces exactly the combination
+WDY-2200 validated on hardware (cycle 1: install + clean reboot → capsule
+applied, `esrt_lowest_supported_version` advanced from 0 to 2556416).
+
+Only the post-OS-update reboot is version-gated. The gate's rollback reboot
+keeps the plain (now syncing) path: it is a recovery action on a device already
+in a bad state, where the reliable immediate restart is the right trade.
+
+**Hang watchdog.** A clean shutdown can block on stuck unmounts or containers
+that will not stop, and today's reboot is instantaneous — so B2 introduces a new
+way to wedge a device mid-update. After issuing the clean reboot, the agent waits
+`cleanRebootGrace`; if it is still running, it logs loudly and falls back to
+`unix.Sync()` + `syscall.Reboot`. This is a risk the change creates, not a
+speculative one, so the fallback ships with it. Grace: 60s.
+
+`reboot_other.go` (non-Linux) keeps returning its unsupported error; the new
+clean-reboot entry point is Linux-only and the OS-update path is Linux-only in
+practice.
+
+## Part C — stop reporting a healthcheck failure that never happened
+
+`os_cmd.go:774` hardcodes `"critical services failed healthchecks"` for every
+rollback, and `:881` renders `"Last OS update: rolled back after failed
+healthchecks."`. With `DelegatedHealth`, `health.d` is never reached when the
+boot verifier already marked the deployment failed — so both statements are
+false in exactly the WDY-2200 case, and they point the reader at the wrong layer.
+
+Classify **in the CLI**, from the `Note` and `Services` the agent already sends.
+No proto field and no agent change, which matters: every agent already in the
+field reports the note, so the message becomes honest on existing devices
+immediately rather than after an agent rollout.
+
+```go
+type osRollbackReason int   // rollbackReasonUnknown | ...Healthchecks | ...NotBooted
+
+func classifyOSRollback(services []*agentpb....ServiceResult, note string) osRollbackReason
+```
+
+Precedence, in order:
+
+1. any service with `STATUS_FAILED` → `Healthchecks`. Only the agent-run
+   `CheckAll` path populates service results, and only with failures it observed.
+2. a never-booted marker in the note → `NotBooted`: `is marked failed`,
+   `firmware fallback`, `never swapped`. Checked before the health marker,
+   because the boot verifier marks a deployment failed before commit ever reaches
+   `health.d`.
+3. `health hook` in the note → `Healthchecks`. This is `engine.HookError` for the
+   gating health phase (`health hook "<name>" failed: <err>`), and it preserves
+   the healthcheck wording for a genuine delegated `health.d` rejection, which
+   carries no service results.
+4. otherwise → `Unknown`.
+
+Matching the note is necessary because the exit code cannot separate these: the
+CLI contract's exit 4 covers both platform-verification and `health.d` failures,
+while an already-marked-failed deployment exits 1.
+
+| Reason | Headline |
+| -- | -- |
+| `NotBooted` | The new OS did not boot; the device fell back to *old* and the update was rolled back. |
+| `Healthchecks` | Current wording, unchanged. |
+| `Unknown` | Update was rolled back to *X*. — plus the existing `Reason:` note, asserting nothing. |
+
+The unknown case is the load-bearing one: when classification does not match, the
+CLI must not claim healthchecks failed. Applies to `OUTCOME_ROLLED_BACK`,
+`OUTCOME_ROLLBACK_FAILED`, and the `update-status` headlines, and to the returned
+exit errors as well as the printed messages.
+
+A structured reason field on the status response remains the better long-term
+answer and would delete the matching; it is a follow-up, not a blocker.
+
+## Testing
+
+Part A: table test over `""`, dev versions, `0.16.1`, `0.17.0`,
+`WendyOS-0.17.0`, `0.17.0-nightly`, `0.18.1`, `0.18.2`, `1.0.0`, and an
+unparseable string, asserting the fail-open boundary at 0.18.1.
+
+Part B: `rebootSystem` and the clean-reboot path get injectable seams for the
+sync call, the `systemctl` exec, and the grace timer, following the existing
+injected-side-effect style of `oshealth.Gate`. Tests assert: sync happens before
+reboot on the plain path; the clean path shells out to systemd on an affected
+version and not on an unaffected one; and the watchdog falls back after the grace
+period when the clean reboot does not take effect.
+
+Part C: `TestClassifyOSRollback` covers the precedence table directly — each
+marker, case-insensitivity, a failed service outranking a never-booted note,
+skipped services not counting, a real `health hook` rejection, a platform-verify
+rejection staying unknown, and the empty record. `TestEvaluateOSUpdateOutcome`
+and `TestFormatOSUpdateStatus` gain a `wantNotContains` assertion so the rendered
+message *and* the returned error are both checked for the absence of
+"healthcheck" in the never-booted and unknown cases — that absence is the actual
+requirement, and asserting only on `wantContains` would not catch a regression.
+
+Note `wendyos-update` has no CI at all (WDY-2200 open question), so `cb2c7b5`'s
+own regression test runs nowhere. Not fixed here, but it is why parts A–C carry
+their own tests in this repo.
+
+## Delivery
+
+Part C ships first and alone, because it is CLI-only and needs no agent rollout
+to take effect on devices already in the field. Parts A and B follow in a second
+PR; they are agent-side and land with an agent release.
+
+1. **PR 1 (this one) — C:** rollback-reason classification and CLI wording.
+2. **PR 2 — A + B:** the `osworkarounds` package and the durable/clean reboot
+   wired to it, with the hang watchdog.
+
+Ordering them this way also means the honest message is in place *before* the
+reboot fix changes behaviour, so any residual rollback still reports its real
+cause.


### PR DESCRIPTION
## Why

Updating a Jetson AGX Thor (`wendystudio-walter`) from 0.17.0 to a PR-226 0.18.2 image rolled back, and the CLI said:

```
✗ OS update rolled back: critical services failed healthchecks
```

No healthcheck had run. The device rebooted straight back onto the old slot, and `wendyos-update`'s boot verifier marked the deployment failed *before* commit:

```
boot verifier: firmware fallback detected running=A target=B
boot verifier: marking pending deployment failed artifact=...wendyos-0.18.2
```

With `DelegatedHealth`, `/etc/wendyos-update/health.d` is only reached *inside* a commit that gets that far — so in this case it never ran at all. The CLI hardcoded the healthcheck wording for every rollback (`os_cmd.go:774`, `:881`), which sent the investigation to the wrong layer for a long time. This is WDY-2200 follow-up 4.

## What

Classify the rollback from the `Note` and `Services` the agent **already** sends, in this precedence:

| Signal | Reason |
| -- | -- |
| any `STATUS_FAILED` service | healthchecks — only the agent-run `CheckAll` populates these |
| `is marked failed` / `firmware fallback` / `never swapped` | the new OS never booted |
| `health hook "<x>" failed` | healthchecks — `engine.HookError`, delegated `health.d`, which carries no service results |
| anything else | **unknown** — report the rollback and the captured reason, assert no cause |

Never-booted markers are checked before the health marker, because the boot verifier marks a deployment failed before commit ever reaches `health.d`, so a record carrying both is a never-booted one.

Before → after, for the exact record from the device:

```
- Update failed post-reboot healthchecks and was rolled back to WendyOS-0.17.0.
+ The new OS did not boot; the device fell back to WendyOS-0.17.0 and the update was rolled back.
  Reason: wendyos-update commit failed: exit status 1 (pending update ... is marked failed; run rollback)
```

Applied to `OUTCOME_ROLLED_BACK`, `OUTCOME_ROLLBACK_FAILED`, the `update-status` headlines, **and** the returned exit errors.

## Why note-matching, and why in the CLI

The exit code cannot separate these cases: the CLI contract's exit 4 covers both platform-verification and `health.d` failures, while an already-marked-failed deployment exits 1.

Doing it CLI-side rather than adding a proto field is deliberate — every agent already in the field reports the note, so the message becomes honest on existing devices immediately instead of after an agent rollout. A structured reason field on the status response is the better long-term answer and would delete the matching; noted as a follow-up, not a blocker.

## The unknown case is the point

When classification does not match, the CLI must not invent a cause. The tests assert the **absence** of "healthcheck" in both the rendered message and the returned error, because that absence is the actual requirement — `wantContains` alone would not catch a regression.

## Tests

TDD throughout: the wording tests were watched failing against the old strings first. `TestClassifyOSRollback` covers each marker, case-insensitivity, a failed service outranking a never-booted note, skipped services not counting, a genuine `health hook` rejection, a platform-verify rejection staying unknown, and the empty record. I also verified the suite bites by temporarily removing two markers and the case-folding and confirming exactly those three cases failed.

`go test ./internal/cli/...` passes; `gofmt`, `go vet`, `go build ./...` clean.

## Also in here

- **Drive-by in the same file:** `downloadArtifactToTemp` asserted the bubbletea final model without comma-ok, which would panic mid-download and leave the temp file behind instead of returning a diagnosable error. Pre-existing on `main`; the repo's own check flags it on every edit to this file.
- **Docs:** the `health.d` example output was not the real format (`health hook "<name>" failed: ...`), and the new never-booted / unknown forms are documented.
- **Spec** (`specs/2026-08-10-jetson-ota-clean-reboot-design.md`) recording the full WDY-2200 diagnosis.

## Not in this PR

The spec describes three parts; this is part C only. Parts A and B — an `osworkarounds` package and the actual root-cause fix, making the agent's reboot durable (`unix.Sync` before `syscall.Reboot`, plus a clean `systemctl reboot` with a hang watchdog on affected OS versions) — are agent-side and follow in a second PR. Ordering it this way means the honest message is in place before the reboot fix changes behaviour.

## Verification note

The rendering is unit-tested against the real recorded note from the affected device, but I have not re-run a live OTA end to end against this build — the device has since been remediated onto 0.18.2, so the failing condition is no longer reproducible on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158EbZT5mte7g7P8e79h1AV
