### PR TITLE
Speed up Stagefile builds and deployments

### DIFF
--- a/Proto/wendy/agent/services/v1/wendy_agent_v1_container_service.proto
+++ b/Proto/wendy/agent/services/v1/wendy_agent_v1_container_service.proto
@@ -33,6 +33,12 @@ service WendyContainerService {
     // skip decompressing and content-chunking layers the device can reuse as-is
     // — for those layers no dedup is possible, so chunking would be pure waste.
     rpc QueryLayers(QueryLayersRequest) returns (QueryLayersResponse);
+    // PrepareImage assembles chunk-backed layers and unpacks their snapshots
+    // before RunContainer. The CLI starts this RPC before uploading missing
+    // chunks, allowing device-side assembly/unpack to overlap the transfer.
+    // RunContainer remains the source of truth and repeats these idempotent
+    // operations, so callers can fall back safely when this RPC is unavailable.
+    rpc PrepareImage(RunContainerLayersRequest) returns (PrepareImageResponse);
 }
 
 message ListContainersRequest {}
@@ -384,3 +390,5 @@ message PortEntry {
 message MCPChunk {
     bytes data = 1;
 }
+
+message PrepareImageResponse {}

--- a/go/internal/agent/containerd/chunkstore.go
+++ b/go/internal/agent/containerd/chunkstore.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/containerd/errdefs"
 	digest "github.com/opencontainers/go-digest"
@@ -39,9 +40,32 @@ const defaultChunkStagingDir = "/var/lib/wendy/chunk-staging"
 // deploys staging different content do not collide.
 type staging struct {
 	dir string
+	mu  sync.Mutex
+	// changed is closed and replaced whenever a new chunk becomes visible.
+	// Closing broadcasts to every concurrent image preparation waiter, unlike
+	// sending on a shared channel (which would wake only one waiter).
+	changed chan struct{}
 }
 
-func newStaging(dir string) *staging { return &staging{dir: dir} }
+func newStaging(dir string) *staging {
+	return &staging{dir: dir, changed: make(chan struct{})}
+}
+
+// changes returns the current broadcast generation. Callers subscribe before
+// checking availability so a write racing the check either becomes visible to
+// that check or closes the returned channel; no wakeup can be lost.
+func (s *staging) changes() <-chan struct{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.changed
+}
+
+func (s *staging) notifyChanged() {
+	s.mu.Lock()
+	close(s.changed)
+	s.changed = make(chan struct{})
+	s.mu.Unlock()
+}
 
 // path returns the on-disk location for a chunk hash.
 func (s *staging) path(h [32]byte) string {
@@ -96,6 +120,7 @@ func (s *staging) write(h [32]byte, data []byte) error {
 		os.Remove(tmpName)
 		return err
 	}
+	s.notifyChanged()
 	return nil
 }
 

--- a/go/internal/agent/containerd/prepare.go
+++ b/go/internal/agent/containerd/prepare.go
@@ -1,0 +1,128 @@
+package containerd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containerd/containerd/v2/core/leases"
+	"github.com/containerd/errdefs"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"go.uber.org/zap"
+
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+// PrepareImage waits for chunk-backed layers to arrive, reassembles them, and
+// applies their snapshots from base to top. It is intended to run concurrently
+// with the CLI's WriteChunks calls, so device-side disk and decompression work
+// overlaps network transfer. The final image record is assembled before return;
+// RunContainer safely repeats all operations through their existing fast paths.
+func (c *Client) PrepareImage(ctx context.Context, imageName string, layers []*agentpb.RunContainerLayerHeader, imageConfig []byte) error {
+	ctx = c.withNamespace(ctx)
+	cleanupCtx := c.withNamespace(context.Background())
+
+	ctx, doneLease, err := c.client.WithLease(ctx, leases.WithExpiration(unpackLeaseExpiration))
+	if err != nil {
+		return fmt.Errorf("creating image preparation lease: %w", err)
+	}
+	defer func() {
+		if err := doneLease(cleanupCtx); err != nil {
+			c.logger.Warn("Failed to release image preparation lease; relying on expiration backstop",
+				zap.Duration("expiration", unpackLeaseExpiration),
+				zap.Error(err),
+			)
+		}
+	}()
+
+	sn := c.client.SnapshotService(c.snapshotter)
+	parentChainID := ""
+	for i, layer := range layers {
+		if layer == nil {
+			return fmt.Errorf("layer %d is nil", i)
+		}
+
+		diffID := layer.GetDiffId()
+		if diffID == "" {
+			diffID = layer.GetDigest()
+		}
+		if _, err := digest.Parse(diffID); err != nil {
+			return fmt.Errorf("parsing diff ID for layer %d: %w", i, err)
+		}
+		chainID := computeChainID(parentChainID, diffID)
+
+		hashes, err := prepareChunkHashes(layer.GetChunkHashes())
+		if err != nil {
+			return fmt.Errorf("layer %d: %w", i, err)
+		}
+		if len(hashes) > 0 {
+			if err := c.waitForChunks(ctx, hashes); err != nil {
+				return fmt.Errorf("waiting for layer %d chunks: %w", i, err)
+			}
+			if err := c.AssembleLayerFromChunks(ctx, diffID, hashes); err != nil {
+				return fmt.Errorf("reassembling layer %d: %w", i, err)
+			}
+		}
+
+		if _, err := sn.Stat(ctx, chainID); err == nil {
+			parentChainID = chainID
+			continue
+		} else if !errdefs.IsNotFound(err) {
+			return fmt.Errorf("checking snapshot for layer %d: %w", i, err)
+		}
+
+		layerDigest, err := digest.Parse(layer.GetDigest())
+		if err != nil {
+			return fmt.Errorf("parsing digest for layer %d: %w", i, err)
+		}
+		desc := ocispec.Descriptor{
+			MediaType: layerMediaType(layer.GetCompression(), layer.GetGzip()),
+			Digest:    layerDigest,
+			Size:      layer.GetSize(),
+		}
+		if _, err := c.applyLayerSnapshot(ctx, cleanupCtx, sn, imageName, i, desc, parentChainID, chainID); err != nil {
+			return err
+		}
+		parentChainID = chainID
+	}
+
+	if err := c.AssembleImage(ctx, imageName, layers, imageConfig); err != nil {
+		return fmt.Errorf("assembling prepared image: %w", err)
+	}
+	c.logger.Info("Prepared image before container start",
+		zap.String("image", normalizeImageName(imageName)),
+		zap.Int("layers", len(layers)),
+	)
+	return nil
+}
+
+func prepareChunkHashes(raw [][]byte) ([][32]byte, error) {
+	hashes := make([][32]byte, 0, len(raw))
+	for i, b := range raw {
+		if len(b) != 32 {
+			return nil, fmt.Errorf("chunk hash %d must be 32 bytes, got %d", i, len(b))
+		}
+		var h [32]byte
+		copy(h[:], b)
+		hashes = append(hashes, h)
+	}
+	return hashes, nil
+}
+
+func (c *Client) waitForChunks(ctx context.Context, hashes [][32]byte) error {
+	for {
+		changed := c.staging.changes()
+		missing, err := c.MissingChunks(ctx, hashes)
+		if err != nil {
+			return err
+		}
+		if len(missing) == 0 {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-changed:
+		}
+	}
+}

--- a/go/internal/agent/containerd/prepare_test.go
+++ b/go/internal/agent/containerd/prepare_test.go
@@ -1,0 +1,64 @@
+package containerd
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWaitForChunksUnblocksWhenChunkIsStaged(t *testing.T) {
+	dir := t.TempDir()
+	index, err := NewChunkIndex(filepath.Join(dir, "index.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := &Client{chunkIndex: index, staging: newStaging(filepath.Join(dir, "staging"))}
+	data := []byte("arrives while preparation is waiting")
+	hash := sha256.Sum256(data)
+
+	done := make(chan error, 2)
+	for range 2 {
+		go func() {
+			done <- c.waitForChunks(context.Background(), [][32]byte{hash})
+		}()
+	}
+
+	if err := c.StageChunk(context.Background(), hash, data); err != nil {
+		t.Fatal(err)
+	}
+	for range 2 {
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("waitForChunks: %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("waitForChunks did not broadcast the staged chunk")
+		}
+	}
+}
+
+func TestWaitForChunksHonorsCancellation(t *testing.T) {
+	dir := t.TempDir()
+	index, err := NewChunkIndex(filepath.Join(dir, "index.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := &Client{chunkIndex: index, staging: newStaging(filepath.Join(dir, "staging"))}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = c.waitForChunks(ctx, [][32]byte{{1}})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("waitForChunks error = %v, want context.Canceled", err)
+	}
+}
+
+func TestPrepareChunkHashesRejectsMalformedHash(t *testing.T) {
+	if _, err := prepareChunkHashes([][]byte{{1, 2, 3}}); err == nil {
+		t.Fatal("expected malformed chunk hash error")
+	}
+}

--- a/go/internal/agent/containerd/unpack.go
+++ b/go/internal/agent/containerd/unpack.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/errdefs"
 	"github.com/google/uuid"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"go.uber.org/zap"
 )
 
@@ -180,59 +181,18 @@ func (c *Client) UnpackImage(ctx context.Context, img containerd.Image, progress
 			})
 		}
 
-		// Unique per-attempt active key so concurrent unpacks of the same
-		// image (or a stale key from a crashed prior attempt) can't collide
-		// on the AlreadyExists path and clobber each other's in-progress
-		// snapshot. The lease pins the active snapshot during this loop
-		// iteration; only the committed chain-ID snapshot needs gc.root
-		// to survive lease release.
-		activeKey := fmt.Sprintf("extract-%s-%d-%s", img.Name(), i, uuid.NewString())
-		mounts, err := sn.Prepare(ctx, activeKey, parentChainID)
+		reused, err := c.applyLayerSnapshot(ctx, cleanupCtx, sn, img.Name(), i, layerDesc, parentChainID, chainID)
 		if err != nil {
-			return fmt.Errorf("preparing snapshot for layer %d: %w", i, err)
+			return err
 		}
-
-		if _, err := c.client.DiffService().Apply(ctx, layerDesc, mounts); err != nil {
-			c.removeActiveSnapshot(cleanupCtx, sn, activeKey, "active snapshot after apply failure", i)
-			return fmt.Errorf("applying layer %d: %w", i, err)
-		}
-
-		gcRootOpt := snapshots.WithLabels(map[string]string{
-			labelKeyGCRoot: gcTimestamp(),
-		})
-		commitErr := sn.Commit(ctx, chainID, activeKey, gcRootOpt)
-		switch {
-		case commitErr == nil:
-			c.logger.Debug("Unpacked layer",
-				zap.Int("layer", i),
-				zap.String("chain_id", chainID),
-				zap.Int64("size", layerDesc.Size),
-			)
-			if progress != nil {
-				progress(UnpackProgress{
-					Phase:       "layer",
-					LayerIndex:  i,
-					TotalLayers: totalLayers,
-					LayerSize:   layerDesc.Size,
-					Reused:      false,
-				})
-			}
-		// A concurrent unpack committed the same chain ID first. Our
-		// active key still exists; clean it up and report the layer
-		// as reused rather than freshly unpacked.
-		case errdefs.IsAlreadyExists(commitErr):
-			c.removeActiveSnapshot(cleanupCtx, sn, activeKey, "active snapshot after concurrent commit", i)
-			if progress != nil {
-				progress(UnpackProgress{
-					Phase:       "layer",
-					LayerIndex:  i,
-					TotalLayers: totalLayers,
-					LayerSize:   layerDesc.Size,
-					Reused:      true,
-				})
-			}
-		default:
-			return fmt.Errorf("committing snapshot for layer %d: %w", i, commitErr)
+		if progress != nil {
+			progress(UnpackProgress{
+				Phase:       "layer",
+				LayerIndex:  i,
+				TotalLayers: totalLayers,
+				LayerSize:   layerDesc.Size,
+				Reused:      reused,
+			})
 		}
 
 		parentChainID = chainID
@@ -243,6 +203,55 @@ func (c *Client) UnpackImage(ctx context.Context, img containerd.Image, progress
 	}
 
 	return nil
+}
+
+// applyLayerSnapshot applies one layer descriptor on top of parentChainID and
+// commits it under chainID. The caller must hold a containerd lease. Returning
+// reused=true means another concurrent preparation committed the same chain ID
+// first; that is a successful idempotent outcome.
+func (c *Client) applyLayerSnapshot(
+	ctx, cleanupCtx context.Context,
+	sn snapshots.Snapshotter,
+	imageName string,
+	layer int,
+	layerDesc ocispec.Descriptor,
+	parentChainID, chainID string,
+) (reused bool, err error) {
+	// Unique per-attempt active key so concurrent unpacks of the same image (or
+	// a stale key from a crashed prior attempt) cannot collide or clobber each
+	// other's in-progress snapshot.
+	activeKey := fmt.Sprintf("extract-%s-%d-%s", imageName, layer, uuid.NewString())
+	mounts, err := sn.Prepare(ctx, activeKey, parentChainID)
+	if err != nil {
+		return false, fmt.Errorf("preparing snapshot for layer %d: %w", layer, err)
+	}
+
+	if _, err := c.client.DiffService().Apply(ctx, layerDesc, mounts); err != nil {
+		c.removeActiveSnapshot(cleanupCtx, sn, activeKey, "active snapshot after apply failure", layer)
+		return false, fmt.Errorf("applying layer %d: %w", layer, err)
+	}
+
+	gcRootOpt := snapshots.WithLabels(map[string]string{
+		labelKeyGCRoot: gcTimestamp(),
+	})
+	commitErr := sn.Commit(ctx, chainID, activeKey, gcRootOpt)
+	switch {
+	case commitErr == nil:
+		c.logger.Debug("Unpacked layer",
+			zap.Int("layer", layer),
+			zap.String("chain_id", chainID),
+			zap.Int64("size", layerDesc.Size),
+		)
+		return false, nil
+	case errdefs.IsAlreadyExists(commitErr):
+		// A concurrent unpack committed the same chain ID first. Our active
+		// key still exists and must be removed.
+		c.removeActiveSnapshot(cleanupCtx, sn, activeKey, "active snapshot after concurrent commit", layer)
+		return true, nil
+	default:
+		c.removeActiveSnapshot(cleanupCtx, sn, activeKey, "active snapshot after commit failure", layer)
+		return false, fmt.Errorf("committing snapshot for layer %d: %w", layer, commitErr)
+	}
 }
 
 // removeActiveSnapshot deletes an active snapshot key as part of error recovery,

--- a/go/internal/agent/services/container_service.go
+++ b/go/internal/agent/services/container_service.go
@@ -300,6 +300,76 @@ func (s *ContainerService) WriteChunks(stream grpc.ClientStreamingServer[agentpb
 	}
 }
 
+// PrepareImage starts the device-side half of a chunk-diff deploy before all
+// missing chunks have arrived. The containerd implementation waits for each
+// layer's chunks, then assembles and unpacks layers from base to top while the
+// CLI continues uploading later layers. RunContainer repeats the work through
+// idempotent fast paths, so a lost response cannot leave deploy state ambiguous.
+func (s *ContainerService) PrepareImage(ctx context.Context, req *agentpb.RunContainerLayersRequest) (*agentpb.PrepareImageResponse, error) {
+	if err := s.verifyImageSignature(req.GetImageConfig(), req.GetImageSignature()); err != nil {
+		return nil, err
+	}
+	if err := s.validateSignedLayerBinding(req.GetImageConfig(), req.GetLayers()); err != nil {
+		return nil, err
+	}
+
+	preparer, ok := s.containerd.(ImagePreparer)
+	if !ok {
+		return nil, status.Error(codes.Unimplemented, "image preparation is not supported by this runtime")
+	}
+	if err := preparer.PrepareImage(ctx, req.GetImageName(), req.GetLayers(), req.GetImageConfig()); err != nil {
+		return nil, status.Errorf(codes.Internal, "preparing image: %v", err)
+	}
+	return &agentpb.PrepareImageResponse{}, nil
+}
+
+func (s *ContainerService) verifyImageSignature(imageConfig, signature []byte) error {
+	imageDigest := sha256.Sum256(imageConfig)
+	if err := s.imageVerifier.Verify(imageDigest[:], signature); err != nil {
+		switch {
+		case errors.Is(err, sigverify.ErrUnsigned):
+			return status.Error(codes.FailedPrecondition, "container image is unsigned; refusing to run")
+		case errors.Is(err, sigverify.ErrBadSignature):
+			return status.Error(codes.DataLoss, "container image signature verification failed; refusing to run")
+		default:
+			return status.Errorf(codes.Internal, "container image signature verification error: %v", err)
+		}
+	}
+	return nil
+}
+
+// validateSignedLayerBinding ensures an enabled image signature authenticates
+// the exact ordered diff IDs that preparation will persist. AssembleImage
+// intentionally re-derives RootFS from the wire headers, so checking only the
+// config signature without this comparison would let an authenticated config
+// be paired with attacker-chosen layer content.
+func (s *ContainerService) validateSignedLayerBinding(imageConfig []byte, layers []*agentpb.RunContainerLayerHeader) error {
+	if !s.imageVerifier.Enabled() {
+		return nil
+	}
+	var cfg struct {
+		RootFS struct {
+			DiffIDs []string `json:"diff_ids"`
+		} `json:"rootfs"`
+	}
+	if err := json.Unmarshal(imageConfig, &cfg); err != nil {
+		return status.Errorf(codes.InvalidArgument, "invalid signed image config: %v", err)
+	}
+	if len(cfg.RootFS.DiffIDs) != len(layers) {
+		return status.Errorf(codes.InvalidArgument, "signed image config has %d diff IDs but request has %d layers", len(cfg.RootFS.DiffIDs), len(layers))
+	}
+	for i, layer := range layers {
+		wireDiffID := layer.GetDiffId()
+		if wireDiffID == "" {
+			wireDiffID = layer.GetDigest()
+		}
+		if cfg.RootFS.DiffIDs[i] != wireDiffID {
+			return status.Errorf(codes.InvalidArgument, "signed image config diff ID %d does not match requested layer", i)
+		}
+	}
+	return nil
+}
+
 func (s *ContainerService) RunContainer(req *agentpb.RunContainerLayersRequest, stream grpc.ServerStreamingServer[agentpb.RunContainerLayersResponse]) error {
 	ctx := stream.Context()
 
@@ -324,16 +394,11 @@ func (s *ContainerService) RunContainer(req *agentpb.RunContainerLayersRequest, 
 	phaseStart := runStartedAt
 	var verifyDur, layerAssembleDur, imageAssembleDur, createDur time.Duration
 
-	imageDigest := sha256.Sum256(req.GetImageConfig())
-	if err := s.imageVerifier.Verify(imageDigest[:], req.GetImageSignature()); err != nil {
-		switch {
-		case errors.Is(err, sigverify.ErrUnsigned):
-			return status.Error(codes.FailedPrecondition, "container image is unsigned; refusing to run")
-		case errors.Is(err, sigverify.ErrBadSignature):
-			return status.Error(codes.DataLoss, "container image signature verification failed; refusing to run")
-		default:
-			return status.Errorf(codes.Internal, "container image signature verification error: %v", err)
-		}
+	if err := s.verifyImageSignature(req.GetImageConfig(), req.GetImageSignature()); err != nil {
+		return err
+	}
+	if err := s.validateSignedLayerBinding(req.GetImageConfig(), req.GetLayers()); err != nil {
+		return err
 	}
 
 	verifyDur = time.Since(phaseStart)

--- a/go/internal/agent/services/container_service_imagesig_test.go
+++ b/go/internal/agent/services/container_service_imagesig_test.go
@@ -21,6 +21,16 @@ import (
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
 
+type imagePrepareMock struct {
+	mockContainerdClient
+	prepareCalls int
+}
+
+func (m *imagePrepareMock) PrepareImage(_ context.Context, _ string, _ []*agentpb.RunContainerLayerHeader, _ []byte) error {
+	m.prepareCalls++
+	return nil
+}
+
 // containerImageMldsaKeypairForTest generates an ephemeral ML-DSA65 keypair
 // and returns an enabled sigverify.Verifier pinned to the public key, plus a
 // sign function for the private key. Mirrors mldsaKeypairForTest in
@@ -134,7 +144,8 @@ func TestNewContainerService_ImageVerifierIsSeparateFromAgentBinaryKey(t *testin
 func TestRunContainer_ImageSignatureVerification(t *testing.T) {
 	verifier, sign := containerImageMldsaKeypairForTest(t)
 
-	imageConfig := []byte(`{"config":{"Cmd":["/entrypoint"]}}`)
+	const layerDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	imageConfig := []byte(`{"config":{"Cmd":["/entrypoint"]},"rootfs":{"type":"layers","diff_ids":["` + layerDigest + `"]}}`)
 	sum := sha256.Sum256(imageConfig)
 	digest := sum[:]
 
@@ -143,7 +154,7 @@ func TestRunContainer_ImageSignatureVerification(t *testing.T) {
 			ImageName: "test-image:latest",
 			AppName:   "sig-test-app",
 			Layers: []*agentpb.RunContainerLayerHeader{
-				{Digest: "sha256:layerdigest", Size: 10, DiffId: "sha256:layerdiffid"},
+				{Digest: layerDigest, Size: 10, DiffId: layerDigest},
 			},
 			ImageConfig:    imageConfig,
 			ImageSignature: sig,
@@ -215,6 +226,51 @@ func TestRunContainer_ImageSignatureVerification(t *testing.T) {
 		}
 		if mock.assembleImageCalls != 0 {
 			t.Errorf("assembleImageCalls = %d, want 0 (tampered signature must not be assembled)", mock.assembleImageCalls)
+		}
+	})
+}
+
+func TestPrepareImage_VerifiesBeforePreparation(t *testing.T) {
+	verifier, sign := containerImageMldsaKeypairForTest(t)
+	imageConfig := []byte(`{"rootfs":{"type":"layers","diff_ids":["sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]}}`)
+	sum := sha256.Sum256(imageConfig)
+	request := func(signature []byte) *agentpb.RunContainerLayersRequest {
+		return &agentpb.RunContainerLayersRequest{
+			ImageName:      "test-image:latest",
+			ImageConfig:    imageConfig,
+			ImageSignature: signature,
+			Layers: []*agentpb.RunContainerLayerHeader{{
+				Digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				DiffId: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				Size:   1,
+			}},
+		}
+	}
+
+	t.Run("valid signature permits persistent preparation", func(t *testing.T) {
+		mock := &imagePrepareMock{}
+		client, cleanup := startContainerServerWithVerifier(t, mock, verifier)
+		defer cleanup()
+
+		if _, err := client.PrepareImage(context.Background(), request(sign(sum[:]))); err != nil {
+			t.Fatalf("PrepareImage: %v", err)
+		}
+		if mock.prepareCalls != 1 {
+			t.Fatalf("prepareCalls = %d, want 1", mock.prepareCalls)
+		}
+	})
+
+	t.Run("invalid signature is rejected before preparation", func(t *testing.T) {
+		mock := &imagePrepareMock{}
+		client, cleanup := startContainerServerWithVerifier(t, mock, verifier)
+		defer cleanup()
+
+		_, err := client.PrepareImage(context.Background(), request(nil))
+		if status.Code(err) != codes.FailedPrecondition {
+			t.Fatalf("code = %v, want FailedPrecondition; err = %v", status.Code(err), err)
+		}
+		if mock.prepareCalls != 0 {
+			t.Fatalf("prepareCalls = %d, want 0", mock.prepareCalls)
 		}
 	})
 }

--- a/go/internal/agent/services/interfaces.go
+++ b/go/internal/agent/services/interfaces.go
@@ -98,6 +98,14 @@ type ContainerdClient interface {
 	GetContainerRestartPolicyLabel(ctx context.Context, appName string) (string, error)
 }
 
+// ImagePreparer is the optional fast-deploy capability that assembles
+// chunk-backed image layers and unpacks their snapshots before RunContainer.
+// It stays separate from ContainerdClient so older test doubles and alternate
+// runtimes can decline the optimization without affecting normal deploys.
+type ImagePreparer interface {
+	PrepareImage(ctx context.Context, imageName string, layers []*agentpb.RunContainerLayerHeader, imageConfig []byte) error
+}
+
 // ContainerExecer is the optional capability to run a process inside a running
 // container with an interactive PTY (docker `exec -it`). The ExecContainer RPC
 // type-asserts for it; a client that does not implement it yields Unimplemented.

--- a/go/internal/cli/assets/docs/apps/wendy-services.md
+++ b/go/internal/cli/assets/docs/apps/wendy-services.md
@@ -112,7 +112,7 @@ In attached mode, each service's readiness→postStart sequence fires asynchrono
 
 When `appCfg.Services` is non-empty, `wendy run` routes to the multi-service pipeline:
 
-1. **Parallel build** — all service images are built and pushed concurrently. By default, up to 4 simultaneous builds run; for large groups (8+ services), builds throttle to 2 concurrent to protect the device registry tunnel. Override with `--max-concurrency`. In interactive terminals a per-service spinner displays each service's status (`waiting` → `building…` → `built (Xs)` / `failed`). While a service builds, its row names the Dockerfile step currently running and, where that step's output exposes it, appends live progress after a `·` separator:
+1. **Parallel build** — all service images are built and pushed concurrently, with up to 4 simultaneous builds by default. Override with `--max-concurrency`. In interactive terminals a per-service spinner displays each service's status (`waiting` → `building…` → `built (Xs)` / `failed`). While a service builds, its row names the Dockerfile step currently running and, where that step's output exposes it, appends live progress after a `·` separator:
 
     ⠹ api         [4/9] RUN pip install -r requirements.txt · 61%  128.0MB/797.3MB  95.2MB/s
 
@@ -158,7 +158,7 @@ All standard `wendy run` flags apply. The following are particularly relevant fo
 | `--deploy` | Build and create all containers but do not start them. |
 | `--detach` | Start all containers but do not stream logs. |
 | `--keep-going` | Deploy services that build successfully instead of aborting the whole group on the first build/push failure. |
-| `--max-concurrency <n>` | Max service images to build+push at once. 0 = auto-throttle large groups (default). |
+| `--max-concurrency <n>` | Max service images to build+push at once. 0 = default limit of 4. |
 
 ## Example layout
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
@@ -156,7 +156,7 @@ On a **Windows host**, `wendy run` returns an actionable error for Swift project
 | `--product <name>` | Swift Package Manager product to build and run (Swift projects only). |
 | `--service <name>` | Build and run only the named service and its transitive dependencies (multi-service `wendy.json` projects only). Returns an error if the name does not match any key in the `services` map. |
 | `--keep-going` | Deploy services that build successfully instead of aborting the whole group on the first build/push failure (multi-service projects only). |
-| `--max-concurrency <n>` | Max service images to build+push at once in multi-service projects. 0 = auto-throttle large groups (default). |
+| `--max-concurrency <n>` | Max service images to build+push at once in multi-service projects. 0 = default limit of 4. |
 | `--user-args <args>` | Extra arguments to pass to the container at runtime. |
 | `--env <KEY=VALUE>` | Set an environment variable in the container. Repeatable. Overrides a `wendy.json` `env` entry of the same key. See [Environment variables](#environment-variables). |
 | `--chunking <mode>` | Controls the content-based chunking (CBC) chunk-diff deploy path: `auto` (default), `force`, or `off`. See [Deploy path: `--chunking`](#deploy-path---chunking). |

--- a/go/internal/cli/assets/docs/guides/meta.json
+++ b/go/internal/cli/assets/docs/guides/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Guides & Tutorials",
   "description": "Learn how to build with Wendy through practical examples",
-  "pages": ["tutorials", "multi-app-deployments", "llm-integration"]
+  "pages": ["tutorials", "stagefile", "multi-app-deployments", "llm-integration"]
 }

--- a/go/internal/cli/assets/docs/guides/stagefile.mdx
+++ b/go/internal/cli/assets/docs/guides/stagefile.mdx
@@ -1,0 +1,276 @@
+---
+title: Stagefile
+description: Describe an app's container build in YAML so Wendy can cache dependencies, skip unnecessary image builds, and upload only what changed
+---
+
+Most application edits change a few source files, not the operating system, language runtime, or dependencies beneath them. A traditional container build cannot always see that distinction clearly. It may resend a large build context, invalidate an expensive layer, start `buildx`, export the image again, and then discover that almost every byte already exists on the device.
+
+A **Stagefile** makes the distinction explicit. It is a declarative YAML build descriptor named `build.stagefile.yaml`. Wendy compiles it into a real, digest-pinned Dockerfile, builds a standard OCI image, and deploys that image with the normal `wendy run` workflow.
+
+The result is a faster edit-deploy loop without maintaining the easy-to-miss performance details of a hand-written Dockerfile.
+
+## Why use a Stagefile?
+
+### Send a smaller build context
+
+Every local input is declared in `copy.from: local` or by an install step such as `pip.requirements`. From those declarations, Wendy generates a Dockerfile-specific `.dockerignore` that denies everything else.
+
+If an app needs only `app.py` and `requirements.txt`, the builder does not receive `.git`, local virtual environments, model caches, test output, or an unrelated README. This reduces context-transfer work and prevents unrelated edits from invalidating a `COPY` layer. It is the allowlist version of Docker's recommendation to [keep the build context small](https://docs.docker.com/build/cache/optimize/#keep-the-context-small).
+
+### Keep expensive work cached
+
+The compiler puts stable work before frequently changed source and emits persistent, concurrency-safe BuildKit cache mounts for the tools it understands:
+
+- pip, uv, npm, yarn, and pnpm package downloads
+- Cargo package and Go build caches
+- SwiftPM dependency and incremental compilation caches
+- CMake build trees
+
+For example, a Stagefile copies `requirements.txt` and installs it before copying `app.py`. Editing the application does not reinstall Python packages. If the dependency layer must run again, pip can reuse its wheel cache instead of downloading every unchanged package. These are the same [layer-ordering and cache-mount techniques Docker recommends](https://docs.docker.com/build/cache/optimize/), generated consistently for each supported ecosystem.
+
+### Skip the image builder on source-only iterations
+
+On an eligible `wendy run`, the first normal build records the dependency state and adopts the final stage's local `copy` layers in Wendy's persistent OCI layout. On the next run, if only those app files changed, Wendy rebuilds the small copy layers directly and skips `buildx`.
+
+Wendy then compares the image layers with the device through the default chunk-diff deploy path. Unchanged dependency and runtime content stays on the device; only missing content chunks are uploaded. This is why the Stagefile structure improves both halves of the loop: less work to produce the image and less data to transfer afterward.
+
+<Callout type="info">
+  The builder-free fast path applies when the final stage has one or more local
+  `copy` entries, those entries come after any cross-stage copies, and the final
+  stage has no `build` step. If dependencies, build arguments, the target
+  platform, a build-stage source, or the Stagefile itself changes, Wendy safely
+  falls back to a normal image build. `wendy run` also falls back to a registry
+  push if its default chunk-diff deploy cannot be used.
+</Callout>
+
+### Make the optimized path the ordinary path
+
+A Stagefile also removes several sources of build drift:
+
+- Base-image tags resolve to immutable digests in a committed lockfile.
+- npm, yarn, pnpm, and uv use their frozen-lockfile install modes.
+- apt omits recommended packages by default and removes package indexes from the image layer; apk uses `--no-cache` by default.
+- Multi-stage builds copy only declared runtime artifacts into the final image.
+- Unknown or misspelled YAML fields fail validation instead of being ignored.
+- Entrypoints and commands use argv form, and the format has no raw-shell build step.
+- The final stage runs as the non-root UID `65532` unless `user` is set explicitly. CUDA stages default to root because Jetson GPU access requires it.
+
+You still get a conventional Dockerfile and OCI image, but the compiler owns the repetitive correctness and caching details.
+
+## Create your first Stagefile
+
+Suppose a Python app contains these files:
+
+```text
+my-app/
+  app.py
+  requirements.txt
+  wendy.json
+```
+
+Add `build.stagefile.yaml` at the project root:
+
+```yaml
+version: 1
+stages:
+  - name: app
+    from: python:3.12-slim
+    workdir: /app
+    env:
+      PYTHONUNBUFFERED: "1"
+    install:
+      pip:
+        - requirements: requirements.txt
+    copy:
+      - from: local
+        paths: [app.py]
+    healthcheck:
+      exec: [python, -c, "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 30s
+      timeout: 3s
+      startPeriod: 5s
+      retries: 3
+    cmd: [python, app.py]
+```
+
+The order in the YAML describes intent; the compiler produces the optimized sequence:
+
+1. Pin and start from the Python base image.
+2. Copy `requirements.txt` and install dependencies with a pip cache mount.
+3. Copy `app.py` as a separate, late layer.
+4. Add the health check, command, and default non-root user.
+5. Generate an allowlist build context containing only `requirements.txt` and `app.py`.
+
+Run it exactly like any other Wendy app:
+
+```bash
+wendy run
+```
+
+Wendy auto-detects `build.stagefile.yaml`; no build-type flag is required. Use watch mode for the tightest source-edit loop:
+
+```bash
+wendy run --watch
+```
+
+You can validate the image without deploying it:
+
+```bash
+wendy build
+```
+
+The first build writes three files beside the Stagefile:
+
+| File | What to do with it |
+| --- | --- |
+| `build.stagefile.lock.yaml` | Commit it. It records resolved base-image digests, remote-download checksums, and GPU profiles. |
+| `Dockerfile.generated` | Do not edit or commit it. It is regenerated build output. |
+| `Dockerfile.generated.dockerignore` | Do not edit or commit it. It is the derived build-context allowlist. |
+
+Add the generated namespace to `.gitignore`:
+
+```text
+Dockerfile.generated*
+```
+
+<Callout type="warning">
+  Stagefiles are a Wendy build input, not a Docker CLI format. Run `wendy build`
+  or `wendy run` to compile one. If another tool must build the result, generate
+  it first and point that tool at `Dockerfile.generated`.
+</Callout>
+
+## Understand the building blocks
+
+A Stagefile contains a version and an ordered list of stages. Each stage starts from one image and may install dependencies, download pinned content, copy files, or compile a project. The last stage becomes the runtime image.
+
+| Field | Purpose |
+| --- | --- |
+| `name`, `from` | Give the stage a unique name and base image. Base images are pinned by default. |
+| `workdir` | Set the absolute working directory for the stage and, on the final stage, the running container. |
+| `args`, `env` | Declare build arguments and image environment variables. |
+| `install` | Install apt, apk, CMake, pip, npm/yarn/pnpm, or uv dependencies using compiler-selected commands and caches. |
+| `download` | Fetch a URL with a SHA-256 supplied in the Stagefile or resolved into the lockfile. Archives can be extracted as `tar.gz` or `zip`. |
+| `copy` | Copy explicit paths from `local` or from an earlier named stage. Local paths also define the generated build-context allowlist. |
+| `build` | Build Rust, Go, Swift, npm, yarn, or pnpm projects. Release is the default for Rust and Swift; `wendy run --debug` overrides it. |
+| `cuda` | Resolve the CUDA runtime, Python wheel index, library path, and runtime packages from the target device's GPU architecture. |
+| `healthcheck` | Add an exec-form container health check on the final stage. |
+| `entrypoint`, `cmd`, `user` | Configure final-stage runtime behavior without shell-string command parsing. |
+
+### Install dependencies
+
+Use a requirements file or list packages directly. `pip` is a list so packages from different indexes can remain in separate install groups:
+
+```yaml
+install:
+  apt:
+    packages: [libgomp1]
+  pip:
+    - requirements: requirements.txt
+    - packages: ["numpy==2.3.2"]
+```
+
+For Node, commit the matching lockfile. The compiler copies the manifest and lockfile before source and selects the frozen install command:
+
+```yaml
+install:
+  npm:
+    manager: npm       # npm, yarn, or pnpm
+    production: true
+```
+
+For a uv project, the base image must already provide `uv`:
+
+```yaml
+install:
+  uv:
+    extras: [server]
+    dev: false
+```
+
+### Build in one stage, run in another
+
+Compiled apps should keep the toolchain out of the runtime image. This Swift example builds with the full toolchain, then copies only the product into a slim final stage:
+
+```yaml
+version: 1
+stages:
+  - name: build
+    from: swift:6.3.2-noble
+    workdir: /build
+    copy:
+      - from: local
+        paths: [Package.swift]
+      - from: local
+        paths: [Sources]
+    build:
+      lang: swift
+      product: MyApp
+
+  - name: app
+    from: swift:6.3.2-noble-slim
+    copy:
+      - from: build
+        paths: [/build/.build/release/MyApp]
+        dest: /MyApp
+    cmd: [/MyApp]
+```
+
+This still uses Stagefile's SwiftPM caches on incremental builds. Because source compilation happens in the build stage, source edits require the builder; the builder-free app-layer shortcut is intended for copy-only runtime code such as Python scripts, configuration, and static assets.
+
+### Target NVIDIA GPUs without hard-coding a board
+
+Set `cuda: true` on the stage and on the pip group that needs GPU wheels:
+
+```yaml
+version: 1
+stages:
+  - name: app
+    from: ubuntu:22.04
+    workdir: /app
+    cuda: true
+    install:
+      apt:
+        packages: [python3-pip, libgomp1]
+      pip:
+        - packages: ["torch==2.8.0"]
+          cuda: true
+    copy:
+      - from: local
+        paths: [inference.py]
+    cmd: [python3, inference.py]
+```
+
+When you run against a device, Wendy reads its GPU architecture and resolves the matching CUDA profile. The same source can target an Orin or Thor without embedding a JetPack-specific wheel index and runtime package list. The resolved profile is recorded per architecture in `build.stagefile.lock.yaml`.
+
+## Preserve the fast path
+
+Stagefile applies the optimizations automatically, but the shape you declare still matters:
+
+- List the specific files and directories the image needs. `paths: [.]` intentionally opts out of the generated allowlist and sends the project according to your own `.dockerignore`.
+- Keep dependency manifests in `install` and application files in later `copy` entries.
+- In the final stage, place cross-stage copies before local copies. This lets Wendy identify the final local layers safely.
+- Put compilation in an earlier build stage when practical, then copy its runtime artifacts into a smaller final stage.
+- Commit both the Stagefile and its lockfile. Do not hand-edit generated Dockerfiles.
+
+For several build variants, keep one Stagefile per variant:
+
+```text
+build.stagefile.yaml
+build.stagefile.lock.yaml
+gpu.stagefile.yaml
+gpu.stagefile.lock.yaml
+```
+
+The canonical `build.stagefile.yaml` is selected by default. Choose another variant explicitly in automation:
+
+```bash
+wendy run --dockerfile gpu.stagefile.yaml
+```
+
+Variant names may contain letters, digits, underscores, and hyphens, but not dots. See [`wendy build`](/docs/advanced/clients/wendy-cli/commands/build) for detection order, generated filenames, flags, and builder compatibility.
+
+## Next steps
+
+- Browse the [Wendy example Stagefiles](https://github.com/wendylabsinc/wendyos/tree/main/Examples) for Python, Swift, Rust, ROS 2, Compose, and GPU applications.
+- Use [multi-app deployments](/docs/guides/multi-app-deployments) with one Stagefile in each service directory.
+- Read the [`wendy run` reference](/docs/advanced/clients/wendy-cli/commands/run) for watch mode, chunk-diff deployment, and fallback behavior.

--- a/go/internal/cli/commands/builder_lifecycle_test.go
+++ b/go/internal/cli/commands/builder_lifecycle_test.go
@@ -1,0 +1,52 @@
+package commands
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// A registry proxy gets a new port on every CLI invocation. Changing that
+// endpoint must reconfigure and restart the existing builder, not replace it:
+// replacement deletes the warm BuildKit snapshots and makes large CUDA images
+// rehydrate their complete local-cache chain on every run.
+func TestPlaintextBuilderConfigChangePreservesBuilder(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake docker command is a POSIX shell script")
+	}
+
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "docker.log")
+	dockerPath := filepath.Join(binDir, "docker")
+	const fakeDocker = `#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_DOCKER_LOG"
+if [ "$1" = "exec" ] && [ "$3" = "cat" ]; then
+  printf 'stale buildkit config'
+fi
+`
+	if err := os.WriteFile(dockerPath, []byte(fakeDocker), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("FAKE_DOCKER_LOG", logPath)
+	t.Setenv("WENDY_BUILDX_BUILDER", "cache-preserve-test")
+
+	if _, err := ensurePlaintextBuilder(context.Background(), t.TempDir(), "127.0.0.1:61234", io.Discard); err != nil {
+		t.Fatalf("ensurePlaintextBuilder: %v", err)
+	}
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := string(data)
+	if strings.Contains(log, "buildx rm") || strings.Contains(log, "buildx create") {
+		t.Fatalf("config change replaced the builder instead of preserving its cache:\n%s", log)
+	}
+	if !strings.Contains(log, "restart buildx_buildkit_cache-preserve-test0") {
+		t.Fatalf("config change did not restart the existing builder:\n%s", log)
+	}
+}

--- a/go/internal/cli/commands/chunkpush.go
+++ b/go/internal/cli/commands/chunkpush.go
@@ -10,6 +10,8 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/go/internal/shared/chunk"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // maxConcurrentLayerPush bounds how many layers are decompressed, chunked, and
@@ -39,6 +41,21 @@ const maxConcurrentLayerPush = 4
 // by the QueryLayers pre-check) is skipped entirely: it is never decompressed,
 // chunked, or transferred.
 func pushLayersByChunks(ctx context.Context, cs agentpb.WendyContainerServiceClient, layers []localLayer) ([]*agentpb.RunContainerLayerHeader, error) {
+	return pushLayersByChunksWithPrepare(ctx, cs, layers, nil)
+}
+
+// imagePrepareFunc starts an authenticated device-side preparation using the
+// complete ordered layer manifests. It is invoked after manifest resolution
+// but before any missing chunk upload, and is expected to block until the
+// preparation is complete (or the context is cancelled).
+type imagePrepareFunc func(context.Context, []*agentpb.RunContainerLayerHeader) error
+
+// pushLayersByChunksWithPrepare resolves every layer manifest first, then runs
+// prepare concurrently with missing-chunk upload. The short resolution barrier
+// is necessary because the agent must authenticate the image config (which
+// binds the ordered diff IDs) and know each layer's chunk set before it can
+// safely create persistent snapshots.
+func pushLayersByChunksWithPrepare(ctx context.Context, cs agentpb.WendyContainerServiceClient, layers []localLayer, prepare imagePrepareFunc) ([]*agentpb.RunContainerLayerHeader, error) {
 	headers := make([]*agentpb.RunContainerLayerHeader, len(layers))
 
 	// Capability probe: a single empty QueryChunks tells us whether the agent
@@ -84,10 +101,6 @@ func pushLayersByChunks(ctx context.Context, cs agentpb.WendyContainerServiceCli
 		cliLogln("Reusing %s layer(s) already on device; chunking %s.",
 			tui.Value(fmt.Sprintf("%d", skipped)), tui.Value(fmt.Sprintf("%d", len(toPush))))
 	}
-	if len(toPush) == 0 {
-		return headers, nil
-	}
-
 	limit := maxConcurrentLayerPush
 	if n := runtime.GOMAXPROCS(0); n < limit {
 		limit = n
@@ -99,21 +112,73 @@ func pushLayersByChunks(ctx context.Context, cs agentpb.WendyContainerServiceCli
 		limit = 1
 	}
 
-	g, ctx := errgroup.WithContext(ctx)
-	g.SetLimit(limit)
+	resolved := make([]*resolvedChunkLayer, len(layers))
+	defer func() {
+		for _, r := range resolved {
+			if r != nil {
+				r.close()
+			}
+		}
+	}()
+	var resolveGroup errgroup.Group
+	resolveGroup.SetLimit(limit)
 	for _, idx := range toPush {
 		idx, l := idx, layers[idx]
-		g.Go(func() error {
-			h, err := pushLayerByChunks(ctx, cs, l)
+		resolveGroup.Go(func() error {
+			r, err := resolveChunkLayer(l)
 			if err != nil {
 				return err
 			}
-			headers[idx] = h // distinct index per goroutine — preserves layer order
+			resolved[idx] = r
+			headers[idx] = r.header // distinct index per goroutine — preserves layer order
 			return nil
 		})
 	}
-	if err := g.Wait(); err != nil {
+	if err := resolveGroup.Wait(); err != nil {
 		return nil, err
+	}
+
+	prepareCtx, cancelPrepare := context.WithCancel(ctx)
+	defer cancelPrepare()
+	var prepareDone chan error
+	if prepare != nil {
+		prepareDone = make(chan error, 1)
+		go func() {
+			prepareDone <- prepare(prepareCtx, headers)
+		}()
+	}
+
+	uploadGroup, uploadCtx := errgroup.WithContext(ctx)
+	uploadGroup.SetLimit(limit)
+	for _, idx := range toPush {
+		r := resolved[idx]
+		uploadGroup.Go(func() error {
+			return r.upload(uploadCtx, cs)
+		})
+	}
+	if err := uploadGroup.Wait(); err != nil {
+		cancelPrepare()
+		if prepareDone != nil {
+			<-prepareDone
+		}
+		return nil, err
+	}
+
+	if prepareDone != nil {
+		if err := <-prepareDone; err != nil {
+			switch status.Code(err) {
+			case codes.InvalidArgument, codes.FailedPrecondition, codes.DataLoss, codes.PermissionDenied, codes.Unauthenticated:
+				// Security failures must not silently fall through to the registry
+				// path, which has a different trust boundary.
+				return nil, err
+			case codes.Unimplemented:
+				// Older agents use the existing RunContainer assembly/unpack path.
+			default:
+				// Preparation is an optimization. RunContainer repeats all work
+				// idempotently and remains the authoritative error path.
+				cliLogln("Image prewarming unavailable (%v); finishing during start.", err)
+			}
+		}
 	}
 	return headers, nil
 }
@@ -153,7 +218,51 @@ func queryPresentLayers(ctx context.Context, cs agentpb.WendyContainerServiceCli
 // pushLayerByChunks runs the chunk-diff push for a single layer and returns its
 // reassembly header. The uncompressed tar is spilled to a temp file rather than
 // held in RAM; missing chunk bytes are read back from it on demand.
-func pushLayerByChunks(ctx context.Context, cs agentpb.WendyContainerServiceClient, l localLayer) (*agentpb.RunContainerLayerHeader, error) {
+type resolvedChunkLayer struct {
+	l      localLayer
+	header *agentpb.RunContainerLayerHeader
+	dl     *decompressedLayer
+	refs   []chunk.Ref
+}
+
+func (r *resolvedChunkLayer) close() {
+	if r.dl != nil {
+		r.dl.Close()
+		r.dl = nil
+	}
+}
+
+// ensureDecompressed materializes and chunks a cache-hit layer only when the
+// device reports missing chunk bytes. Cache misses already did this during
+// manifest resolution and retain the temporary file through upload.
+func (r *resolvedChunkLayer) ensureDecompressed() error {
+	if r.dl != nil {
+		return nil
+	}
+	d, err := decompressLayerToTemp(r.l)
+	if err != nil {
+		return err
+	}
+	refs, err := chunk.ChunkReaderAt(d.f, d.size)
+	if err != nil {
+		d.Close()
+		return err
+	}
+	// A cache entry is accepted only for the current chunk algorithm version,
+	// so deterministic re-chunking must reproduce its identity and shape.
+	if got := d.diffID; got != r.header.GetDiffId() {
+		d.Close()
+		return fmt.Errorf("cached layer diff ID changed: got %s, want %s", got, r.header.GetDiffId())
+	}
+	if len(refs) != len(r.header.GetChunkHashes()) {
+		d.Close()
+		return fmt.Errorf("cached layer chunk count changed: got %d, want %d", len(refs), len(r.header.GetChunkHashes()))
+	}
+	r.dl, r.refs = d, refs
+	return nil
+}
+
+func resolveChunkLayer(l localLayer) (*resolvedChunkLayer, error) {
 	var (
 		diffID        string
 		size          int64
@@ -161,11 +270,6 @@ func pushLayerByChunks(ctx context.Context, cs agentpb.WendyContainerServiceClie
 		dl            *decompressedLayer // file-backed tar; populated only when we must produce chunk bytes
 		refs          []chunk.Ref        // chunk offsets into dl; populated alongside dl
 	)
-	defer func() {
-		if dl != nil {
-			dl.Close()
-		}
-	}()
 
 	// decompressAndChunk spills the layer to a temp file and chunks it, filling
 	// dl/refs/diffID/size. Both entry points (CLI here and the agent) run the
@@ -178,6 +282,7 @@ func pushLayerByChunks(ctx context.Context, cs agentpb.WendyContainerServiceClie
 		dl = d
 		r, err := chunk.ChunkReaderAt(d.f, d.size)
 		if err != nil {
+			d.Close()
 			return err
 		}
 		refs, diffID, size = r, d.diffID, d.size
@@ -198,9 +303,25 @@ func pushLayerByChunks(ctx context.Context, cs agentpb.WendyContainerServiceClie
 		saveManifestCache(l.Digest, &cachedManifest{DiffID: diffID, Size: size, Hashes: orderedHashes})
 	}
 
+	return &resolvedChunkLayer{
+		l: l,
+		header: &agentpb.RunContainerLayerHeader{
+			Digest:      diffID,
+			DiffId:      diffID,
+			Size:        size,
+			Compression: agentpb.RunContainerLayerHeader_COMPRESSION_NONE,
+			ChunkHashes: orderedHashes,
+		},
+		dl:   dl,
+		refs: refs,
+	}, nil
+}
+
+func (r *resolvedChunkLayer) upload(ctx context.Context, cs agentpb.WendyContainerServiceClient) error {
+	orderedHashes := r.header.GetChunkHashes()
 	qresp, err := cs.QueryChunks(ctx, &agentpb.QueryChunksRequest{ChunkHashes: orderedHashes})
 	if err != nil {
-		return nil, err
+		return err
 	}
 	missing := make(map[[32]byte]bool, len(qresp.GetMissingHashes()))
 	for _, hb := range qresp.GetMissingHashes() {
@@ -215,41 +336,44 @@ func pushLayerByChunks(ctx context.Context, cs agentpb.WendyContainerServiceClie
 		// reproduces the exact hashes in `missing` only because chunking is
 		// deterministic and loadManifestCache rejects manifests from a different
 		// AlgoVersion — so the cached hashes always match what ChunkReaderAt emits.
-		if dl == nil {
-			if err := decompressAndChunk(); err != nil {
-				return nil, err
-			}
+		if err := r.ensureDecompressed(); err != nil {
+			return err
 		}
 		wc, err := cs.WriteChunks(ctx)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		for _, r := range refs {
-			if !missing[r.Hash] {
+		for _, ref := range r.refs {
+			if !missing[ref.Hash] {
 				continue
 			}
-			buf := make([]byte, r.Len) // r.Len <= chunk.MaxSize (256 KiB)
-			if _, err := dl.f.ReadAt(buf, int64(r.Offset)); err != nil {
-				return nil, err
+			buf := make([]byte, ref.Len) // ref.Len <= chunk.MaxSize (256 KiB)
+			if _, err := r.dl.f.ReadAt(buf, int64(ref.Offset)); err != nil {
+				return err
 			}
-			hb := r.Hash // copy
+			hb := ref.Hash // copy
 			if err := wc.Send(&agentpb.WriteChunksRequest{
 				Hash: hb[:],
 				Data: buf,
 			}); err != nil {
-				return nil, err
+				return err
 			}
 		}
 		if _, err := wc.CloseAndRecv(); err != nil {
-			return nil, err
+			return err
 		}
 	}
+	return nil
+}
 
-	return &agentpb.RunContainerLayerHeader{
-		Digest:      diffID,
-		DiffId:      diffID,
-		Size:        size,
-		Compression: agentpb.RunContainerLayerHeader_COMPRESSION_NONE,
-		ChunkHashes: orderedHashes,
-	}, nil
+func pushLayerByChunks(ctx context.Context, cs agentpb.WendyContainerServiceClient, l localLayer) (*agentpb.RunContainerLayerHeader, error) {
+	r, err := resolveChunkLayer(l)
+	if err != nil {
+		return nil, err
+	}
+	defer r.close()
+	if err := r.upload(ctx, cs); err != nil {
+		return nil, err
+	}
+	return r.header, nil
 }

--- a/go/internal/cli/commands/chunkpush_test.go
+++ b/go/internal/cli/commands/chunkpush_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/chunk"
@@ -21,7 +22,77 @@ type fakeContainerClient struct {
 	agentpb.WendyContainerServiceClient // embedded nil — satisfies interface
 	queryFn                             func(*agentpb.QueryChunksRequest) *agentpb.QueryChunksResponse
 	queryLayersFn                       func(*agentpb.QueryLayersRequest) *agentpb.QueryLayersResponse
+	writeFn                             func(*agentpb.WriteChunksRequest) error
 	chunksWritten                       int
+}
+
+// TestPushLayersByChunksPreparesDuringUpload proves the preparation RPC is
+// started after manifests are known but before WriteChunks finishes. This is
+// the wall-clock overlap the optimization exists to create.
+func TestPushLayersByChunksPreparesDuringUpload(t *testing.T) {
+	manifestCacheTestDir = t.TempDir()
+	t.Cleanup(func() { manifestCacheTestDir = "" })
+
+	layerTar := bytes.Repeat([]byte("prewarm-layer-"), 100_000)
+	prepareStarted := make(chan struct{})
+	allowPrepare := make(chan struct{})
+	var once sync.Once
+	fake := &fakeContainerClient{
+		queryFn: func(req *agentpb.QueryChunksRequest) *agentpb.QueryChunksResponse {
+			if len(req.GetChunkHashes()) == 0 {
+				return &agentpb.QueryChunksResponse{}
+			}
+			return &agentpb.QueryChunksResponse{MissingHashes: req.GetChunkHashes()[:1]}
+		},
+		writeFn: func(*agentpb.WriteChunksRequest) error {
+			<-prepareStarted
+			once.Do(func() { close(allowPrepare) })
+			return nil
+		},
+	}
+	prepare := func(_ context.Context, headers []*agentpb.RunContainerLayerHeader) error {
+		if len(headers) != 1 || len(headers[0].GetChunkHashes()) == 0 {
+			t.Fatalf("prepare received incomplete layer manifests: %#v", headers)
+		}
+		close(prepareStarted)
+		<-allowPrepare
+		return nil
+	}
+
+	headers, err := pushLayersByChunksWithPrepare(context.Background(), fake, []localLayer{{
+		Digest:    "sha256:" + sha256Hex(layerTar),
+		DiffID:    "sha256:" + sha256Hex(layerTar),
+		MediaType: "application/vnd.oci.image.layer.v1.tar",
+		Blob:      layerTar,
+	}}, prepare)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(headers) != 1 {
+		t.Fatalf("headers = %d, want 1", len(headers))
+	}
+}
+
+func TestPushLayersByChunksPrepareUnimplementedFallsBack(t *testing.T) {
+	manifestCacheTestDir = t.TempDir()
+	t.Cleanup(func() { manifestCacheTestDir = "" })
+
+	layerTar := []byte("already available layer")
+	fake := &fakeContainerClient{
+		queryFn: func(*agentpb.QueryChunksRequest) *agentpb.QueryChunksResponse {
+			return &agentpb.QueryChunksResponse{}
+		},
+	}
+	_, err := pushLayersByChunksWithPrepare(context.Background(), fake, []localLayer{{
+		Digest:    "sha256:" + sha256Hex(layerTar),
+		MediaType: "application/vnd.oci.image.layer.v1.tar",
+		Blob:      layerTar,
+	}}, func(context.Context, []*agentpb.RunContainerLayerHeader) error {
+		return status.Error(codes.Unimplemented, "old agent")
+	})
+	if err != nil {
+		t.Fatalf("Unimplemented preparation must fall back to RunContainer, got %v", err)
+	}
 }
 
 func (f *fakeContainerClient) QueryChunks(_ context.Context, in *agentpb.QueryChunksRequest, _ ...grpc.CallOption) (*agentpb.QueryChunksResponse, error) {
@@ -48,8 +119,11 @@ type fakeWriteChunksStream struct {
 	parent                                                                              *fakeContainerClient
 }
 
-func (s *fakeWriteChunksStream) Send(_ *agentpb.WriteChunksRequest) error {
+func (s *fakeWriteChunksStream) Send(req *agentpb.WriteChunksRequest) error {
 	s.parent.chunksWritten++
+	if s.parent.writeFn != nil {
+		return s.parent.writeFn(req)
+	}
 	return nil
 }
 

--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -125,7 +125,9 @@ func buildComposeServicesParallel(ctx context.Context, conn *grpcclient.AgentCon
 	var wg sync.WaitGroup
 	for _, name := range names {
 		job := jobs[name]
-		wg.Go(func() {
+		wg.Add(1)
+		go func(name string, job composeBuildJob) {
+			defer wg.Done()
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
@@ -161,7 +163,7 @@ func buildComposeServicesParallel(ctx context.Context, conn *grpcclient.AgentCon
 				cliLogln("Service %s built (%s).", name, dur.Round(time.Millisecond))
 			}
 			results <- result{name: name, err: err, log: logBuf.String()}
-		})
+		}(name, job)
 	}
 
 	go func() {

--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -11,7 +12,9 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/distribution/reference"
 	"google.golang.org/grpc/codes"
@@ -71,6 +74,121 @@ type composeService struct {
 	Profiles    yaml.Node `yaml:"profiles"`
 	Secrets     yaml.Node `yaml:"secrets"`
 	ExtraHosts  yaml.Node `yaml:"extra_hosts"`
+}
+
+// composeBuildJob is all per-service state needed after Compose parsing and
+// Stagefile compilation have completed. Keeping preparation out of the build
+// goroutines avoids duplicate writes when several services intentionally share
+// one context and build file.
+type composeBuildJob struct {
+	contextDir string
+	dockerfile string
+	repo       string
+	buildArgs  map[string]string
+}
+
+// buildComposeServiceImage is replaceable in tests so the parallel scheduler
+// can be exercised without Docker or a device registry.
+var buildComposeServiceImage = buildAndPushImageForAgent
+
+// buildComposeServicesParallel runs independent Compose build-and-push jobs
+// concurrently. A Wendy image push is part of the BuildKit invocation, so this
+// also means another service can start building while an earlier one uploads.
+func buildComposeServicesParallel(ctx context.Context, conn *grpcclient.AgentConnection, regPort int, agentOS, builder, platform string, jobs map[string]composeBuildJob, maxConcurrency int) (map[string]error, error) {
+	names := make([]string, 0, len(jobs))
+	for name := range jobs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	if len(names) == 0 {
+		return map[string]error{}, nil
+	}
+
+	concurrency := resolveBuildConcurrency(len(names), maxConcurrency)
+	if maxConcurrency > 0 && concurrency < len(names) {
+		cliLogln("Building up to %d service(s) at a time (--max-concurrency).", concurrency)
+	}
+
+	type result struct {
+		name string
+		err  error
+		log  string
+	}
+	results := make(chan result, len(names))
+	sem := make(chan struct{}, concurrency)
+
+	var prog *tea.Program
+	if isInteractiveTerminal() {
+		prog = tui.NewProgressProgram(tui.NewMultiSpinner(fmt.Sprintf("Building %d Compose service(s)...", len(names)), names))
+	}
+
+	var wg sync.WaitGroup
+	for _, name := range names {
+		job := jobs[name]
+		wg.Go(func() {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			if prog != nil {
+				prog.Send(tui.MultiSpinnerStartMsg{Name: name})
+			} else {
+				cliLogln("Building service %s for %s...", name, tui.Value(platform))
+			}
+
+			start := time.Now()
+			var logBuf bytes.Buffer
+			var buildOut io.Writer = os.Stdout
+			var logOut io.Writer = os.Stderr
+			var tally func() tui.BuildTally = func() tui.BuildTally { return tui.BuildTally{} }
+			if prog != nil {
+				emit, getTally := newServiceProgressEmitter(prog, name)
+				tally = getTally
+				buildOut = io.MultiWriter(tui.NewBuildParser(emit), &logBuf)
+				logOut = &logBuf
+			}
+
+			// The repo also scopes buildx's local cache export. Concurrent writers
+			// must not share that directory; BuildKit cache mounts inside the
+			// builder (APT, pip, etc.) remain shared by their explicit mount IDs.
+			err := buildComposeServiceImage(ctx, conn, regPort, agentOS, builder, job.contextDir, job.repo, platform, job.dockerfile, job.buildArgs, job.repo, buildOut, logOut)
+			dur := time.Since(start)
+			if prog != nil {
+				t := tally()
+				prog.Send(tui.MultiSpinnerDoneMsg{Name: name, Err: err, Dur: dur, Cached: t.Cached, Rebuilt: t.Rebuilt})
+			} else if err != nil {
+				cliLogln("Service %s build failed: %v", name, err)
+			} else {
+				cliLogln("Service %s built (%s).", name, dur.Round(time.Millisecond))
+			}
+			results <- result{name: name, err: err, log: logBuf.String()}
+		})
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+		if prog != nil {
+			prog.Send(tui.MultiSpinnerAllDoneMsg{})
+		}
+	}()
+
+	if prog != nil {
+		if _, err := prog.Run(); err != nil {
+			return nil, fmt.Errorf("compose build progress TUI: %w", err)
+		}
+	}
+
+	failed := map[string]error{}
+	for r := range results {
+		if r.err == nil {
+			continue
+		}
+		failed[r.name] = r.err
+		if r.log != "" && !isRegistryUnavailable(r.err) {
+			fmt.Fprintf(os.Stderr, "\n[%s] build log:\n%s", r.name, r.log)
+		}
+	}
+	return failed, nil
 }
 
 // unsupportedComposeWarnings returns field names from svc that Wendy does not
@@ -881,7 +999,10 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 	// so a cuda: stage in any of them compiles against its GPU architecture.
 	gpuArch := composeGPUArch(ctx, projectDir, cfg, conn)
 
-	// Build and push each service that has a build directive.
+	// Prepare each build before starting the parallel scheduler. In particular,
+	// compile Stagefiles to their generated Dockerfiles once, while errors can
+	// still be attributed directly to the declaring service.
+	jobs := make(map[string]composeBuildJob)
 	for name, svc := range cfg.Services {
 		ctxDir, dockerfile, buildArgs, err := composeBuildContext(svc, projectDir)
 		if err != nil {
@@ -908,15 +1029,20 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 			allBuildArgs[k] = v
 		}
 
-		repo := fmt.Sprintf("%s-%s", projectName, name)
-		// Compose builds run sequentially, so they share the local cache dir
-		// (empty cache key) — no concurrent cache-export race to isolate.
-		composeBuildTitle := fmt.Sprintf("Building service %s for %s...", name, tui.Value(platform))
-		if err := runBuildWithProgress(ctx, composeBuildTitle, dumpRawUnlessRegistryUnavailable, func(stream, logw io.Writer) error {
-			return buildAndPushImageForAgent(ctx, conn, regPort, agentOS, opts.builder, ctxDir, repo, platform, dockerfile, allBuildArgs, "", stream, logw)
-		}); err != nil {
-			return fmt.Errorf("building service %s: %w", name, err)
+		jobs[name] = composeBuildJob{
+			contextDir: ctxDir,
+			dockerfile: dockerfile,
+			repo:       fmt.Sprintf("%s-%s", projectName, name),
+			buildArgs:  allBuildArgs,
 		}
+	}
+
+	failedBuilds, err := buildComposeServicesParallel(ctx, conn, regPort, agentOS, opts.builder, platform, jobs, opts.maxConcurrency)
+	if err != nil {
+		return err
+	}
+	if len(failedBuilds) > 0 {
+		return joinServiceErrors(failedBuilds)
 	}
 
 	cliRestartPolicy := resolveRestartPolicy(opts)

--- a/go/internal/cli/commands/compose_test.go
+++ b/go/internal/cli/commands/compose_test.go
@@ -1,17 +1,79 @@
 package commands
 
 import (
+	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
+
+// A Compose build includes its registry upload in the same builder call. This
+// barrier therefore proves both that service image builds overlap and that a
+// later build need not wait for an earlier service to finish uploading.
+func TestBuildComposeServicesParallelOverlapsBuildAndPush(t *testing.T) {
+	origBuild := buildComposeServiceImage
+	origInteractive := isInteractiveTerminalFn
+	t.Cleanup(func() {
+		buildComposeServiceImage = origBuild
+		isInteractiveTerminalFn = origInteractive
+	})
+	isInteractiveTerminalFn = func() bool { return false }
+
+	const count = 4
+	jobs := make(map[string]composeBuildJob, count)
+	for i := range count {
+		name := string(rune('a' + i))
+		jobs[name] = composeBuildJob{contextDir: name, dockerfile: "Dockerfile", repo: "app-" + name}
+	}
+
+	var started sync.WaitGroup
+	started.Add(count)
+	var mu sync.Mutex
+	cacheKeys := map[string]string{}
+	buildComposeServiceImage = func(_ context.Context, _ *grpcclient.AgentConnection, _ int, _, _, _, repo, _, _ string, _ map[string]string, cacheKey string, _, _ io.Writer) error {
+		mu.Lock()
+		cacheKeys[repo] = cacheKey
+		mu.Unlock()
+		started.Done()
+		started.Wait()
+		return nil
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		failed, err := buildComposeServicesParallel(context.Background(), nil, 5000, "linux", "docker", "linux/arm64", jobs, count)
+		if err == nil && len(failed) != 0 {
+			err = joinServiceErrors(failed)
+		}
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("buildComposeServicesParallel: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Compose services did not enter build-and-push concurrently")
+	}
+
+	for _, job := range jobs {
+		if cacheKeys[job.repo] != job.repo {
+			t.Errorf("repo %q used cache key %q; concurrent exports need per-service isolation", job.repo, cacheKeys[job.repo])
+		}
+	}
+}
 
 func writeComposeFile(t *testing.T, dir, name, body string) {
 	t.Helper()

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -1488,21 +1488,23 @@ func buildkitRegistryConfig(registryAddr string, plainHTTP bool, keypair *[2]str
 	return sb.String()
 }
 
-// removeBuilder removes a buildx builder, falling back to deleting the
-// instance file directly when `docker buildx rm` fails (e.g. because the
-// stored config contains IPv6 brackets that the host TOML parser rejects).
-func removeBuilder(ctx context.Context, name string) {
-	rmCmd := exec.CommandContext(ctx, "docker", "buildx", "rm", name)
-	if rmCmd.Run() == nil {
-		return
+// ensureRegistryBuilderInstance creates builderName only when it does not
+// already exist. Registry configuration changes are deliberately not handled
+// here: callers update the existing container in place so its BuildKit state
+// volume survives dynamic proxy-port and certificate changes.
+func ensureRegistryBuilderInstance(ctx context.Context, builderName string) (created bool, err error) {
+	if exec.CommandContext(ctx, "docker", "buildx", "inspect", builderName).Run() == nil {
+		return false, nil
 	}
-	// Fallback: remove the instance file and kill the container directly.
-	home, err := os.UserHomeDir()
-	if err == nil {
-		os.Remove(filepath.Join(home, ".docker", "buildx", "instances", name))
-		os.Remove(filepath.Join(home, ".docker", "buildx", "activity", name))
+	cmd := exec.CommandContext(ctx, "docker", "buildx", "create",
+		"--name", builderName,
+		"--driver", "docker-container",
+		"--driver-opt", "network=host",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return false, fmt.Errorf("creating buildx builder %q: %s: %w", builderName, string(out), err)
 	}
-	exec.CommandContext(ctx, "docker", "rm", "-f", "buildx_buildkit_"+name+"0").Run()
+	return true, nil
 }
 
 // ensurePlaintextBuilder ensures the "wendy" buildx builder exists with plain
@@ -1522,27 +1524,18 @@ func ensurePlaintextBuilder(ctx context.Context, configDir, registryAddr string,
 	appliedConfig, _ := os.ReadFile(appliedPath)
 	configChanged := string(appliedConfig) != fullConfig
 
-	cmd := exec.CommandContext(ctx, "docker", "buildx", "inspect", builderName)
-	builderExists := cmd.Run() == nil
-
-	if builderExists && configChanged {
-		removeBuilder(ctx, builderName)
-		builderExists = false
+	created, err := ensureRegistryBuilderInstance(ctx, builderName)
+	if err != nil {
+		return "", err
 	}
-
-	if !builderExists {
-		cmd = exec.CommandContext(ctx, "docker", "buildx", "create",
-			"--name", builderName,
-			"--driver", "docker-container",
-			"--driver-opt", "network=host",
-		)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			return "", fmt.Errorf("creating buildx builder %q: %s: %w", builderName, string(out), err)
-		}
+	if created {
 		configChanged = true // always inject config into a newly created builder
 	}
 
-	// Inject the real config into the builder container and restart only when needed.
+	// Inject the real config into the existing builder container and restart only
+	// when needed. In particular, do not remove/recreate the builder when the
+	// per-run registry proxy port changes: its /var/lib/buildkit state is held in
+	// a Docker volume, and an in-place restart preserves warm image snapshots.
 	// Also re-inject if the container was destroyed (e.g. after colima restart) or
 	// was bootstrapped without config injection (default buildkitd.toml lacks http=true).
 	containerName := "buildx_buildkit_" + builderName + "0"
@@ -1627,7 +1620,7 @@ func ensureMTLSBuilder(ctx context.Context, configDir, registryAddr, containerCe
 	// public leaf certificate. The certificate is public material; no private
 	// key material or derivative is persisted (SOC2-C1, NIST-SC-28, ISO27001-A.8).
 	// When the cert changes (rotation, new device), the digest changes and the
-	// builder is torn down and rebuilt.
+	// builder is reconfigured and restarted in place.
 	certDigest := sha256.Sum256([]byte(leafCertPEM))
 	appliedState := fullConfig +
 		"\n---CERTHASH---\n" + hex.EncodeToString(certDigest[:])
@@ -1635,27 +1628,17 @@ func ensureMTLSBuilder(ctx context.Context, configDir, registryAddr, containerCe
 	appliedConfig, _ := os.ReadFile(appliedPath)
 	configChanged := string(appliedConfig) != appliedState
 
-	cmd := exec.CommandContext(ctx, "docker", "buildx", "inspect", builderName)
-	builderExists := cmd.Run() == nil
-
-	if builderExists && configChanged {
-		removeBuilder(ctx, builderName)
-		builderExists = false
+	created, err := ensureRegistryBuilderInstance(ctx, builderName)
+	if err != nil {
+		return "", err
 	}
-
-	if !builderExists {
-		cmd = exec.CommandContext(ctx, "docker", "buildx", "create",
-			"--name", builderName,
-			"--driver", "docker-container",
-			"--driver-opt", "network=host",
-		)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			return "", fmt.Errorf("creating buildx builder %q: %s: %w", builderName, string(out), err)
-		}
+	if created {
 		configChanged = true // always inject certs and config into a newly created builder
 	}
 
 	// Only copy certs and restart the builder when something actually changed.
+	// Reconfigure an existing builder in place so its /var/lib/buildkit volume —
+	// and therefore its warm image snapshots — survives per-run proxy-port changes.
 	// Restarting while another parallel build uses the same builder kills that build.
 	if configChanged {
 		if err := copyCertsToBuilder(ctx, builderName, hostCertDir, containerCertDir); err != nil {

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -25,28 +25,12 @@ import (
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
 
-const (
-	maxConcurrentBuilds = 4
+const maxConcurrentBuilds = 4
 
-	// Builds and pushes are fused in one buildx invocation, so build concurrency
-	// also bounds how many multi-GB images push through the single device-registry
-	// mTLS tunnel at once. Large groups (e.g. the 14-service go2 template, with a
-	// ~10 GB GPU image) collapse that tunnel under full fan-out, so groups at or
-	// above largeGroupThreshold are throttled to largeGroupConcurrency concurrent
-	// builds (WDY-1690). This is the heuristic default; users can override it with
-	// --max-concurrency (WDY-1693).
-	largeGroupThreshold   = 8
-	largeGroupConcurrency = 2
-)
-
-// multiBuildConcurrency returns the auto (heuristic) number of service images to
-// build+push at once for a group of numServices, throttling large groups to
-// protect the shared device registry tunnel (WDY-1690).
+// multiBuildConcurrency returns the default number of service images to
+// build+push at once for a group of numServices.
 func multiBuildConcurrency(numServices int) int {
 	n := maxConcurrentBuilds
-	if numServices >= largeGroupThreshold {
-		n = largeGroupConcurrency
-	}
 	if n > numServices {
 		n = numServices
 	}
@@ -58,7 +42,7 @@ func multiBuildConcurrency(numServices int) int {
 
 // resolveBuildConcurrency returns the effective build+push concurrency for
 // buildCount services. A positive override (--max-concurrency, WDY-1693) takes
-// precedence over the auto heuristic; either way the result is clamped to
+// precedence over the default; either way the result is clamped to
 // [1, buildCount].
 func resolveBuildConcurrency(buildCount, override int) int {
 	if buildCount < 1 {
@@ -142,9 +126,9 @@ var planResolveDockerfile = resolveDockerfile
 
 // maxConcurrentPlans bounds how many services are planned at once. Planning is
 // local work — a build-file resolve (a Stagefile compile, for a Stagefile
-// project) plus a full walk-and-hash of the build context — so unlike
-// maxConcurrentBuilds this is not throttled to protect the device registry
-// tunnel; it only keeps a very large group from opening every context at once.
+// project) plus a full walk-and-hash of the build context. Its higher limit
+// keeps planning fast without letting a very large group open every context at
+// once.
 const maxConcurrentPlans = 8
 
 // servicePlan is the per-service work that has to happen before we can decide
@@ -589,11 +573,8 @@ func buildServicesParallel(
 		}
 	}
 	concurrency := resolveBuildConcurrency(buildCount, maxConcurrency)
-	switch {
-	case maxConcurrency > 0 && concurrency < buildCount:
+	if maxConcurrency > 0 && concurrency < buildCount {
 		cliLogln("Building up to %d service(s) at a time (--max-concurrency).", concurrency)
-	case maxConcurrency <= 0 && concurrency < maxConcurrentBuilds && concurrency < buildCount:
-		cliLogln("Throttling to %d concurrent builds for %d services to protect the device registry tunnel (WDY-1690); override with --max-concurrency.", concurrency, buildCount)
 	}
 	sem := make(chan struct{}, concurrency)
 

--- a/go/internal/cli/commands/pushretry_test.go
+++ b/go/internal/cli/commands/pushretry_test.go
@@ -46,9 +46,9 @@ func TestMultiBuildConcurrency(t *testing.T) {
 		{1, 1},  // capped to numServices
 		{3, 3},  // small group, below default cap
 		{4, 4},  // at default cap
-		{7, 4},  // still default cap just under large threshold
-		{8, 2},  // large group -> throttled
-		{14, 2}, // the go2 template -> throttled
+		{7, 4},  // above default cap
+		{8, 4},  // large groups retain the default cap
+		{14, 4}, // the go2 template retains the default cap
 	}
 	for _, tt := range tests {
 		if got := multiBuildConcurrency(tt.numServices); got != tt.want {
@@ -63,15 +63,15 @@ func TestResolveBuildConcurrency(t *testing.T) {
 		override   int
 		want       int
 	}{
-		// override = 0 -> auto heuristic (multiBuildConcurrency)
+		// override = 0 -> default (multiBuildConcurrency)
 		{0, 0, 1},  // nothing to build -> floor 1
 		{4, 0, 4},  // small group, default cap
-		{14, 0, 2}, // large group -> auto-throttled
+		{14, 0, 4}, // large group, default cap
 		// override > 0 -> use it, clamped to [1, buildCount]
 		{14, 1, 1}, // explicit serialization
-		{14, 6, 6}, // explicit higher than auto
+		{14, 6, 6}, // explicit higher than default
 		{3, 10, 3}, // override capped to buildCount
-		{5, 0, 4},  // 5 services, below large threshold -> default cap 4
+		{5, 0, 4},  // above default cap
 	}
 	for _, tt := range tests {
 		if got := resolveBuildConcurrency(tt.buildCount, tt.override); got != tt.want {

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -489,8 +489,10 @@ type runOptions struct {
 	product              string
 	service              string
 	keepGoing            bool
-	maxConcurrency       int
-	userArgs             []string
+	// maxConcurrency bounds simultaneous service build-and-push jobs for both
+	// standalone multi-service manifests and Compose projects.
+	maxConcurrency int
+	userArgs       []string
 	// env are extra KEY=VALUE environment variables injected into the container
 	// at create time (CreateContainerRequest.Env). Set by --env, and by fleet
 	// deploys to wire cross-component discovery (e.g. WENDY_FLEET_PEERS) into a
@@ -582,7 +584,7 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.product, "product", "", "Swift Package Manager product to build and run")
 	cmd.Flags().StringVar(&opts.service, "service", "", "Build and run only the named service and its dependencies (multi-service projects)")
 	cmd.Flags().BoolVar(&opts.keepGoing, "keep-going", false, "Multi-service: deploy services that build successfully instead of aborting the whole group on the first build/push failure")
-	cmd.Flags().IntVar(&opts.maxConcurrency, "max-concurrency", 0, "Multi-service: max service images to build+push at once (0 = auto-throttle large groups)")
+	cmd.Flags().IntVar(&opts.maxConcurrency, "max-concurrency", 0, "Multi-service/Compose: max service images to build+push at once (0 = default limit of 4)")
 	cmd.Flags().StringSliceVar(&opts.userArgs, "user-args", nil, "Extra arguments to pass to the container")
 	cmd.Flags().StringArrayVar(&opts.env, "env", nil, "Set an environment variable in the container as KEY=VALUE; repeatable, and overrides wendy.json env of the same key")
 	cmd.Flags().StringVar(&opts.chunking, "chunking", chunkingAuto, "Content-defined chunking (CBC) deploy path: auto (try chunk-diff, fall back to registry push), force (chunk-diff only, no fallback), or off (registry push only)")
@@ -713,7 +715,7 @@ func runCommand(ctx context.Context, opts runOptions) error {
 		return err
 	}
 	if opts.maxConcurrency < 0 {
-		return fmt.Errorf("--max-concurrency must be >= 0 (0 = auto)")
+		return fmt.Errorf("--max-concurrency must be >= 0 (0 = default limit of 4)")
 	}
 	if err := validateChunkingMode(opts.chunking); err != nil {
 		return err
@@ -2456,13 +2458,6 @@ func deployByChunkDiff(ctx context.Context, conn *grpcclient.AgentConnection, cw
 	}
 	mark("read+decompress layers")
 
-	cliLogln("Diffing %s layer(s) against device...", tui.Value(fmt.Sprintf("%d", len(layers))))
-	headers, err := pushLayersByChunks(ctx, conn.ContainerService, layers)
-	if err != nil {
-		return nil, err
-	}
-	mark("chunk+query+write")
-
 	appConfigData, err := json.Marshal(appCfg)
 	if err != nil {
 		return nil, err
@@ -2472,6 +2467,22 @@ func deployByChunkDiff(ctx context.Context, conn *grpcclient.AgentConnection, cw
 		return nil, fmt.Errorf("reading image signature from %s: %w", imageSignaturePathEnv, err)
 	}
 	imageName := strings.ToLower(appCfg.AppID) + ":latest"
+	prepare := func(prepareCtx context.Context, headers []*agentpb.RunContainerLayerHeader) error {
+		_, prepareErr := conn.ContainerService.PrepareImage(prepareCtx, &agentpb.RunContainerLayersRequest{
+			ImageName:      imageName,
+			Layers:         headers,
+			ImageConfig:    imageConfig,
+			ImageSignature: imageSignature,
+		})
+		return prepareErr
+	}
+
+	cliLogln("Diffing %s layer(s) against device...", tui.Value(fmt.Sprintf("%d", len(layers))))
+	headers, err := pushLayersByChunksWithPrepare(ctx, conn.ContainerService, layers, prepare)
+	if err != nil {
+		return nil, err
+	}
+	mark("chunk+query+write+prepare")
 	// Carry the post-start agent-hook metadata so the agent runs the in-container
 	// hook on start, matching the registry path's StartContainer call.
 	runCtx := contextWithPostStartAgentHook(ctx, appCfg)

--- a/go/internal/stagefile/codegen/cachescope_test.go
+++ b/go/internal/stagefile/codegen/cachescope_test.go
@@ -39,6 +39,38 @@ func pipStage(platform string, groups ...spec.PipInstall) spec.Stage {
 		Install: &spec.Install{Pip: groups}}
 }
 
+func aptStage(from string, packages ...string) spec.Stage {
+	return spec.Stage{Name: "app", From: from,
+		Install: &spec.Install{Apt: &spec.AptInstall{Packages: packages}}}
+}
+
+// Explicit IDs, rather than target-path defaults, are what make the cache
+// visible to separately compiled Stagefiles and concurrent buildx clients.
+func TestAptCachesAreSharedAcrossCompatibleStagefiles(t *testing.T) {
+	a := mountIDs(t, gen(t, "linux/arm64", aptStage("debian:12", "curl")))
+	b := mountIDs(t, gen(t, "linux/arm64", aptStage("debian:12", "git")))
+	if len(a) != 2 || len(b) != 2 {
+		t.Fatalf("APT must mount lists and archives caches, got %v / %v", a, b)
+	}
+	if a[0] != b[0] || a[1] != b[1] {
+		t.Fatalf("compatible Stagefiles do not share APT caches: %v / %v", a, b)
+	}
+}
+
+// APT indexes and .debs are distribution- and architecture-specific. Keeping
+// those scopes apart prevents a cache hit from crossing incompatible roots.
+func TestAptCachesSeparateBaseImagesAndPlatforms(t *testing.T) {
+	base := mountIDs(t, gen(t, "linux/arm64", aptStage("debian:12", "curl")))
+	otherImage := mountIDs(t, gen(t, "linux/arm64", aptStage("ubuntu:24.04", "curl")))
+	otherPlatform := mountIDs(t, gen(t, "linux/amd64", aptStage("debian:12", "curl")))
+	if base[0] == otherImage[0] || base[1] == otherImage[1] {
+		t.Fatalf("different base images share APT caches: %v / %v", base, otherImage)
+	}
+	if base[0] == otherPlatform[0] || base[1] == otherPlatform[1] {
+		t.Fatalf("different platforms share APT caches: %v / %v", base, otherPlatform)
+	}
+}
+
 // Without an id BuildKit scopes a cache mount by its target path alone, so
 // every pip install in every concurrently-built service queues on one
 // sharing=locked mount — including installs that could not share a single

--- a/go/internal/stagefile/codegen/cachescope_test.go
+++ b/go/internal/stagefile/codegen/cachescope_test.go
@@ -71,6 +71,22 @@ func TestAptCachesSeparateBaseImagesAndPlatforms(t *testing.T) {
 	}
 }
 
+// pin: false intentionally avoids resolving the base image, so the compiler
+// cannot safely persist package state across builds: the same tag may refer to
+// a different distribution snapshot next time.
+func TestAptCachesDisabledForUnpinnedBase(t *testing.T) {
+	no := false
+	s := aptStage("debian:12", "curl")
+	s.Pin = &no
+	out := gen(t, "linux/arm64", s)
+	if strings.Contains(out, "type=cache") {
+		t.Fatalf("unpinned base uses persistent APT caches:\n%s", out)
+	}
+	if !strings.Contains(out, "rm -rf /var/lib/apt/lists/*") {
+		t.Fatalf("uncached APT install leaves package indexes in the image:\n%s", out)
+	}
+}
+
 // Without an id BuildKit scopes a cache mount by its target path alone, so
 // every pip install in every concurrently-built service queues on one
 // sharing=locked mount — including installs that could not share a single

--- a/go/internal/stagefile/codegen/codegen.go
+++ b/go/internal/stagefile/codegen/codegen.go
@@ -111,7 +111,11 @@ func Generate(f *spec.File, images, downloads map[string]string, platform string
 			install = &spec.Install{}
 		}
 		if install.Apt != nil {
-			lines = append(lines, aptInstallLines(install.Apt)...)
+			// Include the resolved base-image digest in the APT cache scope. Two
+			// Stagefiles using the same base can safely share indexes and .debs,
+			// while a moved tag (or a different distro) gets a fresh cache.
+			aptBase := s.From + "@" + images[s.From]
+			lines = append(lines, aptInstallLines(install.Apt, aptBase, stagePlatform)...)
 		}
 		if install.Apk != nil {
 			lines = append(lines, apkInstallLines(install.Apk)...)
@@ -373,14 +377,14 @@ func cmakeCacheID(repository, platform string) string {
 // by BuildKit itself (ADD --checksum, so the fetch never runs inside the
 // container and the key can't drift), and one sources.list.d entry per
 // repository.
-func aptRepositoryLines(repos []spec.AptRepository) []string {
+func aptRepositoryLines(repos []spec.AptRepository, base, platform string) []string {
 	if len(repos) == 0 {
 		return nil
 	}
-	lines := []string{
-		"RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \\",
-		"    && rm -rf /var/lib/apt/lists/*",
-	}
+	// The bootstrap can only use the base image's repositories; the declared
+	// repositories are added after ca-certificates and their pinned keys exist.
+	lines := []string{aptRun(base, platform, nil,
+		"apt-get update && apt-get install -y --no-install-recommends ca-certificates")}
 	for _, r := range repos {
 		ext := ".gpg"
 		if r.Key.Format == "armored" {
@@ -400,8 +404,39 @@ func aptRepositoryLines(repos []spec.AptRepository) []string {
 	return lines
 }
 
-func aptInstallLines(a *spec.AptInstall) []string {
-	lines := aptRepositoryLines(a.Repositories)
+// aptCacheScope returns a stable description of every input that controls the
+// contents of APT's indexes and package archive. Package names are deliberately
+// excluded: compatible Stagefiles should share downloads even when they install
+// different subsets. Repository order is preserved because it can affect APT
+// priority when otherwise-equivalent sources are declared more than once.
+func aptCacheScope(base, platform string, repos []spec.AptRepository) []string {
+	parts := []string{base, platform}
+	for _, r := range repos {
+		parts = append(parts, r.Name, r.URL, strings.Join(r.Suites, "\x1f"), strings.Join(r.Components, "\x1f"), r.Key.URL, r.Key.SHA256, r.Key.Format)
+	}
+	return parts
+}
+
+// aptRun gives APT two persistent BuildKit caches: package indexes (so update
+// can use conditional requests instead of downloading every index afresh) and
+// downloaded .debs. Explicit IDs make those caches reusable across separately
+// compiled Stagefiles. sharing=locked is required because APT itself takes
+// exclusive locks in both directories.
+func aptRun(base, platform string, repos []spec.AptRepository, command string) string {
+	scope := aptCacheScope(base, platform, repos)
+	mounts := []cacheMount{
+		{id: scopedCacheID("apt-lists", scope...), target: "/var/lib/apt/lists"},
+		{id: scopedCacheID("apt-archives", scope...), target: "/var/cache/apt"},
+	}
+	// Debian/Ubuntu container images normally install docker-clean, whose APT
+	// hooks delete every downloaded .deb after the command. Removing that hook
+	// is what lets the archive mount actually retain packages for sibling builds;
+	// the mount itself remains outside the resulting image layer.
+	return cacheRunMounts(mounts, "rm -f /etc/apt/apt.conf.d/docker-clean && "+command)
+}
+
+func aptInstallLines(a *spec.AptInstall, base, platform string) []string {
+	lines := aptRepositoryLines(a.Repositories, base, platform)
 	parts := []string{"apt-get", "update", "&&", "apt-get", "install", "-y"}
 	if !a.Recommends {
 		parts = append(parts, "--no-install-recommends")
@@ -409,10 +444,7 @@ func aptInstallLines(a *spec.AptInstall) []string {
 	for _, p := range a.Packages {
 		parts = append(parts, shellQuote(p))
 	}
-	return append(lines,
-		"RUN "+strings.Join(parts, " ")+" \\",
-		"    && rm -rf /var/lib/apt/lists/*",
-	)
+	return append(lines, aptRun(base, platform, a.Repositories, strings.Join(parts, " ")))
 }
 
 func apkInstallLines(a *spec.ApkInstall) []string {

--- a/go/internal/stagefile/codegen/codegen.go
+++ b/go/internal/stagefile/codegen/codegen.go
@@ -112,9 +112,14 @@ func Generate(f *spec.File, images, downloads map[string]string, platform string
 		}
 		if install.Apt != nil {
 			// Include the resolved base-image digest in the APT cache scope. Two
-			// Stagefiles using the same base can safely share indexes and .debs,
-			// while a moved tag (or a different distro) gets a fresh cache.
-			aptBase := s.From + "@" + images[s.From]
+			// Stagefiles using the same pinned base can safely share indexes and
+			// .debs, while a moved tag (or a different distro) gets a fresh cache.
+			// An unpinned stage has no immutable base identity, so leave aptBase
+			// empty to disable persistent APT caches for that stage.
+			aptBase := ""
+			if pinned {
+				aptBase = s.From + "@" + digest
+			}
 			lines = append(lines, aptInstallLines(install.Apt, aptBase, stagePlatform)...)
 		}
 		if install.Apk != nil {
@@ -423,6 +428,14 @@ func aptCacheScope(base, platform string, repos []spec.AptRepository) []string {
 // compiled Stagefiles. sharing=locked is required because APT itself takes
 // exclusive locks in both directories.
 func aptRun(base, platform string, repos []spec.AptRepository, command string) string {
+	// pin: false deliberately leaves the base image unresolved. Without an
+	// immutable base identity, a persistent cache could carry indexes or .debs
+	// across incompatible images after a tag moves. Keep the uncached layer
+	// small by removing its package indexes after each APT invocation.
+	if base == "" {
+		return "RUN " + command + " \\\n" +
+			"    && rm -rf /var/lib/apt/lists/*"
+	}
 	scope := aptCacheScope(base, platform, repos)
 	mounts := []cacheMount{
 		{id: scopedCacheID("apt-lists", scope...), target: "/var/lib/apt/lists"},

--- a/go/internal/stagefile/codegen/codegen_test.go
+++ b/go/internal/stagefile/codegen/codegen_test.go
@@ -95,8 +95,9 @@ func TestGenerateAptInstall(t *testing.T) {
 		t.Fatalf("Generate: %v", err)
 	}
 	want := "FROM debian:12@sha256:abc123 AS app\n" +
-		"RUN apt-get update && apt-get install -y --no-install-recommends 'curl' 'git' \\\n" +
-		"    && rm -rf /var/lib/apt/lists/*\n" +
+		"RUN --mount=type=cache,sharing=locked,id=stagefile-apt-lists-068acc661142d56e,target=/var/lib/apt/lists \\\n" +
+		"    --mount=type=cache,sharing=locked,id=stagefile-apt-archives-068acc661142d56e,target=/var/cache/apt \\\n" +
+		"    rm -f /etc/apt/apt.conf.d/docker-clean && apt-get update && apt-get install -y --no-install-recommends 'curl' 'git'\n" +
 		"USER 65532\n"
 	if out != want {
 		t.Fatalf("got:\n%q\nwant:\n%q", out, want)
@@ -116,8 +117,9 @@ func TestGenerateAptInstallWithRecommends(t *testing.T) {
 		t.Fatalf("Generate: %v", err)
 	}
 	want := "FROM debian:12@sha256:abc123 AS app\n" +
-		"RUN apt-get update && apt-get install -y 'curl' \\\n" +
-		"    && rm -rf /var/lib/apt/lists/*\n" +
+		"RUN --mount=type=cache,sharing=locked,id=stagefile-apt-lists-068acc661142d56e,target=/var/lib/apt/lists \\\n" +
+		"    --mount=type=cache,sharing=locked,id=stagefile-apt-archives-068acc661142d56e,target=/var/cache/apt \\\n" +
+		"    rm -f /etc/apt/apt.conf.d/docker-clean && apt-get update && apt-get install -y 'curl'\n" +
 		"USER 65532\n"
 	if out != want {
 		t.Fatalf("got:\n%q\nwant:\n%q", out, want)
@@ -473,8 +475,9 @@ func TestGenerateAptInstallQuotesPackageNames(t *testing.T) {
 		t.Fatalf("Generate: %v", err)
 	}
 	want := "FROM debian:12@sha256:abc123 AS app\n" +
-		"RUN apt-get update && apt-get install -y --no-install-recommends 'curl && echo pwned' \\\n" +
-		"    && rm -rf /var/lib/apt/lists/*\n" +
+		"RUN --mount=type=cache,sharing=locked,id=stagefile-apt-lists-068acc661142d56e,target=/var/lib/apt/lists \\\n" +
+		"    --mount=type=cache,sharing=locked,id=stagefile-apt-archives-068acc661142d56e,target=/var/cache/apt \\\n" +
+		"    rm -f /etc/apt/apt.conf.d/docker-clean && apt-get update && apt-get install -y --no-install-recommends 'curl && echo pwned'\n" +
 		"USER 65532\n"
 	if out != want {
 		t.Fatalf("got:\n%q\nwant:\n%q", out, want)

--- a/go/internal/stagefile/codegen/golden_test.go
+++ b/go/internal/stagefile/codegen/golden_test.go
@@ -29,8 +29,9 @@ func TestGenerateGoldenExampleFixture(t *testing.T) {
 		t.Fatalf("Generate: %v", err)
 	}
 	want := "FROM python:3.12-slim@sha256:abc123 AS deps\n" +
-		"RUN apt-get update && apt-get install -y --no-install-recommends 'build-essential' \\\n" +
-		"    && rm -rf /var/lib/apt/lists/*\n" +
+		"RUN --mount=type=cache,sharing=locked,id=stagefile-apt-lists-c27f20c14e43eb07,target=/var/lib/apt/lists \\\n" +
+		"    --mount=type=cache,sharing=locked,id=stagefile-apt-archives-c27f20c14e43eb07,target=/var/cache/apt \\\n" +
+		"    rm -f /etc/apt/apt.conf.d/docker-clean && apt-get update && apt-get install -y --no-install-recommends 'build-essential'\n" +
 		"COPY requirements.txt requirements.txt\n" +
 		"RUN --mount=type=cache,sharing=locked,id=stagefile-pip-96a296d224f285c6,target=/root/.cache/pip pip install -r 'requirements.txt'\n" +
 		"\n" +

--- a/go/proto/gen/agentpb/wendy_agent_v1_container_service.pb.go
+++ b/go/proto/gen/agentpb/wendy_agent_v1_container_service.pb.go
@@ -2868,6 +2868,42 @@ func (x *MCPChunk) GetData() []byte {
 	return nil
 }
 
+type PrepareImageResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PrepareImageResponse) Reset() {
+	*x = PrepareImageResponse{}
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[47]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PrepareImageResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PrepareImageResponse) ProtoMessage() {}
+
+func (x *PrepareImageResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[47]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PrepareImageResponse.ProtoReflect.Descriptor instead.
+func (*PrepareImageResponse) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescGZIP(), []int{47}
+}
+
 type ExecContainerRequest_ExecStart struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	AppName       string                 `protobuf:"bytes,1,opt,name=app_name,json=appName,proto3" json:"app_name,omitempty"`
@@ -2880,7 +2916,7 @@ type ExecContainerRequest_ExecStart struct {
 
 func (x *ExecContainerRequest_ExecStart) Reset() {
 	*x = ExecContainerRequest_ExecStart{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[47]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2892,7 +2928,7 @@ func (x *ExecContainerRequest_ExecStart) String() string {
 func (*ExecContainerRequest_ExecStart) ProtoMessage() {}
 
 func (x *ExecContainerRequest_ExecStart) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[47]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2944,7 +2980,7 @@ type RunContainerLayersResponse_Started struct {
 
 func (x *RunContainerLayersResponse_Started) Reset() {
 	*x = RunContainerLayersResponse_Started{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[48]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2956,7 +2992,7 @@ func (x *RunContainerLayersResponse_Started) String() string {
 func (*RunContainerLayersResponse_Started) ProtoMessage() {}
 
 func (x *RunContainerLayersResponse_Started) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[48]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2981,7 +3017,7 @@ type RunContainerLayersResponse_ConsoleOutput struct {
 
 func (x *RunContainerLayersResponse_ConsoleOutput) Reset() {
 	*x = RunContainerLayersResponse_ConsoleOutput{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[49]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2993,7 +3029,7 @@ func (x *RunContainerLayersResponse_ConsoleOutput) String() string {
 func (*RunContainerLayersResponse_ConsoleOutput) ProtoMessage() {}
 
 func (x *RunContainerLayersResponse_ConsoleOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[49]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3220,7 +3256,8 @@ const file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDes
 	"\x04port\x18\x02 \x01(\rR\x04port\x12\x18\n" +
 	"\aaddress\x18\x03 \x01(\tR\aaddress\"\x1e\n" +
 	"\bMCPChunk\x12\x12\n" +
-	"\x04data\x18\x01 \x01(\fR\x04data2\x89\x12\n" +
+	"\x04data\x18\x01 \x01(\fR\x04data\"\x16\n" +
+	"\x14PrepareImageResponse2\xfc\x12\n" +
 	"\x15WendyContainerService\x12`\n" +
 	"\n" +
 	"ListLayers\x12*.wendy.agent.services.v1.ListLayersRequest\x1a$.wendy.agent.services.v1.LayerHeader0\x01\x12i\n" +
@@ -3243,7 +3280,8 @@ const file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDes
 	"\tStreamMCP\x12!.wendy.agent.services.v1.MCPChunk\x1a!.wendy.agent.services.v1.MCPChunk(\x010\x01\x12h\n" +
 	"\vQueryChunks\x12+.wendy.agent.services.v1.QueryChunksRequest\x1a,.wendy.agent.services.v1.QueryChunksResponse\x12j\n" +
 	"\vWriteChunks\x12+.wendy.agent.services.v1.WriteChunksRequest\x1a,.wendy.agent.services.v1.WriteChunksResponse(\x01\x12h\n" +
-	"\vQueryLayers\x12+.wendy.agent.services.v1.QueryLayersRequest\x1a,.wendy.agent.services.v1.QueryLayersResponseb\x06proto3"
+	"\vQueryLayers\x12+.wendy.agent.services.v1.QueryLayersRequest\x1a,.wendy.agent.services.v1.QueryLayersResponse\x12q\n" +
+	"\fPrepareImage\x122.wendy.agent.services.v1.RunContainerLayersRequest\x1a-.wendy.agent.services.v1.PrepareImageResponseb\x06proto3"
 
 var (
 	file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDescOnce sync.Once
@@ -3258,7 +3296,7 @@ func file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDesc
 }
 
 var file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes = make([]protoimpl.MessageInfo, 50)
+var file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_msgTypes = make([]protoimpl.MessageInfo, 51)
 var file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_goTypes = []any{
 	(CreateContainerProgress_Phase)(0),               // 0: wendy.agent.services.v1.CreateContainerProgress.Phase
 	(RunContainerLayerHeader_CompressionType)(0),     // 1: wendy.agent.services.v1.RunContainerLayerHeader.CompressionType
@@ -3309,36 +3347,37 @@ var file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_goTypes 
 	(*GetContainerPortsResponse)(nil),                // 46: wendy.agent.services.v1.GetContainerPortsResponse
 	(*PortEntry)(nil),                                // 47: wendy.agent.services.v1.PortEntry
 	(*MCPChunk)(nil),                                 // 48: wendy.agent.services.v1.MCPChunk
-	(*ExecContainerRequest_ExecStart)(nil),           // 49: wendy.agent.services.v1.ExecContainerRequest.ExecStart
-	(*RunContainerLayersResponse_Started)(nil),       // 50: wendy.agent.services.v1.RunContainerLayersResponse.Started
-	(*RunContainerLayersResponse_ConsoleOutput)(nil), // 51: wendy.agent.services.v1.RunContainerLayersResponse.ConsoleOutput
-	(*AppContainer)(nil),                             // 52: AppContainer
-	(*RestartPolicy)(nil),                            // 53: RestartPolicy
-	(*BatteryStats)(nil),                             // 54: BatteryStats
+	(*PrepareImageResponse)(nil),                     // 49: wendy.agent.services.v1.PrepareImageResponse
+	(*ExecContainerRequest_ExecStart)(nil),           // 50: wendy.agent.services.v1.ExecContainerRequest.ExecStart
+	(*RunContainerLayersResponse_Started)(nil),       // 51: wendy.agent.services.v1.RunContainerLayersResponse.Started
+	(*RunContainerLayersResponse_ConsoleOutput)(nil), // 52: wendy.agent.services.v1.RunContainerLayersResponse.ConsoleOutput
+	(*AppContainer)(nil),                             // 53: AppContainer
+	(*RestartPolicy)(nil),                            // 54: RestartPolicy
+	(*BatteryStats)(nil),                             // 55: BatteryStats
 }
 var file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_depIdxs = []int32{
-	52, // 0: wendy.agent.services.v1.ListContainersResponse.container:type_name -> AppContainer
+	53, // 0: wendy.agent.services.v1.ListContainersResponse.container:type_name -> AppContainer
 	13, // 1: wendy.agent.services.v1.QueryLayersResponse.present:type_name -> wendy.agent.services.v1.PresentLayer
 	25, // 2: wendy.agent.services.v1.RunContainerLayersRequest.layers:type_name -> wendy.agent.services.v1.RunContainerLayerHeader
-	53, // 3: wendy.agent.services.v1.RunContainerLayersRequest.restart_policy:type_name -> RestartPolicy
-	53, // 4: wendy.agent.services.v1.CreateContainerRequest.restart_policy:type_name -> RestartPolicy
+	54, // 3: wendy.agent.services.v1.RunContainerLayersRequest.restart_policy:type_name -> RestartPolicy
+	54, // 4: wendy.agent.services.v1.CreateContainerRequest.restart_policy:type_name -> RestartPolicy
 	0,  // 5: wendy.agent.services.v1.CreateContainerProgress.phase:type_name -> wendy.agent.services.v1.CreateContainerProgress.Phase
 	18, // 6: wendy.agent.services.v1.CreateContainerProgressResponse.progress:type_name -> wendy.agent.services.v1.CreateContainerProgress
 	17, // 7: wendy.agent.services.v1.CreateContainerProgressResponse.completed:type_name -> wendy.agent.services.v1.CreateContainerResponse
-	53, // 8: wendy.agent.services.v1.StartContainerRequest.restart_policy:type_name -> RestartPolicy
-	49, // 9: wendy.agent.services.v1.ExecContainerRequest.start:type_name -> wendy.agent.services.v1.ExecContainerRequest.ExecStart
+	54, // 8: wendy.agent.services.v1.StartContainerRequest.restart_policy:type_name -> RestartPolicy
+	50, // 9: wendy.agent.services.v1.ExecContainerRequest.start:type_name -> wendy.agent.services.v1.ExecContainerRequest.ExecStart
 	22, // 10: wendy.agent.services.v1.ExecContainerRequest.resize:type_name -> wendy.agent.services.v1.WindowSize
 	1,  // 11: wendy.agent.services.v1.RunContainerLayerHeader.compression:type_name -> wendy.agent.services.v1.RunContainerLayerHeader.CompressionType
-	50, // 12: wendy.agent.services.v1.RunContainerLayersResponse.started:type_name -> wendy.agent.services.v1.RunContainerLayersResponse.Started
-	51, // 13: wendy.agent.services.v1.RunContainerLayersResponse.stdout_output:type_name -> wendy.agent.services.v1.RunContainerLayersResponse.ConsoleOutput
-	51, // 14: wendy.agent.services.v1.RunContainerLayersResponse.stderr_output:type_name -> wendy.agent.services.v1.RunContainerLayersResponse.ConsoleOutput
+	51, // 12: wendy.agent.services.v1.RunContainerLayersResponse.started:type_name -> wendy.agent.services.v1.RunContainerLayersResponse.Started
+	52, // 13: wendy.agent.services.v1.RunContainerLayersResponse.stdout_output:type_name -> wendy.agent.services.v1.RunContainerLayersResponse.ConsoleOutput
+	52, // 14: wendy.agent.services.v1.RunContainerLayersResponse.stderr_output:type_name -> wendy.agent.services.v1.RunContainerLayersResponse.ConsoleOutput
 	32, // 15: wendy.agent.services.v1.ListVolumesResponse.volumes:type_name -> wendy.agent.services.v1.VolumeInfo
 	36, // 16: wendy.agent.services.v1.ListContainerStatsResponse.stats:type_name -> wendy.agent.services.v1.ContainerStats
 	41, // 17: wendy.agent.services.v1.GetResourceStatsResponse.host:type_name -> wendy.agent.services.v1.HostStats
 	44, // 18: wendy.agent.services.v1.GetResourceStatsResponse.containers:type_name -> wendy.agent.services.v1.ResourceContainerStats
 	43, // 19: wendy.agent.services.v1.HostStats.gpus:type_name -> wendy.agent.services.v1.GpuStats
 	42, // 20: wendy.agent.services.v1.HostStats.thermal_zones:type_name -> wendy.agent.services.v1.ThermalZone
-	54, // 21: wendy.agent.services.v1.HostStats.battery:type_name -> BatteryStats
+	55, // 21: wendy.agent.services.v1.HostStats.battery:type_name -> BatteryStats
 	47, // 22: wendy.agent.services.v1.GetContainerPortsResponse.ports:type_name -> wendy.agent.services.v1.PortEntry
 	22, // 23: wendy.agent.services.v1.ExecContainerRequest.ExecStart.term_size:type_name -> wendy.agent.services.v1.WindowSize
 	4,  // 24: wendy.agent.services.v1.WendyContainerService.ListLayers:input_type -> wendy.agent.services.v1.ListLayersRequest
@@ -3361,28 +3400,30 @@ var file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_depIdxs 
 	7,  // 41: wendy.agent.services.v1.WendyContainerService.QueryChunks:input_type -> wendy.agent.services.v1.QueryChunksRequest
 	9,  // 42: wendy.agent.services.v1.WendyContainerService.WriteChunks:input_type -> wendy.agent.services.v1.WriteChunksRequest
 	11, // 43: wendy.agent.services.v1.WendyContainerService.QueryLayers:input_type -> wendy.agent.services.v1.QueryLayersRequest
-	14, // 44: wendy.agent.services.v1.WendyContainerService.ListLayers:output_type -> wendy.agent.services.v1.LayerHeader
-	6,  // 45: wendy.agent.services.v1.WendyContainerService.WriteLayer:output_type -> wendy.agent.services.v1.WriteLayerResponse
-	17, // 46: wendy.agent.services.v1.WendyContainerService.CreateContainer:output_type -> wendy.agent.services.v1.CreateContainerResponse
-	19, // 47: wendy.agent.services.v1.WendyContainerService.CreateContainerWithProgress:output_type -> wendy.agent.services.v1.CreateContainerProgressResponse
-	26, // 48: wendy.agent.services.v1.WendyContainerService.RunContainer:output_type -> wendy.agent.services.v1.RunContainerLayersResponse
-	26, // 49: wendy.agent.services.v1.WendyContainerService.StartContainer:output_type -> wendy.agent.services.v1.RunContainerLayersResponse
-	26, // 50: wendy.agent.services.v1.WendyContainerService.AttachContainer:output_type -> wendy.agent.services.v1.RunContainerLayersResponse
-	24, // 51: wendy.agent.services.v1.WendyContainerService.ExecContainer:output_type -> wendy.agent.services.v1.ExecContainerResponse
-	28, // 52: wendy.agent.services.v1.WendyContainerService.StopContainer:output_type -> wendy.agent.services.v1.StopContainerResponse
-	30, // 53: wendy.agent.services.v1.WendyContainerService.DeleteContainer:output_type -> wendy.agent.services.v1.DeleteContainerResponse
-	3,  // 54: wendy.agent.services.v1.WendyContainerService.ListContainers:output_type -> wendy.agent.services.v1.ListContainersResponse
-	33, // 55: wendy.agent.services.v1.WendyContainerService.ListVolumes:output_type -> wendy.agent.services.v1.ListVolumesResponse
-	35, // 56: wendy.agent.services.v1.WendyContainerService.RemoveVolume:output_type -> wendy.agent.services.v1.RemoveVolumeResponse
-	38, // 57: wendy.agent.services.v1.WendyContainerService.ListContainerStats:output_type -> wendy.agent.services.v1.ListContainerStatsResponse
-	40, // 58: wendy.agent.services.v1.WendyContainerService.GetResourceStats:output_type -> wendy.agent.services.v1.GetResourceStatsResponse
-	46, // 59: wendy.agent.services.v1.WendyContainerService.GetContainerPorts:output_type -> wendy.agent.services.v1.GetContainerPortsResponse
-	48, // 60: wendy.agent.services.v1.WendyContainerService.StreamMCP:output_type -> wendy.agent.services.v1.MCPChunk
-	8,  // 61: wendy.agent.services.v1.WendyContainerService.QueryChunks:output_type -> wendy.agent.services.v1.QueryChunksResponse
-	10, // 62: wendy.agent.services.v1.WendyContainerService.WriteChunks:output_type -> wendy.agent.services.v1.WriteChunksResponse
-	12, // 63: wendy.agent.services.v1.WendyContainerService.QueryLayers:output_type -> wendy.agent.services.v1.QueryLayersResponse
-	44, // [44:64] is the sub-list for method output_type
-	24, // [24:44] is the sub-list for method input_type
+	15, // 44: wendy.agent.services.v1.WendyContainerService.PrepareImage:input_type -> wendy.agent.services.v1.RunContainerLayersRequest
+	14, // 45: wendy.agent.services.v1.WendyContainerService.ListLayers:output_type -> wendy.agent.services.v1.LayerHeader
+	6,  // 46: wendy.agent.services.v1.WendyContainerService.WriteLayer:output_type -> wendy.agent.services.v1.WriteLayerResponse
+	17, // 47: wendy.agent.services.v1.WendyContainerService.CreateContainer:output_type -> wendy.agent.services.v1.CreateContainerResponse
+	19, // 48: wendy.agent.services.v1.WendyContainerService.CreateContainerWithProgress:output_type -> wendy.agent.services.v1.CreateContainerProgressResponse
+	26, // 49: wendy.agent.services.v1.WendyContainerService.RunContainer:output_type -> wendy.agent.services.v1.RunContainerLayersResponse
+	26, // 50: wendy.agent.services.v1.WendyContainerService.StartContainer:output_type -> wendy.agent.services.v1.RunContainerLayersResponse
+	26, // 51: wendy.agent.services.v1.WendyContainerService.AttachContainer:output_type -> wendy.agent.services.v1.RunContainerLayersResponse
+	24, // 52: wendy.agent.services.v1.WendyContainerService.ExecContainer:output_type -> wendy.agent.services.v1.ExecContainerResponse
+	28, // 53: wendy.agent.services.v1.WendyContainerService.StopContainer:output_type -> wendy.agent.services.v1.StopContainerResponse
+	30, // 54: wendy.agent.services.v1.WendyContainerService.DeleteContainer:output_type -> wendy.agent.services.v1.DeleteContainerResponse
+	3,  // 55: wendy.agent.services.v1.WendyContainerService.ListContainers:output_type -> wendy.agent.services.v1.ListContainersResponse
+	33, // 56: wendy.agent.services.v1.WendyContainerService.ListVolumes:output_type -> wendy.agent.services.v1.ListVolumesResponse
+	35, // 57: wendy.agent.services.v1.WendyContainerService.RemoveVolume:output_type -> wendy.agent.services.v1.RemoveVolumeResponse
+	38, // 58: wendy.agent.services.v1.WendyContainerService.ListContainerStats:output_type -> wendy.agent.services.v1.ListContainerStatsResponse
+	40, // 59: wendy.agent.services.v1.WendyContainerService.GetResourceStats:output_type -> wendy.agent.services.v1.GetResourceStatsResponse
+	46, // 60: wendy.agent.services.v1.WendyContainerService.GetContainerPorts:output_type -> wendy.agent.services.v1.GetContainerPortsResponse
+	48, // 61: wendy.agent.services.v1.WendyContainerService.StreamMCP:output_type -> wendy.agent.services.v1.MCPChunk
+	8,  // 62: wendy.agent.services.v1.WendyContainerService.QueryChunks:output_type -> wendy.agent.services.v1.QueryChunksResponse
+	10, // 63: wendy.agent.services.v1.WendyContainerService.WriteChunks:output_type -> wendy.agent.services.v1.WriteChunksResponse
+	12, // 64: wendy.agent.services.v1.WendyContainerService.QueryLayers:output_type -> wendy.agent.services.v1.QueryLayersResponse
+	49, // 65: wendy.agent.services.v1.WendyContainerService.PrepareImage:output_type -> wendy.agent.services.v1.PrepareImageResponse
+	45, // [45:66] is the sub-list for method output_type
+	24, // [24:45] is the sub-list for method input_type
 	24, // [24:24] is the sub-list for extension type_name
 	24, // [24:24] is the sub-list for extension extendee
 	0,  // [0:24] is the sub-list for field type_name
@@ -3428,7 +3469,7 @@ func file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_init() 
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDesc), len(file_wendy_agent_services_v1_wendy_agent_v1_container_service_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   50,
+			NumMessages:   51,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/go/proto/gen/agentpb/wendy_agent_v1_container_service_grpc.pb.go
+++ b/go/proto/gen/agentpb/wendy_agent_v1_container_service_grpc.pb.go
@@ -39,6 +39,7 @@ const (
 	WendyContainerService_QueryChunks_FullMethodName                 = "/wendy.agent.services.v1.WendyContainerService/QueryChunks"
 	WendyContainerService_WriteChunks_FullMethodName                 = "/wendy.agent.services.v1.WendyContainerService/WriteChunks"
 	WendyContainerService_QueryLayers_FullMethodName                 = "/wendy.agent.services.v1.WendyContainerService/QueryLayers"
+	WendyContainerService_PrepareImage_FullMethodName                = "/wendy.agent.services.v1.WendyContainerService/PrepareImage"
 )
 
 // WendyContainerServiceClient is the client API for WendyContainerService service.
@@ -73,6 +74,12 @@ type WendyContainerServiceClient interface {
 	// skip decompressing and content-chunking layers the device can reuse as-is
 	// — for those layers no dedup is possible, so chunking would be pure waste.
 	QueryLayers(ctx context.Context, in *QueryLayersRequest, opts ...grpc.CallOption) (*QueryLayersResponse, error)
+	// PrepareImage assembles chunk-backed layers and unpacks their snapshots
+	// before RunContainer. The CLI starts this RPC before uploading missing
+	// chunks, allowing device-side assembly/unpack to overlap the transfer.
+	// RunContainer remains the source of truth and repeats these idempotent
+	// operations, so callers can fall back safely when this RPC is unavailable.
+	PrepareImage(ctx context.Context, in *RunContainerLayersRequest, opts ...grpc.CallOption) (*PrepareImageResponse, error)
 }
 
 type wendyContainerServiceClient struct {
@@ -343,6 +350,16 @@ func (c *wendyContainerServiceClient) QueryLayers(ctx context.Context, in *Query
 	return out, nil
 }
 
+func (c *wendyContainerServiceClient) PrepareImage(ctx context.Context, in *RunContainerLayersRequest, opts ...grpc.CallOption) (*PrepareImageResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(PrepareImageResponse)
+	err := c.cc.Invoke(ctx, WendyContainerService_PrepareImage_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // WendyContainerServiceServer is the server API for WendyContainerService service.
 // All implementations must embed UnimplementedWendyContainerServiceServer
 // for forward compatibility.
@@ -375,6 +392,12 @@ type WendyContainerServiceServer interface {
 	// skip decompressing and content-chunking layers the device can reuse as-is
 	// — for those layers no dedup is possible, so chunking would be pure waste.
 	QueryLayers(context.Context, *QueryLayersRequest) (*QueryLayersResponse, error)
+	// PrepareImage assembles chunk-backed layers and unpacks their snapshots
+	// before RunContainer. The CLI starts this RPC before uploading missing
+	// chunks, allowing device-side assembly/unpack to overlap the transfer.
+	// RunContainer remains the source of truth and repeats these idempotent
+	// operations, so callers can fall back safely when this RPC is unavailable.
+	PrepareImage(context.Context, *RunContainerLayersRequest) (*PrepareImageResponse, error)
 	mustEmbedUnimplementedWendyContainerServiceServer()
 }
 
@@ -444,6 +467,9 @@ func (UnimplementedWendyContainerServiceServer) WriteChunks(grpc.ClientStreaming
 }
 func (UnimplementedWendyContainerServiceServer) QueryLayers(context.Context, *QueryLayersRequest) (*QueryLayersResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method QueryLayers not implemented")
+}
+func (UnimplementedWendyContainerServiceServer) PrepareImage(context.Context, *RunContainerLayersRequest) (*PrepareImageResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method PrepareImage not implemented")
 }
 func (UnimplementedWendyContainerServiceServer) mustEmbedUnimplementedWendyContainerServiceServer() {}
 func (UnimplementedWendyContainerServiceServer) testEmbeddedByValue()                               {}
@@ -736,6 +762,24 @@ func _WendyContainerService_QueryLayers_Handler(srv interface{}, ctx context.Con
 	return interceptor(ctx, in, info, handler)
 }
 
+func _WendyContainerService_PrepareImage_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RunContainerLayersRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WendyContainerServiceServer).PrepareImage(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: WendyContainerService_PrepareImage_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WendyContainerServiceServer).PrepareImage(ctx, req.(*RunContainerLayersRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // WendyContainerService_ServiceDesc is the grpc.ServiceDesc for WendyContainerService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -782,6 +826,10 @@ var WendyContainerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "QueryLayers",
 			Handler:    _WendyContainerService_QueryLayers_Handler,
+		},
+		{
+			MethodName: "PrepareImage",
+			Handler:    _WendyContainerService_PrepareImage_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{


### PR DESCRIPTION
## What changed

- add stable, scoped BuildKit caches for Stagefile APT installs and preserve the builder across deploys
- build independent Compose services concurrently with bounded concurrency and per-service progress/results
- add a `PrepareImage` agent RPC so layer assembly and snapshot unpacking can overlap missing-chunk upload, while keeping `RunContainer` as the idempotent fallback
- document the Stagefile workflow and add coverage for cache scoping, builder lifecycle, parallel builds, chunk upload, image preparation, and signature validation

## Why

Stagefile and multi-service deploys repeated avoidable package downloads and builder setup, serialized otherwise-independent builds, and waited for every missing image chunk to arrive before device-side image preparation began.

## Impact

Repeated Stagefile builds should reuse more work, Compose projects can build services in parallel, and chunk-based deployments can overlap transfer with device-side assembly and unpacking. Older agents remain supported through the existing `RunContainer` path.

## Validation

- `gofmt -l` on all changed Go files
- `git diff --check`
- `go test ./internal/agent/containerd ./internal/agent/services ./internal/cli/commands ./internal/stagefile/codegen`