### PR TITLE
Preserve unchanged services in watch mode

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
@@ -181,6 +181,17 @@ single redeploy runs after edits settle. Build output is hidden unless a build
 fails; pass `--verbose` to always show it, or `--debounce <ms>` to tune the quiet
 period.
 
+For multi-service `wendy.json` and Compose projects deployed to WendyOS, watch
+mode fingerprints each service's build inputs and effective runtime configuration
+independently. After the initial deploy, services that are unchanged and still
+running are left untouched: they are not rebuilt, recreated, or restarted.
+Changed services are redeployed in dependency order. A missing, stopped, or
+otherwise non-running service is not preserved and goes through the normal
+deploy path.
+When the primary of a `shared-network` or `shared-ipc` group changes, the group
+is restarted together because its other containers share that primary's Linux
+namespaces.
+
 > **Note:** `wendy watch` is kept as a hidden alias for `wendy run --watch` for
 > backward compatibility, but `wendy run --watch` is the supported entry point.
 

--- a/go/internal/cli/commands/commands_test.go
+++ b/go/internal/cli/commands/commands_test.go
@@ -103,12 +103,18 @@ func TestWithWatchInvariants(t *testing.T) {
 	if !got.yes {
 		t.Error("yes should be forced true in watch mode")
 	}
+	if got.watchState == nil {
+		t.Error("watch mode should initialize per-session deploy state")
+	}
 
 	// Other options must be preserved.
 	in := runOptions{product: "demo", prefix: "apps/demo", chunking: chunkingForce}
 	out := withWatchInvariants(in)
 	if out.product != "demo" || out.prefix != "apps/demo" || out.chunking != chunkingForce {
 		t.Errorf("watch invariants clobbered unrelated options: %+v", out)
+	}
+	if again := withWatchInvariants(out); again.watchState != out.watchState {
+		t.Error("watch invariants replaced existing session state")
 	}
 }
 

--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -43,6 +43,17 @@ func normalizeImageRef(ref string) string {
 	return reference.TagNameOnly(named).String()
 }
 
+func composeServiceWatchHash(imageIdentity string, cfg *appconfig.AppConfig, cmd string, userArgs []string, restartPolicy *agentpb.RestartPolicy, env []string) (string, error) {
+	return watchDesiredHash(struct {
+		ImageIdentity string
+		Config        *appconfig.AppConfig
+		Cmd           string
+		UserArgs      []string
+		RestartPolicy *agentpb.RestartPolicy
+		Env           []string
+	}{imageIdentity, cfg, cmd, userArgs, restartPolicy, env})
+}
+
 // composeConfig is a minimal representation of a docker-compose file.
 type composeConfig struct {
 	Services map[string]composeService `yaml:"services"`
@@ -1000,6 +1011,14 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 	// Resolved once for the project: every service lands on this one device,
 	// so a cuda: stage in any of them compiles against its GPU architecture.
 	gpuArch := composeGPUArch(ctx, projectDir, cfg, conn)
+	deviceKey := deviceFingerprintKey(versionResp)
+	states := map[string]agentpb.AppRunningState{}
+	if opts.watchState != nil {
+		states = deviceContainerStates(ctx, conn)
+	}
+	preserve := map[string]bool{}
+	desiredHashes := map[string]string{}
+	candidates := map[string]watchServiceCandidate{}
 
 	// Prepare each build before starting the parallel scheduler. In particular,
 	// compile Stagefiles to their generated Dockerfiles once, while errors can
@@ -1008,15 +1027,6 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 	for name, svc := range cfg.Services {
 		ctxDir, dockerfile, buildArgs, err := composeBuildContext(svc, projectDir)
 		if err != nil {
-			return fmt.Errorf("service %s: %w", name, err)
-		}
-		if ctxDir == "" {
-			continue // uses pre-built image
-		}
-		// Compile a Stagefile (or apply safe in-memory Dockerfile fixes) the
-		// same way the single-service path does — docker build itself knows
-		// nothing about build.stagefile.yaml.
-		if dockerfile, err = prepareDockerBuildFile(ctxDir, dockerfile, gpuArch, debugStagefileOptions(opts.debug)...); err != nil {
 			return fmt.Errorf("service %s: %w", name, err)
 		}
 
@@ -1031,12 +1041,51 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 			allBuildArgs[k] = v
 		}
 
+		imageIdentity := normalizeImageRef(svc.Image)
+		if ctxDir != "" {
+			// Compile a Stagefile (or apply safe in-memory Dockerfile fixes) the
+			// same way the single-service path does — docker build itself knows
+			// nothing about build.stagefile.yaml.
+			if dockerfile, err = prepareDockerBuildFile(ctxDir, dockerfile, gpuArch, debugStagefileOptions(opts.debug)...); err != nil {
+				return fmt.Errorf("service %s: %w", name, err)
+			}
+			imageIdentity, err = computeBuildInputHash(ctxDir, dockerfile, platform, allBuildArgs, composeEnv(svc))
+			if err != nil {
+				return fmt.Errorf("hashing service %s build inputs: %w", name, err)
+			}
+		}
+
+		appCfg := svcCfgs[name]
+		restartPolicy := resolveRestartPolicy(opts)
+		if restartPolicy.GetMode() == agentpb.RestartPolicyMode_DEFAULT && svc.Restart != "" {
+			restartPolicy = composeRestartPolicy(svc.Restart)
+		}
+		cmd, extraArgs := composeArgv(svc)
+		desiredHash, hashErr := composeServiceWatchHash(imageIdentity, appCfg, cmd, extraArgs, restartPolicy, composeEnv(svc))
+		if hashErr == nil {
+			desiredHashes[name] = desiredHash
+			candidates[name] = watchServiceCandidate{appID: appCfg.AppID, containerName: appCfg.ContainerName(), desiredHash: desiredHash}
+		}
+		if opts.watchState != nil {
+			preserve = selectPreservedWatchServices(opts.watchState, deviceKey, candidates, states)
+			if preserve[name] {
+				continue
+			}
+		}
+
+		if ctxDir == "" {
+			continue // uses pre-built image
+		}
+
 		jobs[name] = composeBuildJob{
 			contextDir: ctxDir,
 			dockerfile: dockerfile,
 			repo:       fmt.Sprintf("%s-%s", projectName, name),
 			buildArgs:  allBuildArgs,
 		}
+	}
+	if n := len(preserve); n > 0 {
+		cliLogln("%d of %d Compose services unchanged and running; leaving them untouched.", n, len(cfg.Services))
 	}
 
 	failedBuilds, err := buildComposeServicesParallel(ctx, conn, regPort, agentOS, opts.builder, platform, jobs, opts.maxConcurrency)
@@ -1053,6 +1102,23 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 	ordered, err := serviceOrder(cfg)
 	if err != nil {
 		return err
+	}
+	if len(ordered) > 0 {
+		adjustedPreserve := adjustSharedNamespacePreserve(ordered, preserve, svcCfgs[ordered[0]].Isolation)
+		if len(adjustedPreserve) < len(preserve) {
+			cliLogln("Shared-namespace primary changed; restarting the affected Compose service group.")
+		}
+		preserve = adjustedPreserve
+	}
+	if len(preserve) > 0 {
+		ordered = filterPreservedServices(ordered, preserve)
+		if len(ordered) == 0 {
+			cliLogln("All Compose services are unchanged and running; nothing to redeploy.")
+			return nil
+		}
+		// A partial watch cycle does not own the preserved services, so it must
+		// not re-run the app-level lifecycle fallback for the whole group.
+		appLevelCfg = nil
 	}
 
 	for _, name := range ordered {
@@ -1151,7 +1217,18 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 	}()
 
 	if opts.detach {
-		return composeStartDetached(ctx, runCtx, conn, ordered, svcCfgs, svcLifecycleCfgs, appLevelCfg, projectName)
+		if err := composeStartDetached(ctx, runCtx, conn, ordered, svcCfgs, svcLifecycleCfgs, appLevelCfg, projectName); err != nil {
+			return err
+		}
+		if ctx.Err() == nil {
+			for _, name := range ordered {
+				if h := desiredHashes[name]; h != "" {
+					appCfg := svcCfgs[name]
+					opts.watchState.record(watchServiceKey(deviceKey, appCfg.AppID, name), h)
+				}
+			}
+		}
+		return nil
 	}
 
 	// Attached mode: stream output from all containers concurrently with

--- a/go/internal/cli/commands/compose_test.go
+++ b/go/internal/cli/commands/compose_test.go
@@ -75,6 +75,40 @@ func TestBuildComposeServicesParallelOverlapsBuildAndPush(t *testing.T) {
 	}
 }
 
+func TestComposeServiceWatchHashTracksCreateRequest(t *testing.T) {
+	cfg := &appconfig.AppConfig{AppID: "demo", ServiceName: "api"}
+	policy := &agentpb.RestartPolicy{Mode: agentpb.RestartPolicyMode_UNLESS_STOPPED}
+	base, err := composeServiceWatchHash("image-a", cfg, "server", []string{"--port", "80"}, policy, []string{"MODE=prod"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name   string
+		image  string
+		cmd    string
+		args   []string
+		env    []string
+		policy *agentpb.RestartPolicy
+	}{
+		{"image", "image-b", "server", []string{"--port", "80"}, []string{"MODE=prod"}, policy},
+		{"command", "image-a", "worker", []string{"--port", "80"}, []string{"MODE=prod"}, policy},
+		{"args", "image-a", "server", []string{"--port", "81"}, []string{"MODE=prod"}, policy},
+		{"env", "image-a", "server", []string{"--port", "80"}, []string{"MODE=dev"}, policy},
+		{"restart", "image-a", "server", []string{"--port", "80"}, []string{"MODE=prod"}, &agentpb.RestartPolicy{Mode: agentpb.RestartPolicyMode_NO}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := composeServiceWatchHash(tc.image, cfg, tc.cmd, tc.args, tc.policy, tc.env)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got == base {
+				t.Fatalf("%s change did not invalidate watch hash", tc.name)
+			}
+		})
+	}
+}
+
 func writeComposeFile(t *testing.T, dir, name, body string) {
 	t.Helper()
 	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -189,6 +189,15 @@ func serviceFingerprintKey(appID, service string) string {
 	return appID + "/svc/" + service
 }
 
+func multiServiceWatchHash(buildHash string, cfg *appconfig.AppConfig, env []string, restartPolicy *agentpb.RestartPolicy) (string, error) {
+	return watchDesiredHash(struct {
+		BuildHash     string
+		Config        *appconfig.AppConfig
+		Env           []string
+		RestartPolicy *agentpb.RestartPolicy
+	}{buildHash, cfg, env, restartPolicy})
+}
+
 // deviceContainerNames returns the lowercased set of container identities the
 // device currently knows about (any running state). ListContainers reports one
 // entry per app group whose AppName is the bare app id; per-service identities
@@ -197,11 +206,11 @@ func serviceFingerprintKey(appID, service string) string {
 // AppConfig.ContainerName / multiServiceContainerName so callers can look a
 // service up directly. Best-effort: on any RPC error it returns an empty set, so
 // callers simply don't skip anything.
-func deviceContainerNames(ctx context.Context, conn *grpcclient.AgentConnection) map[string]bool {
-	present := map[string]bool{}
+func deviceContainerStates(ctx context.Context, conn *grpcclient.AgentConnection) map[string]agentpb.AppRunningState {
+	states := map[string]agentpb.AppRunningState{}
 	stream, err := conn.ContainerService.ListContainers(ctx, &agentpb.ListContainersRequest{})
 	if err != nil {
-		return present
+		return states
 	}
 	for {
 		resp, recvErr := stream.Recv()
@@ -209,19 +218,27 @@ func deviceContainerNames(ctx context.Context, conn *grpcclient.AgentConnection)
 			break
 		}
 		if recvErr != nil {
-			return present
+			return states
 		}
 		c := resp.GetContainer()
 		if c == nil {
 			continue
 		}
 		app := c.GetAppName()
-		present[strings.ToLower(app)] = true
+		states[strings.ToLower(app)] = c.GetRunningState()
 		for _, s := range c.GetServices() {
 			if s.GetName() != "" {
-				present[strings.ToLower(app+"_"+s.GetName())] = true
+				states[strings.ToLower(app+"_"+s.GetName())] = s.GetRunningState()
 			}
 		}
+	}
+	return states
+}
+
+func deviceContainerNames(ctx context.Context, conn *grpcclient.AgentConnection) map[string]bool {
+	present := map[string]bool{}
+	for name := range deviceContainerStates(ctx, conn) {
+		present[name] = true
 	}
 	return present
 }
@@ -375,8 +392,50 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	deviceKey := deviceFingerprintKey(versionResp)
 	sfOpts := debugStagefileOptions(opts.debug)
 	skip, hashes, dockerfiles := planServicePushSkips(ctx, conn, cwd, appCfg.AppID, deviceKey, platform, appCfg, services, buildArgs, sfOpts...)
+
+	// Build the full per-service create configs before selecting watch work: a
+	// service is unchanged only when both its image inputs and its effective
+	// runtime configuration match the last successful cycle.
+	svcCfgs := make(map[string]*appconfig.AppConfig, len(services))
+	svcLifecycleCfgs := make(map[string]*appconfig.AppConfig, len(services))
+	for name, svc := range services {
+		svcCfgs[name] = multiServiceCreateConfig(appCfg, name, svc)
+		svcLifecycleCfgs[name] = multiServiceLifecycleConfig(appCfg.AppID, name, svc)
+	}
+
+	preserve := map[string]bool{}
+	desiredHashes := map[string]string{}
+	if opts.watchState != nil {
+		states := deviceContainerStates(ctx, conn)
+		candidates := map[string]watchServiceCandidate{}
+		for name, svc := range services {
+			buildHash, planned := hashes[name]
+			if !planned {
+				continue
+			}
+			desiredHash, err := multiServiceWatchHash(buildHash, svcCfgs[name], expandServiceEnv(appCfg, svc), resolveRestartPolicy(opts))
+			if err != nil {
+				continue
+			}
+			desiredHashes[name] = desiredHash
+			candidates[name] = watchServiceCandidate{
+				appID:         appCfg.AppID,
+				containerName: multiServiceContainerName(appCfg.AppID, name),
+				desiredHash:   desiredHash,
+			}
+		}
+		preserve = selectPreservedWatchServices(opts.watchState, deviceKey, candidates, states)
+		for name := range preserve {
+			skip[name] = true
+		}
+		if n := len(preserve); n > 0 {
+			cliLogln("%d of %d services unchanged and running; leaving them untouched.", n, len(services))
+		}
+	}
 	if n := len(skip); n > 0 {
-		cliLogln("%d of %d services unchanged and already on device; skipping their build/push.", n, len(services))
+		if opts.watchState == nil {
+			cliLogln("%d of %d services unchanged and already on device; skipping their build/push.", n, len(services))
+		}
 	}
 
 	// Build all service images in parallel, then create and start containers.
@@ -427,22 +486,24 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	if err != nil {
 		return err
 	}
-
-	// Build the full per-service create configs and separate CLI-private
-	// lifecycle views. The latter preserve declaration scope so inherited
-	// top-level HTTP does not execute once per service.
-	svcCfgs := make(map[string]*appconfig.AppConfig, len(services))
-	svcLifecycleCfgs := make(map[string]*appconfig.AppConfig, len(services))
-	for name, svc := range services {
-		svcCfgs[name] = multiServiceCreateConfig(appCfg, name, svc)
-		svcLifecycleCfgs[name] = multiServiceLifecycleConfig(appCfg.AppID, name, svc)
+	adjustedPreserve := adjustSharedNamespacePreserve(ordered, preserve, appCfg.Isolation)
+	if len(adjustedPreserve) < len(preserve) {
+		cliLogln("Shared-namespace primary changed; restarting the affected service group.")
+	}
+	preserve = adjustedPreserve
+	if len(preserve) > 0 {
+		ordered = filterPreservedServices(ordered, preserve)
+		if len(ordered) == 0 {
+			cliLogln("All services are unchanged and running; nothing to redeploy.")
+			return partialErr
+		}
 	}
 
 	// The app-level fallback fires the group's top-level readiness/hooks once,
 	// after ALL services have started — a guarantee that cannot hold on a subset
 	// run (--service), so disable it there.
 	appLevelCfg := appLevelLifecycleConfig(appCfg.AppID, appCfg)
-	if opts.service != "" {
+	if opts.service != "" || len(preserve) > 0 {
 		appLevelCfg = nil
 	}
 
@@ -498,6 +559,13 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	// next service is created.
 	if err := startAndStreamServices(ctx, conn, appCfg.AppID, ordered, opts, createService, svcCfgs, svcLifecycleCfgs, appLevelCfg); err != nil {
 		return err
+	}
+	if ctx.Err() == nil {
+		for _, name := range ordered {
+			if h := desiredHashes[name]; h != "" {
+				opts.watchState.record(watchServiceKey(deviceKey, appCfg.AppID, name), h)
+			}
+		}
 	}
 	// In --keep-going mode, exit non-zero after deploying the healthy subset so
 	// callers/CI still see that some services failed.

--- a/go/internal/cli/commands/multibuild_test.go
+++ b/go/internal/cli/commands/multibuild_test.go
@@ -13,7 +13,40 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
 	"github.com/wendylabsinc/wendy/go/internal/stagefile"
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
+
+func TestMultiServiceWatchHashTracksBuildAndRuntimeState(t *testing.T) {
+	cfg := &appconfig.AppConfig{AppID: "demo", ServiceName: "api"}
+	policy := &agentpb.RestartPolicy{Mode: agentpb.RestartPolicyMode_UNLESS_STOPPED}
+	base, err := multiServiceWatchHash("build-a", cfg, []string{"MODE=prod"}, policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name   string
+		build  string
+		cfg    *appconfig.AppConfig
+		env    []string
+		policy *agentpb.RestartPolicy
+	}{
+		{"build", "build-b", cfg, []string{"MODE=prod"}, policy},
+		{"config", "build-a", &appconfig.AppConfig{AppID: "demo", ServiceName: "worker"}, []string{"MODE=prod"}, policy},
+		{"env", "build-a", cfg, []string{"MODE=dev"}, policy},
+		{"restart", "build-a", cfg, []string{"MODE=prod"}, &agentpb.RestartPolicy{Mode: agentpb.RestartPolicyMode_NO}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := multiServiceWatchHash(tc.build, tc.cfg, tc.env, tc.policy)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got == base {
+				t.Fatalf("%s change did not invalidate watch hash", tc.name)
+			}
+		})
+	}
+}
 
 // newServiceTree writes n service directories under a fresh temp root, each
 // with a minimal Dockerfile, and returns the root plus the services map.

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -501,6 +501,10 @@ type runOptions struct {
 	// quietBuild suppresses the image build (buildx) output, surfacing it only
 	// when the build fails. Set by `wendy watch` to keep the redeploy loop quiet.
 	quietBuild bool
+	// watchState tracks the effective per-service state successfully deployed by
+	// this watch session. Multi-service deploys use it to leave unchanged,
+	// already-running containers completely untouched on later cycles.
+	watchState *watchDeployState
 	// gpuArch overrides the GPU architecture a Stagefile cuda: stage compiles
 	// against. Normally the selected device answers this; the flag exists for
 	// building against a board that isn't the one in front of you.

--- a/go/internal/cli/commands/watch.go
+++ b/go/internal/cli/commands/watch.go
@@ -2,6 +2,9 @@ package commands
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"io/fs"
 	"os"
 	"os/signal"
@@ -12,6 +15,8 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/cobra"
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
 
 // newWatchCmd builds the `wendy watch` command: it watches the project
@@ -66,7 +71,94 @@ func newWatchCmd() *cobra.Command {
 func withWatchInvariants(opts runOptions) runOptions {
 	opts.detach = true
 	opts.yes = true
+	if opts.watchState == nil {
+		opts.watchState = &watchDeployState{hashes: map[string]string{}}
+	}
 	return opts
+}
+
+// watchDeployState is intentionally scoped to one watch process. The first
+// deploy establishes a known-good baseline; later deploys may preserve a
+// service only when its effective desired-state hash still matches and the
+// device independently reports its container as running.
+type watchDeployState struct {
+	mu     sync.Mutex
+	hashes map[string]string
+}
+
+func (s *watchDeployState) matches(key, hash string) bool {
+	if s == nil {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.hashes[key] == hash
+}
+
+func (s *watchDeployState) record(key, hash string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.hashes[key] = hash
+}
+
+func watchServiceKey(deviceKey, appID, service string) string {
+	return deviceKey + "/" + appID + "/" + service
+}
+
+// watchDesiredHash hashes the complete effective desired state of one service.
+// Callers include both its image/build identity and its runtime configuration,
+// so a watch cycle never preserves a container whose settings have changed.
+func watchDesiredHash(v any) (string, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(append([]byte("wendy-watch-service-v1\x00"), b...))
+	return hex.EncodeToString(sum[:]), nil
+}
+
+type watchServiceCandidate struct {
+	appID         string
+	containerName string
+	desiredHash   string
+}
+
+// selectPreservedWatchServices returns services that are both unchanged since
+// this watch session last deployed them and currently running on the device.
+// Either condition failing makes the service part of the next repair/deploy.
+func selectPreservedWatchServices(state *watchDeployState, deviceKey string, candidates map[string]watchServiceCandidate, deviceStates map[string]agentpb.AppRunningState) map[string]bool {
+	preserve := map[string]bool{}
+	for name, candidate := range candidates {
+		key := watchServiceKey(deviceKey, candidate.appID, name)
+		if state.matches(key, candidate.desiredHash) && deviceStates[strings.ToLower(candidate.containerName)] == agentpb.AppRunningState_RUNNING {
+			preserve[name] = true
+		}
+	}
+	return preserve
+}
+
+func filterPreservedServices(ordered []string, preserve map[string]bool) []string {
+	changed := make([]string, 0, len(ordered))
+	for _, name := range ordered {
+		if !preserve[name] {
+			changed = append(changed, name)
+		}
+	}
+	return changed
+}
+
+// adjustSharedNamespacePreserve expands a primary-service redeploy to the
+// whole shared-namespace group. Secondaries bake the primary PID's namespaces
+// into their OCI specs, so they are genuinely affected when that primary is
+// replaced even if their own desired-state hashes did not change.
+func adjustSharedNamespacePreserve(ordered []string, preserve map[string]bool, isolation string) map[string]bool {
+	if len(ordered) == 0 || !appconfig.IsSharedNamespaceIsolation(isolation) || preserve[ordered[0]] {
+		return preserve
+	}
+	return map[string]bool{}
 }
 
 func watchCommand(ctx context.Context, opts runOptions, debounce time.Duration) error {

--- a/go/internal/cli/commands/watch_test.go
+++ b/go/internal/cli/commands/watch_test.go
@@ -2,7 +2,10 @@ package commands
 
 import (
 	"path/filepath"
+	"reflect"
 	"testing"
+
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
 
 func TestWatchShouldIgnore(t *testing.T) {
@@ -36,5 +39,75 @@ func TestWatchShouldIgnore(t *testing.T) {
 		if got := watchShouldIgnore(filepath.Join(root, filepath.FromSlash(c.rel)), root); got != c.ignore {
 			t.Errorf("watchShouldIgnore(%q) = %v, want %v", c.rel, got, c.ignore)
 		}
+	}
+}
+
+func TestSelectPreservedWatchServicesRequiresUnchangedAndRunning(t *testing.T) {
+	state := &watchDeployState{hashes: map[string]string{}}
+	const deviceKey = "device"
+	state.record(watchServiceKey(deviceKey, "app", "api"), "same")
+	state.record(watchServiceKey(deviceKey, "app", "worker"), "old")
+	state.record(watchServiceKey(deviceKey, "app", "stopped"), "same")
+
+	candidates := map[string]watchServiceCandidate{
+		"api":     {appID: "app", containerName: "app_api", desiredHash: "same"},
+		"worker":  {appID: "app", containerName: "app_worker", desiredHash: "new"},
+		"stopped": {appID: "app", containerName: "app_stopped", desiredHash: "same"},
+		"missing": {appID: "app", containerName: "app_missing", desiredHash: "same"},
+	}
+	deviceStates := map[string]agentpb.AppRunningState{
+		"app_api":     agentpb.AppRunningState_RUNNING,
+		"app_worker":  agentpb.AppRunningState_RUNNING,
+		"app_stopped": agentpb.AppRunningState_STOPPED,
+	}
+
+	got := selectPreservedWatchServices(state, deviceKey, candidates, deviceStates)
+	if !reflect.DeepEqual(got, map[string]bool{"api": true}) {
+		t.Fatalf("preserved services = %v, want only unchanged running api", got)
+	}
+}
+
+func TestFilterPreservedServicesKeepsChangedDependencyOrder(t *testing.T) {
+	ordered := []string{"db", "api", "worker"}
+	got := filterPreservedServices(ordered, map[string]bool{"db": true, "worker": true})
+	if !reflect.DeepEqual(got, []string{"api"}) {
+		t.Fatalf("filtered services = %v, want [api]", got)
+	}
+	if !reflect.DeepEqual(ordered, []string{"db", "api", "worker"}) {
+		t.Fatalf("filter mutated input order: %v", ordered)
+	}
+}
+
+func TestAdjustSharedNamespacePreserve(t *testing.T) {
+	ordered := []string{"primary", "secondary", "worker"}
+	preserve := map[string]bool{"secondary": true, "worker": true}
+	got := adjustSharedNamespacePreserve(ordered, preserve, "shared-network")
+	if len(got) != 0 {
+		t.Fatalf("preserved services = %v; primary replacement affects whole shared namespace", got)
+	}
+
+	preserve = map[string]bool{"primary": true, "worker": true}
+	got = adjustSharedNamespacePreserve(ordered, preserve, "shared-ipc")
+	if !reflect.DeepEqual(got, preserve) {
+		t.Fatalf("secondary-only change should preserve unrelated group members: got %v, want %v", got, preserve)
+	}
+
+	got = adjustSharedNamespacePreserve(ordered, map[string]bool{"secondary": true}, "isolated")
+	if !got["secondary"] {
+		t.Fatalf("isolated service was unnecessarily marked for restart: %v", got)
+	}
+}
+
+func TestWatchDesiredHashIncludesRuntimeConfiguration(t *testing.T) {
+	a, err := watchDesiredHash(struct{ Env []string }{Env: []string{"MODE=prod"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := watchDesiredHash(struct{ Env []string }{Env: []string{"MODE=dev"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a == b {
+		t.Fatal("runtime configuration change did not change desired-state hash")
 	}
 }


### PR DESCRIPTION
## Summary

- fingerprint each multi-service and Compose service independently during a watch session
- leave unchanged services completely untouched when the device reports them running
- rebuild, recreate, and restart only changed or non-running services
- restart a shared-network/shared-IPC group when its primary changes, since the remaining containers depend on that primary's Linux namespaces
- document the selective watch behavior

## Why

`wendy run --watch` reran the full multi-service deployment pipeline after every file change. Even services whose build inputs and runtime configuration were unchanged could be rebuilt, recreated, and restarted, disrupting otherwise healthy workloads.

The watch loop now keeps an in-memory known-good baseline after its initial deployment. A service is preserved only when its build identity and effective create/start configuration still match and the device independently reports the container as running. This state is scoped to the watch process, so a new invocation starts conservatively with a normal deployment.

## User impact

Editing one service no longer interrupts unrelated services in a multi-service `wendy.json` or Compose app deployed to WendyOS. Missing, stopped, changed, or otherwise non-running services continue through the normal repair/deploy path.

## Validation

- `go test ./internal/cli/...`
- `go vet ./internal/cli/commands`
- `git diff --check`
