### PR TITLE
Speed up and stabilize Stagefile deployments

### DIFF
--- a/.github/ci-tests/python-gpu/Dockerfile.cuda13
+++ b/.github/ci-tests/python-gpu/Dockerfile.cuda13
@@ -1,0 +1,23 @@
+FROM nvidia/cuda:13.0.2-cudnn-runtime-ubuntu24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 python3-venv libgomp1 libnuma1 \
+    libnvpl-blas0 libnvpl-lapack0 cuda-cupti-13-0 libcudss0-cuda-13 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Jetson AI Lab's CUDA-13 SBSA wheel contains kernels for Thor (sm_110) and
+# Spark (sm_121).
+# Use the immutable, hashed wheel URL so pip cannot select the CPU-only
+# aarch64 package from PyPI. Its ordinary Python dependencies still resolve
+# from PyPI.
+RUN python3 -m venv /opt/venv \
+    && /opt/venv/bin/pip install --no-cache-dir \
+       'https://pypi.jetson-ai-lab.io/sbsa/cu130/+f/e65/21b6628938478/torch-2.9.1-cp312-cp312-linux_aarch64.whl#sha256=e6521b662893847896ece6740a6f3bd996c8a067d7b3334aadd6e3dcef47fd64' \
+       numpy
+
+ENV PATH="/opt/venv/bin:${PATH}" \
+    LD_LIBRARY_PATH="/usr/lib/aarch64-linux-gnu/libcudss/13:${LD_LIBRARY_PATH}" \
+    PYTHONUNBUFFERED=1
+WORKDIR /app
+COPY main.py .
+CMD ["python3", "main.py"]

--- a/.github/ci-tests/python-onnx-gpu/Dockerfile.cuda13
+++ b/.github/ci-tests/python-onnx-gpu/Dockerfile.cuda13
@@ -1,0 +1,20 @@
+FROM nvidia/cuda:13.0.2-cudnn-runtime-ubuntu24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 python3-venv libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Jetson AI Lab's CUDA-13 SBSA wheel targets CUDA-13 devices including Thor
+# (sm_110) and Spark (sm_121).
+# Pin its immutable, hashed URL while allowing the wheel's ordinary Python
+# dependencies to resolve from PyPI.
+RUN python3 -m venv /opt/venv \
+    && /opt/venv/bin/pip install --no-cache-dir \
+       'https://pypi.jetson-ai-lab.io/sbsa/cu130/+f/012/c10bef23a39f0/onnxruntime_gpu-1.24.0-cp312-cp312-linux_aarch64.whl#sha256=012c10bef23a39f074730d158b72f797a7314f2695c65835a0669b57282422f6' \
+       onnx numpy
+
+ENV PATH="/opt/venv/bin:${PATH}" \
+    PYTHONUNBUFFERED=1
+WORKDIR /app
+COPY main.py .
+CMD ["python3", "main.py"]

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -355,8 +355,16 @@ jobs:
           builder_slug="$(printf '%s' "$INPUT_HOSTNAME" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_.-]+/-/g; s/^-+//; s/-+$//')"
           BUILDER="wendy-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}-${builder_slug}"
           BUILDER="${BUILDER:0:128}"
-          docker buildx rm "$BUILDER" --force 2>/dev/null || true
-          trap 'docker buildx rm "$BUILDER" --force 2>/dev/null || true' EXIT
+          # Wendy appends -oci to WENDY_BUILDX_BUILDER for chunk-diff exports.
+          # Remove that actual builder too; cleaning only the unsuffixed name
+          # leaked one buildkitd container per integration run until the runner
+          # exhausted memory.
+          cleanup_builders() {
+            docker buildx rm "${BUILDER}-oci" --force 2>/dev/null || true
+            docker buildx rm "$BUILDER" --force 2>/dev/null || true
+          }
+          cleanup_builders
+          trap cleanup_builders EXIT
 
           echo "==> Starting tests on $INPUT_HOSTNAME (builder: $BUILDER)"
           # DOCKER_HOST is often unset here. ssh re-joins its arguments into one
@@ -483,8 +491,14 @@ jobs:
           builder_slug="$(printf '%s' "$INPUT_HOSTNAME" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_.-]+/-/g; s/^-+//; s/-+$//')"
           BUILDER="wendy-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}-${builder_slug}"
           BUILDER="${BUILDER:0:128}"
-          docker buildx rm "$BUILDER" --force 2>/dev/null || true
-          trap 'docker buildx rm "$BUILDER" --force 2>/dev/null || true' EXIT
+          # The CLI creates ${BUILDER}-oci for chunk-diff exports; clean both
+          # names so a buildkitd container is not leaked after every CI run.
+          cleanup_builders() {
+            docker buildx rm "${BUILDER}-oci" --force 2>/dev/null || true
+            docker buildx rm "$BUILDER" --force 2>/dev/null || true
+          }
+          cleanup_builders
+          trap cleanup_builders EXIT
 
           echo "==> Starting tests on $INPUT_HOSTNAME (builder: $BUILDER)"
           WENDY_BUILDX_BUILDER="$BUILDER" go/scripts/test-ci.sh "${TEST_ARGS[@]}" -h "$INPUT_HOSTNAME"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -152,6 +152,7 @@ jobs:
           EXPECTED=(
             "wendy-SER9.local"
             "wendyos-jetson-thor-ci.local"
+            "wendyos-thor.local"
             "wendyos-dynamic-channel.local"
           )
 

--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -289,9 +289,12 @@ jobs:
           builder_slug="$(printf '%s' "$INPUT_HOSTNAME" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_.-]+/-/g; s/^-+//; s/-+$//')"
           BUILDER="wendy-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}-${builder_slug}"
           BUILDER="${BUILDER:0:128}"
-          docker buildx rm "$BUILDER" --force 2>/dev/null || true
-          cleanup() { docker buildx rm "$BUILDER" --force 2>/dev/null || true; }
-          trap cleanup EXIT
+          cleanup_builders() {
+            docker buildx rm "${BUILDER}-oci" --force 2>/dev/null || true
+            docker buildx rm "$BUILDER" --force 2>/dev/null || true
+          }
+          cleanup_builders
+          trap cleanup_builders EXIT
 
           WENDY_BUILDX_BUILDER="$BUILDER" scripts/test-templates.sh "${ARGS[@]}"
 

--- a/Proto/wendy/agent/services/v2/container_service.proto
+++ b/Proto/wendy/agent/services/v2/container_service.proto
@@ -13,6 +13,10 @@ service WendyContainerService {
     rpc ListVolumes(ListVolumesRequest) returns (ListVolumesResponse);
     rpc RemoveVolume(RemoveVolumeRequest) returns (RemoveVolumeResponse);
     rpc ListContainerStats(ListContainerStatsRequest) returns (ListContainerStatsResponse);
+    // Releases Wendy's explicit GC pins from pushed layer blobs and unpacked
+    // snapshots. Containerd's reference graph continues to preserve current
+    // images and active containers; only cache data becomes collectible.
+    rpc PruneCache(PruneCacheRequest) returns (PruneCacheResponse);
 }
 
 message StartContainerRequest {
@@ -90,4 +94,23 @@ message ListContainerStatsRequest {}
 
 message ListContainerStatsResponse {
     repeated ContainerStats stats = 1;
+}
+
+message PruneCacheRequest {
+    // Reports what would be released without changing containerd metadata.
+    bool dry_run = 1;
+}
+
+message PruneCacheResponse {
+    // Number and aggregate compressed size of pushed layer blobs whose Wendy
+    // GC-root pin was (or would be, for dry_run) released.
+    uint64 content_blobs = 1;
+    uint64 content_bytes = 2;
+    // Number and aggregate filesystem usage of unpacked snapshots whose Wendy
+    // GC-root pin was (or would be, for dry_run) released.
+    uint64 snapshots = 3;
+    uint64 snapshot_bytes = 4;
+    // Newly written cache entries are retained for this many seconds to avoid
+    // disrupting an in-flight deployment between layer RPCs.
+    uint64 minimum_age_seconds = 5;
 }

--- a/go/internal/agent/containerd/cache_prune.go
+++ b/go/internal/agent/containerd/cache_prune.go
@@ -1,0 +1,144 @@
+package containerd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/snapshots"
+	digest "github.com/opencontainers/go-digest"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/services"
+)
+
+// cachePruneGracePeriod keeps cache roots that may belong to an in-flight
+// deployment. A layer push spans multiple RPCs, so there is no single lease
+// covering the entire transfer until AssembleImage creates the final image
+// reference. A day safely covers even unusually large/slow edge deployments.
+const cachePruneGracePeriod = 24 * time.Hour
+
+type cacheContentStore interface {
+	Walk(context.Context, content.WalkFunc, ...string) error
+	Update(context.Context, content.Info, ...string) (content.Info, error)
+}
+
+type cacheSnapshotter interface {
+	Walk(context.Context, snapshots.WalkFunc, ...string) error
+	Update(context.Context, snapshots.Info, ...string) (snapshots.Info, error)
+	Usage(context.Context, string) (snapshots.Usage, error)
+}
+
+type contentCacheCandidate struct {
+	info content.Info
+}
+
+type snapshotCacheCandidate struct {
+	info  snapshots.Info
+	usage snapshots.Usage
+}
+
+// PruneCache releases Wendy's explicit GC roots from cache entries old enough
+// not to belong to an in-flight deployment. Containerd's own reference graph
+// remains authoritative, preserving current images and active containers while
+// its normal GC reclaims entries that are now unreachable.
+func (c *Client) PruneCache(ctx context.Context, dryRun bool) (services.CachePruneResult, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	ctx = c.withNamespace(ctx)
+	result, err := pruneCacheRoots(
+		ctx,
+		c.client.ContentStore(),
+		c.client.SnapshotService(c.snapshotter),
+		time.Now().Add(-cachePruneGracePeriod),
+		dryRun,
+	)
+	result.MinimumAgeSeconds = uint64(cachePruneGracePeriod / time.Second)
+	return result, err
+}
+
+func pruneCacheRoots(ctx context.Context, cs cacheContentStore, sn cacheSnapshotter, cutoff time.Time, dryRun bool) (services.CachePruneResult, error) {
+	var (
+		result             services.CachePruneResult
+		contentCandidates  []contentCacheCandidate
+		snapshotCandidates []snapshotCacheCandidate
+	)
+
+	if err := cs.Walk(ctx, func(info content.Info) error {
+		if info.Labels[labelKeyWendyLayer] != "true" || !cacheRootOlderThan(info.Labels[labelKeyGCRoot], cutoff) {
+			return nil
+		}
+		contentCandidates = append(contentCandidates, contentCacheCandidate{info: info})
+		result.ContentBlobs++
+		if info.Size > 0 {
+			result.ContentBytes += uint64(info.Size)
+		}
+		return nil
+	}); err != nil {
+		return services.CachePruneResult{}, fmt.Errorf("listing cached content: %w", err)
+	}
+
+	if err := sn.Walk(ctx, func(_ context.Context, info snapshots.Info) error {
+		if info.Kind != snapshots.KindCommitted || !isWendyCacheSnapshot(info) || !cacheRootOlderThan(info.Labels[labelKeyGCRoot], cutoff) {
+			return nil
+		}
+		usage, _ := sn.Usage(ctx, info.Name) // best-effort accounting must not block cleanup
+		snapshotCandidates = append(snapshotCandidates, snapshotCacheCandidate{info: info, usage: usage})
+		result.Snapshots++
+		if usage.Size > 0 {
+			result.SnapshotBytes += uint64(usage.Size)
+		}
+		return nil
+	}); err != nil {
+		return services.CachePruneResult{}, fmt.Errorf("listing cached snapshots: %w", err)
+	}
+
+	if dryRun {
+		return result, nil
+	}
+
+	for _, candidate := range contentCandidates {
+		candidate.info.Labels = labelsWithout(candidate.info.Labels, labelKeyGCRoot)
+		if _, err := cs.Update(ctx, candidate.info, "labels"); err != nil {
+			return result, fmt.Errorf("releasing cache root from content %s: %w", candidate.info.Digest, err)
+		}
+	}
+	for _, candidate := range snapshotCandidates {
+		candidate.info.Labels = labelsWithout(candidate.info.Labels, labelKeyGCRoot)
+		if _, err := sn.Update(ctx, candidate.info, "labels"); err != nil {
+			return result, fmt.Errorf("releasing cache root from snapshot %s: %w", candidate.info.Name, err)
+		}
+	}
+
+	return result, nil
+}
+
+func cacheRootOlderThan(value string, cutoff time.Time) bool {
+	if value == "" {
+		return false
+	}
+	created, err := time.Parse(time.RFC3339, value)
+	return err == nil && !created.After(cutoff)
+}
+
+func isWendyCacheSnapshot(info snapshots.Info) bool {
+	if info.Labels[labelKeyWendySnapshot] == "true" {
+		return true
+	}
+	// Agents predating labelKeyWendySnapshot used the OCI chain ID as the
+	// snapshot name and set the same GC root. Recognize that exact legacy shape
+	// so upgrades can clean the cache already accumulated on devices.
+	d, err := digest.Parse(info.Name)
+	return err == nil && d.Algorithm() == digest.SHA256
+}
+
+func labelsWithout(labels map[string]string, key string) map[string]string {
+	out := make(map[string]string, len(labels))
+	for k, v := range labels {
+		if k != key {
+			out[k] = v
+		}
+	}
+	return out
+}

--- a/go/internal/agent/containerd/cache_prune_test.go
+++ b/go/internal/agent/containerd/cache_prune_test.go
@@ -1,0 +1,126 @@
+package containerd
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/snapshots"
+	digest "github.com/opencontainers/go-digest"
+)
+
+type fakeCacheContentStore struct {
+	infos   []content.Info
+	updates []content.Info
+}
+
+func (f *fakeCacheContentStore) Walk(_ context.Context, fn content.WalkFunc, _ ...string) error {
+	for _, info := range f.infos {
+		if err := fn(info); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *fakeCacheContentStore) Update(_ context.Context, info content.Info, _ ...string) (content.Info, error) {
+	f.updates = append(f.updates, info)
+	return info, nil
+}
+
+type fakeCacheSnapshotter struct {
+	infos   []snapshots.Info
+	usage   map[string]snapshots.Usage
+	updates []snapshots.Info
+}
+
+func (f *fakeCacheSnapshotter) Walk(ctx context.Context, fn snapshots.WalkFunc, _ ...string) error {
+	for _, info := range f.infos {
+		if err := fn(ctx, info); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *fakeCacheSnapshotter) Update(_ context.Context, info snapshots.Info, _ ...string) (snapshots.Info, error) {
+	f.updates = append(f.updates, info)
+	return info, nil
+}
+
+func (f *fakeCacheSnapshotter) Usage(_ context.Context, key string) (snapshots.Usage, error) {
+	return f.usage[key], nil
+}
+
+func TestPruneCacheRootsDryRunSelectsOnlyOldWendyCache(t *testing.T) {
+	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+	old := now.Add(-2 * time.Hour).Format(time.RFC3339)
+	recent := now.Add(-10 * time.Minute).Format(time.RFC3339)
+	legacySnapshot := digest.FromString("legacy-snapshot").String()
+
+	cs := &fakeCacheContentStore{infos: []content.Info{
+		{Digest: digest.FromString("old"), Size: 100, Labels: map[string]string{labelKeyWendyLayer: "true", labelKeyGCRoot: old}},
+		{Digest: digest.FromString("recent"), Size: 200, Labels: map[string]string{labelKeyWendyLayer: "true", labelKeyGCRoot: recent}},
+		{Digest: digest.FromString("foreign"), Size: 300, Labels: map[string]string{labelKeyGCRoot: old}},
+	}}
+	sn := &fakeCacheSnapshotter{
+		infos: []snapshots.Info{
+			{Name: "wendy", Kind: snapshots.KindCommitted, Labels: map[string]string{labelKeyWendySnapshot: "true", labelKeyGCRoot: old}},
+			{Name: legacySnapshot, Kind: snapshots.KindCommitted, Labels: map[string]string{labelKeyGCRoot: old}},
+			{Name: "recent", Kind: snapshots.KindCommitted, Labels: map[string]string{labelKeyWendySnapshot: "true", labelKeyGCRoot: recent}},
+			{Name: "foreign", Kind: snapshots.KindCommitted, Labels: map[string]string{labelKeyGCRoot: old}},
+			{Name: "active", Kind: snapshots.KindActive, Labels: map[string]string{labelKeyWendySnapshot: "true", labelKeyGCRoot: old}},
+		},
+		usage: map[string]snapshots.Usage{"wendy": {Size: 400}, legacySnapshot: {Size: 500}},
+	}
+
+	got, err := pruneCacheRoots(context.Background(), cs, sn, now.Add(-time.Hour), true)
+	if err != nil {
+		t.Fatalf("pruneCacheRoots: %v", err)
+	}
+	if got.ContentBlobs != 1 || got.ContentBytes != 100 || got.Snapshots != 2 || got.SnapshotBytes != 900 {
+		t.Fatalf("result = %+v", got)
+	}
+	if len(cs.updates) != 0 || len(sn.updates) != 0 {
+		t.Fatalf("dry run mutated stores: content=%d snapshots=%d", len(cs.updates), len(sn.updates))
+	}
+}
+
+func TestPruneCacheRootsRemovesOnlyGCRootLabel(t *testing.T) {
+	old := time.Date(2026, 8, 12, 10, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	cs := &fakeCacheContentStore{infos: []content.Info{{
+		Digest: digest.FromString("layer"), Size: 12,
+		Labels: map[string]string{labelKeyWendyLayer: "true", labelKeyGCRoot: old, "keep": "content"},
+	}}}
+	sn := &fakeCacheSnapshotter{
+		infos: []snapshots.Info{{
+			Name: "snapshot", Kind: snapshots.KindCommitted,
+			Labels: map[string]string{labelKeyWendySnapshot: "true", labelKeyGCRoot: old, "keep": "snapshot"},
+		}},
+		usage: map[string]snapshots.Usage{"snapshot": {Size: 34}},
+	}
+
+	_, err := pruneCacheRoots(context.Background(), cs, sn, time.Date(2026, 8, 12, 11, 0, 0, 0, time.UTC), false)
+	if err != nil {
+		t.Fatalf("pruneCacheRoots: %v", err)
+	}
+	if len(cs.updates) != 1 || cs.updates[0].Labels["keep"] != "content" {
+		t.Fatalf("content update = %+v", cs.updates)
+	}
+	if _, ok := cs.updates[0].Labels[labelKeyGCRoot]; ok {
+		t.Fatal("content GC root was not removed")
+	}
+	if len(sn.updates) != 1 || sn.updates[0].Labels["keep"] != "snapshot" {
+		t.Fatalf("snapshot update = %+v", sn.updates)
+	}
+	if _, ok := sn.updates[0].Labels[labelKeyGCRoot]; ok {
+		t.Fatal("snapshot GC root was not removed")
+	}
+}
+
+func TestCacheRootOlderThanRejectsInvalidTimestamp(t *testing.T) {
+	if cacheRootOlderThan("not-a-time", time.Now()) {
+		t.Fatal("invalid timestamp must fail safe")
+	}
+}

--- a/go/internal/agent/containerd/helpers.go
+++ b/go/internal/agent/containerd/helpers.go
@@ -75,6 +75,11 @@ const labelKeyGCRoot = "containerd.io/gc.root"
 // labelKeyWendyLayer marks a content blob as a Wendy-pushed layer.
 const labelKeyWendyLayer = "sh.wendy.layer"
 
+// labelKeyWendySnapshot marks a committed layer snapshot created by Wendy's
+// custom unpacker. It lets cache pruning avoid touching GC roots owned by other
+// containerd clients in the same namespace.
+const labelKeyWendySnapshot = "sh.wendy.snapshot"
+
 // labelKeyAppID is the app identity (appId from wendy.json) for every
 // Wendy-managed container. Always set, regardless of whether the app uses
 // multi-service naming. Used to find all containers belonging to an app without

--- a/go/internal/agent/containerd/unpack.go
+++ b/go/internal/agent/containerd/unpack.go
@@ -198,7 +198,8 @@ func (c *Client) UnpackImage(ctx context.Context, img containerd.Image, progress
 		}
 
 		gcRootOpt := snapshots.WithLabels(map[string]string{
-			labelKeyGCRoot: gcTimestamp(),
+			labelKeyGCRoot:        gcTimestamp(),
+			labelKeyWendySnapshot: "true",
 		})
 		commitErr := sn.Commit(ctx, chainID, activeKey, gcRootOpt)
 		switch {

--- a/go/internal/agent/services/container_service_v2.go
+++ b/go/internal/agent/services/container_service_v2.go
@@ -123,6 +123,27 @@ func (s *ContainerServiceV2) ListContainerStats(ctx context.Context, _ *agentpbv
 	return &agentpbv2.ListContainerStatsResponse{Stats: v2stats}, nil
 }
 
+func (s *ContainerServiceV2) PruneCache(ctx context.Context, req *agentpbv2.PruneCacheRequest) (*agentpbv2.PruneCacheResponse, error) {
+	if s.v1.containerd == nil {
+		return nil, status.Error(codes.FailedPrecondition, "containerd is not available")
+	}
+	pruner, ok := s.v1.containerd.(ContainerdCachePruner)
+	if !ok {
+		return nil, status.Error(codes.Unimplemented, "container cache pruning is not supported")
+	}
+	result, err := pruner.PruneCache(ctx, req.GetDryRun())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to prune container cache: %v", err)
+	}
+	return &agentpbv2.PruneCacheResponse{
+		ContentBlobs:      result.ContentBlobs,
+		ContentBytes:      result.ContentBytes,
+		Snapshots:         result.Snapshots,
+		SnapshotBytes:     result.SnapshotBytes,
+		MinimumAgeSeconds: result.MinimumAgeSeconds,
+	}, nil
+}
+
 // mapAppContainerToV2 converts a v1 AppContainer to its v2 equivalent,
 // mapping the running state enum explicitly (v1 STOPPED=0/RUNNING=1 vs v2 STOPPED=1/RUNNING=2).
 func mapAppContainerToV2(c *agentpb.AppContainer) *agentpbv2.AppContainer {

--- a/go/internal/agent/services/container_service_v2_test.go
+++ b/go/internal/agent/services/container_service_v2_test.go
@@ -62,3 +62,46 @@ func TestContainerServiceV2_ListContainers_Empty(t *testing.T) {
 		t.Errorf("expected EOF for empty list, got %v", err)
 	}
 }
+
+type cachePruningContainerdClient struct {
+	*mockContainerdClient
+	result CachePruneResult
+	dryRun bool
+}
+
+func (c *cachePruningContainerdClient) PruneCache(_ context.Context, dryRun bool) (CachePruneResult, error) {
+	c.dryRun = dryRun
+	return c.result, nil
+}
+
+func TestContainerServiceV2_PruneCache(t *testing.T) {
+	mc := &cachePruningContainerdClient{
+		mockContainerdClient: &mockContainerdClient{},
+		result: CachePruneResult{
+			ContentBlobs: 2, ContentBytes: 30, Snapshots: 4, SnapshotBytes: 50, MinimumAgeSeconds: 3600,
+		},
+	}
+	client, cleanup := startContainerV2Server(t, mc)
+	defer cleanup()
+
+	resp, err := client.PruneCache(context.Background(), &agentpbv2.PruneCacheRequest{DryRun: true})
+	if err != nil {
+		t.Fatalf("PruneCache: %v", err)
+	}
+	if !mc.dryRun {
+		t.Fatal("dry_run was not forwarded")
+	}
+	if resp.GetContentBlobs() != 2 || resp.GetContentBytes() != 30 || resp.GetSnapshots() != 4 || resp.GetSnapshotBytes() != 50 || resp.GetMinimumAgeSeconds() != 3600 {
+		t.Fatalf("response = %+v", resp)
+	}
+}
+
+func TestContainerServiceV2_PruneCacheUnsupported(t *testing.T) {
+	client, cleanup := startContainerV2Server(t, &mockContainerdClient{})
+	defer cleanup()
+
+	_, err := client.PruneCache(context.Background(), &agentpbv2.PruneCacheRequest{})
+	if status.Code(err) != codes.Unimplemented {
+		t.Fatalf("code = %v; want Unimplemented", status.Code(err))
+	}
+}

--- a/go/internal/agent/services/interfaces.go
+++ b/go/internal/agent/services/interfaces.go
@@ -98,6 +98,25 @@ type ContainerdClient interface {
 	GetContainerRestartPolicyLabel(ctx context.Context, appName string) (string, error)
 }
 
+// CachePruneResult describes Wendy-managed container cache pins released by a
+// ContainerdCachePruner. The byte counts are the aggregate sizes of the
+// affected objects, not a promise that all of those bytes are unreachable:
+// containerd keeps anything still referenced by an image or active container.
+type CachePruneResult struct {
+	ContentBlobs      uint64
+	ContentBytes      uint64
+	Snapshots         uint64
+	SnapshotBytes     uint64
+	MinimumAgeSeconds uint64
+}
+
+// ContainerdCachePruner is an optional capability implemented by the real
+// containerd client. It remains separate from ContainerdClient so existing
+// service fakes do not need to implement maintenance operations.
+type ContainerdCachePruner interface {
+	PruneCache(ctx context.Context, dryRun bool) (CachePruneResult, error)
+}
+
 // ContainerExecer is the optional capability to run a process inside a running
 // container with an interactive PTY (docker `exec -it`). The ExecContainer RPC
 // type-asserts for it; a client that does not implement it yields Unimplemented.

--- a/go/internal/cli/assets/docs/development/testing.md
+++ b/go/internal/cli/assets/docs/development/testing.md
@@ -100,7 +100,7 @@ The harness skips a test rather than failing it when the host or device cannot s
 | Tests | Skipped unless |
 | --- | --- |
 | `swift-*` | the build host has a `swiftly` toolchain (checked instead of `swift`, which on macOS is an Xcode shim that exists with no usable toolchain behind it) |
-| `*-gpu` | the device reports `gpuVendor: nvidia` — these are CUDA tests, and `hasGpu` is also true for a non-NVIDIA GPU with a `/dev/dri` node |
+| `*-gpu` | the device reports `gpuVendor: nvidia` and either `gpuArch: sm_87` or no GPU architecture (for compatibility with older agents). The current PyTorch and ONNX fixtures use JetPack-6 / CUDA-12 images built for Orin; CUDA-13 architectures such as Thor's `sm_110` are skipped until their fixtures are hardware-verified. |
 
 #### Stable release gate
 

--- a/go/internal/cli/assets/docs/development/testing.md
+++ b/go/internal/cli/assets/docs/development/testing.md
@@ -100,7 +100,7 @@ The harness skips a test rather than failing it when the host or device cannot s
 | Tests | Skipped unless |
 | --- | --- |
 | `swift-*` | the build host has a `swiftly` toolchain (checked instead of `swift`, which on macOS is an Xcode shim that exists with no usable toolchain behind it) |
-| `*-gpu` | the device reports `gpuVendor: nvidia` and either `gpuArch: sm_87` or no GPU architecture (for compatibility with older agents). The current PyTorch and ONNX fixtures use JetPack-6 / CUDA-12 images built for Orin; CUDA-13 architectures such as Thor's `sm_110` are skipped until their fixtures are hardware-verified. |
+| `*-gpu` | the device reports `gpuVendor: nvidia` and a supported architecture. Orin (`sm_87`) uses the JetPack-6 / CUDA-12 fixtures; Thor (`sm_110`) and Spark (`sm_121`) use Ubuntu-24.04 / CUDA-13 fixtures. An older agent with no architecture uses CUDA 13 when its device type is `jetson-agx-thor` and otherwise retains the CUDA-12 path for compatibility. Other reported architectures are skipped until a matching fixture is hardware-verified. |
 
 #### Stable release gate
 

--- a/go/internal/cli/commands/build.go
+++ b/go/internal/cli/commands/build.go
@@ -218,10 +218,14 @@ func newBuildCmd() *cobra.Command {
 				appID = appCfg.AppID
 			}
 
+			sfOpts := debugStagefileOptions(opts.debug)
+			if cfgErr == nil && selected.Type != "compose" {
+				sfOpts = append(sfOpts, frameworkStagefileOptions(appCfg.Frameworks)...)
+			}
 			return buildProject(cmd.Context(), cwd, selected, appID, platform, opts.builder,
 				resolveGPUArch(cmd.Context(), cwd, opts.gpuArch, agentConn(target)),
 				opts.debug,
-				debugStagefileOptions(opts.debug)...)
+				sfOpts...)
 		},
 	}
 

--- a/go/internal/cli/commands/buildprofile_test.go
+++ b/go/internal/cli/commands/buildprofile_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
 )
 
 const swiftStagefileSource = `version: 1
@@ -26,6 +28,30 @@ func writeSwiftStagefileProject(t *testing.T) string {
 		t.Fatal(err)
 	}
 	return dir
+}
+
+func TestFrameworkStagefileOptionsInjectROS2Middleware(t *testing.T) {
+	dir := t.TempDir()
+	source := `version: 1
+stages:
+  - name: app
+    from: ros:humble-ros-base
+    pin: false
+`
+	if err := os.WriteFile(filepath.Join(dir, stagefileSourceName), []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	frameworks := &appconfig.FrameworksConfig{ROS2: &appconfig.ROS2Config{
+		Distro: "humble",
+		RMW:    "cyclonedds",
+	}}
+	if _, err := compileStagefile(dir, stagefileSourceName, "", frameworkStagefileOptions(frameworks)...); err != nil {
+		t.Fatal(err)
+	}
+	got := generatedDockerfileText(t, dir)
+	if !strings.Contains(got, "'ros-humble-rmw-cyclonedds-cpp'") {
+		t.Fatalf("generated Dockerfile missing framework middleware:\n%s", got)
+	}
 }
 
 func generatedDockerfileText(t *testing.T, dir string) string {

--- a/go/internal/cli/commands/buildprogress.go
+++ b/go/internal/cli/commands/buildprogress.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 )
 
@@ -22,6 +23,7 @@ import (
 var (
 	buildProgressInteractive           = func() bool { return isInteractiveTerminal() }
 	buildProgressOut         io.Writer = os.Stdout
+	buildProgressProgram               = func(model tea.Model) *tea.Program { return tui.NewProgressProgram(model) }
 )
 
 func forceBuildProgressInteractive(v bool) func() {
@@ -98,8 +100,8 @@ func detectBuildxProgressMode(ctx context.Context) string {
 // progress UI (the same renderer used by the buildx/buildctl paths).
 func runAppleContainerBuildWithProgress(ctx context.Context, dir, imageName, platform, dockerfile string) error {
 	title := fmt.Sprintf("Building Apple Container image %s for %s...", tui.Value(imageName), tui.Value(platform))
-	return runBuildWithProgress(ctx, title, dumpRawAlways, func(stream, logw io.Writer) error {
-		return buildImageWithAppleContainer(ctx, dir, imageName, platform, dockerfile, nil, stream, logw)
+	return runBuildWithProgress(ctx, title, dumpRawAlways, func(buildCtx context.Context, stream, logw io.Writer) error {
+		return buildImageWithAppleContainer(buildCtx, dir, imageName, platform, dockerfile, nil, stream, logw)
 	})
 }
 
@@ -119,7 +121,7 @@ func dumpRawUnlessRegistryUnavailable(err error) bool { return !isRegistryUnavai
 // written to logw is buffered and surfaced under the same condition. Callers
 // whose failures can trigger a fallback rebuild (which would replay the same
 // output) use the predicate to stay quiet in exactly those cases.
-func runBuildWithProgress(ctx context.Context, title string, dumpRawOnFailure func(error) bool, build func(stream, logw io.Writer) error) error {
+func runBuildWithProgress(ctx context.Context, title string, dumpRawOnFailure func(error) bool, build func(context.Context, io.Writer, io.Writer) error) error {
 	start := time.Now()
 	raw := &boundedBuffer{max: maxRawBuildCapture}
 	var setupLog bytes.Buffer
@@ -129,7 +131,7 @@ func runBuildWithProgress(ctx context.Context, title string, dumpRawOnFailure fu
 		parser := tui.NewBuildParser(emit)
 		stream := io.MultiWriter(parser, raw)
 		fmt.Fprintf(buildProgressOut, "%s\n", title)
-		err := build(stream, &setupLog)
+		err := build(ctx, stream, &setupLog)
 		stopHeartbeat()
 		if err != nil {
 			if ctx.Err() == nil && dumpRawOnFailure(err) {
@@ -144,29 +146,42 @@ func runBuildWithProgress(ctx context.Context, title string, dumpRawOnFailure fu
 
 	// Interactive: run the steps model while the build streams events to it.
 	m := tui.NewBuildStepsModel(title)
-	prog := tui.NewProgressProgram(m)
+	prog := buildProgressProgram(m)
 	parser := tui.NewBuildParser(func(e tui.BuildStepEvent) {
 		prog.Send(tui.BuildStepMsg(e))
 	})
 	stream := io.MultiWriter(parser, raw)
+	buildCtx, cancelBuild := context.WithCancel(ctx)
+	defer cancelBuild()
 
 	buildErrC := make(chan error, 1)
 	go func() {
-		err := build(stream, &setupLog)
+		err := build(buildCtx, stream, &setupLog)
 		prog.Send(tui.BuildAllDoneMsg{Err: err})
 		buildErrC <- err
 	}()
 
 	final, runErr := prog.Run()
 	if runErr != nil {
+		cancelBuild()
+		<-buildErrC
 		return fmt.Errorf("build progress UI: %w", runErr)
 	}
 	fm, ok := final.(tui.BuildStepsModel)
 	if !ok {
+		cancelBuild()
+		<-buildErrC
 		return fmt.Errorf("build progress UI: unexpected final model %T", final)
 	}
 	if cancelErr := fm.Err(); cancelErr == tui.ErrCancelled {
-		return cancelErr
+		// Bubble Tea consumes SIGINT for its own event loop. Explicitly cancel
+		// the solve as well, then wait for the builder goroutine to exit before
+		// returning. Without this, the UI disappeared while docker/buildctl/
+		// Apple Container kept running and later fallbacks could start another
+		// build after the user had already cancelled.
+		cancelBuild()
+		<-buildErrC
+		return ErrUserCancelled
 	}
 	buildErr := <-buildErrC
 	if buildErr != nil {

--- a/go/internal/cli/commands/buildprogress_test.go
+++ b/go/internal/cli/commands/buildprogress_test.go
@@ -7,7 +7,45 @@ import (
 	"io"
 	"strings"
 	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 )
+
+func TestRunBuildWithProgressCtrlCCancelsAndJoinsBuilder(t *testing.T) {
+	restoreInteractive := forceBuildProgressInteractive(true)
+	defer restoreInteractive()
+	originalProgram := buildProgressProgram
+	defer func() { buildProgressProgram = originalProgram }()
+	buildProgressProgram = func(model tea.Model) *tea.Program {
+		return tui.NewProgressProgram(model,
+			tea.WithInput(strings.NewReader("\x03")),
+			tea.WithOutput(io.Discard),
+		)
+	}
+
+	started := make(chan struct{})
+	exited := make(chan struct{})
+	err := runBuildWithProgress(context.Background(), "Building image...", dumpRawAlways, func(ctx context.Context, _, _ io.Writer) error {
+		close(started)
+		<-ctx.Done()
+		close(exited)
+		return ctx.Err()
+	})
+	if !errors.Is(err, ErrUserCancelled) {
+		t.Fatalf("err = %v, want ErrUserCancelled", err)
+	}
+	select {
+	case <-started:
+	default:
+		t.Fatal("builder never started")
+	}
+	select {
+	case <-exited:
+	default:
+		t.Fatal("runBuildWithProgress returned before the cancelled builder exited")
+	}
+}
 
 func TestRunBuildWithProgressPlainSuccess(t *testing.T) {
 	// Force non-interactive rendering and capture stdout via the package sink.
@@ -17,7 +55,7 @@ func TestRunBuildWithProgressPlainSuccess(t *testing.T) {
 	restoreOut := setBuildProgressOut(&out)
 	defer restoreOut()
 
-	err := runBuildWithProgress(context.Background(), "Building image...", dumpRawAlways, func(stream, logw io.Writer) error {
+	err := runBuildWithProgress(context.Background(), "Building image...", dumpRawAlways, func(_ context.Context, stream, logw io.Writer) error {
 		io.WriteString(stream, "#9 [4/6] RUN pip install\n#9 DONE 4.3s\n")
 		io.WriteString(stream, "#6 [1/6] FROM python\n#6 CACHED\n")
 		return nil
@@ -42,7 +80,7 @@ func TestRunBuildWithProgressPrintsRawOnFailure(t *testing.T) {
 	defer restoreOut()
 
 	wantErr := errors.New("docker buildx build failed")
-	err := runBuildWithProgress(context.Background(), "Building image...", dumpRawAlways, func(stream, logw io.Writer) error {
+	err := runBuildWithProgress(context.Background(), "Building image...", dumpRawAlways, func(_ context.Context, stream, logw io.Writer) error {
 		io.WriteString(stream, "#9 [4/6] RUN pip install\n")
 		io.WriteString(stream, "#9 12.34 ERROR: could not find a version\n")
 		io.WriteString(logw, "[buildx] bootstrapping builder\n")
@@ -69,7 +107,7 @@ func TestRunBuildWithProgressSuppressesRawOnFailureWhenDumpDisabled(t *testing.T
 	defer restoreOut()
 
 	wantErr := errors.New("oci layout build failed")
-	err := runBuildWithProgress(context.Background(), "Building image (OCI layout)...", func(error) bool { return false }, func(stream, logw io.Writer) error {
+	err := runBuildWithProgress(context.Background(), "Building image (OCI layout)...", func(error) bool { return false }, func(_ context.Context, stream, logw io.Writer) error {
 		io.WriteString(stream, "#5 [3/5] RUN apt-get install\n")
 		io.WriteString(stream, "#5 12.34 ERROR: package not found\n")
 		io.WriteString(logw, "[buildx] starting builder instance\n")
@@ -100,7 +138,7 @@ func TestChunkDiffBuildLogDumpedForImageBuildFailureUnderAutoChunking(t *testing
 	defer restoreOut()
 
 	wantErr := &imageBuildFailedError{errors.New("container build (OCI layout) failed: exit status 1")}
-	err := runBuildWithProgress(context.Background(), "Building image (OCI layout)...", shouldDumpChunkDiffBuildLog(chunkingAuto), func(stream, logw io.Writer) error {
+	err := runBuildWithProgress(context.Background(), "Building image (OCI layout)...", shouldDumpChunkDiffBuildLog(chunkingAuto), func(_ context.Context, stream, logw io.Writer) error {
 		io.WriteString(stream, "#5 [3/5] COPY Package.swift .\n")
 		io.WriteString(stream, "#5 ERROR: failed to compute cache key: \"/Package.swift\": not found\n")
 		io.WriteString(logw, "[apple-container] building OCI image: container build --progress plain ...\n")

--- a/go/internal/cli/commands/chunkpush.go
+++ b/go/internal/cli/commands/chunkpush.go
@@ -51,6 +51,7 @@ type chunkIndexProgress struct {
 	reporter chunkIndexProgressWriter
 	current  int64
 	total    int64
+	unknown  int
 	started  time.Time
 	last     time.Time
 }
@@ -74,16 +75,59 @@ func (p *chunkIndexProgress) addProcessed(n int64) {
 	p.reportLocked(now, false)
 }
 
-func (p *chunkIndexProgress) addLayerTotal(rawSize int64) {
-	if p == nil || p.reporter == nil || rawSize <= 0 {
+// startLayer registers a layer before indexing begins. Cache-hit manifests know
+// their uncompressed size up front; cache misses do not, so the aggregate total
+// remains undisclosed until every unknown-size layer has finished. This avoids
+// displaying impossible counters such as 5.0GB/1.3GB while parallel layers are
+// still discovering their raw sizes.
+func (p *chunkIndexProgress) startLayer(knownSize int64) {
+	if p == nil || p.reporter == nil {
 		return
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	// Decompression, DiffID hashing, temp-file output, and CDC hashing now share
-	// one pipelined pass over the raw stream.
-	p.total += rawSize
+	if p.started.IsZero() {
+		p.started = time.Now()
+	}
+	if knownSize > 0 {
+		p.total += knownSize
+	} else {
+		p.unknown++
+	}
 	p.reportLocked(time.Now(), true)
+}
+
+// finishLayer replaces the size reserved by startLayer with the actual raw
+// size. For an initially unknown layer this is the point at which its bytes can
+// safely contribute to the displayed denominator.
+func (p *chunkIndexProgress) finishLayer(knownSize, actualSize int64) {
+	if p == nil || p.reporter == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if knownSize > 0 {
+		p.total += actualSize - knownSize
+	} else {
+		if p.unknown > 0 {
+			p.unknown--
+		}
+		p.total += actualSize
+	}
+	p.reportLocked(time.Now(), true)
+}
+
+func (p *chunkIndexProgress) abortLayer(knownSize int64) {
+	if p == nil || p.reporter == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if knownSize > 0 {
+		p.total -= knownSize
+	} else if p.unknown > 0 {
+		p.unknown--
+	}
 }
 
 func (p *chunkIndexProgress) reportLocked(now time.Time, force bool) {
@@ -96,7 +140,11 @@ func (p *chunkIndexProgress) reportLocked(now time.Time, force bool) {
 	if elapsed := now.Sub(p.started).Seconds(); elapsed > 0 {
 		rate = float64(p.current) / elapsed
 	}
-	p.reporter.ReportChunkIndex(p.current, p.total, rate, false)
+	total := p.total
+	if p.unknown > 0 || p.current > total {
+		total = 0
+	}
+	p.reporter.ReportChunkIndex(p.current, total, rate, false)
 }
 
 func (p *chunkIndexProgress) finish() {
@@ -110,7 +158,11 @@ func (p *chunkIndexProgress) finish() {
 	if elapsed := now.Sub(p.started).Seconds(); elapsed > 0 {
 		rate = float64(p.current) / elapsed
 	}
-	p.reporter.ReportChunkIndex(p.current, p.total, rate, true)
+	total := p.total
+	if p.unknown > 0 || p.current > total {
+		total = 0
+	}
+	p.reporter.ReportChunkIndex(p.current, total, rate, true)
 }
 
 func newChunkTransferProgress(output io.Writer) *chunkTransferProgress {
@@ -306,8 +358,6 @@ func pushLayersByChunksWithPrepareMode(ctx context.Context, cs agentpb.WendyCont
 	if err := resolveGroup.Wait(); err != nil {
 		return nil, err
 	}
-	indexProgress.finish()
-
 	prepareCtx, cancelPrepare := context.WithCancel(ctx)
 	defer cancelPrepare()
 	uploadCtx, cancelUpload := context.WithCancel(ctx)
@@ -337,6 +387,7 @@ func pushLayersByChunksWithPrepareMode(ctx context.Context, cs agentpb.WendyCont
 		})
 	}
 	uploadErr := uploadGroup.Wait()
+	indexProgress.finish()
 	if uploadErr != nil {
 		cancelPrepare()
 		if prepareDone != nil {
@@ -433,6 +484,14 @@ func (r *resolvedChunkLayer) ensureDecompressed(progress *chunkIndexProgress) er
 	if r.dl != nil {
 		return nil
 	}
+	knownSize := r.header.GetSize()
+	progress.startLayer(knownSize)
+	finished := false
+	defer func() {
+		if !finished {
+			progress.abortLayer(knownSize)
+		}
+	}()
 	var lastCompleted int64
 	d, refs, err := decompressAndChunkLayerToTemp(r.l, func(completed int64) {
 		progress.addProcessed(completed - lastCompleted)
@@ -441,7 +500,8 @@ func (r *resolvedChunkLayer) ensureDecompressed(progress *chunkIndexProgress) er
 	if err != nil {
 		return err
 	}
-	progress.addLayerTotal(d.size)
+	progress.finishLayer(knownSize, d.size)
+	finished = true
 	// A cache entry is accepted only for the current chunk algorithm version,
 	// so deterministic re-chunking must reproduce its identity and shape.
 	if got := d.diffID; got != r.header.GetDiffId() {
@@ -469,6 +529,13 @@ func resolveChunkLayer(l localLayer, progress *chunkIndexProgress) (*resolvedChu
 	// same pass, filling dl/refs/diffID/size. Both entry points run the
 	// identical region+FastCDC algorithm, so these hashes match the device's.
 	decompressAndChunk := func() error {
+		progress.startLayer(0)
+		finished := false
+		defer func() {
+			if !finished {
+				progress.abortLayer(0)
+			}
+		}()
 		var lastCompleted int64
 		d, r, err := decompressAndChunkLayerToTemp(l, func(completed int64) {
 			progress.addProcessed(completed - lastCompleted)
@@ -478,7 +545,8 @@ func resolveChunkLayer(l localLayer, progress *chunkIndexProgress) (*resolvedChu
 			return err
 		}
 		dl = d
-		progress.addLayerTotal(d.size)
+		progress.finishLayer(0, d.size)
+		finished = true
 		refs, diffID, size = r, d.diffID, d.size
 		return nil
 	}

--- a/go/internal/cli/commands/chunkpush.go
+++ b/go/internal/cli/commands/chunkpush.go
@@ -3,7 +3,10 @@ package commands
 import (
 	"context"
 	"fmt"
+	"io"
 	"runtime"
+	"sync"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 
@@ -22,6 +25,138 @@ import (
 // already parallelized across cores (chunk.ChunkReaderAt), so this need not
 // equal the core count.
 const maxConcurrentLayerPush = 4
+
+// chunkTransferProgressWriter is implemented by interactive build output
+// adapters that can display chunk-upload bytes directly. Keeping this as an
+// optional extension of io.Writer preserves quiet and non-interactive callers.
+type chunkTransferProgressWriter interface {
+	ReportChunkTransfer(current, total int64, rate float64)
+}
+
+type chunkIndexProgressWriter interface {
+	ReportChunkIndex(current, total int64, rate float64, done bool)
+}
+
+type chunkTransferProgress struct {
+	mu       sync.Mutex
+	reporter chunkTransferProgressWriter
+	current  int64
+	total    int64
+	started  time.Time
+	last     time.Time
+}
+
+type chunkIndexProgress struct {
+	mu       sync.Mutex
+	reporter chunkIndexProgressWriter
+	current  int64
+	total    int64
+	started  time.Time
+	last     time.Time
+}
+
+func newChunkIndexProgress(output io.Writer) *chunkIndexProgress {
+	reporter, _ := output.(chunkIndexProgressWriter)
+	return &chunkIndexProgress{reporter: reporter}
+}
+
+func (p *chunkIndexProgress) addProcessed(n int64) {
+	if p == nil || p.reporter == nil || n <= 0 {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	now := time.Now()
+	if p.started.IsZero() {
+		p.started = now
+	}
+	p.current += n
+	p.reportLocked(now, false)
+}
+
+func (p *chunkIndexProgress) addLayerTotal(rawSize int64) {
+	if p == nil || p.reporter == nil || rawSize <= 0 {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	// Decompression, DiffID hashing, temp-file output, and CDC hashing now share
+	// one pipelined pass over the raw stream.
+	p.total += rawSize
+	p.reportLocked(time.Now(), true)
+}
+
+func (p *chunkIndexProgress) reportLocked(now time.Time, force bool) {
+	const interval = 100 * time.Millisecond
+	if !force && !p.last.IsZero() && now.Sub(p.last) < interval {
+		return
+	}
+	p.last = now
+	rate := float64(0)
+	if elapsed := now.Sub(p.started).Seconds(); elapsed > 0 {
+		rate = float64(p.current) / elapsed
+	}
+	p.reporter.ReportChunkIndex(p.current, p.total, rate, false)
+}
+
+func (p *chunkIndexProgress) finish() {
+	if p == nil || p.reporter == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	now := time.Now()
+	rate := float64(0)
+	if elapsed := now.Sub(p.started).Seconds(); elapsed > 0 {
+		rate = float64(p.current) / elapsed
+	}
+	p.reporter.ReportChunkIndex(p.current, p.total, rate, true)
+}
+
+func newChunkTransferProgress(output io.Writer) *chunkTransferProgress {
+	reporter, _ := output.(chunkTransferProgressWriter)
+	return &chunkTransferProgress{reporter: reporter}
+}
+
+func (p *chunkTransferProgress) addTotal(n int64) {
+	if p == nil || p.reporter == nil || n <= 0 {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.started.IsZero() {
+		p.started = time.Now()
+	}
+	p.total += n
+	p.reportLocked(time.Now(), true)
+}
+
+func (p *chunkTransferProgress) addSent(n int64) {
+	if p == nil || p.reporter == nil || n <= 0 {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	now := time.Now()
+	if p.started.IsZero() {
+		p.started = now
+	}
+	p.current += n
+	p.reportLocked(now, p.current >= p.total)
+}
+
+func (p *chunkTransferProgress) reportLocked(now time.Time, force bool) {
+	const interval = 100 * time.Millisecond
+	if !force && !p.last.IsZero() && now.Sub(p.last) < interval {
+		return
+	}
+	p.last = now
+	rate := float64(0)
+	if elapsed := now.Sub(p.started).Seconds(); elapsed > 0 {
+		rate = float64(p.current) / elapsed
+	}
+	p.reporter.ReportChunkTransfer(p.current, p.total, rate)
+}
 
 // pushLayersByChunks implements chunk-diff layer push for a set of OCI layers,
 // processing up to maxConcurrentLayerPush layers concurrently. For each layer it:
@@ -50,12 +185,44 @@ func pushLayersByChunks(ctx context.Context, cs agentpb.WendyContainerServiceCli
 // preparation is complete (or the context is cancelled).
 type imagePrepareFunc func(context.Context, []*agentpb.RunContainerLayerHeader) error
 
+// blocksChunkPrepareFallback marks integrity and identity failures that must
+// not be retried through a transport with a different trust boundary.
+func blocksChunkPrepareFallback(err error) bool {
+	switch status.Code(err) {
+	case codes.InvalidArgument, codes.FailedPrecondition, codes.DataLoss,
+		codes.PermissionDenied, codes.Unauthenticated:
+		return true
+	default:
+		return false
+	}
+}
+
 // pushLayersByChunksWithPrepare resolves every layer manifest first, then runs
 // prepare concurrently with missing-chunk upload. The short resolution barrier
 // is necessary because the agent must authenticate the image config (which
 // binds the ordered diff IDs) and know each layer's chunk set before it can
 // safely create persistent snapshots.
 func pushLayersByChunksWithPrepare(ctx context.Context, cs agentpb.WendyContainerServiceClient, layers []localLayer, prepare imagePrepareFunc) ([]*agentpb.RunContainerLayerHeader, error) {
+	return pushLayersByChunksWithPrepareOutput(ctx, cs, layers, prepare, nil)
+}
+
+// pushLayersByChunksWithPrepareOutput is the writer-aware form used while a
+// live build renderer owns the terminal. Status goes through output instead of
+// printing over Bubble Tea's frame. A nil output preserves the ordinary CLI
+// behavior for callers without a live renderer.
+func pushLayersByChunksWithPrepareOutput(ctx context.Context, cs agentpb.WendyContainerServiceClient, layers []localLayer, prepare imagePrepareFunc, output io.Writer) ([]*agentpb.RunContainerLayerHeader, error) {
+	return pushLayersByChunksWithPrepareMode(ctx, cs, layers, prepare, output, false)
+}
+
+// pushLayersByChunksWithStrictPrepareOutput is for callers, such as Compose,
+// that will create a container by image name after this function returns. They
+// cannot use the single-container path's lenient "finish during RunContainer"
+// behavior: PrepareImage must have registered the named image first.
+func pushLayersByChunksWithStrictPrepareOutput(ctx context.Context, cs agentpb.WendyContainerServiceClient, layers []localLayer, prepare imagePrepareFunc, output io.Writer) ([]*agentpb.RunContainerLayerHeader, error) {
+	return pushLayersByChunksWithPrepareMode(ctx, cs, layers, prepare, output, true)
+}
+
+func pushLayersByChunksWithPrepareMode(ctx context.Context, cs agentpb.WendyContainerServiceClient, layers []localLayer, prepare imagePrepareFunc, output io.Writer, strictPrepare bool) ([]*agentpb.RunContainerLayerHeader, error) {
 	headers := make([]*agentpb.RunContainerLayerHeader, len(layers))
 
 	// Capability probe: a single empty QueryChunks tells us whether the agent
@@ -70,7 +237,7 @@ func pushLayersByChunksWithPrepare(ctx context.Context, cs agentpb.WendyContaine
 	// can skip them entirely. A layer the device already holds yields no dedup, so
 	// decompressing and content-chunking it would be pure waste. Degrades to
 	// chunking every layer when the agent is too old or the query fails.
-	present := queryPresentLayers(ctx, cs, layers)
+	present := queryPresentLayers(ctx, cs, layers, output)
 
 	// Build the present-layer headers up front and collect the indices that still
 	// need a chunk-diff push. A present-layer header carries no chunk hashes, so
@@ -98,7 +265,7 @@ func pushLayersByChunksWithPrepare(ctx context.Context, cs agentpb.WendyContaine
 		toPush = append(toPush, i)
 	}
 	if skipped > 0 {
-		cliLogln("Reusing %s layer(s) already on device; chunking %s.",
+		chunkPushLogln(output, "Reusing %s layer(s) already on device; chunking %s.",
 			tui.Value(fmt.Sprintf("%d", skipped)), tui.Value(fmt.Sprintf("%d", len(toPush))))
 	}
 	limit := maxConcurrentLayerPush
@@ -113,6 +280,8 @@ func pushLayersByChunksWithPrepare(ctx context.Context, cs agentpb.WendyContaine
 	}
 
 	resolved := make([]*resolvedChunkLayer, len(layers))
+	indexProgress := newChunkIndexProgress(output)
+	transferProgress := newChunkTransferProgress(output)
 	defer func() {
 		for _, r := range resolved {
 			if r != nil {
@@ -125,7 +294,7 @@ func pushLayersByChunksWithPrepare(ctx context.Context, cs agentpb.WendyContaine
 	for _, idx := range toPush {
 		idx, l := idx, layers[idx]
 		resolveGroup.Go(func() error {
-			r, err := resolveChunkLayer(l)
+			r, err := resolveChunkLayer(l, indexProgress)
 			if err != nil {
 				return err
 			}
@@ -137,6 +306,7 @@ func pushLayersByChunksWithPrepare(ctx context.Context, cs agentpb.WendyContaine
 	if err := resolveGroup.Wait(); err != nil {
 		return nil, err
 	}
+	indexProgress.finish()
 
 	prepareCtx, cancelPrepare := context.WithCancel(ctx)
 	defer cancelPrepare()
@@ -153,7 +323,7 @@ func pushLayersByChunksWithPrepare(ctx context.Context, cs agentpb.WendyContaine
 	for _, idx := range toPush {
 		r := resolved[idx]
 		uploadGroup.Go(func() error {
-			return r.upload(uploadCtx, cs)
+			return r.upload(uploadCtx, cs, indexProgress, transferProgress)
 		})
 	}
 	if err := uploadGroup.Wait(); err != nil {
@@ -166,6 +336,9 @@ func pushLayersByChunksWithPrepare(ctx context.Context, cs agentpb.WendyContaine
 
 	if prepareDone != nil {
 		if err := <-prepareDone; err != nil {
+			if strictPrepare {
+				return nil, err
+			}
 			switch status.Code(err) {
 			case codes.InvalidArgument, codes.FailedPrecondition, codes.DataLoss, codes.PermissionDenied, codes.Unauthenticated:
 				// Security failures must not silently fall through to the registry
@@ -176,7 +349,7 @@ func pushLayersByChunksWithPrepare(ctx context.Context, cs agentpb.WendyContaine
 			default:
 				// Preparation is an optimization. RunContainer repeats all work
 				// idempotently and remains the authoritative error path.
-				cliLogln("Image prewarming unavailable (%v); finishing during start.", err)
+				chunkPushLogln(output, "Image prewarming unavailable (%v); finishing during start.", err)
 			}
 		}
 	}
@@ -188,7 +361,7 @@ func pushLayersByChunksWithPrepare(ctx context.Context, cs agentpb.WendyContaine
 // known diff ID are not queried. The pre-check is a pure optimization: an agent
 // too old to implement QueryLayers (Unimplemented), or any query error, yields a
 // nil map so the caller chunks every layer as before.
-func queryPresentLayers(ctx context.Context, cs agentpb.WendyContainerServiceClient, layers []localLayer) map[string]int64 {
+func queryPresentLayers(ctx context.Context, cs agentpb.WendyContainerServiceClient, layers []localLayer, output io.Writer) map[string]int64 {
 	diffIDs := make([]string, 0, len(layers))
 	for _, l := range layers {
 		if l.DiffID != "" {
@@ -204,7 +377,7 @@ func queryPresentLayers(ctx context.Context, cs agentpb.WendyContainerServiceCli
 			// The agent supports chunk-diff (the probe succeeded) but the layer
 			// pre-check failed for another reason; chunk everything rather than
 			// abort the deploy over a missed optimization.
-			cliLogln("Layer pre-check unavailable (%v); chunking all layers.", err)
+			chunkPushLogln(output, "Layer pre-check unavailable (%v); chunking all layers.", err)
 		}
 		return nil
 	}
@@ -213,6 +386,14 @@ func queryPresentLayers(ctx context.Context, cs agentpb.WendyContainerServiceCli
 		out[p.GetDiffId()] = p.GetSize()
 	}
 	return out
+}
+
+func chunkPushLogln(output io.Writer, format string, args ...any) {
+	if output == nil {
+		cliLogln(format, args...)
+		return
+	}
+	fmt.Fprintln(output, cliStyle.Render(fmt.Sprintf(format, args...)))
 }
 
 // pushLayerByChunks runs the chunk-diff push for a single layer and returns its
@@ -235,19 +416,19 @@ func (r *resolvedChunkLayer) close() {
 // ensureDecompressed materializes and chunks a cache-hit layer only when the
 // device reports missing chunk bytes. Cache misses already did this during
 // manifest resolution and retain the temporary file through upload.
-func (r *resolvedChunkLayer) ensureDecompressed() error {
+func (r *resolvedChunkLayer) ensureDecompressed(progress *chunkIndexProgress) error {
 	if r.dl != nil {
 		return nil
 	}
-	d, err := decompressLayerToTemp(r.l)
+	var lastCompleted int64
+	d, refs, err := decompressAndChunkLayerToTemp(r.l, func(completed int64) {
+		progress.addProcessed(completed - lastCompleted)
+		lastCompleted = completed
+	})
 	if err != nil {
 		return err
 	}
-	refs, err := chunk.ChunkReaderAt(d.f, d.size)
-	if err != nil {
-		d.Close()
-		return err
-	}
+	progress.addLayerTotal(d.size)
 	// A cache entry is accepted only for the current chunk algorithm version,
 	// so deterministic re-chunking must reproduce its identity and shape.
 	if got := d.diffID; got != r.header.GetDiffId() {
@@ -262,7 +443,7 @@ func (r *resolvedChunkLayer) ensureDecompressed() error {
 	return nil
 }
 
-func resolveChunkLayer(l localLayer) (*resolvedChunkLayer, error) {
+func resolveChunkLayer(l localLayer, progress *chunkIndexProgress) (*resolvedChunkLayer, error) {
 	var (
 		diffID        string
 		size          int64
@@ -271,20 +452,20 @@ func resolveChunkLayer(l localLayer) (*resolvedChunkLayer, error) {
 		refs          []chunk.Ref        // chunk offsets into dl; populated alongside dl
 	)
 
-	// decompressAndChunk spills the layer to a temp file and chunks it, filling
-	// dl/refs/diffID/size. Both entry points (CLI here and the agent) run the
+	// decompressAndChunk streams the layer to a temp file and chunks it in the
+	// same pass, filling dl/refs/diffID/size. Both entry points run the
 	// identical region+FastCDC algorithm, so these hashes match the device's.
 	decompressAndChunk := func() error {
-		d, err := decompressLayerToTemp(l)
+		var lastCompleted int64
+		d, r, err := decompressAndChunkLayerToTemp(l, func(completed int64) {
+			progress.addProcessed(completed - lastCompleted)
+			lastCompleted = completed
+		})
 		if err != nil {
 			return err
 		}
 		dl = d
-		r, err := chunk.ChunkReaderAt(d.f, d.size)
-		if err != nil {
-			d.Close()
-			return err
-		}
+		progress.addLayerTotal(d.size)
 		refs, diffID, size = r, d.diffID, d.size
 		return nil
 	}
@@ -317,7 +498,7 @@ func resolveChunkLayer(l localLayer) (*resolvedChunkLayer, error) {
 	}, nil
 }
 
-func (r *resolvedChunkLayer) upload(ctx context.Context, cs agentpb.WendyContainerServiceClient) error {
+func (r *resolvedChunkLayer) upload(ctx context.Context, cs agentpb.WendyContainerServiceClient, indexProgress *chunkIndexProgress, transferProgress *chunkTransferProgress) error {
 	orderedHashes := r.header.GetChunkHashes()
 	qresp, err := cs.QueryChunks(ctx, &agentpb.QueryChunksRequest{ChunkHashes: orderedHashes})
 	if err != nil {
@@ -336,9 +517,16 @@ func (r *resolvedChunkLayer) upload(ctx context.Context, cs agentpb.WendyContain
 		// reproduces the exact hashes in `missing` only because chunking is
 		// deterministic and loadManifestCache rejects manifests from a different
 		// AlgoVersion — so the cached hashes always match what ChunkReaderAt emits.
-		if err := r.ensureDecompressed(); err != nil {
+		if err := r.ensureDecompressed(indexProgress); err != nil {
 			return err
 		}
+		var missingBytes int64
+		for _, ref := range r.refs {
+			if missing[ref.Hash] {
+				missingBytes += int64(ref.Len)
+			}
+		}
+		transferProgress.addTotal(missingBytes)
 		wc, err := cs.WriteChunks(ctx)
 		if err != nil {
 			return err
@@ -358,6 +546,7 @@ func (r *resolvedChunkLayer) upload(ctx context.Context, cs agentpb.WendyContain
 			}); err != nil {
 				return err
 			}
+			transferProgress.addSent(int64(len(buf)))
 		}
 		if _, err := wc.CloseAndRecv(); err != nil {
 			return err
@@ -367,12 +556,12 @@ func (r *resolvedChunkLayer) upload(ctx context.Context, cs agentpb.WendyContain
 }
 
 func pushLayerByChunks(ctx context.Context, cs agentpb.WendyContainerServiceClient, l localLayer) (*agentpb.RunContainerLayerHeader, error) {
-	r, err := resolveChunkLayer(l)
+	r, err := resolveChunkLayer(l, nil)
 	if err != nil {
 		return nil, err
 	}
 	defer r.close()
-	if err := r.upload(ctx, cs); err != nil {
+	if err := r.upload(ctx, cs, nil, nil); err != nil {
 		return nil, err
 	}
 	return r.header, nil

--- a/go/internal/cli/commands/chunkpush_test.go
+++ b/go/internal/cli/commands/chunkpush_test.go
@@ -14,6 +14,30 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+func TestPushLayersByChunksRoutesStatusToOutput(t *testing.T) {
+	diffID := "sha256:" + strings.Repeat("ab", 32)
+	fake := &fakeContainerClient{
+		queryFn: func(*agentpb.QueryChunksRequest) *agentpb.QueryChunksResponse {
+			return &agentpb.QueryChunksResponse{}
+		},
+		queryLayersFn: func(*agentpb.QueryLayersRequest) *agentpb.QueryLayersResponse {
+			return &agentpb.QueryLayersResponse{
+				Present: []*agentpb.PresentLayer{{DiffId: diffID, Size: 4096}},
+			}
+		},
+	}
+	var output bytes.Buffer
+	_, err := pushLayersByChunksWithPrepareOutput(context.Background(), fake, []localLayer{{
+		DiffID: diffID,
+	}}, nil, &output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := output.String(); !strings.Contains(got, "Reusing 1 layer(s) already on device; chunking 0.") {
+		t.Fatalf("routed status = %q", got)
+	}
+}
+
 // fakeContainerClient satisfies agentpb.WendyContainerServiceClient via the
 // embedded-interface trick. Only QueryChunks, QueryLayers, and WriteChunks are
 // overridden; all other methods panic (they must not be called by
@@ -92,6 +116,28 @@ func TestPushLayersByChunksPrepareUnimplementedFallsBack(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("Unimplemented preparation must fall back to RunContainer, got %v", err)
+	}
+}
+
+func TestPushLayersByChunksStrictPrepareReturnsUnimplemented(t *testing.T) {
+	manifestCacheTestDir = t.TempDir()
+	t.Cleanup(func() { manifestCacheTestDir = "" })
+
+	layerTar := []byte("already available layer")
+	fake := &fakeContainerClient{
+		queryFn: func(*agentpb.QueryChunksRequest) *agentpb.QueryChunksResponse {
+			return &agentpb.QueryChunksResponse{}
+		},
+	}
+	_, err := pushLayersByChunksWithStrictPrepareOutput(context.Background(), fake, []localLayer{{
+		Digest:    "sha256:" + sha256Hex(layerTar),
+		MediaType: "application/vnd.oci.image.layer.v1.tar",
+		Blob:      layerTar,
+	}}, func(context.Context, []*agentpb.RunContainerLayerHeader) error {
+		return status.Error(codes.Unimplemented, "old agent")
+	}, nil)
+	if status.Code(err) != codes.Unimplemented {
+		t.Fatalf("strict preparation error = %v, want Unimplemented", err)
 	}
 }
 

--- a/go/internal/cli/commands/chunkpush_test.go
+++ b/go/internal/cli/commands/chunkpush_test.go
@@ -3,17 +3,83 @@ package commands
 import (
 	"bytes"
 	"context"
+	"io"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/go/internal/shared/chunk"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+type chunkProgressRecorder struct {
+	io.Writer
+	events []tui.BuildStepEvent
+}
+
+func (r *chunkProgressRecorder) ReportChunkIndex(current, total int64, rate float64, done bool) {
+	status := tui.BuildStepRunning
+	if done {
+		status = tui.BuildStepDone
+	}
+	r.events = append(r.events, tui.BuildStepEvent{
+		Status: status,
+		Bytes:  tui.ByteProgress{Current: current, Total: total, Rate: rate},
+	})
+}
+
+func TestChunkIndexProgressDoesNotReportPartialTotal(t *testing.T) {
+	recorder := &chunkProgressRecorder{Writer: io.Discard}
+	progress := newChunkIndexProgress(recorder)
+
+	progress.startLayer(100)
+	progress.addProcessed(100)
+	progress.startLayer(0)
+	progress.last = time.Time{} // bypass the live-update throttle for this assertion
+	progress.addProcessed(50)
+
+	last := recorder.events[len(recorder.events)-1]
+	if last.Bytes.Current != 150 || last.Bytes.Total != 0 {
+		t.Fatalf("progress with unknown layer = %d/%d, want 150/unknown", last.Bytes.Current, last.Bytes.Total)
+	}
+
+	progress.finishLayer(0, 50)
+	last = recorder.events[len(recorder.events)-1]
+	if last.Bytes.Current != 150 || last.Bytes.Total != 150 {
+		t.Fatalf("progress after sizes resolve = %d/%d, want 150/150", last.Bytes.Current, last.Bytes.Total)
+	}
+}
+
+func TestComposeChunkProgressKeepsUploadVisible(t *testing.T) {
+	var events []tui.BuildStepEvent
+	w := &composeBuildProgressWriter{
+		Writer: io.Discard,
+		emit:   func(e tui.BuildStepEvent) { events = append(events, e) },
+	}
+
+	w.ReportChunkIndex(50, 100, 10, false)
+	w.ReportChunkTransfer(10, 100, 5)
+	w.ReportChunkIndex(75, 100, 10, false)
+	w.ReportChunkIndex(100, 100, 10, true)
+
+	if len(events) != 3 {
+		t.Fatalf("emitted %d events, want initial index, upload, and index completion", len(events))
+	}
+	if events[0].Display != "indexing changed layer content" || events[0].Kind != tui.BuildVertexSetup {
+		t.Fatalf("first event = %#v, want indexing setup event", events[0])
+	}
+	if events[1].Display != "uploading missing chunks" || events[1].Status != tui.BuildStepRunning {
+		t.Fatalf("second event = %#v, want running upload", events[1])
+	}
+	if events[2].Status != tui.BuildStepDone {
+		t.Fatalf("third event = %#v, want index completion", events[2])
+	}
+}
 
 func TestPushLayersByChunksRoutesStatusToOutput(t *testing.T) {
 	diffID := "sha256:" + strings.Repeat("ab", 32)

--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -98,14 +99,47 @@ type composeBuildJob struct {
 	buildArgs  map[string]string
 }
 
+type composeBuildProgressWriter struct {
+	io.Writer
+	emit func(tui.BuildStepEvent)
+}
+
+func (w *composeBuildProgressWriter) ReportChunkTransfer(current, total int64, rate float64) {
+	w.emit(tui.BuildStepEvent{
+		ID:      "chunk-upload",
+		Kind:    tui.BuildVertexExport,
+		Display: "uploading missing chunks",
+		Status:  tui.BuildStepRunning,
+		Bytes:   tui.ByteProgress{Current: current, Total: total, Rate: rate},
+	})
+}
+
+func (w *composeBuildProgressWriter) ReportChunkIndex(current, total int64, rate float64, done bool) {
+	status := tui.BuildStepRunning
+	if done {
+		status = tui.BuildStepDone
+	}
+	w.emit(tui.BuildStepEvent{
+		ID:      "chunk-index",
+		Kind:    tui.BuildVertexStep,
+		Display: "indexing changed layer content",
+		Status:  status,
+		Bytes:   tui.ByteProgress{Current: current, Total: total, Rate: rate},
+	})
+}
+
 // buildComposeServiceImage is replaceable in tests so the parallel scheduler
 // can be exercised without Docker or a device registry.
-var buildComposeServiceImage = buildAndPushImageForAgent
+var buildComposeServiceImage = buildAndPrepareComposeImageForAgent
 
-// buildComposeServicesParallel runs independent Compose build-and-push jobs
-// concurrently. A Wendy image push is part of the BuildKit invocation, so this
-// also means another service can start building while an earlier one uploads.
-func buildComposeServicesParallel(ctx context.Context, conn *grpcclient.AgentConnection, regPort int, agentOS, builder, platform string, jobs map[string]composeBuildJob, maxConcurrency int) (map[string]error, error) {
+// buildComposeServicesParallel runs independent Compose image jobs
+// concurrently. By default each job builds a persistent OCI layout and sends
+// only content chunks the device does not already have; --chunking=off keeps
+// the registry-push path for compatibility.
+func buildComposeServicesParallel(ctx context.Context, conn *grpcclient.AgentConnection, regPort int, agentOS, builder, platform, chunking string, jobs map[string]composeBuildJob, maxConcurrency int, quietBuild bool) (map[string]error, error) {
+	buildCtx, cancelBuild := context.WithCancel(ctx)
+	defer cancelBuild()
+
 	names := make([]string, 0, len(jobs))
 	for name := range jobs {
 		names = append(names, name)
@@ -116,7 +150,7 @@ func buildComposeServicesParallel(ctx context.Context, conn *grpcclient.AgentCon
 	}
 
 	concurrency := resolveBuildConcurrency(len(names), maxConcurrency)
-	if maxConcurrency > 0 && concurrency < len(names) {
+	if !quietBuild && maxConcurrency > 0 && concurrency < len(names) {
 		cliLogln("Building up to %d service(s) at a time (--max-concurrency).", concurrency)
 	}
 
@@ -129,7 +163,7 @@ func buildComposeServicesParallel(ctx context.Context, conn *grpcclient.AgentCon
 	sem := make(chan struct{}, concurrency)
 
 	var prog *tea.Program
-	if isInteractiveTerminal() {
+	if !quietBuild && isInteractiveTerminal() {
 		prog = tui.NewProgressProgram(tui.NewMultiSpinner(fmt.Sprintf("Building %d Compose service(s)...", len(names)), names))
 	}
 
@@ -139,12 +173,21 @@ func buildComposeServicesParallel(ctx context.Context, conn *grpcclient.AgentCon
 		wg.Add(1)
 		go func(name string, job composeBuildJob) {
 			defer wg.Done()
-			sem <- struct{}{}
+			select {
+			case sem <- struct{}{}:
+			case <-buildCtx.Done():
+				results <- result{name: name, err: buildCtx.Err()}
+				return
+			}
 			defer func() { <-sem }()
+			if err := buildCtx.Err(); err != nil {
+				results <- result{name: name, err: err}
+				return
+			}
 
 			if prog != nil {
 				prog.Send(tui.MultiSpinnerStartMsg{Name: name})
-			} else {
+			} else if !quietBuild {
 				cliLogln("Building service %s for %s...", name, tui.Value(platform))
 			}
 
@@ -156,21 +199,37 @@ func buildComposeServicesParallel(ctx context.Context, conn *grpcclient.AgentCon
 			if prog != nil {
 				emit, getTally := newServiceProgressEmitter(prog, name)
 				tally = getTally
-				buildOut = io.MultiWriter(tui.NewBuildParser(emit), &logBuf)
+				buildOut = &composeBuildProgressWriter{
+					Writer: io.MultiWriter(tui.NewBuildParser(emit), &logBuf),
+					emit:   emit,
+				}
+				logOut = &logBuf
+			} else if quietBuild {
+				buildOut = &logBuf
 				logOut = &logBuf
 			}
 
 			// The repo also scopes buildx's local cache export. Concurrent writers
 			// must not share that directory; BuildKit cache mounts inside the
 			// builder (APT, pip, etc.) remain shared by their explicit mount IDs.
-			err := buildComposeServiceImage(ctx, conn, regPort, agentOS, builder, job.contextDir, job.repo, platform, job.dockerfile, job.buildArgs, job.repo, buildOut, logOut)
+			buildImage := buildComposeServiceImage
+			if chunking == chunkingOff {
+				buildImage = buildAndPushImageForAgent
+			} else if chunking == chunkingForce {
+				buildImage = buildAndPrepareComposeImageForAgentForce
+			}
+			err := buildImage(buildCtx, conn, regPort, agentOS, builder, job.contextDir, job.repo, platform, job.dockerfile, job.buildArgs, job.repo, buildOut, logOut)
 			dur := time.Since(start)
 			if prog != nil {
 				t := tally()
 				prog.Send(tui.MultiSpinnerDoneMsg{Name: name, Err: err, Dur: dur, Cached: t.Cached, Rebuilt: t.Rebuilt})
 			} else if err != nil {
-				cliLogln("Service %s build failed: %v", name, err)
-			} else {
+				if buildCtx.Err() == nil {
+					if !quietBuild {
+						cliLogln("Service %s build failed: %v", name, err)
+					}
+				}
+			} else if !quietBuild {
 				cliLogln("Service %s built (%s).", name, dur.Round(time.Millisecond))
 			}
 			results <- result{name: name, err: err, log: logBuf.String()}
@@ -185,9 +244,18 @@ func buildComposeServicesParallel(ctx context.Context, conn *grpcclient.AgentCon
 		}
 	}()
 
+	var progressErr error
 	if prog != nil {
-		if _, err := prog.Run(); err != nil {
-			return nil, fmt.Errorf("compose build progress TUI: %w", err)
+		final, runErr := prog.Run()
+		if runErr != nil {
+			cancelBuild()
+			progressErr = fmt.Errorf("compose build progress TUI: %w", runErr)
+		} else if fm, ok := final.(tui.MultiSpinnerModel); !ok {
+			cancelBuild()
+			progressErr = fmt.Errorf("compose build progress TUI: unexpected final model %T", final)
+		} else if errors.Is(fm.Err(), tui.ErrCancelled) {
+			cancelBuild()
+			progressErr = ErrUserCancelled
 		}
 	}
 
@@ -197,9 +265,15 @@ func buildComposeServicesParallel(ctx context.Context, conn *grpcclient.AgentCon
 			continue
 		}
 		failed[r.name] = r.err
-		if r.log != "" && !isRegistryUnavailable(r.err) {
+		if progressErr == nil && buildCtx.Err() == nil && r.log != "" && !isRegistryUnavailable(r.err) {
 			fmt.Fprintf(os.Stderr, "\n[%s] build log:\n%s", r.name, r.log)
 		}
+	}
+	if progressErr != nil {
+		return nil, progressErr
+	}
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
 	}
 	return failed, nil
 }
@@ -335,6 +409,14 @@ func composeStagefileOverride(dir, gpuArch string, sfOpts ...stagefile.Option) (
 	if err != nil {
 		return "", nil, err
 	}
+	companion, _, err := appconfig.LoadComposeCompanion(dir)
+	if err != nil {
+		return "", nil, fmt.Errorf("companion wendy.json: %w", err)
+	}
+	serviceConfigs, _, err := buildComposeServiceConfigs(strings.ToLower(filepath.Base(dir)), cfg, companion)
+	if err != nil {
+		return "", nil, err
+	}
 	overrides := map[string]any{}
 	for name, svc := range cfg.Services {
 		ctxDir, dockerfile, _, err := composeBuildContext(svc, dir)
@@ -344,7 +426,9 @@ func composeStagefileOverride(dir, gpuArch string, sfOpts ...stagefile.Option) (
 		if ctxDir == "" || !stagefile.IsSourceName(dockerfile) {
 			continue
 		}
-		compiled, err := prepareDockerBuildFile(ctxDir, dockerfile, gpuArch, sfOpts...)
+		serviceOpts := append([]stagefile.Option{}, sfOpts...)
+		serviceOpts = append(serviceOpts, frameworkStagefileOptions(serviceConfigs[name].Frameworks)...)
+		compiled, err := prepareDockerBuildFile(ctxDir, dockerfile, gpuArch, serviceOpts...)
 		if err != nil {
 			return "", nil, fmt.Errorf("service %s: %w", name, err)
 		}
@@ -924,8 +1008,8 @@ func (w *serviceLogWriter) Flush() {
 }
 
 // runComposeWithAgent orchestrates a docker-compose project on a WendyOS device:
-// builds service images, pushes them to the device registry, creates containers,
-// and streams their combined output. When a companion wendy.json exists in the
+// builds and prepares service images, creates containers, and streams their
+// combined output. When a companion wendy.json exists in the
 // same directory it is merged to supply Wendy-specific config (entitlements,
 // isolation, frameworks) without modifying the compose file.
 func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, projectDir string, opts runOptions) error {
@@ -1041,12 +1125,14 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 			allBuildArgs[k] = v
 		}
 
+		appCfg := svcCfgs[name]
 		imageIdentity := normalizeImageRef(svc.Image)
 		if ctxDir != "" {
 			// Compile a Stagefile (or apply safe in-memory Dockerfile fixes) the
 			// same way the single-service path does — docker build itself knows
 			// nothing about build.stagefile.yaml.
-			if dockerfile, err = prepareDockerBuildFile(ctxDir, dockerfile, gpuArch, debugStagefileOptions(opts.debug)...); err != nil {
+			sfOpts := append(debugStagefileOptions(opts.debug), frameworkStagefileOptions(appCfg.Frameworks)...)
+			if dockerfile, err = prepareDockerBuildFile(ctxDir, dockerfile, gpuArch, sfOpts...); err != nil {
 				return fmt.Errorf("service %s: %w", name, err)
 			}
 			imageIdentity, err = computeBuildInputHash(ctxDir, dockerfile, platform, allBuildArgs, composeEnv(svc))
@@ -1055,7 +1141,6 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 			}
 		}
 
-		appCfg := svcCfgs[name]
 		restartPolicy := resolveRestartPolicy(opts)
 		if restartPolicy.GetMode() == agentpb.RestartPolicyMode_DEFAULT && svc.Restart != "" {
 			restartPolicy = composeRestartPolicy(svc.Restart)
@@ -1088,7 +1173,7 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 		cliLogln("%d of %d Compose services unchanged and running; leaving them untouched.", n, len(cfg.Services))
 	}
 
-	failedBuilds, err := buildComposeServicesParallel(ctx, conn, regPort, agentOS, opts.builder, platform, jobs, opts.maxConcurrency)
+	failedBuilds, err := buildComposeServicesParallel(ctx, conn, regPort, agentOS, opts.builder, platform, opts.chunking, jobs, opts.maxConcurrency, opts.quietBuild)
 	if err != nil {
 		return err
 	}

--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -101,10 +101,15 @@ type composeBuildJob struct {
 
 type composeBuildProgressWriter struct {
 	io.Writer
-	emit func(tui.BuildStepEvent)
+	emit          func(tui.BuildStepEvent)
+	progressMu    sync.Mutex
+	uploadStarted bool
 }
 
 func (w *composeBuildProgressWriter) ReportChunkTransfer(current, total int64, rate float64) {
+	w.progressMu.Lock()
+	defer w.progressMu.Unlock()
+	w.uploadStarted = true
 	w.emit(tui.BuildStepEvent{
 		ID:      "chunk-upload",
 		Kind:    tui.BuildVertexExport,
@@ -119,9 +124,18 @@ func (w *composeBuildProgressWriter) ReportChunkIndex(current, total int64, rate
 	if done {
 		status = tui.BuildStepDone
 	}
+	w.progressMu.Lock()
+	defer w.progressMu.Unlock()
+	// Indexing and upload intentionally overlap across layers. The Compose TUI
+	// has one detail line per service, so once upload begins it is the more useful
+	// signal and late index updates must not repeatedly replace it. Still forward
+	// the terminal event so consumers can close the synthetic index step.
+	if w.uploadStarted && status == tui.BuildStepRunning {
+		return
+	}
 	w.emit(tui.BuildStepEvent{
 		ID:      "chunk-index",
-		Kind:    tui.BuildVertexStep,
+		Kind:    tui.BuildVertexSetup,
 		Display: "indexing changed layer content",
 		Status:  status,
 		Bytes:   tui.ByteProgress{Current: current, Total: total, Rate: rate},

--- a/go/internal/cli/commands/compose_test.go
+++ b/go/internal/cli/commands/compose_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -52,7 +53,7 @@ func TestBuildComposeServicesParallelOverlapsBuildAndPush(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		failed, err := buildComposeServicesParallel(context.Background(), nil, 5000, "linux", "docker", "linux/arm64", jobs, count)
+		failed, err := buildComposeServicesParallel(context.Background(), nil, 5000, "linux", "docker", "linux/arm64", chunkingAuto, jobs, count, false)
 		if err == nil && len(failed) != 0 {
 			err = joinServiceErrors(failed)
 		}
@@ -72,6 +73,108 @@ func TestBuildComposeServicesParallelOverlapsBuildAndPush(t *testing.T) {
 		if cacheKeys[job.repo] != job.repo {
 			t.Errorf("repo %q used cache key %q; concurrent exports need per-service isolation", job.repo, cacheKeys[job.repo])
 		}
+	}
+}
+
+func TestBuildComposeServicesParallelCancellationDoesNotStartQueuedBuilds(t *testing.T) {
+	originalBuild := buildComposeServiceImage
+	originalInteractive := isInteractiveTerminalFn
+	t.Cleanup(func() {
+		buildComposeServiceImage = originalBuild
+		isInteractiveTerminalFn = originalInteractive
+	})
+	isInteractiveTerminalFn = func() bool { return false }
+
+	jobs := map[string]composeBuildJob{}
+	for _, name := range []string{"a", "b", "c", "d"} {
+		jobs[name] = composeBuildJob{contextDir: name, dockerfile: "Dockerfile", repo: "app-" + name}
+	}
+
+	started := make(chan struct{}, len(jobs))
+	var mu sync.Mutex
+	startCount := 0
+	buildComposeServiceImage = func(ctx context.Context, _ *grpcclient.AgentConnection, _ int, _, _, _, _, _, _ string, _ map[string]string, _ string, _, _ io.Writer) error {
+		mu.Lock()
+		startCount++
+		mu.Unlock()
+		started <- struct{}{}
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	type outcome struct {
+		failed map[string]error
+		err    error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		failed, err := buildComposeServicesParallel(ctx, nil, 5000, "linux", "docker", "linux/arm64", chunkingAuto, jobs, 1, false)
+		done <- outcome{failed: failed, err: err}
+	}()
+
+	select {
+	case <-started:
+		cancel()
+	case <-time.After(5 * time.Second):
+		t.Fatal("first Compose service build did not start")
+	}
+
+	select {
+	case got := <-done:
+		if !errors.Is(got.err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled", got.err)
+		}
+		if got.failed != nil {
+			t.Fatalf("failed = %v, want nil for operation cancellation", got.failed)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Compose builder did not return after cancellation")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if startCount != 1 {
+		t.Fatalf("started %d Compose builders after cancellation, want exactly the active one", startCount)
+	}
+}
+
+func TestBuildComposeServicesParallelQuietBuildDoesNotOpenTUI(t *testing.T) {
+	originalBuild := buildComposeServiceImage
+	originalInteractive := isInteractiveTerminalFn
+	t.Cleanup(func() {
+		buildComposeServiceImage = originalBuild
+		isInteractiveTerminalFn = originalInteractive
+	})
+	// quietBuild must short-circuit the terminal/TUI branch entirely.
+	isInteractiveTerminalFn = func() bool {
+		t.Fatal("quiet Compose build queried interactive terminal state")
+		return true
+	}
+
+	called := false
+	buildComposeServiceImage = func(_ context.Context, _ *grpcclient.AgentConnection, _ int, _, _, _, _, _, _ string, _ map[string]string, _ string, stream, logw io.Writer) error {
+		called = true
+		if stream == os.Stdout || stream == os.Stderr || logw == os.Stdout || logw == os.Stderr {
+			t.Fatal("quiet Compose build streamed builder output to the terminal")
+		}
+		_, _ = io.WriteString(stream, "builder progress\n")
+		_, _ = io.WriteString(logw, "builder setup\n")
+		return nil
+	}
+
+	jobs := map[string]composeBuildJob{
+		"api": {contextDir: "api", dockerfile: "Dockerfile", repo: "app-api"},
+	}
+	failed, err := buildComposeServicesParallel(context.Background(), nil, 5000, "linux", "docker", "linux/arm64", chunkingAuto, jobs, 1, true)
+	if err != nil {
+		t.Fatalf("quiet Compose build: %v", err)
+	}
+	if len(failed) != 0 {
+		t.Fatalf("quiet Compose failures = %v", failed)
+	}
+	if !called {
+		t.Fatal("quiet Compose builder was not called")
 	}
 }
 
@@ -1253,6 +1356,19 @@ func TestComposeStagefileOverride(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(proj, "docker-compose.yml"), []byte(compose), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	companion := `{
+  "appId": "sh.wendy.compose-test",
+  "services": {
+    "server": {
+      "frameworks": {
+        "ros2": {"distro": "humble", "rmw": "cyclonedds"}
+      }
+    }
+  }
+}`
+	if err := os.WriteFile(filepath.Join(proj, "wendy.json"), []byte(companion), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	path, cleanup, err := composeStagefileOverride(proj, "")
 	if err != nil {
@@ -1291,6 +1407,9 @@ func TestComposeStagefileOverride(t *testing.T) {
 	}
 	if !strings.Contains(string(generated), "sha256:fakepindigest") {
 		t.Fatalf("generated Dockerfile missing pinned digest:\n%s", generated)
+	}
+	if !strings.Contains(string(generated), "'ros-humble-rmw-cyclonedds-cpp'") {
+		t.Fatalf("generated Dockerfile missing service framework middleware:\n%s", generated)
 	}
 }
 

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -85,6 +85,7 @@ func newDeviceCmd() *cobra.Command {
 		newDeviceRenameCmd(),
 		newDeviceUpdateCmd(),
 		newDeviceSyncTimeCmd(),
+		newDeviceCacheCmd(),
 		newVolumesCmd(),
 	)
 	addToGroup("hardware",
@@ -347,6 +348,13 @@ func newDeviceInfoLikeCmd(use string, deprecated bool) *cobra.Command {
 					}
 					out["partitions"] = parts
 				}
+				if alert, ok := highDiskUsage(partitions, diskUsedBytes, diskTotalBytes); ok {
+					out["diskWarning"] = map[string]any{
+						"mountpoint":       alert.Mountpoint,
+						"usedPercent":      alert.UsedPercent,
+						"thresholdPercent": diskWarningThresholdPercent,
+					}
+				}
 				if gpuVendor != "" {
 					out["gpuVendor"] = gpuVendor
 				}
@@ -413,6 +421,9 @@ func newDeviceInfoLikeCmd(use string, deprecated bool) *cobra.Command {
 				fmt.Print(formatPartitionTable(partitions))
 			} else if diskUsedBytes != nil && diskTotalBytes != nil {
 				fmt.Printf("%s %s\n", tui.Dim("Disk Usage:"), tui.Value(formatDiskUsage(*diskUsedBytes, *diskTotalBytes)))
+			}
+			if alert, ok := highDiskUsage(partitions, diskUsedBytes, diskTotalBytes); ok {
+				fmt.Println(tui.WarningMessage(diskUsageWarningText(alert)))
 			}
 			if len(netInterfaces) > 0 {
 				fmt.Print(formatNetworkInterfaces(netInterfaces))

--- a/go/internal/cli/commands/device_cache.go
+++ b/go/internal/cli/commands/device_cache.go
@@ -1,0 +1,114 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+
+	"github.com/spf13/cobra"
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type deviceCachePruneClient interface {
+	PruneCache(context.Context, *agentpbv2.PruneCacheRequest, ...grpc.CallOption) (*agentpbv2.PruneCacheResponse, error)
+}
+
+func newDeviceCacheCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cache",
+		Short: "Manage cached container data on the target device",
+	}
+	cmd.AddCommand(newDeviceCachePruneCmd())
+	return cmd
+}
+
+func newDeviceCachePruneCmd() *cobra.Command {
+	var dryRun bool
+	cmd := &cobra.Command{
+		Use:   "prune",
+		Short: "Release unused container layer and snapshot caches",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			conn, err := connectToAgent(cmd.Context(), SuppressUpdateCheck())
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+			return runDeviceCachePrune(cmd.Context(), conn, cmd.OutOrStdout(), dryRun, jsonOutput)
+		},
+	}
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Report eligible cache data without releasing it")
+	return cmd
+}
+
+func runDeviceCachePrune(ctx context.Context, conn *grpcclient.AgentConnection, out io.Writer, dryRun, jsonOut bool) error {
+	client := agentpbv2.NewWendyContainerServiceClient(conn.Conn)
+	return runDeviceCachePruneRPC(ctx, client, out, dryRun, jsonOut)
+}
+
+func runDeviceCachePruneRPC(ctx context.Context, client deviceCachePruneClient, out io.Writer, dryRun, jsonOut bool) error {
+	resp, err := client.PruneCache(ctx, &agentpbv2.PruneCacheRequest{DryRun: dryRun})
+	if err != nil {
+		if status.Code(err) == codes.Unimplemented {
+			return fmt.Errorf("this device agent does not support cache pruning; update it with 'wendy device update'")
+		}
+		return fmt.Errorf("pruning device cache: %w", err)
+	}
+	if jsonOut {
+		data, err := json.MarshalIndent(map[string]any{
+			"dryRun":            dryRun,
+			"contentBlobs":      resp.GetContentBlobs(),
+			"contentBytes":      resp.GetContentBytes(),
+			"snapshots":         resp.GetSnapshots(),
+			"snapshotBytes":     resp.GetSnapshotBytes(),
+			"minimumAgeSeconds": resp.GetMinimumAgeSeconds(),
+		}, "", "  ")
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprintln(out, string(data))
+		return err
+	}
+
+	totalObjects := resp.GetContentBlobs() + resp.GetSnapshots()
+	totalBytes := saturatingAdd(resp.GetContentBytes(), resp.GetSnapshotBytes())
+	if totalObjects == 0 {
+		_, err = fmt.Fprintf(out, "No cache entries older than %s are eligible for pruning.\n", formatCacheAge(resp.GetMinimumAgeSeconds()))
+		return err
+	}
+	action := "Released"
+	if dryRun {
+		action = "Eligible"
+	}
+	if _, err = fmt.Fprintf(out, "%s: %s across %d layer blobs and %d snapshots.\n",
+		action, formatBytes(int64(min(totalBytes, uint64(math.MaxInt64)))), resp.GetContentBlobs(), resp.GetSnapshots()); err != nil {
+		return err
+	}
+	if !dryRun {
+		_, err = fmt.Fprintln(out, "Containerd will reclaim unreachable data in the background; current images and active apps are preserved.")
+	}
+	return err
+}
+
+func saturatingAdd(a, b uint64) uint64 {
+	if math.MaxUint64-a < b {
+		return math.MaxUint64
+	}
+	return a + b
+}
+
+func formatCacheAge(seconds uint64) string {
+	if seconds%3600 == 0 {
+		return fmt.Sprintf("%dh", seconds/3600)
+	}
+	if seconds%60 == 0 {
+		return fmt.Sprintf("%dm", seconds/60)
+	}
+	return fmt.Sprintf("%ds", seconds)
+}

--- a/go/internal/cli/commands/device_cache_test.go
+++ b/go/internal/cli/commands/device_cache_test.go
@@ -1,0 +1,61 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type fakeDeviceCachePruneClient struct {
+	response *agentpbv2.PruneCacheResponse
+	dryRun   bool
+	err      error
+}
+
+func (f *fakeDeviceCachePruneClient) PruneCache(_ context.Context, req *agentpbv2.PruneCacheRequest, _ ...grpc.CallOption) (*agentpbv2.PruneCacheResponse, error) {
+	f.dryRun = req.GetDryRun()
+	return f.response, f.err
+}
+
+func TestRunDeviceCachePruneRPCExplainsOldAgent(t *testing.T) {
+	fake := &fakeDeviceCachePruneClient{err: status.Error(codes.Unimplemented, "unknown method")}
+	err := runDeviceCachePruneRPC(context.Background(), fake, &bytes.Buffer{}, false, false)
+	if err == nil || !strings.Contains(err.Error(), "wendy device update") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestRunDeviceCachePruneRPCDryRun(t *testing.T) {
+	fake := &fakeDeviceCachePruneClient{response: &agentpbv2.PruneCacheResponse{
+		ContentBlobs: 2, ContentBytes: 1_000, Snapshots: 3, SnapshotBytes: 2_000, MinimumAgeSeconds: 3600,
+	}}
+	var out bytes.Buffer
+	if err := runDeviceCachePruneRPC(context.Background(), fake, &out, true, false); err != nil {
+		t.Fatalf("runDeviceCachePruneRPC: %v", err)
+	}
+	if !fake.dryRun || !strings.Contains(out.String(), "Eligible: 3.0 kB") {
+		t.Fatalf("output = %q, dryRun=%v", out.String(), fake.dryRun)
+	}
+}
+
+func TestRunDeviceCachePruneRPCJSON(t *testing.T) {
+	fake := &fakeDeviceCachePruneClient{response: &agentpbv2.PruneCacheResponse{ContentBlobs: 1, MinimumAgeSeconds: 3600}}
+	var out bytes.Buffer
+	if err := runDeviceCachePruneRPC(context.Background(), fake, &out, false, true); err != nil {
+		t.Fatalf("runDeviceCachePruneRPC: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("JSON: %v", err)
+	}
+	if got["contentBlobs"] != float64(1) || got["minimumAgeSeconds"] != float64(3600) {
+		t.Fatalf("JSON = %v", got)
+	}
+}

--- a/go/internal/cli/commands/disk_warning.go
+++ b/go/internal/cli/commands/disk_warning.go
@@ -1,0 +1,62 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+const diskWarningThresholdPercent int64 = 85
+
+type diskUsageAlert struct {
+	Mountpoint  string
+	UsedPercent int64
+}
+
+// highDiskUsage returns the fullest partition above the warning threshold.
+// Partition data takes precedence over the legacy root-only fields.
+func highDiskUsage(partitions []*agentpb.DiskPartition, legacyUsed, legacyTotal *int64) (diskUsageAlert, bool) {
+	var (
+		best      diskUsageAlert
+		bestRatio float64
+	)
+	for _, p := range partitions {
+		if p == nil || p.GetTotalBytes() <= 0 || p.GetUsedBytes() < 0 {
+			continue
+		}
+		ratio := float64(p.GetUsedBytes()) / float64(p.GetTotalBytes())
+		if ratio > float64(diskWarningThresholdPercent)/100 && ratio > bestRatio {
+			bestRatio = ratio
+			best = diskUsageAlert{Mountpoint: p.GetMountpoint(), UsedPercent: int64(ratio * 100)}
+		}
+	}
+	if bestRatio > 0 {
+		return best, true
+	}
+	if len(partitions) == 0 && legacyUsed != nil && legacyTotal != nil && *legacyTotal > 0 && *legacyUsed >= 0 {
+		ratio := float64(*legacyUsed) / float64(*legacyTotal)
+		if ratio > float64(diskWarningThresholdPercent)/100 {
+			return diskUsageAlert{Mountpoint: "/", UsedPercent: int64(ratio * 100)}, true
+		}
+	}
+	return diskUsageAlert{}, false
+}
+
+func diskUsageWarningText(alert diskUsageAlert) string {
+	mountpoint := alert.Mountpoint
+	if mountpoint == "" {
+		mountpoint = "the device disk"
+	} else {
+		mountpoint = fmt.Sprintf("disk %s", mountpoint)
+	}
+	return fmt.Sprintf("%s is %d%% full. Free cached container data with 'wendy device cache prune'.", mountpoint, alert.UsedPercent)
+}
+
+func printRunDiskUsageWarning(resp *agentpb.GetAgentVersionResponse) {
+	if resp == nil {
+		return
+	}
+	if alert, ok := highDiskUsage(resp.GetPartitions(), resp.DiskUsedBytes, resp.DiskTotalBytes); ok {
+		cliNotice("Warning: %s", diskUsageWarningText(alert))
+	}
+}

--- a/go/internal/cli/commands/disk_warning_test.go
+++ b/go/internal/cli/commands/disk_warning_test.go
@@ -1,0 +1,30 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+func TestHighDiskUsageThresholdAndFullestPartition(t *testing.T) {
+	parts := []*agentpb.DiskPartition{
+		{Mountpoint: "/", UsedBytes: 850, TotalBytes: 1000},
+		{Mountpoint: "/data", UsedBytes: 960, TotalBytes: 1000},
+		{Mountpoint: "/boot", UsedBytes: 9, TotalBytes: 10},
+	}
+	alert, ok := highDiskUsage(parts, nil, nil)
+	if !ok || alert.Mountpoint != "/data" || alert.UsedPercent != 96 {
+		t.Fatalf("alert = %+v, ok=%v", alert, ok)
+	}
+	if !strings.Contains(diskUsageWarningText(alert), "wendy device cache prune") {
+		t.Fatal("warning does not include remediation command")
+	}
+}
+
+func TestHighDiskUsageDoesNotWarnAtExactlyThreshold(t *testing.T) {
+	used, total := int64(85), int64(100)
+	if alert, ok := highDiskUsage(nil, &used, &total); ok {
+		t.Fatalf("unexpected alert: %+v", alert)
+	}
+}

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -627,6 +627,24 @@ func debugStagefileOptions(debug bool) []stagefile.Option {
 	return []stagefile.Option{stagefile.WithBuildProfile(stagefile.BuildProfileDebug)}
 }
 
+// frameworkStagefileOptions translates runtime framework configuration into
+// compiler inputs. The project declares ROS 2 once in wendy.json; Stagefile
+// then supplies the matching middleware package instead of making every
+// service repeat Wendy's resolved distro/RMW choice in install.apt.
+func frameworkStagefileOptions(frameworks *appconfig.FrameworksConfig) []stagefile.Option {
+	if frameworks == nil || frameworks.ROS2 == nil {
+		return nil
+	}
+	return ros2StagefileOptions(frameworks.ROS2)
+}
+
+func ros2StagefileOptions(ros2 *appconfig.ROS2Config) []stagefile.Option {
+	if ros2 == nil {
+		return nil
+	}
+	return []stagefile.Option{stagefile.WithROS2Runtime(ros2.ResolvedDistro(), ros2.ResolvedRMW())}
+}
+
 // hasContainerBuildFile reports whether dir holds any docker build source
 // (Stagefile, Dockerfile/Containerfile, or a variant of either) without the
 // compile / write side effects resolveDockerfile now has — for callers that
@@ -2168,13 +2186,116 @@ func buildAndPushImageViaOCILayout(ctx context.Context, dir, registryAddr, repo,
 	if cacheKey == "" {
 		cacheKey = repo
 	}
-	if err := buildImageToOCILayoutDirWithDocker(ctx, dir, dockerfile, platform, buildArgs, layoutDir, ociDeploymentCacheKey(cacheKey, platform), streamOutput, logOutput); err != nil {
+	native, err := buildOrUpdateOCILayout(dir, dockerfile, platform, buildArgs, layoutDir, func() error {
+		return buildImageToOCILayoutDirWithDocker(ctx, dir, dockerfile, platform, buildArgs, layoutDir, ociDeploymentCacheKey(cacheKey, platform), streamOutput, logOutput)
+	})
+	if err != nil {
 		return err
+	}
+	if native {
+		fmt.Fprintln(logOutput, "[stagefile] app layer(s) rebuilt from content; buildx and cache export skipped")
 	}
 
 	fmt.Fprintf(logOutput, "[registry] pushing OCI image to %s/%s:latest\n", registryAddr, repo)
 	if err := pushOCILayoutToRegistry(ctx, layoutDir, platform, registryAddr, repo, useMTLS); err != nil {
 		return err
+	}
+	return nil
+}
+
+// buildAndPrepareComposeImageForAgent is the default Compose image path. It
+// builds into the same persistent OCI layout used by single-service chunk
+// deploys, updates Stagefile app layers natively when dependencies are stable,
+// and transfers missing content-defined chunks straight to the agent. The
+// prepared image is registered under repo:latest, so Compose's existing
+// CreateContainer orchestration can consume it without a registry round-trip.
+//
+// Agents that predate PrepareImage (or any other non-build chunk-path failure)
+// fall back to pushing this exact already-built layout to the device registry;
+// the image is never rebuilt for the fallback.
+func buildAndPrepareComposeImageForAgent(ctx context.Context, conn *grpcclient.AgentConnection, regPort int, agentOS, builder, dir, repo, platform, dockerfile string, buildArgs map[string]string, cacheKey string, streamOutput, logOutput io.Writer) error {
+	return buildAndPrepareComposeImage(ctx, conn, regPort, agentOS, builder, dir, repo, platform, dockerfile, buildArgs, cacheKey, streamOutput, logOutput, true)
+}
+
+func buildAndPrepareComposeImageForAgentForce(ctx context.Context, conn *grpcclient.AgentConnection, regPort int, agentOS, builder, dir, repo, platform, dockerfile string, buildArgs map[string]string, cacheKey string, streamOutput, logOutput io.Writer) error {
+	return buildAndPrepareComposeImage(ctx, conn, regPort, agentOS, builder, dir, repo, platform, dockerfile, buildArgs, cacheKey, streamOutput, logOutput, false)
+}
+
+func buildAndPrepareComposeImage(ctx context.Context, conn *grpcclient.AgentConnection, regPort int, agentOS, builder, dir, repo, platform, dockerfile string, buildArgs map[string]string, cacheKey string, streamOutput, logOutput io.Writer, allowRegistryFallback bool) error {
+	normalized, err := normalizeImageBuilder(builder)
+	if err != nil {
+		return err
+	}
+	if normalized != imageBuilderDocker {
+		return buildAndPushImageForAgent(ctx, conn, regPort, agentOS, builder, dir, repo, platform, dockerfile, buildArgs, cacheKey, streamOutput, logOutput)
+	}
+
+	userCache, err := os.UserCacheDir()
+	if err != nil {
+		return fmt.Errorf("finding user cache directory: %w", err)
+	}
+	repo = strings.ToLower(repo)
+	layoutDir := chunkLayoutDir(userCache, repo, platform)
+	releaseLayout, err := lockOCILayoutDir(ctx, layoutDir)
+	if err != nil {
+		return err
+	}
+	defer releaseLayout()
+	defer func() { _ = gcOCILayoutDir(layoutDir) }()
+
+	if cacheKey == "" {
+		cacheKey = repo
+	}
+	native, err := buildOrUpdateOCILayout(dir, dockerfile, platform, buildArgs, layoutDir, func() error {
+		return buildImageToOCILayoutDirWithDocker(ctx, dir, dockerfile, platform, buildArgs, layoutDir, ociDeploymentCacheKey(cacheKey, platform), streamOutput, logOutput)
+	})
+	if err != nil {
+		return err
+	}
+	if native {
+		fmt.Fprintln(logOutput, "[stagefile] app layer(s) rebuilt from content; buildx and cache export skipped")
+	}
+
+	layers, imageConfig, err := readOCILayoutDirLayers(layoutDir, platform)
+	if err != nil {
+		return err
+	}
+	imageSignature, err := readOptionalSignature(os.Getenv(imageSignaturePathEnv))
+	if err != nil {
+		return fmt.Errorf("reading image signature from %s: %w", imageSignaturePathEnv, err)
+	}
+	// Match the reference Compose passes to CreateContainer below. PrepareImage
+	// records this exact name in containerd even though no registry is involved.
+	imageName := fmt.Sprintf("localhost:%d/%s:latest", regPort, repo)
+	prepare := func(prepareCtx context.Context, headers []*agentpb.RunContainerLayerHeader) error {
+		_, prepareErr := conn.ContainerService.PrepareImage(prepareCtx, &agentpb.RunContainerLayersRequest{
+			ImageName:      imageName,
+			Layers:         headers,
+			ImageConfig:    imageConfig,
+			ImageSignature: imageSignature,
+		})
+		return prepareErr
+	}
+	if _, chunkErr := pushLayersByChunksWithStrictPrepareOutput(ctx, conn.ContainerService, layers, prepare, streamOutput); chunkErr == nil {
+		fmt.Fprintf(logOutput, "[chunks] prepared %s from missing content\n", imageName)
+		return nil
+	} else if ctx.Err() != nil {
+		return chunkErr
+	} else if blocksChunkPrepareFallback(chunkErr) {
+		return chunkErr
+	} else if !allowRegistryFallback {
+		return fmt.Errorf("chunk-diff image preparation failed and --chunking=force disables the registry fallback: %w", chunkErr)
+	} else {
+		fmt.Fprintf(logOutput, "[chunks] prepare unavailable (%v); falling back to registry push of the existing OCI layout\n", chunkErr)
+	}
+
+	registryAddr, useMTLS, cleanup, dialErr, resolveErr := resolveRegistryForSwiftAgent(ctx, conn, regPort)
+	if resolveErr != nil {
+		return resolveErr
+	}
+	defer cleanup()
+	if err := pushOCILayoutToRegistry(ctx, layoutDir, platform, registryAddr, repo, useMTLS); err != nil {
+		return maybeRegistryUnavailable(agentOS, conn.Host, dialErr, err)
 	}
 	return nil
 }

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1388,7 +1388,20 @@ var lanBrowseFn func(ctx context.Context, timeout time.Duration) ([]models.LANDe
 
 func init() {
 	lanBrowseFn = func(ctx context.Context, timeout time.Duration) ([]models.LANDevice, error) {
-		return discovery.CollectLAN(ctx, cliLANStreamOptions(), timeout)
+		services, err := discovery.BrowseMDNSServices(ctx, "_wendyos._udp", timeout)
+		if err != nil {
+			return nil, err
+		}
+		devices := make([]models.LANDevice, 0, len(services))
+		for _, svc := range services {
+			devices = append(devices, models.LANDevice{
+				Hostname:         svc.Hostname,
+				IPAddress:        svc.IPAddress,
+				Port:             svc.Port,
+				NetworkInterface: svc.InterfaceName,
+			})
+		}
+		return devices, nil
 	}
 }
 
@@ -1440,7 +1453,8 @@ func stripZone(host string) string {
 
 // orderDialCandidates de-duplicates ips and orders them by how likely a dial to
 // each is to reach a device on an ordinary LAN: IPv4 first, then routable IPv6,
-// then link-local and ULA IPv6 last.
+// then link-local and ULA IPv6 last. Connect paths add host-interface preference
+// with orderRoutedDialCandidates below.
 //
 // The ordering is a preference *within an exhaustive walk*, not a filter. The
 // single-address resolvers this replaced also preferred IPv4, but they THREW
@@ -1448,6 +1462,14 @@ func stripZone(host string) string {
 // look unreachable. Anything unparseable is dropped rather than passed through:
 // a non-address in this list can only produce a dial that cannot succeed.
 func orderDialCandidates(ips []string) []string {
+	ordered := orderDialCandidatesUnbounded(ips)
+	if len(ordered) > maxDialCandidates {
+		ordered = ordered[:maxDialCandidates]
+	}
+	return ordered
+}
+
+func orderDialCandidatesUnbounded(ips []string) []string {
 	var v4, v6Global, v6Local []string
 	seen := map[string]bool{}
 	for _, raw := range ips {
@@ -1473,6 +1495,14 @@ func orderDialCandidates(ips []string) []string {
 	ordered = append(ordered, v4...)
 	ordered = append(ordered, v6Global...)
 	ordered = append(ordered, v6Local...)
+	return ordered
+}
+
+// orderRoutedDialCandidates adds host-interface preference to the ordinary
+// address-family ordering. It runs before the candidate cap so a wired answer
+// cannot be dropped merely because several Wi-Fi/IPv6 records arrived first.
+func orderRoutedDialCandidates(ips []string) []string {
+	ordered := preferWiredDialCandidates(orderDialCandidatesUnbounded(ips))
 	if len(ordered) > maxDialCandidates {
 		ordered = ordered[:maxDialCandidates]
 	}
@@ -1492,19 +1522,33 @@ func resolveHostAllMDNSFallback(ctx context.Context, host string) []string {
 	rctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	ips, err := osLookupHostFn(rctx, host)
 	cancel()
-	if err == nil {
-		// A resolver that answers with nothing usable is treated as a failure
-		// so the mDNS browse still gets its turn; the old single-address form
-		// returned early on a non-empty-but-unparseable answer.
-		if ordered := orderDialCandidates(ips); len(ordered) > 0 {
-			return ordered
+	if err != nil {
+		ips = nil
+	}
+
+	ordered := orderRoutedDialCandidates(ips)
+	// A .local hostname can legitimately answer once per interface. When the
+	// discovery cache tells us its saved path is Wi-Fi or internally inconsistent
+	// (for example en7 metadata with an en0-routed IP), merge interface-scoped
+	// DNS-SD sightings even though the system resolver returned an answer. Once a
+	// correct wired address is cached, the last-known-good path avoids this browse.
+	normalized := strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+	needsInterfaceBrowse := len(ordered) == 0
+	if !needsInterfaceBrowse && strings.HasSuffix(normalized, ".local") {
+		if cached, ok := cachedDeviceHostEntry(host); ok {
+			needsInterfaceBrowse = !shouldUseCachedDeviceAddress(cached.InterfaceName, cached.IP)
 		}
 	}
-	return orderDialCandidates(resolveMDNSHostAll(ctx, host))
+	if needsInterfaceBrowse && strings.HasSuffix(normalized, ".local") {
+		ips = append(ips, resolveMDNSHostAll(ctx, host)...)
+	}
+	return orderRoutedDialCandidates(ips)
 }
 
 // resolveAddrOnce resolves a host:port whose host is a DNS/mDNS name to an
-// IPv4-preferred IP:port, so the dials below target a literal IP. gRPC
+// preferred IP:port, so the dials below target a literal IP. A wired host route
+// outranks Wi-Fi; within equal/unknown transports IPv4 keeps its usual lead.
+// gRPC
 // otherwise resolves the name separately for every ClientConn we open (mTLS
 // port, mTLS port+1, plaintext), and an mDNS ".local" name that resolves to
 // both IPv6 and IPv4 can cost a multi-second IPv6 connect timeout per dial on
@@ -1516,7 +1560,7 @@ func resolveAddrOnce(ctx context.Context, addr string) string {
 }
 
 // resolveAddrCandidates is resolveAddrOnce's list-returning form: every address
-// the host answers to, each joined back to port, in orderDialCandidates order.
+// the host answers to, each joined back to port, in routed-candidate order.
 // It never returns an empty slice — on any resolution failure the sole element
 // is addr unchanged, so gRPC's own resolver remains the last fallback exactly as
 // before.
@@ -1803,9 +1847,11 @@ func defaultDeviceUnreachableError(hostname string, err error) error {
 
 // connectWithAutoTLSDiagnostics resolves plaintextAddr and runs the mTLS/
 // plaintext dial ladder (see dialAgentLadder) against it. A DNS/mDNS-name host
-// with a device-cache entry (any age; see cachedDeviceEntry) skips resolution
-// entirely and dials the cached IP directly — the "instant connect" fast
-// path. That cached IP can be stale (the device moved, rebooted onto a new
+// with a device-cache entry (any age; see cachedDeviceEntry) normally skips
+// resolution and dials the cached IP directly — the "instant connect" fast
+// path. A row positively observed on Wi-Fi is re-resolved so a simultaneous
+// Ethernet answer can win; legacy/unknown and wired rows stay instant. The
+// cached IP can be stale (the device moved, rebooted onto a new
 // DHCP lease, etc.), so this distinguishes a dead cached IP from a live one
 // that simply failed its handshake:
 //
@@ -1851,7 +1897,7 @@ func connectWithAutoTLSDiagnostics(ctx context.Context, plaintextAddr string) (*
 	pinKey := pinKeyForAddr(originalAddr)
 	fromCache := false
 	if plainHost, plainPort, splitErr := net.SplitHostPort(plaintextAddr); splitErr == nil && net.ParseIP(plainHost) == nil {
-		if e, ok := cachedDeviceHostEntry(plainHost); ok && e.IP != "" {
+		if e, ok := cachedDeviceHostEntry(plainHost); ok && shouldUseCachedDeviceAddress(e.InterfaceName, e.IP) {
 			cachedAddr := net.JoinHostPort(e.IP, plainPort)
 			switch {
 			case e.MTLS && e.Port > 0:
@@ -2046,10 +2092,11 @@ func cacheConnectSuccess(originalAddr string, conn *grpcclient.AgentConnection) 
 		return
 	}
 	entry := discoverycache.Entry{
-		Hostname: cacheHostnameForStorage(host),
-		IP:       conn.Host,
-		Port:     port,
-		MTLS:     conn.IsMTLS,
+		Hostname:      cacheHostnameForStorage(host),
+		IP:            conn.Host,
+		Port:          port,
+		MTLS:          conn.IsMTLS,
+		InterfaceName: routeInterfaceForIP(conn.Host),
 	}
 	if org, ok := conn.ObservedServerOrg(); ok {
 		entry.OrgID = org

--- a/go/internal/cli/commands/helpers_dial_candidates_test.go
+++ b/go/internal/cli/commands/helpers_dial_candidates_test.go
@@ -290,6 +290,61 @@ func TestOrderDialCandidates(t *testing.T) {
 	})
 }
 
+func TestOrderRoutedDialCandidatesPrefersEthernetBeforeCandidateCap(t *testing.T) {
+	original := dialCandidateRoutePreferenceFn
+	dialCandidateRoutePreferenceFn = func(ip string) routePreference {
+		if ip == "10.0.0.4" {
+			return routeWired
+		}
+		return routeWireless
+	}
+	t.Cleanup(func() { dialCandidateRoutePreferenceFn = original })
+
+	got := orderRoutedDialCandidates([]string{"10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4"})
+	want := []string{"10.0.0.4", "10.0.0.1", "10.0.0.2"}
+	if len(got) != len(want) {
+		t.Fatalf("orderRoutedDialCandidates = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("orderRoutedDialCandidates = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestCachedWiFiAddressDoesNotBypassFreshResolution(t *testing.T) {
+	original := networkInterfaceRoutePreferenceFn
+	originalRoute := routeInterfaceForIPFn
+	t.Cleanup(func() {
+		networkInterfaceRoutePreferenceFn = original
+		routeInterfaceForIPFn = originalRoute
+	})
+	routeInterfaceForIPFn = func(string) string { return "en0" }
+
+	networkInterfaceRoutePreferenceFn = func(string) routePreference { return routeWireless }
+	if shouldUseCachedDeviceAddress("en0", "192.168.1.20") {
+		t.Fatal("a cached Wi-Fi route must not suppress fresh multi-address resolution")
+	}
+	networkInterfaceRoutePreferenceFn = func(string) routePreference { return routeWired }
+	if !shouldUseCachedDeviceAddress("en0", "192.168.1.30") {
+		t.Fatal("a cached wired route should retain the last-known-good fast path")
+	}
+	networkInterfaceRoutePreferenceFn = func(string) routePreference { return routeUnknown }
+	if !shouldUseCachedDeviceAddress("", "192.168.1.40") {
+		t.Fatal("a legacy cache row with no interface metadata should retain the fast path")
+	}
+
+	networkInterfaceRoutePreferenceFn = func(name string) routePreference {
+		if name == "en7" {
+			return routeWired
+		}
+		return routeWireless
+	}
+	if shouldUseCachedDeviceAddress("en7", "192.168.1.50") {
+		t.Fatal("a cached address routed over en0 must not be trusted merely because its sighting was labelled en7")
+	}
+}
+
 // deadLoopbackAddr reserves and releases two consecutive ports on a loopback
 // host, so both the address itself and its port+1 mTLS rung refuse instantly
 // rather than hanging. It skips rather than fails when the host cannot be bound

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -439,7 +439,7 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	}
 
 	// Build all service images in parallel, then create and start containers.
-	failed, buildErr := buildServicesParallel(ctx, conn, regPort, agentOS, cwd, appCfg.AppID, services, platform, buildArgs, opts.builder, skip, dockerfiles, opts.maxConcurrency, sfOpts...)
+	failed, buildErr := buildServicesParallel(ctx, conn, regPort, agentOS, cwd, appCfg.AppID, services, platform, buildArgs, opts.builder, skip, dockerfiles, opts.maxConcurrency, opts.quietBuild, sfOpts...)
 	if buildErr != nil {
 		return buildErr
 	}
@@ -611,8 +611,12 @@ func buildServicesParallel(
 	skip map[string]bool,
 	dockerfiles map[string]string,
 	maxConcurrency int,
+	quietBuild bool,
 	sfOpts ...stagefile.Option,
 ) (map[string]error, error) {
+	buildCtx, cancelBuild := context.WithCancel(ctx)
+	defer cancelBuild()
+
 	names := make([]string, 0, len(services))
 	for n := range services {
 		names = append(names, n)
@@ -621,7 +625,7 @@ func buildServicesParallel(
 
 	// Resolved once for the group: every service deploys to this one device,
 	// so they share its GPU architecture.
-	gpuArch := serviceGPUArch(ctx, cwd, services, conn)
+	gpuArch := serviceGPUArch(buildCtx, cwd, services, conn)
 
 	type result struct {
 		name string
@@ -641,13 +645,13 @@ func buildServicesParallel(
 		}
 	}
 	concurrency := resolveBuildConcurrency(buildCount, maxConcurrency)
-	if maxConcurrency > 0 && concurrency < buildCount {
+	if !quietBuild && maxConcurrency > 0 && concurrency < buildCount {
 		cliLogln("Building up to %d service(s) at a time (--max-concurrency).", concurrency)
 	}
 	sem := make(chan struct{}, concurrency)
 
 	var prog *tea.Program
-	if isInteractiveTerminal() {
+	if !quietBuild && isInteractiveTerminal() {
 		title := fmt.Sprintf("Building %d service(s)...", len(names))
 		m := tui.NewMultiSpinner(title, names)
 		prog = tui.NewProgressProgram(m)
@@ -664,19 +668,28 @@ func buildServicesParallel(
 				if prog != nil {
 					prog.Send(tui.MultiSpinnerStartMsg{Name: name})
 					prog.Send(tui.MultiSpinnerDoneMsg{Name: name, Err: nil, Dur: 0})
-				} else {
+				} else if !quietBuild {
 					cliLogln("Service %s unchanged; skipping build/push (already on device).", name)
 				}
 				results <- result{name: name}
 				return
 			}
 
-			sem <- struct{}{}
+			select {
+			case sem <- struct{}{}:
+			case <-buildCtx.Done():
+				results <- result{name: name, err: buildCtx.Err()}
+				return
+			}
 			defer func() { <-sem }()
+			if err := buildCtx.Err(); err != nil {
+				results <- result{name: name, err: err}
+				return
+			}
 
 			if prog != nil {
 				prog.Send(tui.MultiSpinnerStartMsg{Name: name})
-			} else {
+			} else if !quietBuild {
 				cliLogln("Building service %s...", name)
 			}
 
@@ -700,11 +713,13 @@ func buildServicesParallel(
 				tally = getTally
 				parser := tui.NewBuildParser(emit)
 				buildOut = io.MultiWriter(parser, &logBuf)
+			} else if quietBuild {
+				buildOut = &logBuf
 			} else {
 				buildOut = os.Stdout
 			}
 			var logOutW io.Writer = &logBuf
-			if prog == nil {
+			if prog == nil && !quietBuild {
 				logOutW = os.Stderr
 			}
 			err := dockerfileErr
@@ -712,7 +727,7 @@ func buildServicesParallel(
 				// Pass the per-service repo as the build's cache key so each concurrent
 				// build gets its own isolated local buildx cache dir (WDY-1689); sharing
 				// one dir corrupts BuildKit's cache-export ingest store under concurrency.
-				err = buildServiceImage(ctx, conn, regPort, agentOS, builder, contextDir, repo, platform, dockerfile, buildArgs, repo, buildOut, logOutW)
+				err = buildServiceImage(buildCtx, conn, regPort, agentOS, builder, contextDir, repo, platform, dockerfile, buildArgs, repo, buildOut, logOutW)
 			}
 			dur := time.Since(start)
 
@@ -720,8 +735,12 @@ func buildServicesParallel(
 				t := tally()
 				prog.Send(tui.MultiSpinnerDoneMsg{Name: name, Err: err, Dur: dur, Cached: t.Cached, Rebuilt: t.Rebuilt})
 			} else if err != nil {
-				cliLogln("Service %s build failed: %v", name, err)
-			} else {
+				if buildCtx.Err() == nil {
+					if !quietBuild {
+						cliLogln("Service %s build failed: %v", name, err)
+					}
+				}
+			} else if !quietBuild {
 				cliLogln("Service %s built (%s).", name, dur.Round(time.Millisecond))
 			}
 
@@ -738,9 +757,21 @@ func buildServicesParallel(
 		}
 	}()
 
+	var progressErr error
 	if prog != nil {
-		if _, runErr := prog.Run(); runErr != nil {
-			return nil, fmt.Errorf("build progress TUI: %w", runErr)
+		final, runErr := prog.Run()
+		if runErr != nil {
+			cancelBuild()
+			progressErr = fmt.Errorf("build progress TUI: %w", runErr)
+		} else if fm, ok := final.(tui.MultiSpinnerModel); !ok {
+			cancelBuild()
+			progressErr = fmt.Errorf("build progress TUI: unexpected final model %T", final)
+		} else if errors.Is(fm.Err(), tui.ErrCancelled) {
+			// One Ctrl-C owns cancellation for the entire service group. Queued
+			// services never start, and all active builder commands share this
+			// context so they unwind before we return.
+			cancelBuild()
+			progressErr = ErrUserCancelled
 		}
 	}
 
@@ -754,10 +785,16 @@ func buildServicesParallel(
 			failed[r.name] = r.err
 			// Skip the raw replay for the friendly "no registry on the Mac agent"
 			// error — the retried-push spam would bury the actionable message.
-			if r.log != "" && !isRegistryUnavailable(r.err) {
+			if progressErr == nil && buildCtx.Err() == nil && r.log != "" && !isRegistryUnavailable(r.err) {
 				fmt.Fprintf(os.Stderr, "\n[%s] build log:\n%s", r.name, r.log)
 			}
 		}
+	}
+	if progressErr != nil {
+		return nil, progressErr
+	}
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
 	}
 	return failed, nil
 }

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -344,6 +344,7 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	if err != nil {
 		return fmt.Errorf("querying device version: %w", err)
 	}
+	printRunDiskUsageWarning(versionResp)
 	agentOS := versionResp.GetOs()
 	architecture := versionResp.GetCpuArchitecture()
 	if architecture == "" {

--- a/go/internal/cli/commands/multibuild_test.go
+++ b/go/internal/cli/commands/multibuild_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -170,7 +171,7 @@ func TestBuildServicesParallelReusesPlannedDockerfile(t *testing.T) {
 	}
 
 	failed, infraErr := buildServicesParallel(
-		context.Background(), nil, 5000, "linux", root, appID, services, "linux/arm64", nil, "docker", nil, planned, len(services))
+		context.Background(), nil, 5000, "linux", root, appID, services, "linux/arm64", nil, "docker", nil, planned, len(services), false)
 	if infraErr != nil {
 		t.Fatalf("unexpected infra error: %v", infraErr)
 	}
@@ -183,6 +184,112 @@ func TestBuildServicesParallelReusesPlannedDockerfile(t *testing.T) {
 		if got[repo] != planned[name] {
 			t.Errorf("service %s built with dockerfile %q, want the planned %q", name, got[repo], planned[name])
 		}
+	}
+}
+
+func TestBuildServicesParallelCancellationStopsActiveAndQueuedBuilds(t *testing.T) {
+	root, services := newServiceTree(t, 4)
+	planned := make(map[string]string, len(services))
+	for name := range services {
+		planned[name] = "Dockerfile"
+	}
+
+	originalBuild := buildServiceImage
+	originalInteractive := isInteractiveTerminalFn
+	t.Cleanup(func() {
+		buildServiceImage = originalBuild
+		isInteractiveTerminalFn = originalInteractive
+	})
+	isInteractiveTerminalFn = func() bool { return false }
+
+	started := make(chan struct{}, len(services))
+	var mu sync.Mutex
+	startCount := 0
+	buildServiceImage = func(ctx context.Context, _ *grpcclient.AgentConnection, _ int, _, _, _, _, _, _ string, _ map[string]string, _ string, _, _ io.Writer) error {
+		mu.Lock()
+		startCount++
+		mu.Unlock()
+		started <- struct{}{}
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	type outcome struct {
+		failed map[string]error
+		err    error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		failed, err := buildServicesParallel(ctx, nil, 5000, "linux", root, "app", services,
+			"linux/arm64", nil, "docker", nil, planned, 1, false)
+		done <- outcome{failed: failed, err: err}
+	}()
+
+	select {
+	case <-started:
+		cancel()
+	case <-time.After(5 * time.Second):
+		t.Fatal("first service build did not start")
+	}
+
+	select {
+	case got := <-done:
+		if !errors.Is(got.err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled", got.err)
+		}
+		if got.failed != nil {
+			t.Fatalf("failed = %v, want nil for operation cancellation", got.failed)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("parallel builder did not return after cancellation")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if startCount != 1 {
+		t.Fatalf("started %d service builders after cancellation, want exactly the active one", startCount)
+	}
+}
+
+func TestBuildServicesParallelQuietBuildDoesNotOpenTUI(t *testing.T) {
+	root, services := newServiceTree(t, 1)
+	originalBuild := buildServiceImage
+	originalInteractive := isInteractiveTerminalFn
+	t.Cleanup(func() {
+		buildServiceImage = originalBuild
+		isInteractiveTerminalFn = originalInteractive
+	})
+	isInteractiveTerminalFn = func() bool {
+		t.Fatal("quiet multi-service build queried interactive terminal state")
+		return true
+	}
+
+	called := false
+	buildServiceImage = func(_ context.Context, _ *grpcclient.AgentConnection, _ int, _, _, _, _, _, _ string, _ map[string]string, _ string, stream, logw io.Writer) error {
+		called = true
+		if stream == os.Stdout || stream == os.Stderr || logw == os.Stdout || logw == os.Stderr {
+			t.Fatal("quiet multi-service build streamed builder output to the terminal")
+		}
+		_, _ = io.WriteString(stream, "builder progress\n")
+		_, _ = io.WriteString(logw, "builder setup\n")
+		return nil
+	}
+
+	planned := map[string]string{}
+	for name := range services {
+		planned[name] = "Dockerfile"
+	}
+	failed, err := buildServicesParallel(context.Background(), nil, 5000, "linux", root, "app", services,
+		"linux/arm64", nil, "docker", nil, planned, 1, true)
+	if err != nil {
+		t.Fatalf("quiet multi-service build: %v", err)
+	}
+	if len(failed) != 0 {
+		t.Fatalf("quiet multi-service failures = %v", failed)
+	}
+	if !called {
+		t.Fatal("quiet multi-service builder was not called")
 	}
 }
 
@@ -206,7 +313,7 @@ func TestBuildServicesParallelResolvesWhenPlanningSkippedIt(t *testing.T) {
 	}
 
 	failed, infraErr := buildServicesParallel(
-		context.Background(), nil, 5000, "linux", root, appID, services, "linux/arm64", nil, "docker", nil, nil, len(services))
+		context.Background(), nil, 5000, "linux", root, appID, services, "linux/arm64", nil, "docker", nil, nil, len(services), false)
 	if infraErr != nil {
 		t.Fatalf("unexpected infra error: %v", infraErr)
 	}

--- a/go/internal/cli/commands/nativelayers.go
+++ b/go/internal/cli/commands/nativelayers.go
@@ -272,6 +272,48 @@ func nativeBuildEligibility(cwd, dockerfile string) (*spec.File, bool) {
 	return sf, true
 }
 
+// buildOrUpdateOCILayout gives every persistent OCI-layout caller the same
+// Stagefile-aware fast path. If only final-stage local copies changed, their
+// deterministic layers are rebuilt and content-addressed in-process; Docker,
+// the multi-gigabyte local cache exporter, and unchanged dependency layers are
+// skipped entirely. A dependency change or any failed safety guard falls back
+// to buildx, after which the resulting app layers are adopted for the next
+// iteration.
+//
+// The caller must hold the layout directory lock for the whole call. buildx is
+// responsible only for updating the layout; pushing or chunking it remains the
+// caller's concern.
+func buildOrUpdateOCILayout(cwd, dockerfile, platform string, buildArgs map[string]string, layoutDir string, buildx func() error) (native bool, err error) {
+	sf, eligible := nativeBuildEligibility(cwd, dockerfile)
+	depsHash := ""
+	if eligible {
+		if h, hashErr := nativeDepsHash(cwd, dockerfile, platform, buildArgs, sf); hashErr == nil {
+			depsHash = h
+		} else {
+			eligible = false
+		}
+	}
+
+	if eligible {
+		if st, ok := loadNativeState(layoutDir); ok && st.DepsHash == depsHash {
+			if done, rebuildErr := tryNativeRebuild(layoutDir, platform, cwd, sf, st); rebuildErr == nil && done {
+				return true, nil
+			}
+		}
+	}
+
+	if err := buildx(); err != nil {
+		return false, err
+	}
+	if eligible {
+		// Adoption is an optimization. Refusing a layout whose final layers do
+		// not exactly match Stagefile's declared local copies leaves the valid
+		// buildx image untouched and simply retries buildx next time.
+		_, _ = adoptNativeLayers(layoutDir, platform, cwd, sf, depsHash)
+	}
+	return false, nil
+}
+
 // ociManifest captures the standard OCI image-manifest fields the splice
 // mutates. Annotations are preserved; anything nonstandard would be dropped,
 // which buildx-produced image manifests don't carry.

--- a/go/internal/cli/commands/nativelayers_test.go
+++ b/go/internal/cli/commands/nativelayers_test.go
@@ -486,6 +486,51 @@ func TestAdoptAndSpliceNativeLayers(t *testing.T) {
 	}
 }
 
+func TestBuildOrUpdateOCILayoutSkipsBuildxAfterAdoption(t *testing.T) {
+	proj := t.TempDir()
+	writeFile(t, proj, "build.stagefile.yaml", `version: 1
+stages:
+  - name: app
+    from: python:3.11-slim
+    copy:
+      - from: local
+        paths: [main.py]
+        dest: app/
+`)
+	writeFile(t, proj, "Dockerfile.generated", "FROM python:3.11-slim AS app\nCOPY main.py app/\n")
+	writeFile(t, proj, "main.py", "print('v1')\n")
+
+	layout := t.TempDir()
+	buildxCalls := 0
+	buildx := func() error {
+		buildxCalls++
+		depsTar := tarBytes(t, map[string]string{"usr/lib/python/dep.py": "dep"})
+		appTar := tarBytes(t, map[string]string{"app/": "", "app/main.py": "print('v1')\n"})
+		writeTwoLayerLayoutDir(t, layout, depsTar, appTar, "")
+		return nil
+	}
+
+	native, err := buildOrUpdateOCILayout(proj, "Dockerfile.generated", "linux/arm64", nil, layout, buildx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if native || buildxCalls != 1 {
+		t.Fatalf("first build: native=%v buildxCalls=%d, want false/1", native, buildxCalls)
+	}
+	if _, ok := loadNativeState(layout); !ok {
+		t.Fatal("first build should adopt native app layers")
+	}
+
+	writeFile(t, proj, "main.py", "print('v2')\n")
+	native, err = buildOrUpdateOCILayout(proj, "Dockerfile.generated", "linux/arm64", nil, layout, buildx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !native || buildxCalls != 1 {
+		t.Fatalf("warm app edit: native=%v buildxCalls=%d, want true/1", native, buildxCalls)
+	}
+}
+
 func TestAdoptNativeLayersRejectsFileSetMismatch(t *testing.T) {
 	proj := t.TempDir()
 	writeFile(t, proj, "main.py", "print('v1')\n")

--- a/go/internal/cli/commands/ocilayers.go
+++ b/go/internal/cli/commands/ocilayers.go
@@ -1039,7 +1039,7 @@ func buildxOCIExportArgs(builder, platform, dockerfile, cacheFromDir, cacheToDir
 	if cacheFromDir != "" {
 		args = append(args, "--cache-from", "type=local,src="+filepath.ToSlash(cacheFromDir))
 	}
-	args = append(args, "--cache-to", "type=local,dest="+filepath.ToSlash(cacheToDir))
+	args = append(args, "--cache-to", "type=local,dest="+filepath.ToSlash(cacheToDir)+",compression=uncompressed")
 	keys := make([]string, 0, len(buildArgs))
 	for k := range buildArgs {
 		keys = append(keys, k)
@@ -1048,7 +1048,13 @@ func buildxOCIExportArgs(builder, platform, dockerfile, cacheFromDir, cacheToDir
 	for _, k := range keys {
 		args = append(args, "--build-arg", k+"="+buildArgs[k])
 	}
-	output := "type=oci,dest=" + dest
+	// The chunk-diff path consumes uncompressed layer tar streams and hashes
+	// their DiffIDs before sending only missing chunks to the agent. Asking the
+	// OCI exporter to gzip those layers first adds a full-image compression pass
+	// (especially expensive for multi-gigabyte CUDA libraries), only for the
+	// chunking path to decompress them again. Keep the persistent layout in the
+	// representation the deploy path actually consumes.
+	output := "type=oci,dest=" + dest + ",compression=uncompressed"
 	if tarFalse {
 		output += ",tar=false"
 	}

--- a/go/internal/cli/commands/ocilayers.go
+++ b/go/internal/cli/commands/ocilayers.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/klauspost/compress/zstd"
+	"github.com/wendylabsinc/wendy/go/internal/shared/chunk"
 )
 
 // localLayer addresses a single image layer's COMPRESSED blob plus the metadata
@@ -746,6 +747,21 @@ func (d *decompressedLayer) Close() {
 // (a few MiB) rather than the whole layer. The returned file is positioned for
 // random access via ReadAt; the caller must Close it.
 func decompressLayerToTemp(l localLayer) (*decompressedLayer, error) {
+	return decompressLayerToTempProgress(l, nil)
+}
+
+type progressWriteFunc func(int64)
+
+func (fn progressWriteFunc) Write(p []byte) (int, error) {
+	if fn != nil {
+		fn(int64(len(p)))
+	}
+	return len(p), nil
+}
+
+// decompressLayerToTempProgress is decompressLayerToTemp with byte telemetry
+// for the uncompressed stream. The callback runs on the copying goroutine.
+func decompressLayerToTempProgress(l localLayer, progress func(int64)) (*decompressedLayer, error) {
 	cr, err := l.compressedReader()
 	if err != nil {
 		return nil, err
@@ -762,7 +778,11 @@ func decompressLayerToTemp(l localLayer) (*decompressedLayer, error) {
 		return nil, fmt.Errorf("create layer temp file: %w", err)
 	}
 	h := sha256.New()
-	n, err := io.Copy(io.MultiWriter(f, h), r)
+	writers := []io.Writer{f, h}
+	if progress != nil {
+		writers = append(writers, progressWriteFunc(progress))
+	}
+	n, err := io.Copy(io.MultiWriter(writers...), r)
 	if err != nil {
 		_ = f.Close()
 		_ = os.Remove(f.Name())
@@ -773,6 +793,41 @@ func decompressLayerToTemp(l localLayer) (*decompressedLayer, error) {
 		size:   n,
 		diffID: "sha256:" + hex.EncodeToString(h.Sum(nil)),
 	}, nil
+}
+
+// decompressAndChunkLayerToTemp fuses decompression, DiffID hashing, temp-file
+// materialization, and content indexing into one pass over the raw tar. The
+// previous cache-miss path wrote the whole layer and then reread it through
+// ChunkReaderAt, which made a multi-GiB CUDA layer pay two full disk passes
+// before upload could begin.
+func decompressAndChunkLayerToTemp(l localLayer, progress func(completed int64)) (*decompressedLayer, []chunk.Ref, error) {
+	cr, err := l.compressedReader()
+	if err != nil {
+		return nil, nil, err
+	}
+	defer cr.Close()
+	r, cleanup, err := layerTarReader(cr, l.MediaType)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer cleanup()
+
+	f, err := os.CreateTemp("", "wendy-layer-*")
+	if err != nil {
+		return nil, nil, fmt.Errorf("create layer temp file: %w", err)
+	}
+	h := sha256.New()
+	refs, n, err := chunk.ChunkStream(io.TeeReader(r, io.MultiWriter(f, h)), progress)
+	if err != nil {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return nil, nil, fmt.Errorf("decompress and index layer: %w", err)
+	}
+	return &decompressedLayer{
+		f:      f,
+		size:   n,
+		diffID: "sha256:" + hex.EncodeToString(h.Sum(nil)),
+	}, refs, nil
 }
 
 // digestToHex converts a "sha256:<hex>" digest string to the bare hex portion.
@@ -953,13 +1008,25 @@ func ociDeploymentCacheKey(appID, platform string) string {
 	return strings.ToLower(strings.TrimSpace(appID)) + "\x00" + strings.ToLower(strings.TrimSpace(platform))
 }
 
+// legacyOCICacheKey recovers the pre-platform cache key from a current OCI
+// deployment key. It is used only as a read-through migration source: new
+// exports always remain platform-isolated, while the first build after an
+// upgrade can still consume gigabytes of valid dependency cache accumulated
+// under the former app-only namespace.
+func legacyOCICacheKey(cacheKey string) (string, bool) {
+	appID, platform, ok := strings.Cut(cacheKey, "\x00")
+	if !ok || appID == "" || platform == "" {
+		return "", false
+	}
+	return appID, true
+}
+
 // buildxOCIExportArgs assembles the `docker buildx build` argument vector for
 // an OCI export (tar or layout-dir). Pure function for testability; build-arg
 // keys are sorted for a reproducible command line.
-func buildxOCIExportArgs(builder, platform, dockerfile, cacheDir, dest string, tarFalse bool, buildArgs map[string]string, haveCacheIndex bool) []string {
+func buildxOCIExportArgs(builder, platform, dockerfile, cacheFromDir, cacheToDir, dest string, tarFalse bool, buildArgs map[string]string) []string {
 	// buildkitd inside the Linux VM appends "/index.json" to the cache src/dest,
 	// so pass forward-slash paths to avoid mixed-separator warnings on Windows.
-	cacheDirSlash := filepath.ToSlash(cacheDir)
 	args := []string{
 		"buildx", "build",
 		"--builder", builder,
@@ -969,10 +1036,10 @@ func buildxOCIExportArgs(builder, platform, dockerfile, cacheDir, dest string, t
 	if dockerfile != "" {
 		args = append(args, "-f", dockerfile)
 	}
-	if haveCacheIndex {
-		args = append(args, "--cache-from", "type=local,src="+cacheDirSlash)
+	if cacheFromDir != "" {
+		args = append(args, "--cache-from", "type=local,src="+filepath.ToSlash(cacheFromDir))
 	}
-	args = append(args, "--cache-to", "type=local,dest="+cacheDirSlash)
+	args = append(args, "--cache-to", "type=local,dest="+filepath.ToSlash(cacheToDir))
 	keys := make([]string, 0, len(buildArgs))
 	for k := range buildArgs {
 		keys = append(keys, k)
@@ -1056,8 +1123,17 @@ func buildImageWithBuildxOCIExport(ctx context.Context, cwd, dockerfile, platfor
 			return err
 		}
 	}
-	_, cacheIndexErr := os.Stat(filepath.Join(cacheDir, "index.json"))
-	args := buildxOCIExportArgs(buildxBuilder, platform, resolvedDockerfile, cacheDir, dest, tarFalse, buildArgs, cacheIndexErr == nil)
+	cacheFromDir := ""
+	if _, statErr := os.Stat(filepath.Join(cacheDir, "index.json")); statErr == nil {
+		cacheFromDir = cacheDir
+	} else if legacyKey, ok := legacyOCICacheKey(cacheKey); ok {
+		legacyDir := buildxLocalCacheDir(userCache, legacyKey)
+		if _, legacyErr := os.Stat(filepath.Join(legacyDir, "index.json")); legacyErr == nil {
+			cacheFromDir = legacyDir
+			fmt.Fprintf(stderr, "[buildx] importing legacy cache %s into platform-scoped cache\n", legacyDir)
+		}
+	}
+	args := buildxOCIExportArgs(buildxBuilder, platform, resolvedDockerfile, cacheFromDir, cacheDir, dest, tarFalse, buildArgs)
 
 	submark("  build: setup (cache/env)")
 

--- a/go/internal/cli/commands/ocilayers_test.go
+++ b/go/internal/cli/commands/ocilayers_test.go
@@ -571,8 +571,8 @@ func TestBuildxOCIExportAllowsIndependentConcurrentSolves(t *testing.T) {
 
 func TestBuildxOCIExportArgs(t *testing.T) {
 	t.Run("dir mode, no cache index, sorted build args", func(t *testing.T) {
-		got := buildxOCIExportArgs("wendy-oci", "linux/arm64", "/proj/Dockerfile", "/c/buildx", "/dest/layout", true,
-			map[string]string{"ZED": "2", "ALPHA": "1"}, false)
+		got := buildxOCIExportArgs("wendy-oci", "linux/arm64", "/proj/Dockerfile", "", "/c/buildx", "/dest/layout", true,
+			map[string]string{"ZED": "2", "ALPHA": "1"})
 		want := []string{
 			"buildx", "build",
 			"--builder", "wendy-oci",
@@ -590,13 +590,13 @@ func TestBuildxOCIExportArgs(t *testing.T) {
 		}
 	})
 	t.Run("tar mode with cache index, no dockerfile", func(t *testing.T) {
-		got := buildxOCIExportArgs("wendy-oci", "linux/arm64", "", "/c/buildx", "/tmp/image.tar", false, nil, true)
+		got := buildxOCIExportArgs("wendy-oci", "linux/arm64", "", "/c/legacy", "/c/buildx", "/tmp/image.tar", false, nil)
 		want := []string{
 			"buildx", "build",
 			"--builder", "wendy-oci",
 			"--platform", "linux/arm64",
 			"--progress", "plain",
-			"--cache-from", "type=local,src=/c/buildx",
+			"--cache-from", "type=local,src=/c/legacy",
 			"--cache-to", "type=local,dest=/c/buildx",
 			"--output", "type=oci,dest=/tmp/image.tar",
 			".",
@@ -605,6 +605,17 @@ func TestBuildxOCIExportArgs(t *testing.T) {
 			t.Fatalf("args mismatch:\n got  %q\n want %q", got, want)
 		}
 	})
+}
+
+func TestLegacyOCICacheKey(t *testing.T) {
+	key := ociDeploymentCacheKey("RobotKit-Yolo-Fruits", "linux/arm64")
+	got, ok := legacyOCICacheKey(key)
+	if !ok || got != "robotkit-yolo-fruits" {
+		t.Fatalf("legacyOCICacheKey(%q) = %q, %v", key, got, ok)
+	}
+	if _, ok := legacyOCICacheKey("ordinary-cache-key"); ok {
+		t.Fatal("ordinary cache key must not be treated as a migrated OCI key")
+	}
 }
 
 // readOCILayoutLayers must reference layer blobs by their byte range in the

--- a/go/internal/cli/commands/ocilayers_test.go
+++ b/go/internal/cli/commands/ocilayers_test.go
@@ -579,10 +579,10 @@ func TestBuildxOCIExportArgs(t *testing.T) {
 			"--platform", "linux/arm64",
 			"--progress", "plain",
 			"-f", "/proj/Dockerfile",
-			"--cache-to", "type=local,dest=/c/buildx",
+			"--cache-to", "type=local,dest=/c/buildx,compression=uncompressed",
 			"--build-arg", "ALPHA=1",
 			"--build-arg", "ZED=2",
-			"--output", "type=oci,dest=/dest/layout,tar=false",
+			"--output", "type=oci,dest=/dest/layout,compression=uncompressed,tar=false",
 			".",
 		}
 		if fmt.Sprint(got) != fmt.Sprint(want) {
@@ -597,8 +597,8 @@ func TestBuildxOCIExportArgs(t *testing.T) {
 			"--platform", "linux/arm64",
 			"--progress", "plain",
 			"--cache-from", "type=local,src=/c/legacy",
-			"--cache-to", "type=local,dest=/c/buildx",
-			"--output", "type=oci,dest=/tmp/image.tar",
+			"--cache-to", "type=local,dest=/c/buildx,compression=uncompressed",
+			"--output", "type=oci,dest=/tmp/image.tar,compression=uncompressed",
 			".",
 		}
 		if fmt.Sprint(got) != fmt.Sprint(want) {

--- a/go/internal/cli/commands/route_preference.go
+++ b/go/internal/cli/commands/route_preference.go
@@ -1,0 +1,104 @@
+package commands
+
+import (
+	"net"
+	"net/netip"
+	"sort"
+	"strings"
+)
+
+// routePreference ranks the host-side path an address would use. It is kept
+// deliberately small: route discovery is a performance hint, never a reason to
+// discard an address or weaken the authenticated dial ladder.
+type routePreference uint8
+
+const (
+	routeUnknown routePreference = iota
+	routeWireless
+	routeWired
+)
+
+// dialCandidateRoutePreferenceFn is a seam for deterministic candidate-order
+// and cached-address tests.
+var dialCandidateRoutePreferenceFn = dialCandidateRoutePreference
+
+var networkInterfaceRoutePreferenceFn = networkInterfaceRoutePreference
+
+var routeInterfaceForIPFn = routeInterfaceForIP
+
+func dialCandidateRoutePreference(rawIP string) routePreference {
+	return networkInterfaceRoutePreferenceFn(routeInterfaceForIPFn(rawIP))
+}
+
+// routeInterfaceForIP asks the kernel which source address it would use for a
+// UDP route to rawIP, then maps that source back to an interface. DialUDP does
+// not send a packet; this avoids interface-name assumptions and follows the
+// same routing table the later TCP connection will use.
+func routeInterfaceForIP(rawIP string) string {
+	addr, err := netip.ParseAddr(strings.TrimSpace(rawIP))
+	if err != nil {
+		return ""
+	}
+	if addr.Zone() != "" {
+		return addr.Zone()
+	}
+	remote := &net.UDPAddr{IP: net.ParseIP(addr.String()), Port: 9}
+	conn, err := net.DialUDP("udp", nil, remote)
+	if err != nil {
+		return ""
+	}
+	localIP := conn.LocalAddr().(*net.UDPAddr).IP
+	_ = conn.Close()
+
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return ""
+	}
+	for i := range ifaces {
+		addrs, err := ifaces[i].Addrs()
+		if err != nil {
+			continue
+		}
+		for _, candidate := range addrs {
+			ip, _, err := net.ParseCIDR(candidate.String())
+			if err == nil && ip.Equal(localIP) {
+				return ifaces[i].Name
+			}
+		}
+	}
+	return ""
+}
+
+func cachedRoutePreference(interfaceName, ip string) routePreference {
+	// A legacy/connect-minted cache row may not know which interface observed
+	// it. Preserve that fast path; only positive discovery metadata that names a
+	// Wi-Fi interface is enough to pay for fresh multi-address resolution.
+	if routedInterface := routeInterfaceForIPFn(ip); routedInterface != "" && interfaceName != "" && routedInterface != interfaceName {
+		// Discovery metadata and the kernel route must describe the same path.
+		// Old Darwin discovery could label an answer en7 while globally resolving
+		// its IP to en0; trusting that row forever pinned deploys to Wi-Fi.
+		if networkInterfaceRoutePreferenceFn(interfaceName) != routeWired || networkInterfaceRoutePreferenceFn(routedInterface) != routeWired {
+			return routeWireless
+		}
+	}
+	return networkInterfaceRoutePreferenceFn(interfaceName)
+}
+
+func shouldUseCachedDeviceAddress(interfaceName, ip string) bool {
+	return strings.TrimSpace(ip) != "" && cachedRoutePreference(interfaceName, ip) != routeWireless
+}
+
+// preferWiredDialCandidates stably promotes addresses routed over a wired
+// interface. Unknown routes retain resolver order, and every address remains
+// in the exhaustive authenticated walk.
+func preferWiredDialCandidates(candidates []string) []string {
+	ordered := append([]string(nil), candidates...)
+	preferences := make(map[string]routePreference, len(ordered))
+	for _, candidate := range ordered {
+		preferences[candidate] = dialCandidateRoutePreferenceFn(candidate)
+	}
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return preferences[ordered[i]] > preferences[ordered[j]]
+	})
+	return ordered
+}

--- a/go/internal/cli/commands/route_preference_darwin.go
+++ b/go/internal/cli/commands/route_preference_darwin.go
@@ -1,0 +1,71 @@
+//go:build darwin
+
+package commands
+
+import (
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+var darwinPortKinds = sync.OnceValue(func() map[string]routePreference {
+	out, err := exec.Command("/usr/sbin/networksetup", "-listallhardwareports").Output()
+	if err != nil {
+		return nil
+	}
+	return parseDarwinInterfaceRoutePreferences(string(out))
+})
+
+var darwinBridgeKinds sync.Map
+
+func parseDarwinInterfaceRoutePreferences(output string) map[string]routePreference {
+	result := map[string]routePreference{}
+	hardwarePort := ""
+	for _, raw := range strings.Split(output, "\n") {
+		line := strings.TrimSpace(raw)
+		switch {
+		case strings.HasPrefix(line, "Hardware Port:"):
+			hardwarePort = strings.TrimSpace(strings.TrimPrefix(line, "Hardware Port:"))
+		case strings.HasPrefix(line, "Device:"):
+			name := strings.TrimSpace(strings.TrimPrefix(line, "Device:"))
+			if name == "" {
+				continue
+			}
+			label := strings.ToLower(hardwarePort)
+			switch {
+			case strings.Contains(label, "wi-fi"), strings.Contains(label, "wifi"), strings.Contains(label, "airport"):
+				result[name] = routeWireless
+			case strings.Contains(label, "ethernet"), strings.Contains(label, "lan"), strings.Contains(label, "thunderbolt"), strings.Contains(label, "usb"):
+				result[name] = routeWired
+			}
+		}
+	}
+	return result
+}
+
+func networkInterfaceRoutePreference(name string) routePreference {
+	name = strings.TrimSpace(name)
+	if preference := darwinPortKinds()[name]; preference != routeUnknown {
+		return preference
+	}
+	if !strings.HasPrefix(name, "bridge") {
+		return routeUnknown
+	}
+	if cached, ok := darwinBridgeKinds.Load(name); ok {
+		return cached.(routePreference)
+	}
+	preference := routeUnknown
+	if out, err := exec.Command("/sbin/ifconfig", name).Output(); err == nil {
+		for _, raw := range strings.Split(string(out), "\n") {
+			fields := strings.Fields(strings.TrimSpace(raw))
+			if len(fields) < 2 || fields[0] != "member:" {
+				continue
+			}
+			if memberPreference := darwinPortKinds()[fields[1]]; memberPreference > preference {
+				preference = memberPreference
+			}
+		}
+	}
+	darwinBridgeKinds.Store(name, preference)
+	return preference
+}

--- a/go/internal/cli/commands/route_preference_darwin_test.go
+++ b/go/internal/cli/commands/route_preference_darwin_test.go
@@ -1,0 +1,23 @@
+//go:build darwin
+
+package commands
+
+import "testing"
+
+func TestParseDarwinInterfaceRoutePreferences(t *testing.T) {
+	ports := `Hardware Port: USB 10/100/1000 LAN
+Device: en7
+Ethernet Address: aa:bb:cc:dd:ee:ff
+
+Hardware Port: Wi-Fi
+Device: en0
+Ethernet Address: 11:22:33:44:55:66
+`
+	got := parseDarwinInterfaceRoutePreferences(ports)
+	if got["en7"] != routeWired {
+		t.Fatalf("en7 preference = %v, want wired", got["en7"])
+	}
+	if got["en0"] != routeWireless {
+		t.Fatalf("en0 preference = %v, want wireless", got["en0"])
+	}
+}

--- a/go/internal/cli/commands/route_preference_linux.go
+++ b/go/internal/cli/commands/route_preference_linux.go
@@ -1,0 +1,25 @@
+//go:build linux
+
+package commands
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func networkInterfaceRoutePreference(name string) routePreference {
+	name = strings.TrimSpace(name)
+	if name == "" || filepath.Base(name) != name {
+		return routeUnknown
+	}
+	iface, err := net.InterfaceByName(name)
+	if err != nil || iface.Flags&net.FlagLoopback != 0 {
+		return routeUnknown
+	}
+	if _, err := os.Stat(filepath.Join("/sys/class/net", name, "wireless")); err == nil {
+		return routeWireless
+	}
+	return routeWired
+}

--- a/go/internal/cli/commands/route_preference_other.go
+++ b/go/internal/cli/commands/route_preference_other.go
@@ -1,0 +1,5 @@
+//go:build !darwin && !linux && !windows
+
+package commands
+
+func networkInterfaceRoutePreference(string) routePreference { return routeUnknown }

--- a/go/internal/cli/commands/route_preference_windows.go
+++ b/go/internal/cli/commands/route_preference_windows.go
@@ -1,0 +1,36 @@
+//go:build windows
+
+package commands
+
+import (
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+var windowsWirelessInterfaces = sync.OnceValue(func() map[string]bool {
+	out, err := exec.Command("netsh", "wlan", "show", "interfaces").Output()
+	if err != nil {
+		return nil
+	}
+	result := map[string]bool{}
+	for _, raw := range strings.Split(string(out), "\n") {
+		line := strings.TrimSpace(raw)
+		key, value, ok := strings.Cut(line, ":")
+		if ok && strings.EqualFold(strings.TrimSpace(key), "Name") {
+			result[strings.ToLower(strings.TrimSpace(value))] = true
+		}
+	}
+	return result
+})
+
+func networkInterfaceRoutePreference(name string) routePreference {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if name == "" {
+		return routeUnknown
+	}
+	if windowsWirelessInterfaces()[name] {
+		return routeWireless
+	}
+	return routeWired
+}

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -559,17 +559,19 @@ func newRunCmd() *cobra.Command {
 		Short: "Build and run application on a WendyOS device",
 		Long:  "Reads wendy.json from the current directory or --prefix directory, builds a container image, and deploys it to the target device.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := validateEnvFlag(opts.env); err != nil {
-				return err
-			}
-			if watch {
-				// In watch mode, hide build output unless a build fails (unless
-				// --verbose); detached + non-interactive are enforced by
-				// watchCommand. This mirrors `wendy watch`.
-				opts.quietBuild = !verbose
-				return watchCommand(cmd.Context(), opts, time.Duration(debounceMS)*time.Millisecond)
-			}
-			return runCommand(cmd.Context(), opts)
+			return runWithInterruptContext(cmd.Context(), func(runCtx context.Context) error {
+				if err := validateEnvFlag(opts.env); err != nil {
+					return err
+				}
+				if watch {
+					// In watch mode, hide build output unless a build fails (unless
+					// --verbose); detached + non-interactive are enforced by
+					// watchCommand. This mirrors `wendy watch`.
+					opts.quietBuild = !verbose
+					return watchCommand(runCtx, opts, time.Duration(debounceMS)*time.Millisecond)
+				}
+				return runCommand(runCtx, opts)
+			})
 		},
 	}
 
@@ -597,6 +599,50 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&verbose, "verbose", false, "Watch mode (--watch): always show build output (default: hidden unless the build fails)")
 
 	return cmd
+}
+
+// runWithInterruptContext gives every phase of `wendy run` the same
+// cancellation signal, including provider builds that do not use Wendy's build
+// progress UI. Previously only the individual Bubble Tea program observed
+// Ctrl-C during a build; its docker/OrbStack/Apple Container subprocess kept a
+// live parent context, so parallel services and fallback builders each surfaced
+// another cancellation of their own.
+func runWithInterruptContext(parent context.Context, run func(context.Context) error) error {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+	defer signal.Stop(sigCh)
+	return runWithInterruptChannel(parent, sigCh, run)
+}
+
+func runWithInterruptChannel(parent context.Context, sigCh <-chan os.Signal, run func(context.Context) error) error {
+	ctx, cancel := context.WithCancelCause(parent)
+	done := make(chan struct{})
+	handlerDone := make(chan struct{})
+	go func() {
+		defer close(handlerDone)
+		select {
+		case <-sigCh:
+			cancel(ErrUserCancelled)
+		case <-done:
+		}
+	}()
+
+	err := run(ctx)
+	// If the operation returned from the subprocess's copy of SIGINT before
+	// the goroutine above was scheduled, consume the already-buffered signal
+	// here so cancellation is still classified consistently.
+	select {
+	case <-sigCh:
+		cancel(ErrUserCancelled)
+	default:
+	}
+	close(done)
+	<-handlerDone
+	cancel(nil)
+	if errors.Is(context.Cause(ctx), ErrUserCancelled) && err != nil {
+		return ErrUserCancelled
+	}
+	return err
 }
 
 // resolveRunTarget resolves the target device for the run command. It first
@@ -857,6 +903,25 @@ func runCommand(ctx context.Context, opts runOptions) error {
 		}
 	}
 	mark("resolve + connect device")
+
+	// Build-file selection happens before wendy.json is loaded so device
+	// discovery and picker behavior stay cheap. Once both config and target are
+	// known, recompile a selected Stagefile with framework-derived runtime
+	// packages. This is idempotent and touches no project source; it only updates
+	// Wendy's generated Dockerfile/lock artifacts.
+	if sfOpts := ros2StagefileOptions(appCfg.ResolveROS2ConfigForService(opts.service)); len(sfOpts) > 0 {
+		if source, ok := stagefileSourceForGenerated(opts.dockerfile); ok {
+			if _, statErr := os.Stat(filepath.Join(cwd, source)); statErr == nil {
+				sfOpts = append(debugStagefileOptions(opts.debug), sfOpts...)
+				resolved, compileErr := prepareDockerBuildFile(cwd, source,
+					resolveGPUArch(ctx, cwd, opts.gpuArch, agentConn(target)), sfOpts...)
+				if compileErr != nil {
+					return compileErr
+				}
+				opts.dockerfile = resolved
+			}
+		}
+	}
 
 	// Provider-based run path.
 	if target.External != nil && target.Provider != nil {
@@ -1721,8 +1786,8 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 		// Single-service build: no concurrency, so keep the shared local cache dir
 		// (empty cache key) for cross-run cache reuse.
 		buildTitle := fmt.Sprintf("Building and pushing image for %s...", tui.Value(platform))
-		if err := runBuildWithProgress(ctx, buildTitle, dumpRawUnlessRegistryUnavailable, func(stream, logw io.Writer) error {
-			return buildAndPushImageForAgent(ctx, conn, regPort, agentOS, opts.builder, cwd, repo, platform, opts.dockerfile, buildArgs, "", stream, logw)
+		if err := runBuildWithProgress(ctx, buildTitle, dumpRawUnlessRegistryUnavailable, func(buildCtx context.Context, stream, logw io.Writer) error {
+			return buildAndPushImageForAgent(buildCtx, conn, regPort, agentOS, opts.builder, cwd, repo, platform, opts.dockerfile, buildArgs, "", stream, logw)
 		}); err != nil {
 			if isRegistryUnavailable(err) {
 				// Return the friendly error bare (matching the Swift path above) —
@@ -2432,12 +2497,12 @@ func deployByChunkDiff(ctx context.Context, conn *grpcclient.AgentConnection, cw
 	var hint *ociReuseHint
 
 	buildTitle := fmt.Sprintf("Building image (OCI layout) for %s...", tui.Value(platform))
-	runBuild := func(build func(stream, logw io.Writer) error) error {
+	runBuild := func(build func(context.Context, io.Writer, io.Writer) error) error {
 		if opts.quietBuild {
 			// wendy watch: keep the legacy quiet behavior (buffer, surface only on
 			// genuine failure) rather than rendering a live UI under the watcher.
 			var buildLog bytes.Buffer
-			if err := build(&buildLog, &buildLog); err != nil {
+			if err := build(ctx, &buildLog, &buildLog); err != nil {
 				if ctx.Err() == nil {
 					_, _ = os.Stderr.Write(buildLog.Bytes())
 				}
@@ -2471,8 +2536,8 @@ func deployByChunkDiff(ctx context.Context, conn *grpcclient.AgentConnection, cw
 			return nil, hint, err
 		}
 		defer releaseLayout()
-		build := func(stream, logw io.Writer) error {
-			return buildImageToOCILayoutDirWithDocker(ctx, cwd, dockerfile, platform, buildArgs, layoutDir, ociDeploymentCacheKey(appCfg.AppID, platform), stream, logw)
+		build := func(buildCtx context.Context, stream, logw io.Writer) error {
+			return buildImageToOCILayoutDirWithDocker(buildCtx, cwd, dockerfile, platform, buildArgs, layoutDir, ociDeploymentCacheKey(appCfg.AppID, platform), stream, logw)
 		}
 
 		// Native fast path: for a Stagefile project whose deps inputs are
@@ -2549,8 +2614,8 @@ func deployByChunkDiff(ctx context.Context, conn *grpcclient.AgentConnection, cw
 		}
 		defer os.RemoveAll(tmp)
 		ociTar := filepath.Join(tmp, "image.tar")
-		if err := runBuild(func(stream, logw io.Writer) error {
-			return buildImageToOCILayout(ctx, cwd, dockerfile, platform, buildArgs, opts.builder, ociTar, ociDeploymentCacheKey(appCfg.AppID, platform), stream, logw)
+		if err := runBuild(func(buildCtx context.Context, stream, logw io.Writer) error {
+			return buildImageToOCILayout(buildCtx, cwd, dockerfile, platform, buildArgs, opts.builder, ociTar, ociDeploymentCacheKey(appCfg.AppID, platform), stream, logw)
 		}); err != nil {
 			return nil, hint, err
 		}

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -1510,6 +1510,7 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 	if err != nil {
 		return fmt.Errorf("querying device version: %w", err)
 	}
+	printRunDiskUsageWarning(versionResp)
 	mark("agent GetAgentVersion (in runWithAgent)")
 	agentOS := versionResp.GetOs()
 	architecture := versionResp.GetCpuArchitecture()

--- a/go/internal/cli/commands/run_cancel_test.go
+++ b/go/internal/cli/commands/run_cancel_test.go
@@ -1,0 +1,27 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestRunWithInterruptChannelCancelsProviderBuildOnce(t *testing.T) {
+	interrupts := make(chan os.Signal, 1)
+	buildExited := false
+
+	err := runWithInterruptChannel(context.Background(), interrupts, func(ctx context.Context) error {
+		interrupts <- os.Interrupt
+		<-ctx.Done()
+		buildExited = true
+		return errors.New("provider builder stopped")
+	})
+
+	if !errors.Is(err, ErrUserCancelled) {
+		t.Fatalf("err = %v, want ErrUserCancelled", err)
+	}
+	if !buildExited {
+		t.Fatal("interrupt wrapper returned before provider build exited")
+	}
+}

--- a/go/internal/cli/commands/stress_test.go
+++ b/go/internal/cli/commands/stress_test.go
@@ -52,7 +52,7 @@ func TestBuildServicesParallelIsolatesCacheDirs(t *testing.T) {
 	}
 
 	failed, infraErr := buildServicesParallel(
-		context.Background(), nil, 5000, "", root, appID, services, "linux/arm64", nil, "docker", nil, nil, len(names))
+		context.Background(), nil, 5000, "", root, appID, services, "linux/arm64", nil, "docker", nil, nil, len(names), false)
 	if infraErr != nil {
 		t.Fatalf("unexpected infra error: %v", infraErr)
 	}
@@ -199,7 +199,7 @@ func TestBuildServicesParallelStress(t *testing.T) {
 
 	maxConc := 1 + r.Intn(8)
 	failed, infraErr := buildServicesParallel(
-		context.Background(), nil, 5000, "linux", root, appID, services, "linux/arm64", nil, "docker", skip, nil, maxConc)
+		context.Background(), nil, 5000, "linux", root, appID, services, "linux/arm64", nil, "docker", skip, nil, maxConc, false)
 	if infraErr != nil {
 		t.Fatalf("unexpected infra error: %v", infraErr)
 	}

--- a/go/internal/cli/commands/watch.go
+++ b/go/internal/cli/commands/watch.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"io/fs"
 	"os"
 	"os/signal"
@@ -182,19 +183,25 @@ func watchCommand(ctx context.Context, opts runOptions, debounce time.Duration) 
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	var stopOnce sync.Once
+	stopWatch := func() {
+		stopOnce.Do(func() {
+			cliLogln("\nStopping watch.")
+			cancel()
+		})
+	}
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt)
 	defer signal.Stop(sigCh)
 	go func() {
 		select {
 		case <-sigCh:
-			cliLogln("\nStopping watch.")
-			cancel()
+			stopWatch()
 		case <-ctx.Done():
 		}
 	}()
 
-	deployer := &debouncedDeployer{opts: opts}
+	deployer := &debouncedDeployer{opts: opts, stopWatch: stopWatch}
 
 	cliLogln("Watching %s for changes (Ctrl-C to stop)...", root)
 	deployer.trigger(ctx) // initial deploy
@@ -243,9 +250,12 @@ func watchCommand(ctx context.Context, opts runOptions, debounce time.Duration) 
 // recent one.
 type debouncedDeployer struct {
 	opts      runOptions
+	stopWatch context.CancelFunc
 	mu        sync.Mutex
 	cancelCur context.CancelFunc
 }
+
+var watchRunCommand = runCommand
 
 func (d *debouncedDeployer) trigger(parent context.Context) {
 	d.mu.Lock()
@@ -259,9 +269,18 @@ func (d *debouncedDeployer) trigger(parent context.Context) {
 	go func() {
 		start := time.Now()
 		cliLogln("↻ change detected — redeploying...")
-		if err := runCommand(runCtx, d.opts); err != nil {
+		if err := watchRunCommand(runCtx, d.opts); err != nil {
 			if runCtx.Err() != nil {
 				return // superseded by a newer change or shutting down
+			}
+			if errors.Is(err, ErrUserCancelled) {
+				// Ctrl-C read by an interactive build UI arrives as a key event,
+				// not an OS signal. Treat it exactly like the signal path instead
+				// of reporting a failed deploy and continuing to watch.
+				if d.stopWatch != nil {
+					d.stopWatch()
+				}
+				return
 			}
 			cliLogln("✗ deploy failed: %v (still watching)", err)
 			return

--- a/go/internal/cli/commands/watch_test.go
+++ b/go/internal/cli/commands/watch_test.go
@@ -1,12 +1,32 @@
 package commands
 
 import (
+	"context"
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
+
+func TestDebouncedDeployerUserCancellationStopsWatch(t *testing.T) {
+	originalRun := watchRunCommand
+	t.Cleanup(func() { watchRunCommand = originalRun })
+	watchRunCommand = func(context.Context, runOptions) error { return ErrUserCancelled }
+
+	stopped := make(chan struct{})
+	d := &debouncedDeployer{
+		stopWatch: func() { close(stopped) },
+	}
+	d.trigger(context.Background())
+
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("watch did not stop after the build UI returned ErrUserCancelled")
+	}
+}
 
 func TestWatchShouldIgnore(t *testing.T) {
 	root := t.TempDir()

--- a/go/internal/cli/tui/multispinner.go
+++ b/go/internal/cli/tui/multispinner.go
@@ -58,22 +58,31 @@ type multiSpinnerRow struct {
 //	  ⠋ api        building...
 //	  ⠋ frontend   building...
 type MultiSpinnerModel struct {
-	title   string
-	rows    []multiSpinnerRow
-	byName  map[string]int
-	spinner spinner.Model
-	hints   hintRotator
-	width   int
-	done    bool
-	err     error
+	title  string
+	rows   []multiSpinnerRow
+	byName map[string]int
+	// nameWidth is wide enough for the longest service name plus a separator.
+	// Keeping it on the model avoids lipgloss wrapping names longer than the
+	// old fixed 12-cell column into extra physical lines, which confuses the
+	// Bubble Tea renderer's line accounting.
+	nameWidth int
+	spinner   spinner.Model
+	hints     hintRotator
+	width     int
+	done      bool
+	err       error
 }
 
 func NewMultiSpinner(title string, names []string) MultiSpinnerModel {
 	rows := make([]multiSpinnerRow, len(names))
 	byName := make(map[string]int, len(names))
+	nameWidth := 12
 	for i, n := range names {
 		rows[i] = multiSpinnerRow{name: n, status: MultiSpinnerPending}
 		byName[n] = i
+		if w := lipgloss.Width(n) + 1; w > nameWidth {
+			nameWidth = w
+		}
 	}
 
 	s := spinner.New()
@@ -81,11 +90,12 @@ func NewMultiSpinner(title string, names []string) MultiSpinnerModel {
 	s.Style = lipgloss.NewStyle().Foreground(ColorPrimary)
 
 	return MultiSpinnerModel{
-		title:   title,
-		rows:    rows,
-		byName:  byName,
-		spinner: s,
-		hints:   newHintRotator(),
+		title:     title,
+		rows:      rows,
+		byName:    byName,
+		nameWidth: nameWidth,
+		spinner:   s,
+		hints:     newHintRotator(),
 	}
 }
 
@@ -152,7 +162,6 @@ func (m MultiSpinnerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 var (
 	msCheckStyle = lipgloss.NewStyle().Foreground(ColorAccent).Bold(true)
 	msCrossStyle = lipgloss.NewStyle().Foreground(ColorError).Bold(true)
-	msNameStyle  = lipgloss.NewStyle().Width(12)
 	msDimStyle   = lipgloss.NewStyle().Foreground(ColorDim)
 	msErrorStyle = lipgloss.NewStyle().Foreground(ColorError)
 	msTitleStyle = lipgloss.NewStyle().Foreground(ColorPrimary)
@@ -172,6 +181,7 @@ func (m MultiSpinnerModel) View() string {
 	}
 
 	var sb strings.Builder
+	nameStyle := lipgloss.NewStyle().Width(m.nameWidth)
 	sb.WriteString(fmt.Sprintf("%s %s\n", m.spinner.View(), msTitleStyle.Render(m.title)))
 
 	for _, r := range m.rows {
@@ -179,7 +189,7 @@ func (m MultiSpinnerModel) View() string {
 		case MultiSpinnerPending:
 			sb.WriteString(fmt.Sprintf("  %s %s%s\n",
 				msDimStyle.Render("·"),
-				msDimStyle.Render(msNameStyle.Render(r.name)),
+				msDimStyle.Render(nameStyle.Render(r.name)),
 				msDimStyle.Render("waiting"),
 			))
 
@@ -190,7 +200,7 @@ func (m MultiSpinnerModel) View() string {
 			}
 			sb.WriteString(fmt.Sprintf("  %s %s%s\n",
 				m.spinner.View(),
-				msNameStyle.Render(r.name),
+				nameStyle.Render(r.name),
 				msDimStyle.Render(detail),
 			))
 
@@ -199,14 +209,14 @@ func (m MultiSpinnerModel) View() string {
 				r.cached, r.rebuilt, r.dur.Round(time.Millisecond))
 			sb.WriteString(fmt.Sprintf("  %s %s%s\n",
 				msCheckStyle.Render("✓"),
-				msNameStyle.Render(r.name),
+				nameStyle.Render(r.name),
 				msDimStyle.Render(note),
 			))
 
 		case MultiSpinnerFailed:
 			sb.WriteString(fmt.Sprintf("  %s %s%s\n",
 				msCrossStyle.Render("✗"),
-				msNameStyle.Render(r.name),
+				nameStyle.Render(r.name),
 				msErrorStyle.Render("failed"),
 			))
 		}

--- a/go/internal/cli/tui/multispinner_test.go
+++ b/go/internal/cli/tui/multispinner_test.go
@@ -17,3 +17,21 @@ func TestMultiSpinnerDoneRowShowsCacheCounts(t *testing.T) {
 		t.Fatalf("done row missing cache counts:\n%s", v)
 	}
 }
+
+func TestMultiSpinnerLongServiceNamesStayOnOneLine(t *testing.T) {
+	names := []string{"health-high-low", "transcription", "website-frontend"}
+	m := NewMultiSpinner("Building 3 service(s)...", names)
+
+	v := m.View()
+	lines := strings.Split(strings.TrimSuffix(v, "\n"), "\n")
+	// The title, one line per service, and one hint. A fixed-width lipgloss
+	// style used to wrap every name longer than 12 cells into an extra line.
+	if got, want := len(lines), len(names)+2; got != want {
+		t.Fatalf("view has %d lines, want %d:\n%s", got, want, v)
+	}
+	for _, name := range names {
+		if got := strings.Count(v, name); got != 1 {
+			t.Errorf("service name %q appears %d times in view:\n%s", name, got, v)
+		}
+	}
+}

--- a/go/internal/shared/chunk/chunk.go
+++ b/go/internal/shared/chunk/chunk.go
@@ -17,6 +17,7 @@ import (
 	"io"
 	"math/rand"
 	"runtime"
+	"sync"
 
 	"golang.org/x/sync/errgroup"
 )
@@ -39,6 +40,17 @@ const AlgoVersion = 2
 // dedup cost of these forced seams is ~one chunk per region (<0.5%), while still
 // yielding hundreds of regions for a multi-GiB layer — plenty of parallelism.
 const regionSize = 16 << 20 // 16 MiB
+
+// maxConcurrentReaderAtRegions bounds the process-wide transient memory used
+// by ChunkReaderAt. Parallel deploys multiply at several levels (Compose
+// services × image layers × regions); allowing every call to independently use
+// GOMAXPROCS workers retained nearly 800 MiB of 16 MiB buffers in practice.
+// Four slots keep the hot working set at 64 MiB while still overlapping disk
+// reads and hashing across independent layers and services. This changes only
+// scheduling, never region seams, chunk boundaries, or hashes.
+const maxConcurrentReaderAtRegions = 4
+
+var readerAtRegionSlots = make(chan struct{}, maxConcurrentReaderAtRegions)
 
 // FastCDC normalized-chunking masks. AvgSize is 2^16, so the target is 16 hash
 // bits; normalization makes cuts harder than target before AvgSize (maskS, 18
@@ -80,6 +92,70 @@ func Chunk(r io.Reader) ([]Ref, error) {
 	return ChunkBytes(data)
 }
 
+// ChunkStream content-chunks a sequential stream without first materializing
+// it or rereading it. It preserves ChunkReaderAt's fixed region seams and
+// therefore produces identical refs for the same bytes. Region processing is
+// overlapped with reading the following region and shares the process-wide
+// memory slots used by ChunkReaderAt.
+func ChunkStream(r io.Reader, progress func(completed int64)) ([]Ref, int64, error) {
+	type regionResult struct{ refs []Ref }
+	var (
+		g          errgroup.Group
+		parts      []*regionResult
+		total      int64
+		progressMu sync.Mutex
+		completed  int64
+	)
+
+	for {
+		readerAtRegionSlots <- struct{}{}
+		buf := make([]byte, regionSize)
+		n, err := io.ReadFull(r, buf)
+		if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+			<-readerAtRegionSlots
+			_ = g.Wait()
+			return nil, total, err
+		}
+		if n == 0 {
+			<-readerAtRegionSlots
+			break
+		}
+
+		buf = buf[:n]
+		base := total
+		total += int64(n)
+		part := &regionResult{}
+		parts = append(parts, part)
+		g.Go(func() error {
+			defer func() { <-readerAtRegionSlots }()
+			part.refs = fastCDCRegion(buf, uint64(base))
+			if progress != nil {
+				progressMu.Lock()
+				completed += int64(len(buf))
+				progress(completed)
+				progressMu.Unlock()
+			}
+			return nil
+		})
+		if err == io.ErrUnexpectedEOF {
+			break
+		}
+	}
+	if err := g.Wait(); err != nil {
+		return nil, total, err
+	}
+
+	count := 0
+	for _, part := range parts {
+		count += len(part.refs)
+	}
+	refs := make([]Ref, 0, count)
+	for _, part := range parts {
+		refs = append(refs, part.refs...)
+	}
+	return refs, total, nil
+}
+
 // ChunkBytes returns the content-defined chunks of an in-memory buffer. Regions
 // are chunked concurrently and reference data directly (no copy).
 func ChunkBytes(data []byte) ([]Ref, error) {
@@ -101,6 +177,14 @@ func ChunkBytes(data []byte) ([]Ref, error) {
 // the worker count rather than the whole input — important on the agent, which
 // re-chunks multi-GiB layers without holding them in RAM.
 func ChunkReaderAt(ra io.ReaderAt, size int64) ([]Ref, error) {
+	return ChunkReaderAtWithProgress(ra, size, nil)
+}
+
+// ChunkReaderAtWithProgress is ChunkReaderAt with an optional concurrency-safe
+// progress callback. completed advances once a region has been fully read,
+// boundary-scanned, and hashed; total is always size. Callbacks are serialized
+// in increasing completed-byte order and must return promptly.
+func ChunkReaderAtWithProgress(ra io.ReaderAt, size int64, progress func(completed, total int64)) ([]Ref, error) {
 	if size < 0 {
 		return nil, fmt.Errorf("chunk: negative size %d", size)
 	}
@@ -111,14 +195,25 @@ func ChunkReaderAt(ra io.ReaderAt, size int64) ([]Ref, error) {
 	if n == 0 {
 		return nil, nil
 	}
+	var progressMu sync.Mutex
+	var completed int64
 	return chunkRegions(n, func(start, end int) ([]Ref, error) {
+		readerAtRegionSlots <- struct{}{}
+		defer func() { <-readerAtRegionSlots }()
 		buf := make([]byte, end-start)
 		// io.ReaderAt fills buf fully unless it returns an error; a full read may
 		// still report io.EOF, so trust the byte count rather than the error.
 		if got, err := ra.ReadAt(buf, int64(start)); got != len(buf) {
 			return nil, fmt.Errorf("chunk: short read at %d: %d/%d bytes: %w", start, got, len(buf), err)
 		}
-		return fastCDCRegion(buf, uint64(start)), nil
+		refs := fastCDCRegion(buf, uint64(start))
+		if progress != nil {
+			progressMu.Lock()
+			completed += int64(end - start)
+			progress(completed, size)
+			progressMu.Unlock()
+		}
+		return refs, nil
 	})
 }
 

--- a/go/internal/shared/chunk/chunk_parallel_test.go
+++ b/go/internal/shared/chunk/chunk_parallel_test.go
@@ -5,7 +5,9 @@ import (
 	"crypto/rand"
 	"io"
 	"runtime"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // randData returns n bytes that are deterministic within a single test run but
@@ -31,9 +33,8 @@ func refsEqual(a, b []Ref) bool {
 	return true
 }
 
-// The three entry points used by the two callers (CLI: ChunkBytes over an
-// in-memory tar; agent: ChunkReaderAt over the content store; and the legacy
-// Chunk(io.Reader)) MUST agree byte-for-byte, or device-side dedup breaks.
+// Every entry point used by the CLI and agent MUST agree byte-for-byte, or
+// device-side dedup breaks.
 func TestEntryPointParity(t *testing.T) {
 	for _, size := range []int{0, 1, 1 << 10, int(MinSize), int(MaxSize) + 1, regionSize - 1, regionSize, regionSize + 7, 3*regionSize + 12345} {
 		data := randData(t, size)
@@ -55,6 +56,22 @@ func TestEntryPointParity(t *testing.T) {
 		}
 		if !refsEqual(fromBytes, fromReader) {
 			t.Fatalf("size %d: ChunkBytes vs Chunk differ (%d vs %d chunks)", size, len(fromBytes), len(fromReader))
+		}
+		var progress int64
+		fromStream, streamed, err := ChunkStream(bytes.NewReader(data), func(completed int64) {
+			if completed < progress {
+				t.Errorf("size %d: ChunkStream progress moved backward: %d after %d", size, completed, progress)
+			}
+			progress = completed
+		})
+		if err != nil {
+			t.Fatalf("size %d: ChunkStream: %v", size, err)
+		}
+		if streamed != int64(size) || progress != int64(size) {
+			t.Fatalf("size %d: ChunkStream bytes/progress = %d/%d", size, streamed, progress)
+		}
+		if !refsEqual(fromBytes, fromStream) {
+			t.Fatalf("size %d: ChunkBytes vs ChunkStream differ (%d vs %d chunks)", size, len(fromBytes), len(fromStream))
 		}
 	}
 }
@@ -122,6 +139,64 @@ func (s shortReaderAt) ReadAt(p []byte, off int64) (int, error) {
 func TestChunkReaderAtPropagatesError(t *testing.T) {
 	if _, err := ChunkReaderAt(shortReaderAt{}, int64(regionSize+1)); err == nil {
 		t.Fatal("expected error from failing ReaderAt, got nil")
+	}
+}
+
+type blockingReaderAt struct {
+	current atomic.Int32
+	peak    atomic.Int32
+	release <-chan struct{}
+}
+
+func (r *blockingReaderAt) ReadAt(p []byte, _ int64) (int, error) {
+	current := r.current.Add(1)
+	for peak := r.peak.Load(); current > peak && !r.peak.CompareAndSwap(peak, current); peak = r.peak.Load() {
+	}
+	<-r.release
+	clear(p)
+	r.current.Add(-1)
+	return len(p), nil
+}
+
+func TestChunkReaderAtBoundsRegionBuffersProcessWide(t *testing.T) {
+	originalProcs := runtime.GOMAXPROCS(maxConcurrentReaderAtRegions + 2)
+	t.Cleanup(func() { runtime.GOMAXPROCS(originalProcs) })
+
+	release := make(chan struct{})
+	reader := &blockingReaderAt{release: release}
+	done := make(chan error, 3)
+	// Several independent calls model concurrent Compose services/layers. A
+	// per-call limit would still allow all six regions through; only the shared
+	// admission pool keeps their aggregate at four.
+	for range 3 {
+		go func() {
+			_, err := ChunkReaderAt(reader, int64(2*regionSize))
+			done <- err
+		}()
+	}
+
+	deadline := time.After(2 * time.Second)
+	for reader.current.Load() < maxConcurrentReaderAtRegions {
+		select {
+		case <-deadline:
+			close(release)
+			t.Fatal("ChunkReaderAt did not fill the expected region-worker slots")
+		default:
+			runtime.Gosched()
+		}
+	}
+	// Give every extra region goroutine a chance to run. Without the global
+	// slots, peak would rise above four while all reads are held at the barrier.
+	time.Sleep(20 * time.Millisecond)
+	if peak := reader.peak.Load(); peak != maxConcurrentReaderAtRegions {
+		close(release)
+		t.Fatalf("simultaneous ReaderAt regions = %d, want %d", peak, maxConcurrentReaderAtRegions)
+	}
+	close(release)
+	for range 3 {
+		if err := <-done; err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 

--- a/go/internal/shared/discovery/discovery_darwin.go
+++ b/go/internal/shared/discovery/discovery_darwin.go
@@ -28,9 +28,10 @@ func init() {
 // browseResult identifies one mDNS browse answer: the instance and domain
 // dns_sd.h reported, plus the interface it arrived on.
 type browseResult struct {
-	instanceName  string
-	domain        string
-	interfaceName string
+	instanceName   string
+	domain         string
+	interfaceName  string
+	interfaceIndex uint32
 }
 
 func darwinCachedInterfaceLinkSpeed(ctx context.Context, interfaceName string, linkSpeeds map[string]string) string {

--- a/go/internal/shared/discovery/dnssd_darwin.c
+++ b/go/internal/shared/discovery/dnssd_darwin.c
@@ -40,9 +40,39 @@ static void resolve_reply(DNSServiceRef ref, DNSServiceFlags flags,
 
 DNSServiceErrorType wendy_dnssd_resolve(DNSServiceRef *ref, const char *name,
                                         const char *regtype, const char *domain,
+                                        uint32_t interface_index,
                                         uintptr_t handle) {
-  // kDNSServiceInterfaceIndexAny matches the previous `dns-sd -L` behaviour,
-  // which did not pin the resolve to the interface the browse replied on.
-  return DNSServiceResolve(ref, 0, kDNSServiceInterfaceIndexAny, name, regtype,
+  return DNSServiceResolve(ref, 0, interface_index, name, regtype,
                            domain, resolve_reply, (void *)handle);
+}
+
+static void addr_reply(DNSServiceRef ref, DNSServiceFlags flags,
+                       uint32_t ifIndex, DNSServiceErrorType err,
+                       const char *hostname, const struct sockaddr *address,
+                       uint32_t ttl, void *ctx) {
+  (void)ref;
+  (void)hostname;
+  (void)ttl;
+  char text[INET6_ADDRSTRLEN] = {0};
+  if (err == kDNSServiceErr_NoError && address != NULL) {
+    if (address->sa_family == AF_INET) {
+      inet_ntop(AF_INET, &((const struct sockaddr_in *)address)->sin_addr,
+                text, sizeof(text));
+    } else if (address->sa_family == AF_INET6) {
+      inet_ntop(AF_INET6, &((const struct sockaddr_in6 *)address)->sin6_addr,
+                text, sizeof(text));
+    }
+  }
+  wendyDNSSDAddrReply((uintptr_t)ctx, (uint32_t)flags, ifIndex, (int32_t)err,
+                      text);
+}
+
+DNSServiceErrorType wendy_dnssd_getaddrinfo(DNSServiceRef *ref,
+                                            const char *hostname,
+                                            uint32_t interface_index,
+                                            uintptr_t handle) {
+  return DNSServiceGetAddrInfo(ref, 0, interface_index,
+                               kDNSServiceProtocol_IPv4 |
+                                   kDNSServiceProtocol_IPv6,
+                               hostname, addr_reply, (void *)handle);
 }

--- a/go/internal/shared/discovery/dnssd_darwin.go
+++ b/go/internal/shared/discovery/dnssd_darwin.go
@@ -50,6 +50,7 @@ var dnssdResolveTimeout = 1 * time.Second
 type dnssdSession struct {
 	onBrowse  func(flags uint32, ifIndex uint32, name, domain string)
 	onResolve func(host string, port int, txt []byte)
+	onAddress func(flags uint32, ifIndex uint32, address string)
 
 	// err and stop are written by the reply callback and read by the poll loop
 	// that invoked DNSServiceProcessResult. Callbacks run synchronously on that
@@ -126,6 +127,26 @@ func wendyDNSSDResolveReply(handle C.uintptr_t, errCode C.int32_t, host *C.char,
 	s.stop = true
 }
 
+//export wendyDNSSDAddrReply
+func wendyDNSSDAddrReply(handle C.uintptr_t, flags C.uint32_t, ifIndex C.uint32_t, errCode C.int32_t, address *C.char) {
+	s := lookupSession(uintptr(handle))
+	if s == nil {
+		return
+	}
+	if err := dnssdError(C.DNSServiceErrorType(errCode)); err != nil {
+		s.err = err
+		s.stop = true
+		return
+	}
+	s.onAddress(uint32(flags), uint32(ifIndex), C.GoString(address))
+	// mDNSResponder marks all but the final answer in the current batch with
+	// MoreComing. Waiting for that final callback lets the caller prefer IPv4
+	// without turning a single address lookup into a long-lived browse.
+	if uint32(flags)&uint32(C.kDNSServiceFlagsMoreComing) == 0 {
+		s.stop = true
+	}
+}
+
 // runDNSSDSession starts an operation and pumps its socket until ctx ends, the
 // callback sets stop, or an error occurs. Deallocating the ref closes the
 // daemon connection, so nothing survives this function.
@@ -191,9 +212,10 @@ func dnssdBrowseStream(ctx context.Context, serviceType string, onResult func(br
 				interfaceName = iface.Name
 			}
 			onResult(browseResult{
-				instanceName:  name,
-				domain:        domain,
-				interfaceName: interfaceName,
+				instanceName:   name,
+				domain:         domain,
+				interfaceName:  interfaceName,
+				interfaceIndex: ifIndex,
 			})
 		},
 	}
@@ -266,7 +288,7 @@ func dnssdResolveInstance(ctx context.Context, inst browseResult, serviceType st
 	}
 
 	err := runDNSSDSession(ctx, session, func(ref *C.DNSServiceRef, handle C.uintptr_t) C.DNSServiceErrorType {
-		return C.wendy_dnssd_resolve(ref, cName, cServiceType, cDomain, handle)
+		return C.wendy_dnssd_resolve(ref, cName, cServiceType, cDomain, C.uint32_t(inst.interfaceIndex), handle)
 	})
 	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 		return "", 0, nil, err
@@ -278,4 +300,46 @@ func dnssdResolveInstance(ctx context.Context, inst browseResult, serviceType st
 		txtRecords = make(map[string]string)
 	}
 	return hostname, port, txtRecords, nil
+}
+
+// dnssdResolveAddresses asks mDNSResponder for addresses on the exact
+// interface that produced the browse answer. A global LookupHost here can
+// return a Wi-Fi A record for an instance seen over USB Ethernet, producing an
+// internally inconsistent "en7 + Wi-Fi IP" device and routing the deployment
+// over the wrong link.
+func dnssdResolveAddresses(ctx context.Context, hostname string, inst browseResult) ([]string, error) {
+	cHostname := C.CString(hostname)
+	defer C.free(unsafe.Pointer(cHostname))
+
+	var addresses []string
+	session := &dnssdSession{
+		onAddress: func(_ uint32, ifIndex uint32, address string) {
+			if address == "" {
+				return
+			}
+			ip := net.ParseIP(address)
+			if ip != nil && ip.IsLinkLocalUnicast() && strings.Contains(address, ":") {
+				zone := inst.interfaceName
+				if zone == "" {
+					if iface, err := net.InterfaceByIndex(int(ifIndex)); err == nil {
+						zone = iface.Name
+					}
+				}
+				if zone != "" {
+					address += "%" + zone
+				}
+			}
+			addresses = append(addresses, address)
+		},
+	}
+	err := runDNSSDSession(ctx, session, func(ref *C.DNSServiceRef, handle C.uintptr_t) C.DNSServiceErrorType {
+		return C.wendy_dnssd_getaddrinfo(ref, cHostname, C.uint32_t(inst.interfaceIndex), handle)
+	})
+	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		return nil, err
+	}
+	if len(addresses) == 0 {
+		return nil, fmt.Errorf("could not resolve address for %q on interface %q", hostname, inst.interfaceName)
+	}
+	return addresses, nil
 }

--- a/go/internal/shared/discovery/dnssd_darwin.h
+++ b/go/internal/shared/discovery/dnssd_darwin.h
@@ -14,6 +14,12 @@ DNSServiceErrorType wendy_dnssd_browse(DNSServiceRef *ref, const char *regtype,
 
 DNSServiceErrorType wendy_dnssd_resolve(DNSServiceRef *ref, const char *name,
                                         const char *regtype, const char *domain,
+                                        uint32_t interface_index,
                                         uintptr_t handle);
+
+DNSServiceErrorType wendy_dnssd_getaddrinfo(DNSServiceRef *ref,
+                                            const char *hostname,
+                                            uint32_t interface_index,
+                                            uintptr_t handle);
 
 #endif

--- a/go/internal/shared/discovery/mdns.go
+++ b/go/internal/shared/discovery/mdns.go
@@ -177,10 +177,9 @@ func BrowseMDNSServicesContinuous(ctx context.Context, serviceType string) (<-ch
 // BrowseMDNSServices collects services of serviceType from the platform mdns
 // backend, returning once the network has settled: browseSettle after the
 // most recently discovered service, or timeout, whichever comes first.
-// Results are deduplicated by InstanceName+Hostname+Port — a re-announcement
-// of the same instance (mdnsStreamBackend does not dedup itself) collapses
-// into a single entry, matching every per-platform batch browse this
-// replaces.
+// Results are deduplicated by instance, host, port, address, and interface. A
+// repeat announcement collapses, while a multi-homed service retains one
+// answer per path so connection selection can choose Ethernet over Wi-Fi.
 func BrowseMDNSServices(ctx context.Context, serviceType string, timeout time.Duration) ([]MDNSService, error) {
 	if timeout == 0 {
 		timeout = defaultTimeout
@@ -226,7 +225,7 @@ func BrowseMDNSServices(ctx context.Context, serviceType string, timeout time.Du
 	for {
 		select {
 		case svc := <-found:
-			key := fmt.Sprintf("%s-%s-%d", svc.InstanceName, svc.Hostname, svc.Port)
+			key := fmt.Sprintf("%s-%s-%d-%s-%s", svc.InstanceName, svc.Hostname, svc.Port, svc.IPAddress, svc.InterfaceName)
 			if !seen[key] {
 				seen[key] = true
 				services = append(services, svc)

--- a/go/internal/shared/discovery/mdns_darwin.go
+++ b/go/internal/shared/discovery/mdns_darwin.go
@@ -5,8 +5,12 @@ package discovery
 import (
 	"context"
 	"net"
+	"net/netip"
+	"strings"
 	"sync"
 )
+
+var routeInterfaceForMDNSAddressFn = routeInterfaceForMDNSAddress
 
 // resolveMDNSService resolves a browse result into an MDNSService. Its only
 // caller, mdnsStreamResolveAndEmit, invokes it (via the resolveServiceFn
@@ -19,11 +23,9 @@ func resolveMDNSService(ctx context.Context, inst browseResult, serviceType stri
 		return MDNSService{}, err
 	}
 
-	// Through the resolver rather than net.LookupHost, which ignores ctx —
-	// DefaultResolver keeps the system resolver, which .local names need.
 	ipAddr := ""
-	if addrs, lookupErr := net.DefaultResolver.LookupHost(ctx, hostname); lookupErr == nil {
-		ipAddr = preferIPv4Addr(addrs)
+	if addrs, lookupErr := dnssdResolveAddresses(ctx, hostname, inst); lookupErr == nil {
+		ipAddr = preferInterfaceRoutedAddr(addrs, inst.interfaceName)
 	}
 
 	return MDNSService{
@@ -33,6 +35,67 @@ func resolveMDNSService(ctx context.Context, inst browseResult, serviceType stri
 		Port:         port,
 		TXTRecords:   txtRecords,
 	}, nil
+}
+
+// preferInterfaceRoutedAddr chooses an address whose kernel route still uses
+// the interface that produced the DNS-SD answer. This matters for direct links
+// whose device-side IPv4 subnet overlaps a broader default route: mDNSResponder
+// can correctly return 192.168.123.x on Ethernet while an ordinary dial to it
+// would still leave through Wi-Fi. If no route maps exactly (a physical member
+// may be represented by its bridge), prefer non-link-local IPv6; its advertised
+// on-link prefix retains the interface scope and avoids the overlapping IPv4
+// route.
+func preferInterfaceRoutedAddr(addrs []string, interfaceName string) string {
+	var exact []string
+	for _, addr := range addrs {
+		if routeInterfaceForMDNSAddressFn(addr) == interfaceName {
+			exact = append(exact, addr)
+		}
+	}
+	if len(exact) > 0 {
+		return preferIPv4Addr(exact)
+	}
+	for _, addr := range addrs {
+		ip := net.ParseIP(strings.SplitN(addr, "%", 2)[0])
+		if ip != nil && ip.To4() == nil && !ip.IsLinkLocalUnicast() {
+			return addr
+		}
+	}
+	return preferIPv4Addr(addrs)
+}
+
+func routeInterfaceForMDNSAddress(raw string) string {
+	addr, err := netip.ParseAddr(strings.TrimSpace(raw))
+	if err != nil {
+		return ""
+	}
+	if addr.Zone() != "" {
+		return addr.Zone()
+	}
+	remote := &net.UDPAddr{IP: net.ParseIP(addr.String()), Port: 9}
+	conn, err := net.DialUDP("udp", nil, remote)
+	if err != nil {
+		return ""
+	}
+	localIP := conn.LocalAddr().(*net.UDPAddr).IP
+	_ = conn.Close()
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return ""
+	}
+	for _, iface := range ifaces {
+		ifaceAddrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, candidate := range ifaceAddrs {
+			ip, _, err := net.ParseCIDR(candidate.String())
+			if err == nil && ip.Equal(localIP) {
+				return iface.Name
+			}
+		}
+	}
+	return ""
 }
 
 // resolveWorkers bounds how many browse results mdnsStreamBackend resolves
@@ -71,8 +134,16 @@ func mdnsStreamBackend(ctx context.Context, serviceType string, emit func(MDNSSe
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for inst := range jobs {
-				mdnsStreamResolveAndEmit(ctx, inst, serviceType, emit)
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case inst, ok := <-jobs:
+					if !ok {
+						return
+					}
+					mdnsStreamResolveAndEmit(ctx, inst, serviceType, emit)
+				}
 			}
 		}()
 	}
@@ -84,10 +155,9 @@ func mdnsStreamBackend(ctx context.Context, serviceType string, emit func(MDNSSe
 		}
 	})
 
-	// Closing jobs (rather than relying solely on ctx) lets any resolver still
-	// draining a backlog finish it instead of abandoning already-queued work;
-	// each resolve is itself ctx-bounded, so this cannot outlive ctx by more
-	// than one dnssdResolveTimeout.
+	// Closing jobs lets workers finish a naturally-ended browse. On cancellation
+	// their ctx arm wins and intentionally abandons queued refreshes; draining a
+	// full queue could otherwise multiply shutdown latency by resolve timeout.
 	close(jobs)
 	wg.Wait()
 	return err

--- a/go/internal/shared/discovery/mdns_darwin_test.go
+++ b/go/internal/shared/discovery/mdns_darwin_test.go
@@ -230,3 +230,23 @@ func TestMDNSStreamResolveAndEmitFallback(t *testing.T) {
 		}
 	})
 }
+
+func TestPreferInterfaceRoutedAddrAvoidsIPv4OnWrongInterface(t *testing.T) {
+	original := routeInterfaceForMDNSAddressFn
+	t.Cleanup(func() { routeInterfaceForMDNSAddressFn = original })
+	routeInterfaceForMDNSAddressFn = func(addr string) string {
+		switch addr {
+		case "192.168.123.18":
+			return "en0"
+		case "fdde:2b9::18":
+			return "bridge104"
+		default:
+			return ""
+		}
+	}
+
+	got := preferInterfaceRoutedAddr([]string{"192.168.123.18", "fdde:2b9::18"}, "en7")
+	if got != "fdde:2b9::18" {
+		t.Fatalf("preferInterfaceRoutedAddr = %q, want Ethernet ULA instead of wrong-interface IPv4", got)
+	}
+}

--- a/go/internal/stagefile/codegen/codegen.go
+++ b/go/internal/stagefile/codegen/codegen.go
@@ -84,6 +84,20 @@ func Generate(f *spec.File, images, downloads map[string]string, platform string
 			return "", fmt.Errorf("stage %q declares cuda: but no GPU target was resolved for this build", s.Name)
 		}
 
+		// CUDA runtime wheels are by far the largest dependency layer in a GPU
+		// image. Build them from the pinned base in an independent stage so an
+		// unrelated edit to the app stage's APT/CMake dependencies cannot evict
+		// several gigabytes of otherwise-identical CUDA content. The final
+		// COPY --link below rebases this content onto the app stage without
+		// coupling its cache key to the app stage's parent filesystem.
+		cudaRuntimeStage := ""
+		if s.CUDA {
+			cudaRuntimeStage = cudaRuntimeStageName(i, f.Stages)
+			blocks = append(blocks, strings.Join(cudaRuntimeStageLines(
+				s, digest, pinned, stagePlatform, cudaRuntimeStage, *cudaProfile,
+			), "\n"))
+		}
+
 		lines := []string{fromLine(s.From, digest, s.Name, stagePlatform)}
 		lines = append(lines, kvLines("ARG", s.Args)...)
 		lines = append(lines, kvLines("ENV", stageEnv(&s, cudaProfile))...)
@@ -128,7 +142,11 @@ func Generate(f *spec.File, images, downloads map[string]string, platform string
 		if len(install.CMake) > 0 {
 			lines = append(lines, cmakeInstallLines(install.CMake, stagePlatform)...)
 		}
-		lines = append(lines, pipGroupLines(install.Pip, s.CUDA, cudaProfile, stagePlatform)...)
+		if cudaRuntimeStage != "" {
+			lines = append(lines, fmt.Sprintf("COPY --link --from=%s %s %s",
+				cudaRuntimeStage, cudaPythonRoot, cudaPythonRoot))
+		}
+		lines = append(lines, pipGroupLines(install.Pip, cudaProfile, stagePlatform)...)
 		if install.Npm != nil {
 			lines = append(lines, npmInstallLines(install.Npm)...)
 		}
@@ -564,6 +582,57 @@ func pipInstallLines(p *spec.PipInstall, cudaProfile *gpu.Profile, platform stri
 	return lines
 }
 
+// cudaPythonRoot is a dedicated, compiler-owned Python import root for the
+// generated CUDA runtime stage. Keeping these packages out of the base
+// interpreter's site-packages makes the directory safe to promote wholesale
+// with COPY --link, independently of the app stage's APT/CMake history.
+const cudaPythonRoot = "/opt/stagefile/cuda/python"
+
+// cudaRuntimeStageName returns a generated stage name that cannot collide with
+// a user-declared stage. Stage names are references rather than image-visible
+// state, so the stable stage index is sufficient to keep generated output
+// deterministic.
+func cudaRuntimeStageName(stageIndex int, stages []spec.Stage) string {
+	used := make(map[string]bool, len(stages))
+	for _, s := range stages {
+		used[s.Name] = true
+	}
+	base := fmt.Sprintf("stagefile-cuda-runtime-%d", stageIndex)
+	name := base
+	for suffix := 2; used[name]; suffix++ {
+		name = fmt.Sprintf("%s-%d", base, suffix)
+	}
+	return name
+}
+
+// cudaRuntimeStageLines builds the target profile's large, stable runtime in
+// an independent stage. pip is bootstrapped only when the pinned base does not
+// already provide it; the APT caches are scoped exactly like a normal
+// install.apt block, but user-declared packages and repositories deliberately
+// do not participate in this stage's cache key.
+func cudaRuntimeStageLines(s spec.Stage, digest string, pinned bool, platform, name string, profile gpu.Profile) []string {
+	lines := []string{fromLine(s.From, digest, name, platform)}
+	aptBase := ""
+	if pinned {
+		aptBase = s.From + "@" + digest
+	}
+	bootstrap := "command -v pip >/dev/null 2>&1 || " +
+		"(apt-get update && apt-get install -y --no-install-recommends 'python3-pip')"
+	lines = append(lines, aptRun(aptBase, platform, nil, bootstrap))
+
+	p := spec.PipInstall{Packages: profile.Runtime}
+	parts := []string{"pip", "install", "--target", shellQuote(cudaPythonRoot)}
+	for _, pkg := range p.Packages {
+		parts = append(parts, shellQuote(pkg))
+	}
+	lines = append(lines, cacheRunID(
+		pipCacheID(&p, "", platform),
+		"/root/.cache/pip",
+		strings.Join(parts, " "),
+	))
+	return lines
+}
+
 func npmInstallLines(n *spec.NpmInstall) []string {
 	manager := n.Manager
 	if manager == "" {
@@ -736,55 +805,27 @@ func stageEnv(s *spec.Stage, cudaProfile *gpu.Profile) map[string]string {
 	if !s.CUDA || cudaProfile == nil {
 		return s.Env
 	}
-	env := make(map[string]string, len(s.Env)+1)
+	env := make(map[string]string, len(s.Env)+2)
 	for k, v := range s.Env {
 		env[k] = v
 	}
 	env[spec.LDLibraryPath] = cudaProfile.LibDir
+	if existing := env["PYTHONPATH"]; existing != "" {
+		env["PYTHONPATH"] = cudaPythonRoot + ":" + existing
+	} else {
+		env["PYTHONPATH"] = cudaPythonRoot
+	}
 	return env
 }
 
-// pipGroupLines emits the stage's pip groups, splicing in the CUDA runtime
-// group a GPU stage needs.
-//
-// The runtime lands directly after the last group that asked for the GPU
-// index, and before any ordinary PyPI group. That position is not cosmetic:
-// the runtime changes only when the profile does, while app dependencies
-// change constantly, and a later group's edit must not invalidate the layer
-// holding several hundred megabytes of CUDA libraries.
-func pipGroupLines(groups []spec.PipInstall, stageCUDA bool, cudaProfile *gpu.Profile, platform string) []string {
-	runtimeAfter := -1
-	for i, g := range groups {
-		if g.CUDA {
-			runtimeAfter = i
-		}
-	}
-
+// pipGroupLines emits user-declared pip groups. A CUDA stage's generated
+// runtime is promoted from its independent stage immediately before these
+// lines; only the user-selected GPU wheels and ordinary app dependencies are
+// linear descendants of the app's OS/native dependencies.
+func pipGroupLines(groups []spec.PipInstall, cudaProfile *gpu.Profile, platform string) []string {
 	var lines []string
-	emitRuntime := func() {
-		if !stageCUDA || cudaProfile == nil {
-			return
-		}
-		// A separate invocation from the wheels above, with no --index-url,
-		// so it resolves from PyPI. Folding the two together would make the
-		// vendor index primary and PyPI an extra index, and pip would then be
-		// free to satisfy either package from either source — resolving torch
-		// from PyPI, which is the wrong-architecture wheel this whole feature
-		// exists to avoid.
-		lines = append(lines, pipInstallLines(&spec.PipInstall{Packages: cudaProfile.Runtime}, nil, platform)...)
-	}
-
 	for i := range groups {
 		lines = append(lines, pipInstallLines(&groups[i], cudaProfile, platform)...)
-		if i == runtimeAfter {
-			emitRuntime()
-		}
-	}
-	if runtimeAfter == -1 {
-		// A GPU stage that installs no GPU wheels of its own still gets the
-		// runtime — it may be loading CUDA through something apt or cmake
-		// installed.
-		emitRuntime()
 	}
 	return lines
 }

--- a/go/internal/stagefile/codegen/codegen_cuda_test.go
+++ b/go/internal/stagefile/codegen/codegen_cuda_test.go
@@ -94,6 +94,12 @@ func TestGenerateCUDARuntimeIsASeparateUnindexedInstall(t *testing.T) {
 	if strings.Contains(runtimeLine, "torch") {
 		t.Errorf("runtime install merged with the wheel group:\n%s", runtimeLine)
 	}
+	if !strings.Contains(runtimeLine, "--target '/opt/stagefile/cuda/python'") {
+		t.Errorf("runtime install is not isolated under the compiler-owned prefix:\n%s", runtimeLine)
+	}
+	if !strings.Contains(out, "COPY --link --from=stagefile-cuda-runtime-0 /opt/stagefile/cuda/python /opt/stagefile/cuda/python") {
+		t.Errorf("runtime is not promoted as an independent linked layer:\n%s", out)
+	}
 }
 
 // The runtime layer holds hundreds of megabytes and changes only when the
@@ -171,13 +177,43 @@ func TestGenerateCUDAPipCacheScopedByTheResolvedIndex(t *testing.T) {
 	if len(ids) != 3 {
 		t.Fatalf("expected 3 pip installs (wheels, runtime, app), got %d\n%s", len(ids), out)
 	}
-	// The GPU wheels resolve from the profile's index; the runtime and the app
-	// dependencies both resolve from PyPI and may share.
+	// The generated runtime stage is emitted first. It and the ordinary app
+	// dependencies resolve from PyPI and may share; the GPU wheels use the
+	// profile's vendor index and must remain separate.
+	if ids[0] != ids[2] {
+		t.Errorf("two PyPI groups landed in different caches: %q vs %q", ids[0], ids[2])
+	}
 	if ids[0] == ids[1] {
 		t.Errorf("GPU wheel group shares a cache with the PyPI runtime group (id %q)", ids[0])
 	}
-	if ids[1] != ids[2] {
-		t.Errorf("two PyPI groups landed in different caches: %q vs %q", ids[1], ids[2])
+}
+
+// The generated CUDA runtime stage must be a pure function of the pinned base,
+// target platform, and GPU profile. User APT edits belong only to the app stage
+// and therefore cannot invalidate the multi-gigabyte runtime layer.
+func TestGenerateCUDARuntimeStageIgnoresUserAPTChanges(t *testing.T) {
+	generate := func(packages ...string) string {
+		return mustGenerateCUDA(t, spec.Stage{
+			CUDA: true,
+			Install: &spec.Install{
+				Apt: &spec.AptInstall{Packages: packages},
+				Pip: []spec.PipInstall{{Packages: []string{"torch==2.8.0"}, CUDA: true}},
+			},
+		})
+	}
+	prefix := func(out string) string {
+		marker := "\nFROM ubuntu:22.04@sha256:abc123 AS app\n"
+		before, _, ok := strings.Cut(out, marker)
+		if !ok {
+			t.Fatalf("generated output missing app-stage marker:\n%s", out)
+		}
+		return before
+	}
+
+	before := prefix(generate("python3-pip"))
+	after := prefix(generate("python3-pip", "ros-humble-rmw-cyclonedds-cpp"))
+	if before != after {
+		t.Errorf("CUDA runtime stage changed after an app APT edit\n--- before ---\n%s\n--- after ---\n%s", before, after)
 	}
 }
 

--- a/go/internal/stagefile/gpu/profile.go
+++ b/go/internal/stagefile/gpu/profile.go
@@ -58,6 +58,7 @@ var cuda12Runtime = []string{
 	"nvidia-cusolver-cu12",
 	"nvidia-cusparse-cu12",
 	"nvidia-cusparselt-cu12",
+	"nvidia-cufile-cu12",
 	"nvidia-nccl-cu12",
 	"nvidia-nvtx-cu12",
 	"nvidia-nvjitlink-cu12",

--- a/go/internal/stagefile/gpu/profile_test.go
+++ b/go/internal/stagefile/gpu/profile_test.go
@@ -1,0 +1,12 @@
+package gpu
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestCUDA12RuntimeIncludesCUFile(t *testing.T) {
+	if !slices.Contains(cuda12Runtime, "nvidia-cufile-cu12") {
+		t.Fatal("CUDA 12 runtime is missing nvidia-cufile-cu12; PyTorch's Jetson wheel links libcufile.so.0")
+	}
+}

--- a/go/internal/stagefile/ros2_test.go
+++ b/go/internal/stagefile/ros2_test.go
@@ -1,0 +1,55 @@
+package stagefile
+
+import (
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/stagefile/spec"
+)
+
+func TestApplyROS2RuntimeAddsResolvedMiddlewareToFinalStage(t *testing.T) {
+	f := &spec.File{Version: 1, Stages: []spec.Stage{
+		{Name: "builder", From: "ros:humble-ros-base"},
+		{Name: "app", From: "ros:humble-ros-base", Install: &spec.Install{
+			Apt: &spec.AptInstall{Packages: []string{"python3-pip"}},
+		}},
+	}}
+
+	applyROS2Runtime(f, "humble", "rmw_cyclonedds_cpp")
+	if len(f.Stages[0].Install.LocalFiles()) != 0 {
+		t.Fatal("framework runtime must not modify build-only stages")
+	}
+	got := f.Stages[1].Install.Apt.Packages
+	if len(got) != 2 || got[0] != "python3-pip" || got[1] != "ros-humble-rmw-cyclonedds-cpp" {
+		t.Fatalf("final APT packages = %v", got)
+	}
+
+	applyROS2Runtime(f, "humble", "rmw_cyclonedds_cpp")
+	if len(f.Stages[1].Install.Apt.Packages) != 2 {
+		t.Fatal("framework package injection must be idempotent")
+	}
+}
+
+func TestApplyROS2RuntimeCreatesInstallBlock(t *testing.T) {
+	f := &spec.File{Version: 1, Stages: []spec.Stage{{Name: "app", From: "ros:jazzy-ros-base"}}}
+	applyROS2Runtime(f, "jazzy", "rmw_fastrtps_cpp")
+	got := f.Stages[0].Install.Apt.Packages
+	if len(got) != 1 || got[0] != "ros-jazzy-rmw-fastrtps-cpp" {
+		t.Fatalf("APT packages = %v", got)
+	}
+}
+
+func TestApplyROS2RuntimeRejectsUnvalidatedCompilerInputs(t *testing.T) {
+	for _, tc := range []struct {
+		distro string
+		rmw    string
+	}{
+		{distro: "humble;touch-pwned", rmw: "rmw_cyclonedds_cpp"},
+		{distro: "humble", rmw: "rmw_evil_cpp"},
+	} {
+		f := &spec.File{Version: 1, Stages: []spec.Stage{{Name: "app", From: "ros:humble-ros-base"}}}
+		applyROS2Runtime(f, tc.distro, tc.rmw)
+		if f.Stages[0].Install != nil {
+			t.Fatalf("applyROS2Runtime(%q, %q) mutated the stage", tc.distro, tc.rmw)
+		}
+	}
+}

--- a/go/internal/stagefile/stagefile.go
+++ b/go/internal/stagefile/stagefile.go
@@ -57,6 +57,8 @@ type options struct {
 	gpuArch      string
 	buildProfile string
 	source       string
+	ros2Distro   string
+	ros2RMW      string
 }
 
 // WithSource names which Stagefile in dir to compile, for a project that
@@ -107,6 +109,18 @@ func WithBuildProfile(profile string) Option {
 	}
 }
 
+// WithROS2Runtime teaches the compiler about the runtime framework selected in
+// wendy.json. Stagefiles describe application dependencies; they should not
+// have to repeat the middleware package implied by frameworks.ros2. The CLI
+// passes resolved, validated values here and the compiler idempotently adds the
+// matching package to the final stage's APT install.
+func WithROS2Runtime(distro, rmw string) Option {
+	return func(o *options) {
+		o.ros2Distro = strings.ToLower(strings.TrimSpace(distro))
+		o.ros2RMW = strings.ToLower(strings.TrimSpace(rmw))
+	}
+}
+
 // CompileFile reads a Stagefile from dir — the canonical build.stagefile.yaml
 // unless WithSource names a variant — resolves any missing lockfile image refs
 // against a live registry (existing pins are never touched — only an explicit
@@ -136,7 +150,7 @@ func CompileFile(dir, platform string, opts ...Option) (dockerfile, dockerignore
 			return sharedHasher(url)
 		}
 	}
-	return compileFile(dir, source, platform, o.gpuArch, o.buildProfile, sharedResolver, hasher)
+	return compileFileWithFramework(dir, source, platform, o.gpuArch, o.buildProfile, o.ros2Distro, o.ros2RMW, sharedResolver, hasher)
 }
 
 // NeedsGPUTarget reports whether ANY Stagefile in dir declares a cuda: stage,
@@ -220,6 +234,10 @@ func resolveCUDAProfile(f *spec.File, arch string, l *lock.File) (*gpu.Profile, 
 // CompileFile, allowing tests to exercise it with a fake resolver and hasher
 // instead of a live registry and live URLs.
 func compileFile(dir, source, platform, gpuArch, buildProfile string, resolver lock.Resolver, hasher lock.Hasher) (dockerfile, dockerignore string, err error) {
+	return compileFileWithFramework(dir, source, platform, gpuArch, buildProfile, "", "", resolver, hasher)
+}
+
+func compileFileWithFramework(dir, source, platform, gpuArch, buildProfile, ros2Distro, ros2RMW string, resolver lock.Resolver, hasher lock.Hasher) (dockerfile, dockerignore string, err error) {
 	sourcePath := filepath.Join(dir, source)
 	raw, err := os.ReadFile(sourcePath)
 	if err != nil {
@@ -230,6 +248,7 @@ func compileFile(dir, source, platform, gpuArch, buildProfile string, resolver l
 		return "", "", err
 	}
 	applyBuildProfile(f, buildProfile)
+	applyROS2Runtime(f, ros2Distro, ros2RMW)
 
 	lockPath := filepath.Join(dir, LockName(source))
 	existing, err := lock.Load(lockPath)
@@ -271,6 +290,51 @@ func compileFile(dir, source, platform, gpuArch, buildProfile string, resolver l
 	}
 	dockerignore = dockerignorepkg.Derive(dockerignorepkg.LocalPaths(f))
 	return dockerfile, dockerignore, nil
+}
+
+// applyROS2Runtime appends the RMW implementation package implied by the
+// framework config. The final stage is the runnable image; build-only stages do
+// not need the middleware. Package names are constructed only from values the
+// appconfig validator has already reduced to its fixed RMW allowlist.
+func applyROS2Runtime(f *spec.File, distro, rmw string) {
+	if f == nil || len(f.Stages) == 0 || distro == "" || rmw == "" {
+		return
+	}
+	// Keep the compiler-side boundary closed even though normal CLI callers
+	// already pass values validated by appconfig. WithROS2Runtime is a public
+	// library option and must not turn arbitrary strings into APT packages.
+	packageSuffix := map[string]string{
+		"rmw_cyclonedds_cpp": "rmw-cyclonedds-cpp",
+		"rmw_fastrtps_cpp":   "rmw-fastrtps-cpp",
+		"rmw_connextdds":     "rmw-connextdds",
+		"rmw_gurumdds_cpp":   "rmw-gurumdds-cpp",
+	}[rmw]
+	if packageSuffix == "" || !validROS2Distro(distro) {
+		return
+	}
+	pkg := "ros-" + distro + "-" + packageSuffix
+	final := &f.Stages[len(f.Stages)-1]
+	if final.Install == nil {
+		final.Install = &spec.Install{}
+	}
+	if final.Install.Apt == nil {
+		final.Install.Apt = &spec.AptInstall{}
+	}
+	for _, existing := range final.Install.Apt.Packages {
+		if existing == pkg {
+			return
+		}
+	}
+	final.Install.Apt.Packages = append(final.Install.Apt.Packages, pkg)
+}
+
+func validROS2Distro(distro string) bool {
+	for i, r := range distro {
+		if (r < 'a' || r > 'z') && (i == 0 || r < '0' || r > '9') {
+			return false
+		}
+	}
+	return distro != ""
 }
 
 // applyBuildProfile overrides the compile profile of every build stage that has

--- a/go/proto/gen/agentpb/v2/container_service.pb.go
+++ b/go/proto/gen/agentpb/v2/container_service.pb.go
@@ -877,6 +877,133 @@ func (x *ListContainerStatsResponse) GetStats() []*ContainerStats {
 	return nil
 }
 
+type PruneCacheRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Reports what would be released without changing containerd metadata.
+	DryRun        bool `protobuf:"varint,1,opt,name=dry_run,json=dryRun,proto3" json:"dry_run,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PruneCacheRequest) Reset() {
+	*x = PruneCacheRequest{}
+	mi := &file_wendy_agent_services_v2_container_service_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PruneCacheRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PruneCacheRequest) ProtoMessage() {}
+
+func (x *PruneCacheRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_container_service_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PruneCacheRequest.ProtoReflect.Descriptor instead.
+func (*PruneCacheRequest) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_container_service_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *PruneCacheRequest) GetDryRun() bool {
+	if x != nil {
+		return x.DryRun
+	}
+	return false
+}
+
+type PruneCacheResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Number and aggregate compressed size of pushed layer blobs whose Wendy
+	// GC-root pin was (or would be, for dry_run) released.
+	ContentBlobs uint64 `protobuf:"varint,1,opt,name=content_blobs,json=contentBlobs,proto3" json:"content_blobs,omitempty"`
+	ContentBytes uint64 `protobuf:"varint,2,opt,name=content_bytes,json=contentBytes,proto3" json:"content_bytes,omitempty"`
+	// Number and aggregate filesystem usage of unpacked snapshots whose Wendy
+	// GC-root pin was (or would be, for dry_run) released.
+	Snapshots     uint64 `protobuf:"varint,3,opt,name=snapshots,proto3" json:"snapshots,omitempty"`
+	SnapshotBytes uint64 `protobuf:"varint,4,opt,name=snapshot_bytes,json=snapshotBytes,proto3" json:"snapshot_bytes,omitempty"`
+	// Newly written cache entries are retained for this many seconds to avoid
+	// disrupting an in-flight deployment between layer RPCs.
+	MinimumAgeSeconds uint64 `protobuf:"varint,5,opt,name=minimum_age_seconds,json=minimumAgeSeconds,proto3" json:"minimum_age_seconds,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *PruneCacheResponse) Reset() {
+	*x = PruneCacheResponse{}
+	mi := &file_wendy_agent_services_v2_container_service_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PruneCacheResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PruneCacheResponse) ProtoMessage() {}
+
+func (x *PruneCacheResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_container_service_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PruneCacheResponse.ProtoReflect.Descriptor instead.
+func (*PruneCacheResponse) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_container_service_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *PruneCacheResponse) GetContentBlobs() uint64 {
+	if x != nil {
+		return x.ContentBlobs
+	}
+	return 0
+}
+
+func (x *PruneCacheResponse) GetContentBytes() uint64 {
+	if x != nil {
+		return x.ContentBytes
+	}
+	return 0
+}
+
+func (x *PruneCacheResponse) GetSnapshots() uint64 {
+	if x != nil {
+		return x.Snapshots
+	}
+	return 0
+}
+
+func (x *PruneCacheResponse) GetSnapshotBytes() uint64 {
+	if x != nil {
+		return x.SnapshotBytes
+	}
+	return 0
+}
+
+func (x *PruneCacheResponse) GetMinimumAgeSeconds() uint64 {
+	if x != nil {
+		return x.MinimumAgeSeconds
+	}
+	return 0
+}
+
 type ContainerStreamResponse_Started struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -885,7 +1012,7 @@ type ContainerStreamResponse_Started struct {
 
 func (x *ContainerStreamResponse_Started) Reset() {
 	*x = ContainerStreamResponse_Started{}
-	mi := &file_wendy_agent_services_v2_container_service_proto_msgTypes[17]
+	mi := &file_wendy_agent_services_v2_container_service_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -897,7 +1024,7 @@ func (x *ContainerStreamResponse_Started) String() string {
 func (*ContainerStreamResponse_Started) ProtoMessage() {}
 
 func (x *ContainerStreamResponse_Started) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v2_container_service_proto_msgTypes[17]
+	mi := &file_wendy_agent_services_v2_container_service_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -922,7 +1049,7 @@ type ContainerStreamResponse_ConsoleOutput struct {
 
 func (x *ContainerStreamResponse_ConsoleOutput) Reset() {
 	*x = ContainerStreamResponse_ConsoleOutput{}
-	mi := &file_wendy_agent_services_v2_container_service_proto_msgTypes[18]
+	mi := &file_wendy_agent_services_v2_container_service_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -934,7 +1061,7 @@ func (x *ContainerStreamResponse_ConsoleOutput) String() string {
 func (*ContainerStreamResponse_ConsoleOutput) ProtoMessage() {}
 
 func (x *ContainerStreamResponse_ConsoleOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v2_container_service_proto_msgTypes[18]
+	mi := &file_wendy_agent_services_v2_container_service_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1009,7 +1136,15 @@ const file_wendy_agent_services_v2_container_service_proto_rawDesc = "" +
 	"\rstorage_bytes\x18\x03 \x01(\x03R\fstorageBytes\"\x1b\n" +
 	"\x19ListContainerStatsRequest\"[\n" +
 	"\x1aListContainerStatsResponse\x12=\n" +
-	"\x05stats\x18\x01 \x03(\v2'.wendy.agent.services.v2.ContainerStatsR\x05stats2\xb8\a\n" +
+	"\x05stats\x18\x01 \x03(\v2'.wendy.agent.services.v2.ContainerStatsR\x05stats\",\n" +
+	"\x11PruneCacheRequest\x12\x17\n" +
+	"\adry_run\x18\x01 \x01(\bR\x06dryRun\"\xd3\x01\n" +
+	"\x12PruneCacheResponse\x12#\n" +
+	"\rcontent_blobs\x18\x01 \x01(\x04R\fcontentBlobs\x12#\n" +
+	"\rcontent_bytes\x18\x02 \x01(\x04R\fcontentBytes\x12\x1c\n" +
+	"\tsnapshots\x18\x03 \x01(\x04R\tsnapshots\x12%\n" +
+	"\x0esnapshot_bytes\x18\x04 \x01(\x04R\rsnapshotBytes\x12.\n" +
+	"\x13minimum_age_seconds\x18\x05 \x01(\x04R\x11minimumAgeSeconds2\x9f\b\n" +
 	"\x15WendyContainerService\x12t\n" +
 	"\x0eStartContainer\x12..wendy.agent.services.v2.StartContainerRequest\x1a0.wendy.agent.services.v2.ContainerStreamResponse0\x01\x12x\n" +
 	"\x0fAttachContainer\x12/.wendy.agent.services.v2.AttachContainerRequest\x1a0.wendy.agent.services.v2.ContainerStreamResponse(\x010\x01\x12n\n" +
@@ -1018,7 +1153,9 @@ const file_wendy_agent_services_v2_container_service_proto_rawDesc = "" +
 	"\x0eListContainers\x12..wendy.agent.services.v2.ListContainersRequest\x1a/.wendy.agent.services.v2.ListContainersResponse0\x01\x12h\n" +
 	"\vListVolumes\x12+.wendy.agent.services.v2.ListVolumesRequest\x1a,.wendy.agent.services.v2.ListVolumesResponse\x12k\n" +
 	"\fRemoveVolume\x12,.wendy.agent.services.v2.RemoveVolumeRequest\x1a-.wendy.agent.services.v2.RemoveVolumeResponse\x12}\n" +
-	"\x12ListContainerStats\x122.wendy.agent.services.v2.ListContainerStatsRequest\x1a3.wendy.agent.services.v2.ListContainerStatsResponseB>Z<github.com/wendylabsinc/wendy/proto/gen/agentpb/v2;agentpbv2b\x06proto3"
+	"\x12ListContainerStats\x122.wendy.agent.services.v2.ListContainerStatsRequest\x1a3.wendy.agent.services.v2.ListContainerStatsResponse\x12e\n" +
+	"\n" +
+	"PruneCache\x12*.wendy.agent.services.v2.PruneCacheRequest\x1a+.wendy.agent.services.v2.PruneCacheResponseB>Z<github.com/wendylabsinc/wendy/proto/gen/agentpb/v2;agentpbv2b\x06proto3"
 
 var (
 	file_wendy_agent_services_v2_container_service_proto_rawDescOnce sync.Once
@@ -1032,7 +1169,7 @@ func file_wendy_agent_services_v2_container_service_proto_rawDescGZIP() []byte {
 	return file_wendy_agent_services_v2_container_service_proto_rawDescData
 }
 
-var file_wendy_agent_services_v2_container_service_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
+var file_wendy_agent_services_v2_container_service_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
 var file_wendy_agent_services_v2_container_service_proto_goTypes = []any{
 	(*StartContainerRequest)(nil),                 // 0: wendy.agent.services.v2.StartContainerRequest
 	(*AttachContainerRequest)(nil),                // 1: wendy.agent.services.v2.AttachContainerRequest
@@ -1051,15 +1188,17 @@ var file_wendy_agent_services_v2_container_service_proto_goTypes = []any{
 	(*ContainerStats)(nil),                        // 14: wendy.agent.services.v2.ContainerStats
 	(*ListContainerStatsRequest)(nil),             // 15: wendy.agent.services.v2.ListContainerStatsRequest
 	(*ListContainerStatsResponse)(nil),            // 16: wendy.agent.services.v2.ListContainerStatsResponse
-	(*ContainerStreamResponse_Started)(nil),       // 17: wendy.agent.services.v2.ContainerStreamResponse.Started
-	(*ContainerStreamResponse_ConsoleOutput)(nil), // 18: wendy.agent.services.v2.ContainerStreamResponse.ConsoleOutput
-	(*AppContainer)(nil),                          // 19: wendy.agent.services.v2.AppContainer
+	(*PruneCacheRequest)(nil),                     // 17: wendy.agent.services.v2.PruneCacheRequest
+	(*PruneCacheResponse)(nil),                    // 18: wendy.agent.services.v2.PruneCacheResponse
+	(*ContainerStreamResponse_Started)(nil),       // 19: wendy.agent.services.v2.ContainerStreamResponse.Started
+	(*ContainerStreamResponse_ConsoleOutput)(nil), // 20: wendy.agent.services.v2.ContainerStreamResponse.ConsoleOutput
+	(*AppContainer)(nil),                          // 21: wendy.agent.services.v2.AppContainer
 }
 var file_wendy_agent_services_v2_container_service_proto_depIdxs = []int32{
-	17, // 0: wendy.agent.services.v2.ContainerStreamResponse.started:type_name -> wendy.agent.services.v2.ContainerStreamResponse.Started
-	18, // 1: wendy.agent.services.v2.ContainerStreamResponse.stdout_output:type_name -> wendy.agent.services.v2.ContainerStreamResponse.ConsoleOutput
-	18, // 2: wendy.agent.services.v2.ContainerStreamResponse.stderr_output:type_name -> wendy.agent.services.v2.ContainerStreamResponse.ConsoleOutput
-	19, // 3: wendy.agent.services.v2.ListContainersResponse.container:type_name -> wendy.agent.services.v2.AppContainer
+	19, // 0: wendy.agent.services.v2.ContainerStreamResponse.started:type_name -> wendy.agent.services.v2.ContainerStreamResponse.Started
+	20, // 1: wendy.agent.services.v2.ContainerStreamResponse.stdout_output:type_name -> wendy.agent.services.v2.ContainerStreamResponse.ConsoleOutput
+	20, // 2: wendy.agent.services.v2.ContainerStreamResponse.stderr_output:type_name -> wendy.agent.services.v2.ContainerStreamResponse.ConsoleOutput
+	21, // 3: wendy.agent.services.v2.ListContainersResponse.container:type_name -> wendy.agent.services.v2.AppContainer
 	10, // 4: wendy.agent.services.v2.ListVolumesResponse.volumes:type_name -> wendy.agent.services.v2.VolumeInfo
 	14, // 5: wendy.agent.services.v2.ListContainerStatsResponse.stats:type_name -> wendy.agent.services.v2.ContainerStats
 	0,  // 6: wendy.agent.services.v2.WendyContainerService.StartContainer:input_type -> wendy.agent.services.v2.StartContainerRequest
@@ -1070,16 +1209,18 @@ var file_wendy_agent_services_v2_container_service_proto_depIdxs = []int32{
 	9,  // 11: wendy.agent.services.v2.WendyContainerService.ListVolumes:input_type -> wendy.agent.services.v2.ListVolumesRequest
 	12, // 12: wendy.agent.services.v2.WendyContainerService.RemoveVolume:input_type -> wendy.agent.services.v2.RemoveVolumeRequest
 	15, // 13: wendy.agent.services.v2.WendyContainerService.ListContainerStats:input_type -> wendy.agent.services.v2.ListContainerStatsRequest
-	2,  // 14: wendy.agent.services.v2.WendyContainerService.StartContainer:output_type -> wendy.agent.services.v2.ContainerStreamResponse
-	2,  // 15: wendy.agent.services.v2.WendyContainerService.AttachContainer:output_type -> wendy.agent.services.v2.ContainerStreamResponse
-	4,  // 16: wendy.agent.services.v2.WendyContainerService.StopContainer:output_type -> wendy.agent.services.v2.StopContainerResponse
-	6,  // 17: wendy.agent.services.v2.WendyContainerService.DeleteContainer:output_type -> wendy.agent.services.v2.DeleteContainerResponse
-	8,  // 18: wendy.agent.services.v2.WendyContainerService.ListContainers:output_type -> wendy.agent.services.v2.ListContainersResponse
-	11, // 19: wendy.agent.services.v2.WendyContainerService.ListVolumes:output_type -> wendy.agent.services.v2.ListVolumesResponse
-	13, // 20: wendy.agent.services.v2.WendyContainerService.RemoveVolume:output_type -> wendy.agent.services.v2.RemoveVolumeResponse
-	16, // 21: wendy.agent.services.v2.WendyContainerService.ListContainerStats:output_type -> wendy.agent.services.v2.ListContainerStatsResponse
-	14, // [14:22] is the sub-list for method output_type
-	6,  // [6:14] is the sub-list for method input_type
+	17, // 14: wendy.agent.services.v2.WendyContainerService.PruneCache:input_type -> wendy.agent.services.v2.PruneCacheRequest
+	2,  // 15: wendy.agent.services.v2.WendyContainerService.StartContainer:output_type -> wendy.agent.services.v2.ContainerStreamResponse
+	2,  // 16: wendy.agent.services.v2.WendyContainerService.AttachContainer:output_type -> wendy.agent.services.v2.ContainerStreamResponse
+	4,  // 17: wendy.agent.services.v2.WendyContainerService.StopContainer:output_type -> wendy.agent.services.v2.StopContainerResponse
+	6,  // 18: wendy.agent.services.v2.WendyContainerService.DeleteContainer:output_type -> wendy.agent.services.v2.DeleteContainerResponse
+	8,  // 19: wendy.agent.services.v2.WendyContainerService.ListContainers:output_type -> wendy.agent.services.v2.ListContainersResponse
+	11, // 20: wendy.agent.services.v2.WendyContainerService.ListVolumes:output_type -> wendy.agent.services.v2.ListVolumesResponse
+	13, // 21: wendy.agent.services.v2.WendyContainerService.RemoveVolume:output_type -> wendy.agent.services.v2.RemoveVolumeResponse
+	16, // 22: wendy.agent.services.v2.WendyContainerService.ListContainerStats:output_type -> wendy.agent.services.v2.ListContainerStatsResponse
+	18, // 23: wendy.agent.services.v2.WendyContainerService.PruneCache:output_type -> wendy.agent.services.v2.PruneCacheResponse
+	15, // [15:24] is the sub-list for method output_type
+	6,  // [6:15] is the sub-list for method input_type
 	6,  // [6:6] is the sub-list for extension type_name
 	6,  // [6:6] is the sub-list for extension extendee
 	0,  // [0:6] is the sub-list for field type_name
@@ -1106,7 +1247,7 @@ func file_wendy_agent_services_v2_container_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_wendy_agent_services_v2_container_service_proto_rawDesc), len(file_wendy_agent_services_v2_container_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   19,
+			NumMessages:   21,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/go/proto/gen/agentpb/v2/container_service_grpc.pb.go
+++ b/go/proto/gen/agentpb/v2/container_service_grpc.pb.go
@@ -27,6 +27,7 @@ const (
 	WendyContainerService_ListVolumes_FullMethodName        = "/wendy.agent.services.v2.WendyContainerService/ListVolumes"
 	WendyContainerService_RemoveVolume_FullMethodName       = "/wendy.agent.services.v2.WendyContainerService/RemoveVolume"
 	WendyContainerService_ListContainerStats_FullMethodName = "/wendy.agent.services.v2.WendyContainerService/ListContainerStats"
+	WendyContainerService_PruneCache_FullMethodName         = "/wendy.agent.services.v2.WendyContainerService/PruneCache"
 )
 
 // WendyContainerServiceClient is the client API for WendyContainerService service.
@@ -41,6 +42,10 @@ type WendyContainerServiceClient interface {
 	ListVolumes(ctx context.Context, in *ListVolumesRequest, opts ...grpc.CallOption) (*ListVolumesResponse, error)
 	RemoveVolume(ctx context.Context, in *RemoveVolumeRequest, opts ...grpc.CallOption) (*RemoveVolumeResponse, error)
 	ListContainerStats(ctx context.Context, in *ListContainerStatsRequest, opts ...grpc.CallOption) (*ListContainerStatsResponse, error)
+	// Releases Wendy's explicit GC pins from pushed layer blobs and unpacked
+	// snapshots. Containerd's reference graph continues to preserve current
+	// images and active containers; only cache data becomes collectible.
+	PruneCache(ctx context.Context, in *PruneCacheRequest, opts ...grpc.CallOption) (*PruneCacheResponse, error)
 }
 
 type wendyContainerServiceClient struct {
@@ -152,6 +157,16 @@ func (c *wendyContainerServiceClient) ListContainerStats(ctx context.Context, in
 	return out, nil
 }
 
+func (c *wendyContainerServiceClient) PruneCache(ctx context.Context, in *PruneCacheRequest, opts ...grpc.CallOption) (*PruneCacheResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(PruneCacheResponse)
+	err := c.cc.Invoke(ctx, WendyContainerService_PruneCache_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // WendyContainerServiceServer is the server API for WendyContainerService service.
 // All implementations must embed UnimplementedWendyContainerServiceServer
 // for forward compatibility.
@@ -164,6 +179,10 @@ type WendyContainerServiceServer interface {
 	ListVolumes(context.Context, *ListVolumesRequest) (*ListVolumesResponse, error)
 	RemoveVolume(context.Context, *RemoveVolumeRequest) (*RemoveVolumeResponse, error)
 	ListContainerStats(context.Context, *ListContainerStatsRequest) (*ListContainerStatsResponse, error)
+	// Releases Wendy's explicit GC pins from pushed layer blobs and unpacked
+	// snapshots. Containerd's reference graph continues to preserve current
+	// images and active containers; only cache data becomes collectible.
+	PruneCache(context.Context, *PruneCacheRequest) (*PruneCacheResponse, error)
 	mustEmbedUnimplementedWendyContainerServiceServer()
 }
 
@@ -197,6 +216,9 @@ func (UnimplementedWendyContainerServiceServer) RemoveVolume(context.Context, *R
 }
 func (UnimplementedWendyContainerServiceServer) ListContainerStats(context.Context, *ListContainerStatsRequest) (*ListContainerStatsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListContainerStats not implemented")
+}
+func (UnimplementedWendyContainerServiceServer) PruneCache(context.Context, *PruneCacheRequest) (*PruneCacheResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method PruneCache not implemented")
 }
 func (UnimplementedWendyContainerServiceServer) mustEmbedUnimplementedWendyContainerServiceServer() {}
 func (UnimplementedWendyContainerServiceServer) testEmbeddedByValue()                               {}
@@ -338,6 +360,24 @@ func _WendyContainerService_ListContainerStats_Handler(srv interface{}, ctx cont
 	return interceptor(ctx, in, info, handler)
 }
 
+func _WendyContainerService_PruneCache_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PruneCacheRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WendyContainerServiceServer).PruneCache(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: WendyContainerService_PruneCache_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WendyContainerServiceServer).PruneCache(ctx, req.(*PruneCacheRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // WendyContainerService_ServiceDesc is the grpc.ServiceDesc for WendyContainerService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -364,6 +404,10 @@ var WendyContainerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListContainerStats",
 			Handler:    _WendyContainerService_ListContainerStats_Handler,
+		},
+		{
+			MethodName: "PruneCache",
+			Handler:    _WendyContainerService_PruneCache_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/go/scripts/test-ci.sh
+++ b/go/scripts/test-ci.sh
@@ -291,9 +291,12 @@ device_field() {
 if [[ -z "$VERSION_JSON" ]]; then
     echo -e "${YELLOW}==> WARNING: 'wendy device info' returned nothing — the agent under test cannot be identified${RESET}"
 fi
+DEVICE_TYPE=$(device_field deviceType '')
+DEVICE_GPU_ARCH=$(device_field gpuArch '')
+
 echo -e "${BOLD}==> Agent version: $(device_field version 'unknown')${RESET}"
 echo -e "${BOLD}==> Device OS: $(device_field os 'unknown') $(device_field osVersion 'unknown')${RESET}"
-echo -e "${BOLD}==> Device type: $(device_field deviceType 'none reported') ($(device_field cpuArchitecture 'unknown'))${RESET}"
+echo -e "${BOLD}==> Device type: ${DEVICE_TYPE:-none reported} ($(device_field cpuArchitecture 'unknown'))${RESET}"
 
 # ── Device capability detection ──────────────────────────────────────
 
@@ -305,7 +308,19 @@ DEVICE_HAS_CUDA=false
 if [[ "$DEVICE_GPU_VENDOR" == "nvidia" ]]; then
     DEVICE_HAS_CUDA=true
 fi
-echo -e "${BOLD}==> CUDA GPU: ${DEVICE_HAS_CUDA} (vendor: ${DEVICE_GPU_VENDOR:-none})${RESET}"
+
+# The current Python GPU fixtures are JetPack-6 / CUDA-12 images built for
+# Orin's sm_87. An NVIDIA vendor bit alone is not enough: Thor is sm_110 and
+# needs a CUDA-13 userspace image, so running these fixtures there produces
+# CUDA error 801 (PyTorch) and missing libcublasLt.so.12 (ONNX) rather than a
+# meaningful GPU-entitlement verdict. Older agents did not report gpuArch, so
+# preserve their established NVIDIA behavior; every reported architecture is
+# opt-in after its fixture has been hardware-verified.
+DEVICE_SUPPORTS_GPU_FIXTURES=false
+if [[ "$DEVICE_HAS_CUDA" == "true" ]] && [[ -z "$DEVICE_GPU_ARCH" || "$DEVICE_GPU_ARCH" == "sm_87" ]]; then
+    DEVICE_SUPPORTS_GPU_FIXTURES=true
+fi
+echo -e "${BOLD}==> CUDA GPU: ${DEVICE_HAS_CUDA} (vendor: ${DEVICE_GPU_VENDOR:-none}, arch: ${DEVICE_GPU_ARCH:-unknown})${RESET}"
 
 # The Swift tests build their image with swift-container-plugin, so this host
 # needs a Swift toolchain — which the CLI provisions through swiftly, and
@@ -403,6 +418,11 @@ for test_name in "${TESTS[@]}"; do
 
     if [[ "$test_name" == *"-gpu"* ]] && [[ "$DEVICE_HAS_CUDA" != "true" ]]; then
         skip_test "$test_name" "no NVIDIA GPU (vendor: ${DEVICE_GPU_VENDOR:-none})"
+        continue
+    fi
+
+    if [[ "$test_name" == *"-gpu"* ]] && [[ "$DEVICE_SUPPORTS_GPU_FIXTURES" != "true" ]]; then
+        skip_test "$test_name" "CI GPU fixtures support sm_87; device reports ${DEVICE_GPU_ARCH:-an unknown architecture}"
         continue
     fi
 

--- a/go/scripts/test-ci.sh
+++ b/go/scripts/test-ci.sh
@@ -121,6 +121,24 @@ run_test() {
     return $rc
 }
 
+# A per-run docker-container builder is shared by every integration fixture.
+# If buildkitd is OOM-killed or loses its gRPC socket, leaving that dead builder
+# in place turns one transient host failure into a long list of unrelated test
+# failures. This recovery is deliberately gated on WENDY_BUILDX_BUILDER, which
+# the CI workflows set to their disposable builder; local user builders are
+# never removed automatically.
+recover_ci_oci_builder() {
+    local output="$1"
+    [[ -n "${WENDY_BUILDX_BUILDER:-}" ]] || return 1
+    grep -qiE \
+        'failed to receive status:.*(EOF|Unavailable)|error reading from server: EOF|/run/buildkit/buildkitd\.sock: connect: connection refused|failed to list workers:.*Unavailable|ResourceExhausted:.*cannot allocate memory' \
+        <<<"$output" || return 1
+
+    local builder="${WENDY_BUILDX_BUILDER}-oci"
+    echo "    BuildKit daemon failed; recreating disposable CI builder $builder and retrying once"
+    docker buildx rm "$builder" --force >/dev/null 2>&1 || true
+}
+
 # ── Container verdict ────────────────────────────────────────────────
 # An attached `wendy run` exits 0 whatever the container did, so its exit code
 # only tells us the deploy worked. Every standard test asserts inside the app
@@ -193,12 +211,17 @@ run_container_test() {
     app_id=$(app_id_for_test "$test_dir")
 
     container_test_passes() {
-        local out
+        local out rc
         # --no-restart stops the agent restarting a test app that has done its
         # job and exited, which otherwise churns the recorded state (a
         # short-lived app reads back as CRASH_LOOPING).
         out=$("$WENDY" run --device "$HOSTNAME" --prefix "$test_dir" --no-restart "$@" 2>&1)
-        local rc=$?
+        rc=$?
+        if [[ $rc -ne 0 ]] && recover_ci_oci_builder "$out"; then
+            echo "$out"
+            out=$("$WENDY" run --device "$HOSTNAME" --prefix "$test_dir" --no-restart "$@" 2>&1)
+            rc=$?
+        fi
         echo "$out"
         if [[ $rc -ne 0 ]]; then
             return $rc
@@ -309,16 +332,29 @@ if [[ "$DEVICE_GPU_VENDOR" == "nvidia" ]]; then
     DEVICE_HAS_CUDA=true
 fi
 
-# The current Python GPU fixtures are JetPack-6 / CUDA-12 images built for
-# Orin's sm_87. An NVIDIA vendor bit alone is not enough: Thor is sm_110 and
-# needs a CUDA-13 userspace image, so running these fixtures there produces
-# CUDA error 801 (PyTorch) and missing libcublasLt.so.12 (ONNX) rather than a
-# meaningful GPU-entitlement verdict. Older agents did not report gpuArch, so
-# preserve their established NVIDIA behavior; every reported architecture is
-# opt-in after its fixture has been hardware-verified.
-DEVICE_SUPPORTS_GPU_FIXTURES=false
-if [[ "$DEVICE_HAS_CUDA" == "true" ]] && [[ -z "$DEVICE_GPU_ARCH" || "$DEVICE_GPU_ARCH" == "sm_87" ]]; then
-    DEVICE_SUPPORTS_GPU_FIXTURES=true
+# GPU framework wheels are architecture-specific. Pick a userspace that
+# matches the device instead of treating the NVIDIA vendor bit as sufficient:
+# Orin (sm_87) uses the existing JetPack-6 / CUDA-12 fixture, while Thor
+# (sm_110) uses the Ubuntu-24.04 / CUDA-13 fixture. Older agents did not report
+# gpuArch, so identify Thor by device type and preserve CUDA-12 behavior for
+# other older NVIDIA devices. Every other reported architecture remains opt-in
+# after its fixture is hardware-verified.
+DEVICE_GPU_FIXTURE_DOCKERFILE=""
+if [[ "$DEVICE_HAS_CUDA" == "true" ]]; then
+    case "$DEVICE_GPU_ARCH" in
+        sm_87)          DEVICE_GPU_FIXTURE_DOCKERFILE="Dockerfile" ;;
+        sm_110|sm_121)  DEVICE_GPU_FIXTURE_DOCKERFILE="Dockerfile.cuda13" ;;
+        "")
+            # gpuArch was added after Thor support. Device type lets those
+            # older Thor agents select CUDA 13 without regressing older Orin
+            # and generic NVIDIA agents, which retain the CUDA-12 fixture.
+            if [[ "$DEVICE_TYPE" == "jetson-agx-thor" ]]; then
+                DEVICE_GPU_FIXTURE_DOCKERFILE="Dockerfile.cuda13"
+            else
+                DEVICE_GPU_FIXTURE_DOCKERFILE="Dockerfile"
+            fi
+            ;;
+    esac
 fi
 echo -e "${BOLD}==> CUDA GPU: ${DEVICE_HAS_CUDA} (vendor: ${DEVICE_GPU_VENDOR:-none}, arch: ${DEVICE_GPU_ARCH:-unknown})${RESET}"
 
@@ -421,8 +457,8 @@ for test_name in "${TESTS[@]}"; do
         continue
     fi
 
-    if [[ "$test_name" == *"-gpu"* ]] && [[ "$DEVICE_SUPPORTS_GPU_FIXTURES" != "true" ]]; then
-        skip_test "$test_name" "CI GPU fixtures support sm_87; device reports ${DEVICE_GPU_ARCH:-an unknown architecture}"
+    if [[ "$test_name" == *"-gpu"* ]] && [[ -z "$DEVICE_GPU_FIXTURE_DOCKERFILE" ]]; then
+        skip_test "$test_name" "CI GPU fixtures support sm_87, sm_110, and sm_121; device reports ${DEVICE_GPU_ARCH:-an unknown architecture}"
         continue
     fi
 
@@ -640,7 +676,13 @@ for test_name in "${TESTS[@]}"; do
     fi
 
     # ── Standard single-container tests ─────────────────────────────────
-    run_container_test "$test_name" "$test_dir"
+    if [[ "$test_name" == *"-gpu"* ]]; then
+        # Both GPU test directories contain architecture-specific Dockerfiles,
+        # so name the selected one explicitly and avoid an interactive picker.
+        run_container_test "$test_name" "$test_dir" --dockerfile "$DEVICE_GPU_FIXTURE_DOCKERFILE"
+    else
+        run_container_test "$test_name" "$test_dir"
+    fi
 done
 
 # ── Summary ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Stack

This is a follow-up stacked on #1690. Its base is intentionally `agent/watch-only-changed-services`.

## Summary

- isolate heavyweight CUDA/Python runtime setup in compiler-managed Stagefile layers so ordinary app dependency and source edits do not invalidate it
- derive ROS 2 middleware packages from `wendy.json`, keeping RobotKit and other projects free of Wendy-specific install duplication
- make Compose use persistent OCI layouts, native content-addressed app-layer updates, direct missing-chunk preparation, and an existing-layout registry fallback
- migrate valid legacy app-only BuildKit caches into platform-scoped cache namespaces
- fuse decompression, DiffID hashing, temporary-layer output, and content-defined indexing into one pipelined pass
- cap chunk-region buffers process-wide at four 16 MiB regions, preventing Compose concurrency from multiplying live heap past the CLI ceiling
- show content-index and chunk-upload byte counts and throughput in the build UI
- resolve multi-homed mDNS answers on the interface that advertised them, rank kernel-routed wired paths first, understand macOS bridge members, and reject inconsistent cached interface/address pairs
- propagate Ctrl-C through parallel builders and keep long Compose service names on one terminal line

## Why

Stagefile deploys were paying several avoidable costs at once. A small app edit could invalidate a multi-gigabyte CUDA runtime layer; Compose rebuilt or exported more than necessary; and a cold chunk manifest decompressed the layer to disk before rereading the entire uncompressed tar for content indexing. With many Compose services, each independent indexer also allocated GOMAXPROCS-sized pools of 16 MiB region buffers, producing an observed 893 MiB live heap.

Separately, Darwin discovery retained the interface that received a DNS-SD browse answer but resolved the hostname globally. On a host connected to Woof over both Wi-Fi and Ethernet, that produced an internally inconsistent Ethernet label paired with a Wi-Fi address and pinned uploads to the slower path.

## User impact

RobotKit does not need project-side cache or middleware workarounds. Unchanged dependency layers remain reusable, source-only Stagefile updates can bypass buildx and cache export, and cold content indexing no longer performs a second full layer read. Subsequent deployments reuse the persisted chunk manifest and device content.

On multi-homed devices, Wendy now chooses the address whose actual kernel route is wired. Manual verification against `woof.local` showed the agent connection and registry streams using Woof's Ethernet ULA rather than `192.168.0.107` over Wi-Fi.

## Validation

- `go test ./...`
- `git diff --check`
- rebuilt the development CLI with `make build-cli`
- verified the fused stream chunker matches byte-for-byte at empty, tiny, region-boundary, and multi-region sizes
- verified active agent and registry TCP sockets used Woof's Ethernet ULA path
