### PR TITLE
Add safe device cache pruning and disk usage warnings

### DIFF
--- a/Proto/wendy/agent/services/v2/container_service.proto
+++ b/Proto/wendy/agent/services/v2/container_service.proto
@@ -13,6 +13,10 @@ service WendyContainerService {
     rpc ListVolumes(ListVolumesRequest) returns (ListVolumesResponse);
     rpc RemoveVolume(RemoveVolumeRequest) returns (RemoveVolumeResponse);
     rpc ListContainerStats(ListContainerStatsRequest) returns (ListContainerStatsResponse);
+    // Releases Wendy's explicit GC pins from pushed layer blobs and unpacked
+    // snapshots. Containerd's reference graph continues to preserve current
+    // images and active containers; only cache data becomes collectible.
+    rpc PruneCache(PruneCacheRequest) returns (PruneCacheResponse);
 }
 
 message StartContainerRequest {
@@ -90,4 +94,23 @@ message ListContainerStatsRequest {}
 
 message ListContainerStatsResponse {
     repeated ContainerStats stats = 1;
+}
+
+message PruneCacheRequest {
+    // Reports what would be released without changing containerd metadata.
+    bool dry_run = 1;
+}
+
+message PruneCacheResponse {
+    // Number and aggregate compressed size of pushed layer blobs whose Wendy
+    // GC-root pin was (or would be, for dry_run) released.
+    uint64 content_blobs = 1;
+    uint64 content_bytes = 2;
+    // Number and aggregate filesystem usage of unpacked snapshots whose Wendy
+    // GC-root pin was (or would be, for dry_run) released.
+    uint64 snapshots = 3;
+    uint64 snapshot_bytes = 4;
+    // Newly written cache entries are retained for this many seconds to avoid
+    // disrupting an in-flight deployment between layer RPCs.
+    uint64 minimum_age_seconds = 5;
 }

--- a/go/internal/agent/containerd/cache_prune.go
+++ b/go/internal/agent/containerd/cache_prune.go
@@ -1,0 +1,144 @@
+package containerd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/snapshots"
+	digest "github.com/opencontainers/go-digest"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/services"
+)
+
+// cachePruneGracePeriod keeps cache roots that may belong to an in-flight
+// deployment. A layer push spans multiple RPCs, so there is no single lease
+// covering the entire transfer until AssembleImage creates the final image
+// reference. A day safely covers even unusually large/slow edge deployments.
+const cachePruneGracePeriod = 24 * time.Hour
+
+type cacheContentStore interface {
+	Walk(context.Context, content.WalkFunc, ...string) error
+	Update(context.Context, content.Info, ...string) (content.Info, error)
+}
+
+type cacheSnapshotter interface {
+	Walk(context.Context, snapshots.WalkFunc, ...string) error
+	Update(context.Context, snapshots.Info, ...string) (snapshots.Info, error)
+	Usage(context.Context, string) (snapshots.Usage, error)
+}
+
+type contentCacheCandidate struct {
+	info content.Info
+}
+
+type snapshotCacheCandidate struct {
+	info  snapshots.Info
+	usage snapshots.Usage
+}
+
+// PruneCache releases Wendy's explicit GC roots from cache entries old enough
+// not to belong to an in-flight deployment. Containerd's own reference graph
+// remains authoritative, preserving current images and active containers while
+// its normal GC reclaims entries that are now unreachable.
+func (c *Client) PruneCache(ctx context.Context, dryRun bool) (services.CachePruneResult, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	ctx = c.withNamespace(ctx)
+	result, err := pruneCacheRoots(
+		ctx,
+		c.client.ContentStore(),
+		c.client.SnapshotService(c.snapshotter),
+		time.Now().Add(-cachePruneGracePeriod),
+		dryRun,
+	)
+	result.MinimumAgeSeconds = uint64(cachePruneGracePeriod / time.Second)
+	return result, err
+}
+
+func pruneCacheRoots(ctx context.Context, cs cacheContentStore, sn cacheSnapshotter, cutoff time.Time, dryRun bool) (services.CachePruneResult, error) {
+	var (
+		result             services.CachePruneResult
+		contentCandidates  []contentCacheCandidate
+		snapshotCandidates []snapshotCacheCandidate
+	)
+
+	if err := cs.Walk(ctx, func(info content.Info) error {
+		if info.Labels[labelKeyWendyLayer] != "true" || !cacheRootOlderThan(info.Labels[labelKeyGCRoot], cutoff) {
+			return nil
+		}
+		contentCandidates = append(contentCandidates, contentCacheCandidate{info: info})
+		result.ContentBlobs++
+		if info.Size > 0 {
+			result.ContentBytes += uint64(info.Size)
+		}
+		return nil
+	}); err != nil {
+		return services.CachePruneResult{}, fmt.Errorf("listing cached content: %w", err)
+	}
+
+	if err := sn.Walk(ctx, func(_ context.Context, info snapshots.Info) error {
+		if info.Kind != snapshots.KindCommitted || !isWendyCacheSnapshot(info) || !cacheRootOlderThan(info.Labels[labelKeyGCRoot], cutoff) {
+			return nil
+		}
+		usage, _ := sn.Usage(ctx, info.Name) // best-effort accounting must not block cleanup
+		snapshotCandidates = append(snapshotCandidates, snapshotCacheCandidate{info: info, usage: usage})
+		result.Snapshots++
+		if usage.Size > 0 {
+			result.SnapshotBytes += uint64(usage.Size)
+		}
+		return nil
+	}); err != nil {
+		return services.CachePruneResult{}, fmt.Errorf("listing cached snapshots: %w", err)
+	}
+
+	if dryRun {
+		return result, nil
+	}
+
+	for _, candidate := range contentCandidates {
+		candidate.info.Labels = labelsWithout(candidate.info.Labels, labelKeyGCRoot)
+		if _, err := cs.Update(ctx, candidate.info, "labels"); err != nil {
+			return result, fmt.Errorf("releasing cache root from content %s: %w", candidate.info.Digest, err)
+		}
+	}
+	for _, candidate := range snapshotCandidates {
+		candidate.info.Labels = labelsWithout(candidate.info.Labels, labelKeyGCRoot)
+		if _, err := sn.Update(ctx, candidate.info, "labels"); err != nil {
+			return result, fmt.Errorf("releasing cache root from snapshot %s: %w", candidate.info.Name, err)
+		}
+	}
+
+	return result, nil
+}
+
+func cacheRootOlderThan(value string, cutoff time.Time) bool {
+	if value == "" {
+		return false
+	}
+	created, err := time.Parse(time.RFC3339, value)
+	return err == nil && !created.After(cutoff)
+}
+
+func isWendyCacheSnapshot(info snapshots.Info) bool {
+	if info.Labels[labelKeyWendySnapshot] == "true" {
+		return true
+	}
+	// Agents predating labelKeyWendySnapshot used the OCI chain ID as the
+	// snapshot name and set the same GC root. Recognize that exact legacy shape
+	// so upgrades can clean the cache already accumulated on devices.
+	d, err := digest.Parse(info.Name)
+	return err == nil && d.Algorithm() == digest.SHA256
+}
+
+func labelsWithout(labels map[string]string, key string) map[string]string {
+	out := make(map[string]string, len(labels))
+	for k, v := range labels {
+		if k != key {
+			out[k] = v
+		}
+	}
+	return out
+}

--- a/go/internal/agent/containerd/cache_prune_test.go
+++ b/go/internal/agent/containerd/cache_prune_test.go
@@ -1,0 +1,126 @@
+package containerd
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/snapshots"
+	digest "github.com/opencontainers/go-digest"
+)
+
+type fakeCacheContentStore struct {
+	infos   []content.Info
+	updates []content.Info
+}
+
+func (f *fakeCacheContentStore) Walk(_ context.Context, fn content.WalkFunc, _ ...string) error {
+	for _, info := range f.infos {
+		if err := fn(info); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *fakeCacheContentStore) Update(_ context.Context, info content.Info, _ ...string) (content.Info, error) {
+	f.updates = append(f.updates, info)
+	return info, nil
+}
+
+type fakeCacheSnapshotter struct {
+	infos   []snapshots.Info
+	usage   map[string]snapshots.Usage
+	updates []snapshots.Info
+}
+
+func (f *fakeCacheSnapshotter) Walk(ctx context.Context, fn snapshots.WalkFunc, _ ...string) error {
+	for _, info := range f.infos {
+		if err := fn(ctx, info); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *fakeCacheSnapshotter) Update(_ context.Context, info snapshots.Info, _ ...string) (snapshots.Info, error) {
+	f.updates = append(f.updates, info)
+	return info, nil
+}
+
+func (f *fakeCacheSnapshotter) Usage(_ context.Context, key string) (snapshots.Usage, error) {
+	return f.usage[key], nil
+}
+
+func TestPruneCacheRootsDryRunSelectsOnlyOldWendyCache(t *testing.T) {
+	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+	old := now.Add(-2 * time.Hour).Format(time.RFC3339)
+	recent := now.Add(-10 * time.Minute).Format(time.RFC3339)
+	legacySnapshot := digest.FromString("legacy-snapshot").String()
+
+	cs := &fakeCacheContentStore{infos: []content.Info{
+		{Digest: digest.FromString("old"), Size: 100, Labels: map[string]string{labelKeyWendyLayer: "true", labelKeyGCRoot: old}},
+		{Digest: digest.FromString("recent"), Size: 200, Labels: map[string]string{labelKeyWendyLayer: "true", labelKeyGCRoot: recent}},
+		{Digest: digest.FromString("foreign"), Size: 300, Labels: map[string]string{labelKeyGCRoot: old}},
+	}}
+	sn := &fakeCacheSnapshotter{
+		infos: []snapshots.Info{
+			{Name: "wendy", Kind: snapshots.KindCommitted, Labels: map[string]string{labelKeyWendySnapshot: "true", labelKeyGCRoot: old}},
+			{Name: legacySnapshot, Kind: snapshots.KindCommitted, Labels: map[string]string{labelKeyGCRoot: old}},
+			{Name: "recent", Kind: snapshots.KindCommitted, Labels: map[string]string{labelKeyWendySnapshot: "true", labelKeyGCRoot: recent}},
+			{Name: "foreign", Kind: snapshots.KindCommitted, Labels: map[string]string{labelKeyGCRoot: old}},
+			{Name: "active", Kind: snapshots.KindActive, Labels: map[string]string{labelKeyWendySnapshot: "true", labelKeyGCRoot: old}},
+		},
+		usage: map[string]snapshots.Usage{"wendy": {Size: 400}, legacySnapshot: {Size: 500}},
+	}
+
+	got, err := pruneCacheRoots(context.Background(), cs, sn, now.Add(-time.Hour), true)
+	if err != nil {
+		t.Fatalf("pruneCacheRoots: %v", err)
+	}
+	if got.ContentBlobs != 1 || got.ContentBytes != 100 || got.Snapshots != 2 || got.SnapshotBytes != 900 {
+		t.Fatalf("result = %+v", got)
+	}
+	if len(cs.updates) != 0 || len(sn.updates) != 0 {
+		t.Fatalf("dry run mutated stores: content=%d snapshots=%d", len(cs.updates), len(sn.updates))
+	}
+}
+
+func TestPruneCacheRootsRemovesOnlyGCRootLabel(t *testing.T) {
+	old := time.Date(2026, 8, 12, 10, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	cs := &fakeCacheContentStore{infos: []content.Info{{
+		Digest: digest.FromString("layer"), Size: 12,
+		Labels: map[string]string{labelKeyWendyLayer: "true", labelKeyGCRoot: old, "keep": "content"},
+	}}}
+	sn := &fakeCacheSnapshotter{
+		infos: []snapshots.Info{{
+			Name: "snapshot", Kind: snapshots.KindCommitted,
+			Labels: map[string]string{labelKeyWendySnapshot: "true", labelKeyGCRoot: old, "keep": "snapshot"},
+		}},
+		usage: map[string]snapshots.Usage{"snapshot": {Size: 34}},
+	}
+
+	_, err := pruneCacheRoots(context.Background(), cs, sn, time.Date(2026, 8, 12, 11, 0, 0, 0, time.UTC), false)
+	if err != nil {
+		t.Fatalf("pruneCacheRoots: %v", err)
+	}
+	if len(cs.updates) != 1 || cs.updates[0].Labels["keep"] != "content" {
+		t.Fatalf("content update = %+v", cs.updates)
+	}
+	if _, ok := cs.updates[0].Labels[labelKeyGCRoot]; ok {
+		t.Fatal("content GC root was not removed")
+	}
+	if len(sn.updates) != 1 || sn.updates[0].Labels["keep"] != "snapshot" {
+		t.Fatalf("snapshot update = %+v", sn.updates)
+	}
+	if _, ok := sn.updates[0].Labels[labelKeyGCRoot]; ok {
+		t.Fatal("snapshot GC root was not removed")
+	}
+}
+
+func TestCacheRootOlderThanRejectsInvalidTimestamp(t *testing.T) {
+	if cacheRootOlderThan("not-a-time", time.Now()) {
+		t.Fatal("invalid timestamp must fail safe")
+	}
+}

--- a/go/internal/agent/containerd/helpers.go
+++ b/go/internal/agent/containerd/helpers.go
@@ -75,6 +75,11 @@ const labelKeyGCRoot = "containerd.io/gc.root"
 // labelKeyWendyLayer marks a content blob as a Wendy-pushed layer.
 const labelKeyWendyLayer = "sh.wendy.layer"
 
+// labelKeyWendySnapshot marks a committed layer snapshot created by Wendy's
+// custom unpacker. It lets cache pruning avoid touching GC roots owned by other
+// containerd clients in the same namespace.
+const labelKeyWendySnapshot = "sh.wendy.snapshot"
+
 // labelKeyAppID is the app identity (appId from wendy.json) for every
 // Wendy-managed container. Always set, regardless of whether the app uses
 // multi-service naming. Used to find all containers belonging to an app without

--- a/go/internal/agent/containerd/unpack.go
+++ b/go/internal/agent/containerd/unpack.go
@@ -198,7 +198,8 @@ func (c *Client) UnpackImage(ctx context.Context, img containerd.Image, progress
 		}
 
 		gcRootOpt := snapshots.WithLabels(map[string]string{
-			labelKeyGCRoot: gcTimestamp(),
+			labelKeyGCRoot:        gcTimestamp(),
+			labelKeyWendySnapshot: "true",
 		})
 		commitErr := sn.Commit(ctx, chainID, activeKey, gcRootOpt)
 		switch {

--- a/go/internal/agent/services/container_service_v2.go
+++ b/go/internal/agent/services/container_service_v2.go
@@ -123,6 +123,27 @@ func (s *ContainerServiceV2) ListContainerStats(ctx context.Context, _ *agentpbv
 	return &agentpbv2.ListContainerStatsResponse{Stats: v2stats}, nil
 }
 
+func (s *ContainerServiceV2) PruneCache(ctx context.Context, req *agentpbv2.PruneCacheRequest) (*agentpbv2.PruneCacheResponse, error) {
+	if s.v1.containerd == nil {
+		return nil, status.Error(codes.FailedPrecondition, "containerd is not available")
+	}
+	pruner, ok := s.v1.containerd.(ContainerdCachePruner)
+	if !ok {
+		return nil, status.Error(codes.Unimplemented, "container cache pruning is not supported")
+	}
+	result, err := pruner.PruneCache(ctx, req.GetDryRun())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to prune container cache: %v", err)
+	}
+	return &agentpbv2.PruneCacheResponse{
+		ContentBlobs:      result.ContentBlobs,
+		ContentBytes:      result.ContentBytes,
+		Snapshots:         result.Snapshots,
+		SnapshotBytes:     result.SnapshotBytes,
+		MinimumAgeSeconds: result.MinimumAgeSeconds,
+	}, nil
+}
+
 // mapAppContainerToV2 converts a v1 AppContainer to its v2 equivalent,
 // mapping the running state enum explicitly (v1 STOPPED=0/RUNNING=1 vs v2 STOPPED=1/RUNNING=2).
 func mapAppContainerToV2(c *agentpb.AppContainer) *agentpbv2.AppContainer {

--- a/go/internal/agent/services/container_service_v2_test.go
+++ b/go/internal/agent/services/container_service_v2_test.go
@@ -62,3 +62,46 @@ func TestContainerServiceV2_ListContainers_Empty(t *testing.T) {
 		t.Errorf("expected EOF for empty list, got %v", err)
 	}
 }
+
+type cachePruningContainerdClient struct {
+	*mockContainerdClient
+	result CachePruneResult
+	dryRun bool
+}
+
+func (c *cachePruningContainerdClient) PruneCache(_ context.Context, dryRun bool) (CachePruneResult, error) {
+	c.dryRun = dryRun
+	return c.result, nil
+}
+
+func TestContainerServiceV2_PruneCache(t *testing.T) {
+	mc := &cachePruningContainerdClient{
+		mockContainerdClient: &mockContainerdClient{},
+		result: CachePruneResult{
+			ContentBlobs: 2, ContentBytes: 30, Snapshots: 4, SnapshotBytes: 50, MinimumAgeSeconds: 3600,
+		},
+	}
+	client, cleanup := startContainerV2Server(t, mc)
+	defer cleanup()
+
+	resp, err := client.PruneCache(context.Background(), &agentpbv2.PruneCacheRequest{DryRun: true})
+	if err != nil {
+		t.Fatalf("PruneCache: %v", err)
+	}
+	if !mc.dryRun {
+		t.Fatal("dry_run was not forwarded")
+	}
+	if resp.GetContentBlobs() != 2 || resp.GetContentBytes() != 30 || resp.GetSnapshots() != 4 || resp.GetSnapshotBytes() != 50 || resp.GetMinimumAgeSeconds() != 3600 {
+		t.Fatalf("response = %+v", resp)
+	}
+}
+
+func TestContainerServiceV2_PruneCacheUnsupported(t *testing.T) {
+	client, cleanup := startContainerV2Server(t, &mockContainerdClient{})
+	defer cleanup()
+
+	_, err := client.PruneCache(context.Background(), &agentpbv2.PruneCacheRequest{})
+	if status.Code(err) != codes.Unimplemented {
+		t.Fatalf("code = %v; want Unimplemented", status.Code(err))
+	}
+}

--- a/go/internal/agent/services/interfaces.go
+++ b/go/internal/agent/services/interfaces.go
@@ -98,6 +98,25 @@ type ContainerdClient interface {
 	GetContainerRestartPolicyLabel(ctx context.Context, appName string) (string, error)
 }
 
+// CachePruneResult describes Wendy-managed container cache pins released by a
+// ContainerdCachePruner. The byte counts are the aggregate sizes of the
+// affected objects, not a promise that all of those bytes are unreachable:
+// containerd keeps anything still referenced by an image or active container.
+type CachePruneResult struct {
+	ContentBlobs      uint64
+	ContentBytes      uint64
+	Snapshots         uint64
+	SnapshotBytes     uint64
+	MinimumAgeSeconds uint64
+}
+
+// ContainerdCachePruner is an optional capability implemented by the real
+// containerd client. It remains separate from ContainerdClient so existing
+// service fakes do not need to implement maintenance operations.
+type ContainerdCachePruner interface {
+	PruneCache(ctx context.Context, dryRun bool) (CachePruneResult, error)
+}
+
 // ContainerExecer is the optional capability to run a process inside a running
 // container with an interactive PTY (docker `exec -it`). The ExecContainer RPC
 // type-asserts for it; a client that does not implement it yields Unimplemented.

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -85,6 +85,7 @@ func newDeviceCmd() *cobra.Command {
 		newDeviceRenameCmd(),
 		newDeviceUpdateCmd(),
 		newDeviceSyncTimeCmd(),
+		newDeviceCacheCmd(),
 		newVolumesCmd(),
 	)
 	addToGroup("hardware",
@@ -347,6 +348,13 @@ func newDeviceInfoLikeCmd(use string, deprecated bool) *cobra.Command {
 					}
 					out["partitions"] = parts
 				}
+				if alert, ok := highDiskUsage(partitions, diskUsedBytes, diskTotalBytes); ok {
+					out["diskWarning"] = map[string]any{
+						"mountpoint":       alert.Mountpoint,
+						"usedPercent":      alert.UsedPercent,
+						"thresholdPercent": diskWarningThresholdPercent,
+					}
+				}
 				if gpuVendor != "" {
 					out["gpuVendor"] = gpuVendor
 				}
@@ -413,6 +421,9 @@ func newDeviceInfoLikeCmd(use string, deprecated bool) *cobra.Command {
 				fmt.Print(formatPartitionTable(partitions))
 			} else if diskUsedBytes != nil && diskTotalBytes != nil {
 				fmt.Printf("%s %s\n", tui.Dim("Disk Usage:"), tui.Value(formatDiskUsage(*diskUsedBytes, *diskTotalBytes)))
+			}
+			if alert, ok := highDiskUsage(partitions, diskUsedBytes, diskTotalBytes); ok {
+				fmt.Println(tui.WarningMessage(diskUsageWarningText(alert)))
 			}
 			if len(netInterfaces) > 0 {
 				fmt.Print(formatNetworkInterfaces(netInterfaces))

--- a/go/internal/cli/commands/device_cache.go
+++ b/go/internal/cli/commands/device_cache.go
@@ -1,0 +1,114 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+
+	"github.com/spf13/cobra"
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type deviceCachePruneClient interface {
+	PruneCache(context.Context, *agentpbv2.PruneCacheRequest, ...grpc.CallOption) (*agentpbv2.PruneCacheResponse, error)
+}
+
+func newDeviceCacheCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cache",
+		Short: "Manage cached container data on the target device",
+	}
+	cmd.AddCommand(newDeviceCachePruneCmd())
+	return cmd
+}
+
+func newDeviceCachePruneCmd() *cobra.Command {
+	var dryRun bool
+	cmd := &cobra.Command{
+		Use:   "prune",
+		Short: "Release unused container layer and snapshot caches",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			conn, err := connectToAgent(cmd.Context(), SuppressUpdateCheck())
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+			return runDeviceCachePrune(cmd.Context(), conn, cmd.OutOrStdout(), dryRun, jsonOutput)
+		},
+	}
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Report eligible cache data without releasing it")
+	return cmd
+}
+
+func runDeviceCachePrune(ctx context.Context, conn *grpcclient.AgentConnection, out io.Writer, dryRun, jsonOut bool) error {
+	client := agentpbv2.NewWendyContainerServiceClient(conn.Conn)
+	return runDeviceCachePruneRPC(ctx, client, out, dryRun, jsonOut)
+}
+
+func runDeviceCachePruneRPC(ctx context.Context, client deviceCachePruneClient, out io.Writer, dryRun, jsonOut bool) error {
+	resp, err := client.PruneCache(ctx, &agentpbv2.PruneCacheRequest{DryRun: dryRun})
+	if err != nil {
+		if status.Code(err) == codes.Unimplemented {
+			return fmt.Errorf("this device agent does not support cache pruning; update it with 'wendy device update'")
+		}
+		return fmt.Errorf("pruning device cache: %w", err)
+	}
+	if jsonOut {
+		data, err := json.MarshalIndent(map[string]any{
+			"dryRun":            dryRun,
+			"contentBlobs":      resp.GetContentBlobs(),
+			"contentBytes":      resp.GetContentBytes(),
+			"snapshots":         resp.GetSnapshots(),
+			"snapshotBytes":     resp.GetSnapshotBytes(),
+			"minimumAgeSeconds": resp.GetMinimumAgeSeconds(),
+		}, "", "  ")
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprintln(out, string(data))
+		return err
+	}
+
+	totalObjects := resp.GetContentBlobs() + resp.GetSnapshots()
+	totalBytes := saturatingAdd(resp.GetContentBytes(), resp.GetSnapshotBytes())
+	if totalObjects == 0 {
+		_, err = fmt.Fprintf(out, "No cache entries older than %s are eligible for pruning.\n", formatCacheAge(resp.GetMinimumAgeSeconds()))
+		return err
+	}
+	action := "Released"
+	if dryRun {
+		action = "Eligible"
+	}
+	if _, err = fmt.Fprintf(out, "%s: %s across %d layer blobs and %d snapshots.\n",
+		action, formatBytes(int64(min(totalBytes, uint64(math.MaxInt64)))), resp.GetContentBlobs(), resp.GetSnapshots()); err != nil {
+		return err
+	}
+	if !dryRun {
+		_, err = fmt.Fprintln(out, "Containerd will reclaim unreachable data in the background; current images and active apps are preserved.")
+	}
+	return err
+}
+
+func saturatingAdd(a, b uint64) uint64 {
+	if math.MaxUint64-a < b {
+		return math.MaxUint64
+	}
+	return a + b
+}
+
+func formatCacheAge(seconds uint64) string {
+	if seconds%3600 == 0 {
+		return fmt.Sprintf("%dh", seconds/3600)
+	}
+	if seconds%60 == 0 {
+		return fmt.Sprintf("%dm", seconds/60)
+	}
+	return fmt.Sprintf("%ds", seconds)
+}

--- a/go/internal/cli/commands/device_cache_test.go
+++ b/go/internal/cli/commands/device_cache_test.go
@@ -1,0 +1,61 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type fakeDeviceCachePruneClient struct {
+	response *agentpbv2.PruneCacheResponse
+	dryRun   bool
+	err      error
+}
+
+func (f *fakeDeviceCachePruneClient) PruneCache(_ context.Context, req *agentpbv2.PruneCacheRequest, _ ...grpc.CallOption) (*agentpbv2.PruneCacheResponse, error) {
+	f.dryRun = req.GetDryRun()
+	return f.response, f.err
+}
+
+func TestRunDeviceCachePruneRPCExplainsOldAgent(t *testing.T) {
+	fake := &fakeDeviceCachePruneClient{err: status.Error(codes.Unimplemented, "unknown method")}
+	err := runDeviceCachePruneRPC(context.Background(), fake, &bytes.Buffer{}, false, false)
+	if err == nil || !strings.Contains(err.Error(), "wendy device update") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestRunDeviceCachePruneRPCDryRun(t *testing.T) {
+	fake := &fakeDeviceCachePruneClient{response: &agentpbv2.PruneCacheResponse{
+		ContentBlobs: 2, ContentBytes: 1_000, Snapshots: 3, SnapshotBytes: 2_000, MinimumAgeSeconds: 3600,
+	}}
+	var out bytes.Buffer
+	if err := runDeviceCachePruneRPC(context.Background(), fake, &out, true, false); err != nil {
+		t.Fatalf("runDeviceCachePruneRPC: %v", err)
+	}
+	if !fake.dryRun || !strings.Contains(out.String(), "Eligible: 3.0 kB") {
+		t.Fatalf("output = %q, dryRun=%v", out.String(), fake.dryRun)
+	}
+}
+
+func TestRunDeviceCachePruneRPCJSON(t *testing.T) {
+	fake := &fakeDeviceCachePruneClient{response: &agentpbv2.PruneCacheResponse{ContentBlobs: 1, MinimumAgeSeconds: 3600}}
+	var out bytes.Buffer
+	if err := runDeviceCachePruneRPC(context.Background(), fake, &out, false, true); err != nil {
+		t.Fatalf("runDeviceCachePruneRPC: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("JSON: %v", err)
+	}
+	if got["contentBlobs"] != float64(1) || got["minimumAgeSeconds"] != float64(3600) {
+		t.Fatalf("JSON = %v", got)
+	}
+}

--- a/go/internal/cli/commands/disk_warning.go
+++ b/go/internal/cli/commands/disk_warning.go
@@ -1,0 +1,62 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+const diskWarningThresholdPercent int64 = 85
+
+type diskUsageAlert struct {
+	Mountpoint  string
+	UsedPercent int64
+}
+
+// highDiskUsage returns the fullest partition above the warning threshold.
+// Partition data takes precedence over the legacy root-only fields.
+func highDiskUsage(partitions []*agentpb.DiskPartition, legacyUsed, legacyTotal *int64) (diskUsageAlert, bool) {
+	var (
+		best      diskUsageAlert
+		bestRatio float64
+	)
+	for _, p := range partitions {
+		if p == nil || p.GetTotalBytes() <= 0 || p.GetUsedBytes() < 0 {
+			continue
+		}
+		ratio := float64(p.GetUsedBytes()) / float64(p.GetTotalBytes())
+		if ratio > float64(diskWarningThresholdPercent)/100 && ratio > bestRatio {
+			bestRatio = ratio
+			best = diskUsageAlert{Mountpoint: p.GetMountpoint(), UsedPercent: int64(ratio * 100)}
+		}
+	}
+	if bestRatio > 0 {
+		return best, true
+	}
+	if len(partitions) == 0 && legacyUsed != nil && legacyTotal != nil && *legacyTotal > 0 && *legacyUsed >= 0 {
+		ratio := float64(*legacyUsed) / float64(*legacyTotal)
+		if ratio > float64(diskWarningThresholdPercent)/100 {
+			return diskUsageAlert{Mountpoint: "/", UsedPercent: int64(ratio * 100)}, true
+		}
+	}
+	return diskUsageAlert{}, false
+}
+
+func diskUsageWarningText(alert diskUsageAlert) string {
+	mountpoint := alert.Mountpoint
+	if mountpoint == "" {
+		mountpoint = "the device disk"
+	} else {
+		mountpoint = fmt.Sprintf("disk %s", mountpoint)
+	}
+	return fmt.Sprintf("%s is %d%% full. Free cached container data with 'wendy device cache prune'.", mountpoint, alert.UsedPercent)
+}
+
+func printRunDiskUsageWarning(resp *agentpb.GetAgentVersionResponse) {
+	if resp == nil {
+		return
+	}
+	if alert, ok := highDiskUsage(resp.GetPartitions(), resp.DiskUsedBytes, resp.DiskTotalBytes); ok {
+		cliNotice("Warning: %s", diskUsageWarningText(alert))
+	}
+}

--- a/go/internal/cli/commands/disk_warning_test.go
+++ b/go/internal/cli/commands/disk_warning_test.go
@@ -1,0 +1,30 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+func TestHighDiskUsageThresholdAndFullestPartition(t *testing.T) {
+	parts := []*agentpb.DiskPartition{
+		{Mountpoint: "/", UsedBytes: 850, TotalBytes: 1000},
+		{Mountpoint: "/data", UsedBytes: 960, TotalBytes: 1000},
+		{Mountpoint: "/boot", UsedBytes: 9, TotalBytes: 10},
+	}
+	alert, ok := highDiskUsage(parts, nil, nil)
+	if !ok || alert.Mountpoint != "/data" || alert.UsedPercent != 96 {
+		t.Fatalf("alert = %+v, ok=%v", alert, ok)
+	}
+	if !strings.Contains(diskUsageWarningText(alert), "wendy device cache prune") {
+		t.Fatal("warning does not include remediation command")
+	}
+}
+
+func TestHighDiskUsageDoesNotWarnAtExactlyThreshold(t *testing.T) {
+	used, total := int64(85), int64(100)
+	if alert, ok := highDiskUsage(nil, &used, &total); ok {
+		t.Fatalf("unexpected alert: %+v", alert)
+	}
+}

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -344,6 +344,7 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	if err != nil {
 		return fmt.Errorf("querying device version: %w", err)
 	}
+	printRunDiskUsageWarning(versionResp)
 	agentOS := versionResp.GetOs()
 	architecture := versionResp.GetCpuArchitecture()
 	if architecture == "" {

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -1510,6 +1510,7 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 	if err != nil {
 		return fmt.Errorf("querying device version: %w", err)
 	}
+	printRunDiskUsageWarning(versionResp)
 	mark("agent GetAgentVersion (in runWithAgent)")
 	agentOS := versionResp.GetOs()
 	architecture := versionResp.GetCpuArchitecture()

--- a/go/proto/gen/agentpb/v2/container_service.pb.go
+++ b/go/proto/gen/agentpb/v2/container_service.pb.go
@@ -877,6 +877,133 @@ func (x *ListContainerStatsResponse) GetStats() []*ContainerStats {
 	return nil
 }
 
+type PruneCacheRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Reports what would be released without changing containerd metadata.
+	DryRun        bool `protobuf:"varint,1,opt,name=dry_run,json=dryRun,proto3" json:"dry_run,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PruneCacheRequest) Reset() {
+	*x = PruneCacheRequest{}
+	mi := &file_wendy_agent_services_v2_container_service_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PruneCacheRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PruneCacheRequest) ProtoMessage() {}
+
+func (x *PruneCacheRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_container_service_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PruneCacheRequest.ProtoReflect.Descriptor instead.
+func (*PruneCacheRequest) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_container_service_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *PruneCacheRequest) GetDryRun() bool {
+	if x != nil {
+		return x.DryRun
+	}
+	return false
+}
+
+type PruneCacheResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Number and aggregate compressed size of pushed layer blobs whose Wendy
+	// GC-root pin was (or would be, for dry_run) released.
+	ContentBlobs uint64 `protobuf:"varint,1,opt,name=content_blobs,json=contentBlobs,proto3" json:"content_blobs,omitempty"`
+	ContentBytes uint64 `protobuf:"varint,2,opt,name=content_bytes,json=contentBytes,proto3" json:"content_bytes,omitempty"`
+	// Number and aggregate filesystem usage of unpacked snapshots whose Wendy
+	// GC-root pin was (or would be, for dry_run) released.
+	Snapshots     uint64 `protobuf:"varint,3,opt,name=snapshots,proto3" json:"snapshots,omitempty"`
+	SnapshotBytes uint64 `protobuf:"varint,4,opt,name=snapshot_bytes,json=snapshotBytes,proto3" json:"snapshot_bytes,omitempty"`
+	// Newly written cache entries are retained for this many seconds to avoid
+	// disrupting an in-flight deployment between layer RPCs.
+	MinimumAgeSeconds uint64 `protobuf:"varint,5,opt,name=minimum_age_seconds,json=minimumAgeSeconds,proto3" json:"minimum_age_seconds,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *PruneCacheResponse) Reset() {
+	*x = PruneCacheResponse{}
+	mi := &file_wendy_agent_services_v2_container_service_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PruneCacheResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PruneCacheResponse) ProtoMessage() {}
+
+func (x *PruneCacheResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v2_container_service_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PruneCacheResponse.ProtoReflect.Descriptor instead.
+func (*PruneCacheResponse) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v2_container_service_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *PruneCacheResponse) GetContentBlobs() uint64 {
+	if x != nil {
+		return x.ContentBlobs
+	}
+	return 0
+}
+
+func (x *PruneCacheResponse) GetContentBytes() uint64 {
+	if x != nil {
+		return x.ContentBytes
+	}
+	return 0
+}
+
+func (x *PruneCacheResponse) GetSnapshots() uint64 {
+	if x != nil {
+		return x.Snapshots
+	}
+	return 0
+}
+
+func (x *PruneCacheResponse) GetSnapshotBytes() uint64 {
+	if x != nil {
+		return x.SnapshotBytes
+	}
+	return 0
+}
+
+func (x *PruneCacheResponse) GetMinimumAgeSeconds() uint64 {
+	if x != nil {
+		return x.MinimumAgeSeconds
+	}
+	return 0
+}
+
 type ContainerStreamResponse_Started struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -885,7 +1012,7 @@ type ContainerStreamResponse_Started struct {
 
 func (x *ContainerStreamResponse_Started) Reset() {
 	*x = ContainerStreamResponse_Started{}
-	mi := &file_wendy_agent_services_v2_container_service_proto_msgTypes[17]
+	mi := &file_wendy_agent_services_v2_container_service_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -897,7 +1024,7 @@ func (x *ContainerStreamResponse_Started) String() string {
 func (*ContainerStreamResponse_Started) ProtoMessage() {}
 
 func (x *ContainerStreamResponse_Started) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v2_container_service_proto_msgTypes[17]
+	mi := &file_wendy_agent_services_v2_container_service_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -922,7 +1049,7 @@ type ContainerStreamResponse_ConsoleOutput struct {
 
 func (x *ContainerStreamResponse_ConsoleOutput) Reset() {
 	*x = ContainerStreamResponse_ConsoleOutput{}
-	mi := &file_wendy_agent_services_v2_container_service_proto_msgTypes[18]
+	mi := &file_wendy_agent_services_v2_container_service_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -934,7 +1061,7 @@ func (x *ContainerStreamResponse_ConsoleOutput) String() string {
 func (*ContainerStreamResponse_ConsoleOutput) ProtoMessage() {}
 
 func (x *ContainerStreamResponse_ConsoleOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v2_container_service_proto_msgTypes[18]
+	mi := &file_wendy_agent_services_v2_container_service_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1009,7 +1136,15 @@ const file_wendy_agent_services_v2_container_service_proto_rawDesc = "" +
 	"\rstorage_bytes\x18\x03 \x01(\x03R\fstorageBytes\"\x1b\n" +
 	"\x19ListContainerStatsRequest\"[\n" +
 	"\x1aListContainerStatsResponse\x12=\n" +
-	"\x05stats\x18\x01 \x03(\v2'.wendy.agent.services.v2.ContainerStatsR\x05stats2\xb8\a\n" +
+	"\x05stats\x18\x01 \x03(\v2'.wendy.agent.services.v2.ContainerStatsR\x05stats\",\n" +
+	"\x11PruneCacheRequest\x12\x17\n" +
+	"\adry_run\x18\x01 \x01(\bR\x06dryRun\"\xd3\x01\n" +
+	"\x12PruneCacheResponse\x12#\n" +
+	"\rcontent_blobs\x18\x01 \x01(\x04R\fcontentBlobs\x12#\n" +
+	"\rcontent_bytes\x18\x02 \x01(\x04R\fcontentBytes\x12\x1c\n" +
+	"\tsnapshots\x18\x03 \x01(\x04R\tsnapshots\x12%\n" +
+	"\x0esnapshot_bytes\x18\x04 \x01(\x04R\rsnapshotBytes\x12.\n" +
+	"\x13minimum_age_seconds\x18\x05 \x01(\x04R\x11minimumAgeSeconds2\x9f\b\n" +
 	"\x15WendyContainerService\x12t\n" +
 	"\x0eStartContainer\x12..wendy.agent.services.v2.StartContainerRequest\x1a0.wendy.agent.services.v2.ContainerStreamResponse0\x01\x12x\n" +
 	"\x0fAttachContainer\x12/.wendy.agent.services.v2.AttachContainerRequest\x1a0.wendy.agent.services.v2.ContainerStreamResponse(\x010\x01\x12n\n" +
@@ -1018,7 +1153,9 @@ const file_wendy_agent_services_v2_container_service_proto_rawDesc = "" +
 	"\x0eListContainers\x12..wendy.agent.services.v2.ListContainersRequest\x1a/.wendy.agent.services.v2.ListContainersResponse0\x01\x12h\n" +
 	"\vListVolumes\x12+.wendy.agent.services.v2.ListVolumesRequest\x1a,.wendy.agent.services.v2.ListVolumesResponse\x12k\n" +
 	"\fRemoveVolume\x12,.wendy.agent.services.v2.RemoveVolumeRequest\x1a-.wendy.agent.services.v2.RemoveVolumeResponse\x12}\n" +
-	"\x12ListContainerStats\x122.wendy.agent.services.v2.ListContainerStatsRequest\x1a3.wendy.agent.services.v2.ListContainerStatsResponseB>Z<github.com/wendylabsinc/wendy/proto/gen/agentpb/v2;agentpbv2b\x06proto3"
+	"\x12ListContainerStats\x122.wendy.agent.services.v2.ListContainerStatsRequest\x1a3.wendy.agent.services.v2.ListContainerStatsResponse\x12e\n" +
+	"\n" +
+	"PruneCache\x12*.wendy.agent.services.v2.PruneCacheRequest\x1a+.wendy.agent.services.v2.PruneCacheResponseB>Z<github.com/wendylabsinc/wendy/proto/gen/agentpb/v2;agentpbv2b\x06proto3"
 
 var (
 	file_wendy_agent_services_v2_container_service_proto_rawDescOnce sync.Once
@@ -1032,7 +1169,7 @@ func file_wendy_agent_services_v2_container_service_proto_rawDescGZIP() []byte {
 	return file_wendy_agent_services_v2_container_service_proto_rawDescData
 }
 
-var file_wendy_agent_services_v2_container_service_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
+var file_wendy_agent_services_v2_container_service_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
 var file_wendy_agent_services_v2_container_service_proto_goTypes = []any{
 	(*StartContainerRequest)(nil),                 // 0: wendy.agent.services.v2.StartContainerRequest
 	(*AttachContainerRequest)(nil),                // 1: wendy.agent.services.v2.AttachContainerRequest
@@ -1051,15 +1188,17 @@ var file_wendy_agent_services_v2_container_service_proto_goTypes = []any{
 	(*ContainerStats)(nil),                        // 14: wendy.agent.services.v2.ContainerStats
 	(*ListContainerStatsRequest)(nil),             // 15: wendy.agent.services.v2.ListContainerStatsRequest
 	(*ListContainerStatsResponse)(nil),            // 16: wendy.agent.services.v2.ListContainerStatsResponse
-	(*ContainerStreamResponse_Started)(nil),       // 17: wendy.agent.services.v2.ContainerStreamResponse.Started
-	(*ContainerStreamResponse_ConsoleOutput)(nil), // 18: wendy.agent.services.v2.ContainerStreamResponse.ConsoleOutput
-	(*AppContainer)(nil),                          // 19: wendy.agent.services.v2.AppContainer
+	(*PruneCacheRequest)(nil),                     // 17: wendy.agent.services.v2.PruneCacheRequest
+	(*PruneCacheResponse)(nil),                    // 18: wendy.agent.services.v2.PruneCacheResponse
+	(*ContainerStreamResponse_Started)(nil),       // 19: wendy.agent.services.v2.ContainerStreamResponse.Started
+	(*ContainerStreamResponse_ConsoleOutput)(nil), // 20: wendy.agent.services.v2.ContainerStreamResponse.ConsoleOutput
+	(*AppContainer)(nil),                          // 21: wendy.agent.services.v2.AppContainer
 }
 var file_wendy_agent_services_v2_container_service_proto_depIdxs = []int32{
-	17, // 0: wendy.agent.services.v2.ContainerStreamResponse.started:type_name -> wendy.agent.services.v2.ContainerStreamResponse.Started
-	18, // 1: wendy.agent.services.v2.ContainerStreamResponse.stdout_output:type_name -> wendy.agent.services.v2.ContainerStreamResponse.ConsoleOutput
-	18, // 2: wendy.agent.services.v2.ContainerStreamResponse.stderr_output:type_name -> wendy.agent.services.v2.ContainerStreamResponse.ConsoleOutput
-	19, // 3: wendy.agent.services.v2.ListContainersResponse.container:type_name -> wendy.agent.services.v2.AppContainer
+	19, // 0: wendy.agent.services.v2.ContainerStreamResponse.started:type_name -> wendy.agent.services.v2.ContainerStreamResponse.Started
+	20, // 1: wendy.agent.services.v2.ContainerStreamResponse.stdout_output:type_name -> wendy.agent.services.v2.ContainerStreamResponse.ConsoleOutput
+	20, // 2: wendy.agent.services.v2.ContainerStreamResponse.stderr_output:type_name -> wendy.agent.services.v2.ContainerStreamResponse.ConsoleOutput
+	21, // 3: wendy.agent.services.v2.ListContainersResponse.container:type_name -> wendy.agent.services.v2.AppContainer
 	10, // 4: wendy.agent.services.v2.ListVolumesResponse.volumes:type_name -> wendy.agent.services.v2.VolumeInfo
 	14, // 5: wendy.agent.services.v2.ListContainerStatsResponse.stats:type_name -> wendy.agent.services.v2.ContainerStats
 	0,  // 6: wendy.agent.services.v2.WendyContainerService.StartContainer:input_type -> wendy.agent.services.v2.StartContainerRequest
@@ -1070,16 +1209,18 @@ var file_wendy_agent_services_v2_container_service_proto_depIdxs = []int32{
 	9,  // 11: wendy.agent.services.v2.WendyContainerService.ListVolumes:input_type -> wendy.agent.services.v2.ListVolumesRequest
 	12, // 12: wendy.agent.services.v2.WendyContainerService.RemoveVolume:input_type -> wendy.agent.services.v2.RemoveVolumeRequest
 	15, // 13: wendy.agent.services.v2.WendyContainerService.ListContainerStats:input_type -> wendy.agent.services.v2.ListContainerStatsRequest
-	2,  // 14: wendy.agent.services.v2.WendyContainerService.StartContainer:output_type -> wendy.agent.services.v2.ContainerStreamResponse
-	2,  // 15: wendy.agent.services.v2.WendyContainerService.AttachContainer:output_type -> wendy.agent.services.v2.ContainerStreamResponse
-	4,  // 16: wendy.agent.services.v2.WendyContainerService.StopContainer:output_type -> wendy.agent.services.v2.StopContainerResponse
-	6,  // 17: wendy.agent.services.v2.WendyContainerService.DeleteContainer:output_type -> wendy.agent.services.v2.DeleteContainerResponse
-	8,  // 18: wendy.agent.services.v2.WendyContainerService.ListContainers:output_type -> wendy.agent.services.v2.ListContainersResponse
-	11, // 19: wendy.agent.services.v2.WendyContainerService.ListVolumes:output_type -> wendy.agent.services.v2.ListVolumesResponse
-	13, // 20: wendy.agent.services.v2.WendyContainerService.RemoveVolume:output_type -> wendy.agent.services.v2.RemoveVolumeResponse
-	16, // 21: wendy.agent.services.v2.WendyContainerService.ListContainerStats:output_type -> wendy.agent.services.v2.ListContainerStatsResponse
-	14, // [14:22] is the sub-list for method output_type
-	6,  // [6:14] is the sub-list for method input_type
+	17, // 14: wendy.agent.services.v2.WendyContainerService.PruneCache:input_type -> wendy.agent.services.v2.PruneCacheRequest
+	2,  // 15: wendy.agent.services.v2.WendyContainerService.StartContainer:output_type -> wendy.agent.services.v2.ContainerStreamResponse
+	2,  // 16: wendy.agent.services.v2.WendyContainerService.AttachContainer:output_type -> wendy.agent.services.v2.ContainerStreamResponse
+	4,  // 17: wendy.agent.services.v2.WendyContainerService.StopContainer:output_type -> wendy.agent.services.v2.StopContainerResponse
+	6,  // 18: wendy.agent.services.v2.WendyContainerService.DeleteContainer:output_type -> wendy.agent.services.v2.DeleteContainerResponse
+	8,  // 19: wendy.agent.services.v2.WendyContainerService.ListContainers:output_type -> wendy.agent.services.v2.ListContainersResponse
+	11, // 20: wendy.agent.services.v2.WendyContainerService.ListVolumes:output_type -> wendy.agent.services.v2.ListVolumesResponse
+	13, // 21: wendy.agent.services.v2.WendyContainerService.RemoveVolume:output_type -> wendy.agent.services.v2.RemoveVolumeResponse
+	16, // 22: wendy.agent.services.v2.WendyContainerService.ListContainerStats:output_type -> wendy.agent.services.v2.ListContainerStatsResponse
+	18, // 23: wendy.agent.services.v2.WendyContainerService.PruneCache:output_type -> wendy.agent.services.v2.PruneCacheResponse
+	15, // [15:24] is the sub-list for method output_type
+	6,  // [6:15] is the sub-list for method input_type
 	6,  // [6:6] is the sub-list for extension type_name
 	6,  // [6:6] is the sub-list for extension extendee
 	0,  // [0:6] is the sub-list for field type_name
@@ -1106,7 +1247,7 @@ func file_wendy_agent_services_v2_container_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_wendy_agent_services_v2_container_service_proto_rawDesc), len(file_wendy_agent_services_v2_container_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   19,
+			NumMessages:   21,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/go/proto/gen/agentpb/v2/container_service_grpc.pb.go
+++ b/go/proto/gen/agentpb/v2/container_service_grpc.pb.go
@@ -27,6 +27,7 @@ const (
 	WendyContainerService_ListVolumes_FullMethodName        = "/wendy.agent.services.v2.WendyContainerService/ListVolumes"
 	WendyContainerService_RemoveVolume_FullMethodName       = "/wendy.agent.services.v2.WendyContainerService/RemoveVolume"
 	WendyContainerService_ListContainerStats_FullMethodName = "/wendy.agent.services.v2.WendyContainerService/ListContainerStats"
+	WendyContainerService_PruneCache_FullMethodName         = "/wendy.agent.services.v2.WendyContainerService/PruneCache"
 )
 
 // WendyContainerServiceClient is the client API for WendyContainerService service.
@@ -41,6 +42,10 @@ type WendyContainerServiceClient interface {
 	ListVolumes(ctx context.Context, in *ListVolumesRequest, opts ...grpc.CallOption) (*ListVolumesResponse, error)
 	RemoveVolume(ctx context.Context, in *RemoveVolumeRequest, opts ...grpc.CallOption) (*RemoveVolumeResponse, error)
 	ListContainerStats(ctx context.Context, in *ListContainerStatsRequest, opts ...grpc.CallOption) (*ListContainerStatsResponse, error)
+	// Releases Wendy's explicit GC pins from pushed layer blobs and unpacked
+	// snapshots. Containerd's reference graph continues to preserve current
+	// images and active containers; only cache data becomes collectible.
+	PruneCache(ctx context.Context, in *PruneCacheRequest, opts ...grpc.CallOption) (*PruneCacheResponse, error)
 }
 
 type wendyContainerServiceClient struct {
@@ -152,6 +157,16 @@ func (c *wendyContainerServiceClient) ListContainerStats(ctx context.Context, in
 	return out, nil
 }
 
+func (c *wendyContainerServiceClient) PruneCache(ctx context.Context, in *PruneCacheRequest, opts ...grpc.CallOption) (*PruneCacheResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(PruneCacheResponse)
+	err := c.cc.Invoke(ctx, WendyContainerService_PruneCache_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // WendyContainerServiceServer is the server API for WendyContainerService service.
 // All implementations must embed UnimplementedWendyContainerServiceServer
 // for forward compatibility.
@@ -164,6 +179,10 @@ type WendyContainerServiceServer interface {
 	ListVolumes(context.Context, *ListVolumesRequest) (*ListVolumesResponse, error)
 	RemoveVolume(context.Context, *RemoveVolumeRequest) (*RemoveVolumeResponse, error)
 	ListContainerStats(context.Context, *ListContainerStatsRequest) (*ListContainerStatsResponse, error)
+	// Releases Wendy's explicit GC pins from pushed layer blobs and unpacked
+	// snapshots. Containerd's reference graph continues to preserve current
+	// images and active containers; only cache data becomes collectible.
+	PruneCache(context.Context, *PruneCacheRequest) (*PruneCacheResponse, error)
 	mustEmbedUnimplementedWendyContainerServiceServer()
 }
 
@@ -197,6 +216,9 @@ func (UnimplementedWendyContainerServiceServer) RemoveVolume(context.Context, *R
 }
 func (UnimplementedWendyContainerServiceServer) ListContainerStats(context.Context, *ListContainerStatsRequest) (*ListContainerStatsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListContainerStats not implemented")
+}
+func (UnimplementedWendyContainerServiceServer) PruneCache(context.Context, *PruneCacheRequest) (*PruneCacheResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method PruneCache not implemented")
 }
 func (UnimplementedWendyContainerServiceServer) mustEmbedUnimplementedWendyContainerServiceServer() {}
 func (UnimplementedWendyContainerServiceServer) testEmbeddedByValue()                               {}
@@ -338,6 +360,24 @@ func _WendyContainerService_ListContainerStats_Handler(srv interface{}, ctx cont
 	return interceptor(ctx, in, info, handler)
 }
 
+func _WendyContainerService_PruneCache_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PruneCacheRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WendyContainerServiceServer).PruneCache(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: WendyContainerService_PruneCache_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WendyContainerServiceServer).PruneCache(ctx, req.(*PruneCacheRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // WendyContainerService_ServiceDesc is the grpc.ServiceDesc for WendyContainerService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -364,6 +404,10 @@ var WendyContainerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListContainerStats",
 			Handler:    _WendyContainerService_ListContainerStats_Handler,
+		},
+		{
+			MethodName: "PruneCache",
+			Handler:    _WendyContainerService_PruneCache_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{


### PR DESCRIPTION
## What changed

- adds a v2 `PruneCache` agent RPC and `wendy device cache prune` CLI command, including `--dry-run` and JSON output
- releases only Wendy-owned containerd GC-root cache pins; current images and active containers remain protected by containerd's reference graph
- recognizes legacy Wendy snapshot cache entries so devices that already accumulated data can be cleaned
- retains cache entries newer than 24 hours to avoid disrupting in-flight multi-RPC deployments
- warns when the fullest device partition exceeds 85% usage in `wendy device info`, its JSON output, and `wendy run` (single- and multi-service paths)

## Why

Wendy's pushed layers and custom-unpacked snapshots are explicitly pinned with `containerd.io/gc.root`. Those pins were never released, so repeated builds can grow device storage indefinitely even after old image manifests become unreachable.

## User impact

Users can inspect eligible storage with:

```sh
wendy device cache prune --dry-run
```

and release it with:

```sh
wendy device cache prune
```

Volumes, apps, current images, and active container snapshots are not deleted. Containerd reclaims newly unreachable data asynchronously.

## Validation

- `go test ./...`
- post-rebase: `go test ./internal/agent/containerd ./internal/agent/services ./internal/cli/commands`
- `make build-cli`
- `wendy device cache --help`
- `wendy device cache prune --help`
- `git diff --check`
