### PR TITLE
Fail early on unhealthy Docker builders

### DIFF
--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -1397,6 +1397,9 @@ func ensureBuildxBuilder(ctx context.Context, registryAddr string, useMTLS bool,
 	if err != nil {
 		return "", "", err
 	}
+	if err := ensureBuildxBuilderFreeSpace(ctx, builderName, w); err != nil {
+		return "", "", err
+	}
 
 	// Add a /etc/hosts entry inside the builder container so it can resolve
 	// the alias to the real IPv6 address.
@@ -1440,6 +1443,9 @@ func ensureOCIExportBuilder(ctx context.Context, w io.Writer) (string, error) {
 	// full robust path below.
 	containerName := "buildx_buildkit_" + builderName + "0"
 	if out, err := exec.CommandContext(ctx, "docker", "inspect", "-f", "{{.State.Running}}", containerName).Output(); err == nil && strings.TrimSpace(string(out)) == "true" {
+		if err := ensureBuildxBuilderFreeSpace(ctx, builderName, w); err != nil {
+			return "", err
+		}
 		return builderName, nil
 	}
 
@@ -1464,7 +1470,10 @@ func ensureOCIExportBuilder(ctx context.Context, w io.Writer) (string, error) {
 	// crucially, performs no config injection or container restart.
 	bootstrapCmd := exec.CommandContext(ctx, "docker", "buildx", "inspect", "--bootstrap", "--builder", builderName)
 	if out, err := bootstrapCmd.CombinedOutput(); err != nil {
-		return "", fmt.Errorf("bootstrapping builder %q: %s: %w", builderName, string(out), err)
+		return "", diagnoseDockerBuilderError(ctx, fmt.Sprintf("bootstrapping builder %q", builderName), out, err)
+	}
+	if err := ensureBuildxBuilderFreeSpace(ctx, builderName, w); err != nil {
+		return "", err
 	}
 	return builderName, nil
 }
@@ -1556,7 +1565,7 @@ func ensurePlaintextBuilder(ctx context.Context, configDir, registryAddr string,
 		// Builder exists with correct config — just ensure it's running.
 		bootstrapCmd := exec.CommandContext(ctx, "docker", "buildx", "inspect", "--bootstrap", "--builder", builderName)
 		if out, err := bootstrapCmd.CombinedOutput(); err != nil {
-			return "", fmt.Errorf("bootstrapping builder: %s: %w", string(out), err)
+			return "", diagnoseDockerBuilderError(ctx, "bootstrapping BuildKit builder", out, err)
 		}
 	}
 
@@ -1652,7 +1661,7 @@ func ensureMTLSBuilder(ctx context.Context, configDir, registryAddr, containerCe
 		// Builder exists with correct config — just ensure it's running.
 		bootstrapCmd := exec.CommandContext(ctx, "docker", "buildx", "inspect", "--bootstrap", "--builder", builderName)
 		if out, err := bootstrapCmd.CombinedOutput(); err != nil {
-			return "", fmt.Errorf("bootstrapping builder: %s: %w", string(out), err)
+			return "", diagnoseDockerBuilderError(ctx, "bootstrapping mTLS BuildKit builder", out, err)
 		}
 	}
 
@@ -1666,7 +1675,7 @@ func copyCertsToBuilder(ctx context.Context, builderName, hostCertDir, container
 	// Bootstrap the builder to ensure the container is running.
 	cmd := exec.CommandContext(ctx, "docker", "buildx", "inspect", "--bootstrap", "--builder", builderName)
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("bootstrapping builder: %s: %w", string(out), err)
+		return diagnoseDockerBuilderError(ctx, "bootstrapping BuildKit builder for certificate injection", out, err)
 	}
 
 	// The docker-container driver names the container buildx_buildkit_<name>0.
@@ -1688,7 +1697,7 @@ func updateBuilderConfig(ctx context.Context, builderName, config string, w io.W
 	fmt.Fprintf(w, "[buildx] bootstrapping builder %q\n", builderName)
 	bootstrapCmd := exec.CommandContext(ctx, "docker", "buildx", "inspect", "--bootstrap", "--builder", builderName)
 	if out, err := bootstrapCmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("bootstrapping builder: %s: %w", string(out), err)
+		return diagnoseDockerBuilderError(ctx, "bootstrapping BuildKit builder for configuration", out, err)
 	}
 	fmt.Fprintf(w, "[buildx] bootstrap done\n")
 
@@ -1732,13 +1741,13 @@ func updateBuilderConfig(ctx context.Context, builderName, config string, w io.W
 	fmt.Fprintf(w, "[buildx] restarting container %q\n", containerName)
 	cmd = exec.CommandContext(ctx, "docker", "restart", containerName)
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("restarting builder: %s: %w", string(out), err)
+		return diagnoseDockerBuilderError(ctx, "restarting BuildKit builder", out, err)
 	}
 	fmt.Fprintf(w, "[buildx] container restarted, waiting for buildkitd\n")
 
 	bootstrapAfterRestart := exec.CommandContext(ctx, "docker", "buildx", "inspect", "--bootstrap", "--builder", builderName)
 	if out, err := bootstrapAfterRestart.CombinedOutput(); err != nil {
-		return fmt.Errorf("waiting for builder after restart: %s: %w", string(out), err)
+		return diagnoseDockerBuilderError(ctx, "waiting for BuildKit builder after restart", out, err)
 	}
 	fmt.Fprintf(w, "[buildx] builder ready\n")
 

--- a/go/internal/cli/commands/docker_health.go
+++ b/go/internal/cli/commands/docker_health.go
@@ -1,0 +1,127 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+const (
+	minimumBuildkitFreeBytes = int64(1 << 30)
+	warnBuildkitFreeBytes    = int64(10 << 30)
+)
+
+// dockerBackendDescription identifies the daemon Wendy is actually using.
+// DOCKER_HOST overrides the selected context, so report it first when present.
+func dockerBackendDescription(ctx context.Context) string {
+	if host := strings.TrimSpace(os.Getenv("DOCKER_HOST")); host != "" {
+		return "DOCKER_HOST=" + host
+	}
+	out, err := exec.CommandContext(ctx, "docker", "context", "show").Output()
+	if err == nil {
+		if name := strings.TrimSpace(string(out)); name != "" {
+			return "context=" + name
+		}
+	}
+	return "current Docker context"
+}
+
+// dockerOperationError turns common local-daemon failures into actionable
+// diagnostics. These errors happen before Wendy transfers or replaces an app,
+// so users should repair or select a healthy builder rather than retry blindly.
+func dockerOperationError(ctx context.Context, operation string, output []byte, err error) error {
+	detail := strings.TrimSpace(string(output))
+	if detail == "" {
+		detail = err.Error()
+	}
+	backend := dockerBackendDescription(ctx)
+	lower := strings.ToLower(detail + " " + err.Error())
+
+	switch {
+	case strings.Contains(lower, "input/output error") || strings.Contains(lower, "i/o error"):
+		return fmt.Errorf(
+			"%s failed on %s because Docker's local image/container store returned an I/O error; the daemon may answer 'docker version' while its storage is still unreadable. Repair or restart that Docker backend, or select a healthy one with DOCKER_HOST, before retrying: %s: %w",
+			operation, backend, detail, err,
+		)
+	case strings.Contains(lower, "no space left on device"):
+		return fmt.Errorf(
+			"%s failed on %s because the Docker/BuildKit filesystem is full. Free unused builder data or increase that backend's disk allocation before retrying: %s: %w",
+			operation, backend, detail, err,
+		)
+	case strings.Contains(lower, "marked for removal"):
+		return fmt.Errorf(
+			"%s failed on %s because the BuildKit container is stuck pending removal. Check the Docker backend for storage errors before recreating the builder; if the backend is healthy, select or recreate the builder and retry: %s: %w",
+			operation, backend, detail, err,
+		)
+	default:
+		return fmt.Errorf("%s failed on %s: %s: %w", operation, backend, detail, err)
+	}
+}
+
+// diagnoseDockerBuilderError checks whether a failed builder operation is only
+// the visible symptom of an unreadable Docker image store. The read-only image
+// listing runs only after a failure, so healthy builds keep the fast path.
+func diagnoseDockerBuilderError(ctx context.Context, operation string, operationOutput []byte, operationErr error) error {
+	out, err := exec.CommandContext(ctx, "docker", "image", "ls", "--quiet", "--no-trunc").CombinedOutput()
+	if err != nil {
+		storageErr := dockerOperationError(ctx, "checking Docker image-store health", out, err)
+		return fmt.Errorf("%w (diagnosed after %s failed: %s)", storageErr, operation, strings.TrimSpace(string(operationOutput)))
+	}
+	return dockerOperationError(ctx, operation, operationOutput, operationErr)
+}
+
+// parsePOSIXDFAvailableBytes reads the Available column from `df -Pk` output.
+func parsePOSIXDFAvailableBytes(output []byte) (int64, error) {
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		fields := strings.Fields(lines[i])
+		if len(fields) < 4 {
+			continue
+		}
+		availableKiB, err := strconv.ParseInt(fields[3], 10, 64)
+		if err != nil || availableKiB < 0 {
+			continue
+		}
+		if availableKiB > math.MaxInt64/1024 {
+			return 0, fmt.Errorf("available block count overflows bytes")
+		}
+		return availableKiB * 1024, nil
+	}
+	return 0, fmt.Errorf("could not find the Available column in df output %q", strings.TrimSpace(string(output)))
+}
+
+// ensureBuildxBuilderFreeSpace verifies the filesystem that backs BuildKit,
+// not merely the host filesystem. Sparse Docker Desktop disks and small Colima
+// profiles can have very different free space from the host.
+func ensureBuildxBuilderFreeSpace(ctx context.Context, builderName string, w io.Writer) error {
+	containerName := "buildx_buildkit_" + builderName + "0"
+	out, err := exec.CommandContext(ctx, "docker", "exec", containerName,
+		"df", "-Pk", "/var/lib/buildkit").CombinedOutput()
+	if err != nil {
+		return diagnoseDockerBuilderError(ctx, "checking BuildKit free space", out, err)
+	}
+
+	available, err := parsePOSIXDFAvailableBytes(out)
+	if err != nil {
+		// A future BuildKit image may format df differently. Do not break all
+		// builds over an advisory probe when the command itself succeeded.
+		fmt.Fprintf(w, "[buildx] warning: could not parse free space for builder %q: %v\n", builderName, err)
+		return nil
+	}
+	if available < minimumBuildkitFreeBytes {
+		return fmt.Errorf(
+			"BuildKit builder %q on %s has only %s free; Wendy requires at least %s before starting a build. Free unused builder data or increase the Docker/Colima disk allocation",
+			builderName, dockerBackendDescription(ctx), formatBytes(available), formatBytes(minimumBuildkitFreeBytes),
+		)
+	}
+	if available < warnBuildkitFreeBytes {
+		fmt.Fprintf(w, "[buildx] warning: builder %q on %s has only %s free; large CUDA or Isaac images may exhaust it\n",
+			builderName, dockerBackendDescription(ctx), formatBytes(available))
+	}
+	return nil
+}

--- a/go/internal/cli/commands/docker_health_test.go
+++ b/go/internal/cli/commands/docker_health_test.go
@@ -1,0 +1,157 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestParsePOSIXDFAvailableBytes(t *testing.T) {
+	output := []byte("Filesystem 1024-blocks Used Available Capacity Mounted on\n/dev/vdb1 41922560 40873984 1048576 98% /var/lib/docker\n")
+	got, err := parsePOSIXDFAvailableBytes(output)
+	if err != nil {
+		t.Fatalf("parsePOSIXDFAvailableBytes: %v", err)
+	}
+	if want := int64(1 << 30); got != want {
+		t.Fatalf("available bytes = %d, want %d", got, want)
+	}
+}
+
+func TestParsePOSIXDFAvailableBytesRejectsMalformedOutput(t *testing.T) {
+	if _, err := parsePOSIXDFAvailableBytes([]byte("not df output")); err == nil {
+		t.Fatal("expected malformed df output to fail")
+	}
+}
+
+func TestDockerOperationErrorClassifiesStorageIO(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "unix:///tmp/test-docker.sock")
+	err := dockerOperationError(
+		context.Background(),
+		"bootstrapping BuildKit builder",
+		[]byte("write /var/lib/desktop-containerd/daemon/io.containerd.metadata.v1.bolt/meta.db: input/output error"),
+		errors.New("exit status 1"),
+	)
+	msg := err.Error()
+	for _, want := range []string{
+		"Docker's local image/container store returned an I/O error",
+		"DOCKER_HOST=unix:///tmp/test-docker.sock",
+		"select a healthy one with DOCKER_HOST",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error = %q, want substring %q", msg, want)
+		}
+	}
+}
+
+func TestDockerOperationErrorClassifiesFullBuilder(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "unix:///tmp/test-docker.sock")
+	err := dockerOperationError(
+		context.Background(),
+		"exporting image",
+		[]byte("write /var/lib/buildkit/content/ingest/data: no space left on device"),
+		errors.New("exit status 1"),
+	)
+	if msg := err.Error(); !strings.Contains(msg, "Docker/BuildKit filesystem is full") {
+		t.Fatalf("error = %q, want full-filesystem diagnostic", msg)
+	}
+}
+
+func TestDockerOperationErrorClassifiesBuilderPendingRemoval(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "unix:///tmp/test-docker.sock")
+	err := dockerOperationError(
+		context.Background(),
+		"bootstrapping BuildKit builder",
+		[]byte("container is marked for removal and cannot be started"),
+		errors.New("exit status 1"),
+	)
+	if msg := err.Error(); !strings.Contains(msg, "stuck pending removal") {
+		t.Fatalf("error = %q, want pending-removal diagnostic", msg)
+	}
+}
+
+func TestDiagnoseDockerBuilderErrorFindsUnderlyingImageStoreIO(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake docker command is a POSIX shell script")
+	}
+	binDir := t.TempDir()
+	dockerPath := filepath.Join(binDir, "docker")
+	const script = `#!/bin/sh
+printf '%s\n' 'open /var/lib/desktop-containerd/daemon/io.containerd.content.v1.content/blobs/sha256/test: input/output error' >&2
+exit 1
+`
+	if err := os.WriteFile(dockerPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("DOCKER_HOST", "unix:///tmp/test-docker.sock")
+
+	err := diagnoseDockerBuilderError(
+		context.Background(),
+		"bootstrapping BuildKit builder",
+		[]byte("container is marked for removal and cannot be started"),
+		errors.New("exit status 1"),
+	)
+	msg := err.Error()
+	for _, want := range []string{
+		"Docker's local image/container store returned an I/O error",
+		"diagnosed after bootstrapping BuildKit builder failed",
+		"container is marked for removal",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error = %q, want substring %q", msg, want)
+		}
+	}
+}
+
+func TestEnsureBuildxBuilderFreeSpaceRejectsExhaustedBuilder(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake docker command is a POSIX shell script")
+	}
+	installFakeDockerDF(t, "0")
+	t.Setenv("DOCKER_HOST", "unix:///tmp/test-docker.sock")
+
+	err := ensureBuildxBuilderFreeSpace(context.Background(), "test", &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected exhausted builder filesystem to fail")
+	}
+	for _, want := range []string{"has only 0 B free", "at least 1.1 GB", "increase the Docker/Colima disk allocation"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, want substring %q", err, want)
+		}
+	}
+}
+
+func TestEnsureBuildxBuilderFreeSpaceWarnsWhenLow(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake docker command is a POSIX shell script")
+	}
+	// Five GiB is enough to proceed but below the ten-GiB warning threshold.
+	installFakeDockerDF(t, "5242880")
+	t.Setenv("DOCKER_HOST", "unix:///tmp/test-docker.sock")
+	var output bytes.Buffer
+
+	if err := ensureBuildxBuilderFreeSpace(context.Background(), "test", &output); err != nil {
+		t.Fatalf("ensureBuildxBuilderFreeSpace: %v", err)
+	}
+	if msg := output.String(); !strings.Contains(msg, "large CUDA or Isaac images may exhaust it") {
+		t.Fatalf("warning = %q, want large-image capacity warning", msg)
+	}
+}
+
+func installFakeDockerDF(t *testing.T, availableKiB string) {
+	t.Helper()
+	binDir := t.TempDir()
+	dockerPath := filepath.Join(binDir, "docker")
+	script := "#!/bin/sh\n" +
+		"printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\\n'\n" +
+		"printf '/dev/vdb1 41922560 41922560 " + availableKiB + " 100%% /var/lib/docker\\n'\n"
+	if err := os.WriteFile(dockerPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}


### PR DESCRIPTION
## What changed
- Identify the Docker backend in builder failures.
- Probe the image store only after a builder failure, exposing underlying containerd I/O corruption instead of only the stale BuildKit symptom.
- Check free space inside /var/lib/buildkit, blocking below 1 GiB and warning below 10 GiB.
- Apply the safeguards to registry, mTLS, plaintext, and OCI builder paths.

## Why
A deployment passed the existing docker version check but then failed because Docker Desktop's containerd metadata and blobs returned I/O errors. The Colima fallback was independently 100% full and later failed with no space left on device. Wendy surfaced only a BuildKit container marked for removal, which sent diagnosis toward deleting a builder instead of checking the backend first.

This PR is intentionally stacked on #1689 so its diff contains only the health and capacity safeguards.

## Impact
Wendy now fails before build, transfer, or app replacement with an actionable backend-specific error. The image-store probe does not run on healthy builds; the normal path adds one read-only df check per builder initialization.

## Validation
- go test ./internal/cli/commands -count=1
- go test ./... -count=1
- go vet ./internal/cli/commands
- go build ./cmd/wendy