### PR TITLE
Fix Jetson GPU entitlement device access

### DIFF
--- a/go/internal/agent/oci/entitlements.go
+++ b/go/internal/agent/oci/entitlements.go
@@ -241,28 +241,14 @@ func applyGPU(spec *Spec) {
 		// recorded here — the host path is never re-opened by the runtime on
 		// this (root) path, so a post-scan swap of the host node cannot
 		// change what the container receives.
-		seen := map[[2]int64]bool{}
-		for _, n := range nodes {
-			spec.Linux.Devices = append(spec.Linux.Devices, LinuxDevice{
-				Path:  n.path,
-				Type:  "c",
-				Major: n.major,
-				Minor: n.minor,
-			})
-			key := [2]int64{n.major, n.minor}
-			if seen[key] {
-				continue
-			}
-			seen[key] = true
-			maj, min := n.major, n.minor
-			spec.Linux.Resources.Devices = append(spec.Linux.Resources.Devices, LinuxDeviceCgroup{
-				Allow:  true,
-				Type:   "c",
-				Major:  &maj,
-				Minor:  &min,
-				Access: "rw",
-			})
-		}
+		addExactDeviceNodes(spec, nodes)
+	}
+
+	// JetPack 6 requires access to the DRM render node for CUDA initialization
+	// on the integrated GPU. Grant renderD* only; card* nodes and compositor
+	// sockets remain exclusive to the separate display entitlement.
+	if boardInfo.IsJetson() {
+		addExactDeviceNodes(spec, discoverJetsonRenderDeviceNodes())
 	}
 
 	// Add environment variables for NVIDIA.
@@ -293,6 +279,11 @@ var nvidiaDeviceGlobs = []string{
 	"/dev/nvgpu/igpu*/*",
 }
 
+// jetsonRenderDeviceGlobs is separate from the generic NVIDIA node scan so
+// discrete-GPU hosts keep their existing entitlement shape. Behind a var so
+// tests can redirect it into a temporary device tree.
+var jetsonRenderDeviceGlobs = []string{"/dev/dri/renderD*"}
+
 // nvidiaDeviceNameRe is the allowlist of node names the GPU entitlement will
 // grant from the globs above. Glob results are host filesystem input; an
 // unexpected name (say, a planted /dev/nvidia-evil char device) is rejected
@@ -309,6 +300,7 @@ var nvhostGPUDeviceNameRe = regexp.MustCompile(`^nvhost-(gpu|(?:as|ctrl|ctxsw|db
 // sufficient to grant it to a container.
 var nvgpuDeviceNameRe = regexp.MustCompile(`^(as|channel|ctrl|ctxsw|dbg|nvsched|nvsched_ctrl_fifo|power|prof|prof-ctx|prof-dev|sched|tsg)$`)
 var nvgpuDirNameRe = regexp.MustCompile(`^igpu[0-9]+$`)
+var renderDeviceNameRe = regexp.MustCompile(`^renderD[0-9]+$`)
 
 type nvidiaDeviceNode struct {
 	path         string
@@ -339,6 +331,52 @@ func discoverNvidiaDeviceNodes() []nvidiaDeviceNode {
 		}
 	}
 	return nodes
+}
+
+func discoverJetsonRenderDeviceNodes() []nvidiaDeviceNode {
+	var nodes []nvidiaDeviceNode
+	for _, pattern := range jetsonRenderDeviceGlobs {
+		matches, _ := filepath.Glob(pattern)
+		for _, p := range matches {
+			if filepath.Base(filepath.Dir(p)) != "dri" || !renderDeviceNameRe.MatchString(filepath.Base(p)) {
+				continue
+			}
+			major, minor, err := statCharDevice(p)
+			if err != nil {
+				continue
+			}
+			nodes = append(nodes, nvidiaDeviceNode{path: p, major: major, minor: minor})
+		}
+	}
+	return nodes
+}
+
+// addExactDeviceNodes adds runc device definitions and least-privilege cgroup
+// rules for live host nodes. Rules are exact major:minor pairs and grant open
+// access only (rw, never mknod).
+func addExactDeviceNodes(spec *Spec, nodes []nvidiaDeviceNode) {
+	seen := map[[2]int64]bool{}
+	for _, n := range nodes {
+		spec.Linux.Devices = append(spec.Linux.Devices, LinuxDevice{
+			Path:  n.path,
+			Type:  "c",
+			Major: n.major,
+			Minor: n.minor,
+		})
+		key := [2]int64{n.major, n.minor}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		maj, min := n.major, n.minor
+		spec.Linux.Resources.Devices = append(spec.Linux.Resources.Devices, LinuxDeviceCgroup{
+			Allow:  true,
+			Type:   "c",
+			Major:  &maj,
+			Minor:  &min,
+			Access: "rw",
+		})
+	}
 }
 
 func isAllowedNvidiaDevicePath(p string) bool {

--- a/go/internal/agent/oci/entitlements.go
+++ b/go/internal/agent/oci/entitlements.go
@@ -272,15 +272,33 @@ func applyGPU(spec *Spec) {
 // nvidiaDeviceGlobs are the NVIDIA device-node patterns the GPU entitlement
 // scans to build its fallback device list. /dev/nvidia* covers nvidia0..N,
 // nvidiactl, nvidia-uvm, nvidia-uvm-tools and nvidia-modeset; nvidia-caps/*
-// covers the capability nodes (major 501 on Thor). Behind a var so tests can
-// redirect into a tempdir.
-var nvidiaDeviceGlobs = []string{"/dev/nvidia*", "/dev/nvidia-caps/*"}
+// covers the capability nodes (major 501 on Thor). Jetson's L4T CSV can lag
+// the live nvgpu driver node set, so also discover the tightly allowlisted
+// nvhost and integrated-GPU nodes. Behind a var so tests can redirect into a
+// tempdir.
+var nvidiaDeviceGlobs = []string{
+	"/dev/nvidia*",
+	"/dev/nvidia-caps/*",
+	"/dev/nvhost-*gpu",
+	"/dev/nvgpu/igpu*/*",
+}
 
 // nvidiaDeviceNameRe is the allowlist of node names the GPU entitlement will
 // grant from the globs above. Glob results are host filesystem input; an
 // unexpected name (say, a planted /dev/nvidia-evil char device) is rejected
 // rather than handed to the container.
 var nvidiaDeviceNameRe = regexp.MustCompile(`^(nvidia[0-9]+|nvidiactl|nvidia-uvm|nvidia-uvm-tools|nvidia-modeset|nvidia-cap[0-9]+)$`)
+
+// nvhostGPUDeviceNameRe admits only the GPU-specific nvhost nodes exposed by
+// NVIDIA's nvgpu driver. In particular, JetPack 6.2 adds the scheduler control
+// FIFO that older L4T devices.csv files omit.
+var nvhostGPUDeviceNameRe = regexp.MustCompile(`^nvhost-(gpu|(?:as|ctrl|ctxsw|dbg|nvsched|nvsched_ctrl_fifo|power|prof|prof-ctx|prof-dev|sched|tsg)-gpu)$`)
+
+// nvgpuDeviceNameRe is restricted to children of an igpuN directory by
+// isAllowedNvidiaDevicePath; matching a generic basename elsewhere is not
+// sufficient to grant it to a container.
+var nvgpuDeviceNameRe = regexp.MustCompile(`^(as|channel|ctrl|ctxsw|dbg|nvsched|nvsched_ctrl_fifo|power|prof|prof-ctx|prof-dev|sched|tsg)$`)
+var nvgpuDirNameRe = regexp.MustCompile(`^igpu[0-9]+$`)
 
 type nvidiaDeviceNode struct {
 	path         string
@@ -304,13 +322,21 @@ func discoverNvidiaDeviceNodes() []nvidiaDeviceNode {
 			if err != nil {
 				continue
 			}
-			if !nvidiaDeviceNameRe.MatchString(filepath.Base(p)) {
+			if !isAllowedNvidiaDevicePath(p) {
 				continue
 			}
 			nodes = append(nodes, nvidiaDeviceNode{path: p, major: major, minor: minor})
 		}
 	}
 	return nodes
+}
+
+func isAllowedNvidiaDevicePath(p string) bool {
+	base := filepath.Base(p)
+	if nvidiaDeviceNameRe.MatchString(base) || nvhostGPUDeviceNameRe.MatchString(base) {
+		return true
+	}
+	return nvgpuDirNameRe.MatchString(filepath.Base(filepath.Dir(p))) && nvgpuDeviceNameRe.MatchString(base)
 }
 
 // statCharDevice resolves a host path to its character-device major:minor,

--- a/go/internal/agent/oci/entitlements.go
+++ b/go/internal/agent/oci/entitlements.go
@@ -180,6 +180,16 @@ func SetDeviceCapabilities(spec *Spec) {
 func applyGPU(spec *Spec) {
 	// Add the nvidia group GID for device access.
 	spec.Process.User.AdditionalGids = appendUnique(spec.Process.User.AdditionalGids, nvidiaGroupGID)
+	// Jetson's integrated GPU also requires the host render group. Resolve the
+	// live GID instead of assuming a distro-specific value (104 on the G1's
+	// JetPack 6 image). Group membership alone exposes no additional node: the
+	// exact GPU devices and cgroup rules below remain the access boundary.
+	boardInfo := boardDetect()
+	if boardInfo.IsJetson() {
+		if gid, ok := lookupRenderGID(); ok {
+			spec.Process.User.AdditionalGids = appendUnique(spec.Process.User.AdditionalGids, gid)
+		}
+	}
 
 	// Derive the device list from the live host nodes: nvidia-uvm's major is
 	// dynamically allocated on modern drivers (487 on Thor/JetPack 7, not the
@@ -264,7 +274,7 @@ func applyGPU(spec *Spec) {
 	// On Raspberry Pi, also expose the VideoCore mailbox device for board
 	// telemetry. The node is absent on Jetson/generic hosts, where this is
 	// skipped entirely.
-	if boardDetect().IsRaspberryPi() {
+	if boardInfo.IsRaspberryPi() {
 		applyVCIO(spec)
 	}
 }

--- a/go/internal/agent/oci/entitlements_test.go
+++ b/go/internal/agent/oci/entitlements_test.go
@@ -2146,10 +2146,12 @@ func installFakeNvidiaDevTree(t *testing.T, numbers map[string][2]int64) string 
 	}
 
 	origGlobs := nvidiaDeviceGlobs
+	origRenderGlobs := jetsonRenderDeviceGlobs
 	origStat := statCharDevice
 	origBoard := boardDetect
 	t.Cleanup(func() {
 		nvidiaDeviceGlobs = origGlobs
+		jetsonRenderDeviceGlobs = origRenderGlobs
 		statCharDevice = origStat
 		boardDetect = origBoard
 	})
@@ -2160,6 +2162,7 @@ func installFakeNvidiaDevTree(t *testing.T, numbers map[string][2]int64) string 
 		filepath.Join(dev, "nvhost-*gpu"),
 		filepath.Join(dev, "nvgpu", "igpu*", "*"),
 	}
+	jetsonRenderDeviceGlobs = []string{filepath.Join(dev, "dri", "renderD*")}
 	statCharDevice = func(p string) (int64, int64, error) {
 		rel, err := filepath.Rel(dev, p)
 		if err != nil {
@@ -2173,6 +2176,63 @@ func installFakeNvidiaDevTree(t *testing.T, numbers map[string][2]int64) string 
 	}
 	boardDetect = func() board.Info { return board.Info{Kind: board.Jetson} }
 	return dev
+}
+
+func TestApplyGPU_JetsonAddsOnlyDRMRenderNodes(t *testing.T) {
+	dev := installFakeNvidiaDevTree(t, map[string][2]int64{
+		"nvidia0":        {195, 0},
+		"dri/renderD128": {226, 128},
+		"dri/renderD129": {226, 129},
+		"dri/card0":      {226, 0},
+		"dri/renderDfoo": {226, 200},
+	})
+
+	spec := gpuSpec(t)
+	for path, minor := range map[string]int64{
+		filepath.Join(dev, "dri", "renderD128"): 128,
+		filepath.Join(dev, "dri", "renderD129"): 129,
+	} {
+		d, ok := deviceForPath(spec, path)
+		if !ok {
+			t.Errorf("Jetson GPU entitlement did not add %s", path)
+			continue
+		}
+		if d.Major != 226 || d.Minor != minor {
+			t.Errorf("%s = c %d:%d, want c 226:%d", path, d.Major, d.Minor, minor)
+		}
+		if !hasExactDeviceRule(spec, 226, minor) {
+			t.Errorf("Jetson GPU entitlement did not allow c 226:%d", minor)
+		}
+	}
+
+	for _, path := range []string{
+		filepath.Join(dev, "dri", "card0"),
+		filepath.Join(dev, "dri", "renderDfoo"),
+	} {
+		if _, ok := deviceForPath(spec, path); ok {
+			t.Errorf("Jetson GPU entitlement granted non-render node %s", path)
+		}
+	}
+	if hasMountDest(spec, "/dev/dri") {
+		t.Error("GPU entitlement must not bind the whole /dev/dri tree")
+	}
+}
+
+func TestApplyGPU_NonJetsonOmitsDRMRenderNodes(t *testing.T) {
+	dev := installFakeNvidiaDevTree(t, map[string][2]int64{
+		"nvidia0":        {195, 0},
+		"dri/renderD128": {226, 128},
+	})
+	boardDetect = func() board.Info { return board.Info{Kind: board.Generic} }
+
+	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
+	cfg := &appconfig.AppConfig{AppID: "test", Entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementGPU}}}
+	if err := ApplyEntitlements(spec, cfg, ApplyOptions{}); err != nil {
+		t.Fatalf("ApplyEntitlements: %v", err)
+	}
+	if _, ok := deviceForPath(spec, filepath.Join(dev, "dri", "renderD128")); ok {
+		t.Error("non-Jetson GPU entitlement must not add DRM render nodes")
+	}
 }
 
 func TestApplyGPU_SupplementsStaleJetsonCSVWithSchedulerControlDevices(t *testing.T) {

--- a/go/internal/agent/oci/entitlements_test.go
+++ b/go/internal/agent/oci/entitlements_test.go
@@ -169,6 +169,83 @@ func TestApplyEntitlements_GPU(t *testing.T) {
 	}
 }
 
+func TestApplyGPU_JetsonAddsResolvedRenderGID(t *testing.T) {
+	origBoard := boardDetect
+	origRender := lookupRenderGID
+	t.Cleanup(func() {
+		boardDetect = origBoard
+		lookupRenderGID = origRender
+	})
+	boardDetect = func() board.Info { return board.Info{Kind: board.Jetson} }
+	lookupRenderGID = func() (uint32, bool) { return 104, true }
+
+	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
+	cfg := &appconfig.AppConfig{
+		AppID:        "test-app",
+		Entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementGPU}},
+	}
+	if err := ApplyEntitlements(spec, cfg, ApplyOptions{}); err != nil {
+		t.Fatalf("ApplyEntitlements() error = %v", err)
+	}
+
+	if !hasGID(spec, nvidiaGroupGID) {
+		t.Errorf("Jetson GPU entitlement missing NVIDIA/video GID %d", nvidiaGroupGID)
+	}
+	if !hasGID(spec, 104) {
+		t.Error("Jetson GPU entitlement missing resolved render GID 104")
+	}
+}
+
+func TestApplyGPU_JetsonWithoutRenderGroupKeepsVideoGID(t *testing.T) {
+	origBoard := boardDetect
+	origRender := lookupRenderGID
+	t.Cleanup(func() {
+		boardDetect = origBoard
+		lookupRenderGID = origRender
+	})
+	boardDetect = func() board.Info { return board.Info{Kind: board.Jetson} }
+	lookupRenderGID = func() (uint32, bool) { return 0, false }
+
+	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
+	cfg := &appconfig.AppConfig{
+		AppID:        "test-app",
+		Entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementGPU}},
+	}
+	if err := ApplyEntitlements(spec, cfg, ApplyOptions{}); err != nil {
+		t.Fatalf("ApplyEntitlements() error = %v", err)
+	}
+
+	if !hasGID(spec, nvidiaGroupGID) {
+		t.Errorf("Jetson GPU entitlement missing NVIDIA/video GID %d", nvidiaGroupGID)
+	}
+	if hasGID(spec, 0) {
+		t.Error("Jetson GPU entitlement added a render GID when lookup failed")
+	}
+}
+
+func TestApplyGPU_NonJetsonDoesNotAddRenderGID(t *testing.T) {
+	origBoard := boardDetect
+	origRender := lookupRenderGID
+	t.Cleanup(func() {
+		boardDetect = origBoard
+		lookupRenderGID = origRender
+	})
+	boardDetect = func() board.Info { return board.Info{Kind: board.Generic} }
+	lookupRenderGID = func() (uint32, bool) {
+		t.Fatal("non-Jetson GPU entitlement must not resolve the render group")
+		return 0, false
+	}
+
+	spec := DefaultSpec("/rootfs", []string{"/bin/sh"})
+	cfg := &appconfig.AppConfig{
+		AppID:        "test-app",
+		Entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementGPU}},
+	}
+	if err := ApplyEntitlements(spec, cfg, ApplyOptions{}); err != nil {
+		t.Fatalf("ApplyEntitlements() error = %v", err)
+	}
+}
+
 // installFakeVCIO points vcioDevicePath at a temp file, makes statMajor report
 // the given major for it, and reports the host as a Raspberry Pi — so the
 // vcio branch of applyGPU can be exercised without a real /dev/vcio (which only

--- a/go/internal/agent/oci/entitlements_test.go
+++ b/go/internal/agent/oci/entitlements_test.go
@@ -2049,10 +2049,9 @@ func TestApplyEntitlements_NoBuild_LeavesSandboxHardened(t *testing.T) {
 
 // ---------- GPU fallback device derivation (WDY-1804) ----------
 
-// installFakeNvidiaDevTree builds a fake /dev with the Jetson AGX Thor
-// (JetPack 7.2) NVIDIA node layout and injects each node's real-world
-// major:minor via statCharDevice (plain files can't carry device numbers
-// without root/mknod). Restored on cleanup.
+// installFakeNvidiaDevTree builds a fake /dev with NVIDIA device nodes and
+// injects each node's real-world major:minor via statCharDevice (plain files
+// can't carry device numbers without root/mknod). Restored on cleanup.
 func installFakeNvidiaDevTree(t *testing.T, numbers map[string][2]int64) string {
 	t.Helper()
 	dev := t.TempDir()
@@ -2060,7 +2059,11 @@ func installFakeNvidiaDevTree(t *testing.T, numbers map[string][2]int64) string 
 		t.Fatal(err)
 	}
 	for name := range numbers {
-		if err := os.WriteFile(filepath.Join(dev, name), nil, 0o644); err != nil {
+		devicePath := filepath.Join(dev, name)
+		if err := os.MkdirAll(filepath.Dir(devicePath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(devicePath, nil, 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -2077,6 +2080,8 @@ func installFakeNvidiaDevTree(t *testing.T, numbers map[string][2]int64) string 
 	nvidiaDeviceGlobs = []string{
 		filepath.Join(dev, "nvidia*"),
 		filepath.Join(dev, "nvidia-caps", "*"),
+		filepath.Join(dev, "nvhost-*gpu"),
+		filepath.Join(dev, "nvgpu", "igpu*", "*"),
 	}
 	statCharDevice = func(p string) (int64, int64, error) {
 		rel, err := filepath.Rel(dev, p)
@@ -2091,6 +2096,52 @@ func installFakeNvidiaDevTree(t *testing.T, numbers map[string][2]int64) string 
 	}
 	boardDetect = func() board.Info { return board.Info{Kind: board.Jetson} }
 	return dev
+}
+
+func TestApplyGPU_SupplementsStaleJetsonCSVWithSchedulerControlDevices(t *testing.T) {
+	dev := installFakeNvidiaDevTree(t, map[string][2]int64{
+		"nvhost-nvsched_ctrl_fifo-gpu":  {487, 10},
+		"nvgpu/igpu0/nvsched_ctrl_fifo": {487, 22},
+		"nvhost-evil-gpu":               {8, 1},
+		"nvgpu/igpu0/evil":              {8, 2},
+	})
+
+	spec := gpuSpec(t)
+
+	for path, want := range map[string][2]int64{
+		filepath.Join(dev, "nvhost-nvsched_ctrl_fifo-gpu"):        {487, 10},
+		filepath.Join(dev, "nvgpu", "igpu0", "nvsched_ctrl_fifo"): {487, 22},
+	} {
+		d, ok := deviceForPath(spec, path)
+		if !ok {
+			t.Errorf("GPU entitlement did not add %s", path)
+			continue
+		}
+		if d.Major != want[0] || d.Minor != want[1] {
+			t.Errorf("%s = c %d:%d, want c %d:%d", path, d.Major, d.Minor, want[0], want[1])
+		}
+		if !hasExactDeviceRule(spec, want[0], want[1]) {
+			t.Errorf("GPU entitlement did not allow c %d:%d", want[0], want[1])
+		}
+	}
+
+	for _, path := range []string{
+		filepath.Join(dev, "nvhost-evil-gpu"),
+		filepath.Join(dev, "nvgpu", "igpu0", "evil"),
+	} {
+		if _, ok := deviceForPath(spec, path); ok {
+			t.Errorf("GPU entitlement granted unexpected node %s", path)
+		}
+	}
+}
+
+func hasExactDeviceRule(spec *Spec, major, minor int64) bool {
+	for _, d := range spec.Linux.Resources.Devices {
+		if d.Allow && d.Major != nil && d.Minor != nil && *d.Major == major && *d.Minor == minor && d.Access == "rw" {
+			return true
+		}
+	}
+	return false
 }
 
 func gpuSpec(t *testing.T) *Spec {


### PR DESCRIPTION
## Summary

Fix Jetson GPU app access by extending the GPU entitlement with the narrow host resources CUDA needs on Jetson:

- add the host `render` supplementary group when present;
- pass only discovered `/dev/dri/renderD*` character devices, with exact major/minor cgroup rules;
- retain the tightly allowlisted Jetson NVIDIA/nvhost scheduler-control devices;
- do not pass DRM card nodes, the whole `/dev/dri` directory, display sockets, or `mknod` access.

## Root cause and live proof

The G1 voice workload had the expected Jetson NVIDIA nodes and group IDs but no DRM render nodes, so `cuInit` returned 801. Adding the existing broad display entitlement made the same workload return `cuInit=0`, isolating the missing render-device access. This change provides only those render nodes.

On a Unitree G1 Jetson Orin NX (JetPack 6.2, `sm_87`), using the agent built from final commit `e0b97aa96771939de7719e66f7ab0a240fc523d4`:

- agent version: `pr1699-e0b97aa96`
- agent SHA-256: `bcc9776466fdeb22d5d8569451be17cc936f34109fe3879625abc37c8375d482`
- direct app probe: `cuInit=0 devices=1`
- container receives only `/dev/dri/renderD128` and `/dev/dri/renderD129` (character major 226, exact minors)
- Parakeet/Kokoro select CUDA execution providers
- llama.cpp finds one Orin CUDA device (compute capability 8.7, VMM enabled) and reports GPU offload supported
- Silero, Parakeet v3, Qwen3 1.7B, and Kokoro readiness passes

The voice app was then restarted after its PowerConf USB device appeared and established a 48 kHz full-duplex session. Talkback hardware readiness is useful end-to-end deployment evidence, but is not part of this WendyOS code change.

## Validation

- `go test ./internal/agent/oci`
- `go test ./internal/agent/cdi ./internal/agent/containerd`
- `go vet ./internal/agent/oci`
- `go test -p=1 -gcflags=all=-c=1 ./... -race -count=1 -timeout 120s`
- `go vet ./...`

Coverage includes Jetson render GID lookup/fallback, render-node discovery and filtering, exact device rules, non-Jetson omission, and the existing scheduler-device path.

## Deployment measurement

The final app replacement was run through Docker Layer Optimizer and completed in 2.906 seconds. No build, export, transfer, unpack, replacement, or readiness phase markers were observed, so the full 2.906 seconds is reported as unclassified rather than attributed to fabricated phases.
