### PR TITLE
feat(agent): serve file sync into persistent volumes

### DIFF
--- a/Proto/wendy/agent/services/v2/file_sync_service.proto
+++ b/Proto/wendy/agent/services/v2/file_sync_service.proto
@@ -26,6 +26,22 @@ message FileSyncRequest {
 message FileSyncStart {
     string           app_id   = 1;
     FileSyncManifest manifest = 2;
+
+    // Sync into a persistent volume (/var/lib/wendy/volumes/<volume>) instead
+    // of an app sync root. Mutually exclusive with app_id: exactly one of the
+    // two selects the sync root. The Linux agent implements volume mode only;
+    // app_id mode is the macOS agent's native-app sync.
+    string volume = 3;
+
+    // Restrict the session to this subtree of the sync root. The manifest the
+    // agent replies with covers only paths under the prefix, and every path in
+    // the session (chunk, commit, chmod, delete) is interpreted relative to it.
+    //
+    // Without this, pushing one file into a volume makes the agent hash every
+    // file already in that volume to build its manifest — for a volume holding
+    // several 50 MB models that is seconds of wasted I/O per push — and the
+    // client sees unrelated files as candidates for deletion.
+    string path_prefix = 4;
 }
 
 message FileSyncChunk {

--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -261,6 +261,7 @@ func main() {
 	bluetoothSvc := services.NewBluetoothService(logger, btManager)
 	agentUpdateSvc := services.NewAgentUpdateService(logger, installer)
 	osUpdateSvc := services.NewOSUpdateService(logger)
+	fileSyncSvcV2 := services.NewFileSyncServiceV2(logger)
 	containerSvcV2 := services.NewContainerServiceV2(containerSvc)
 	provisioningSvcV2 := services.NewProvisioningServiceV2(provisioningSvc)
 	audioSvcV2 := services.NewAudioServiceV2(audioSvc)
@@ -579,6 +580,14 @@ func main() {
 		// plaintext pre-provisioning server (handing anyone on the LAN a host
 		// root shell) and on the local admin socket.
 		agentpb.RegisterWendyShellServiceServer(srv, shellSvc)
+
+		// WendyFileSyncService writes into persistent volumes. It is registered
+		// only here for the same reason as the shell service: on the plaintext
+		// pre-provisioning server it would let anyone on the LAN write files
+		// that a GPU app later loads, and on the local admin socket it would
+		// add nothing (an admin-entitled container already has the volume
+		// bind-mounted).
+		agentpbv2.RegisterWendyFileSyncServiceServer(srv, fileSyncSvcV2)
 
 		// Compute mTLS port = agentPort + 1.
 		portNum, err := strconv.Atoi(agentPort)

--- a/go/internal/agent/services/available_space_other.go
+++ b/go/internal/agent/services/available_space_other.go
@@ -1,0 +1,9 @@
+//go:build !(linux || darwin || freebsd)
+
+package services
+
+// availableBytes cannot be determined on this platform. Callers treat the
+// false return as "unknown" and proceed rather than blocking every write.
+func availableBytes(string) (int64, bool) {
+	return 0, false
+}

--- a/go/internal/agent/services/available_space_unix.go
+++ b/go/internal/agent/services/available_space_unix.go
@@ -1,0 +1,27 @@
+//go:build linux || darwin || freebsd
+
+package services
+
+import "golang.org/x/sys/unix"
+
+// availableBytes reports the space a non-privileged write can still use on the
+// filesystem holding path.
+//
+// It reads Bavail rather than Bfree: filesystems reserve a slice of free space
+// for root, and sizing a push against space it cannot actually use is how a
+// "there is room" check ends with ENOSPC halfway through a 50 MB model.
+func availableBytes(path string) (int64, bool) {
+	var stat unix.Statfs_t
+	if err := unix.Statfs(path, &stat); err != nil {
+		return 0, false
+	}
+	blockSize := int64(stat.Bsize)
+	if blockSize <= 0 {
+		return 0, false
+	}
+	avail := int64(stat.Bavail)
+	if avail < 0 || avail > (1<<62)/blockSize {
+		return 0, false
+	}
+	return avail * blockSize, true
+}

--- a/go/internal/agent/services/file_sync_service_v2.go
+++ b/go/internal/agent/services/file_sync_service_v2.go
@@ -1,0 +1,730 @@
+package services
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
+)
+
+// sha256Len is the byte length of every digest on the wire. Sizes are checked
+// explicitly rather than trusted, so a truncated digest fails as a bad request
+// instead of silently comparing equal to a truncated computed digest.
+const sha256Len = 32
+
+// fileSyncTempPrefix marks in-progress transfers. It matches the prefix the
+// macOS agent uses so both agents produce the same on-disk shape, and manifest
+// walks skip it: a partially transferred file must never be advertised as
+// present, or a client would diff against a file that does not exist yet.
+const fileSyncTempPrefix = ".WENDY-"
+
+// fileSyncDiskReserve is the free space the agent refuses to consume. A device
+// that fills its root partition cannot apply agent or OS updates, so a push is
+// rejected while there is still room to recover rather than after the disk is
+// full.
+const fileSyncDiskReserve = 64 << 20 // 64 MiB
+
+// FileSyncServiceV2 syncs files into a device's persistent volumes.
+//
+// The protocol is the one the CLI already speaks for macOS-target deploys:
+// the client opens with a manifest, the agent replies with its own, and the
+// client sends only what differs. This implementation serves persistent
+// volumes (/var/lib/wendy/volumes/<name>) rather than app sync roots, which is
+// what makes it possible to put a large artifact — a model, a calibration
+// file, a map — on a running device without rebuilding its image.
+type FileSyncServiceV2 struct {
+	agentpbv2.UnimplementedWendyFileSyncServiceServer
+	logger *zap.Logger
+
+	// Seams (overridden in tests).
+	volumesDir string
+	availBytes func(path string) (int64, bool)
+}
+
+// FileSyncOption adjusts the service at construction.
+type FileSyncOption func(*FileSyncServiceV2)
+
+// WithVolumesDir overrides the directory persistent volumes live in. Exported
+// so tests outside this package — the CLI's end-to-end sync tests, which drive
+// the real client against the real service — can point it at a temp directory.
+func WithVolumesDir(dir string) FileSyncOption {
+	return func(s *FileSyncServiceV2) { s.volumesDir = dir }
+}
+
+// NewFileSyncServiceV2 builds the service against the real volumes directory.
+func NewFileSyncServiceV2(logger *zap.Logger, opts ...FileSyncOption) *FileSyncServiceV2 {
+	svc := &FileSyncServiceV2{
+		logger:     logger,
+		volumesDir: volumesDir,
+		availBytes: availableBytes,
+	}
+	for _, opt := range opts {
+		opt(svc)
+	}
+	return svc
+}
+
+// syncSession is the per-stream state. It exists so the deferred cleanup of an
+// interrupted transfer has one owner: every error path must remove the temp
+// file, and a client that disconnects mid-file is the common case, not the
+// exceptional one.
+type syncSession struct {
+	svc *FileSyncServiceV2
+	// volumeRoot is the volume directory: the containment base for every path
+	// in the session, and the path free space is measured against. It always
+	// exists, unlike the prefix subtree, which a push may be creating.
+	volumeRoot string
+	// prefix is the validated subtree paths are relative to, slash-separated
+	// and possibly empty.
+	prefix string
+	// manifestByPath is what the client declared it intends to send. Every
+	// chunk, commit and chmod is checked against it, so the session can never
+	// be talked into writing a file the opening manifest did not describe.
+	manifestByPath map[string]*agentpbv2.FileSyncEntry
+	finalized      map[string]bool
+	active         *fileTransfer
+}
+
+type fileTransfer struct {
+	path        string
+	entry       *agentpbv2.FileSyncEntry
+	destination string
+	tempPath    string
+	file        *os.File
+	hasher      hash.Hash
+	received    int64
+	nextSeq     uint64
+}
+
+// SyncFiles serves one sync session. The first message selects the sync root;
+// everything after it is interpreted relative to that root.
+func (s *FileSyncServiceV2) SyncFiles(stream grpc.BidiStreamingServer[agentpbv2.FileSyncRequest, agentpbv2.FileSyncResponse]) error {
+	first, err := stream.Recv()
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return status.Error(codes.InvalidArgument, "stream closed before FileSyncStart")
+		}
+		return err
+	}
+	start, ok := first.GetRequestType().(*agentpbv2.FileSyncRequest_Start)
+	if !ok {
+		return status.Errorf(codes.InvalidArgument, "first message must be FileSyncStart, got %T", first.GetRequestType())
+	}
+
+	volumeRoot, prefix, err := s.resolveRoot(start.Start)
+	if err != nil {
+		return err
+	}
+
+	session := &syncSession{
+		svc:        s,
+		volumeRoot: volumeRoot,
+		prefix:     prefix,
+		finalized:  make(map[string]bool),
+	}
+	defer session.cleanupActive()
+
+	session.manifestByPath, err = session.buildManifestLookup(start.Start.GetManifest().GetFiles())
+	if err != nil {
+		return err
+	}
+
+	// Reply with what is already here so the client can send only what differs.
+	agentManifest, err := buildAgentManifest(session.scanRoot())
+	if err != nil {
+		return err
+	}
+	if err := stream.Send(&agentpbv2.FileSyncResponse{
+		ResponseType: &agentpbv2.FileSyncResponse_Manifest{
+			Manifest: &agentpbv2.FileSyncManifest{Files: agentManifest},
+		},
+	}); err != nil {
+		return err
+	}
+
+	s.logger.Info("FileSyncStart",
+		zap.String("volume", start.Start.GetVolume()),
+		zap.String("path_prefix", start.Start.GetPathPrefix()),
+		zap.Int("client_files", len(start.Start.GetManifest().GetFiles())),
+		zap.Int("agent_files", len(agentManifest)),
+	)
+
+	for {
+		msg, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if err := session.handle(msg, stream); err != nil {
+			return err
+		}
+	}
+
+	// A stream that ends mid-file is an error, not a silent partial write: the
+	// deferred cleanup removes the temp file and the client learns the push
+	// did not land.
+	if session.active != nil {
+		return status.Errorf(codes.InvalidArgument, "stream ended without commit for %q", session.active.path)
+	}
+
+	return stream.Send(&agentpbv2.FileSyncResponse{
+		ResponseType: &agentpbv2.FileSyncResponse_Complete{Complete: &agentpbv2.FileSyncComplete{}},
+	})
+}
+
+// resolveRoot maps a FileSyncStart onto the volume directory it addresses and
+// the validated path prefix within it.
+//
+// The volume root is the only containment base the session ever uses. Resolving
+// paths against the prefix directory instead would let a symlink planted at the
+// prefix redefine what "inside" means, which is precisely the escape the
+// containment check exists to stop.
+func (s *FileSyncServiceV2) resolveRoot(start *agentpbv2.FileSyncStart) (volumeRoot, prefix string, err error) {
+	volume := start.GetVolume()
+	switch {
+	case volume == "" && start.GetAppId() != "":
+		// App sync roots are the macOS agent's native-app deploy path. On
+		// Linux apps run as containers and their writable state is a volume,
+		// so there is no app root to sync into.
+		return "", "", status.Error(codes.Unimplemented,
+			"this agent syncs into persistent volumes; set FileSyncStart.volume (app_id sync roots are macOS-only)")
+	case volume == "":
+		return "", "", status.Error(codes.InvalidArgument, "FileSyncStart.volume is required")
+	case start.GetAppId() != "":
+		return "", "", status.Error(codes.InvalidArgument, "FileSyncStart.volume and app_id are mutually exclusive")
+	}
+
+	// A volume name is a single directory name, never a path.
+	if volume != filepath.Base(volume) || volume == "." || volume == ".." || strings.ContainsRune(volume, os.PathSeparator) {
+		return "", "", status.Errorf(codes.InvalidArgument, "invalid volume name %q", volume)
+	}
+
+	volumeRoot = filepath.Join(s.volumesDir, volume)
+	info, err := os.Stat(volumeRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Deliberately not created on demand. Volumes come into existence
+			// when an app declares a persist entitlement; auto-creating one
+			// here would make a typo look like a successful push into a
+			// directory no app will ever read.
+			return "", "", status.Errorf(codes.NotFound,
+				"volume %q does not exist on this device (volumes are created by an app's persist entitlement)", volume)
+		}
+		return "", "", status.Errorf(codes.Internal, "stat volume %q: %v", volume, err)
+	}
+	if !info.IsDir() {
+		return "", "", status.Errorf(codes.FailedPrecondition, "volume %q is not a directory", volume)
+	}
+
+	prefix = start.GetPathPrefix()
+	if prefix == "" {
+		return volumeRoot, "", nil
+	}
+	// Validate the prefix now — including symlink resolution — so the manifest
+	// walk cannot be pointed at a directory outside the volume. The directory
+	// itself is deliberately not created: a session that only reads the
+	// manifest (a listing) must not leave a directory behind on the device.
+	if _, err := validatedDestination(volumeRoot, prefix); err != nil {
+		return "", "", err
+	}
+	return volumeRoot, filepath.ToSlash(prefix), nil
+}
+
+func (s *syncSession) handle(msg *agentpbv2.FileSyncRequest, stream grpc.BidiStreamingServer[agentpbv2.FileSyncRequest, agentpbv2.FileSyncResponse]) error {
+	switch m := msg.GetRequestType().(type) {
+	case *agentpbv2.FileSyncRequest_Chunk:
+		return s.handleChunk(m.Chunk)
+	case *agentpbv2.FileSyncRequest_Commit:
+		return s.handleCommit(m.Commit, stream)
+	case *agentpbv2.FileSyncRequest_Chmod:
+		return s.handleChmod(m.Chmod, stream)
+	case *agentpbv2.FileSyncRequest_Delete:
+		return s.handleDelete(m.Delete)
+	case *agentpbv2.FileSyncRequest_Start:
+		return status.Error(codes.InvalidArgument, "duplicate FileSyncStart in stream")
+	default:
+		return status.Errorf(codes.InvalidArgument, "unexpected message %T", msg.GetRequestType())
+	}
+}
+
+func (s *syncSession) handleChunk(chunk *agentpbv2.FileSyncChunk) error {
+	entry, err := s.manifestEntry(chunk.GetPath())
+	if err != nil {
+		return err
+	}
+	if s.finalized[chunk.GetPath()] {
+		return status.Errorf(codes.InvalidArgument, "path already finalized: %q", chunk.GetPath())
+	}
+	if len(chunk.GetSha256()) != sha256Len {
+		return status.Errorf(codes.InvalidArgument, "chunk sha256 must be %d bytes for %q", sha256Len, chunk.GetPath())
+	}
+	if len(chunk.GetData()) == 0 && entry.GetSize() > 0 {
+		return status.Errorf(codes.InvalidArgument, "zero-length chunk for non-empty file %q", chunk.GetPath())
+	}
+
+	if s.active == nil {
+		if err := s.beginTransfer(chunk.GetPath(), entry); err != nil {
+			return err
+		}
+	} else if s.active.path != chunk.GetPath() {
+		// Interleaving files would mean several open temp files and no clear
+		// owner for cleanup; the client sends one file at a time.
+		return status.Errorf(codes.InvalidArgument,
+			"cannot switch from %q to %q mid-transfer", s.active.path, chunk.GetPath())
+	}
+
+	t := s.active
+	firstEmptyChunk := t.received == 0 && t.entry.GetSize() == 0 && t.nextSeq == 0
+	if t.received >= t.entry.GetSize() && !firstEmptyChunk {
+		return status.Errorf(codes.InvalidArgument, "extra chunk after declared size for %q", chunk.GetPath())
+	}
+	if chunk.GetSequence() != t.nextSeq {
+		return status.Errorf(codes.InvalidArgument,
+			"unexpected chunk sequence for %q: want %d, got %d", chunk.GetPath(), t.nextSeq, chunk.GetSequence())
+	}
+	size := t.received + int64(len(chunk.GetData()))
+	if size > t.entry.GetSize() {
+		return status.Errorf(codes.InvalidArgument,
+			"chunk for %q exceeds declared size %d", chunk.GetPath(), t.entry.GetSize())
+	}
+
+	// Hash before writing so a corrupt chunk never reaches the disk. The
+	// running digest is verified per chunk, which is what turns a silent
+	// truncation on a flaky link into a loud failure.
+	t.hasher.Write(chunk.GetData())
+	if size != chunk.GetCumulativeSize() {
+		return status.Errorf(codes.DataLoss,
+			"cumulative size mismatch for %q: want %d, got %d", chunk.GetPath(), size, chunk.GetCumulativeSize())
+	}
+	if !bytes.Equal(t.hasher.Sum(nil), chunk.GetSha256()) {
+		return status.Errorf(codes.DataLoss, "chunk sha256 mismatch for %q", chunk.GetPath())
+	}
+
+	if _, err := t.file.Write(chunk.GetData()); err != nil {
+		return status.Errorf(codes.Internal, "writing %q: %v", chunk.GetPath(), err)
+	}
+	t.received = size
+	t.nextSeq++
+	return nil
+}
+
+// beginTransfer opens the temp file for a new file transfer, after checking
+// there is room for it.
+func (s *syncSession) beginTransfer(path string, entry *agentpbv2.FileSyncEntry) error {
+	destination, err := s.resolve(path)
+	if err != nil {
+		return err
+	}
+	if err := s.svc.checkSpace(s.volumeRoot, entry.GetSize()); err != nil {
+		return err
+	}
+	dir := filepath.Dir(destination)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return status.Errorf(codes.Internal, "creating directory for %q: %v", path, err)
+	}
+	// The temp file sits next to its destination so the commit is a rename
+	// within one filesystem, and carries the target digest so a crashed
+	// transfer is identifiable rather than anonymous garbage.
+	temp := filepath.Join(dir, fileSyncTempPrefix+hex.EncodeToString(entry.GetSha256())+"~"+filepath.Base(destination))
+	f, err := os.OpenFile(temp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return status.Errorf(codes.Internal, "creating temp file for %q: %v", path, err)
+	}
+	s.active = &fileTransfer{
+		path:        path,
+		entry:       entry,
+		destination: destination,
+		tempPath:    temp,
+		file:        f,
+		hasher:      sha256.New(),
+	}
+	return nil
+}
+
+func (s *syncSession) handleCommit(commit *agentpbv2.FileSyncCommit, stream grpc.BidiStreamingServer[agentpbv2.FileSyncRequest, agentpbv2.FileSyncResponse]) error {
+	t := s.active
+	if t == nil {
+		return status.Errorf(codes.InvalidArgument, "no active transfer to commit for %q", commit.GetPath())
+	}
+	if t.path != commit.GetPath() {
+		return status.Errorf(codes.InvalidArgument,
+			"commit path %q does not match active transfer %q", commit.GetPath(), t.path)
+	}
+	if len(commit.GetSha256()) != sha256Len {
+		return status.Errorf(codes.InvalidArgument, "commit sha256 must be %d bytes for %q", sha256Len, commit.GetPath())
+	}
+	if commit.GetSize() != t.entry.GetSize() {
+		return status.Errorf(codes.InvalidArgument,
+			"commit size mismatch for %q: manifest %d, commit %d", commit.GetPath(), t.entry.GetSize(), commit.GetSize())
+	}
+	if !bytes.Equal(commit.GetSha256(), t.entry.GetSha256()) {
+		return status.Errorf(codes.InvalidArgument, "commit sha256 does not match manifest for %q", commit.GetPath())
+	}
+	if t.received != t.entry.GetSize() {
+		return status.Errorf(codes.DataLoss,
+			"size mismatch for %q: want %d, got %d", commit.GetPath(), t.entry.GetSize(), t.received)
+	}
+	if !bytes.Equal(t.hasher.Sum(nil), t.entry.GetSha256()) {
+		return status.Errorf(codes.DataLoss, "sha256 mismatch for %q", commit.GetPath())
+	}
+
+	if err := s.finishTransfer(t); err != nil {
+		return err
+	}
+	s.active = nil
+	s.finalized[commit.GetPath()] = true
+
+	s.svc.logger.Info("file committed",
+		zap.String("path", commit.GetPath()),
+		zap.Int64("size", commit.GetSize()),
+	)
+	return stream.Send(&agentpbv2.FileSyncResponse{
+		ResponseType: &agentpbv2.FileSyncResponse_Ack{Ack: &agentpbv2.FileSyncAck{Path: commit.GetPath()}},
+	})
+}
+
+// finishTransfer makes the transferred bytes visible at their destination,
+// atomically. An app that watches the volume must never observe a partial
+// file: it either sees the old bytes or the complete new ones.
+func (s *syncSession) finishTransfer(t *fileTransfer) error {
+	if err := t.file.Sync(); err != nil {
+		return status.Errorf(codes.Internal, "fsync %q: %v", t.path, err)
+	}
+	if err := t.file.Close(); err != nil {
+		return status.Errorf(codes.Internal, "closing %q: %v", t.path, err)
+	}
+	t.file = nil
+
+	if err := os.Chmod(t.tempPath, fileMode(t.entry.GetMode())); err != nil {
+		return status.Errorf(codes.Internal, "chmod %q: %v", t.path, err)
+	}
+	if err := os.Rename(t.tempPath, t.destination); err != nil {
+		return status.Errorf(codes.Internal, "renaming %q into place: %v", t.path, err)
+	}
+	if err := fsyncDir(filepath.Dir(t.destination)); err != nil {
+		return status.Errorf(codes.Internal, "%v", err)
+	}
+	return nil
+}
+
+func (s *syncSession) handleChmod(chmod *agentpbv2.FileSyncChmod, stream grpc.BidiStreamingServer[agentpbv2.FileSyncRequest, agentpbv2.FileSyncResponse]) error {
+	if s.active != nil {
+		return status.Error(codes.InvalidArgument, "cannot change mode while a transfer is active")
+	}
+	entry, err := s.manifestEntry(chmod.GetPath())
+	if err != nil {
+		return err
+	}
+	if s.finalized[chmod.GetPath()] {
+		return status.Errorf(codes.InvalidArgument, "path already finalized: %q", chmod.GetPath())
+	}
+	// A mode-only update is the client asserting the content is already
+	// correct. Verifying size and digest against the manifest keeps that
+	// assertion honest rather than letting it silently apply to other bytes.
+	if chmod.GetSize() != entry.GetSize() || !bytes.Equal(chmod.GetSha256(), entry.GetSha256()) || chmod.GetMode() != entry.GetMode() {
+		return status.Errorf(codes.InvalidArgument, "mode update does not match manifest for %q", chmod.GetPath())
+	}
+	destination, err := s.resolve(chmod.GetPath())
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(destination); err != nil {
+		if os.IsNotExist(err) {
+			return status.Errorf(codes.NotFound, "cannot change mode, %q does not exist", chmod.GetPath())
+		}
+		return status.Errorf(codes.Internal, "stat %q: %v", chmod.GetPath(), err)
+	}
+	if err := os.Chmod(destination, fileMode(chmod.GetMode())); err != nil {
+		return status.Errorf(codes.Internal, "chmod %q: %v", chmod.GetPath(), err)
+	}
+	s.finalized[chmod.GetPath()] = true
+	return stream.Send(&agentpbv2.FileSyncResponse{
+		ResponseType: &agentpbv2.FileSyncResponse_Ack{Ack: &agentpbv2.FileSyncAck{Path: chmod.GetPath()}},
+	})
+}
+
+func (s *syncSession) handleDelete(del *agentpbv2.FileSyncDelete) error {
+	if s.active != nil {
+		return status.Error(codes.InvalidArgument, "cannot delete while a transfer is active")
+	}
+	seen := make(map[string]bool, len(del.GetPaths()))
+	for _, p := range del.GetPaths() {
+		if seen[p] {
+			return status.Errorf(codes.InvalidArgument, "duplicate delete path %q", p)
+		}
+		seen[p] = true
+		if s.finalized[p] {
+			return status.Errorf(codes.InvalidArgument, "path already finalized: %q", p)
+		}
+		destination, err := s.resolve(p)
+		if err != nil {
+			return err
+		}
+		// Only regular files: a delete must not be able to remove a whole
+		// subtree of a volume, which is what `volumes remove` is for.
+		info, err := os.Lstat(destination)
+		if err != nil {
+			if os.IsNotExist(err) {
+				s.finalized[p] = true
+				continue
+			}
+			return status.Errorf(codes.Internal, "stat %q: %v", p, err)
+		}
+		if info.IsDir() {
+			return status.Errorf(codes.InvalidArgument, "%q is a directory", p)
+		}
+		if err := os.Remove(destination); err != nil {
+			return status.Errorf(codes.Internal, "removing %q: %v", p, err)
+		}
+		if err := fsyncDir(filepath.Dir(destination)); err != nil {
+			return status.Errorf(codes.Internal, "%v", err)
+		}
+		s.finalized[p] = true
+		s.svc.logger.Info("file deleted", zap.String("path", p))
+	}
+	return nil
+}
+
+// resolve maps a session-relative path onto an absolute destination, checked
+// for containment inside the volume root.
+func (s *syncSession) resolve(rel string) (string, error) {
+	if s.prefix == "" {
+		return validatedDestination(s.volumeRoot, rel)
+	}
+	// Validate the client's component on its own first, so a traversal is
+	// reported as such instead of being silently absorbed by the join.
+	if _, err := validatedDestination(s.volumeRoot, rel); err != nil {
+		return "", err
+	}
+	return validatedDestination(s.volumeRoot, path.Join(s.prefix, rel))
+}
+
+// scanRoot is the directory the agent manifest describes.
+func (s *syncSession) scanRoot() string {
+	if s.prefix == "" {
+		return s.volumeRoot
+	}
+	return filepath.Join(s.volumeRoot, filepath.FromSlash(s.prefix))
+}
+
+func (s *syncSession) manifestEntry(path string) (*agentpbv2.FileSyncEntry, error) {
+	entry, ok := s.manifestByPath[path]
+	if !ok {
+		return nil, status.Errorf(codes.InvalidArgument, "no manifest entry for %q", path)
+	}
+	return entry, nil
+}
+
+// buildManifestLookup indexes the opening manifest, rejecting anything that
+// could not be written safely before a single byte is accepted.
+func (s *syncSession) buildManifestLookup(entries []*agentpbv2.FileSyncEntry) (map[string]*agentpbv2.FileSyncEntry, error) {
+	lookup := make(map[string]*agentpbv2.FileSyncEntry, len(entries))
+	for _, e := range entries {
+		if _, err := s.resolve(e.GetPath()); err != nil {
+			return nil, err
+		}
+		if len(e.GetSha256()) != sha256Len {
+			return nil, status.Errorf(codes.InvalidArgument, "manifest sha256 must be %d bytes for %q", sha256Len, e.GetPath())
+		}
+		if e.GetSize() < 0 {
+			return nil, status.Errorf(codes.InvalidArgument, "negative size for %q", e.GetPath())
+		}
+		if lookup[e.GetPath()] != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "duplicate manifest entry for %q", e.GetPath())
+		}
+		lookup[e.GetPath()] = e
+	}
+	return lookup, nil
+}
+
+func (s *syncSession) cleanupActive() {
+	if s.active == nil {
+		return
+	}
+	if s.active.file != nil {
+		_ = s.active.file.Close()
+	}
+	_ = os.Remove(s.active.tempPath)
+	s.active = nil
+}
+
+// checkSpace refuses a transfer that would leave the filesystem too full to
+// recover. When free space cannot be determined the transfer proceeds: a
+// missing statfs is not a reason to make the device unusable for pushes.
+func (s *FileSyncServiceV2) checkSpace(root string, size int64) error {
+	avail, ok := s.availBytes(root)
+	if !ok {
+		return nil
+	}
+	if avail-size < fileSyncDiskReserve {
+		return status.Errorf(codes.ResourceExhausted,
+			"not enough space: %d bytes free, need %d plus a %d byte reserve",
+			avail, size, int64(fileSyncDiskReserve))
+	}
+	return nil
+}
+
+// buildAgentManifest walks root and describes every regular file in it.
+func buildAgentManifest(root string) ([]*agentpbv2.FileSyncEntry, error) {
+	var entries []*agentpbv2.FileSyncEntry
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		// Skip symlinks and devices: the manifest describes bytes this service
+		// owns, and following a link out of the volume would report a file the
+		// client could then be told to overwrite.
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		if strings.HasPrefix(d.Name(), fileSyncTempPrefix) {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		digest, size, err := hashFile(path)
+		if err != nil {
+			return err
+		}
+		entries = append(entries, &agentpbv2.FileSyncEntry{
+			Path:   filepath.ToSlash(rel),
+			Size:   size,
+			Sha256: digest,
+			Mode:   uint32(info.Mode().Perm()),
+		})
+		return nil
+	})
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, status.Errorf(codes.Internal, "building manifest: %v", err)
+	}
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].GetPath() < entries[j].GetPath() })
+	return entries, nil
+}
+
+func hashFile(path string) ([]byte, int64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	size, err := io.Copy(h, f)
+	if err != nil {
+		return nil, 0, err
+	}
+	return h.Sum(nil), size, nil
+}
+
+// validatedDestination resolves a client-supplied relative path against root
+// and guarantees the result stays inside it.
+//
+// Containment is checked after resolving symlinks on the deepest existing
+// ancestor, not just lexically: a volume is writable by the app that owns it,
+// so a link planted inside the volume pointing at /etc is a path an attacker
+// can actually create, and a purely lexical check would follow it.
+func validatedDestination(root, rel string) (string, error) {
+	if rel == "" {
+		return "", status.Error(codes.InvalidArgument, "path must not be empty")
+	}
+	if strings.HasPrefix(rel, "/") || filepath.IsAbs(rel) {
+		return "", status.Errorf(codes.InvalidArgument, "path must be relative: %q", rel)
+	}
+	for _, component := range strings.Split(filepath.ToSlash(rel), "/") {
+		switch component {
+		case "", ".", "..":
+			return "", status.Errorf(codes.InvalidArgument, "path must not contain empty, . or .. components: %q", rel)
+		}
+	}
+
+	destination := filepath.Join(root, filepath.FromSlash(rel))
+
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", status.Errorf(codes.Internal, "resolving sync root: %v", err)
+	}
+
+	// EvalSymlinks needs an existing path, and the destination usually does not
+	// exist yet. Walk up to the deepest ancestor that does and check that.
+	ancestor := destination
+	for {
+		if _, err := os.Lstat(ancestor); err == nil {
+			break
+		}
+		parent := filepath.Dir(ancestor)
+		if parent == ancestor {
+			break
+		}
+		ancestor = parent
+	}
+	resolvedAncestor, err := filepath.EvalSymlinks(ancestor)
+	if err != nil {
+		return "", status.Errorf(codes.Internal, "resolving path %q: %v", rel, err)
+	}
+	if resolvedAncestor != resolvedRoot && !strings.HasPrefix(resolvedAncestor, resolvedRoot+string(os.PathSeparator)) {
+		return "", status.Errorf(codes.InvalidArgument, "path escapes the sync root: %q", rel)
+	}
+	return destination, nil
+}
+
+// fileMode maps a manifest mode onto permission bits, defaulting to 0644 for
+// clients that leave it unset. Only permission bits are honoured — setuid and
+// friends are never applied to a file arriving over the wire.
+func fileMode(mode uint32) os.FileMode {
+	perm := os.FileMode(mode).Perm()
+	if perm == 0 {
+		return 0o644
+	}
+	return perm
+}
+
+// fsyncDir flushes a directory entry so a rename or unlink survives power
+// loss. Edge devices lose power without warning, which is exactly when a
+// half-applied update is worst.
+func fsyncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return fmt.Errorf("open dir for fsync: %w", err)
+	}
+	syncErr := d.Sync()
+	closeErr := d.Close()
+	if syncErr != nil {
+		return fmt.Errorf("fsync dir: %w", syncErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close dir after fsync: %w", closeErr)
+	}
+	return nil
+}

--- a/go/internal/agent/services/file_sync_service_v2_test.go
+++ b/go/internal/agent/services/file_sync_service_v2_test.go
@@ -1,0 +1,604 @@
+package services
+
+import (
+	"crypto/sha256"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
+)
+
+// fileSyncStream replays a scripted client into the service and records what
+// the service sent back.
+type fileSyncStream struct {
+	grpc.ServerStream
+	msgs []*agentpbv2.FileSyncRequest
+	pos  int
+	sent []*agentpbv2.FileSyncResponse
+}
+
+func (s *fileSyncStream) Recv() (*agentpbv2.FileSyncRequest, error) {
+	if s.pos >= len(s.msgs) {
+		return nil, io.EOF
+	}
+	m := s.msgs[s.pos]
+	s.pos++
+	return m, nil
+}
+
+func (s *fileSyncStream) Send(r *agentpbv2.FileSyncResponse) error {
+	s.sent = append(s.sent, r)
+	return nil
+}
+
+// newTestService points the service at a temp dir standing in for
+// /var/lib/wendy/volumes and reports plenty of free space unless a test says
+// otherwise.
+func newTestService(t *testing.T) (*FileSyncServiceV2, string) {
+	t.Helper()
+	dir := t.TempDir()
+	svc := &FileSyncServiceV2{
+		logger:     zap.NewNop(),
+		volumesDir: dir,
+		availBytes: func(string) (int64, bool) { return 1 << 40, true },
+	}
+	return svc, dir
+}
+
+func makeVolume(t *testing.T, volumesDir, name string) string {
+	t.Helper()
+	path := filepath.Join(volumesDir, name)
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("creating volume: %v", err)
+	}
+	return path
+}
+
+func entryFor(path string, data []byte, mode uint32) *agentpbv2.FileSyncEntry {
+	sum := sha256.Sum256(data)
+	return &agentpbv2.FileSyncEntry{
+		Path:   path,
+		Size:   int64(len(data)),
+		Sha256: sum[:],
+		Mode:   mode,
+	}
+}
+
+// pushScript is the message sequence a client sends to push one file in a
+// single chunk.
+func pushScript(volume, prefix, path string, data []byte, mode uint32) []*agentpbv2.FileSyncRequest {
+	entry := entryFor(path, data, mode)
+	sum := sha256.Sum256(data)
+	return []*agentpbv2.FileSyncRequest{
+		{RequestType: &agentpbv2.FileSyncRequest_Start{Start: &agentpbv2.FileSyncStart{
+			Volume:     volume,
+			PathPrefix: prefix,
+			Manifest:   &agentpbv2.FileSyncManifest{Files: []*agentpbv2.FileSyncEntry{entry}},
+		}}},
+		{RequestType: &agentpbv2.FileSyncRequest_Chunk{Chunk: &agentpbv2.FileSyncChunk{
+			Path:           path,
+			Data:           data,
+			Sequence:       0,
+			CumulativeSize: int64(len(data)),
+			Sha256:         sum[:],
+		}}},
+		{RequestType: &agentpbv2.FileSyncRequest_Commit{Commit: &agentpbv2.FileSyncCommit{
+			Path:   path,
+			Sha256: sum[:],
+			Size:   int64(len(data)),
+		}}},
+	}
+}
+
+func runStream(t *testing.T, svc *FileSyncServiceV2, msgs []*agentpbv2.FileSyncRequest) (*fileSyncStream, error) {
+	t.Helper()
+	stream := &fileSyncStream{msgs: msgs}
+	return stream, svc.SyncFiles(stream)
+}
+
+func requireCode(t *testing.T, err error, want codes.Code) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected %s, got nil error", want)
+	}
+	if got := status.Code(err); got != want {
+		t.Fatalf("expected %s, got %s (%v)", want, got, err)
+	}
+}
+
+func TestPushWritesFileIntoVolume(t *testing.T) {
+	svc, volumes := newTestService(t)
+	volume := makeVolume(t, volumes, "edge-detector-data")
+
+	data := []byte("onnx-model-bytes")
+	_, err := runStream(t, svc, pushScript("edge-detector-data", "models", "sffa_yolo.onnx", data, 0o644))
+	if err != nil {
+		t.Fatalf("SyncFiles: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(volume, "models", "sffa_yolo.onnx"))
+	if err != nil {
+		t.Fatalf("reading pushed file: %v", err)
+	}
+	if string(got) != string(data) {
+		t.Fatalf("content mismatch: got %q, want %q", got, data)
+	}
+}
+
+// A pushed artifact must be readable by the app that mounts the volume, which
+// runs as a different user than the agent.
+func TestPushAppliesManifestMode(t *testing.T) {
+	svc, volumes := newTestService(t)
+	volume := makeVolume(t, volumes, "data")
+
+	_, err := runStream(t, svc, pushScript("data", "", "model.bin", []byte("x"), 0o644))
+	if err != nil {
+		t.Fatalf("SyncFiles: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(volume, "model.bin"))
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o644 {
+		t.Fatalf("mode: got %o, want 644", perm)
+	}
+}
+
+// The manifest the agent replies with is what lets the client skip a file it
+// already pushed.
+func TestStartReturnsManifestOfExistingFiles(t *testing.T) {
+	svc, volumes := newTestService(t)
+	volume := makeVolume(t, volumes, "data")
+	existing := []byte("already here")
+	if err := os.WriteFile(filepath.Join(volume, "old.bin"), existing, 0o644); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	stream, err := runStream(t, svc, []*agentpbv2.FileSyncRequest{
+		{RequestType: &agentpbv2.FileSyncRequest_Start{Start: &agentpbv2.FileSyncStart{
+			Volume:   "data",
+			Manifest: &agentpbv2.FileSyncManifest{},
+		}}},
+	})
+	if err != nil {
+		t.Fatalf("SyncFiles: %v", err)
+	}
+
+	manifest := stream.sent[0].GetManifest()
+	if manifest == nil || len(manifest.GetFiles()) != 1 {
+		t.Fatalf("expected 1 manifest entry, got %+v", stream.sent[0])
+	}
+	entry := manifest.GetFiles()[0]
+	want := sha256.Sum256(existing)
+	if entry.GetPath() != "old.bin" || string(entry.GetSha256()) != string(want[:]) {
+		t.Fatalf("unexpected manifest entry: %+v", entry)
+	}
+}
+
+// A push into a volume of models must not report the other models as stale, or
+// a mirroring client would delete them.
+func TestPathPrefixScopesManifest(t *testing.T) {
+	svc, volumes := newTestService(t)
+	volume := makeVolume(t, volumes, "data")
+	if err := os.WriteFile(filepath.Join(volume, "unrelated.txt"), []byte("keep me"), 0o644); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	stream, err := runStream(t, svc, []*agentpbv2.FileSyncRequest{
+		{RequestType: &agentpbv2.FileSyncRequest_Start{Start: &agentpbv2.FileSyncStart{
+			Volume:     "data",
+			PathPrefix: "models",
+			Manifest:   &agentpbv2.FileSyncManifest{},
+		}}},
+	})
+	if err != nil {
+		t.Fatalf("SyncFiles: %v", err)
+	}
+	if files := stream.sent[0].GetManifest().GetFiles(); len(files) != 0 {
+		t.Fatalf("expected empty scoped manifest, got %+v", files)
+	}
+}
+
+func TestCorruptChunkIsRejectedAndLeavesNoFile(t *testing.T) {
+	svc, volumes := newTestService(t)
+	volume := makeVolume(t, volumes, "data")
+
+	data := []byte("good bytes")
+	msgs := pushScript("data", "", "model.bin", data, 0o644)
+	// Flip the payload after the manifest declared its digest — the shape a
+	// silently corrupted transfer takes.
+	chunk := msgs[1].GetChunk()
+	chunk.Data = []byte("bad bytes!")
+
+	_, err := runStream(t, svc, msgs)
+	requireCode(t, err, codes.DataLoss)
+
+	entries, readErr := os.ReadDir(volume)
+	if readErr != nil {
+		t.Fatalf("reading volume: %v", readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected no files left behind, got %d", len(entries))
+	}
+}
+
+// A client that dies mid-file must not leave a temp file behind, and must
+// never leave a partial file at the destination.
+func TestInterruptedTransferCleansUp(t *testing.T) {
+	svc, volumes := newTestService(t)
+	volume := makeVolume(t, volumes, "data")
+
+	data := []byte("first half second half")
+	entry := entryFor("model.bin", data, 0o644)
+	half := data[:10]
+	sum := sha256.Sum256(half)
+
+	// Start and one chunk, then EOF with no commit.
+	_, err := runStream(t, svc, []*agentpbv2.FileSyncRequest{
+		{RequestType: &agentpbv2.FileSyncRequest_Start{Start: &agentpbv2.FileSyncStart{
+			Volume:   "data",
+			Manifest: &agentpbv2.FileSyncManifest{Files: []*agentpbv2.FileSyncEntry{entry}},
+		}}},
+		{RequestType: &agentpbv2.FileSyncRequest_Chunk{Chunk: &agentpbv2.FileSyncChunk{
+			Path:           "model.bin",
+			Data:           half,
+			CumulativeSize: int64(len(half)),
+			Sha256:         sum[:],
+		}}},
+	})
+	requireCode(t, err, codes.InvalidArgument)
+
+	entries, readErr := os.ReadDir(volume)
+	if readErr != nil {
+		t.Fatalf("reading volume: %v", readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected no leftovers, got %v", entries)
+	}
+}
+
+func TestPathTraversalIsRejected(t *testing.T) {
+	svc, volumes := newTestService(t)
+	makeVolume(t, volumes, "data")
+
+	for _, path := range []string{"../escape.bin", "models/../../escape.bin", "/etc/passwd", "./x.bin"} {
+		t.Run(path, func(t *testing.T) {
+			_, err := runStream(t, svc, pushScript("data", "", path, []byte("x"), 0o644))
+			requireCode(t, err, codes.InvalidArgument)
+		})
+	}
+}
+
+// A volume is writable by the app that owns it, so a symlink pointing out of
+// the volume is something an attacker can actually plant.
+func TestSymlinkEscapeIsRejected(t *testing.T) {
+	svc, volumes := newTestService(t)
+	volume := makeVolume(t, volumes, "data")
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(volume, "escape")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	_, err := runStream(t, svc, pushScript("data", "", "escape/owned.bin", []byte("x"), 0o644))
+	requireCode(t, err, codes.InvalidArgument)
+
+	if _, statErr := os.Stat(filepath.Join(outside, "owned.bin")); !os.IsNotExist(statErr) {
+		t.Fatalf("file escaped the volume")
+	}
+}
+
+// The prefix is client-supplied, so a symlink planted at it must not be able
+// to redefine what "inside the volume" means for the rest of the session.
+func TestSymlinkedPathPrefixIsRejected(t *testing.T) {
+	svc, volumes := newTestService(t)
+	volume := makeVolume(t, volumes, "data")
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(volume, "models")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	_, err := runStream(t, svc, pushScript("data", "models", "owned.bin", []byte("x"), 0o644))
+	requireCode(t, err, codes.InvalidArgument)
+
+	if _, statErr := os.Stat(filepath.Join(outside, "owned.bin")); !os.IsNotExist(statErr) {
+		t.Fatalf("file escaped the volume via the path prefix")
+	}
+}
+
+// Organising artifacts into a subdirectory is the normal case, and the
+// directory will not exist on the first push.
+func TestPushCreatesMissingPrefixDirectories(t *testing.T) {
+	svc, volumes := newTestService(t)
+	volume := makeVolume(t, volumes, "data")
+
+	if _, err := runStream(t, svc, pushScript("data", "models/fire", "v2.onnx", []byte("weights"), 0o644)); err != nil {
+		t.Fatalf("SyncFiles: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(volume, "models", "fire", "v2.onnx"))
+	if err != nil {
+		t.Fatalf("reading pushed file: %v", err)
+	}
+	if string(got) != "weights" {
+		t.Fatalf("got %q, want weights", got)
+	}
+}
+
+// A listing must not have side effects on the device.
+func TestListingDoesNotCreatePrefixDirectory(t *testing.T) {
+	svc, volumes := newTestService(t)
+	volume := makeVolume(t, volumes, "data")
+
+	if _, err := runStream(t, svc, []*agentpbv2.FileSyncRequest{
+		{RequestType: &agentpbv2.FileSyncRequest_Start{Start: &agentpbv2.FileSyncStart{
+			Volume:     "data",
+			PathPrefix: "models",
+			Manifest:   &agentpbv2.FileSyncManifest{},
+		}}},
+	}); err != nil {
+		t.Fatalf("SyncFiles: %v", err)
+	}
+
+	if _, statErr := os.Stat(filepath.Join(volume, "models")); !os.IsNotExist(statErr) {
+		t.Fatalf("listing created the prefix directory")
+	}
+}
+
+func TestInvalidVolumeNamesAreRejected(t *testing.T) {
+	svc, volumes := newTestService(t)
+	makeVolume(t, volumes, "data")
+
+	for _, volume := range []string{"..", ".", "../../etc", "sub/dir"} {
+		t.Run(volume, func(t *testing.T) {
+			_, err := runStream(t, svc, pushScript(volume, "", "x.bin", []byte("x"), 0o644))
+			requireCode(t, err, codes.InvalidArgument)
+		})
+	}
+}
+
+// Volumes exist because an app declared a persist entitlement. Creating one on
+// demand would turn a typo into a push that reports success and lands where
+// nothing reads it.
+func TestUnknownVolumeIsNotFound(t *testing.T) {
+	svc, volumes := newTestService(t)
+	makeVolume(t, volumes, "data")
+
+	_, err := runStream(t, svc, pushScript("typo-data", "", "x.bin", []byte("x"), 0o644))
+	requireCode(t, err, codes.NotFound)
+
+	if _, statErr := os.Stat(filepath.Join(volumes, "typo-data")); !os.IsNotExist(statErr) {
+		t.Fatalf("volume was created implicitly")
+	}
+}
+
+func TestAppIDModeIsUnimplemented(t *testing.T) {
+	svc, _ := newTestService(t)
+
+	_, err := runStream(t, svc, []*agentpbv2.FileSyncRequest{
+		{RequestType: &agentpbv2.FileSyncRequest_Start{Start: &agentpbv2.FileSyncStart{
+			AppId:    "com.example.app",
+			Manifest: &agentpbv2.FileSyncManifest{},
+		}}},
+	})
+	requireCode(t, err, codes.Unimplemented)
+}
+
+// Filling the root partition breaks agent and OS updates, so a push that would
+// do it fails before any bytes are written.
+func TestPushIsRejectedWhenDiskIsFull(t *testing.T) {
+	svc, volumes := newTestService(t)
+	volume := makeVolume(t, volumes, "data")
+	svc.availBytes = func(string) (int64, bool) { return fileSyncDiskReserve + 8, true }
+
+	_, err := runStream(t, svc, pushScript("data", "", "model.bin", []byte("more than eight bytes"), 0o644))
+	requireCode(t, err, codes.ResourceExhausted)
+
+	entries, readErr := os.ReadDir(volume)
+	if readErr != nil {
+		t.Fatalf("reading volume: %v", readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected no partial file, got %v", entries)
+	}
+}
+
+// Free space that cannot be measured must not block every push.
+func TestPushProceedsWhenFreeSpaceIsUnknown(t *testing.T) {
+	svc, volumes := newTestService(t)
+	makeVolume(t, volumes, "data")
+	svc.availBytes = func(string) (int64, bool) { return 0, false }
+
+	if _, err := runStream(t, svc, pushScript("data", "", "model.bin", []byte("x"), 0o644)); err != nil {
+		t.Fatalf("SyncFiles: %v", err)
+	}
+}
+
+func TestChunkNotInManifestIsRejected(t *testing.T) {
+	svc, volumes := newTestService(t)
+	makeVolume(t, volumes, "data")
+
+	msgs := pushScript("data", "", "declared.bin", []byte("x"), 0o644)
+	msgs[1].GetChunk().Path = "undeclared.bin"
+
+	_, err := runStream(t, svc, msgs)
+	requireCode(t, err, codes.InvalidArgument)
+}
+
+func TestDeleteRemovesFile(t *testing.T) {
+	svc, volumes := newTestService(t)
+	volume := makeVolume(t, volumes, "data")
+	target := filepath.Join(volume, "old.onnx")
+	if err := os.WriteFile(target, []byte("stale"), 0o644); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	_, err := runStream(t, svc, []*agentpbv2.FileSyncRequest{
+		{RequestType: &agentpbv2.FileSyncRequest_Start{Start: &agentpbv2.FileSyncStart{
+			Volume:   "data",
+			Manifest: &agentpbv2.FileSyncManifest{},
+		}}},
+		{RequestType: &agentpbv2.FileSyncRequest_Delete{Delete: &agentpbv2.FileSyncDelete{
+			Paths: []string{"old.onnx"},
+		}}},
+	})
+	if err != nil {
+		t.Fatalf("SyncFiles: %v", err)
+	}
+	if _, statErr := os.Stat(target); !os.IsNotExist(statErr) {
+		t.Fatalf("file was not deleted")
+	}
+}
+
+// Removing a whole subtree is what `volumes remove` is for; a file delete must
+// not become a recursive one.
+func TestDeleteRefusesDirectories(t *testing.T) {
+	svc, volumes := newTestService(t)
+	volume := makeVolume(t, volumes, "data")
+	if err := os.MkdirAll(filepath.Join(volume, "models"), 0o755); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	_, err := runStream(t, svc, []*agentpbv2.FileSyncRequest{
+		{RequestType: &agentpbv2.FileSyncRequest_Start{Start: &agentpbv2.FileSyncStart{
+			Volume:   "data",
+			Manifest: &agentpbv2.FileSyncManifest{},
+		}}},
+		{RequestType: &agentpbv2.FileSyncRequest_Delete{Delete: &agentpbv2.FileSyncDelete{
+			Paths: []string{"models"},
+		}}},
+	})
+	requireCode(t, err, codes.InvalidArgument)
+
+	if _, statErr := os.Stat(filepath.Join(volume, "models")); statErr != nil {
+		t.Fatalf("directory was removed: %v", statErr)
+	}
+}
+
+// Replacing a model an app may be reading must be atomic: the app sees either
+// the old bytes or the new ones.
+func TestPushOverwritesExistingFile(t *testing.T) {
+	svc, volumes := newTestService(t)
+	volume := makeVolume(t, volumes, "data")
+	target := filepath.Join(volume, "model.bin")
+	if err := os.WriteFile(target, []byte("v1"), 0o644); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	if _, err := runStream(t, svc, pushScript("data", "", "model.bin", []byte("v2-longer"), 0o644)); err != nil {
+		t.Fatalf("SyncFiles: %v", err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("reading: %v", err)
+	}
+	if string(got) != "v2-longer" {
+		t.Fatalf("got %q, want v2-longer", got)
+	}
+	entries, err := os.ReadDir(volume)
+	if err != nil {
+		t.Fatalf("reading volume: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("temp file left behind: %v", entries)
+	}
+}
+
+// A transfer split across chunks is the normal case for a 50 MB artifact.
+func TestMultiChunkTransfer(t *testing.T) {
+	svc, volumes := newTestService(t)
+	volume := makeVolume(t, volumes, "data")
+
+	data := []byte("chunk-one-chunk-two-chunk-three")
+	entry := entryFor("model.bin", data, 0o644)
+	msgs := []*agentpbv2.FileSyncRequest{
+		{RequestType: &agentpbv2.FileSyncRequest_Start{Start: &agentpbv2.FileSyncStart{
+			Volume:   "data",
+			Manifest: &agentpbv2.FileSyncManifest{Files: []*agentpbv2.FileSyncEntry{entry}},
+		}}},
+	}
+	for i, seq := 0, uint64(0); i < len(data); i, seq = i+10, seq+1 {
+		end := min(i+10, len(data))
+		running := sha256.Sum256(data[:end])
+		msgs = append(msgs, &agentpbv2.FileSyncRequest{
+			RequestType: &agentpbv2.FileSyncRequest_Chunk{Chunk: &agentpbv2.FileSyncChunk{
+				Path:           "model.bin",
+				Data:           data[i:end],
+				Sequence:       seq,
+				CumulativeSize: int64(end),
+				Sha256:         running[:],
+			}},
+		})
+	}
+	sum := sha256.Sum256(data)
+	msgs = append(msgs, &agentpbv2.FileSyncRequest{
+		RequestType: &agentpbv2.FileSyncRequest_Commit{Commit: &agentpbv2.FileSyncCommit{
+			Path:   "model.bin",
+			Sha256: sum[:],
+			Size:   int64(len(data)),
+		}},
+	})
+
+	if _, err := runStream(t, svc, msgs); err != nil {
+		t.Fatalf("SyncFiles: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(volume, "model.bin"))
+	if err != nil {
+		t.Fatalf("reading: %v", err)
+	}
+	if string(got) != string(data) {
+		t.Fatalf("got %q, want %q", got, data)
+	}
+}
+
+func TestOutOfOrderChunkIsRejected(t *testing.T) {
+	svc, volumes := newTestService(t)
+	makeVolume(t, volumes, "data")
+
+	msgs := pushScript("data", "", "model.bin", []byte("x"), 0o644)
+	msgs[1].GetChunk().Sequence = 7
+
+	_, err := runStream(t, svc, msgs)
+	requireCode(t, err, codes.InvalidArgument)
+}
+
+func TestFirstMessageMustBeStart(t *testing.T) {
+	svc, volumes := newTestService(t)
+	makeVolume(t, volumes, "data")
+
+	_, err := runStream(t, svc, []*agentpbv2.FileSyncRequest{
+		{RequestType: &agentpbv2.FileSyncRequest_Chunk{Chunk: &agentpbv2.FileSyncChunk{Path: "x"}}},
+	})
+	requireCode(t, err, codes.InvalidArgument)
+}
+
+// Temp files are an implementation detail of an in-flight push; advertising
+// one would make a client diff against a file that does not exist yet.
+func TestManifestSkipsTempFiles(t *testing.T) {
+	svc, volumes := newTestService(t)
+	volume := makeVolume(t, volumes, "data")
+	if err := os.WriteFile(filepath.Join(volume, fileSyncTempPrefix+"abc~model.bin"), []byte("partial"), 0o600); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	stream, err := runStream(t, svc, []*agentpbv2.FileSyncRequest{
+		{RequestType: &agentpbv2.FileSyncRequest_Start{Start: &agentpbv2.FileSyncStart{
+			Volume:   "data",
+			Manifest: &agentpbv2.FileSyncManifest{},
+		}}},
+	})
+	if err != nil {
+		t.Fatalf("SyncFiles: %v", err)
+	}
+	if files := stream.sent[0].GetManifest().GetFiles(); len(files) != 0 {
+		t.Fatalf("temp file advertised: %+v", files)
+	}
+}

--- a/go/internal/agent/services/pem_files.go
+++ b/go/internal/agent/services/pem_files.go
@@ -50,17 +50,8 @@ func syncWriteFile(path string, data []byte, perm os.FileMode) error {
 	// fsync the directory so the rename is durable on power loss. Open/close
 	// failures are reported too: skipping the fsync silently would drop the
 	// durability guarantee this helper exists to provide.
-	d, err := os.Open(dir)
-	if err != nil {
-		return fmt.Errorf("open dir for fsync after rename: %w", err)
-	}
-	syncErr := d.Sync()
-	closeErr := d.Close()
-	if syncErr != nil {
-		return fmt.Errorf("fsync dir after rename: %w", syncErr)
-	}
-	if closeErr != nil {
-		return fmt.Errorf("close dir after fsync: %w", closeErr)
+	if err := fsyncDir(dir); err != nil {
+		return fmt.Errorf("%w after rename", err)
 	}
 	return nil
 }

--- a/go/proto/gen/agentpb/v2/file_sync_service.pb.go
+++ b/go/proto/gen/agentpb/v2/file_sync_service.pb.go
@@ -220,9 +220,23 @@ func (*FileSyncRequest_Chmod) isFileSyncRequest_RequestType() {}
 func (*FileSyncRequest_Delete) isFileSyncRequest_RequestType() {}
 
 type FileSyncStart struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	AppId         string                 `protobuf:"bytes,1,opt,name=app_id,json=appId,proto3" json:"app_id,omitempty"`
-	Manifest      *FileSyncManifest      `protobuf:"bytes,2,opt,name=manifest,proto3" json:"manifest,omitempty"`
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	AppId    string                 `protobuf:"bytes,1,opt,name=app_id,json=appId,proto3" json:"app_id,omitempty"`
+	Manifest *FileSyncManifest      `protobuf:"bytes,2,opt,name=manifest,proto3" json:"manifest,omitempty"`
+	// Sync into a persistent volume (/var/lib/wendy/volumes/<volume>) instead
+	// of an app sync root. Mutually exclusive with app_id: exactly one of the
+	// two selects the sync root. The Linux agent implements volume mode only;
+	// app_id mode is the macOS agent's native-app sync.
+	Volume string `protobuf:"bytes,3,opt,name=volume,proto3" json:"volume,omitempty"`
+	// Restrict the session to this subtree of the sync root. The manifest the
+	// agent replies with covers only paths under the prefix, and every path in
+	// the session (chunk, commit, chmod, delete) is interpreted relative to it.
+	//
+	// Without this, pushing one file into a volume makes the agent hash every
+	// file already in that volume to build its manifest — for a volume holding
+	// several 50 MB models that is seconds of wasted I/O per push — and the
+	// client sees unrelated files as candidates for deletion.
+	PathPrefix    string `protobuf:"bytes,4,opt,name=path_prefix,json=pathPrefix,proto3" json:"path_prefix,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -269,6 +283,20 @@ func (x *FileSyncStart) GetManifest() *FileSyncManifest {
 		return x.Manifest
 	}
 	return nil
+}
+
+func (x *FileSyncStart) GetVolume() string {
+	if x != nil {
+		return x.Volume
+	}
+	return ""
+}
+
+func (x *FileSyncStart) GetPathPrefix() string {
+	if x != nil {
+		return x.PathPrefix
+	}
+	return ""
 }
 
 type FileSyncChunk struct {
@@ -757,10 +785,13 @@ const file_wendy_agent_services_v2_file_sync_service_proto_rawDesc = "" +
 	"\x06commit\x18\x03 \x01(\v2'.wendy.agent.services.v2.FileSyncCommitH\x00R\x06commit\x12>\n" +
 	"\x05chmod\x18\x04 \x01(\v2&.wendy.agent.services.v2.FileSyncChmodH\x00R\x05chmod\x12A\n" +
 	"\x06delete\x18\x05 \x01(\v2'.wendy.agent.services.v2.FileSyncDeleteH\x00R\x06deleteB\x0e\n" +
-	"\frequest_type\"m\n" +
+	"\frequest_type\"\xa6\x01\n" +
 	"\rFileSyncStart\x12\x15\n" +
 	"\x06app_id\x18\x01 \x01(\tR\x05appId\x12E\n" +
-	"\bmanifest\x18\x02 \x01(\v2).wendy.agent.services.v2.FileSyncManifestR\bmanifest\"\x94\x01\n" +
+	"\bmanifest\x18\x02 \x01(\v2).wendy.agent.services.v2.FileSyncManifestR\bmanifest\x12\x16\n" +
+	"\x06volume\x18\x03 \x01(\tR\x06volume\x12\x1f\n" +
+	"\vpath_prefix\x18\x04 \x01(\tR\n" +
+	"pathPrefix\"\x94\x01\n" +
 	"\rFileSyncChunk\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12\x12\n" +
 	"\x04data\x18\x02 \x01(\fR\x04data\x12\x1a\n" +


### PR DESCRIPTION
## Why

There is no supported way to put a file on a running WendyOS app. `wendy device volumes` offers `list` and `remove`; nothing anywhere pushes bytes. So a team swapping 20–50 MB model weights either rebuilds the image (half a day per candidate) or — what actually happens — starts an **unauthenticated HTTP receiver on a device with a camera and a GPU**, tunnels to it, uploads, and hopes to remember to kill it.

Full context: the wendy-console team wrote this up as a platform request (fire-detection ONNX evaluation), and the same shape recurs for lens calibration, maps/URDF, and operator-tuned config bundles. Without a platform primitive, every app grows its own upload endpoint, each with its own auth, path-traversal bug, and quota handling.

## What this changes

The protocol already exists. `WendyFileSyncService` is what the CLI speaks to deploy to a **macOS** target — manifest diffing, chunked transfer, per-chunk digests — and only the Swift agent implements it. It also addresses files by app sync root, which a Linux device does not have.

This implements the service in the Linux agent against **persistent volumes**, adding two fields to `FileSyncStart`:

| field | meaning |
|---|---|
| `volume` | sync into `/var/lib/wendy/volumes/<name>` instead of an app root. Mutually exclusive with `app_id`, which stays macOS-only (`Unimplemented` here). |
| `path_prefix` | scope the session to a subtree. Without it, pushing one model makes the agent hash every other model in the volume, and the client sees unrelated files as stale. |

No new RPCs: `ls` falls out of the manifest the agent already replies with, and `rm` out of `FileSyncDelete`. The CLI verbs are a follow-up PR; this one is the receiver.

## Review notes

- **Registered on the mTLS server only** (next to `WendyShellService`, for the reason its comment gives). In `registerAllServices` it would also land on the pre-provisioning plaintext server, handing anyone on the LAN the ability to write files a GPU app later loads.
- **Containment base is always the volume root**, checked after resolving symlinks on the deepest existing ancestor — including for the `path_prefix` itself. A volume is writable by the app that owns it, so a symlink pointing at `/etc` is one an attacker can actually plant; resolving paths against the prefix directory would let that symlink redefine "inside".
- **Volumes are never created on demand.** They exist because an app declared a persist entitlement, so auto-creating one turns a typo into a push that reports success into a directory nothing reads (`NotFound` instead).
- **Commits are atomic**: temp file in the same directory → fsync → rename → fsync parent. An app watching the volume never sees a partial model, so apps need no "is this file finished" protocol. (`syncWriteFile` in `pem_files.go` grew the same parent-dir fsync; that logic is now shared as `fsyncDir`.)
- **Pushes stop with 64 MiB free.** A device that fills its root partition can't apply agent or OS updates — we've hit that. Uses `Bavail`, not `Bfree`.
- **A listing has no side effects** — it does not create the prefix directory.

## Testing

`go test ./internal/agent/services/` — 20 new tests covering the happy path, multi-chunk transfer, atomic overwrite, corrupt-chunk rejection with no leftovers, interrupted transfer cleanup, path traversal, symlink escape (both at the file and at the prefix), unknown volume, disk-full rejection, unmeasurable-free-space fallthrough, and temp-file hiding. Full `go test ./...` and `go vet ./...` pass.

Not yet exercised against hardware — it needs an agent build on a device, which the follow-up CLI PR makes possible to drive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
