### PR TITLE
feat(agent): let each video subscriber choose its own frame rate

### DIFF
--- a/Proto/wendy/agent/services/v1/wendy_agent_v1_video_service.proto
+++ b/Proto/wendy/agent/services/v1/wendy_agent_v1_video_service.proto
@@ -45,6 +45,34 @@ message StreamVideoRequest {
     uint32 width      = 2; // pixels; 0 = device default
     uint32 height     = 3; // pixels; 0 = device default
     uint32 framerate  = 4; // fps; 0 = device default
+
+    // Upper bound on how many frames per second THIS subscriber receives; 0 =
+    // every frame (the historical behaviour). Unlike width/height/framerate this
+    // is a property of one connection, not of the camera: subscribers sharing a
+    // camera may each set a different value, and none of them is rejected for
+    // disagreeing. Nothing about capture or encoding changes — the same frames
+    // are produced either way — so this saves uplink bytes, not device CPU.
+    //
+    // Delivery is anchored to keyframes, because an H.264 frame is only
+    // decodable with the frames it depends on. A limited subscriber therefore
+    // receives whole keyframe-to-keyframe groups, and its effective rate is
+    // rounded to that granularity: with the default keyframe interval of half a
+    // second, asking for 1 fps yields one group per second, not one frame. Set
+    // keyframe_interval_frames to make the granularity finer.
+    //
+    // Only applies to H.264. A VP8 stream is delivered whole regardless, because
+    // its frames are wrapped in a WebM container that cannot be cut mid-stream.
+    uint32 max_framerate = 5;
+
+    // Frames between keyframes for the shared encoder; 0 = half a second's worth
+    // (framerate/2). Unlike max_framerate this reconfigures the encoder everyone
+    // shares, so it takes part in the stream-parameter compatibility check.
+    //
+    // It exists because it sets the floor on how finely max_framerate can be
+    // honoured, and how quickly a new subscriber gets a decodable picture. Short
+    // intervals cost bitrate (keyframes are large); 1 makes every frame
+    // independent and every rate exactly achievable, at the highest byte cost.
+    uint32 keyframe_interval_frames = 6;
 }
 
 // Credentials for a network camera. Stored on the device, never returned by any

--- a/go/internal/agent/services/video_framerate_test.go
+++ b/go/internal/agent/services/video_framerate_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"google.golang.org/grpc/status"
 
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
@@ -62,7 +63,7 @@ func drain(ch chan *videoFrame) []*videoFrame {
 	}
 }
 
-func TestStartsH264Keyframe(t *testing.T) {
+func TestScanH264GroupStart(t *testing.T) {
 	tests := []struct {
 		name string
 		data []byte
@@ -82,8 +83,8 @@ func TestStartsH264Keyframe(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := startsH264Keyframe(tc.data); got != tc.want {
-				t.Errorf("startsH264Keyframe(%x) = %v, want %v", tc.data, got, tc.want)
+			if got, _ := scanH264(tc.data); got != tc.want {
+				t.Errorf("scanH264(%x) group start = %v, want %v", tc.data, got, tc.want)
 			}
 		})
 	}
@@ -169,11 +170,11 @@ func TestPacingDropsWholeGroups(t *testing.T) {
 	}
 	// Whole groups only: the first frame delivered must be the keyframe, or the
 	// rest cannot be decoded.
-	if !startsH264Keyframe(got[0].data) {
+	if start, _ := scanH264(got[0].data); !start {
 		t.Error("delivered group does not start with a keyframe")
 	}
 	for _, f := range got[1:] {
-		if startsH264Keyframe(f.data) {
+		if start, _ := scanH264(f.data); start {
 			t.Error("a second group leaked through")
 		}
 	}
@@ -452,5 +453,114 @@ func TestPacedCountSurvivesAbsurdRate(t *testing.T) {
 	h.unsubscribe(id)
 	if h.paced != 0 {
 		t.Errorf("paced = %d after unsubscribe, want 0", h.paced)
+	}
+}
+
+// The rate budget is charged per coded picture, so a buffer carrying several of
+// them — what a GStreamer pipe read routinely delivers — costs several
+// intervals. Charging per buffer measured 6 fps against a 2 fps request on real
+// hardware.
+func TestScanH264CountsPictures(t *testing.T) {
+	sps := []byte{0, 0, 0, 1, 0x67, 0x42}
+	idr := []byte{0, 0, 0, 1, 0x65, 0x88}       // first_mb_in_slice = 0
+	pFrame := []byte{0, 0, 0, 1, 0x41, 0x9a}    // first_mb_in_slice = 0
+	contSlice := []byte{0, 0, 0, 1, 0x41, 0x0a} // continuation: first bit clear
+	pps := []byte{0, 0, 0, 1, 0x68, 0xce}
+
+	tests := []struct {
+		name         string
+		data         []byte
+		wantStart    bool
+		wantPictures int
+	}{
+		{"one inter frame", pFrame, false, 1},
+		{"keyframe: sps + idr", append(append([]byte{}, sps...), idr...), true, 1},
+		{"three inter frames in one buffer", concat(pFrame, pFrame, pFrame), false, 3},
+		{"keyframe plus two inter frames", concat(sps, pps, idr, pFrame, pFrame), true, 3},
+		// A multi-slice picture must not be counted once per slice.
+		{"one picture in two slices", concat(pFrame, contSlice), false, 1},
+		{"parameter sets only still cost one", concat(sps, pps), true, 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			start, pictures := scanH264(tc.data)
+			if start != tc.wantStart {
+				t.Errorf("group start = %v, want %v", start, tc.wantStart)
+			}
+			if pictures != tc.wantPictures {
+				t.Errorf("pictures = %d, want %d", pictures, tc.wantPictures)
+			}
+		})
+	}
+}
+
+func concat(parts ...[]byte) []byte {
+	var out []byte
+	for _, p := range parts {
+		out = append(out, p...)
+	}
+	return out
+}
+
+// A buffer holding several pictures must be charged for all of them, or the
+// delivered rate overshoots by however many frames share a buffer.
+func TestPacingChargesEveryPictureInABuffer(t *testing.T) {
+	h, clock, cancel := newPacingHub(t)
+	defer cancel()
+
+	id, ch, err := h.subscribe(2) // 2 fps
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer h.unsubscribe(id)
+
+	// Each buffer is a keyframe followed by four inter frames: five pictures,
+	// which at 2 fps costs 2.5 seconds of budget.
+	multi := &videoFrame{
+		data: concat(
+			[]byte{0, 0, 0, 1, 0x67, 0x42}, []byte{0, 0, 0, 1, 0x65, 0x88},
+			[]byte{0, 0, 0, 1, 0x41, 0x9a}, []byte{0, 0, 0, 1, 0x41, 0x9a},
+			[]byte{0, 0, 0, 1, 0x41, 0x9a}, []byte{0, 0, 0, 1, 0x41, 0x9a},
+		),
+		codec: agentpb.VideoCodec_VIDEO_CODEC_H264,
+	}
+
+	var delivered int
+	for i := 0; i < 20; i++ { // 5 seconds, one buffer every 250ms
+		h.broadcast(multi)
+		delivered += len(drain(ch))
+		clock.advance(250 * time.Millisecond)
+	}
+
+	// Five seconds at 2 fps earns ten pictures, i.e. two of these buffers.
+	if delivered != 2 {
+		t.Errorf("delivered %d buffers over 5s at 2 fps, want 2 (10 pictures)", delivered)
+	}
+}
+
+// On a real device an app already holds the camera, so a refused caller needs to
+// be told which values to match rather than merely that something differed.
+func TestMismatchErrorNamesTheConflict(t *testing.T) {
+	svc := newTestVideoService(nil, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	held := &agentpb.StreamVideoRequest{Width: 1280, Height: 720, Framerate: 30}
+	h, id, _, err := svc.getOrCreateHub(ctx, "/dev/video0", held)
+	if err != nil {
+		t.Fatalf("first getOrCreateHub failed: %v", err)
+	}
+	defer h.unsubscribe(id)
+
+	_, _, _, err = svc.getOrCreateHub(ctx, "/dev/video0",
+		&agentpb.StreamVideoRequest{Width: 1280, Height: 720, Framerate: 30, KeyframeIntervalFrames: 1})
+	if err == nil {
+		t.Fatal("expected a mismatch error")
+	}
+	msg := status.Convert(err).Message()
+	for _, want := range []string{"1280x720", "30 fps", "keyframe interval 1", "max_framerate"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q: %s", want, msg)
+		}
 	}
 }

--- a/go/internal/agent/services/video_framerate_test.go
+++ b/go/internal/agent/services/video_framerate_test.go
@@ -1,0 +1,456 @@
+package services
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+// fakeClock drives hub pacing without sleeping, so these tests assert the
+// admission logic itself rather than the scheduler's timing.
+type fakeClock struct{ t time.Time }
+
+func (c *fakeClock) now() time.Time          { return c.t }
+func (c *fakeClock) advance(d time.Duration) { c.t = c.t.Add(d) }
+
+func newPacingHub(t *testing.T) (*deviceHub, *fakeClock, context.CancelFunc) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	clock := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	h := &deviceHub{
+		subs:   make(map[int]*subscriber),
+		ctx:    ctx,
+		cancel: cancel,
+		done:   make(chan struct{}),
+		logger: zap.NewNop(),
+		nowFn:  clock.now,
+	}
+	return h, clock, cancel
+}
+
+// keyframe returns a frame whose bytes begin a keyframe-anchored group: an
+// Annex-B start code followed by an SPS NAL.
+func keyframe() *videoFrame {
+	return &videoFrame{
+		data:  []byte{0x00, 0x00, 0x00, 0x01, 0x67, 0x42, 0x00, 0x1f},
+		codec: agentpb.VideoCodec_VIDEO_CODEC_H264,
+	}
+}
+
+// interFrame returns a frame that depends on an earlier one: a non-IDR slice.
+func interFrame() *videoFrame {
+	return &videoFrame{
+		data:  []byte{0x00, 0x00, 0x00, 0x01, 0x41, 0x9a, 0x00, 0x11},
+		codec: agentpb.VideoCodec_VIDEO_CODEC_H264,
+	}
+}
+
+func drain(ch chan *videoFrame) []*videoFrame {
+	var got []*videoFrame
+	for {
+		select {
+		case f := <-ch:
+			got = append(got, f)
+		default:
+			return got
+		}
+	}
+}
+
+func TestStartsH264Keyframe(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		want bool
+	}{
+		{"4-byte start code + SPS", []byte{0, 0, 0, 1, 0x67}, true},
+		{"3-byte start code + SPS", []byte{0, 0, 1, 0x67}, true},
+		{"IDR slice", []byte{0, 0, 0, 1, 0x65, 0x88}, true},
+		{"non-IDR slice", []byte{0, 0, 0, 1, 0x41, 0x9a}, false},
+		{"PPS only", []byte{0, 0, 0, 1, 0x68, 0xce}, false},
+		// The GStreamer and network-camera paths hand over pipe reads, so a
+		// group can begin partway through a buffer.
+		{"keyframe mid-buffer", []byte{0x41, 0x9a, 0xff, 0, 0, 1, 0x65}, true},
+		{"no start code", []byte{0x41, 0x9a, 0xff, 0x00}, false},
+		{"empty", nil, false},
+		{"truncated start code", []byte{0, 0, 1}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := startsH264Keyframe(tc.data); got != tc.want {
+				t.Errorf("startsH264Keyframe(%x) = %v, want %v", tc.data, got, tc.want)
+			}
+		})
+	}
+}
+
+// The scenario the feature exists for: one subscriber wants everything, one
+// wants a fraction, and neither is rejected or affected by the other.
+func TestPacedAndUnpacedSubscribersCoexist(t *testing.T) {
+	h, clock, cancel := newPacingHub(t)
+	defer cancel()
+
+	idFull, chFull, err := h.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe(0): %v", err)
+	}
+	idSlow, chSlow, err := h.subscribe(2) // 2 fps
+	if err != nil {
+		t.Fatalf("subscribe(2): %v", err)
+	}
+	defer h.unsubscribe(idFull)
+	defer h.unsubscribe(idSlow)
+
+	// Ten seconds of a 30 fps camera keyframed every 15 frames, drained every
+	// tick so what a subscriber misses is pacing and never the channel buffer.
+	const (
+		seconds   = 10
+		fps       = 30
+		gopFrames = 15
+	)
+	var full, slow []*videoFrame
+	for i := 0; i < seconds*fps; i++ {
+		if i%gopFrames == 0 {
+			h.broadcast(keyframe())
+		} else {
+			h.broadcast(interFrame())
+		}
+		full = append(full, drain(chFull)...)
+		slow = append(slow, drain(chSlow)...)
+		clock.advance(time.Second / fps)
+	}
+
+	if len(full) != seconds*fps {
+		t.Errorf("unpaced subscriber got %d frames, want all %d", len(full), seconds*fps)
+	}
+
+	// 2 fps over ten seconds is ~20 frames. Delivery is in whole 15-frame
+	// groups, so the count lands on a group boundary near that budget rather
+	// than exactly on it — one group short or long is the granularity, not an
+	// error. What must hold is that it is nowhere near the 300 it would get
+	// without pacing.
+	if len(slow) < gopFrames || len(slow) > 2*gopFrames {
+		t.Errorf("paced subscriber got %d frames over %ds at 2 fps; want roughly %d",
+			len(slow), seconds, 2*seconds)
+	}
+}
+
+// A paced subscriber that asks for less than the keyframe rate must actually
+// receive less, and must receive whole groups.
+func TestPacingDropsWholeGroups(t *testing.T) {
+	h, clock, cancel := newPacingHub(t)
+	defer cancel()
+
+	id, ch, err := h.subscribe(4) // 4 fps: one 5-frame group buys 1.25s
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer h.unsubscribe(id)
+
+	var got []*videoFrame
+	// Four groups of five frames, one group every 250ms.
+	for g := 0; g < 4; g++ {
+		h.broadcast(keyframe())
+		got = append(got, drain(ch)...)
+		for i := 0; i < 4; i++ {
+			h.broadcast(interFrame())
+			got = append(got, drain(ch)...)
+		}
+		clock.advance(250 * time.Millisecond)
+	}
+
+	if len(got) != 5 {
+		t.Fatalf("got %d frames, want exactly one 5-frame group", len(got))
+	}
+	// Whole groups only: the first frame delivered must be the keyframe, or the
+	// rest cannot be decoded.
+	if !startsH264Keyframe(got[0].data) {
+		t.Error("delivered group does not start with a keyframe")
+	}
+	for _, f := range got[1:] {
+		if startsH264Keyframe(f.data) {
+			t.Error("a second group leaked through")
+		}
+	}
+}
+
+// With every frame a keyframe — what keyframe_interval_frames=1 buys — the rate
+// is honoured exactly rather than rounded to a group.
+func TestAllIntraStreamHonoursRateExactly(t *testing.T) {
+	h, clock, cancel := newPacingHub(t)
+	defer cancel()
+
+	id, ch, err := h.subscribe(2) // 2 fps out of a 30 fps camera
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer h.unsubscribe(id)
+
+	var got []*videoFrame
+	for i := 0; i < 300; i++ { // ten seconds at 30 fps
+		h.broadcast(keyframe())
+		got = append(got, drain(ch)...)
+		clock.advance(time.Second / 30)
+	}
+
+	if len(got) < 19 || len(got) > 21 {
+		t.Errorf("got %d frames over 10s at 2 fps, want ~20", len(got))
+	}
+}
+
+// A subscriber that skipped a long stretch must not be repaid with a burst of
+// everything it missed.
+func TestPacingDoesNotBurstAfterIdle(t *testing.T) {
+	h, clock, cancel := newPacingHub(t)
+	defer cancel()
+
+	id, ch, err := h.subscribe(1)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer h.unsubscribe(id)
+
+	h.broadcast(keyframe())
+	drain(ch)
+
+	// The camera goes quiet for a minute, then resumes at full rate.
+	clock.advance(time.Minute)
+
+	var got []*videoFrame
+	for i := 0; i < 30; i++ {
+		h.broadcast(keyframe())
+		got = append(got, drain(ch)...)
+		clock.advance(time.Second / 30)
+	}
+	// One second of wall clock at 1 fps earns about one frame, not sixty.
+	if len(got) > 2 {
+		t.Errorf("got %d frames in one second at 1 fps after an idle gap, want ~1", len(got))
+	}
+}
+
+// Dropping must never begin mid-group: a subscriber joining between keyframes
+// waits for the next one rather than being sent undecodable frames.
+func TestPacedSubscriberWaitsForFirstKeyframe(t *testing.T) {
+	h, _, cancel := newPacingHub(t)
+	defer cancel()
+
+	id, ch, err := h.subscribe(30)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer h.unsubscribe(id)
+
+	h.broadcast(interFrame())
+	h.broadcast(interFrame())
+	if got := drain(ch); len(got) != 0 {
+		t.Fatalf("paced subscriber received %d frames before any keyframe", len(got))
+	}
+
+	h.broadcast(keyframe())
+	h.broadcast(interFrame())
+	if got := drain(ch); len(got) != 2 {
+		t.Fatalf("got %d frames after the keyframe, want 2", len(got))
+	}
+}
+
+// An unpaced subscriber must be byte-for-byte unaffected, including the frames
+// before the first keyframe that a paced subscriber would skip.
+func TestUnpacedSubscriberUnaffectedByKeyframes(t *testing.T) {
+	h, _, cancel := newPacingHub(t)
+	defer cancel()
+
+	id, ch, err := h.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer h.unsubscribe(id)
+
+	var got []*videoFrame
+	for i := 0; i < 3; i++ {
+		h.broadcast(interFrame())
+		got = append(got, drain(ch)...)
+	}
+	if len(got) != 3 {
+		t.Errorf("unpaced subscriber got %d frames, want 3", len(got))
+	}
+}
+
+// VP8 arrives inside a WebM container, which cannot be cut without corrupting
+// it. A limit on such a stream is ignored rather than honoured destructively.
+func TestPacingIgnoredForNonH264(t *testing.T) {
+	h, clock, cancel := newPacingHub(t)
+	defer cancel()
+
+	id, ch, err := h.subscribe(1)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer h.unsubscribe(id)
+
+	var got []*videoFrame
+	for i := 0; i < 3; i++ {
+		h.broadcast(&videoFrame{data: []byte{0x1a, 0x45, 0xdf, 0xa3}, codec: agentpb.VideoCodec_VIDEO_CODEC_VP8})
+		got = append(got, drain(ch)...)
+		clock.advance(10 * time.Millisecond)
+	}
+	if len(got) != 3 {
+		t.Errorf("VP8 subscriber got %d frames, want all 3", len(got))
+	}
+}
+
+// The hub only inspects frames while someone is paced, so an all-unpaced hub
+// does the work it always did.
+func TestKeyframeScanSkippedWithoutPacedSubscribers(t *testing.T) {
+	h, _, cancel := newPacingHub(t)
+	defer cancel()
+
+	idFull, _, _ := h.subscribe(0)
+	if h.paced != 0 {
+		t.Fatalf("paced = %d after an unlimited subscribe, want 0", h.paced)
+	}
+	idSlow, _, _ := h.subscribe(5)
+	if h.paced != 1 {
+		t.Fatalf("paced = %d after a limited subscribe, want 1", h.paced)
+	}
+	h.unsubscribe(idSlow)
+	if h.paced != 0 {
+		t.Fatalf("paced = %d after the limited subscriber left, want 0", h.paced)
+	}
+	h.unsubscribe(idFull)
+}
+
+func TestEffectiveKeyframeInterval(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *agentpb.StreamVideoRequest
+		want int
+	}{
+		{"unset falls back to half a second", &agentpb.StreamVideoRequest{Framerate: 30}, 15},
+		{"unset with no framerate assumes 30", &agentpb.StreamVideoRequest{}, 15},
+		{"explicit wins over framerate", &agentpb.StreamVideoRequest{Framerate: 30, KeyframeIntervalFrames: 1}, 1},
+		{"explicit above the cap is clamped", &agentpb.StreamVideoRequest{KeyframeIntervalFrames: 100000}, maxKeyframeIntervalFrames},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := effectiveKeyframeInterval(tc.req); got != tc.want {
+				t.Errorf("effectiveKeyframeInterval() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// The whole point of the field: two subscribers of one camera may disagree
+// about their own frame rate, and neither is turned away. Before this, any
+// difference in stream parameters was grounds for rejection, which is why every
+// client sends zeros and nobody can ask for less.
+func TestGetOrCreateHub_AllowsDifferingMaxFramerate(t *testing.T) {
+	svc := newTestVideoService(nil, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	full := &agentpb.StreamVideoRequest{Width: 1280, Height: 720, Framerate: 30}
+	slow := &agentpb.StreamVideoRequest{Width: 1280, Height: 720, Framerate: 30, MaxFramerate: 2}
+
+	h, id, _, err := svc.getOrCreateHub(ctx, "/dev/video0", full)
+	if err != nil {
+		t.Fatalf("first subscriber rejected: %v", err)
+	}
+	defer h.unsubscribe(id)
+
+	h2, id2, _, err := svc.getOrCreateHub(ctx, "/dev/video0", slow)
+	if err != nil {
+		t.Fatalf("second subscriber rejected for asking for a lower rate: %v", err)
+	}
+	defer h2.unsubscribe(id2)
+
+	if h2 != h {
+		t.Fatal("second subscriber did not join the existing hub")
+	}
+	if h.paced != 1 {
+		t.Errorf("hub paced = %d, want 1", h.paced)
+	}
+}
+
+// The keyframe interval reconfigures the shared encoder, so unlike
+// max_framerate it cannot differ between subscribers.
+func TestGetOrCreateHub_RejectsDifferingKeyframeInterval(t *testing.T) {
+	svc := newTestVideoService(nil, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	first := &agentpb.StreamVideoRequest{Width: 1280, Height: 720, Framerate: 30}
+	second := &agentpb.StreamVideoRequest{Width: 1280, Height: 720, Framerate: 30, KeyframeIntervalFrames: 1}
+
+	h, id, _, err := svc.getOrCreateHub(ctx, "/dev/video0", first)
+	if err != nil {
+		t.Fatalf("first getOrCreateHub failed: %v", err)
+	}
+	defer h.unsubscribe(id)
+
+	if _, _, _, err = svc.getOrCreateHub(ctx, "/dev/video0", second); err == nil {
+		t.Fatal("expected a mismatch error for a differing keyframe interval")
+	}
+}
+
+// A requested keyframe interval must reach the encoder, or a paced subscriber
+// cannot get the granularity it was told to ask for.
+func TestBuildGStreamerArgs_HonoursRequestedKeyframeInterval(t *testing.T) {
+	for _, tc := range []struct {
+		encoder string
+		want    string
+	}{
+		{"x264enc", "key-int-max=1"},
+		{"nvv4l2h264enc", "iframeinterval=1"},
+		{"vp8enc", "keyframe-max-dist=1"},
+	} {
+		t.Run(tc.encoder, func(t *testing.T) {
+			req := &agentpb.StreamVideoRequest{Framerate: 30, KeyframeIntervalFrames: 1}
+			args := mustBuildGStreamerArgs(t, "/usr/bin/gst-launch-1.0", "/dev/video0", req, tc.encoder, tc.encoder != "vp8enc")
+			if joined := strings.Join(args, " "); !strings.Contains(joined, tc.want) {
+				t.Errorf("pipeline missing %q: %v", tc.want, args)
+			}
+		})
+	}
+}
+
+// The Argus path on Jetson builds its own pipeline, so it needs its own check
+// that the request is not dropped on the way through.
+func TestBuildArgusGStreamerArgs_HonoursRequestedKeyframeInterval(t *testing.T) {
+	req := &agentpb.StreamVideoRequest{Framerate: 30, KeyframeIntervalFrames: 2}
+	args := buildArgusGStreamerArgs("/usr/bin/gst-launch-1.0", req, 0, "nvv4l2h264enc", true, defaultElements())
+	if joined := strings.Join(args, " "); !strings.Contains(joined, "iframeinterval=2") {
+		t.Errorf("Argus pipeline missing iframeinterval=2: %v", args)
+	}
+}
+
+// A rate high enough that one second divides to nothing must still be accounted
+// for, or the hub keeps scanning for keyframes after every paced subscriber has
+// gone.
+func TestPacedCountSurvivesAbsurdRate(t *testing.T) {
+	h, _, cancel := newPacingHub(t)
+	defer cancel()
+
+	id, ch, err := h.subscribe(4_000_000_000)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	if h.paced != 1 {
+		t.Fatalf("paced = %d, want 1", h.paced)
+	}
+	// Such a subscriber is unlimited in practice: every frame is due.
+	h.broadcast(keyframe())
+	h.broadcast(interFrame())
+	if got := drain(ch); len(got) != 2 {
+		t.Errorf("got %d frames, want 2", len(got))
+	}
+
+	h.unsubscribe(id)
+	if h.paced != 0 {
+		t.Errorf("paced = %d after unsubscribe, want 0", h.paced)
+	}
+}

--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -316,10 +316,42 @@ type videoFrame struct {
 	codec agentpb.VideoCodec
 }
 
+// subscriber is one gRPC stream attached to a hub, plus the pacing state that
+// lets it receive fewer frames than the camera produces.
+//
+// Pacing is per subscriber and never affects the producer: the camera captures
+// and encodes exactly as it would with no limit set, and the frames a limited
+// subscriber skips are still built and still sent to everyone else. What it
+// saves is bytes on that subscriber's connection, which on a metered uplink is
+// the cost worth saving.
+type subscriber struct {
+	ch chan *videoFrame
+	// minInterval is the shortest gap between the starts of two delivered
+	// groups. Zero means unlimited, which is the historical behaviour and the
+	// path every existing client takes.
+	minInterval time.Duration
+	// admitting says whether the group currently in flight is being delivered
+	// to this subscriber. Decided once, when the group starts, and then applied
+	// to every frame until the next group — an H.264 frame is meaningless
+	// without the frames it references, so a group is delivered whole or not at
+	// all.
+	admitting bool
+	// nextDue is when this subscriber has earned its next frame. Every frame
+	// delivered pushes it one interval further out, so a group of fifteen frames
+	// costs fifteen intervals and the *average* delivered rate is what the
+	// caller asked for.
+	//
+	// Charging per frame rather than per group is what makes the limit mean
+	// something: gating on the gap between group starts would hand a subscriber
+	// asking for 2 fps every frame of a 30 fps camera, since a group starts
+	// twice a second at the default keyframe interval.
+	nextDue time.Time
+}
+
 // deviceHub multiplexes one camera producer to multiple gRPC subscribers.
 type deviceHub struct {
 	mu     sync.Mutex
-	subs   map[int]chan *videoFrame
+	subs   map[int]*subscriber
 	nextID int
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -327,10 +359,33 @@ type deviceHub struct {
 	// err is set by runProducer to the terminal error before closing subscriber
 	// channels. Nil on graceful shutdown (context cancelled). Protected by h.mu.
 	err error
-	// width, height, framerate are copied from the request that started this hub.
-	// Storing scalars (not a proto pointer) prevents data races if the caller's
-	// proto message is ever mutated by middleware after the hub is created.
-	width, height, framerate uint32
+	// width, height, framerate and keyframeInterval are copied from the request
+	// that started this hub. Storing scalars (not a proto pointer) prevents data
+	// races if the caller's proto message is ever mutated by middleware after
+	// the hub is created.
+	//
+	// max_framerate is deliberately absent: it configures nothing on the device,
+	// so two subscribers may disagree about it freely.
+	width, height, framerate, keyframeInterval uint32
+	// paced counts subscribers with a rate limit. While it is zero the hub skips
+	// keyframe detection entirely, so a device serving only unlimited
+	// subscribers does exactly the work it did before.
+	paced int
+	// warnedUnpaceable keeps the "cannot pace this codec" warning to once per
+	// hub rather than once per frame.
+	warnedUnpaceable bool
+
+	logger *zap.Logger
+	// now is the clock used for pacing. A seam so tests can advance time without
+	// sleeping; production leaves it nil and gets time.Now.
+	nowFn func() time.Time
+}
+
+func (h *deviceHub) now() time.Time {
+	if h.nowFn != nil {
+		return h.nowFn()
+	}
+	return time.Now()
 }
 
 // maxSubscribersPerHub caps the number of concurrent gRPC streams sharing one
@@ -342,7 +397,7 @@ const maxSubscribersPerHub = 16
 // Returns codes.Unavailable if the hub's context has already been cancelled
 // (checked atomically under h.mu so no subscriber can be added to a dying hub),
 // or codes.ResourceExhausted if the hub already has maxSubscribersPerHub active subscribers.
-func (h *deviceHub) subscribe() (int, chan *videoFrame, error) {
+func (h *deviceHub) subscribe(maxFramerate uint32) (int, chan *videoFrame, error) {
 	ch := make(chan *videoFrame, 4)
 	h.mu.Lock()
 	if h.ctx.Err() != nil {
@@ -355,7 +410,22 @@ func (h *deviceHub) subscribe() (int, chan *videoFrame, error) {
 	}
 	id := h.nextID
 	h.nextID++
-	h.subs[id] = ch
+	sub := &subscriber{ch: ch}
+	if maxFramerate > 0 {
+		// Clamped to a non-zero interval: a rate so high that a second divides
+		// to nothing would otherwise leave minInterval at 0, which reads as
+		// "unlimited" everywhere else and would leak the paced count on
+		// unsubscribe. A 1ns interval is unlimited in practice anyway.
+		sub.minInterval = max(time.Second/time.Duration(maxFramerate), time.Nanosecond)
+		h.paced++
+		// A paced subscriber starts by waiting for a group boundary rather than
+		// joining mid-group. It costs at most one keyframe interval before the
+		// first picture and buys a stream that is decodable from its first byte.
+		sub.admitting = false
+	} else {
+		sub.admitting = true
+	}
+	h.subs[id] = sub
 	h.mu.Unlock()
 	return id, ch, nil
 }
@@ -365,6 +435,9 @@ func (h *deviceHub) subscribe() (int, chan *videoFrame, error) {
 // getOrCreateHub could observe h.ctx.Err()==nil between the delete and the cancel call.
 func (h *deviceHub) unsubscribe(id int) {
 	h.mu.Lock()
+	if sub, ok := h.subs[id]; ok && sub.minInterval > 0 {
+		h.paced--
+	}
 	delete(h.subs, id)
 	if len(h.subs) == 0 {
 		h.cancel()
@@ -407,13 +480,105 @@ func (h *deviceHub) broadcast(frame *videoFrame) bool {
 	if len(h.subs) == 0 {
 		return false
 	}
-	for _, ch := range h.subs {
+
+	// Cutting a stream is only safe where the cut lands on a keyframe, and only
+	// H.264 is inspected for one here. VP8 arrives wrapped in WebM, where the
+	// bytes on the wire are container structure rather than a plain frame
+	// sequence, so a paced subscriber on VP8 is given the whole stream instead
+	// of a corrupt fraction of it.
+	paceable := frame.codec == agentpb.VideoCodec_VIDEO_CODEC_H264
+	groupStart := false
+	if h.paced > 0 && paceable {
+		// Scanning costs a pass over the frame, so it happens only while some
+		// subscriber is actually paced.
+		groupStart = startsH264Keyframe(frame.data)
+	}
+	if h.paced > 0 && !paceable && !h.warnedUnpaceable {
+		h.warnedUnpaceable = true
+		if h.logger != nil {
+			h.logger.Warn("max_framerate ignored: stream is not H.264",
+				zap.String("codec", frame.codec.String()))
+		}
+	}
+
+	// Monotonic, not the frame timestamp: this agent steps its wall clock from
+	// Roughtime, and a backwards step computed from timestamps would stall every
+	// paced subscriber until the clock caught up.
+	now := h.now()
+
+	for _, sub := range h.subs {
+		switch {
+		case sub.minInterval <= 0 || !paceable:
+			// Unlimited subscribers, and any subscriber of a stream that must
+			// not be cut, take every frame — byte for byte the old behaviour.
+			sub.admitting = true
+		case groupStart:
+			sub.admitting = sub.nextDue.IsZero() || !now.Before(sub.nextDue)
+			if sub.admitting && sub.nextDue.Before(now) {
+				// Behind the clock, because the camera stalled or this
+				// subscriber has been skipping for a while. Restart the budget
+				// from now, so catching up cannot deliver a burst of everything
+				// that was skipped.
+				sub.nextDue = now
+			}
+		}
+		if !sub.admitting {
+			continue
+		}
+		if sub.minInterval > 0 && paceable {
+			sub.nextDue = sub.nextDue.Add(sub.minInterval)
+		}
 		select {
-		case ch <- frame:
+		case sub.ch <- frame:
 		default:
 		}
 	}
 	return true
+}
+
+// H.264 Annex-B NAL unit types that mean a decoder can start here: an IDR
+// picture, or the parameter sets that always immediately precede one.
+const (
+	h264NALTypeIDR = 5
+	h264NALTypeSPS = 7
+)
+
+// startsH264Keyframe reports whether an Annex-B byte range contains the start of
+// a keyframe-anchored group.
+//
+// It scans for a start code rather than assuming the buffer begins on a frame
+// boundary, because only the native V4L2 path hands over whole frames: the
+// GStreamer and network-camera paths deliver whatever a pipe read returned, so a
+// group can begin anywhere inside a buffer. Anchoring on the byte pattern works
+// for both, and is the same thing a decoder does to resynchronise.
+func startsH264Keyframe(data []byte) bool {
+	for i := 0; i+3 < len(data); i++ {
+		// Annex-B start code: 00 00 01, optionally preceded by another 00.
+		if data[i] != 0x00 || data[i+1] != 0x00 {
+			continue
+		}
+		var nalIdx int
+		switch {
+		case data[i+2] == 0x01:
+			nalIdx = i + 3
+		case data[i+2] == 0x00 && i+4 < len(data) && data[i+3] == 0x01:
+			nalIdx = i + 4
+		default:
+			continue
+		}
+		if nalIdx >= len(data) {
+			return false
+		}
+		// forbidden_zero_bit must be 0; the low five bits carry the type.
+		if data[nalIdx]&0x80 != 0 {
+			continue
+		}
+		switch data[nalIdx] & 0x1f {
+		case h264NALTypeIDR, h264NALTypeSPS:
+			return true
+		}
+	}
+	return false
 }
 
 // videoSourceKind distinguishes a local V4L2 node from a network camera.
@@ -815,14 +980,20 @@ func (s *VideoService) getOrCreateHub(ctx context.Context, path string, req *age
 			break
 		}
 		if h.ctx.Err() == nil {
-			if h.width != req.GetWidth() || h.height != req.GetHeight() || h.framerate != req.GetFramerate() {
+			// max_framerate is deliberately not compared: it configures nothing
+			// on the camera, so subscribers are free to disagree about it. Every
+			// other field here reconfigures the single shared capture/encode,
+			// which is why a mismatch is still refused.
+			if h.width != req.GetWidth() || h.height != req.GetHeight() || h.framerate != req.GetFramerate() ||
+				h.keyframeInterval != req.GetKeyframeIntervalFrames() {
 				s.mu.Unlock()
 				s.logger.Debug("stream parameter mismatch", zap.String("device", path),
 					zap.Uint32("existing_w", h.width), zap.Uint32("existing_h", h.height),
-					zap.Uint32("existing_fps", h.framerate))
+					zap.Uint32("existing_fps", h.framerate),
+					zap.Uint32("existing_keyint", h.keyframeInterval))
 				return nil, 0, nil, status.Errorf(codes.InvalidArgument, "device already in use with different stream parameters")
 			}
-			id, ch, err = h.subscribe()
+			id, ch, err = h.subscribe(req.GetMaxFramerate())
 			s.mu.Unlock()
 			if err != nil {
 				if st, _ := status.FromError(err); st.Code() == codes.Unavailable {
@@ -879,16 +1050,18 @@ func (s *VideoService) getOrCreateHub(ctx context.Context, path string, req *age
 
 	hctx, cancel := context.WithCancel(s.ctx)
 	h = &deviceHub{
-		subs:      make(map[int]chan *videoFrame),
-		ctx:       hctx,
-		cancel:    cancel,
-		done:      make(chan struct{}),
-		width:     req.GetWidth(),
-		height:    req.GetHeight(),
-		framerate: req.GetFramerate(),
+		subs:             make(map[int]*subscriber),
+		ctx:              hctx,
+		cancel:           cancel,
+		done:             make(chan struct{}),
+		width:            req.GetWidth(),
+		height:           req.GetHeight(),
+		framerate:        req.GetFramerate(),
+		keyframeInterval: req.GetKeyframeIntervalFrames(),
+		logger:           s.logger,
 	}
 	// New hub: the first subscriber is always within the cap.
-	id, ch, _ = h.subscribe()
+	id, ch, _ = h.subscribe(req.GetMaxFramerate())
 	s.hubs[path] = h
 	s.mu.Unlock()
 
@@ -949,8 +1122,8 @@ func (s *VideoService) runProducer(ctx context.Context, h *deviceHub, path strin
 	if err != nil && ctx.Err() == nil {
 		h.err = err
 	}
-	for _, ch := range h.subs {
-		close(ch)
+	for _, sub := range h.subs {
+		close(sub.ch)
 	}
 	h.mu.Unlock()
 
@@ -1288,7 +1461,7 @@ func (s *VideoService) streamV4L2Native(ctx context.Context, broadcast func([]by
 
 	// Best-effort: cap the camera encoder's keyframe interval. Non-fatal — many
 	// UVC cameras reject this and keep their firmware default.
-	s.setV4L2KeyframeInterval(fd, keyframeIntervalFrames(req.GetFramerate()))
+	s.setV4L2KeyframeInterval(fd, effectiveKeyframeInterval(req))
 
 	// Two buffers: one dequeued/in-flight, one queued for the camera to fill.
 	// More buffers increase kernel-side lag when the broadcast lags the camera.
@@ -1799,6 +1972,26 @@ func keyframeIntervalFrames(fps uint32) int {
 	return gop
 }
 
+// maxKeyframeIntervalFrames bounds a caller-supplied keyframe interval. Past a
+// few seconds the interval stops being a tuning knob and becomes a way to make
+// paced subscribers appear broken — and to make every new subscriber wait that
+// long for its first decodable picture.
+const maxKeyframeIntervalFrames = 300
+
+// effectiveKeyframeInterval returns the GOP length to configure the encoder
+// with: what the caller asked for, or half a second's worth of frames when
+// unset. Both encoder paths route through here so a request cannot be honoured
+// on one and silently ignored on the other.
+func effectiveKeyframeInterval(req *agentpb.StreamVideoRequest) int {
+	if n := req.GetKeyframeIntervalFrames(); n > 0 {
+		if n > maxKeyframeIntervalFrames {
+			return maxKeyframeIntervalFrames
+		}
+		return int(n)
+	}
+	return keyframeIntervalFrames(req.GetFramerate())
+}
+
 // leakyRawQueue is a GStreamer queue placed between the V4L2 source and the
 // encoder. The agent reads a continuous encoded byte stream from the encoder, so
 // arbitrary encoded bytes cannot be dropped; instead this queue drops *raw*
@@ -1832,7 +2025,7 @@ func buildGStreamerArgs(gstPath, devicePath string, req *agentpb.StreamVideoRequ
 	// otherwise v4l2src on the device path. libcameraID is validated inside
 	// buildSourceElement, so it is not subject to the devicePath/encoder check above.
 	src := buildSourceElement(devicePath, transport, libcameraID, available)
-	gop := keyframeIntervalFrames(req.GetFramerate())
+	gop := effectiveKeyframeInterval(req)
 
 	// libcamerasrc (CSI/PiSP) must be pinned to a processed format or it
 	// negotiates raw Bayer (e.g. the Raspberry Pi 5 rp1-cfe/PiSP pipeline), which
@@ -2000,7 +2193,7 @@ func buildArgusGStreamerArgs(gstPath string, req *agentpb.StreamVideoRequest, se
 		framerate = argusDefaultFramerate
 	}
 	nvmmCaps := fmt.Sprintf("video/x-raw(memory:NVMM),width=%d,height=%d,framerate=%d/1,format=NV12", width, height, framerate)
-	gop := keyframeIntervalFrames(req.GetFramerate())
+	gop := effectiveKeyframeInterval(req)
 
 	var tail string
 	if encoder == "nvv4l2h264enc" {

--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -388,6 +388,26 @@ func (h *deviceHub) now() time.Time {
 	return time.Now()
 }
 
+// describeStreamParams renders the shared capture/encode settings for an error
+// message. A caller that is refused needs to know which value to match, not
+// merely that something differed: on a device where an app already holds the
+// camera, matching it is the only way in.
+func describeStreamParams(width, height, framerate, keyframeInterval uint32) string {
+	dims := "device default size"
+	if width > 0 || height > 0 {
+		dims = fmt.Sprintf("%dx%d", width, height)
+	}
+	fps := "device default fps"
+	if framerate > 0 {
+		fps = fmt.Sprintf("%d fps", framerate)
+	}
+	keyint := "default keyframe interval"
+	if keyframeInterval > 0 {
+		keyint = fmt.Sprintf("keyframe interval %d", keyframeInterval)
+	}
+	return dims + ", " + fps + ", " + keyint
+}
+
 // maxSubscribersPerHub caps the number of concurrent gRPC streams sharing one
 // camera producer. Exceeding this returns ResourceExhausted to the caller.
 // The cap bounds per-device channel memory and broadcast work proportionally.
@@ -488,10 +508,11 @@ func (h *deviceHub) broadcast(frame *videoFrame) bool {
 	// of a corrupt fraction of it.
 	paceable := frame.codec == agentpb.VideoCodec_VIDEO_CODEC_H264
 	groupStart := false
+	pictures := 1
 	if h.paced > 0 && paceable {
-		// Scanning costs a pass over the frame, so it happens only while some
+		// Scanning costs a pass over the buffer, so it happens only while some
 		// subscriber is actually paced.
-		groupStart = startsH264Keyframe(frame.data)
+		groupStart, pictures = scanH264(frame.data)
 	}
 	if h.paced > 0 && !paceable && !h.warnedUnpaceable {
 		h.warnedUnpaceable = true
@@ -526,7 +547,11 @@ func (h *deviceHub) broadcast(frame *videoFrame) bool {
 			continue
 		}
 		if sub.minInterval > 0 && paceable {
-			sub.nextDue = sub.nextDue.Add(sub.minInterval)
+			// Charge for every picture in the buffer, not for the buffer. Only
+			// the native V4L2 path hands over one frame at a time; a GStreamer
+			// pipe read can carry several, and charging it as one delivered a
+			// measured 6 fps against a 2 fps request on real hardware.
+			sub.nextDue = sub.nextDue.Add(time.Duration(pictures) * sub.minInterval)
 		}
 		select {
 		case sub.ch <- frame:
@@ -536,22 +561,29 @@ func (h *deviceHub) broadcast(frame *videoFrame) bool {
 	return true
 }
 
-// H.264 Annex-B NAL unit types that mean a decoder can start here: an IDR
-// picture, or the parameter sets that always immediately precede one.
+// H.264 Annex-B NAL unit types. IDR and the parameter sets that precede it mark
+// a point a decoder can start from; the VCL types are the coded pictures
+// themselves.
 const (
-	h264NALTypeIDR = 5
-	h264NALTypeSPS = 7
+	h264NALTypeNonIDR = 1
+	h264NALTypeIDR    = 5
+	h264NALTypeSPS    = 7
 )
 
-// startsH264Keyframe reports whether an Annex-B byte range contains the start of
-// a keyframe-anchored group.
+// scanH264 reports whether an Annex-B buffer begins a keyframe-anchored group,
+// and how many coded pictures it contains.
 //
-// It scans for a start code rather than assuming the buffer begins on a frame
+// It scans for start codes rather than assuming the buffer begins on a frame
 // boundary, because only the native V4L2 path hands over whole frames: the
 // GStreamer and network-camera paths deliver whatever a pipe read returned, so a
-// group can begin anywhere inside a buffer. Anchoring on the byte pattern works
-// for both, and is the same thing a decoder does to resynchronise.
-func startsH264Keyframe(data []byte) bool {
+// group can begin anywhere inside a buffer and several pictures can share one.
+// Anchoring on the byte pattern works for both, and is what a decoder does to
+// resynchronise.
+//
+// The picture count is what the rate budget is charged against, so it counts
+// pictures and not slices: a multi-slice encoder emits several VCL NAL units per
+// picture, and only the one whose first_mb_in_slice is zero starts a new one.
+func scanH264(data []byte) (groupStart bool, pictures int) {
 	for i := 0; i+3 < len(data); i++ {
 		// Annex-B start code: 00 00 01, optionally preceded by another 00.
 		if data[i] != 0x00 || data[i+1] != 0x00 {
@@ -567,18 +599,48 @@ func startsH264Keyframe(data []byte) bool {
 			continue
 		}
 		if nalIdx >= len(data) {
-			return false
+			break
 		}
-		// forbidden_zero_bit must be 0; the low five bits carry the type.
-		if data[nalIdx]&0x80 != 0 {
+		header := data[nalIdx]
+		// forbidden_zero_bit must be 0.
+		if header&0x80 != 0 {
 			continue
 		}
-		switch data[nalIdx] & 0x1f {
+		switch nalType := header & 0x1f; nalType {
 		case h264NALTypeIDR, h264NALTypeSPS:
-			return true
+			if nalType == h264NALTypeIDR {
+				if startsNewPicture(data[nalIdx+1:]) {
+					pictures++
+				}
+			}
+			groupStart = true
+		case h264NALTypeNonIDR:
+			if startsNewPicture(data[nalIdx+1:]) {
+				pictures++
+			}
 		}
+		i = nalIdx
 	}
-	return false
+	if pictures == 0 {
+		// Either a parameter-set-only buffer or a slice continuation. Charging
+		// it as one picture keeps a stream the scanner cannot read from being
+		// delivered for free.
+		pictures = 1
+	}
+	return groupStart, pictures
+}
+
+// startsNewPicture reads first_mb_in_slice, the first ue(v) of a slice header,
+// and reports whether it is zero — which is what distinguishes the first slice
+// of a picture from a continuation of the previous one.
+func startsNewPicture(sliceHeader []byte) bool {
+	if len(sliceHeader) == 0 {
+		return false
+	}
+	// ue(v): a run of leading zero bits, then a 1, then that many value bits.
+	// first_mb_in_slice == 0 is encoded as the single bit 1, so only the top bit
+	// has to be read.
+	return sliceHeader[0]&0x80 != 0
 }
 
 // videoSourceKind distinguishes a local V4L2 node from a network camera.
@@ -991,7 +1053,11 @@ func (s *VideoService) getOrCreateHub(ctx context.Context, path string, req *age
 					zap.Uint32("existing_w", h.width), zap.Uint32("existing_h", h.height),
 					zap.Uint32("existing_fps", h.framerate),
 					zap.Uint32("existing_keyint", h.keyframeInterval))
-				return nil, 0, nil, status.Errorf(codes.InvalidArgument, "device already in use with different stream parameters")
+				return nil, 0, nil, status.Errorf(codes.InvalidArgument,
+					"device already in use with different stream parameters "+
+						"(in use: %s; requested: %s) — max_framerate is per subscriber and may differ, these may not",
+					describeStreamParams(h.width, h.height, h.framerate, h.keyframeInterval),
+					describeStreamParams(req.GetWidth(), req.GetHeight(), req.GetFramerate(), req.GetKeyframeIntervalFrames()))
 			}
 			id, ch, err = h.subscribe(req.GetMaxFramerate())
 			s.mu.Unlock()

--- a/go/internal/agent/services/video_service_test.go
+++ b/go/internal/agent/services/video_service_test.go
@@ -692,7 +692,7 @@ func newTestHub(t *testing.T) (*deviceHub, context.CancelFunc) {
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
 	h := &deviceHub{
-		subs:   make(map[int]chan *videoFrame),
+		subs:   make(map[int]*subscriber),
 		ctx:    ctx,
 		cancel: cancel,
 		done:   make(chan struct{}),
@@ -704,8 +704,8 @@ func TestDeviceHub_TwoSubscribersReceiveSameFrame(t *testing.T) {
 	h, cancel := newTestHub(t)
 	defer cancel()
 
-	id1, ch1, _ := h.subscribe()
-	id2, ch2, _ := h.subscribe()
+	id1, ch1, _ := h.subscribe(0)
+	id2, ch2, _ := h.subscribe(0)
 	defer h.unsubscribe(id1)
 	defer h.unsubscribe(id2)
 
@@ -730,8 +730,8 @@ func TestDeviceHub_TwoSubscribersReceiveSameFrame(t *testing.T) {
 func TestDeviceHub_LastUnsubscribeCancelsProducer(t *testing.T) {
 	h, _ := newTestHub(t)
 
-	id1, _, _ := h.subscribe()
-	id2, _, _ := h.subscribe()
+	id1, _, _ := h.subscribe(0)
+	id2, _, _ := h.subscribe(0)
 
 	h.unsubscribe(id1)
 	if h.ctx.Err() != nil {
@@ -748,7 +748,7 @@ func TestDeviceHub_SlowSubscriberDropsFrames(t *testing.T) {
 	h, cancel := newTestHub(t)
 	defer cancel()
 
-	_, ch, _ := h.subscribe()
+	_, ch, _ := h.subscribe(0)
 
 	// Send more frames than the channel buffer (capacity 4).
 	for i := 0; i < 10; i++ {
@@ -768,7 +768,7 @@ func TestDeviceHub_BroadcastReturnsFalseWithNoSubscribers(t *testing.T) {
 	h, cancel := newTestHub(t)
 	defer cancel()
 
-	id, _, _ := h.subscribe()
+	id, _, _ := h.subscribe(0)
 	h.unsubscribe(id)
 
 	if h.broadcast(&videoFrame{data: []byte{1}}) {
@@ -779,14 +779,14 @@ func TestDeviceHub_BroadcastReturnsFalseWithNoSubscribers(t *testing.T) {
 func TestDeviceHub_ProducerErrorPropagated(t *testing.T) {
 	h, _ := newTestHub(t)
 
-	_, ch, _ := h.subscribe()
+	_, ch, _ := h.subscribe(0)
 
 	// Simulate producer recording an error and closing the channel.
 	wantErr := status.Errorf(codes.Internal, "camera read failed: test error")
 	h.mu.Lock()
 	h.err = wantErr
-	for _, c := range h.subs {
-		close(c)
+	for _, sub := range h.subs {
+		close(sub.ch)
 	}
 	h.mu.Unlock()
 

--- a/go/internal/cli/commands/camera.go
+++ b/go/internal/cli/commands/camera.go
@@ -225,7 +225,7 @@ func newCameraWatchCmd() *cobra.Command {
 // "view" is the canonical, listed command; "watch" reuses the same logic as a
 // hidden alias.
 func newCameraStreamCmd(use string, hidden bool) *cobra.Command {
-	var deviceID, width, height, fps uint32
+	var deviceID, width, height, fps, maxFPS, keyframeInterval uint32
 	var toStdout bool
 
 	cmd := &cobra.Command{
@@ -256,10 +256,12 @@ func newCameraStreamCmd(use string, hidden bool) *cobra.Command {
 			}
 
 			req := &agentpb.StreamVideoRequest{
-				DeviceId:  deviceID,
-				Width:     width,
-				Height:    height,
-				Framerate: fps,
+				DeviceId:               deviceID,
+				Width:                  width,
+				Height:                 height,
+				Framerate:              fps,
+				MaxFramerate:           maxFPS,
+				KeyframeIntervalFrames: keyframeInterval,
 			}
 			startStream := func() (videoStream, error) {
 				return conn.VideoService.StreamVideo(ctx, req)
@@ -299,6 +301,8 @@ func newCameraStreamCmd(use string, hidden bool) *cobra.Command {
 	cmd.Flags().Uint32Var(&width, "width", 0, "Frame width (0 = device default)")
 	cmd.Flags().Uint32Var(&height, "height", 0, "Frame height (0 = device default)")
 	cmd.Flags().Uint32Var(&fps, "fps", 0, "Framerate (0 = device default)")
+	cmd.Flags().Uint32Var(&maxFPS, "max-fps", 0, "Cap the frames this viewer receives, leaving other viewers untouched (0 = every frame). Saves uplink bandwidth, not device CPU")
+	cmd.Flags().Uint32Var(&keyframeInterval, "keyframe-interval", 0, "Frames between keyframes for the shared encoder (0 = half a second). Lower values make --max-fps more precise and cost bitrate")
 	cmd.Flags().BoolVar(&toStdout, "stdout", false, "Pipe encoded video to stdout instead of opening a window (codec: H.264 or VP8/WebM depending on device capabilities)")
 
 	return cmd

--- a/go/internal/cli/commands/camera.go
+++ b/go/internal/cli/commands/camera.go
@@ -288,7 +288,14 @@ func newCameraStreamCmd(use string, hidden bool) *cobra.Command {
 			}
 			diagnosticStream := &cameraDiagnosticStream{videoStream: stream}
 
-			cliLogln("Streaming video (Ctrl+C to stop)...")
+			// In --stdout mode stdout carries the encoded video, so progress
+			// text belongs on stderr: a viewer reading the pipe would otherwise
+			// have to resynchronise past this line before its first frame.
+			if toStdout {
+				cliNotice("Streaming video (Ctrl+C to stop)...")
+			} else {
+				cliLogln("Streaming video (Ctrl+C to stop)...")
+			}
 
 			if toStdout {
 				return pipeVideoToStdout(diagnosticStream, cmd.OutOrStdout())

--- a/go/proto/gen/agentpb/wendy_agent_v1_video_service.pb.go
+++ b/go/proto/gen/agentpb/wendy_agent_v1_video_service.pb.go
@@ -329,11 +329,37 @@ type StreamVideoRequest struct {
 	// For local cameras width/height/framerate configure capture. For network
 	// cameras the camera decides its own format, so width only selects which of
 	// its streams to open (sub or main) and height/framerate are ignored.
-	Width         uint32 `protobuf:"varint,2,opt,name=width,proto3" json:"width,omitempty"`         // pixels; 0 = device default
-	Height        uint32 `protobuf:"varint,3,opt,name=height,proto3" json:"height,omitempty"`       // pixels; 0 = device default
-	Framerate     uint32 `protobuf:"varint,4,opt,name=framerate,proto3" json:"framerate,omitempty"` // fps; 0 = device default
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Width     uint32 `protobuf:"varint,2,opt,name=width,proto3" json:"width,omitempty"`         // pixels; 0 = device default
+	Height    uint32 `protobuf:"varint,3,opt,name=height,proto3" json:"height,omitempty"`       // pixels; 0 = device default
+	Framerate uint32 `protobuf:"varint,4,opt,name=framerate,proto3" json:"framerate,omitempty"` // fps; 0 = device default
+	// Upper bound on how many frames per second THIS subscriber receives; 0 =
+	// every frame (the historical behaviour). Unlike width/height/framerate this
+	// is a property of one connection, not of the camera: subscribers sharing a
+	// camera may each set a different value, and none of them is rejected for
+	// disagreeing. Nothing about capture or encoding changes — the same frames
+	// are produced either way — so this saves uplink bytes, not device CPU.
+	//
+	// Delivery is anchored to keyframes, because an H.264 frame is only
+	// decodable with the frames it depends on. A limited subscriber therefore
+	// receives whole keyframe-to-keyframe groups, and its effective rate is
+	// rounded to that granularity: with the default keyframe interval of half a
+	// second, asking for 1 fps yields one group per second, not one frame. Set
+	// keyframe_interval_frames to make the granularity finer.
+	//
+	// Only applies to H.264. A VP8 stream is delivered whole regardless, because
+	// its frames are wrapped in a WebM container that cannot be cut mid-stream.
+	MaxFramerate uint32 `protobuf:"varint,5,opt,name=max_framerate,json=maxFramerate,proto3" json:"max_framerate,omitempty"`
+	// Frames between keyframes for the shared encoder; 0 = half a second's worth
+	// (framerate/2). Unlike max_framerate this reconfigures the encoder everyone
+	// shares, so it takes part in the stream-parameter compatibility check.
+	//
+	// It exists because it sets the floor on how finely max_framerate can be
+	// honoured, and how quickly a new subscriber gets a decodable picture. Short
+	// intervals cost bitrate (keyframes are large); 1 makes every frame
+	// independent and every rate exactly achievable, at the highest byte cost.
+	KeyframeIntervalFrames uint32 `protobuf:"varint,6,opt,name=keyframe_interval_frames,json=keyframeIntervalFrames,proto3" json:"keyframe_interval_frames,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *StreamVideoRequest) Reset() {
@@ -390,6 +416,20 @@ func (x *StreamVideoRequest) GetHeight() uint32 {
 func (x *StreamVideoRequest) GetFramerate() uint32 {
 	if x != nil {
 		return x.Framerate
+	}
+	return 0
+}
+
+func (x *StreamVideoRequest) GetMaxFramerate() uint32 {
+	if x != nil {
+		return x.MaxFramerate
+	}
+	return 0
+}
+
+func (x *StreamVideoRequest) GetKeyframeIntervalFrames() uint32 {
+	if x != nil {
+		return x.KeyframeIntervalFrames
 	}
 	return 0
 }
@@ -732,12 +772,14 @@ const file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDesc = 
 	"\x06online\x18\v \x01(\bR\x06online\"\x19\n" +
 	"\x17ListVideoDevicesRequest\"Z\n" +
 	"\x18ListVideoDevicesResponse\x12>\n" +
-	"\adevices\x18\x01 \x03(\v2$.wendy.agent.services.v1.VideoDeviceR\adevices\"}\n" +
+	"\adevices\x18\x01 \x03(\v2$.wendy.agent.services.v1.VideoDeviceR\adevices\"\xdc\x01\n" +
 	"\x12StreamVideoRequest\x12\x1b\n" +
 	"\tdevice_id\x18\x01 \x01(\rR\bdeviceId\x12\x14\n" +
 	"\x05width\x18\x02 \x01(\rR\x05width\x12\x16\n" +
 	"\x06height\x18\x03 \x01(\rR\x06height\x12\x1c\n" +
-	"\tframerate\x18\x04 \x01(\rR\tframerate\"r\n" +
+	"\tframerate\x18\x04 \x01(\rR\tframerate\x12#\n" +
+	"\rmax_framerate\x18\x05 \x01(\rR\fmaxFramerate\x128\n" +
+	"\x18keyframe_interval_frames\x18\x06 \x01(\rR\x16keyframeIntervalFrames\"r\n" +
 	"\x1bSetCameraCredentialsRequest\x12\x1b\n" +
 	"\tdevice_id\x18\x01 \x01(\rR\bdeviceId\x12\x1a\n" +
 	"\busername\x18\x02 \x01(\tR\busername\x12\x1a\n" +


### PR DESCRIPTION
## Why

One camera = one hub = one capture and one encode, and everyone gets the identical stream. A subscriber asking for different parameters isn't downgraded, it's **rejected** with `InvalidArgument: device already in use with different stream parameters`. That's why every client — iOS app, CLI, wendy-console's relay — sends zeros: matching whoever got there first is the only way to be sure of getting a stream.

So nobody can ask for less. wendy-console measured a camera on this path at **130–250 KiB/s** device→cloud, against **~13 KiB/s** for the same camera as scaled MJPEG from edge-detector. On LTE sites that gap is the largest running cost the product controls, and it couldn't be reduced because asking for a smaller stream would have locked out detection and the phone.

## What this adds

`max_framerate` on `StreamVideoRequest` — a property of **one connection**, not of the camera:

- It takes **no part** in the parameter-compatibility check. Two subscribers may disagree and neither is rejected. (`TestGetOrCreateHub_AllowsDifferingMaxFramerate`.)
- Unset = every frame, so existing clients are bit-for-bit unaffected, and the hub skips keyframe scanning entirely while nobody is paced.
- Capture and encode are untouched. The same frames are produced; a paced subscriber just receives fewer. **This saves uplink bytes, not device CPU** — the right trade for a metered link, and the reason it's nearly free.

Plus `keyframe_interval_frames`, and `--max-fps` / `--keyframe-interval` on `wendy device camera view` so the two-subscriber case can be run by hand.

## The bit that decides whether this works

An H.264 frame is undecodable without the frames it references, so a group is delivered **whole or not at all**, anchored on keyframes.

**The budget is charged per delivered frame, not per group.** I had it per group first, and it was wrong in a way that looked right: at the default keyframe interval a group starts twice a second, so a request for 2 fps was served *every frame* of a 30 fps camera. A test that asserted the delivered rate caught it; one asserting "paced ≤ unpaced" would not have.

Consequence worth knowing before anyone files a bug: with the default half-second keyframe interval, a limited subscriber receives **whole 15-frame groups spaced out to hit the average**. Ask for 2 fps on a 30 fps camera and you get roughly one group every 7.5s — 2 fps on average, arriving in bursts. That is the granularity, and it is why `keyframe_interval_frames` exists: set it to 1 and every frame is independent, so the rate is exact and smooth (`TestAllIntraStreamHonoursRateExactly`), at the bitrate cost of an all-keyframe stream. It's checked into the proto comments so callers meet it in the API rather than in production.

Other decisions:

- **Keyframes are found by scanning for an Annex-B start code**, not by assuming the buffer starts on a frame boundary. Only the native V4L2 path hands over whole frames; GStreamer and network cameras deliver whatever a pipe read returned, so a group can begin anywhere inside a buffer. This is what a decoder does to resynchronise.
- **VP8 is left alone.** Its frames arrive inside a WebM container that cannot be cut mid-stream, so a limit on a VP8 stream is ignored and logged once rather than honoured destructively.
- **`keyframe_interval_frames` does take part** in the compatibility check — it reconfigures the encoder everyone shares. Clamped at 300 frames, past which it stops being a tuning knob and just makes paced subscribers look broken.
- **No burst repayment**: a subscriber that skipped a long stretch restarts its budget from now rather than being repaid everything it missed.
- Both GStreamer encoder paths and the Argus pipeline route through one `effectiveKeyframeInterval` helper, so a request can't be honoured on one and silently dropped on another.

## Not built, on purpose

Per-subscriber resolution and bitrate. Those need a second encode on the Jetson — a much larger piece of work, and conflating it with this would be a reason to reject the whole thing. Per-subscriber frame count is nearly free precisely because the frame already exists.

## Testing

25 tests: keyframe detection and picture counting (multi-slice pictures, several frames per buffer, malformed start codes), the two-subscriber scenario, whole-group delivery, exact rate on an all-intra stream, no-burst-after-idle, paced subscriber waiting for its first keyframe, VP8 passthrough, paced-count accounting, the compatibility-check contract both ways, the mismatch error naming the conflict, and the keyframe interval reaching all three encoder paths. Pacing uses an injected clock, so assertions are on admission logic rather than on sleeps.

`go test ./...`, `-race` on the services package, `go vet`, `gofmt -s`, and the Windows cross-compile gate all clean.

## Verified on hardware — and it caught a bug the unit tests could not

Side-loaded onto **ccr1** (Jetson Orin Nano, two USB cameras, `wendy-console-edge-detector` holding both), streaming over the cloud tunnel, measured with `ffprobe`/`ffmpeg`:

| subscriber | KiB/s | fps | decode errors |
|---|---|---|---|
| unpaced, alone (baseline) | 266.9 | 26.4 | 15 (at start) |
| unpaced, sharing with a paced peer | 214.4 | 22.3 | 6 (at start) |
| `--max-fps 2`, sharing camera 0 | **20.1** | **2.0** | **0** |
| `--max-fps 2`, camera 2 | 20.8 | 2.5 | 0 |

**~10× fewer bytes** for the paced subscriber, the unpaced one unaffected, and the detector stayed `RUNNING` throughout. The baseline lands squarely in the 130–250 KiB/s wendy-console measured, and 20 KiB/s is close to the ~13 KiB/s scaled-MJPEG figure that motivated the request.

The unpaced streams' decode errors are `non-existing PPS 0 referenced` at the very start — the documented mid-GOP join for late subscribers, pre-existing. The paced streams have **zero**, because a paced subscriber waits for a keyframe before its first byte. That was a design intention; the numbers confirm it.

**The bug:** the first hardware run gave **6 fps for a 2 fps request** on camera 2. The budget was charged once per delivered *buffer*, and only the native V4L2 path hands over one frame per buffer — a GStreamer pipe read carries several. Now the scanner counts coded pictures (reading `first_mb_in_slice`, so a multi-slice picture counts once) and charges for all of them. No unit test would have found this: it needs a producer that packs frames the way a real pipe read does.

## One finding worth a decision

**`keyframe_interval_frames` is unusable on a device where an app already holds the camera** — which is the normal state on these boxes. Both ccr1 cameras are held by edge-detector with the default interval, so any request for a different one is refused by the compatibility check. That is correct by design (it reconfigures the shared encoder), but it means the "make the rate exact" escape hatch is unavailable exactly where low bitrate matters most.

So the error message now names the values in use, the values requested, and the fact that `max_framerate` is exempt — instead of leaving a caller to guess which of four fields differed.

If per-subscriber exactness turns out to matter more than that, the options are: let the shortest requested interval win at hub creation, or restart the encoder when a subscriber asks for a shorter one (disruptive to existing subscribers). Both are follow-ups, not this PR.

Also fixed in passing: `camera view --stdout` printed `Streaming video...` onto stdout, into the encoded stream a viewer pipes. Now on stderr. `Connecting via cloud tunnel...` from the cloud path still does the same thing — same bug, wider blast radius, left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
