### PR TITLE
fix(agent): diagnose PMTU black holes in the broker reconnect loop

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wendylabsinc/wendy
 
-go 1.26.5
+go 1.26.6
 
 require (
 	cuelabs.dev/go/oci/ociregistry v0.0.0-20251212221603-3adeb8663819

--- a/go/internal/agent/services/mesh_dialer.go
+++ b/go/internal/agent/services/mesh_dialer.go
@@ -299,7 +299,7 @@ func (d *MeshDialer) meshDialLAN(ctx context.Context, hostport string, deviceID 
 // opening the tunnel; once established the stream survives past ctx.
 func (d *MeshDialer) meshDialBroker(ctx context.Context, deviceID int32, port uint16) (net.Conn, error) {
 	ident := d.identity()
-	opts, md, err := brokerDialOpts(d.logger, ident.orgID, ident.assetID, ident.certPEM, ident.keyPEM, ident.chainPEM)
+	opts, md, err := brokerDialOpts(d.logger, ident.orgID, ident.assetID, ident.certPEM, ident.keyPEM, ident.chainPEM, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/go/internal/agent/services/mesh_roster.go
+++ b/go/internal/agent/services/mesh_roster.go
@@ -122,7 +122,7 @@ func (r *MeshRoster) Sync(ctx context.Context) error {
 		return nil
 	}
 
-	dialOpts, md, err := brokerDialOpts(r.logger, orgID, assetID, certPEM, keyPEM, chainPEM)
+	dialOpts, md, err := brokerDialOpts(r.logger, orgID, assetID, certPEM, keyPEM, chainPEM, nil)
 	if err != nil {
 		return err
 	}

--- a/go/internal/agent/services/tunnel_broker_client.go
+++ b/go/internal/agent/services/tunnel_broker_client.go
@@ -8,10 +8,13 @@ import (
 	"io"
 	"math"
 	"net"
+	"strings"
+	"sync"
 	"time"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
@@ -40,6 +43,11 @@ type TunnelBrokerClient struct {
 	keyPEM   string
 	chainPEM string
 	mtlsPort int
+
+	dialObs *dialObserver
+	// pmtuSuspectCount tracks consecutive connection failures that look like a
+	// path-MTU black hole. Only touched from the Run goroutine.
+	pmtuSuspectCount int
 }
 
 func NewTunnelBrokerClient(logger *zap.Logger, url string, orgID, assetID int32, certPEM, keyPEM, chainPEM string, mtlsPort int) *TunnelBrokerClient {
@@ -52,6 +60,85 @@ func NewTunnelBrokerClient(logger *zap.Logger, url string, orgID, assetID int32,
 		keyPEM:   keyPEM,
 		chainPEM: chainPEM,
 		mtlsPort: mtlsPort,
+		dialObs:  &dialObserver{},
+	}
+}
+
+// dialObserver records whether the current connection attempt reached the
+// broker at TCP level, so a failed RPC can be told apart from a generically
+// unreachable broker: TCP connecting while the TLS handshake never completes
+// is the signature of a path-MTU black hole (carrier LTE/CGNAT links that
+// silently drop full-size packets, WDY-2443).
+type dialObserver struct {
+	mu           sync.Mutex
+	tcpConnected bool
+}
+
+func (o *dialObserver) DialContext(ctx context.Context, addr string) (net.Conn, error) {
+	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", addr)
+	if err == nil {
+		o.markConnected()
+	}
+	return conn, err
+}
+
+func (o *dialObserver) markConnected() {
+	o.mu.Lock()
+	o.tcpConnected = true
+	o.mu.Unlock()
+}
+
+func (o *dialObserver) Reset() {
+	o.mu.Lock()
+	o.tcpConnected = false
+	o.mu.Unlock()
+}
+
+func (o *dialObserver) TCPConnected() bool {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.tcpConnected
+}
+
+// isSuspectedPMTUBlackhole reports whether a broker connection failure looks
+// like a path-MTU black hole: TCP connected, but the TLS handshake died
+// without a TLS alert (EOF, timeout, reset). A genuine certificate rejection
+// carries a TLS alert marker and is excluded, mirroring the CLI-side
+// classification in cmd/wendy/main.go.
+func isSuspectedPMTUBlackhole(err error, tcpConnected bool) bool {
+	if err == nil || !tcpConnected {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "tls:") ||
+		strings.Contains(msg, "bad certificate") ||
+		strings.Contains(msg, "certificate required") {
+		return false
+	}
+	if !strings.Contains(msg, "authentication handshake failed") {
+		return false
+	}
+	return strings.Contains(msg, "eof") ||
+		strings.Contains(msg, "deadline exceeded") ||
+		strings.Contains(msg, "i/o timeout") ||
+		strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "broken pipe")
+}
+
+// notePMTUSuspicion classifies a runOnce failure and, on the second
+// consecutive suspected black hole, emits a single diagnostic pointing at the
+// path MTU. Without this, a black-holed uplink is indistinguishable from an
+// offline broker in the logs and has cost multi-hour field investigations.
+func (c *TunnelBrokerClient) notePMTUSuspicion(err error) {
+	if !isSuspectedPMTUBlackhole(err, c.dialObs.TCPConnected()) {
+		c.pmtuSuspectCount = 0
+		return
+	}
+	c.pmtuSuspectCount++
+	if c.pmtuSuspectCount == 2 {
+		c.logger.Warn("suspected PMTU black hole: TCP connects to the broker but the TLS handshake never completes; check the uplink path MTU (WDY-2443)",
+			zap.String("event", "broker_suspected_pmtu_blackhole"),
+			zap.String("url", c.url))
 	}
 }
 
@@ -68,6 +155,7 @@ func (c *TunnelBrokerClient) Run(ctx context.Context) {
 			))
 			c.logger.Warn("broker connection failed, reconnecting",
 				zap.Error(err), zap.Duration("backoff", backoff))
+			c.notePMTUSuspicion(err)
 			select {
 			case <-time.After(backoff):
 			case <-ctx.Done():
@@ -76,11 +164,13 @@ func (c *TunnelBrokerClient) Run(ctx context.Context) {
 			attempt++
 		} else {
 			attempt = 0
+			c.pmtuSuspectCount = 0
 		}
 	}
 }
 
 func (c *TunnelBrokerClient) runOnce(ctx context.Context) error {
+	c.dialObs.Reset()
 	dialOpts, devMD, err := c.buildDialOpts()
 	if err != nil {
 		return err
@@ -149,7 +239,7 @@ func (c *TunnelBrokerClient) runOnce(ctx context.Context) error {
 }
 
 func (c *TunnelBrokerClient) buildDialOpts() ([]grpc.DialOption, metadata.MD, error) {
-	return brokerDialOpts(c.logger, c.orgID, c.assetID, c.certPEM, c.keyPEM, c.chainPEM)
+	return brokerDialOpts(c.logger, c.orgID, c.assetID, c.certPEM, c.keyPEM, c.chainPEM, c.dialObs)
 }
 
 // brokerDialOpts returns gRPC dial options and identity metadata for any
@@ -217,7 +307,9 @@ func brokerTLSConfig(logger *zap.Logger, certPEM, keyPEM, chainPEM string) (*tls
 
 // agent-originated connection to the tunnel broker. Shared by the presence
 // client (serving side) and the mesh dialer (dialing side).
-func brokerDialOpts(logger *zap.Logger, orgID, assetID int32, certPEM, keyPEM, chainPEM string) ([]grpc.DialOption, metadata.MD, error) {
+// obs may be nil; when set, it observes raw TCP dials so connection failures
+// can be classified as suspected PMTU black holes (see dialObserver).
+func brokerDialOpts(logger *zap.Logger, orgID, assetID int32, certPEM, keyPEM, chainPEM string, obs *dialObserver) ([]grpc.DialOption, metadata.MD, error) {
 	// Identity is asserted two ways during the mTLS rollout:
 	//
 	//   1. The device's client certificate (mTLS). We present the ECDSA leaf +
@@ -243,18 +335,29 @@ func brokerDialOpts(logger *zap.Logger, orgID, assetID int32, certPEM, keyPEM, c
 		"x-wendy-client-cert", certHeader,
 		"x-forwarded-client-cert", certHeader,
 	)
-	return []grpc.DialOption{
+	dialOpts := []grpc.DialOption{
 		grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg)),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
 			Time:                brokerKeepaliveTime,
 			Timeout:             brokerKeepaliveTimeout,
 			PermitWithoutStream: true,
 		}),
+		// Codify the default 20s connect bound so a TLS handshake stalled by a
+		// PMTU black hole (WDY-2443) surfaces as an error deterministically
+		// instead of depending on gRPC's internal default.
+		grpc.WithConnectParams(grpc.ConnectParams{
+			Backoff:           backoff.DefaultConfig,
+			MinConnectTimeout: 20 * time.Second,
+		}),
 		grpc.WithInitialWindowSize(8 * 1024 * 1024),
 		grpc.WithInitialConnWindowSize(16 * 1024 * 1024),
 		grpc.WithReadBufferSize(256 * 1024),
 		grpc.WithWriteBufferSize(256 * 1024),
-	}, md, nil
+	}
+	if obs != nil {
+		dialOpts = append(dialOpts, grpc.WithContextDialer(obs.DialContext))
+	}
+	return dialOpts, md, nil
 }
 
 func (c *TunnelBrokerClient) handleDialRequest(ctx context.Context, client cloudpb.TunnelBrokerServiceClient,

--- a/go/internal/agent/services/tunnel_broker_pmtu_test.go
+++ b/go/internal/agent/services/tunnel_broker_pmtu_test.go
@@ -1,0 +1,138 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestIsSuspectedPMTUBlackhole(t *testing.T) {
+	handshakeEOF := errors.New(`rpc error: code = Unavailable desc = connection error: desc = "transport: authentication handshake failed: EOF"`)
+	handshakeDeadline := errors.New(`rpc error: code = Unavailable desc = connection error: desc = "transport: authentication handshake failed: context deadline exceeded"`)
+	certRejection := errors.New(`rpc error: code = Unavailable desc = connection error: desc = "transport: authentication handshake failed: remote error: tls: bad certificate"`)
+	connRefused := errors.New(`rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 1.2.3.4:50052: connect: connection refused"`)
+
+	cases := []struct {
+		name         string
+		err          error
+		tcpConnected bool
+		want         bool
+	}{
+		{"handshake EOF after TCP connect", handshakeEOF, true, true},
+		{"handshake deadline after TCP connect", handshakeDeadline, true, true},
+		{"handshake EOF without TCP connect", handshakeEOF, false, false},
+		{"cert rejection is not a black hole", certRejection, true, false},
+		{"connection refused is not a black hole", connRefused, true, false},
+		{"nil error", nil, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSuspectedPMTUBlackhole(tc.err, tc.tcpConnected); got != tc.want {
+				t.Fatalf("isSuspectedPMTUBlackhole(%v, %v) = %v, want %v", tc.err, tc.tcpConnected, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDialObserverRecordsTCPConnect(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}
+	}()
+
+	obs := &dialObserver{}
+	if obs.TCPConnected() {
+		t.Fatal("fresh observer reports TCPConnected")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	conn, err := obs.DialContext(ctx, ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial to local listener failed: %v", err)
+	}
+	conn.Close()
+	if !obs.TCPConnected() {
+		t.Fatal("observer did not record successful TCP connect")
+	}
+
+	obs.Reset()
+	if obs.TCPConnected() {
+		t.Fatal("Reset did not clear TCPConnected")
+	}
+
+	// A failed dial must not set the flag.
+	ln.Close()
+	if _, err := obs.DialContext(ctx, ln.Addr().String()); err == nil {
+		t.Fatal("expected dial to closed listener to fail")
+	}
+	if obs.TCPConnected() {
+		t.Fatal("failed dial recorded TCPConnected")
+	}
+}
+
+func TestNotePMTUSuspicionLogsOnceAfterTwoConsecutiveFailures(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	c := NewTunnelBrokerClient(zap.New(core), "broker.example:50052", 1, 2, "", "", "", 0)
+
+	handshakeEOF := errors.New(`rpc error: code = Unavailable desc = connection error: desc = "transport: authentication handshake failed: EOF"`)
+	pmtuLogs := func() int {
+		n := 0
+		for _, entry := range logs.All() {
+			for _, f := range entry.Context {
+				if f.Key == "event" && f.String == "broker_suspected_pmtu_blackhole" {
+					n++
+				}
+			}
+		}
+		return n
+	}
+
+	c.dialObs.markConnected()
+	c.notePMTUSuspicion(handshakeEOF)
+	if got := pmtuLogs(); got != 0 {
+		t.Fatalf("logged after a single failure: %d entries", got)
+	}
+
+	c.dialObs.markConnected()
+	c.notePMTUSuspicion(handshakeEOF)
+	if got := pmtuLogs(); got != 1 {
+		t.Fatalf("expected exactly one PMTU log after two consecutive failures, got %d", got)
+	}
+
+	// Further consecutive failures do not spam the log.
+	c.dialObs.markConnected()
+	c.notePMTUSuspicion(handshakeEOF)
+	if got := pmtuLogs(); got != 1 {
+		t.Fatalf("expected no additional PMTU logs on later failures, got %d", got)
+	}
+
+	// A non-black-hole failure resets the streak, so it takes two more
+	// classified failures before the next log.
+	c.notePMTUSuspicion(errors.New("connection refused"))
+	c.dialObs.markConnected()
+	c.notePMTUSuspicion(handshakeEOF)
+	if got := pmtuLogs(); got != 1 {
+		t.Fatalf("streak did not reset on unrelated failure, got %d logs", got)
+	}
+	c.dialObs.markConnected()
+	c.notePMTUSuspicion(handshakeEOF)
+	if got := pmtuLogs(); got != 2 {
+		t.Fatalf("expected second PMTU log after new streak of two, got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary

Part of [WDY-2443](https://linear.app/wendylabsinc/issue/WDY-2443). On carrier LTE/CGNAT uplinks the agent's TLS handshakes are silently black-holed (path MTU < 1500 + dropped ICMP frag-needed), and the resulting `authentication handshake failed: EOF` retry loop is indistinguishable in the logs from an offline broker. That ambiguity cost a multi-hour field investigation on Enmax1. The OS-side fix ships in WendyOS-Builder (wendylabsinc/WendyOS-Builder#234); this PR makes the failure mode self-identifying in the agent logs.

## Changes (`go/internal/agent/services/tunnel_broker_client.go`)

- **`dialObserver`** wired via `grpc.WithContextDialer` on the broker dial path records whether the raw TCP connect succeeded for the current attempt.
- **`isSuspectedPMTUBlackhole`** classifies failures where TCP connected but the TLS handshake died without a TLS alert (EOF / deadline / reset / broken pipe), mirroring the CLI-side handshake-drop classifier in `cmd/wendy/main.go`. Genuine certificate rejections (`tls:` alerts) are excluded.
- On the **second consecutive** suspected failure, `Run` logs a single Warn — `suspected PMTU black hole: TCP connects to the broker but the TLS handshake never completes; check the uplink path MTU (WDY-2443)` — with a stable `event=broker_suspected_pmtu_blackhole` key. The streak resets on success or on any differently-classified failure, so it cannot spam.
- `brokerDialOpts` now codifies the 20s `MinConnectTimeout` explicitly so a stalled handshake surfaces deterministically instead of relying on gRPC's internal default. `mesh_roster`/`mesh_dialer` pass a nil observer and are behaviorally unchanged.

Deliberately **not** included: `//go:debug tlsmlkem=0`. Disabling post-quantum key exchange fleet-wide is not the fix; `GODEBUG=tlsmlkem=0` remains available as a manual diagnostic via the optional `/etc/default/wendy-agent`.

## Testing

- New `tunnel_broker_pmtu_test.go` (written test-first): classifier table (EOF/deadline/cert-rejection/refused/no-TCP cases), dialObserver connect/reset/failed-dial behavior, and log-once-after-two-consecutive-failures semantics via a zap observer core.
- `go build ./...` and the full `internal/agent/services` package pass; `gofmt`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3p7ZahwwuHxZa5Q354r4G