### PR TITLE
Smoke test Stagefile inheritance in release binaries

### DIFF
--- a/.github/scripts/stagefile-release-smoke_test.sh
+++ b/.github/scripts/stagefile-release-smoke_test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 /absolute/path/to/wendy" >&2
+  exit 2
+fi
+
+wendy_binary="$1"
+if [[ ! -x "$wendy_binary" ]]; then
+  echo "wendy binary is not executable: $wendy_binary" >&2
+  exit 2
+fi
+
+case "$wendy_binary" in
+  /*) ;;
+  *) wendy_binary="$(cd "$(dirname "$wendy_binary")" && pwd)/$(basename "$wendy_binary")" ;;
+esac
+
+fixture_dir="$(mktemp -d)"
+trap 'rm -rf "$fixture_dir"' EXIT
+
+mkdir -p "$fixture_dir/bin"
+
+cat >"$fixture_dir/build.stagefile.yaml" <<'YAML'
+version: 1
+stages:
+  - name: native
+    from: busybox:1.37
+    pin: false
+  - name: app
+    from: native
+YAML
+
+# The smoke test only needs the packaged CLI to reach the image-builder
+# boundary. A fake Docker executable keeps the check fast and proves Stagefile
+# compilation completed without contacting a registry for the local `native`
+# stage.
+cat >"$fixture_dir/bin/docker" <<'SH'
+#!/usr/bin/env sh
+: >"${WENDY_SMOKE_DOCKER_CALLED:?}"
+exit 37
+SH
+chmod +x "$fixture_dir/bin/docker"
+
+docker_called="$fixture_dir/docker-called"
+build_output="$fixture_dir/build-output.txt"
+(
+  cd "$fixture_dir"
+  PATH="$fixture_dir/bin:$PATH" \
+    WENDY_SMOKE_DOCKER_CALLED="$docker_called" \
+    "$wendy_binary" build --builder docker --dockerfile build.stagefile.yaml \
+    >"$build_output" 2>&1 || true
+)
+
+if [[ ! -f "$docker_called" ]]; then
+  echo "packaged CLI did not reach Docker after compiling the Stagefile" >&2
+  cat "$build_output" >&2
+  exit 1
+fi
+
+generated="$fixture_dir/Dockerfile.generated"
+if [[ ! -f "$generated" ]]; then
+  echo "packaged CLI did not generate Dockerfile.generated" >&2
+  cat "$build_output" >&2
+  exit 1
+fi
+
+if ! grep -Eq '^FROM( --platform=[^ ]+)? native AS app$' "$generated"; then
+  echo "prior Stagefile stage was not preserved as the local base" >&2
+  cat "$generated" >&2
+  exit 1
+fi
+
+if grep -Eq '^FROM( --platform=[^ ]+)? native@' "$generated"; then
+  echo "prior Stagefile stage was incorrectly pinned as an external image" >&2
+  cat "$generated" >&2
+  exit 1
+fi
+
+echo "packaged Stagefile inheritance smoke test passed"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -243,6 +243,7 @@ jobs:
             exit 1
           fi
           "./${ARTIFACT}/wendy" --version
+          .github/scripts/stagefile-release-smoke_test.sh "./${ARTIFACT}/wendy"
 
       - name: Create archive
         run: |
@@ -304,6 +305,9 @@ jobs:
           go/scripts/build-wendy.sh "../${ARTIFACT}/wendy"
           # libusb is statically linked (LGPL-2.1): ship its attribution/license.
           cp NOTICE "${ARTIFACT}/NOTICE"
+
+      - name: Smoke test packaged Stagefile compiler
+        run: .github/scripts/stagefile-release-smoke_test.sh "./${{ matrix.artifact-name }}/wendy"
 
       - name: Create archive
         working-directory: .


### PR DESCRIPTION
## What changed

- adds a packaged-CLI smoke test for a Stagefile stage inheriting from a prior local stage
- runs the smoke against native Linux and macOS release artifacts before archiving
- uses a fake Docker boundary so the test is deterministic and takes seconds

## Root cause

The 2026.08.13-010134 CLI release predates commit d57ba5ef6. It treats a local from: native stage as docker.io/library/native:latest and fails before reaching the builder. Source main already fixes the compiler, but no packaged-artifact test prevented release/source drift.

## Validation

- installed 2026.08.13-010134 binary: fails with the exact library/native registry lookup
- current main macOS release artifact built by go/scripts/build-wendy.sh: passes
- Stagefile inheritance compiler/codegen tests pass
- shellcheck and git diff --check pass