### PR TITLE
Skip read-only mounts in disk-full warning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wendylabsinc/wendy
 
-go 1.26.5
+go 1.26.6
 
 require (
 	cuelabs.dev/go/oci/ociregistry v0.0.0-20251212221603-3adeb8663819

--- a/go/internal/agent/services/disk_usage.go
+++ b/go/internal/agent/services/disk_usage.go
@@ -27,22 +27,28 @@ type mountEntry struct {
 }
 
 // parseProcMounts parses the contents of /proc/mounts and returns the real,
-// disk-backed filesystems. A filesystem is considered disk-backed when its
-// source is a path under /dev/, which excludes pseudo-filesystems such as
-// tmpfs, proc, sysfs, cgroup and overlay. Entries are deduplicated by backing
-// device (the first mount of a device wins) so a disk that is bind-mounted in
-// several places is only reported once.
+// disk-backed, writable filesystems. A filesystem is considered disk-backed
+// when its source is a path under /dev/, which excludes pseudo-filesystems such
+// as tmpfs, proc, sysfs, cgroup and overlay. Read-only mounts (loopback-mounted
+// snap squashfs images, ISO images, a read-only rootfs) are skipped: they are
+// permanently ~100% full by design and nothing the user can do — including
+// 'wendy device cache prune' — will ever free space on them. Entries are
+// deduplicated by backing device (the first mount of a device wins) so a disk
+// that is bind-mounted in several places is only reported once.
 func parseProcMounts(content string) []mountEntry {
 	var entries []mountEntry
 	seen := make(map[string]struct{})
 
 	for line := range strings.SplitSeq(content, "\n") {
 		fields := strings.Fields(line)
-		if len(fields) < 3 {
+		if len(fields) < 4 {
 			continue
 		}
 		device := unescapeMountField(fields[0])
 		if !strings.HasPrefix(device, "/dev/") {
+			continue
+		}
+		if mountIsReadOnly(fields[3]) {
 			continue
 		}
 		if _, dup := seen[device]; dup {
@@ -57,6 +63,18 @@ func parseProcMounts(content string) []mountEntry {
 	}
 
 	return entries
+}
+
+// mountIsReadOnly reports whether the comma-separated mount options field from
+// /proc/mounts marks the filesystem read-only ("ro" is always the first option
+// the kernel writes for a read-only mount).
+func mountIsReadOnly(options string) bool {
+	for opt := range strings.SplitSeq(options, ",") {
+		if opt == "ro" {
+			return true
+		}
+	}
+	return false
 }
 
 // unescapeMountField decodes the octal escape sequences (\040 space, \011 tab,

--- a/go/internal/agent/services/disk_usage_test.go
+++ b/go/internal/agent/services/disk_usage_test.go
@@ -47,6 +47,7 @@ tmpfs /run tmpfs rw,nosuid,nodev 0 0
 /dev/mmcblk0p1 /boot vfat rw,relatime 0 0
 cgroup2 /sys/fs/cgroup cgroup2 rw,nosuid,nodev,noexec,relatime 0 0
 overlay /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs overlay rw 0 0
+/dev/loop0 /snap/bare/5 squashfs ro,nodev,relatime 0 0
 /dev/mmcblk0p2 /data ext4 rw,relatime 0 0`
 
 	got := parseProcMounts(content)


### PR DESCRIPTION
## Problem

`wendy run` prints a bogus warning:

```
Warning: disk /snap/bare/5 is 100% full. Free cached container data with 'wendy device cache prune'.
```

`/snap/bare/5` is a snap package: a **read-only squashfs image** loop-mounted from `/dev/loopN`. Read-only squashfs images are always ~100% full by design, so they permanently trip the 85% disk-full threshold. Worse, the suggested fix (`wendy device cache prune`) can *never* free space on a read-only filesystem — the warning is unactionable noise.

## Root cause

`parseProcMounts` (`go/internal/agent/services/disk_usage.go`) filtered mounts only by "device path starts with `/dev/`". Snap loop mounts pass that filter, so they flowed all the way to the CLI's fullest-partition check.

## Fix

Skip read-only mounts at the single point every partition routes through — `parseProcMounts`. The mount-options field (`fields[3]` of `/proc/mounts`) was previously never parsed; now a mount marked `ro` is dropped. This generalizes beyond snaps to ISO images and any read-only rootfs — nothing a user can prune, so nothing worth warning about.

No CLI change needed; the fix lives entirely in the agent's mount enumeration.

## Test

Added a `/dev/loop0 /snap/bare/5 squashfs ro,...` line to the `TestParseProcMounts` fixture and asserted it is excluded from the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)