### PR TITLE
feat(agent): variant API for video streams, with honest capability

### DIFF
--- a/Proto/wendy/agent/services/v1/wendy_agent_v1_video_service.proto
+++ b/Proto/wendy/agent/services/v1/wendy_agent_v1_video_service.proto
@@ -35,6 +35,9 @@ message ListVideoDevicesRequest {}
 
 message ListVideoDevicesResponse {
     repeated VideoDevice devices = 1;
+    // What this device can serve beyond a primary stream. Absent from older
+    // agents, which serve the primary stream only.
+    VideoStreamCapabilities stream_capabilities = 2;
 }
 
 message StreamVideoRequest {
@@ -73,6 +76,56 @@ message StreamVideoRequest {
     // intervals cost bitrate (keyframes are large); 1 makes every frame
     // independent and every rate exactly achievable, at the highest byte cost.
     uint32 keyframe_interval_frames = 6;
+
+    // Ask for a stream at different dimensions or bitrate from the camera's
+    // primary one. Unset means the primary stream, which is what every existing
+    // client gets and what this field must never change for them.
+    //
+    // Like max_framerate this is a property of one connection and takes no part
+    // in the stream-parameter compatibility check, so subscribers may ask for
+    // different variants without any of them being rejected.
+    //
+    // Variants are shared BY VALUE: subscribers asking for the same dimensions
+    // and bitrate are served by one stream between them, so the device's cost
+    // scales with the number of distinct variants, not with the number of
+    // clients. The obvious implementation — one variant per subscriber — is the
+    // expensive one and is deliberately not what this is.
+    //
+    // A device serves a variant only when it can do so without taking capacity
+    // from what else it runs, and reports what it can do in
+    // VideoStreamCapabilities. Ask for one it cannot serve and the request is
+    // refused with a reason; it is never silently downgraded, and never served
+    // by starving another workload on the device.
+    StreamVariant variant = 7;
+}
+
+// A requested stream shape. Zero fields mean "same as the primary stream", so
+// an empty variant is a request for the primary.
+message StreamVariant {
+    uint32 width       = 1; // pixels; 0 = same as primary
+    uint32 height      = 2; // pixels; 0 = same as primary
+    uint32 bitrate_bps = 3; // target bitrate; 0 = encoder default
+}
+
+// What a device can offer beyond its primary stream. Reported so a client can
+// ask for what exists rather than discovering the limits by being refused.
+message VideoStreamCapabilities {
+    // The device has usable video-encode hardware. When false, producing a
+    // second stream costs general CPU that may be committed to other work.
+    bool hardware_encode = 1;
+
+    // How many distinct variants the device will serve at once, beyond the
+    // primary. Zero means variants are unavailable and only the primary stream
+    // (optionally rate-limited per subscriber) can be served.
+    uint32 max_variants = 2;
+
+    // Why max_variants is what it is, in words, for a human reading a log or an
+    // error. Not meant to be parsed.
+    string variant_note = 3;
+
+    // Per-subscriber frame rate limiting (max_framerate) is available. It costs
+    // the device nothing, so it is offered wherever this agent runs.
+    bool per_subscriber_framerate = 4;
 }
 
 // Credentials for a network camera. Stored on the device, never returned by any

--- a/go/internal/agent/services/video_framerate_test.go
+++ b/go/internal/agent/services/video_framerate_test.go
@@ -96,11 +96,11 @@ func TestPacedAndUnpacedSubscribersCoexist(t *testing.T) {
 	h, clock, cancel := newPacingHub(t)
 	defer cancel()
 
-	idFull, chFull, err := h.subscribe(0)
+	idFull, chFull, err := h.subscribe(0, variantKey{}, primaryOnlyCaps())
 	if err != nil {
 		t.Fatalf("subscribe(0): %v", err)
 	}
-	idSlow, chSlow, err := h.subscribe(2) // 2 fps
+	idSlow, chSlow, err := h.subscribe(2, variantKey{}, primaryOnlyCaps()) // 2 fps
 	if err != nil {
 		t.Fatalf("subscribe(2): %v", err)
 	}
@@ -147,7 +147,7 @@ func TestPacingDropsWholeGroups(t *testing.T) {
 	h, clock, cancel := newPacingHub(t)
 	defer cancel()
 
-	id, ch, err := h.subscribe(4) // 4 fps: one 5-frame group buys 1.25s
+	id, ch, err := h.subscribe(4, variantKey{}, primaryOnlyCaps()) // 4 fps: one 5-frame group buys 1.25s
 	if err != nil {
 		t.Fatalf("subscribe: %v", err)
 	}
@@ -186,7 +186,7 @@ func TestAllIntraStreamHonoursRateExactly(t *testing.T) {
 	h, clock, cancel := newPacingHub(t)
 	defer cancel()
 
-	id, ch, err := h.subscribe(2) // 2 fps out of a 30 fps camera
+	id, ch, err := h.subscribe(2, variantKey{}, primaryOnlyCaps()) // 2 fps out of a 30 fps camera
 	if err != nil {
 		t.Fatalf("subscribe: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestPacingDoesNotBurstAfterIdle(t *testing.T) {
 	h, clock, cancel := newPacingHub(t)
 	defer cancel()
 
-	id, ch, err := h.subscribe(1)
+	id, ch, err := h.subscribe(1, variantKey{}, primaryOnlyCaps())
 	if err != nil {
 		t.Fatalf("subscribe: %v", err)
 	}
@@ -240,7 +240,7 @@ func TestPacedSubscriberWaitsForFirstKeyframe(t *testing.T) {
 	h, _, cancel := newPacingHub(t)
 	defer cancel()
 
-	id, ch, err := h.subscribe(30)
+	id, ch, err := h.subscribe(30, variantKey{}, primaryOnlyCaps())
 	if err != nil {
 		t.Fatalf("subscribe: %v", err)
 	}
@@ -265,7 +265,7 @@ func TestUnpacedSubscriberUnaffectedByKeyframes(t *testing.T) {
 	h, _, cancel := newPacingHub(t)
 	defer cancel()
 
-	id, ch, err := h.subscribe(0)
+	id, ch, err := h.subscribe(0, variantKey{}, primaryOnlyCaps())
 	if err != nil {
 		t.Fatalf("subscribe: %v", err)
 	}
@@ -287,7 +287,7 @@ func TestPacingIgnoredForNonH264(t *testing.T) {
 	h, clock, cancel := newPacingHub(t)
 	defer cancel()
 
-	id, ch, err := h.subscribe(1)
+	id, ch, err := h.subscribe(1, variantKey{}, primaryOnlyCaps())
 	if err != nil {
 		t.Fatalf("subscribe: %v", err)
 	}
@@ -310,11 +310,11 @@ func TestKeyframeScanSkippedWithoutPacedSubscribers(t *testing.T) {
 	h, _, cancel := newPacingHub(t)
 	defer cancel()
 
-	idFull, _, _ := h.subscribe(0)
+	idFull, _, _ := h.subscribe(0, variantKey{}, primaryOnlyCaps())
 	if h.paced != 0 {
 		t.Fatalf("paced = %d after an unlimited subscribe, want 0", h.paced)
 	}
-	idSlow, _, _ := h.subscribe(5)
+	idSlow, _, _ := h.subscribe(5, variantKey{}, primaryOnlyCaps())
 	if h.paced != 1 {
 		t.Fatalf("paced = %d after a limited subscribe, want 1", h.paced)
 	}
@@ -436,7 +436,7 @@ func TestPacedCountSurvivesAbsurdRate(t *testing.T) {
 	h, _, cancel := newPacingHub(t)
 	defer cancel()
 
-	id, ch, err := h.subscribe(4_000_000_000)
+	id, ch, err := h.subscribe(4_000_000_000, variantKey{}, primaryOnlyCaps())
 	if err != nil {
 		t.Fatalf("subscribe: %v", err)
 	}
@@ -508,7 +508,7 @@ func TestPacingChargesEveryPictureInABuffer(t *testing.T) {
 	h, clock, cancel := newPacingHub(t)
 	defer cancel()
 
-	id, ch, err := h.subscribe(2) // 2 fps
+	id, ch, err := h.subscribe(2, variantKey{}, primaryOnlyCaps()) // 2 fps
 	if err != nil {
 		t.Fatalf("subscribe: %v", err)
 	}

--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -336,6 +336,9 @@ type subscriber struct {
 	// without the frames it references, so a group is delivered whole or not at
 	// all.
 	admitting bool
+	// variant is what this subscriber asked for, kept so leaving releases the
+	// right entry.
+	variant variantKey
 	// nextDue is when this subscriber has earned its next frame. Every frame
 	// delivered pushes it one interval further out, so a group of fifteen frames
 	// costs fifteen intervals and the *average* delivered rate is what the
@@ -367,6 +370,14 @@ type deviceHub struct {
 	// max_framerate is deliberately absent: it configures nothing on the device,
 	// so two subscribers may disagree about it freely.
 	width, height, framerate, keyframeInterval uint32
+	// negotiatedWidth/Height are what the camera actually settled on, which is
+	// only known once the producer has configured it. A request for exactly
+	// these dimensions is the primary stream, not a variant.
+	negotiatedWidth, negotiatedHeight uint32
+	// variants counts subscribers per distinct variant. Keyed by value, so
+	// subscribers wanting the same shape share one entry — the device's cost
+	// follows the number of keys here, not the number of subscribers.
+	variants map[variantKey]int
 	// paced counts subscribers with a rate limit. While it is zero the hub skips
 	// keyframe detection entirely, so a device serving only unlimited
 	// subscribers does exactly the work it did before.
@@ -417,7 +428,7 @@ const maxSubscribersPerHub = 16
 // Returns codes.Unavailable if the hub's context has already been cancelled
 // (checked atomically under h.mu so no subscriber can be added to a dying hub),
 // or codes.ResourceExhausted if the hub already has maxSubscribersPerHub active subscribers.
-func (h *deviceHub) subscribe(maxFramerate uint32) (int, chan *videoFrame, error) {
+func (h *deviceHub) subscribe(maxFramerate uint32, variant variantKey, caps *agentpb.VideoStreamCapabilities) (int, chan *videoFrame, error) {
 	ch := make(chan *videoFrame, 4)
 	h.mu.Lock()
 	if h.ctx.Err() != nil {
@@ -428,9 +439,15 @@ func (h *deviceHub) subscribe(maxFramerate uint32) (int, chan *videoFrame, error
 		h.mu.Unlock()
 		return 0, nil, status.Errorf(codes.ResourceExhausted, "too many concurrent streams for this device (max %d)", maxSubscribersPerHub)
 	}
+	// Admission before any state is created, so a refused variant leaves the
+	// hub exactly as it was.
+	if err := h.admitVariant(variant, caps); err != nil {
+		h.mu.Unlock()
+		return 0, nil, err
+	}
 	id := h.nextID
 	h.nextID++
-	sub := &subscriber{ch: ch}
+	sub := &subscriber{ch: ch, variant: variant}
 	if maxFramerate > 0 {
 		// Clamped to a non-zero interval: a rate so high that a second divides
 		// to nothing would otherwise leave minInterval at 0, which reads as
@@ -455,8 +472,11 @@ func (h *deviceHub) subscribe(maxFramerate uint32) (int, chan *videoFrame, error
 // getOrCreateHub could observe h.ctx.Err()==nil between the delete and the cancel call.
 func (h *deviceHub) unsubscribe(id int) {
 	h.mu.Lock()
-	if sub, ok := h.subs[id]; ok && sub.minInterval > 0 {
-		h.paced--
+	if sub, ok := h.subs[id]; ok {
+		if sub.minInterval > 0 {
+			h.paced--
+		}
+		h.releaseVariant(sub.variant)
 	}
 	delete(h.subs, id)
 	if len(h.subs) == 0 {
@@ -912,7 +932,13 @@ func (s *VideoService) ListVideoDevices(ctx context.Context, _ *agentpb.ListVide
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to enumerate video devices: %v", err)
 	}
-	return &agentpb.ListVideoDevicesResponse{Devices: devices}, nil
+	return &agentpb.ListVideoDevicesResponse{
+		Devices: devices,
+		// Reported alongside the devices so a client learns what it may ask for
+		// in the same call it uses to find a camera, rather than by having a
+		// request refused.
+		StreamCapabilities: s.videoStreamCapabilities(),
+	}, nil
 }
 
 // resolveSource maps a device ID onto the thing it names. IDs in the network
@@ -1059,7 +1085,7 @@ func (s *VideoService) getOrCreateHub(ctx context.Context, path string, req *age
 					describeStreamParams(h.width, h.height, h.framerate, h.keyframeInterval),
 					describeStreamParams(req.GetWidth(), req.GetHeight(), req.GetFramerate(), req.GetKeyframeIntervalFrames()))
 			}
-			id, ch, err = h.subscribe(req.GetMaxFramerate())
+			id, ch, err = h.subscribe(req.GetMaxFramerate(), variantFromRequest(req), s.videoStreamCapabilities())
 			s.mu.Unlock()
 			if err != nil {
 				if st, _ := status.FromError(err); st.Code() == codes.Unavailable {
@@ -1117,6 +1143,7 @@ func (s *VideoService) getOrCreateHub(ctx context.Context, path string, req *age
 	hctx, cancel := context.WithCancel(s.ctx)
 	h = &deviceHub{
 		subs:             make(map[int]*subscriber),
+		variants:         make(map[variantKey]int),
 		ctx:              hctx,
 		cancel:           cancel,
 		done:             make(chan struct{}),
@@ -1125,15 +1152,40 @@ func (s *VideoService) getOrCreateHub(ctx context.Context, path string, req *age
 		framerate:        req.GetFramerate(),
 		keyframeInterval: req.GetKeyframeIntervalFrames(),
 		logger:           s.logger,
+		// Seeded from the request and corrected by the producer once the camera
+		// has actually negotiated. A caller that names a size explicitly can
+		// therefore ask for a variant of that same size and be recognised as
+		// wanting the primary, without waiting for the camera to come up.
+		negotiatedWidth:  req.GetWidth(),
+		negotiatedHeight: req.GetHeight(),
 	}
-	// New hub: the first subscriber is always within the cap.
-	id, ch, _ = h.subscribe(req.GetMaxFramerate())
+	// New hub: the first subscriber is always within the subscriber cap, but its
+	// variant still has to be admissible — on a hub this new the camera has not
+	// negotiated a size yet, so only the primary stream is certain to be free.
+	id, ch, err = h.subscribe(req.GetMaxFramerate(), variantFromRequest(req), s.videoStreamCapabilities())
+	if err != nil {
+		// The hub was never published, so nothing can be waiting on it; just
+		// release its context.
+		cancel()
+		s.mu.Unlock()
+		return nil, 0, nil, err
+	}
 	s.hubs[path] = h
 	s.mu.Unlock()
 
 	s.wg.Add(1)
 	go s.runProducer(hctx, h, path, req)
 	return h, id, ch, nil
+}
+
+// hubForPath returns the hub currently serving a device path, or nil. Producers
+// use it to publish what the camera negotiated. There is exactly one producer
+// per path at a time — getOrCreateHub waits for a hub's teardown before opening
+// a new one — so the hub found here is always the caller's own.
+func (s *VideoService) hubForPath(path string) *deviceHub {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.hubs[path]
 }
 
 // runProducer drives the capture loop for a single device hub.
@@ -1525,6 +1577,13 @@ func (s *VideoService) streamV4L2Native(ctx context.Context, broadcast func([]by
 		return nativeH264NotSupported{msg: "device switched pixel format away from H264"}
 	}
 
+	// The camera has now settled on a size, which may differ from what was
+	// requested. Publishing it lets a later subscriber ask for exactly these
+	// dimensions and be served the primary stream rather than refused a variant.
+	if h := s.hubForPath(path); h != nil {
+		h.setNegotiatedSize(vfmt.Width, vfmt.Height)
+	}
+
 	// Best-effort: cap the camera encoder's keyframe interval. Non-fatal — many
 	// UVC cameras reject this and keep their firmware default.
 	s.setV4L2KeyframeInterval(fd, effectiveKeyframeInterval(req))
@@ -1784,6 +1843,16 @@ func (s *VideoService) streamGStreamer(ctx context.Context, broadcast func([]byt
 		return status.Errorf(codes.Internal, "unexpected device path format")
 	}
 	s.logger.Info("GStreamer encoder selected", zap.String("encoder", enc.element), zap.String("codec", enc.codec.String()))
+
+	// Publish the size the pipeline will pin, for the same reason the native
+	// path does: a later subscriber asking for exactly this size wants the
+	// primary stream, not a variant.
+	if hub := s.hubForPath(path); hub != nil {
+		isLibcamera := transport == camera.TransportCSI && available != nil && available["libcamerasrc"]
+		if w, h := resolveCaptureSize(path, req, isLibcamera); w > 0 && h > 0 {
+			hub.setNegotiatedSize(w, h)
+		}
+	}
 
 	var args []string
 	if useArgusSource(transport, s.hostIsJetson(), available) {
@@ -2108,17 +2177,7 @@ func buildGStreamerArgs(gstPath, devicePath string, req *agentpb.StreamVideoRequ
 	// Same "default must not mean smallest" rule as the native path: with no
 	// width/height in the caps the source negotiates its first mode, which on UVC
 	// is the smallest. Ask the device what it has and pin the best.
-	capW, capH := req.GetWidth(), req.GetHeight()
-	if (capW == 0 || capH == 0) && !strings.HasPrefix(src, "libcamerasrc") {
-		if bw, bh := bestDefaultFrameSizeForDevice(devicePath); bw > 0 && bh > 0 {
-			if capW == 0 {
-				capW = bw
-			}
-			if capH == 0 {
-				capH = bh
-			}
-		}
-	}
+	capW, capH := resolveCaptureSize(devicePath, req, strings.HasPrefix(src, "libcamerasrc"))
 	if capW > 0 {
 		capsParts = append(capsParts, fmt.Sprintf("width=%d", capW))
 	}
@@ -2155,6 +2214,25 @@ func buildGStreamerArgs(gstPath, devicePath string, req *agentpb.StreamVideoRequ
 	// -q suppresses gst-launch's status messages (e.g. "Setting pipeline to PLAYING")
 	// from being written to stdout and corrupting the binary H264 stream.
 	return append([]string{gstPath, "-q"}, strings.Fields(pipeline)...), nil
+}
+
+// resolveCaptureSize is the size the GStreamer pipeline will pin its caps to:
+// what the caller asked for, with anything left unset filled in from the
+// device's best mode. Shared with the producer so the size reported to clients
+// is the size the pipeline actually requests, rather than a second guess at it.
+func resolveCaptureSize(devicePath string, req *agentpb.StreamVideoRequest, isLibcamera bool) (uint32, uint32) {
+	capW, capH := req.GetWidth(), req.GetHeight()
+	if (capW == 0 || capH == 0) && !isLibcamera {
+		if bw, bh := bestDefaultFrameSizeForDevice(devicePath); bw > 0 && bh > 0 {
+			if capW == 0 {
+				capW = bw
+			}
+			if capH == 0 {
+				capH = bh
+			}
+		}
+	}
+	return capW, capH
 }
 
 // transportToProto maps the internal camera.Transport to the proto enum.

--- a/go/internal/agent/services/video_service_test.go
+++ b/go/internal/agent/services/video_service_test.go
@@ -704,8 +704,8 @@ func TestDeviceHub_TwoSubscribersReceiveSameFrame(t *testing.T) {
 	h, cancel := newTestHub(t)
 	defer cancel()
 
-	id1, ch1, _ := h.subscribe(0)
-	id2, ch2, _ := h.subscribe(0)
+	id1, ch1, _ := h.subscribe(0, variantKey{}, primaryOnlyCaps())
+	id2, ch2, _ := h.subscribe(0, variantKey{}, primaryOnlyCaps())
 	defer h.unsubscribe(id1)
 	defer h.unsubscribe(id2)
 
@@ -730,8 +730,8 @@ func TestDeviceHub_TwoSubscribersReceiveSameFrame(t *testing.T) {
 func TestDeviceHub_LastUnsubscribeCancelsProducer(t *testing.T) {
 	h, _ := newTestHub(t)
 
-	id1, _, _ := h.subscribe(0)
-	id2, _, _ := h.subscribe(0)
+	id1, _, _ := h.subscribe(0, variantKey{}, primaryOnlyCaps())
+	id2, _, _ := h.subscribe(0, variantKey{}, primaryOnlyCaps())
 
 	h.unsubscribe(id1)
 	if h.ctx.Err() != nil {
@@ -748,7 +748,7 @@ func TestDeviceHub_SlowSubscriberDropsFrames(t *testing.T) {
 	h, cancel := newTestHub(t)
 	defer cancel()
 
-	_, ch, _ := h.subscribe(0)
+	_, ch, _ := h.subscribe(0, variantKey{}, primaryOnlyCaps())
 
 	// Send more frames than the channel buffer (capacity 4).
 	for i := 0; i < 10; i++ {
@@ -768,7 +768,7 @@ func TestDeviceHub_BroadcastReturnsFalseWithNoSubscribers(t *testing.T) {
 	h, cancel := newTestHub(t)
 	defer cancel()
 
-	id, _, _ := h.subscribe(0)
+	id, _, _ := h.subscribe(0, variantKey{}, primaryOnlyCaps())
 	h.unsubscribe(id)
 
 	if h.broadcast(&videoFrame{data: []byte{1}}) {
@@ -779,7 +779,7 @@ func TestDeviceHub_BroadcastReturnsFalseWithNoSubscribers(t *testing.T) {
 func TestDeviceHub_ProducerErrorPropagated(t *testing.T) {
 	h, _ := newTestHub(t)
 
-	_, ch, _ := h.subscribe(0)
+	_, ch, _ := h.subscribe(0, variantKey{}, primaryOnlyCaps())
 
 	// Simulate producer recording an error and closing the channel.
 	wantErr := status.Errorf(codes.Internal, "camera read failed: test error")

--- a/go/internal/agent/services/video_variants.go
+++ b/go/internal/agent/services/video_variants.go
@@ -1,0 +1,215 @@
+package services
+
+import (
+	"fmt"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+// A variant is a stream at different dimensions or bitrate from the camera's
+// primary one. This file decides whether a requested variant can be served and
+// how, and reports what the device can offer so a client can ask for something
+// that exists.
+//
+// The design point, stated because the obvious implementation is the expensive
+// one: variants are keyed BY VALUE and shared. Three subscribers asking for
+// 480x270 are served by one variant between them. The device's cost scales with
+// the number of distinct variants, never with the number of clients.
+
+// variantKey identifies a variant by the values that define it. Two requests
+// with equal keys are the same variant and share one stream.
+type variantKey struct {
+	width      uint32
+	height     uint32
+	bitrateBps uint32
+}
+
+// isPrimary reports whether this key asks for anything the primary stream does
+// not already provide.
+func (k variantKey) isPrimary() bool {
+	return k == variantKey{}
+}
+
+func (k variantKey) String() string {
+	if k.isPrimary() {
+		return "primary"
+	}
+	dims := "primary size"
+	if k.width > 0 || k.height > 0 {
+		dims = fmt.Sprintf("%dx%d", k.width, k.height)
+	}
+	if k.bitrateBps > 0 {
+		return fmt.Sprintf("%s @ %d bps", dims, k.bitrateBps)
+	}
+	return dims
+}
+
+// variantRoute is how a device fulfils a variant request. Routes exist in cost
+// order, and a device picks the cheapest one it actually has.
+type variantRoute int
+
+const (
+	// routePrimary serves the request from the stream that already exists. It
+	// costs nothing, and covers both "no variant requested" and "the variant
+	// happens to match what the camera is already producing".
+	routePrimary variantRoute = iota
+	// routeTranscode decodes, scales and re-encodes. It costs real silicon, so
+	// it is offered only where the device has capacity to spare — see
+	// videoStreamCapabilities.
+	routeTranscode
+)
+
+// maxVariantsPerHub bounds the distinct variants one camera will serve, in the
+// same spirit as maxSubscribersPerHub: a client that keeps asking for new
+// shapes must be refused cleanly rather than allowed to fan the device out
+// until everything on it degrades.
+//
+// It is a ceiling, not a promise. A device that cannot afford any variant
+// reports max_variants = 0 regardless of this value.
+const maxVariantsPerHub = 2
+
+// variantFromRequest reads the requested variant, normalising "same as primary"
+// to the zero key.
+func variantFromRequest(req *agentpb.StreamVideoRequest) variantKey {
+	v := req.GetVariant()
+	if v == nil {
+		return variantKey{}
+	}
+	return variantKey{width: v.GetWidth(), height: v.GetHeight(), bitrateBps: v.GetBitrateBps()}
+}
+
+// resolveVariantRoute decides how a requested variant would be served against a
+// primary stream of the given size.
+//
+// primaryW/primaryH are the dimensions the camera actually negotiated, which
+// may differ from what any request asked for (a request of 0 means "device
+// default", and the default is chosen by the camera). Passing 0 for them means
+// the size is not known yet, in which case only an empty variant is certain to
+// be the primary.
+func resolveVariantRoute(key variantKey, primaryW, primaryH uint32) variantRoute {
+	if key.isPrimary() {
+		return routePrimary
+	}
+	// A bitrate request always needs a re-encode: the primary's bitrate is
+	// whatever its encoder chose.
+	if key.bitrateBps > 0 {
+		return routeTranscode
+	}
+	// Asking for exactly what the camera is already producing is free. This is
+	// the case that lets a client state its requirement plainly and still get
+	// the primary when the requirement happens to be met.
+	if primaryW > 0 && primaryH > 0 &&
+		(key.width == 0 || key.width == primaryW) &&
+		(key.height == 0 || key.height == primaryH) {
+		return routePrimary
+	}
+	return routeTranscode
+}
+
+// videoStreamCapabilities reports what this device can serve beyond its primary
+// stream.
+//
+// max_variants is what the agent will actually admit, not what the silicon
+// might one day allow: transcoding is not implemented yet, so it is zero
+// everywhere and the note says why. When a transcode route lands, this is the
+// single place that opens it up, and clients written against this field start
+// getting variants with no change.
+func (s *VideoService) videoStreamCapabilities() *agentpb.VideoStreamCapabilities {
+	hwEncode, encNote := s.hardwareEncodeStatus()
+
+	caps := &agentpb.VideoStreamCapabilities{
+		HardwareEncode:         hwEncode,
+		PerSubscriberFramerate: true,
+		MaxVariants:            0,
+	}
+	if hwEncode {
+		caps.VariantNote = "variant transcoding is not implemented in this agent version; " +
+			"this device has usable encode hardware, so variants can be enabled here without taking CPU from other work"
+	} else {
+		caps.VariantNote = encNote + "; a variant would have to be encoded in software, competing with " +
+			"whatever else this device runs, so it is not offered. Per-subscriber frame rate is available and costs nothing"
+	}
+	return caps
+}
+
+// hardwareEncodeStatus probes for usable video-encode hardware, reusing the
+// same node check the encoder selection path uses so the capability a client
+// reads cannot disagree with the encoder the agent would actually pick.
+func (s *VideoService) hardwareEncodeStatus() (bool, string) {
+	for element, node := range encoderDeviceNodes {
+		if v4l2NodeUsable(node) {
+			return true, fmt.Sprintf("%s is usable via %s", element, node)
+		}
+	}
+	return false, "no usable video-encode hardware found on this device"
+}
+
+// admitVariant registers a subscriber's interest in a variant, or refuses with
+// a reason a caller can act on.
+//
+// Callers must hold h.mu.
+func (h *deviceHub) admitVariant(key variantKey, caps *agentpb.VideoStreamCapabilities) error {
+	if key.isPrimary() {
+		return nil
+	}
+	if resolveVariantRoute(key, h.negotiatedWidth, h.negotiatedHeight) == routePrimary {
+		// Costs nothing: the camera is already producing this.
+		return nil
+	}
+
+	if caps.GetMaxVariants() == 0 {
+		primary := "the primary stream"
+		if h.negotiatedWidth > 0 && h.negotiatedHeight > 0 {
+			primary = fmt.Sprintf("the primary stream (%dx%d)", h.negotiatedWidth, h.negotiatedHeight)
+		}
+		return status.Errorf(codes.FailedPrecondition,
+			"cannot serve variant %s on this device: %s. Request %s, or use max_framerate to receive fewer of its frames",
+			key, caps.GetVariantNote(), primary)
+	}
+
+	// Already serving this exact variant: another subscriber joins it for free.
+	// This is the point of keying by value.
+	if _, exists := h.variants[key]; exists {
+		h.variants[key]++
+		return nil
+	}
+	if uint32(len(h.variants)) >= caps.GetMaxVariants() {
+		return status.Errorf(codes.ResourceExhausted,
+			"this camera is already serving %d distinct stream variants (the maximum); "+
+				"ask for one that is already being served, or the primary stream",
+			len(h.variants))
+	}
+	h.variants[key] = 1
+	return nil
+}
+
+// releaseVariant drops a subscriber's interest, removing the variant once the
+// last subscriber of it leaves.
+//
+// Callers must hold h.mu.
+func (h *deviceHub) releaseVariant(key variantKey) {
+	if key.isPrimary() {
+		return
+	}
+	n, ok := h.variants[key]
+	if !ok {
+		return
+	}
+	if n <= 1 {
+		delete(h.variants, key)
+		return
+	}
+	h.variants[key] = n - 1
+}
+
+// setNegotiatedSize records the size the camera actually settled on, so a later
+// subscriber asking for those exact dimensions is recognised as asking for the
+// primary stream rather than for a variant nobody can serve.
+func (h *deviceHub) setNegotiatedSize(width, height uint32) {
+	h.mu.Lock()
+	h.negotiatedWidth, h.negotiatedHeight = width, height
+	h.mu.Unlock()
+}

--- a/go/internal/agent/services/video_variants_test.go
+++ b/go/internal/agent/services/video_variants_test.go
@@ -1,0 +1,207 @@
+package services
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+// primaryOnlyCaps is what every device reports today: no variants, and
+// per-subscriber frame rate available.
+func primaryOnlyCaps() *agentpb.VideoStreamCapabilities {
+	return &agentpb.VideoStreamCapabilities{
+		MaxVariants:            0,
+		PerSubscriberFramerate: true,
+		VariantNote:            "no usable video-encode hardware found on this device",
+	}
+}
+
+// capsWithVariants stands in for hardware that can afford variants, so the
+// sharing and cap logic is exercised now rather than when a transcode route
+// lands.
+func capsWithVariants(n uint32) *agentpb.VideoStreamCapabilities {
+	return &agentpb.VideoStreamCapabilities{
+		MaxVariants:            n,
+		HardwareEncode:         true,
+		PerSubscriberFramerate: true,
+	}
+}
+
+func newVariantHub(t *testing.T) (*deviceHub, context.CancelFunc) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	return &deviceHub{
+		subs:     make(map[int]*subscriber),
+		variants: make(map[variantKey]int),
+		ctx:      ctx,
+		cancel:   cancel,
+		done:     make(chan struct{}),
+		logger:   zap.NewNop(),
+	}, cancel
+}
+
+func TestResolveVariantRoute(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      variantKey
+		primaryW uint32
+		primaryH uint32
+		want     variantRoute
+	}{
+		{"no variant is the primary", variantKey{}, 1280, 720, routePrimary},
+		{"same size as primary is free", variantKey{width: 1280, height: 720}, 1280, 720, routePrimary},
+		{"width only, matching", variantKey{width: 1280}, 1280, 720, routePrimary},
+		{"smaller needs a re-encode", variantKey{width: 480, height: 270}, 1280, 720, routeTranscode},
+		{"bitrate always needs a re-encode", variantKey{bitrateBps: 200_000}, 1280, 720, routeTranscode},
+		// Before the camera reports a size, nothing but an empty variant is
+		// certain to be free.
+		{"unknown primary size", variantKey{width: 1280, height: 720}, 0, 0, routeTranscode},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveVariantRoute(tc.key, tc.primaryW, tc.primaryH); got != tc.want {
+				t.Errorf("route = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// The design point: subscribers wanting the same shape cost one variant, not
+// one each.
+func TestVariantsAreSharedByValue(t *testing.T) {
+	h, cancel := newVariantHub(t)
+	defer cancel()
+	caps := capsWithVariants(2)
+	small := variantKey{width: 480, height: 270}
+
+	ids := make([]int, 0, 3)
+	for i := 0; i < 3; i++ {
+		id, _, err := h.subscribe(0, small, caps)
+		if err != nil {
+			t.Fatalf("subscriber %d refused: %v", i, err)
+		}
+		ids = append(ids, id)
+	}
+
+	if len(h.variants) != 1 {
+		t.Fatalf("three subscribers on one shape produced %d variants, want 1", len(h.variants))
+	}
+	if h.variants[small] != 3 {
+		t.Errorf("refcount = %d, want 3", h.variants[small])
+	}
+
+	// The variant survives until its last subscriber leaves.
+	h.unsubscribe(ids[0])
+	h.unsubscribe(ids[1])
+	if len(h.variants) != 1 {
+		t.Fatalf("variant dropped while a subscriber remained: %v", h.variants)
+	}
+	h.unsubscribe(ids[2])
+	if len(h.variants) != 0 {
+		t.Errorf("variant outlived its last subscriber: %v", h.variants)
+	}
+}
+
+// Distinct shapes are what cost the device, so they are what the cap counts.
+func TestVariantCapRefusesCleanly(t *testing.T) {
+	h, cancel := newVariantHub(t)
+	defer cancel()
+	caps := capsWithVariants(2)
+
+	for _, k := range []variantKey{{width: 480, height: 270}, {width: 640, height: 360}} {
+		if _, _, err := h.subscribe(0, k, caps); err != nil {
+			t.Fatalf("variant %v refused below the cap: %v", k, err)
+		}
+	}
+
+	_, _, err := h.subscribe(0, variantKey{width: 320, height: 180}, caps)
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("third distinct variant: got %v, want ResourceExhausted", err)
+	}
+	// Refusal must not have left a partial entry behind.
+	if len(h.variants) != 2 {
+		t.Errorf("variants after refusal = %d, want 2", len(h.variants))
+	}
+	// A subscriber joining a variant already served is still welcome.
+	if _, _, err := h.subscribe(0, variantKey{width: 480, height: 270}, caps); err != nil {
+		t.Errorf("joining an existing variant at the cap was refused: %v", err)
+	}
+}
+
+// On hardware that cannot afford a variant, the request is refused with
+// something the caller can act on — never silently downgraded, and never served
+// by taking capacity from other work.
+func TestVariantRefusedWhenDeviceCannotServeIt(t *testing.T) {
+	h, cancel := newVariantHub(t)
+	defer cancel()
+	h.setNegotiatedSize(1280, 720)
+
+	_, _, err := h.subscribe(0, variantKey{width: 480, height: 270}, primaryOnlyCaps())
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("got %v, want FailedPrecondition", err)
+	}
+	msg := status.Convert(err).Message()
+	for _, want := range []string{"480x270", "1280x720", "max_framerate", "no usable video-encode hardware"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("refusal missing %q: %s", want, msg)
+		}
+	}
+}
+
+// Asking for what the camera already produces costs nothing and must be served
+// even where variants are unavailable.
+func TestVariantMatchingPrimaryIsFree(t *testing.T) {
+	h, cancel := newVariantHub(t)
+	defer cancel()
+	h.setNegotiatedSize(1280, 720)
+
+	if _, _, err := h.subscribe(0, variantKey{width: 1280, height: 720}, primaryOnlyCaps()); err != nil {
+		t.Fatalf("variant matching the primary was refused: %v", err)
+	}
+	if len(h.variants) != 0 {
+		t.Errorf("passthrough allocated a variant: %v", h.variants)
+	}
+}
+
+// Every existing client sends no variant at all; that path must stay open on
+// any hardware.
+func TestPrimaryAlwaysAdmitted(t *testing.T) {
+	h, cancel := newVariantHub(t)
+	defer cancel()
+
+	if _, _, err := h.subscribe(0, variantKey{}, primaryOnlyCaps()); err != nil {
+		t.Fatalf("primary subscriber refused: %v", err)
+	}
+	if len(h.variants) != 0 {
+		t.Errorf("primary allocated a variant: %v", h.variants)
+	}
+}
+
+func TestCapabilitiesReportedInDeviceListing(t *testing.T) {
+	svc := newTestVideoService(nil, nil)
+	resp, err := svc.ListVideoDevices(context.Background(), &agentpb.ListVideoDevicesRequest{})
+	if err != nil {
+		t.Fatalf("ListVideoDevices: %v", err)
+	}
+	caps := resp.GetStreamCapabilities()
+	if caps == nil {
+		t.Fatal("no stream capabilities reported")
+	}
+	if !caps.GetPerSubscriberFramerate() {
+		t.Error("per-subscriber frame rate should be reported everywhere this agent runs")
+	}
+	// Transcoding is not implemented yet, so no device may advertise variants —
+	// the capability must describe what the agent will actually admit.
+	if caps.GetMaxVariants() != 0 {
+		t.Errorf("max_variants = %d, want 0 until a transcode route exists", caps.GetMaxVariants())
+	}
+	if caps.GetVariantNote() == "" {
+		t.Error("a device that offers no variants must say why")
+	}
+}

--- a/go/internal/cli/commands/camera.go
+++ b/go/internal/cli/commands/camera.go
@@ -59,7 +59,10 @@ func newCameraListCmd() *cobra.Command {
 
 			devices := resp.GetDevices()
 			if jsonOutput {
-				data, err := json.MarshalIndent(devices, "", "  ")
+				data, err := json.MarshalIndent(struct {
+					Devices            []*agentpb.VideoDevice           `json:"devices"`
+					StreamCapabilities *agentpb.VideoStreamCapabilities `json:"streamCapabilities,omitempty"`
+				}{devices, resp.GetStreamCapabilities()}, "", "  ")
 				if err != nil {
 					return err
 				}
@@ -84,6 +87,16 @@ func newCameraListCmd() *cobra.Command {
 				})
 			}
 			fmt.Print(tui.RenderTable(headers, rows))
+
+			// What this device will serve beyond the primary stream, so the
+			// limits are visible before a request is refused rather than after.
+			if caps := resp.GetStreamCapabilities(); caps != nil {
+				if caps.GetMaxVariants() > 0 {
+					cliLogln("Stream variants: up to %d distinct (shared between viewers asking for the same one).", caps.GetMaxVariants())
+				} else if note := caps.GetVariantNote(); note != "" {
+					cliLogln("Stream variants: unavailable — %s.", note)
+				}
+			}
 			return nil
 		},
 	}
@@ -225,7 +238,7 @@ func newCameraWatchCmd() *cobra.Command {
 // "view" is the canonical, listed command; "watch" reuses the same logic as a
 // hidden alias.
 func newCameraStreamCmd(use string, hidden bool) *cobra.Command {
-	var deviceID, width, height, fps, maxFPS, keyframeInterval uint32
+	var deviceID, width, height, fps, maxFPS, keyframeInterval, variantWidth, variantHeight, variantBitrate uint32
 	var toStdout bool
 
 	cmd := &cobra.Command{
@@ -262,6 +275,16 @@ func newCameraStreamCmd(use string, hidden bool) *cobra.Command {
 				Framerate:              fps,
 				MaxFramerate:           maxFPS,
 				KeyframeIntervalFrames: keyframeInterval,
+			}
+			// Only send a variant when one was actually asked for: an empty
+			// variant and no variant mean the same thing, and older agents
+			// ignore the field entirely.
+			if variantWidth > 0 || variantHeight > 0 || variantBitrate > 0 {
+				req.Variant = &agentpb.StreamVariant{
+					Width:      variantWidth,
+					Height:     variantHeight,
+					BitrateBps: variantBitrate,
+				}
 			}
 			startStream := func() (videoStream, error) {
 				return conn.VideoService.StreamVideo(ctx, req)
@@ -309,6 +332,9 @@ func newCameraStreamCmd(use string, hidden bool) *cobra.Command {
 	cmd.Flags().Uint32Var(&height, "height", 0, "Frame height (0 = device default)")
 	cmd.Flags().Uint32Var(&fps, "fps", 0, "Framerate (0 = device default)")
 	cmd.Flags().Uint32Var(&maxFPS, "max-fps", 0, "Cap the frames this viewer receives, leaving other viewers untouched (0 = every frame). Saves uplink bandwidth, not device CPU")
+	cmd.Flags().Uint32Var(&variantWidth, "variant-width", 0, "Ask for a stream at this width, independently of other viewers (0 = the camera's primary stream)")
+	cmd.Flags().Uint32Var(&variantHeight, "variant-height", 0, "Ask for a stream at this height, independently of other viewers (0 = the camera's primary stream)")
+	cmd.Flags().Uint32Var(&variantBitrate, "variant-bitrate", 0, "Ask for a stream at this bitrate in bits/sec (0 = encoder default). Run 'camera list' to see whether this device serves variants")
 	cmd.Flags().Uint32Var(&keyframeInterval, "keyframe-interval", 0, "Frames between keyframes for the shared encoder (0 = half a second). Lower values make --max-fps more precise and cost bitrate")
 	cmd.Flags().BoolVar(&toStdout, "stdout", false, "Pipe encoded video to stdout instead of opening a window (codec: H.264 or VP8/WebM depending on device capabilities)")
 

--- a/go/proto/gen/agentpb/wendy_agent_v1_video_service.pb.go
+++ b/go/proto/gen/agentpb/wendy_agent_v1_video_service.pb.go
@@ -280,10 +280,13 @@ func (*ListVideoDevicesRequest) Descriptor() ([]byte, []int) {
 }
 
 type ListVideoDevicesResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Devices       []*VideoDevice         `protobuf:"bytes,1,rep,name=devices,proto3" json:"devices,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	Devices []*VideoDevice         `protobuf:"bytes,1,rep,name=devices,proto3" json:"devices,omitempty"`
+	// What this device can serve beyond a primary stream. Absent from older
+	// agents, which serve the primary stream only.
+	StreamCapabilities *VideoStreamCapabilities `protobuf:"bytes,2,opt,name=stream_capabilities,json=streamCapabilities,proto3" json:"stream_capabilities,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *ListVideoDevicesResponse) Reset() {
@@ -323,6 +326,13 @@ func (x *ListVideoDevicesResponse) GetDevices() []*VideoDevice {
 	return nil
 }
 
+func (x *ListVideoDevicesResponse) GetStreamCapabilities() *VideoStreamCapabilities {
+	if x != nil {
+		return x.StreamCapabilities
+	}
+	return nil
+}
+
 type StreamVideoRequest struct {
 	state    protoimpl.MessageState `protogen:"open.v1"`
 	DeviceId uint32                 `protobuf:"varint,1,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty"` // numeric suffix N in /dev/videoN; 0 maps to /dev/video0
@@ -358,8 +368,28 @@ type StreamVideoRequest struct {
 	// intervals cost bitrate (keyframes are large); 1 makes every frame
 	// independent and every rate exactly achievable, at the highest byte cost.
 	KeyframeIntervalFrames uint32 `protobuf:"varint,6,opt,name=keyframe_interval_frames,json=keyframeIntervalFrames,proto3" json:"keyframe_interval_frames,omitempty"`
-	unknownFields          protoimpl.UnknownFields
-	sizeCache              protoimpl.SizeCache
+	// Ask for a stream at different dimensions or bitrate from the camera's
+	// primary one. Unset means the primary stream, which is what every existing
+	// client gets and what this field must never change for them.
+	//
+	// Like max_framerate this is a property of one connection and takes no part
+	// in the stream-parameter compatibility check, so subscribers may ask for
+	// different variants without any of them being rejected.
+	//
+	// Variants are shared BY VALUE: subscribers asking for the same dimensions
+	// and bitrate are served by one stream between them, so the device's cost
+	// scales with the number of distinct variants, not with the number of
+	// clients. The obvious implementation — one variant per subscriber — is the
+	// expensive one and is deliberately not what this is.
+	//
+	// A device serves a variant only when it can do so without taking capacity
+	// from what else it runs, and reports what it can do in
+	// VideoStreamCapabilities. Ask for one it cannot serve and the request is
+	// refused with a reason; it is never silently downgraded, and never served
+	// by starving another workload on the device.
+	Variant       *StreamVariant `protobuf:"bytes,7,opt,name=variant,proto3" json:"variant,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *StreamVideoRequest) Reset() {
@@ -434,6 +464,154 @@ func (x *StreamVideoRequest) GetKeyframeIntervalFrames() uint32 {
 	return 0
 }
 
+func (x *StreamVideoRequest) GetVariant() *StreamVariant {
+	if x != nil {
+		return x.Variant
+	}
+	return nil
+}
+
+// A requested stream shape. Zero fields mean "same as the primary stream", so
+// an empty variant is a request for the primary.
+type StreamVariant struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Width         uint32                 `protobuf:"varint,1,opt,name=width,proto3" json:"width,omitempty"`                             // pixels; 0 = same as primary
+	Height        uint32                 `protobuf:"varint,2,opt,name=height,proto3" json:"height,omitempty"`                           // pixels; 0 = same as primary
+	BitrateBps    uint32                 `protobuf:"varint,3,opt,name=bitrate_bps,json=bitrateBps,proto3" json:"bitrate_bps,omitempty"` // target bitrate; 0 = encoder default
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StreamVariant) Reset() {
+	*x = StreamVariant{}
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StreamVariant) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StreamVariant) ProtoMessage() {}
+
+func (x *StreamVariant) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StreamVariant.ProtoReflect.Descriptor instead.
+func (*StreamVariant) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *StreamVariant) GetWidth() uint32 {
+	if x != nil {
+		return x.Width
+	}
+	return 0
+}
+
+func (x *StreamVariant) GetHeight() uint32 {
+	if x != nil {
+		return x.Height
+	}
+	return 0
+}
+
+func (x *StreamVariant) GetBitrateBps() uint32 {
+	if x != nil {
+		return x.BitrateBps
+	}
+	return 0
+}
+
+// What a device can offer beyond its primary stream. Reported so a client can
+// ask for what exists rather than discovering the limits by being refused.
+type VideoStreamCapabilities struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The device has usable video-encode hardware. When false, producing a
+	// second stream costs general CPU that may be committed to other work.
+	HardwareEncode bool `protobuf:"varint,1,opt,name=hardware_encode,json=hardwareEncode,proto3" json:"hardware_encode,omitempty"`
+	// How many distinct variants the device will serve at once, beyond the
+	// primary. Zero means variants are unavailable and only the primary stream
+	// (optionally rate-limited per subscriber) can be served.
+	MaxVariants uint32 `protobuf:"varint,2,opt,name=max_variants,json=maxVariants,proto3" json:"max_variants,omitempty"`
+	// Why max_variants is what it is, in words, for a human reading a log or an
+	// error. Not meant to be parsed.
+	VariantNote string `protobuf:"bytes,3,opt,name=variant_note,json=variantNote,proto3" json:"variant_note,omitempty"`
+	// Per-subscriber frame rate limiting (max_framerate) is available. It costs
+	// the device nothing, so it is offered wherever this agent runs.
+	PerSubscriberFramerate bool `protobuf:"varint,4,opt,name=per_subscriber_framerate,json=perSubscriberFramerate,proto3" json:"per_subscriber_framerate,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
+}
+
+func (x *VideoStreamCapabilities) Reset() {
+	*x = VideoStreamCapabilities{}
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *VideoStreamCapabilities) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*VideoStreamCapabilities) ProtoMessage() {}
+
+func (x *VideoStreamCapabilities) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use VideoStreamCapabilities.ProtoReflect.Descriptor instead.
+func (*VideoStreamCapabilities) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *VideoStreamCapabilities) GetHardwareEncode() bool {
+	if x != nil {
+		return x.HardwareEncode
+	}
+	return false
+}
+
+func (x *VideoStreamCapabilities) GetMaxVariants() uint32 {
+	if x != nil {
+		return x.MaxVariants
+	}
+	return 0
+}
+
+func (x *VideoStreamCapabilities) GetVariantNote() string {
+	if x != nil {
+		return x.VariantNote
+	}
+	return ""
+}
+
+func (x *VideoStreamCapabilities) GetPerSubscriberFramerate() bool {
+	if x != nil {
+		return x.PerSubscriberFramerate
+	}
+	return false
+}
+
 // Credentials for a network camera. Stored on the device, never returned by any
 // RPC: listings report only has_credentials.
 type SetCameraCredentialsRequest struct {
@@ -447,7 +625,7 @@ type SetCameraCredentialsRequest struct {
 
 func (x *SetCameraCredentialsRequest) Reset() {
 	*x = SetCameraCredentialsRequest{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[4]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -459,7 +637,7 @@ func (x *SetCameraCredentialsRequest) String() string {
 func (*SetCameraCredentialsRequest) ProtoMessage() {}
 
 func (x *SetCameraCredentialsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[4]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -472,7 +650,7 @@ func (x *SetCameraCredentialsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetCameraCredentialsRequest.ProtoReflect.Descriptor instead.
 func (*SetCameraCredentialsRequest) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDescGZIP(), []int{4}
+	return file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *SetCameraCredentialsRequest) GetDeviceId() uint32 {
@@ -504,7 +682,7 @@ type SetCameraCredentialsResponse struct {
 
 func (x *SetCameraCredentialsResponse) Reset() {
 	*x = SetCameraCredentialsResponse{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[5]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -516,7 +694,7 @@ func (x *SetCameraCredentialsResponse) String() string {
 func (*SetCameraCredentialsResponse) ProtoMessage() {}
 
 func (x *SetCameraCredentialsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[5]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -529,7 +707,7 @@ func (x *SetCameraCredentialsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetCameraCredentialsResponse.ProtoReflect.Descriptor instead.
 func (*SetCameraCredentialsResponse) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDescGZIP(), []int{5}
+	return file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDescGZIP(), []int{7}
 }
 
 type ForgetCameraRequest struct {
@@ -541,7 +719,7 @@ type ForgetCameraRequest struct {
 
 func (x *ForgetCameraRequest) Reset() {
 	*x = ForgetCameraRequest{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[6]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -553,7 +731,7 @@ func (x *ForgetCameraRequest) String() string {
 func (*ForgetCameraRequest) ProtoMessage() {}
 
 func (x *ForgetCameraRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[6]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -566,7 +744,7 @@ func (x *ForgetCameraRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ForgetCameraRequest.ProtoReflect.Descriptor instead.
 func (*ForgetCameraRequest) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDescGZIP(), []int{6}
+	return file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ForgetCameraRequest) GetDeviceId() uint32 {
@@ -584,7 +762,7 @@ type ForgetCameraResponse struct {
 
 func (x *ForgetCameraResponse) Reset() {
 	*x = ForgetCameraResponse{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[7]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -596,7 +774,7 @@ func (x *ForgetCameraResponse) String() string {
 func (*ForgetCameraResponse) ProtoMessage() {}
 
 func (x *ForgetCameraResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[7]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -609,7 +787,7 @@ func (x *ForgetCameraResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ForgetCameraResponse.ProtoReflect.Descriptor instead.
 func (*ForgetCameraResponse) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDescGZIP(), []int{7}
+	return file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDescGZIP(), []int{9}
 }
 
 type RefreshCamerasRequest struct {
@@ -620,7 +798,7 @@ type RefreshCamerasRequest struct {
 
 func (x *RefreshCamerasRequest) Reset() {
 	*x = RefreshCamerasRequest{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[8]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -632,7 +810,7 @@ func (x *RefreshCamerasRequest) String() string {
 func (*RefreshCamerasRequest) ProtoMessage() {}
 
 func (x *RefreshCamerasRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[8]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -645,7 +823,7 @@ func (x *RefreshCamerasRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefreshCamerasRequest.ProtoReflect.Descriptor instead.
 func (*RefreshCamerasRequest) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDescGZIP(), []int{8}
+	return file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDescGZIP(), []int{10}
 }
 
 type RefreshCamerasResponse struct {
@@ -657,7 +835,7 @@ type RefreshCamerasResponse struct {
 
 func (x *RefreshCamerasResponse) Reset() {
 	*x = RefreshCamerasResponse{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[9]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -669,7 +847,7 @@ func (x *RefreshCamerasResponse) String() string {
 func (*RefreshCamerasResponse) ProtoMessage() {}
 
 func (x *RefreshCamerasResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[9]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -682,7 +860,7 @@ func (x *RefreshCamerasResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefreshCamerasResponse.ProtoReflect.Descriptor instead.
 func (*RefreshCamerasResponse) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDescGZIP(), []int{9}
+	return file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *RefreshCamerasResponse) GetDevices() []*VideoDevice {
@@ -703,7 +881,7 @@ type VideoFrame struct {
 
 func (x *VideoFrame) Reset() {
 	*x = VideoFrame{}
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[10]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -715,7 +893,7 @@ func (x *VideoFrame) String() string {
 func (*VideoFrame) ProtoMessage() {}
 
 func (x *VideoFrame) ProtoReflect() protoreflect.Message {
-	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[10]
+	mi := &file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -728,7 +906,7 @@ func (x *VideoFrame) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VideoFrame.ProtoReflect.Descriptor instead.
 func (*VideoFrame) Descriptor() ([]byte, []int) {
-	return file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDescGZIP(), []int{10}
+	return file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *VideoFrame) GetData() []byte {
@@ -770,16 +948,28 @@ const file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDesc = 
 	"\x0fhas_credentials\x18\n" +
 	" \x01(\bR\x0ehasCredentials\x12\x16\n" +
 	"\x06online\x18\v \x01(\bR\x06online\"\x19\n" +
-	"\x17ListVideoDevicesRequest\"Z\n" +
+	"\x17ListVideoDevicesRequest\"\xbd\x01\n" +
 	"\x18ListVideoDevicesResponse\x12>\n" +
-	"\adevices\x18\x01 \x03(\v2$.wendy.agent.services.v1.VideoDeviceR\adevices\"\xdc\x01\n" +
+	"\adevices\x18\x01 \x03(\v2$.wendy.agent.services.v1.VideoDeviceR\adevices\x12a\n" +
+	"\x13stream_capabilities\x18\x02 \x01(\v20.wendy.agent.services.v1.VideoStreamCapabilitiesR\x12streamCapabilities\"\x9e\x02\n" +
 	"\x12StreamVideoRequest\x12\x1b\n" +
 	"\tdevice_id\x18\x01 \x01(\rR\bdeviceId\x12\x14\n" +
 	"\x05width\x18\x02 \x01(\rR\x05width\x12\x16\n" +
 	"\x06height\x18\x03 \x01(\rR\x06height\x12\x1c\n" +
 	"\tframerate\x18\x04 \x01(\rR\tframerate\x12#\n" +
 	"\rmax_framerate\x18\x05 \x01(\rR\fmaxFramerate\x128\n" +
-	"\x18keyframe_interval_frames\x18\x06 \x01(\rR\x16keyframeIntervalFrames\"r\n" +
+	"\x18keyframe_interval_frames\x18\x06 \x01(\rR\x16keyframeIntervalFrames\x12@\n" +
+	"\avariant\x18\a \x01(\v2&.wendy.agent.services.v1.StreamVariantR\avariant\"^\n" +
+	"\rStreamVariant\x12\x14\n" +
+	"\x05width\x18\x01 \x01(\rR\x05width\x12\x16\n" +
+	"\x06height\x18\x02 \x01(\rR\x06height\x12\x1f\n" +
+	"\vbitrate_bps\x18\x03 \x01(\rR\n" +
+	"bitrateBps\"\xc2\x01\n" +
+	"\x17VideoStreamCapabilities\x12'\n" +
+	"\x0fhardware_encode\x18\x01 \x01(\bR\x0ehardwareEncode\x12!\n" +
+	"\fmax_variants\x18\x02 \x01(\rR\vmaxVariants\x12!\n" +
+	"\fvariant_note\x18\x03 \x01(\tR\vvariantNote\x128\n" +
+	"\x18per_subscriber_framerate\x18\x04 \x01(\bR\x16perSubscriberFramerate\"r\n" +
 	"\x1bSetCameraCredentialsRequest\x12\x1b\n" +
 	"\tdevice_id\x18\x01 \x01(\rR\bdeviceId\x12\x1a\n" +
 	"\busername\x18\x02 \x01(\tR\busername\x12\x1a\n" +
@@ -825,7 +1015,7 @@ func file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDescGZIP
 }
 
 var file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
+var file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_goTypes = []any{
 	(VideoTransport)(0),                  // 0: wendy.agent.services.v1.VideoTransport
 	(VideoCodec)(0),                      // 1: wendy.agent.services.v1.VideoCodec
@@ -833,34 +1023,38 @@ var file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_goTypes = []
 	(*ListVideoDevicesRequest)(nil),      // 3: wendy.agent.services.v1.ListVideoDevicesRequest
 	(*ListVideoDevicesResponse)(nil),     // 4: wendy.agent.services.v1.ListVideoDevicesResponse
 	(*StreamVideoRequest)(nil),           // 5: wendy.agent.services.v1.StreamVideoRequest
-	(*SetCameraCredentialsRequest)(nil),  // 6: wendy.agent.services.v1.SetCameraCredentialsRequest
-	(*SetCameraCredentialsResponse)(nil), // 7: wendy.agent.services.v1.SetCameraCredentialsResponse
-	(*ForgetCameraRequest)(nil),          // 8: wendy.agent.services.v1.ForgetCameraRequest
-	(*ForgetCameraResponse)(nil),         // 9: wendy.agent.services.v1.ForgetCameraResponse
-	(*RefreshCamerasRequest)(nil),        // 10: wendy.agent.services.v1.RefreshCamerasRequest
-	(*RefreshCamerasResponse)(nil),       // 11: wendy.agent.services.v1.RefreshCamerasResponse
-	(*VideoFrame)(nil),                   // 12: wendy.agent.services.v1.VideoFrame
+	(*StreamVariant)(nil),                // 6: wendy.agent.services.v1.StreamVariant
+	(*VideoStreamCapabilities)(nil),      // 7: wendy.agent.services.v1.VideoStreamCapabilities
+	(*SetCameraCredentialsRequest)(nil),  // 8: wendy.agent.services.v1.SetCameraCredentialsRequest
+	(*SetCameraCredentialsResponse)(nil), // 9: wendy.agent.services.v1.SetCameraCredentialsResponse
+	(*ForgetCameraRequest)(nil),          // 10: wendy.agent.services.v1.ForgetCameraRequest
+	(*ForgetCameraResponse)(nil),         // 11: wendy.agent.services.v1.ForgetCameraResponse
+	(*RefreshCamerasRequest)(nil),        // 12: wendy.agent.services.v1.RefreshCamerasRequest
+	(*RefreshCamerasResponse)(nil),       // 13: wendy.agent.services.v1.RefreshCamerasResponse
+	(*VideoFrame)(nil),                   // 14: wendy.agent.services.v1.VideoFrame
 }
 var file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_depIdxs = []int32{
 	0,  // 0: wendy.agent.services.v1.VideoDevice.transport:type_name -> wendy.agent.services.v1.VideoTransport
 	2,  // 1: wendy.agent.services.v1.ListVideoDevicesResponse.devices:type_name -> wendy.agent.services.v1.VideoDevice
-	2,  // 2: wendy.agent.services.v1.RefreshCamerasResponse.devices:type_name -> wendy.agent.services.v1.VideoDevice
-	1,  // 3: wendy.agent.services.v1.VideoFrame.codec:type_name -> wendy.agent.services.v1.VideoCodec
-	3,  // 4: wendy.agent.services.v1.WendyVideoService.ListVideoDevices:input_type -> wendy.agent.services.v1.ListVideoDevicesRequest
-	5,  // 5: wendy.agent.services.v1.WendyVideoService.StreamVideo:input_type -> wendy.agent.services.v1.StreamVideoRequest
-	6,  // 6: wendy.agent.services.v1.WendyVideoService.SetCameraCredentials:input_type -> wendy.agent.services.v1.SetCameraCredentialsRequest
-	8,  // 7: wendy.agent.services.v1.WendyVideoService.ForgetCamera:input_type -> wendy.agent.services.v1.ForgetCameraRequest
-	10, // 8: wendy.agent.services.v1.WendyVideoService.RefreshCameras:input_type -> wendy.agent.services.v1.RefreshCamerasRequest
-	4,  // 9: wendy.agent.services.v1.WendyVideoService.ListVideoDevices:output_type -> wendy.agent.services.v1.ListVideoDevicesResponse
-	12, // 10: wendy.agent.services.v1.WendyVideoService.StreamVideo:output_type -> wendy.agent.services.v1.VideoFrame
-	7,  // 11: wendy.agent.services.v1.WendyVideoService.SetCameraCredentials:output_type -> wendy.agent.services.v1.SetCameraCredentialsResponse
-	9,  // 12: wendy.agent.services.v1.WendyVideoService.ForgetCamera:output_type -> wendy.agent.services.v1.ForgetCameraResponse
-	11, // 13: wendy.agent.services.v1.WendyVideoService.RefreshCameras:output_type -> wendy.agent.services.v1.RefreshCamerasResponse
-	9,  // [9:14] is the sub-list for method output_type
-	4,  // [4:9] is the sub-list for method input_type
-	4,  // [4:4] is the sub-list for extension type_name
-	4,  // [4:4] is the sub-list for extension extendee
-	0,  // [0:4] is the sub-list for field type_name
+	7,  // 2: wendy.agent.services.v1.ListVideoDevicesResponse.stream_capabilities:type_name -> wendy.agent.services.v1.VideoStreamCapabilities
+	6,  // 3: wendy.agent.services.v1.StreamVideoRequest.variant:type_name -> wendy.agent.services.v1.StreamVariant
+	2,  // 4: wendy.agent.services.v1.RefreshCamerasResponse.devices:type_name -> wendy.agent.services.v1.VideoDevice
+	1,  // 5: wendy.agent.services.v1.VideoFrame.codec:type_name -> wendy.agent.services.v1.VideoCodec
+	3,  // 6: wendy.agent.services.v1.WendyVideoService.ListVideoDevices:input_type -> wendy.agent.services.v1.ListVideoDevicesRequest
+	5,  // 7: wendy.agent.services.v1.WendyVideoService.StreamVideo:input_type -> wendy.agent.services.v1.StreamVideoRequest
+	8,  // 8: wendy.agent.services.v1.WendyVideoService.SetCameraCredentials:input_type -> wendy.agent.services.v1.SetCameraCredentialsRequest
+	10, // 9: wendy.agent.services.v1.WendyVideoService.ForgetCamera:input_type -> wendy.agent.services.v1.ForgetCameraRequest
+	12, // 10: wendy.agent.services.v1.WendyVideoService.RefreshCameras:input_type -> wendy.agent.services.v1.RefreshCamerasRequest
+	4,  // 11: wendy.agent.services.v1.WendyVideoService.ListVideoDevices:output_type -> wendy.agent.services.v1.ListVideoDevicesResponse
+	14, // 12: wendy.agent.services.v1.WendyVideoService.StreamVideo:output_type -> wendy.agent.services.v1.VideoFrame
+	9,  // 13: wendy.agent.services.v1.WendyVideoService.SetCameraCredentials:output_type -> wendy.agent.services.v1.SetCameraCredentialsResponse
+	11, // 14: wendy.agent.services.v1.WendyVideoService.ForgetCamera:output_type -> wendy.agent.services.v1.ForgetCameraResponse
+	13, // 15: wendy.agent.services.v1.WendyVideoService.RefreshCameras:output_type -> wendy.agent.services.v1.RefreshCamerasResponse
+	11, // [11:16] is the sub-list for method output_type
+	6,  // [6:11] is the sub-list for method input_type
+	6,  // [6:6] is the sub-list for extension type_name
+	6,  // [6:6] is the sub-list for extension extendee
+	0,  // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_init() }
@@ -874,7 +1068,7 @@ func file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDesc), len(file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   11,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   1,
 		},


### PR DESCRIPTION
**Stacked on #1707.** Review that first; this is the follow-on that makes stream shape (not just rate) a per-connection property.

## What this is, and what it deliberately is not

A client can now ask for a **variant** — a stream at different dimensions or bitrate from the camera's primary one:

```sh
wendy device camera view --variant-width 480 --variant-height 270
wendy device camera list      # shows what this device will actually serve
```

The API, the sharing model, the cap, and the capability report are all here. **The transcode route is not**, and `max_variants` is `0` on every device today. That is deliberate, and the reason is measured rather than assumed.

## Why no transcode route yet

The proposal this comes from rested on the Jetson having idle encode silicon. I checked before building, on both production Orin Nanos:

| | ccr1 | theta |
|---|---|---|
| `/dev/v4l2-nvenc`, `/dev/nvhost-msenc` | **absent** | **absent** |
| `/dev/v4l2-nvdec` | present | present |
| cores / load average | 6 / **6.27** | 6 / **7.34** |

And the cameras are raw — `/dev/video0` offers YUYV only, `/dev/video2` offers MJPG + YUYV. **Neither has an onboard H.264 encoder**, so the H.264 the agent serves today is *already* produced by a software encoder on that saturated CPU. A variant would be a second software encode on a box with negative headroom, running fire detection. So the honest thing is to refuse it and say why, which is what this PR does.

This isn't permanent. Thor-class boxes have working NVENC, and cameras with onboard H.264 would free the software encode the box is doing now. When a transcode route lands, `videoStreamCapabilities()` is the single place that opens it, and **clients written against this API need no change**.

## The design point

Variants are keyed **by value and shared**. Three subscribers asking for 480×270 are served by one variant between them — cost scales with distinct variants, not with clients. The obvious implementation is one variant per subscriber, and that is the expensive one; the code says so where the key is defined, since the cheap version is not the one you'd write by default.

Four routes exist in cost order; the device picks the cheapest it actually has. Two are live:

- **Primary (live)** — no variant, or a variant matching what the camera is already producing. Costs nothing.
- **Refuse (live)** — a clear `FailedPrecondition` naming the requested shape, the primary's actual size, why the device can't serve it, and that `max_framerate` is available instead. Never a silent downgrade, and never served by taking capacity from something else on the device.
- *Source-provided* and *transcode* — later, behind the capability.

Passthrough needs the size the camera actually settled on, not what was requested (a request of `0` means "device default", and the default is the camera's choice). Both producers now publish it, so a client that asks for exactly the primary's dimensions is recognised as wanting the primary rather than refused a variant nobody can serve.

Like `max_framerate` in #1707, the variant sits **outside** the parameter-compatibility check: it's a property of one connection, so subscribers may differ without any of them being rejected.

## Capability, so clients ask rather than discover

`ListVideoDevices` now reports `VideoStreamCapabilities`: whether encode hardware is usable (probed with the same node check the encoder selection path uses, so the advertised capability cannot disagree with the encoder the agent would pick), how many distinct variants will be admitted, a human-readable reason, and that per-subscriber frame rate is available everywhere.

`camera list` prints it, so the limit is visible before a request is refused:

```
Stream variants: unavailable — no usable video-encode hardware found on this device; a variant
would have to be encoded in software, competing with whatever else this device runs, so it is
not offered. Per-subscriber frame rate is available and costs nothing.
```

## Testing

New tests cover route resolution (including "size not known yet"), value-keyed sharing with refcounts, the cap refusing cleanly without leaving partial state, a subscriber joining an already-served variant *at* the cap, refusal wording on hardware that can't serve one, passthrough when the variant matches the primary, the unchanged primary path, and the capability report. The cap and sharing logic are exercised against a stubbed capability with `max_variants > 0`, so they are tested now rather than when a transcode route lands.

`go test ./...`, `-race` on the services package, `go vet`, `gofmt -s`, and the Windows cross-compile gate all clean.

## Verified on theta

Side-loaded onto **wendy-box-theta** (Jetson Orin Nano, USB cameras, `wendy-console-edge-detector` running throughout):

| check | result |
|---|---|
| capability report | `per_subscriber_framerate: true`, `max_variants` 0, note explaining why — matches the hardware |
| plain subscriber | 512×384, 8.06 MB in 15s — unchanged |
| variant **matching** the primary (512×384) | **served** — 7.29 MB, 709 frames |
| variant 480×270 | **refused**, see below |
| edge-detector | `RUNNING` throughout |

The refusal, in full, as a client receives it:

```
cannot serve variant 480x270 on this device: no usable video-encode hardware found on this
device; a variant would have to be encoded in software, competing with whatever else this
device runs, so it is not offered. Per-subscriber frame rate is available and costs nothing.
Request the primary stream (512x384), or use max_framerate to receive fewer of its frames
```

The matching-variant case is the one that mattered: it is the only proof that the negotiated-size plumbing works, since a unit test cannot know what size a real camera settles on. The camera was asked for nothing in particular and chose 512×384; a client naming exactly those dimensions was served the primary rather than refused a variant nobody can serve, and the refusal for a different size names 512×384 too — so both the success and the failure path read the size the camera actually negotiated.

theta was restored to the released agent afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
