### PR TITLE
fix(agent): make multi-service stops atomic

### DIFF
--- a/go/internal/agent/container/monitor.go
+++ b/go/internal/agent/container/monitor.go
@@ -248,27 +248,23 @@ func (m *ContainerMonitor) Suppress(containerName string) func() {
 }
 
 // restartBlocked reports whether containerName currently has a Suppress
-// handle held on it, or is marked as explicitly stopped under a policy that
-// honors that mark, and so must not be (re)started. Used by restartSingle to
+// handle held on it, or is marked as explicitly stopped, and so must not be
+// (re)started. Used by restartSingle to
 // re-check right before it would call StartContainer — see the comment there
 // for why this differs from the planRestarts-time check.
 //
-// The ExplicitStop arm is policy-aware (via restartPolicyHonorsExplicitStop)
-// rather than unconditional: shouldRestart deliberately restarts
-// RestartAlways containers even after an explicit stop, and an unconditional
-// block here would fight that — planRestarts schedules the restart every
-// tick (log churn, unbounded FailureCount, RestartStatuses misreporting
-// WillRestart=true as if it were crash-looping) while this guard silently
-// swallowed every attempt forever. The suppression arm stays unconditional:
-// suppression means a replace/stop operation is actively tearing the task
-// down right now, which is orthogonal to restart policy.
+// Both arms are unconditional. Restart policies govern spontaneous exits;
+// none of them overrides an explicit user stop. In particular, allowing
+// RestartAlways through here makes a multi-service group's first stopped
+// member schedule a whole-group restart while its siblings are still being
+// stopped.
 func (m *ContainerMonitor) restartBlocked(containerName string) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.suppressed[containerName] > 0 {
 		return true
 	}
-	if state, ok := m.states[containerName]; ok && state.ExplicitStop && restartPolicyHonorsExplicitStop(state.RestartPolicy) {
+	if state, ok := m.states[containerName]; ok && state.ExplicitStop {
 		return true
 	}
 	return false
@@ -415,11 +411,11 @@ func (m *ContainerMonitor) planRestartActions(ctx context.Context, toRestart []s
 					continue
 				}
 				seenGroup[appID] = true
-				if m.groupHasSuppressedMember(ctx, gr, appID) {
-					// A sibling in this group is mid-replace/stop (a Suppress
-					// handle is held on it) even though it didn't itself
-					// qualify for toRestart — e.g. still reporting RUNNING
-					// because the caller hasn't killed its task yet.
+				if m.groupHasBlockedMember(ctx, gr, appID) {
+					// A sibling in this group is mid-replace/stop or was
+					// explicitly stopped, even though it didn't itself qualify
+					// for toRestart — e.g. it still reports RUNNING because
+					// the caller hasn't killed its task yet.
 					// RestartGroup stops/recreates every member, which would
 					// stomp on whatever that operation is doing to the
 					// suppressed one. Defer the whole group restart; the next
@@ -435,20 +431,24 @@ func (m *ContainerMonitor) planRestartActions(ctx context.Context, toRestart []s
 	return actions
 }
 
-// groupHasSuppressedMember reports whether any currently-suppressed container
-// name (see Suppress) belongs to the same shared-namespace group as appID.
-// Suppressed names are usually few (in-flight replace/stop operations), so
-// this scans them directly rather than requiring a reverse appID->members
-// index the monitor doesn't otherwise need.
-func (m *ContainerMonitor) groupHasSuppressedMember(ctx context.Context, gr services.GroupRestarter, appID string) bool {
+// groupHasBlockedMember reports whether any suppressed or explicitly-stopped
+// container belongs to the same shared-namespace group as appID. Blocked names
+// are normally few, so this scans them directly rather than maintaining a
+// second appID-to-members index.
+func (m *ContainerMonitor) groupHasBlockedMember(ctx context.Context, gr services.GroupRestarter, appID string) bool {
 	m.mu.Lock()
-	names := make([]string, 0, len(m.suppressed))
+	blocked := make(map[string]struct{}, len(m.suppressed))
 	for name := range m.suppressed {
-		names = append(names, name)
+		blocked[name] = struct{}{}
+	}
+	for name, state := range m.states {
+		if state.ExplicitStop {
+			blocked[name] = struct{}{}
+		}
 	}
 	m.mu.Unlock()
 
-	for _, name := range names {
+	for name := range blocked {
 		if memberAppID, grouped := gr.GroupRestartAppID(ctx, name); grouped && memberAppID == appID {
 			return true
 		}
@@ -509,6 +509,16 @@ func (m *ContainerMonitor) restartGroup(ctx context.Context, appID string) {
 		delete(m.groupRestarting, appID)
 		m.mu.Unlock()
 	}()
+
+	// Re-check after claiming the in-flight slot. A stop can mark/suppress the
+	// group after planRestartActions chose it but before this goroutine runs.
+	// Without this execution-time guard the stale action can resurrect every
+	// member after the user-visible stop has already completed.
+	if m.groupHasBlockedMember(ctx, gr, appID) {
+		m.logger.Debug("Skipping app group restart: member stopped or suppressed since being scheduled",
+			zap.String("app_id", appID))
+		return
+	}
 	channels, err := gr.RestartGroup(ctx, appID)
 	// RestartGroup can return partially-started services together with an
 	// error (e.g. the primary started but a secondary failed). Drain every
@@ -641,32 +651,11 @@ func (m *ContainerMonitor) planRestarts(containers []*agentpb.AppContainer) []st
 	return toRestart
 }
 
-// restartPolicyHonorsExplicitStop reports whether policy's restart decision
-// is gated by containerState.ExplicitStop. RestartUnlessStopped and
-// RestartOnFailure honor it — a user-initiated stop is meant to stick.
-// RestartAlways deliberately does not: restarting even after an explicit
-// stop is the entire point of "always" (that's the pre-existing, unreviewed-
-// here behavior shouldRestart already implements below). RestartNo never
-// restarts regardless, so the question doesn't apply to it either way.
-//
-// Shared by shouldRestart (the tick-time restart decision) and
-// restartBlocked (restartSingle's just-before-the-call re-check) so the two
-// cannot drift on which policies treat an explicit stop as binding — that
-// drift is exactly what caused an explicitly-stopped RestartAlways app to
-// get stuck in a perpetual scheduled-then-silently-skipped loop before this
-// helper existed.
-func restartPolicyHonorsExplicitStop(policy RestartPolicy) bool {
-	switch policy {
-	case RestartUnlessStopped, RestartOnFailure:
-		return true
-	default: // RestartNo, RestartAlways, and any future/unknown policy.
-		return false
-	}
-}
-
 // shouldRestart determines whether a container should be restarted based on its policy.
 func (m *ContainerMonitor) shouldRestart(state *containerState) bool {
-	if restartPolicyHonorsExplicitStop(state.RestartPolicy) && state.ExplicitStop {
+	// A direct user stop always wins. RestartAlways means "restart after every
+	// spontaneous exit", not "make the stop command ineffective".
+	if state.ExplicitStop {
 		return false
 	}
 	switch state.RestartPolicy {
@@ -679,8 +668,8 @@ func (m *ContainerMonitor) shouldRestart(state *containerState) bool {
 		// exit-code signal from containerd. Until exit-code detection is added,
 		// ON_FAILURE behaves like UNLESS_STOPPED: it restarts on any exit, not
 		// only non-zero ones. MaxRetries is still enforced. The ExplicitStop
-		// check above already ran for this policy (restartPolicyHonorsExplicitStop
-		// includes it), so reaching here means it wasn't set.
+		// ExplicitStop check above already ran, so reaching here means it wasn't
+		// set.
 		if state.MaxRetries > 0 && state.FailureCount >= state.MaxRetries {
 			return false
 		}

--- a/go/internal/agent/container/monitor_checkcontainers_test.go
+++ b/go/internal/agent/container/monitor_checkcontainers_test.go
@@ -443,14 +443,9 @@ func TestRestartSingle_StartsWhenNotBlocked(t *testing.T) {
 	}
 }
 
-// TestCheckContainers_ExplicitlyStoppedAlwaysPolicyStillRestarts is the full
-// round-trip regression guard for fix round 2: an explicitly-stopped
-// RestartAlways app must still be started by a tick. Before this round,
-// restartBlocked's ExplicitStop arm was unconditional, so this exact
-// scenario would loop forever — planRestarts schedules it every tick (it
-// never gated RestartAlways on ExplicitStop) while restartSingle's guard
-// silently swallowed every attempt, so `StartContainer` was never called.
-func TestCheckContainers_ExplicitlyStoppedAlwaysPolicyStillRestarts(t *testing.T) {
+// TestCheckContainers_ExplicitlyStoppedAlwaysPolicyStaysStopped is the full
+// round-trip guard that a manual stop wins over RestartAlways.
+func TestCheckContainers_ExplicitlyStoppedAlwaysPolicyStaysStopped(t *testing.T) {
 	fake := &fakeContainerd{
 		started: make(chan string, 1),
 		containers: []*agentpb.AppContainer{{
@@ -466,11 +461,8 @@ func TestCheckContainers_ExplicitlyStoppedAlwaysPolicyStillRestarts(t *testing.T
 
 	select {
 	case got := <-fake.started:
-		if got != "always-app" {
-			t.Fatalf("started %q, want always-app", got)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("expected StartContainer(always-app) despite ExplicitStop (RestartAlways policy), got none")
+		t.Fatalf("unexpectedly started %q after explicit stop", got)
+	case <-time.After(50 * time.Millisecond):
 	}
 }
 

--- a/go/internal/agent/container/monitor_test.go
+++ b/go/internal/agent/container/monitor_test.go
@@ -159,13 +159,8 @@ func TestContainerMonitor_ShouldRestart_OnFailure(t *testing.T) {
 	}
 }
 
-// TestContainerMonitor_ShouldRestart_Always verifies RestartAlways restarts
-// even when the container has been explicitly stopped. This is pre-existing
-// behavior (restarting after an explicit stop is the entire point of
-// "always") that fix round 2 exists specifically to preserve: restartBlocked
-// must agree with it, or an explicitly-stopped RestartAlways app gets stuck
-// in a perpetual scheduled-by-planRestarts-then-silently-skipped-by-
-// restartSingle loop.
+// TestContainerMonitor_ShouldRestart_Always verifies RestartAlways handles
+// spontaneous exits but still yields to an explicit user stop.
 func TestContainerMonitor_ShouldRestart_Always(t *testing.T) {
 	m := newTestMonitor()
 
@@ -175,44 +170,20 @@ func TestContainerMonitor_ShouldRestart_Always(t *testing.T) {
 	}
 
 	state.ExplicitStop = true
-	if !m.shouldRestart(state) {
-		t.Error("shouldRestart() = false for RestartAlways (explicitly stopped), want true — RestartAlways ignores ExplicitStop by design")
+	if m.shouldRestart(state) {
+		t.Error("shouldRestart() = true for explicitly-stopped RestartAlways, want false")
 	}
 }
 
-// TestRestartPolicyHonorsExplicitStop is a direct table test of the shared
-// predicate shouldRestart and restartBlocked both derive from, so the two
-// cannot silently drift on which policies treat an explicit stop as binding.
-func TestRestartPolicyHonorsExplicitStop(t *testing.T) {
-	tests := []struct {
-		policy RestartPolicy
-		want   bool
-	}{
-		{RestartNo, false},
-		{RestartUnlessStopped, true},
-		{RestartOnFailure, true},
-		{RestartAlways, false},
-		{RestartPolicy(99), false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.policy.String(), func(t *testing.T) {
-			if got := restartPolicyHonorsExplicitStop(tt.policy); got != tt.want {
-				t.Errorf("restartPolicyHonorsExplicitStop(%v) = %v, want %v", tt.policy, got, tt.want)
-			}
-		})
-	}
-}
-
-// TestRestartBlocked_AlwaysPolicyIgnoresExplicitStop is the regression guard
-// for the fix round 2 finding: restartBlocked's ExplicitStop arm must not
-// block a RestartAlways container just because it was explicitly stopped.
-func TestRestartBlocked_AlwaysPolicyIgnoresExplicitStop(t *testing.T) {
+// TestRestartBlocked_AlwaysPolicyHonorsExplicitStop guards the direct-start
+// race between a monitor tick and a user stop.
+func TestRestartBlocked_AlwaysPolicyHonorsExplicitStop(t *testing.T) {
 	m := newTestMonitor()
 	m.Register("com.example.app", RestartAlways, 0)
 	m.MarkExplicitStop("com.example.app")
 
-	if m.restartBlocked("com.example.app") {
-		t.Error("restartBlocked() = true for RestartAlways + ExplicitStop + not suppressed; want false (old semantics: RestartAlways restarts even after explicit stop)")
+	if !m.restartBlocked("com.example.app") {
+		t.Error("restartBlocked() = false for RestartAlways + ExplicitStop; want true")
 	}
 }
 
@@ -244,12 +215,10 @@ func TestRestartBlocked_SuppressedAlwaysStillBlocked(t *testing.T) {
 	}
 }
 
-// TestPlanRestarts_ExplicitlyStoppedAlwaysPolicyStillScheduled locks in
-// pre-round-1 behavior for RestartAlways: even explicitly stopped, a down
-// RestartAlways container must still be scheduled by planRestarts — matching
-// shouldRestart, which never gated RestartAlways on ExplicitStop — with no
-// skip and no double count of FailureCount.
-func TestPlanRestarts_ExplicitlyStoppedAlwaysPolicyStillScheduled(t *testing.T) {
+// TestPlanRestarts_ExplicitlyStoppedAlwaysPolicyStaysStopped is the group-stop
+// regression: an `always` member must not schedule a group restart after a
+// direct user stop.
+func TestPlanRestarts_ExplicitlyStoppedAlwaysPolicyStaysStopped(t *testing.T) {
 	m := newTestMonitor()
 	m.Register("com.example.app", RestartAlways, 0)
 	m.MarkExplicitStop("com.example.app")
@@ -259,15 +228,15 @@ func TestPlanRestarts_ExplicitlyStoppedAlwaysPolicyStillScheduled(t *testing.T) 
 	}
 
 	got := m.planRestarts(stopped)
-	if len(got) != 1 || got[0] != "com.example.app" {
-		t.Errorf("planRestarts = %v; want [com.example.app] (RestartAlways ignores ExplicitStop)", got)
+	if len(got) != 0 {
+		t.Errorf("planRestarts = %v; want none for explicitly-stopped RestartAlways", got)
 	}
 
 	m.mu.Lock()
 	fc := m.states["com.example.app"].FailureCount
 	m.mu.Unlock()
-	if fc != 1 {
-		t.Errorf("FailureCount = %d after one planRestarts call; want 1 (no double count)", fc)
+	if fc != 0 {
+		t.Errorf("FailureCount = %d after explicit stop; want 0", fc)
 	}
 }
 
@@ -408,6 +377,36 @@ func TestPlanRestartActions_DefersGroupWhenMemberSuppressed(t *testing.T) {
 	actions = m.planRestartActions(context.Background(), []string{"app_listener"})
 	if len(actions) != 1 || actions[0].groupAppID != "app" {
 		t.Errorf("planRestartActions after resume = %+v; want one group action for app", actions)
+	}
+}
+
+func TestPlanRestartActions_DefersGroupWhenMemberExplicitlyStopped(t *testing.T) {
+	fake := &fakeContainerdClient{groupOf: map[string]string{
+		"app_talker":   "app",
+		"app_listener": "app",
+	}}
+	m := NewContainerMonitor(zap.NewNop(), fake, nil, time.Second)
+	m.Register("app_talker", RestartAlways, 0)
+	m.MarkExplicitStop("app_talker")
+
+	actions := m.planRestartActions(context.Background(), []string{"app_listener"})
+	if len(actions) != 0 {
+		t.Errorf("planRestartActions = %+v with explicitly-stopped sibling; want no action", actions)
+	}
+}
+
+func TestRestartGroup_SkipsWhenMemberStoppedAfterScheduling(t *testing.T) {
+	fake := &fakeContainerdClient{groupOf: map[string]string{
+		"app_talker":   "app",
+		"app_listener": "app",
+	}}
+	m := NewContainerMonitor(zap.NewNop(), fake, nil, time.Second)
+	m.Register("app_talker", RestartAlways, 0)
+	m.MarkExplicitStop("app_talker")
+
+	m.restartGroup(context.Background(), "app")
+	if len(fake.groupRestarts) != 0 {
+		t.Errorf("RestartGroup calls = %v; want none", fake.groupRestarts)
 	}
 }
 

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -52,6 +52,8 @@ import (
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
 
+var errAppStopping = errors.New("app is currently being stopped")
+
 // Compile-time check that *Client satisfies services.ContainerdClient.
 var _ services.ContainerdClient = (*Client)(nil)
 
@@ -1555,6 +1557,9 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 		}
 	}()
 	ctx = c.withNamespace(ctx)
+	if c.appStopping[appID] {
+		return nil, fmt.Errorf("%w: %q", errAppStopping, appID)
+	}
 
 	// Start streams one container's output, so a bare appID naming a group is
 	// an error here rather than a fan-out.
@@ -1584,6 +1589,13 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 		// ListBootContainers (e.g. a direct restart of a single container).
 		// c.mu is already held here (muHeld), so use the lock-free core.
 		c.hydrateIsolationLocked(appID, labels)
+	}
+	// The parsed name above can be ambiguous when app IDs contain underscores;
+	// repeat the check after authoritative labels resolve the actual app ID.
+	// Since StopContainer sets appStopping while holding this same mutex, a
+	// start is either fully ordered before the stop snapshot or rejected here.
+	if c.appStopping[appID] {
+		return nil, fmt.Errorf("%w: %q", errAppStopping, appID)
 	}
 
 	// Reboot resilience for meshed containers (C-final-review Fix 1): the
@@ -2783,6 +2795,9 @@ func (c *Client) RestartGroup(ctx context.Context, appID string) (map[string]<-c
 	if err != nil {
 		return nil, fmt.Errorf("RestartGroup: resolving service order for %q: %w", appID, err)
 	}
+	if err := c.ensureGroupRestartAllowed(ctx, appID, order); err != nil {
+		return nil, err
+	}
 
 	// 1. Stop every member task so no secondary is left attached to a namespace
 	//    about to be recreated. Containers are kept; only tasks are deleted.
@@ -2804,6 +2819,9 @@ func (c *Client) RestartGroup(ctx context.Context, appID string) (map[string]<-c
 	// 3. Start the primary first so setPrimaryPID records the new live PID
 	//    before any secondary resolves its join against it.
 	primaryName := ContainerName(appID, order[0])
+	if err := c.ensureGroupRestartAllowed(ctx, appID, order); err != nil {
+		return nil, err
+	}
 	primaryCh, err := c.StartContainer(ctx, primaryName, "", nil)
 	if err != nil {
 		return nil, fmt.Errorf("RestartGroup: starting primary %q: %w", primaryName, err)
@@ -2821,6 +2839,9 @@ func (c *Client) RestartGroup(ctx context.Context, appID string) (map[string]<-c
 	//    then start it.
 	for _, svc := range order[1:] {
 		name := ContainerName(appID, svc)
+		if err := c.ensureGroupRestartAllowed(ctx, appID, order); err != nil {
+			return results, err
+		}
 		if rerr := c.refreshSecondaryNamespaces(ctx, name, primaryPID, isolation); rerr != nil {
 			c.logger.Error("RestartGroup: failed to refresh secondary namespaces",
 				zap.String(logfields.AppID, appID), zap.String(logfields.ServiceName, svc), zap.Error(rerr))
@@ -2828,6 +2849,9 @@ func (c *Client) RestartGroup(ctx context.Context, appID string) (map[string]<-c
 		}
 		ch, serr := c.StartContainer(ctx, name, "", nil)
 		if serr != nil {
+			if errors.Is(serr, errAppStopping) {
+				return results, serr
+			}
 			c.logger.Error("RestartGroup: failed to start secondary",
 				zap.String(logfields.AppID, appID), zap.String(logfields.ServiceName, svc), zap.Error(serr))
 			continue
@@ -2835,6 +2859,33 @@ func (c *Client) RestartGroup(ctx context.Context, appID string) (map[string]<-c
 		results[name] = ch
 	}
 	return results, nil
+}
+
+// ensureGroupRestartAllowed prevents a stale monitor action from reviving an
+// app after a user stop. It is called before teardown and again before each
+// member start because a stop can begin at any point in the group operation.
+func (c *Client) ensureGroupRestartAllowed(ctx context.Context, appID string, order []string) error {
+	c.mu.Lock()
+	stopping := c.appStopping[appID]
+	c.mu.Unlock()
+	if stopping {
+		return fmt.Errorf("%w: %q", errAppStopping, appID)
+	}
+	for _, svc := range order {
+		name := ContainerName(appID, svc)
+		ctr, err := c.client.LoadContainer(ctx, name)
+		if err != nil {
+			return fmt.Errorf("RestartGroup: checking stop state for %q: %w", name, err)
+		}
+		labels, err := ctr.Labels(ctx)
+		if err != nil {
+			return fmt.Errorf("RestartGroup: reading stop state for %q: %w", name, err)
+		}
+		if labels[labelKeyStoppedByUser] == "true" {
+			return fmt.Errorf("RestartGroup: app %q was explicitly stopped", appID)
+		}
+	}
+	return nil
 }
 
 // refreshSecondaryNamespaces rewrites a secondary container's stored OCI spec so

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -2795,7 +2795,7 @@ func (c *Client) RestartGroup(ctx context.Context, appID string) (map[string]<-c
 	if err != nil {
 		return nil, fmt.Errorf("RestartGroup: resolving service order for %q: %w", appID, err)
 	}
-	if err := c.ensureGroupRestartAllowed(ctx, appID, order); err != nil {
+	if err := c.ensureGroupRestartAllowed(ctx, appID, order...); err != nil {
 		return nil, err
 	}
 
@@ -2819,7 +2819,7 @@ func (c *Client) RestartGroup(ctx context.Context, appID string) (map[string]<-c
 	// 3. Start the primary first so setPrimaryPID records the new live PID
 	//    before any secondary resolves its join against it.
 	primaryName := ContainerName(appID, order[0])
-	if err := c.ensureGroupRestartAllowed(ctx, appID, order); err != nil {
+	if err := c.ensureGroupRestartAllowed(ctx, appID, order[0]); err != nil {
 		return nil, err
 	}
 	primaryCh, err := c.StartContainer(ctx, primaryName, "", nil)
@@ -2839,7 +2839,7 @@ func (c *Client) RestartGroup(ctx context.Context, appID string) (map[string]<-c
 	//    then start it.
 	for _, svc := range order[1:] {
 		name := ContainerName(appID, svc)
-		if err := c.ensureGroupRestartAllowed(ctx, appID, order); err != nil {
+		if err := c.ensureGroupRestartAllowed(ctx, appID, svc); err != nil {
 			return results, err
 		}
 		if rerr := c.refreshSecondaryNamespaces(ctx, name, primaryPID, isolation); rerr != nil {
@@ -2862,16 +2862,19 @@ func (c *Client) RestartGroup(ctx context.Context, appID string) (map[string]<-c
 }
 
 // ensureGroupRestartAllowed prevents a stale monitor action from reviving an
-// app after a user stop. It is called before teardown and again before each
-// member start because a stop can begin at any point in the group operation.
-func (c *Client) ensureGroupRestartAllowed(ctx context.Context, appID string, order []string) error {
+// app after a user stop. Before teardown callers pass every member so an
+// already-stopped group is left untouched. Before a start they pass only that
+// member: a user stop persists the marker on every member, while appStopping
+// covers teardown in progress, so checking the full group again would only add
+// quadratic containerd metadata reads.
+func (c *Client) ensureGroupRestartAllowed(ctx context.Context, appID string, serviceNames ...string) error {
 	c.mu.Lock()
 	stopping := c.appStopping[appID]
 	c.mu.Unlock()
 	if stopping {
 		return fmt.Errorf("%w: %q", errAppStopping, appID)
 	}
-	for _, svc := range order {
+	for _, svc := range serviceNames {
 		name := ContainerName(appID, svc)
 		ctr, err := c.client.LoadContainer(ctx, name)
 		if err != nil {

--- a/go/internal/agent/containerd/client_test.go
+++ b/go/internal/agent/containerd/client_test.go
@@ -1,6 +1,7 @@
 package containerd
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -1418,6 +1419,17 @@ func TestSuppressRestartsNoopWhenNoMonitor(t *testing.T) {
 		t.Fatal("suppressRestarts returned a nil func with no monitor wired")
 	}
 	resume() // must not panic
+}
+
+func TestStartContainerRejectsStartWhileAppStopping(t *testing.T) {
+	c := &Client{
+		namespace:   "default",
+		appStopping: map[string]bool{"com.example.app": true},
+	}
+	_, err := c.StartContainer(context.Background(), "com.example.app", "", nil)
+	if !errors.Is(err, errAppStopping) {
+		t.Fatalf("StartContainer error = %v; want errAppStopping", err)
+	}
 }
 
 // TestSuppressRestartsDelegatesToMonitor verifies suppressRestarts forwards

--- a/go/internal/agent/services/container_service.go
+++ b/go/internal/agent/services/container_service.go
@@ -1017,22 +1017,32 @@ func (s *ContainerService) StopContainer(ctx context.Context, req *agentpb.StopC
 			s.monitor.MarkExplicitStop(id)
 		}
 	}
+	// Persist intent before beginning teardown. Besides surviving reboot, this
+	// lets a group restart that was queued just before MarkExplicitStop observe
+	// the stop even if its goroutine does not run until after the monitor's
+	// in-memory suppression handles have been released.
+	var persisted []string
+	for _, id := range ids {
+		if err := s.containerd.SetStoppedByUser(ctx, id, true); err != nil {
+			s.logger.Warn("failed to persist stopped-by-user mark",
+				zap.String("container_id", id), zap.Error(err))
+			continue
+		}
+		persisted = append(persisted, id)
+	}
 	if err := s.containerd.StopContainer(ctx, appName); err != nil {
 		if s.monitor != nil {
 			for _, id := range ids {
 				s.monitor.ClearExplicitStop(id)
 			}
 		}
-		return nil, status.Errorf(codes.Internal, "failed to stop container: %v", err)
-	}
-	// Persist the stop so it survives a reboot: the boot reconcile skips
-	// containers carrying this mark, so a deliberate stop is not undone by the
-	// restart policy. Best-effort — a label failure must not fail the stop.
-	for _, id := range ids {
-		if err := s.containerd.SetStoppedByUser(ctx, id, true); err != nil {
-			s.logger.Warn("failed to persist stopped-by-user mark",
-				zap.String("container_id", id), zap.Error(err))
+		for _, id := range persisted {
+			if clearErr := s.containerd.SetStoppedByUser(ctx, id, false); clearErr != nil {
+				s.logger.Warn("failed to roll back stopped-by-user mark",
+					zap.String("container_id", id), zap.Error(clearErr))
+			}
 		}
+		return nil, status.Errorf(codes.Internal, "failed to stop container: %v", err)
 	}
 	s.logger.Info("App stopped", zap.String("app_name", appName), zap.Int("service_count", len(ids)))
 	return &agentpb.StopContainerResponse{}, nil

--- a/go/internal/agent/services/container_service.go
+++ b/go/internal/agent/services/container_service.go
@@ -1036,8 +1036,9 @@ func (s *ContainerService) StopContainer(ctx context.Context, req *agentpb.StopC
 				s.monitor.ClearExplicitStop(id)
 			}
 		}
+		cleanupCtx := context.WithoutCancel(ctx)
 		for _, id := range persisted {
-			if clearErr := s.containerd.SetStoppedByUser(ctx, id, false); clearErr != nil {
+			if clearErr := s.containerd.SetStoppedByUser(cleanupCtx, id, false); clearErr != nil {
 				s.logger.Warn("failed to roll back stopped-by-user mark",
 					zap.String("container_id", id), zap.Error(clearErr))
 			}

--- a/go/internal/agent/services/container_service_test.go
+++ b/go/internal/agent/services/container_service_test.go
@@ -2,11 +2,13 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
@@ -346,6 +348,23 @@ func TestStopContainer_PersistsStoppedByUser(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("expected SetStoppedByUser(test-app, true); calls = %+v", mock.stoppedByUserCalls)
+	}
+}
+
+func TestStopContainer_RollsBackStoppedByUserWhenStopFails(t *testing.T) {
+	mock := &mockContainerdClient{
+		containers: []*agentpb.AppContainer{{AppName: "test-app"}},
+		stopErr:    errors.New("stop failed"),
+	}
+	client, cleanup := startContainerServer(t, mock)
+	defer cleanup()
+
+	if _, err := client.StopContainer(context.Background(), &agentpb.StopContainerRequest{AppName: "test-app"}); err == nil {
+		t.Fatal("StopContainer error = nil; want failure")
+	}
+	want := []stoppedByUserCall{{containerID: "test-app", stopped: true}, {containerID: "test-app", stopped: false}}
+	if !reflect.DeepEqual(mock.stoppedByUserCalls, want) {
+		t.Fatalf("SetStoppedByUser calls = %+v; want %+v", mock.stoppedByUserCalls, want)
 	}
 }
 

--- a/go/internal/agent/services/interfaces.go
+++ b/go/internal/agent/services/interfaces.go
@@ -210,7 +210,7 @@ type ContainerMonitorRegistrar interface {
 	// Unregister removes appName from the monitor.
 	Unregister(appName string)
 	// MarkExplicitStop marks appName as intentionally stopped so it won't be
-	// automatically restarted by an unless-stopped or on-failure policy.
+	// automatically restarted, regardless of restart policy.
 	MarkExplicitStop(appName string)
 	// ClearExplicitStop reverts a prior MarkExplicitStop call, re-enabling
 	// automatic restarts for appName. Used to undo a pre-emptive mark when the


### PR DESCRIPTION
## Summary

- make explicit user stops override every restart policy, including `always`
- block queued or in-flight group restarts once any member is stopped or suppressed
- persist group stop intent before teardown and roll it back if stopping fails
- reject service starts while an app-wide stop is active

## Root cause

The restart monitor treated `restart: always` as stronger than a direct user stop. For multi-service applications, stopping the first member could therefore schedule a whole-group restart while sibling services were still being torn down. A group restart already queued before the stop could also pass the planning-time suppression check and revive members after teardown.

## Impact

`wendy device apps stop <app>` now leaves the entire multi-service application stopped. Spontaneous exits still honor configured restart policies, and starting the app again clears the explicit-stop state as before.

## Validation

- `go test ./internal/agent/container ./internal/agent/services ./internal/agent/containerd`
- `go test -race ./internal/agent/container ./internal/agent/containerd`
- `go test -race ./internal/agent/services -run 'TestStopContainer' -count=1`
- `go test ./internal/agent/... -run '^$'`
- `git diff --check`