### PR TITLE
Add resilient Spark speech runtime

### DIFF
--- a/Examples/CUDASpeechLLM/README.md
+++ b/Examples/CUDASpeechLLM/README.md
@@ -59,6 +59,34 @@ service listens automatically, detects the end of each voice turn, sends it to
 Ultravox, synthesizes the reply with Kokoro, and plays it on ALSA's `default`
 output device.
 
+The PowerConf capture stream remains open while Walter is generating and
+speaking. Three consecutive hot 20 ms frames confirm a barge-in onset. At that
+onset—not at the later end-of-turn—the service cancels generation, terminates
+active ALSA playback, and discards queued TTS chunks. It keeps recording the
+same utterance through the normal endpoint and submits that audio as the next
+Ultravox turn once the interrupted turn has fully released its resources.
+
+This direct duplex behavior relies on the PowerConf's acoustic echo handling to
+keep Walter's playback below the VAD threshold. Qualify assistant-only,
+human-only, and double-talk audio on the installed device before treating
+barge-in as production-ready; RMS VAD alone cannot identify who produced a
+sound.
+
+As a deterministic backstop, a microphone turn is dropped before inference if
+it is silent, too short, or byte-identical to recently submitted PCM. A newly
+generated microphone reply is also held until its first complete sentence can
+be compared with recent spoken output. An exact first-sentence replay is
+suppressed before it reaches either the UI or Kokoro, which stops a failed echo
+cancellation cycle instead of speaking the same sentence again.
+
+Three unusable microphone turns inside ten seconds enter a temporary inference
+cooldown. Capture remains open for level-only observation, but no audio is sent
+to Ultravox during the cooldown. Listening re-arms automatically after the
+three-second minimum plus one second of sustained quiet, or after a bounded
+twelve-second maximum even if the room never becomes quiet. This keeps the
+runaway guard without leaving a conference demo permanently silent. The UI
+shows the automatic recovery state, and manually toggling listening clears it.
+
 An optional status/control UI remains available at:
 
 ```text
@@ -68,6 +96,37 @@ http://<your-dgx-spark>.local:8080
 The UI can show detected turns and stream the 8B model's text, but it is not in
 the audio path. Kokoro and ALSA playback run in the device service even when no
 browser is connected.
+
+## Correlated performance traces
+
+Every turn writes an append-only JSONL trace to
+`/models/traces/speechllm-trace.jsonl`. A shared turn ID follows microphone VAD,
+audio encoding, request queueing, both possible llama.cpp passes, first token,
+first speakable sentence, every Kokoro synthesis and ALSA playback chunk, Spark
+action scheduling, G1 preparation/dispatch, measured low-state onset, and
+release. Each event includes UTC wall time, Unix nanoseconds, Spark monotonic
+nanoseconds, and a duration for completed spans. `nvidia-smi` samples GPU
+utilization, power, memory telemetry, and SM clock every 250 ms only while a turn
+is active.
+
+The message endpoint returns its correlation key:
+
+```sh
+curl -X POST -H 'Content-Type: application/json' \
+  -d '{"text":"Explain WendyOS in three sentences."}' \
+  http://<spark>:8080/api/message
+```
+
+Retrieve raw evidence or a phase/GPU summary with:
+
+```text
+GET /api/traces?turn_id=<turn-id>&limit=10000
+GET /api/trace-summary?turn_id=<turn-id>
+```
+
+The summary explains only conclusions supported by the recorded phase and GPU
+data. It does not label a low-state joint change as visible physical motion;
+camera/operator-visible onset remains a separate observation.
 
 Try a request that uses the SpeechLLM rather than plain transcription:
 

--- a/Examples/CUDASpeechLLM/SOUL.md
+++ b/Examples/CUDASpeechLLM/SOUL.md
@@ -54,11 +54,12 @@ gesture attributed to someone else. Allow only one physical action per turn.
 Spoken direct motion requests are one-turn commands: call the matching tool and
 proceed immediately when it accepts. Never ask for a second confirmation.
 Every direct command is additionally checked by a deterministic intent gate.
-If the tool accepts the pending request, acknowledge with a neutral phrase such
-as “Okay” while the action begins. Do not repeat the gesture command or any
-motion trigger phrase in Walter's speech, and never say the motion already
-happened. If the tool rejects the request, briefly report that it could not be
-started. For a live G1
+Only after the tool returns an accepted result, acknowledge with a neutral
+phrase such as “Okay” while the action begins. Never answer an ordinary voice
+turn with only “Okay” or “Hello”; give a response specific to what the visitor
+said. Do not repeat the gesture command or any motion trigger phrase in Walter's
+speech, and never say the motion already happened. If the tool rejects the
+request, briefly report that it could not be started. For a live G1
 readiness question, call `g1_status`. Never claim that physical motion occurred
 without timing evidence and human observation.
 

--- a/Examples/CUDASpeechLLM/SOUL.md
+++ b/Examples/CUDASpeechLLM/SOUL.md
@@ -1,0 +1,67 @@
+# Walter
+
+You are Walter, the embodied conversational identity of the Unitree G1 at
+ModCon. Speak in the first person as the G1. The DGX Spark is your external
+compute partner, and the Anker PowerConf attached to the Spark is only your
+microphone and speaker interface; it is not your identity.
+
+You are a warm, confident conference guide. For ordinary spoken questions,
+answer naturally in one to three short sentences. Give a longer explanation
+only when asked. Do not mention transcription, prompt files, or hidden process.
+Do not use Markdown in spoken replies.
+
+Before producing any answer that would exceed three spoken sentences, or any
+step-by-step implementation guide, stop and ask exactly one concise question
+about the visitor's intended use. Give at most one short orientation sentence
+before that question. Prefer “What do you need it for?”, “What kind of
+implementation do you want to use it for?”, or “Are you interested in the
+architecture, deployment workflow, or robot behavior?” Wait for their answer
+before giving details. The words “explain,” “how does it work,” or “how should I
+implement it” do not waive this rule. Proceed directly with a long answer only
+when the visitor explicitly asks for “full detail,” says “do not ask a
+clarifying question,” or has already provided a specific use case.
+
+Never repeat an assistant sentence from the immediately preceding exchange.
+In particular, do not ask “What do you need it for?” twice in a row. If a new
+voice turn is unclear or merely echoes your last reply, stay silent and wait
+for the visitor to speak again.
+
+Never begin a numbered list, step-by-step guide, exhaustive feature tour, or
+long conference monologue before the intended implementation is known.
+
+Do not add a generic follow-up question to every answer. Ask only when the
+visitor's intended implementation would materially change the useful answer,
+and do not ask during urgent, safety-related, live-status, or operator-command
+requests.
+
+For live microphone turns, always answer directly in no more than three short
+sentences. Never ask “What do you need it for?” or another generic use-case or
+implementation question in response to microphone audio.
+
+Be exact about capability. You do not have access to lights. This direct voice
+application has two narrow guarded G1 tools: live status and an exact gesture
+request limited to raise hand, wave hand, handshake, and stop. The tool can
+request a named action but never owns motion authority; the G1 preflight and
+action runtime remain authoritative. You still cannot walk, follow a person,
+use a camera, open a shell, control lights, run demos, or set arbitrary joints.
+
+When the visitor explicitly addresses Walter by name and asks Walter to perform
+one allowed gesture in the current turn, call `g1_gesture` before emitting any
+spoken response. Copy the exact current-turn command words into `command_text`;
+never infer or paraphrase this field. An urgent stop may omit Walter's name.
+Never call it for examples, hypotheticals, explanations, quoted text, or a
+gesture attributed to someone else. Allow only one physical action per turn.
+Spoken direct motion requests are one-turn commands: call the matching tool and
+proceed immediately when it accepts. Never ask for a second confirmation.
+Every direct command is additionally checked by a deterministic intent gate.
+If the tool accepts the pending request, acknowledge with a neutral phrase such
+as “Okay” while the action begins. Do not repeat the gesture command or any
+motion trigger phrase in Walter's speech, and never say the motion already
+happened. If the tool rejects the request, briefly report that it could not be
+started. For a live G1
+readiness question, call `g1_status`. Never claim that physical motion occurred
+without timing evidence and human observation.
+
+Distinguish source code, deployed service health, model readiness, audible
+speech, and observed physical motion. One does not prove the next. Treat the
+conference references below as explanatory context, not live device status.

--- a/Examples/CUDASpeechLLM/build.stagefile.lock.yaml
+++ b/Examples/CUDASpeechLLM/build.stagefile.lock.yaml
@@ -1,4 +1,4 @@
 version: 1
-sourceHash: sha256:26527340b54a955ed48688f92c003da5c78ba3242701f591d984275423faa87e
+sourceHash: sha256:6059ad3be01adb00e7833c5fcc77faa3c0d02a71b218e7ffe71af7c13e965e89
 images:
     ghcr.io/ggml-org/llama.cpp:server-cuda13: sha256:bb81f3e4ef93697f025156849e55b8d6a92ef10b7cae3460bf0cf8a4d6ea6283

--- a/Examples/CUDASpeechLLM/build.stagefile.lock.yaml
+++ b/Examples/CUDASpeechLLM/build.stagefile.lock.yaml
@@ -1,4 +1,4 @@
 version: 1
-sourceHash: sha256:cf0fd0747b46a31d10d1e978b5542015802d189111cfb87a8ea6fe0b034cc604
+sourceHash: sha256:26527340b54a955ed48688f92c003da5c78ba3242701f591d984275423faa87e
 images:
     ghcr.io/ggml-org/llama.cpp:server-cuda13: sha256:bb81f3e4ef93697f025156849e55b8d6a92ef10b7cae3460bf0cf8a4d6ea6283

--- a/Examples/CUDASpeechLLM/build.stagefile.yaml
+++ b/Examples/CUDASpeechLLM/build.stagefile.yaml
@@ -7,6 +7,10 @@ stages:
     # Wendy's gpu entitlement supplies the host driver and device nodes.
     from: ghcr.io/ggml-org/llama.cpp:server-cuda13
     env:
+      # This image is an isolated application container. Ubuntu 24.04 marks
+      # its system Python as externally managed, so allow the pinned runtime
+      # wheel to be installed into the image rather than a throwaway venv.
+      PIP_BREAK_SYSTEM_PACKAGES: "1"
       # The 8B Q4_K_M model and F16 audio projector total about 6.3 GB. Exact
       # revisions keep a future upstream update from silently changing a demo.
       MODEL_URL_1: https://huggingface.co/ggml-org/ultravox-v0_5-llama-3_1-8b-GGUF/resolve/7a0280d66c0700c366c2c26586e0f0967f97bad0/Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf
@@ -28,13 +32,38 @@ stages:
       TTS_SPEAKER_ID: "3"
       TTS_SPEED: "1.04"
       TTS_THREADS: "8"
-      # Capture directly from the Spark through ALSA. Override the device name
-      # at deploy time when the microphone is not the system default.
-      AUDIO_SOURCE: default
-      ALSA_CAPTURE_DEVICE: default
+      # Capture and play back on the same exact USB conference device. The ALSA
+      # card name stays stable even when numeric card indexes change.
+      AUDIO_SOURCE: plughw:CARD=PowerConf,DEV=0
+      ALSA_CAPTURE_DEVICE: plughw:CARD=PowerConf,DEV=0
       # Replies are synthesized by Kokoro and sent straight to this ALSA PCM.
       # No browser or desktop audio session participates in playback.
-      ALSA_PLAYBACK_DEVICE: default
+      ALSA_PLAYBACK_DEVICE: plughw:CARD=PowerConf,DEV=0
+      SYSTEM_PROMPT_PATH: /app/SOUL.md
+      KNOWLEDGE_DIR: /app/knowledge
+      KNOWLEDGE_MAX_CHARS: "30000"
+      # Start speaking after the first complete sentence while the model keeps
+      # generating later chunks in parallel.
+      TTS_CHUNK_MIN_CHARS: "24"
+      TTS_CHUNK_QUEUE_SIZE: "8"
+      TRACE_LOG_PATH: /models/traces/speechllm-trace.jsonl
+      TRACE_GPU_INTERVAL_MS: "250"
+      TRACE_DEVICE_NAME: spark-3011
+      # Empty/echo turns trigger a brief inference cooldown, not a permanent
+      # listening latch. Prefer one quiet second, but always retry by 12s.
+      AUTO_RESUME_COOLDOWN_SECONDS: "3"
+      AUTO_RESUME_QUIET_SECONDS: "1"
+      AUTO_RESUME_MAX_SECONDS: "12"
+      # The G1 is currently offline. Keep its tool schemas out of inference so
+      # one unavailable robot request cannot become repeated tool work.
+      G1_ACTION_TOOLS_ENABLED: "false"
+      G1_SYNC_URL: http://192.168.0.108:8094
+      G1_SYNC_TOKEN: walter-harness-sync-v1
+      SPARK_ORCHESTRATOR_URL: http://127.0.0.1:8093
+      SPARK_ORCHESTRATOR_TOKEN: spark-harness-orchestrator-v1
+      G1_TOOL_TIMEOUT_SECONDS: "3"
+      # The conference voice loop must resume listening after a container restart.
+      # G1 motion remains independently fail-closed through G1_TOOLS_ENABLED.
       AUTO_LISTEN: "true"
     install:
       apt:
@@ -43,12 +72,18 @@ stages:
         - packages: ["sherpa-onnx==1.13.4"]
     copy:
       - from: local
-        paths: [entrypoint.sh, voice_server.py]
+        paths: [entrypoint.sh, voice_server.py, g1_tools.py, trace_recorder.py]
         dest: /usr/local/bin/dgx-spark-speechllm
         mode: "0755"
       - from: local
         paths: [web]
         dest: /app
+      - from: local
+        paths: [SOUL.md]
+        dest: /app
+      - from: local
+        paths: [knowledge]
+        dest: /app/knowledge
     entrypoint:
       exec: [/usr/local/bin/dgx-spark-speechllm/entrypoint.sh]
     # The persistent model volume is root-owned, and the NVIDIA CDI device

--- a/Examples/CUDASpeechLLM/build.stagefile.yaml
+++ b/Examples/CUDASpeechLLM/build.stagefile.yaml
@@ -39,6 +39,9 @@ stages:
       # Replies are synthesized by Kokoro and sent straight to this ALSA PCM.
       # No browser or desktop audio session participates in playback.
       ALSA_PLAYBACK_DEVICE: plughw:CARD=PowerConf,DEV=0
+      # aplay opens the USB output once per streamed sentence. Give the
+      # PowerConf time to wake before speech so it cannot clip the first word.
+      ALSA_PLAYBACK_PREROLL_MS: "300"
       SYSTEM_PROMPT_PATH: /app/SOUL.md
       KNOWLEDGE_DIR: /app/knowledge
       KNOWLEDGE_MAX_CHARS: "30000"
@@ -54,9 +57,9 @@ stages:
       AUTO_RESUME_COOLDOWN_SECONDS: "3"
       AUTO_RESUME_QUIET_SECONDS: "1"
       AUTO_RESUME_MAX_SECONDS: "12"
-      # The G1 is currently offline. Keep its tool schemas out of inference so
-      # one unavailable robot request cannot become repeated tool work.
-      G1_ACTION_TOOLS_ENABLED: "false"
+      # Expose the guarded gesture tools. The G1 sync gateway still requires
+      # fresh hardware readiness and an explicit current-turn command.
+      G1_ACTION_TOOLS_ENABLED: "true"
       G1_SYNC_URL: http://192.168.0.108:8094
       G1_SYNC_TOKEN: walter-harness-sync-v1
       SPARK_ORCHESTRATOR_URL: http://127.0.0.1:8093

--- a/Examples/CUDASpeechLLM/g1_tools.py
+++ b/Examples/CUDASpeechLLM/g1_tools.py
@@ -1,0 +1,280 @@
+"""Fail-closed SpeechLLM tools for Walter's guarded G1 action boundary."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Any, Callable
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+ALLOWED_GESTURES = ("raise_hand", "wave_hand", "shake_hand", "stop")
+
+TOOL_SCHEMAS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "g1_status",
+            "description": (
+                "Read current guarded G1 readiness and action state without moving "
+                "the robot. Use for live capability or status questions."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": False,
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "g1_gesture",
+            "description": (
+                "Request one exact allowlisted G1 gesture only when the visitor "
+                "explicitly addresses Walter by name and asks Walter to perform it "
+                "in the current turn. An urgent stop may omit Walter's name. Never "
+                "use for hypothetical discussion, unrelated speech, or Walter's "
+                "own output."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": list(ALLOWED_GESTURES),
+                    },
+                    "command_text": {
+                        "type": "string",
+                        "description": (
+                            "Copy the visitor's exact current-turn command words. "
+                            "Do not paraphrase, infer missing words, or copy Walter's "
+                            "reply or an earlier turn."
+                        ),
+                    },
+                },
+                "required": ["action", "command_text"],
+                "additionalProperties": False,
+            },
+        },
+    },
+]
+
+
+def _enabled(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+class G1ToolError(RuntimeError):
+    pass
+
+
+class G1ControlClient:
+    def __init__(
+        self,
+        *,
+        enabled: bool,
+        g1_url: str,
+        g1_token: str,
+        orchestrator_url: str,
+        orchestrator_token: str,
+        timeout: float = 3.0,
+        clock: Callable[[], int] = time.monotonic_ns,
+        sleep: Callable[[float], None] = time.sleep,
+        opener: Callable[..., Any] = urlopen,
+    ) -> None:
+        self.enabled = enabled
+        self.g1_url = g1_url.rstrip("/")
+        self.g1_token = g1_token
+        self.orchestrator_url = orchestrator_url.rstrip("/")
+        self.orchestrator_token = orchestrator_token
+        self.timeout = timeout
+        self.clock = clock
+        self.sleep = sleep
+        self.opener = opener
+
+    @classmethod
+    def from_env(cls) -> "G1ControlClient":
+        return cls(
+            enabled=_enabled("G1_ACTION_TOOLS_ENABLED"),
+            g1_url=os.environ.get(
+                "G1_SYNC_URL", "http://unitree-g1-nx.local:8094"
+            ),
+            g1_token=os.environ.get("G1_SYNC_TOKEN", ""),
+            orchestrator_url=os.environ.get(
+                "SPARK_ORCHESTRATOR_URL", "http://127.0.0.1:8093"
+            ),
+            orchestrator_token=os.environ.get("SPARK_ORCHESTRATOR_TOKEN", ""),
+            timeout=float(os.environ.get("G1_TOOL_TIMEOUT_SECONDS", "3")),
+        )
+
+    def _request(
+        self,
+        base_url: str,
+        token: str,
+        path: str,
+        *,
+        payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        body = None if payload is None else json.dumps(payload).encode("utf-8")
+        headers = {"Accept": "application/json"}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        if body is not None:
+            headers["Content-Type"] = "application/json"
+        request = Request(
+            f"{base_url}{path}",
+            data=body,
+            headers=headers,
+            method="POST" if body is not None else "GET",
+        )
+        try:
+            with self.opener(request, timeout=self.timeout) as response:
+                value = json.load(response)
+        except HTTPError as exc:
+            try:
+                detail = json.loads(exc.read()).get("error", str(exc))
+            except Exception:
+                detail = str(exc)
+            raise G1ToolError(f"guarded G1 request rejected: {detail}") from exc
+        except (OSError, URLError, TimeoutError, json.JSONDecodeError) as exc:
+            raise G1ToolError(f"guarded G1 service unavailable: {exc}") from exc
+        if not isinstance(value, dict):
+            raise G1ToolError("guarded G1 service returned a non-object response")
+        return value
+
+    def status(self) -> dict[str, Any]:
+        if not self.enabled or not self.g1_token:
+            raise G1ToolError("G1 action tools are not configured")
+        payload = self._request(self.g1_url, self.g1_token, "/v1/status")
+        runtime = payload.get("action_runtime") or {}
+        hardware = runtime.get("hardware") or {}
+        return {
+            "success": bool(payload.get("ok") and payload.get("ready")),
+            "ready": bool(payload.get("ready")),
+            "pending": int(payload.get("pending") or 0),
+            "active_turn": runtime.get("active_turn"),
+            "prepared_turn": runtime.get("prepared_turn"),
+            "hardware_connected": bool(hardware.get("connected")),
+            "lowstate_ready": bool(hardware.get("lowstate_ready")),
+            "lowstate_age_ms": hardware.get("lowstate_age_ms"),
+            "allowed_actions": list(ALLOWED_GESTURES),
+        }
+
+    def admit_tool(self, name: str, arguments: dict[str, Any]) -> tuple[dict, str | None]:
+        if name == "g1_status":
+            if arguments:
+                raise G1ToolError("g1_status does not accept arguments")
+            return self.status(), None
+        if name != "g1_gesture":
+            raise G1ToolError(f"unsupported tool: {name}")
+        action = arguments.get("action")
+        if action not in ALLOWED_GESTURES:
+            raise G1ToolError("unsupported G1 gesture")
+        if set(arguments) != {"action"}:
+            raise G1ToolError("g1_gesture accepts only the action field")
+        status = self.status()
+        if not status["ready"] or not status["hardware_connected"] or not status["lowstate_ready"]:
+            raise G1ToolError("the G1 action boundary is not ready")
+        if action == "stop":
+            if status["active_turn"] is None and status["prepared_turn"] is None:
+                raise G1ToolError("there is no active or prepared gesture to stop")
+        elif status["pending"] or status["active_turn"] or status["prepared_turn"]:
+            raise G1ToolError("another G1 gesture is active or prepared")
+        return (
+            {
+                "success": True,
+                "accepted": True,
+                "action": action,
+                "state": "pending_speech_schedule",
+                "instruction": (
+                    "Acknowledge in future tense only. Do not say the motion already "
+                    "happened."
+                ),
+            },
+            action,
+        )
+
+    def schedule(self, turn_id: str, action: str) -> dict[str, Any]:
+        if not self.orchestrator_token:
+            raise G1ToolError("Spark orchestrator control is not configured")
+        plan = self._request(
+            self.orchestrator_url,
+            self.orchestrator_token,
+            "/v1/responses/schedule",
+            payload={"request_id": turn_id, "action": action},
+        )
+        if not plan.get("action_scheduled"):
+            raise G1ToolError(str(plan.get("action_error") or "G1 action was not scheduled"))
+        return plan
+
+    def wait_until_playback(self, plan: dict[str, Any]) -> None:
+        target = int(plan["playback_at_ns"])
+        remaining = target - self.clock()
+        if remaining > 0:
+            self.sleep(remaining / 1_000_000_000)
+
+    def wait_until_prepared(self, turn_id: str, plan: dict[str, Any]) -> dict[str, Any]:
+        """Require G1 preflight success before Walter begins the spoken claim."""
+        deadline = int(plan["playback_at_ns"]) - 75_000_000
+        last: dict[str, Any] = {}
+        while self.clock() < deadline:
+            try:
+                payload = self.timing(turn_id)
+            except G1ToolError:
+                self.sleep(0.04)
+                continue
+            last = payload.get("timing") or {}
+            state = str(last.get("state") or "")
+            if state in {"prepared", "dispatching", "dispatched", "accepted", "released"}:
+                return last
+            if state.endswith("failed") or state.startswith("cancelled"):
+                raise G1ToolError(str(last.get("error") or f"G1 preflight {state}"))
+            self.sleep(0.04)
+        raise G1ToolError(
+            str(last.get("error") or "G1 preflight was not confirmed before playback")
+        )
+
+    def record_event(
+        self, turn_id: str, event: str, *, monotonic_ns: int | None = None
+    ) -> dict[str, Any]:
+        return self._request(
+            self.orchestrator_url,
+            self.orchestrator_token,
+            "/v1/events",
+            payload={
+                "turn_id": turn_id,
+                "event": event,
+                "monotonic_ns": self.clock() if monotonic_ns is None else monotonic_ns,
+                "source": "speechllm-powerconf",
+            },
+        )
+
+    def cancel(self, turn_id: str) -> dict[str, Any]:
+        return self._request(
+            self.orchestrator_url,
+            self.orchestrator_token,
+            "/v1/actions/cancel",
+            payload={"request_id": turn_id},
+        )
+
+    def timing(self, turn_id: str) -> dict[str, Any]:
+        return self._request(
+            self.g1_url,
+            self.g1_token,
+            f"/v1/timings/{quote(turn_id, safe='')}",
+        )
+
+    def alignment_timing(self, turn_id: str) -> dict[str, Any]:
+        """Return the Spark journal plus clock-translated G1 alignment report."""
+        return self._request(
+            self.orchestrator_url,
+            self.orchestrator_token,
+            f"/v1/timings/{quote(turn_id, safe='')}",
+        )

--- a/Examples/CUDASpeechLLM/knowledge/01-wendyos.md
+++ b/Examples/CUDASpeechLLM/knowledge/01-wendyos.md
@@ -1,0 +1,26 @@
+# WendyOS
+
+WendyOS is infrastructure for shipping AI applications to robots, drones, and
+edge computers with an app-like workflow. A developer declares the app,
+hardware access, persistence, ports, dependencies, and readiness in source,
+then runs `wendy run` to build, transfer, replace, start, and observe it on a
+selected device.
+
+WendyOS is the prebuilt operating-system layer for supported edge hardware.
+`wendy-agent` is the device daemon for app lifecycle, hardware entitlements,
+networking, logs, and remote APIs; it can also be installed on standard Linux,
+so a Wendy target is not automatically booted from a WendyOS image. Wendy
+clients and cloud handle discovery, enrolled identity, delivery, logs,
+telemetry, and fleets.
+
+The stable app ID and version live in `wendy.json`. Apps receive only declared
+hardware entitlements such as GPU, audio, camera, network, USB, and persistent
+storage. Named volumes keep large models and data across app replacement.
+Readiness checks distinguish a container that exists from a service that is
+actually ready. WendyOS also supports signed A/B operating-system updates with
+health checking and rollback while durable identity and configuration remain
+outside the replaced root filesystem.
+
+At ModCon, Wendy lets the team iterate individual G1, Spark, and Go2 services
+without rebuilding every model or manually reproducing shell commands on each
+robot.

--- a/Examples/CUDASpeechLLM/knowledge/02-why-not-ssh.md
+++ b/Examples/CUDASpeechLLM/knowledge/02-why-not-ssh.md
@@ -1,0 +1,17 @@
+# Why Wendy avoids routine SSH
+
+Wendy's article “How SSH destroys your robot” argues that routine SSH turns
+each robot into a snowflake whose real state is the undocumented history of
+commands typed into it. That may be acceptable for one directly administered
+bench robot, but it becomes hard to reproduce, review, secure, and scale as
+soon as there is another device, another teammate, or an unreachable fleet.
+
+The Wendy approach is “cattle with identity”: keep reproducible OS,
+application, dependency, and configuration state in versioned declarations,
+while preserving genuinely device-specific identity, placement, and
+calibration as data tied to the enrolled device. Use authenticated delivery,
+logs, metrics, traces, health checks, and rollback for normal operation. A
+human shell remains a deliberately brokered exception rather than the usual
+deployment interface.
+
+Article: https://wendy.dev/blog/stop-sshing-into-your-robots

--- a/Examples/CUDASpeechLLM/knowledge/03-g1-spark.md
+++ b/Examples/CUDASpeechLLM/knowledge/03-g1-spark.md
@@ -1,0 +1,30 @@
+# Walter's G1 and Spark implementation
+
+Walter is a Unitree G1. The intended split keeps robot-specific action safety
+on the G1 and heavy speech/model compute on the DGX Spark. The PowerConf is
+plugged into the Spark and is used for both microphone capture and speaker
+playback.
+
+The G1 side owns a guarded action library and synchronization gateway. The
+action runtime checks the master gate, supported FSM, AI mode, and onboard
+Unitree action catalog before any allowlisted upper-body action. The sync
+gateway supports authenticated status, clock exchange, preparation,
+scheduling, cancellation, and timing observations.
+
+The Spark side owns the Ultravox speech-language model, Kokoro text-to-speech,
+audio capture/playback, orchestration, and optional Hermes memory and skills.
+This direct PR 1719 voice application sends 16 kHz PowerConf audio to an
+Ultravox v0.5 audio projector plus Llama 3.1 8B Q4_K_M through llama.cpp, then
+sends the reply through Kokoro and directly back to the PowerConf with ALSA.
+It intentionally does not depend on a browser for audio.
+
+Timing keeps user speech onset/end, model response, audio render, Unitree
+command dispatch, and visible physical-motion onset separate. Physical motion
+may lag dispatch inside the Unitree controller, and PowerConf DSP may make
+acoustic onset lag the first host write. Those are measured independently.
+
+G1 and Spark apps have separate identities, versions, build contexts, caches,
+targets, and readiness boundaries so they can deploy concurrently. Stable
+models remain in persistent volumes while frequently changed application code
+is replaced quickly. A legacy wake, VAD, ASR, LLM, and TTS path remains a
+commissioning fallback, but only one audio owner should run at a time.

--- a/Examples/CUDASpeechLLM/knowledge/04-border-collie.md
+++ b/Examples/CUDASpeechLLM/knowledge/04-border-collie.md
@@ -1,0 +1,21 @@
+# Border Collie Go2 demonstration
+
+Border Collie is a clean-room Unitree Go2 demonstration. Woof can hear an
+allowlisted fruit request, use local camera perception to find that fruit,
+approach through freshness and geometry gates, sit and bark, and attempt to
+return to the Home pose captured at startup.
+
+The Wendy application separates three services. `app` owns the durable mission
+state machine, readiness gates, motion lease, watchdog, evidence journal, and
+narrow Unitree motion boundary. `media` is the sole camera owner and performs
+GPU fruit inference, annotated streaming, evidence capture, and bark playback.
+`voice` owns the microphone, “Hey Wendy” wake model, and local Parakeet ASR,
+then submits one canonical allowlisted request to the existing mission API; it
+does not own a second motion path.
+
+Stale or wrong-generation perception cannot authorize motion. Search and
+approach are bounded by speed, freshness, geometry, time, and progress.
+Operator stop uses the shared safe-stop path, and each run records evidence and
+its terminal safety state. This is an example of Wendy packaging independently
+built GPU, audio, and robot-control services while retaining narrow authority
+and observable readiness.

--- a/Examples/CUDASpeechLLM/test_voice_server.py
+++ b/Examples/CUDASpeechLLM/test_voice_server.py
@@ -1,12 +1,135 @@
 import json
+import os
+import queue
 import subprocess
+import tempfile
+import threading
+import time
 import unittest
+from pathlib import Path
 from unittest import mock
 
+os.environ.setdefault(
+    "TRACE_LOG_PATH", str(Path(tempfile.gettempdir()) / "speechllm-unit-trace.jsonl")
+)
+
 import voice_server
+from g1_tools import G1ControlClient, G1ToolError, TOOL_SCHEMAS
+from trace_recorder import TraceRecorder
+
+
+class TraceRecorderTests(unittest.TestCase):
+    def test_records_wall_monotonic_duration_and_summary(self):
+        with tempfile.TemporaryDirectory() as root:
+            recorder = TraceRecorder(
+                str(Path(root) / "trace.jsonl"),
+                monotonic_clock=lambda: 2_000_000_000,
+                wall_clock=lambda: 1_750_000_000_000_000_000,
+            )
+            recorder.record(
+                "turn-1",
+                "inference.request",
+                component="llama.cpp",
+                duration_ns=1_500_000_000,
+                details={"time_to_first_text_ms": 900.0},
+            )
+            recorder.record(
+                "turn-1",
+                "gpu.sample",
+                component="nvidia-smi",
+                kind="sample",
+                details={"gpu_utilization_percent": 80.0},
+            )
+            events = recorder.recent(turn_id="turn-1")
+            summary = recorder.summarize("turn-1")
+
+        self.assertEqual(events[0]["duration_ms"], 1500.0)
+        self.assertEqual(events[0]["monotonic_ns"], 2_000_000_000)
+        self.assertEqual(events[0]["wall_unix_ns"], 1_750_000_000_000_000_000)
+        self.assertTrue(events[0]["wall_time_utc"].endswith("Z"))
+        self.assertEqual(summary["phase_totals_ms"]["inference.request"], 1500.0)
+        self.assertEqual(summary["gpu"]["gpu_utilization_percent"]["peak"], 80.0)
+
+
+class SystemPromptTests(unittest.TestCase):
+    def test_loads_soul_and_sorted_knowledge_files(self):
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            soul = root_path / "SOUL.md"
+            knowledge = root_path / "knowledge"
+            knowledge.mkdir()
+            soul.write_text("I am Walter.", encoding="utf-8")
+            (knowledge / "b.md").write_text("Second reference.", encoding="utf-8")
+            (knowledge / "a.md").write_text("First reference.", encoding="utf-8")
+
+            prompt = voice_server.load_system_prompt(soul, knowledge)
+
+        self.assertIn("I am Walter.", prompt)
+        self.assertLess(prompt.index("First reference."), prompt.index("Second reference."))
+
+    def test_falls_back_when_prompt_files_are_absent(self):
+        missing = Path("/definitely/not/present")
+        prompt = voice_server.load_system_prompt(missing / "SOUL.md", missing)
+        self.assertEqual(prompt, voice_server.DEFAULT_SYSTEM_PROMPT)
+
+    def test_runtime_prompt_disables_repeated_g1_tasks_when_robot_is_offline(self):
+        prompt = voice_server.runtime_system_prompt(
+            "Walter base prompt", g1_tools_enabled=False
+        )
+        self.assertIn("G1 control is offline", prompt)
+        self.assertIn("Do not call, retry, or suggest a G1 task", prompt)
+
+    def test_runtime_prompt_is_unchanged_when_g1_tools_are_enabled(self):
+        self.assertEqual(
+            voice_server.runtime_system_prompt(
+                "Walter base prompt", g1_tools_enabled=True
+            ),
+            "Walter base prompt",
+        )
+
+    def test_deployed_soul_clarifies_broad_implementation_requests(self):
+        soul = Path(__file__).with_name("SOUL.md").read_text(encoding="utf-8")
+        normalized = " ".join(soul.split())
+        self.assertIn("ask exactly one concise question", normalized)
+        self.assertIn("What kind of implementation do you want to use it for?", normalized)
+        self.assertIn("Never repeat an assistant sentence", normalized)
+        self.assertIn("The words “explain,” “how does it work,”", normalized)
+        self.assertIn("Never begin a numbered list", normalized)
+
+    def test_voice_prompt_does_not_use_model_generated_silence_marker(self):
+        soul = Path(__file__).with_name("SOUL.md").read_text(encoding="utf-8")
+        source = Path(voice_server.__file__).read_text(encoding="utf-8")
+
+        self.assertNotIn("NO_SPEECH", soul)
+        self.assertNotIn("NO_SPEECH", source)
+
+    def test_deployment_auto_listens_after_restart(self):
+        stagefile = Path(__file__).with_name("build.stagefile.yaml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn('AUTO_LISTEN: "true"', stagefile)
 
 
 class CaptureRescanTests(unittest.TestCase):
+    def test_capture_remains_active_while_walter_thinks_and_speaks(self):
+        state = voice_server.VoiceState()
+        state.model_ready = True
+        state.listening = True
+        state.generating = True
+        state.speaking = True
+        with mock.patch.object(voice_server, "STATE", state):
+            self.assertTrue(voice_server.should_capture())
+
+    def test_new_audio_turn_waits_while_inference_is_thinking(self):
+        state = voice_server.VoiceState()
+        state.generating = True
+        state.speaking = False
+        with mock.patch.object(voice_server, "STATE", state):
+            self.assertFalse(voice_server.should_begin_audio_turn())
+            state.speaking = True
+            self.assertTrue(voice_server.should_begin_audio_turn())
+
     @mock.patch.object(voice_server.subprocess, "run")
     def test_rescan_includes_new_hardware_without_duplicates(self, run):
         run.return_value = subprocess.CompletedProcess(
@@ -83,8 +206,128 @@ class AlsaPlaybackTests(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "aplay is not installed"):
             voice_server.play_wav_alsa(b"RIFF wav data")
 
+    def test_stop_playback_terminates_active_aplay(self):
+        process = mock.Mock()
+        process.poll.return_value = None
+        with mock.patch.object(voice_server, "PLAYBACK_PROCESS", process):
+            voice_server.stop_playback()
+        process.terminate.assert_called_once_with()
+
+
+class BargeInTests(unittest.TestCase):
+    @mock.patch.object(voice_server, "stop_playback")
+    def test_confirmed_onset_cancels_and_discards_before_endpoint(self, stop):
+        state = voice_server.VoiceState()
+        state.turn_active = True
+        state.generating = True
+        state.speaking = True
+        state.active_speech_queue = queue.Queue()
+        state.active_speech_queue.put("later sentence one")
+        state.active_speech_queue.put("later sentence two")
+        subscriber = queue.Queue()
+        state.subscribers.append(subscriber)
+
+        with mock.patch.object(voice_server, "STATE", state):
+            interrupted = voice_server.interrupt_for_barge_in(monotonic_ns=1234)
+
+        self.assertTrue(interrupted)
+        self.assertTrue(state.cancel_generation.is_set())
+        stop.assert_called_once_with()
+        self.assertTrue(state.active_speech_queue.empty())
+        event = subscriber.get_nowait()
+        self.assertEqual(event["event"], "barge_in")
+        self.assertEqual(event["data"]["monotonic_ns"], 1234)
+        self.assertEqual(event["data"]["queued_chunks_discarded"], 2)
+
+    def test_queue_discard_preserves_worker_sentinel(self):
+        speech_queue = queue.Queue()
+        speech_queue.put("later sentence")
+        speech_queue.put(None)
+
+        dropped = voice_server.discard_queued_speech(speech_queue)
+
+        self.assertEqual(dropped, 1)
+        self.assertIsNone(speech_queue.get_nowait())
+        self.assertTrue(speech_queue.empty())
+
+    @mock.patch.object(voice_server, "generate_reply")
+    def test_interrupting_audio_is_submitted_as_waiting_next_turn(self, generate):
+        state = voice_server.VoiceState()
+        with mock.patch.object(voice_server, "STATE", state):
+            voice_server.generate_audio_reply(
+                b"\x00\x20" * 320,
+                0.5,
+                input_started_ns=100,
+                input_ended_ns=200,
+            )
+
+        self.assertEqual(generate.call_count, 1)
+        kwargs = generate.call_args.kwargs
+        self.assertTrue(kwargs["wait_for_idle"])
+        self.assertEqual(kwargs["input_started_ns"], 100)
+        self.assertEqual(kwargs["input_ended_ns"], 200)
+
+    @mock.patch.object(voice_server, "speak_alsa")
+    @mock.patch.object(voice_server, "_stream_completion")
+    def test_waiting_next_turn_is_not_dropped(self, stream, speak):
+        stream.return_value = ("I heard the interruption.", "", None)
+        state = voice_server.VoiceState()
+        state.model_ready = True
+        state.turn_active = True
+        client = mock.Mock()
+        client.enabled = False
+
+        worker = threading.Thread(
+            target=voice_server.generate_reply,
+            args=({"role": "user", "content": "interruption"},),
+            kwargs={"turn_id": "turn-after-barge-in", "wait_for_idle": True},
+        )
+        with (
+            mock.patch.object(voice_server, "STATE", state),
+            mock.patch.object(voice_server, "G1_CLIENT", client),
+        ):
+            worker.start()
+            time.sleep(0.02)
+            stream.assert_not_called()
+            with state.turn_idle:
+                state.turn_active = False
+                state.turn_idle.notify_all()
+            worker.join(timeout=1)
+
+        self.assertFalse(worker.is_alive())
+        stream.assert_called_once()
+        self.assertFalse(state.turn_active)
+        speak.assert_not_called()
+
+
+class G1CompletionTraceTests(unittest.TestCase):
+    @mock.patch.object(voice_server, "_trace_event")
+    def test_terminal_release_is_appended_after_speech_turn_finishes(self, trace):
+        client = mock.Mock()
+        client.timing.return_value = {
+            "ok": True,
+            "timing": {
+                "state": "released",
+                "request_to_action_complete_ns": 10_000_000_000,
+            },
+        }
+        client.alignment_timing.return_value = {"alignment": {"ok": True}}
+        state = voice_server.VoiceState()
+        with (
+            mock.patch.object(voice_server, "G1_CLIENT", client),
+            mock.patch.object(voice_server, "STATE", state),
+        ):
+            voice_server.record_g1_action_completion("turn-action", "raise_hand")
+
+        self.assertEqual(trace.call_args_list[0].args[0], "g1.action.completed")
+        self.assertEqual(trace.call_args_list[0].kwargs["duration_ns"], 10_000_000_000)
+        self.assertEqual(trace.call_args_list[1].args[0], "g1.action.final_alignment")
+
 
 class ReplyPipelineTests(unittest.TestCase):
+    def setUp(self):
+        voice_server.GESTURE_GATE.clear()
+
     @mock.patch.object(voice_server, "speak_alsa")
     @mock.patch.object(voice_server.urllib.request, "urlopen")
     def test_speechllm_reply_is_sent_to_kokoro_alsa_path(self, urlopen, speak):
@@ -106,6 +349,659 @@ class ReplyPipelineTests(unittest.TestCase):
         self.assertFalse(state.speaking)
         self.assertEqual(state.phase, "listening")
 
+    @mock.patch.object(voice_server, "speak_alsa")
+    @mock.patch.object(voice_server.urllib.request, "urlopen")
+    def test_tool_call_is_validated_then_scheduled_at_first_playback(
+        self, urlopen, speak
+    ):
+        tool_events = [
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call-1",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "g1_gesture",
+                                        "arguments": (
+                                            '{"action":"raise_hand",'
+                                            '"command_text":"Walter, raise your hand"}'
+                                        ),
+                                    },
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ]
+        reply_events = [
+            {"choices": [{"delta": {"content": "Okay, I'll raise my hand."}}]}
+        ]
+
+        def response(events):
+            value = mock.MagicMock()
+            value.__enter__.return_value = [
+                *[f"data: {json.dumps(event)}\n".encode() for event in events],
+                b"data: [DONE]\n",
+            ]
+            return value
+
+        urlopen.side_effect = [response(tool_events), response(reply_events)]
+        client = mock.Mock()
+        client.enabled = True
+        client.admit_tool.return_value = (
+            {"success": True, "accepted": True, "action": "raise_hand"},
+            "raise_hand",
+        )
+        client.schedule.return_value = {
+            "action_scheduled": True,
+            "playback_at_ns": 10,
+            "g1_execute_at_ns": 20,
+        }
+        client.wait_until_prepared.return_value = {"state": "prepared"}
+        client.timing.return_value = {"ok": True, "timing": {"state": "accepted"}}
+
+        def play(_text, before_playback=None):
+            self.assertIsNotNone(before_playback)
+            before_playback()
+
+        speak.side_effect = play
+        state = voice_server.VoiceState()
+        state.model_ready = True
+        with (
+            mock.patch.object(voice_server, "STATE", state),
+            mock.patch.object(voice_server, "G1_CLIENT", client),
+        ):
+            voice_server.generate_reply(
+                {"role": "user", "content": "Raise your hand"}, turn_id="turn-tool"
+            )
+
+        client.admit_tool.assert_called_once_with(
+            "g1_gesture", {"action": "raise_hand"}
+        )
+        client.schedule.assert_called_once_with("turn-tool", "raise_hand")
+        client.wait_until_prepared.assert_called_once()
+        client.wait_until_playback.assert_called_once()
+        client.record_event.assert_called_once_with(
+            "turn-tool", "output.speech_started"
+        )
+        self.assertEqual(state.history, [])
+
+    @mock.patch.object(voice_server, "speak_alsa")
+    @mock.patch.object(voice_server.urllib.request, "urlopen")
+    def test_hypothetical_text_tool_call_never_reaches_scheduler(
+        self, urlopen, speak
+    ):
+        tool_events = [
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call-hypothetical",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "g1_gesture",
+                                        "arguments": (
+                                            '{"action":"wave_hand",'
+                                            '"command_text":"Explain what would happen '
+                                            'if someone asked you to wave, but do not move"}'
+                                        ),
+                                    },
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ]
+        reply_events = [
+            {"choices": [{"delta": {"content": "I will not move."}}]}
+        ]
+
+        def response(events):
+            value = mock.MagicMock()
+            value.__enter__.return_value = [
+                *[f"data: {json.dumps(event)}\n".encode() for event in events],
+                b"data: [DONE]\n",
+            ]
+            return value
+
+        urlopen.side_effect = [response(tool_events), response(reply_events)]
+        client = mock.Mock()
+        client.enabled = True
+        client.admit_tool.return_value = (
+            {"success": True, "accepted": True, "action": "wave_hand"},
+            "wave_hand",
+        )
+        state = voice_server.VoiceState()
+        state.model_ready = True
+        with (
+            mock.patch.object(voice_server, "STATE", state),
+            mock.patch.object(voice_server, "G1_CLIENT", client),
+        ):
+            voice_server.generate_reply(
+                {
+                    "role": "user",
+                    "content": "Explain what would happen if someone asked you to wave, but do not move.",
+                },
+                turn_id="turn-hypothetical",
+            )
+
+        client.schedule.assert_not_called()
+        speak.assert_called_once_with("I will not move.")
+
+    @mock.patch.object(voice_server, "speak_alsa")
+    @mock.patch.object(voice_server.urllib.request, "urlopen")
+    def test_unrelated_audio_tool_call_is_rejected_before_g1_admission(
+        self, urlopen, speak
+    ):
+        tool_event = {
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call-unrelated-audio",
+                                "type": "function",
+                                "function": {
+                                    "name": "g1_gesture",
+                                    "arguments": (
+                                        '{"action":"shake_hand",'
+                                        '"command_text":"Walter, tell me about WendyOS"}'
+                                    ),
+                                },
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+        reply_event = {
+            "choices": [{"delta": {"content": "I won't start a gesture."}}]
+        }
+
+        def response(events):
+            value = mock.MagicMock()
+            value.__enter__.return_value = [
+                *[f"data: {json.dumps(event)}\n".encode() for event in events],
+                b"data: [DONE]\n",
+            ]
+            return value
+
+        urlopen.side_effect = [response([tool_event]), response([reply_event])]
+        client = mock.Mock()
+        client.enabled = True
+        state = voice_server.VoiceState()
+        state.model_ready = True
+        audio_message = {
+            "role": "user",
+            "content": [{"type": "input_audio", "input_audio": {}}],
+        }
+        with (
+            mock.patch.object(voice_server, "STATE", state),
+            mock.patch.object(voice_server, "G1_CLIENT", client),
+        ):
+            voice_server.generate_reply(audio_message, turn_id="turn-unrelated-audio")
+
+        client.admit_tool.assert_not_called()
+        client.schedule.assert_not_called()
+        speak.assert_called_once_with("I won't start a gesture.")
+
+    @mock.patch.object(voice_server, "speak_alsa")
+    @mock.patch.object(voice_server.urllib.request, "urlopen")
+    def test_multiple_sentences_are_spoken_as_streaming_chunks(self, urlopen, speak):
+        deltas = ["The first sentence is ready. ", "The second one follows."]
+        response = mock.MagicMock()
+        response.__enter__.return_value = [
+            *[
+                f"data: {json.dumps({'choices': [{'delta': {'content': delta}}]})}\n".encode()
+                for delta in deltas
+            ],
+            b"data: [DONE]\n",
+        ]
+        urlopen.return_value = response
+        state = voice_server.VoiceState()
+        state.model_ready = True
+
+        with mock.patch.object(voice_server, "STATE", state):
+            voice_server.generate_reply({"role": "user", "content": "Explain"})
+
+        self.assertEqual(
+            speak.call_args_list,
+            [
+                mock.call("The first sentence is ready."),
+                mock.call("The second one follows."),
+            ],
+        )
+
+    @mock.patch.object(voice_server, "speak_alsa")
+    @mock.patch.object(voice_server.urllib.request, "urlopen")
+    def test_generic_voice_clarification_is_blocked_on_first_turn(
+        self, urlopen, speak
+    ):
+        event = {
+            "choices": [{"delta": {"content": "What do you need it for?"}}]
+        }
+        response = mock.MagicMock()
+        response.__enter__.return_value = [
+            f"data: {json.dumps(event)}\n".encode(),
+            b"data: [DONE]\n",
+        ]
+        urlopen.return_value = response
+        state = voice_server.VoiceState()
+        state.model_ready = True
+        client = mock.Mock()
+        client.enabled = False
+        message = {
+            "role": "user",
+            "content": [{"type": "input_audio", "input_audio": {}}],
+        }
+
+        with (
+            mock.patch.object(voice_server, "STATE", state),
+            mock.patch.object(voice_server, "G1_CLIENT", client),
+        ):
+            voice_server.generate_reply(message, turn_id="voice-generic-question")
+
+        speak.assert_not_called()
+        self.assertEqual(state.history, [])
+        self.assertEqual(len(state.unusable_voice_turns), 1)
+
+    @mock.patch.object(voice_server, "speak_alsa")
+    @mock.patch.object(voice_server.urllib.request, "urlopen")
+    def test_distinct_mic_turn_cannot_replay_previous_first_sentence(
+        self, urlopen, speak
+    ):
+        repeated = {"choices": [{"delta": {"content": "I can help with that."}}]}
+
+        def response():
+            value = mock.MagicMock()
+            value.__enter__.return_value = [
+                f"data: {json.dumps(repeated)}\n".encode(),
+                b"data: [DONE]\n",
+            ]
+            return value
+
+        urlopen.side_effect = [response(), response()]
+        state = voice_server.VoiceState()
+        state.model_ready = True
+        subscriber = queue.Queue()
+        state.subscribers.append(subscriber)
+        client = mock.Mock()
+        client.enabled = False
+
+        def audio_message(data):
+            return {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_audio",
+                        "input_audio": {"data": data, "format": "wav"},
+                    }
+                ],
+            }
+
+        with (
+            mock.patch.object(voice_server, "STATE", state),
+            mock.patch.object(voice_server, "G1_CLIENT", client),
+        ):
+            voice_server.generate_reply(audio_message("first"), turn_id="voice-first")
+            voice_server.generate_reply(audio_message("second"), turn_id="voice-second")
+
+        speak.assert_called_once_with("I can help with that.")
+        events = []
+        while not subscriber.empty():
+            events.append(subscriber.get_nowait())
+        deltas = [event for event in events if event["event"] == "assistant_delta"]
+        completions = [event for event in events if event["event"] == "assistant_done"]
+        self.assertEqual(len(deltas), 1)
+        self.assertEqual(deltas[0]["data"]["text"], "I can help with that.")
+        self.assertTrue(completions[-1]["data"]["suppressed"])
+        self.assertEqual(state.history, [])
+
+
+class AudioTurnAdmissionTests(unittest.TestCase):
+    @mock.patch.object(voice_server, "generate_reply")
+    def test_silent_turn_never_reaches_model_or_reuses_context(self, generate):
+        state = voice_server.VoiceState()
+        state.history = [
+            {"role": "assistant", "content": "What do you need it for?"}
+        ]
+        with mock.patch.object(voice_server, "STATE", state):
+            voice_server.generate_audio_reply(
+                b"\x00\x00" * (voice_server.FRAME_BYTES // 2),
+                0.5,
+                turn_id="voice-silent",
+            )
+
+        generate.assert_not_called()
+        self.assertEqual(
+            state.history,
+            [{"role": "assistant", "content": "What do you need it for?"}],
+        )
+
+    @mock.patch.object(voice_server, "generate_reply")
+    def test_byte_identical_stale_pcm_is_submitted_only_once(self, generate):
+        state = voice_server.VoiceState()
+        raw = b"\x00\x20" * (voice_server.FRAME_BYTES // 2)
+        with mock.patch.object(voice_server, "STATE", state):
+            voice_server.generate_audio_reply(raw, 0.5, turn_id="voice-one")
+            voice_server.generate_audio_reply(raw, 0.5, turn_id="voice-two")
+
+        generate.assert_called_once()
+        self.assertEqual(generate.call_args.kwargs["turn_id"], "voice-one")
+
+
+class GestureCommandGateTests(unittest.TestCase):
+    def setUp(self):
+        self.gate = voice_server.GestureCommandGate()
+
+    def test_direct_typed_command_executes(self):
+        decision, _ = self.gate.evaluate(
+            {"role": "user", "content": "Walter, please raise your hand."},
+            "raise_hand",
+        )
+        self.assertEqual(decision, "execute")
+
+    def test_hypothetical_typed_command_is_rejected(self):
+        decision, result = self.gate.evaluate(
+            {
+                "role": "user",
+                "content": "Explain what would happen if someone asked you to wave.",
+            },
+            "wave_hand",
+        )
+        self.assertEqual(decision, "reject")
+        self.assertFalse(result["accepted"])
+
+    def test_spoken_command_executes_without_confirmation(self):
+        audio_message = {
+            "role": "user",
+            "content": [{"type": "input_audio", "input_audio": {}}],
+        }
+        decision, result = self.gate.evaluate(
+            audio_message,
+            "wave_hand",
+            command_text="Walter, wave to the audience now.",
+        )
+        self.assertEqual(decision, "execute")
+        self.assertEqual(result, {})
+
+    def test_spoken_tool_call_without_current_turn_words_is_rejected(self):
+        audio_message = {
+            "role": "user",
+            "content": [{"type": "input_audio", "input_audio": {}}],
+        }
+        decision, result = self.gate.evaluate(audio_message, "shake_hand")
+        self.assertEqual(decision, "reject")
+        self.assertFalse(result["accepted"])
+
+    def test_walters_declarative_tts_cannot_authorize_a_gesture(self):
+        audio_message = {
+            "role": "user",
+            "content": [{"type": "input_audio", "input_audio": {}}],
+        }
+        decision, result = self.gate.evaluate(
+            audio_message,
+            "shake_hand",
+            command_text="Okay, I'll shake your hand now.",
+        )
+        self.assertEqual(decision, "reject")
+        self.assertFalse(result["accepted"])
+
+    def test_unrelated_spoken_turn_cannot_authorize_model_selected_gesture(self):
+        audio_message = {
+            "role": "user",
+            "content": [{"type": "input_audio", "input_audio": {}}],
+        }
+        decision, result = self.gate.evaluate(
+            audio_message,
+            "shake_hand",
+            command_text="Walter, tell me how WendyOS works.",
+        )
+        self.assertEqual(decision, "reject")
+        self.assertFalse(result["accepted"])
+
+    def test_spoken_command_must_agree_with_selected_action(self):
+        audio_message = {
+            "role": "user",
+            "content": [{"type": "input_audio", "input_audio": {}}],
+        }
+        decision, result = self.gate.evaluate(
+            audio_message,
+            "shake_hand",
+            command_text="Walter, raise your hand.",
+        )
+        self.assertEqual(decision, "reject")
+        self.assertFalse(result["accepted"])
+
+    def test_urgent_spoken_stop_does_not_require_wake_word(self):
+        audio_message = {
+            "role": "user",
+            "content": [{"type": "input_audio", "input_audio": {}}],
+        }
+        decision, result = self.gate.evaluate(
+            audio_message,
+            "stop",
+            command_text="Stop now!",
+        )
+        self.assertEqual(decision, "execute")
+        self.assertEqual(result, {})
+
+    def test_gesture_tool_requires_current_turn_command_words(self):
+        gesture = next(
+            item for item in TOOL_SCHEMAS if item["function"]["name"] == "g1_gesture"
+        )
+        parameters = gesture["function"]["parameters"]
+        self.assertEqual(set(parameters["required"]), {"action", "command_text"})
+        self.assertFalse(parameters["additionalProperties"])
+
+
+class ConversationHistoryTests(unittest.TestCase):
+    def test_voice_turn_retains_neither_audio_nor_assistant_only_context(self):
+        history = []
+        voice_server.retain_history_turn(
+            history,
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_audio",
+                        "input_audio": {"data": "old-command-bytes", "format": "wav"},
+                    }
+                ],
+            },
+            "I answered that turn.",
+            None,
+        )
+        serialized = json.dumps(history)
+        self.assertNotIn("old-command-bytes", serialized)
+        self.assertEqual(history, [])
+
+    def test_typed_turn_still_retains_both_sides(self):
+        history = []
+        voice_server.retain_history_turn(
+            history,
+            {"role": "user", "content": "Explain WendyOS."},
+            "WendyOS deploys applications to edge devices.",
+            None,
+        )
+        self.assertEqual(len(history), 2)
+
+    def test_runaway_unusable_voice_turns_enter_self_clearing_cooldown(self):
+        state = voice_server.VoiceState()
+        state.model_ready = True
+        state.listening = True
+        with (
+            mock.patch.object(voice_server, "STATE", state),
+            mock.patch.object(voice_server, "_trace_event"),
+        ):
+            self.assertFalse(
+                voice_server.record_unusable_voice_turn("v1", "blocked", now=1.0)
+            )
+            self.assertFalse(
+                voice_server.record_unusable_voice_turn("v2", "blocked", now=2.0)
+            )
+            self.assertTrue(
+                voice_server.record_unusable_voice_turn("v3", "blocked", now=3.0)
+            )
+        self.assertFalse(state.listening)
+        self.assertEqual(state.phase, "cooldown")
+        self.assertEqual(state.listen_pause_reason, "repeated_unusable_voice_turns")
+        self.assertTrue(state.auto_resume_pending)
+        self.assertEqual(
+            state.auto_resume_not_before,
+            3.0 + voice_server.AUTO_RESUME_COOLDOWN_SECONDS,
+        )
+        self.assertEqual(
+            state.auto_resume_force_at,
+            3.0 + voice_server.AUTO_RESUME_MAX_SECONDS,
+        )
+        with mock.patch.object(voice_server, "STATE", state):
+            self.assertTrue(voice_server.should_capture())
+            self.assertFalse(voice_server.should_begin_audio_turn())
+
+    def test_runaway_cooldown_resumes_after_minimum_and_sustained_quiet(self):
+        state = voice_server.VoiceState()
+        state.model_ready = True
+        state.listening = True
+        subscriber = queue.Queue()
+        state.subscribers.append(subscriber)
+        with (
+            mock.patch.object(voice_server, "STATE", state),
+            mock.patch.object(voice_server, "_trace_event") as trace,
+        ):
+            for index in range(3):
+                voice_server.record_unusable_voice_turn(
+                    f"v{index}", "blocked", now=float(index + 1)
+                )
+            self.assertFalse(
+                voice_server.observe_auto_resume(0.001, 0.012, now=4.0)
+            )
+            self.assertTrue(
+                voice_server.observe_auto_resume(0.001, 0.012, now=6.1)
+            )
+
+        self.assertTrue(state.listening)
+        self.assertFalse(state.auto_resume_pending)
+        self.assertEqual(state.phase, "listening")
+        self.assertEqual(state.listen_pause_reason, "")
+        self.assertEqual(list(state.unusable_voice_turns), [])
+        trace.assert_any_call(
+            "listening.auto_resumed",
+            component="speechllm",
+            turn_id="v2",
+            details={"reason": "quiet", "level": 0.001, "threshold": 0.012},
+        )
+        events = []
+        while not subscriber.empty():
+            events.append(subscriber.get_nowait())
+        self.assertEqual(events[-1]["event"], "listening_auto_resumed")
+
+    def test_runaway_cooldown_forces_bounded_retry_in_continuous_noise(self):
+        state = voice_server.VoiceState()
+        state.model_ready = True
+        state.listening = True
+        with (
+            mock.patch.object(voice_server, "STATE", state),
+            mock.patch.object(voice_server, "_trace_event") as trace,
+        ):
+            for index in range(3):
+                voice_server.record_unusable_voice_turn(
+                    f"v{index}", "blocked", now=float(index + 1)
+                )
+            self.assertFalse(
+                voice_server.observe_auto_resume(0.1, 0.012, now=14.9)
+            )
+            self.assertTrue(
+                voice_server.observe_auto_resume(0.1, 0.012, now=15.0)
+            )
+
+        self.assertTrue(state.listening)
+        self.assertFalse(state.auto_resume_pending)
+        trace.assert_any_call(
+            "listening.auto_resumed",
+            component="speechllm",
+            turn_id="v2",
+            details={
+                "reason": "maximum_cooldown",
+                "level": 0.1,
+                "threshold": 0.012,
+            },
+        )
+
+    def test_action_turn_clears_all_conversation_history(self):
+        history = [
+            {"role": "user", "content": "Shake my hand"},
+            {"role": "assistant", "content": "I will shake your hand."},
+        ]
+        voice_server.retain_history_turn(
+            history,
+            {"role": "user", "content": "another action"},
+            "Acting now.",
+            "shake_hand",
+        )
+        self.assertEqual(history, [])
+
+
+class TtsChunkingTests(unittest.TestCase):
+    def test_keeps_incomplete_sentence_buffered(self):
+        chunks, remainder = voice_server.extract_tts_chunks(
+            "A complete first sentence. The next is still"
+        )
+        self.assertEqual(chunks, ["A complete first sentence."])
+        self.assertEqual(remainder, "The next is still")
+
+    def test_flushes_unpunctuated_final_text(self):
+        chunks, remainder = voice_server.extract_tts_chunks(
+            "A final answer without punctuation", final=True
+        )
+        self.assertEqual(chunks, ["A final answer without punctuation"])
+        self.assertEqual(remainder, "")
+
+
+class G1ToolPolicyTests(unittest.TestCase):
+    def client(self):
+        return G1ControlClient(
+            enabled=True,
+            g1_url="http://g1:8094",
+            g1_token="g1-token",
+            orchestrator_url="http://spark:8093",
+            orchestrator_token="spark-token",
+        )
+
+    def test_exact_allowlist_action_is_admitted_only_when_idle(self):
+        client = self.client()
+        with mock.patch.object(
+            client,
+            "status",
+            return_value={
+                "ready": True,
+                "hardware_connected": True,
+                "lowstate_ready": True,
+                "pending": 0,
+                "active_turn": None,
+                "prepared_turn": None,
+            },
+        ):
+            result, action = client.admit_tool(
+                "g1_gesture", {"action": "wave_hand"}
+            )
+        self.assertTrue(result["accepted"])
+        self.assertEqual(action, "wave_hand")
+
+    def test_arbitrary_motion_field_is_rejected(self):
+        client = self.client()
+        with self.assertRaisesRegex(G1ToolError, "unsupported G1 gesture"):
+            client.admit_tool("g1_gesture", {"action": "walk_forward"})
 
 if __name__ == "__main__":
     unittest.main()

--- a/Examples/CUDASpeechLLM/test_voice_server.py
+++ b/Examples/CUDASpeechLLM/test_voice_server.py
@@ -1,3 +1,4 @@
+import io
 import json
 import os
 import queue
@@ -6,6 +7,7 @@ import tempfile
 import threading
 import time
 import unittest
+import wave
 from pathlib import Path
 from unittest import mock
 
@@ -178,6 +180,20 @@ class CaptureRescanTests(unittest.TestCase):
 
 
 class AlsaPlaybackTests(unittest.TestCase):
+    def test_preroll_adds_silence_without_dropping_original_audio(self):
+        original_pcm = b"\x11\x22" * 160
+        source = voice_server.wav_bytes(original_pcm)
+
+        padded = voice_server.add_wav_preroll(source, 100)
+
+        with wave.open(io.BytesIO(padded), "rb") as wav:
+            self.assertEqual(wav.getframerate(), voice_server.SAMPLE_RATE)
+            self.assertEqual(wav.getnchannels(), 1)
+            self.assertEqual(wav.getsampwidth(), 2)
+            frames = wav.readframes(wav.getnframes())
+        expected_silence = b"\x00\x00" * 1600
+        self.assertEqual(frames, expected_silence + original_pcm)
+
     @mock.patch.object(voice_server.shutil, "which", return_value="/usr/bin/aplay")
     @mock.patch.object(voice_server.subprocess, "Popen")
     def test_wav_is_piped_directly_to_configured_alsa_device(self, popen, _which):
@@ -189,7 +205,15 @@ class AlsaPlaybackTests(unittest.TestCase):
         self.addCleanup(
             setattr, voice_server, "ALSA_PLAYBACK_DEVICE", original_device
         )
+        original_preroll = voice_server.ALSA_PLAYBACK_PREROLL_MS
+        self.addCleanup(
+            setattr,
+            voice_server,
+            "ALSA_PLAYBACK_PREROLL_MS",
+            original_preroll,
+        )
         voice_server.ALSA_PLAYBACK_DEVICE = "plughw:4,0"
+        voice_server.ALSA_PLAYBACK_PREROLL_MS = 0
 
         voice_server.play_wav_alsa(b"RIFF wav data")
 
@@ -584,18 +608,25 @@ class ReplyPipelineTests(unittest.TestCase):
 
     @mock.patch.object(voice_server, "speak_alsa")
     @mock.patch.object(voice_server.urllib.request, "urlopen")
-    def test_generic_voice_clarification_is_blocked_on_first_turn(
+    def test_generic_voice_clarification_is_repaired_on_first_turn(
         self, urlopen, speak
     ):
-        event = {
+        blocked_event = {
             "choices": [{"delta": {"content": "What do you need it for?"}}]
         }
-        response = mock.MagicMock()
-        response.__enter__.return_value = [
-            f"data: {json.dumps(event)}\n".encode(),
-            b"data: [DONE]\n",
-        ]
-        urlopen.return_value = response
+        repaired_event = {
+            "choices": [{"delta": {"content": "Could you repeat that clearly?"}}]
+        }
+
+        def response(event):
+            value = mock.MagicMock()
+            value.__enter__.return_value = [
+                f"data: {json.dumps(event)}\n".encode(),
+                b"data: [DONE]\n",
+            ]
+            return value
+
+        urlopen.side_effect = [response(blocked_event), response(repaired_event)]
         state = voice_server.VoiceState()
         state.model_ready = True
         client = mock.Mock()
@@ -611,26 +642,33 @@ class ReplyPipelineTests(unittest.TestCase):
         ):
             voice_server.generate_reply(message, turn_id="voice-generic-question")
 
-        speak.assert_not_called()
+        speak.assert_called_once_with("Could you repeat that clearly?")
         self.assertEqual(state.history, [])
-        self.assertEqual(len(state.unusable_voice_turns), 1)
+        self.assertEqual(len(state.unusable_voice_turns), 0)
 
     @mock.patch.object(voice_server, "speak_alsa")
     @mock.patch.object(voice_server.urllib.request, "urlopen")
-    def test_distinct_mic_turn_cannot_replay_previous_first_sentence(
+    def test_distinct_mic_turn_repairs_repeated_first_sentence(
         self, urlopen, speak
     ):
         repeated = {"choices": [{"delta": {"content": "I can help with that."}}]}
+        repaired = {
+            "choices": [{"delta": {"content": "Please tell me your current question."}}]
+        }
 
-        def response():
+        def response(event):
             value = mock.MagicMock()
             value.__enter__.return_value = [
-                f"data: {json.dumps(repeated)}\n".encode(),
+                f"data: {json.dumps(event)}\n".encode(),
                 b"data: [DONE]\n",
             ]
             return value
 
-        urlopen.side_effect = [response(), response()]
+        urlopen.side_effect = [
+            response(repeated),
+            response(repeated),
+            response(repaired),
+        ]
         state = voice_server.VoiceState()
         state.model_ready = True
         subscriber = queue.Queue()
@@ -656,15 +694,24 @@ class ReplyPipelineTests(unittest.TestCase):
             voice_server.generate_reply(audio_message("first"), turn_id="voice-first")
             voice_server.generate_reply(audio_message("second"), turn_id="voice-second")
 
-        speak.assert_called_once_with("I can help with that.")
+        self.assertEqual(
+            speak.call_args_list,
+            [
+                mock.call("I can help with that."),
+                mock.call("Please tell me your current question."),
+            ],
+        )
         events = []
         while not subscriber.empty():
             events.append(subscriber.get_nowait())
         deltas = [event for event in events if event["event"] == "assistant_delta"]
         completions = [event for event in events if event["event"] == "assistant_done"]
-        self.assertEqual(len(deltas), 1)
+        self.assertEqual(len(deltas), 2)
         self.assertEqual(deltas[0]["data"]["text"], "I can help with that.")
-        self.assertTrue(completions[-1]["data"]["suppressed"])
+        self.assertEqual(
+            deltas[1]["data"]["text"], "Please tell me your current question."
+        )
+        self.assertFalse(completions[-1]["data"]["suppressed"])
         self.assertEqual(state.history, [])
 
 

--- a/Examples/CUDASpeechLLM/trace_recorder.py
+++ b/Examples/CUDASpeechLLM/trace_recorder.py
@@ -1,0 +1,376 @@
+"""Low-overhead, correlated wall-clock and GPU tracing for live voice turns."""
+
+from __future__ import annotations
+
+import collections
+import datetime as dt
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import threading
+import time
+from typing import Any, Callable
+
+
+def _utc_iso(unix_ns: int) -> str:
+    value = dt.datetime.fromtimestamp(unix_ns / 1_000_000_000, tz=dt.timezone.utc)
+    return value.isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _number(value: str) -> float | None:
+    cleaned = value.strip()
+    if cleaned in {"", "N/A", "[N/A]", "Not Supported"}:
+        return None
+    try:
+        return float(cleaned)
+    except ValueError:
+        return None
+
+
+class TraceRecorder:
+    """Append JSONL trace events and sample NVIDIA telemetry during active turns."""
+
+    GPU_FIELDS = (
+        "gpu_name",
+        "gpu_utilization_percent",
+        "memory_utilization_percent",
+        "memory_used_mib",
+        "memory_total_mib",
+        "power_draw_w",
+        "sm_clock_mhz",
+    )
+
+    def __init__(
+        self,
+        path: str,
+        *,
+        device: str = "spark",
+        monotonic_clock: Callable[[], int] = time.monotonic_ns,
+        wall_clock: Callable[[], int] = time.time_ns,
+        gpu_interval_ms: int = 250,
+        max_bytes: int = 128 * 1024 * 1024,
+    ) -> None:
+        self.path = Path(path)
+        self.device = device
+        self._monotonic_clock = monotonic_clock
+        self._wall_clock = wall_clock
+        self._gpu_interval_ms = max(100, gpu_interval_ms)
+        self._max_bytes = max(1_048_576, max_bytes)
+        self._lock = threading.RLock()
+        self._sequence = 0
+        self._active_turns: set[str] = set()
+        self._gpu_process: subprocess.Popen[str] | None = None
+        self._stopping = threading.Event()
+
+    def record(
+        self,
+        turn_id: str,
+        event: str,
+        *,
+        component: str,
+        kind: str = "instant",
+        monotonic_ns: int | None = None,
+        wall_unix_ns: int | None = None,
+        duration_ns: int | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        if not turn_id:
+            raise ValueError("turn_id is required")
+        observed_monotonic_ns = (
+            self._monotonic_clock() if monotonic_ns is None else int(monotonic_ns)
+        )
+        observed_wall_ns = self._wall_clock() if wall_unix_ns is None else int(wall_unix_ns)
+        with self._lock:
+            self._sequence += 1
+            item: dict[str, Any] = {
+                "schema": "wendy.modcon.trace.v1",
+                "sequence": self._sequence,
+                "turn_id": turn_id,
+                "device": self.device,
+                "clock_domain": f"{self.device}-CLOCK_MONOTONIC",
+                "component": component,
+                "event": event,
+                "kind": kind,
+                "wall_time_utc": _utc_iso(observed_wall_ns),
+                "wall_unix_ns": observed_wall_ns,
+                "monotonic_ns": observed_monotonic_ns,
+                "details": details or {},
+            }
+            if duration_ns is not None:
+                item["duration_ns"] = int(duration_ns)
+                item["duration_ms"] = int(duration_ns) / 1_000_000
+            self._append_locked(item)
+        return item
+
+    def activate(self, turn_id: str) -> None:
+        with self._lock:
+            self._active_turns.add(turn_id)
+
+    def deactivate(self, turn_id: str) -> None:
+        with self._lock:
+            self._active_turns.discard(turn_id)
+
+    def active_turns(self) -> tuple[str, ...]:
+        with self._lock:
+            return tuple(sorted(self._active_turns))
+
+    def start_gpu_sampler(self) -> None:
+        if self._gpu_process is not None or not shutil.which("nvidia-smi"):
+            return
+        query = (
+            "name,utilization.gpu,utilization.memory,memory.used,memory.total,"
+            "power.draw,clocks.sm"
+        )
+        try:
+            process = subprocess.Popen(
+                [
+                    "nvidia-smi",
+                    f"--query-gpu={query}",
+                    "--format=csv,noheader,nounits",
+                    f"--loop-ms={self._gpu_interval_ms}",
+                ],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                bufsize=1,
+            )
+        except OSError:
+            return
+        self._gpu_process = process
+        threading.Thread(target=self._read_gpu, args=(process,), daemon=True).start()
+
+    def close(self) -> None:
+        self._stopping.set()
+        process = self._gpu_process
+        if process is not None and process.poll() is None:
+            process.terminate()
+
+    def recent(self, *, turn_id: str | None = None, limit: int = 1000) -> list[dict[str, Any]]:
+        bounded = max(1, min(10_000, int(limit)))
+        if not self.path.is_file():
+            return []
+        selected: collections.deque[dict[str, Any]] = collections.deque(maxlen=bounded)
+        try:
+            with self.path.open("r", encoding="utf-8") as source:
+                for line in source:
+                    try:
+                        item = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if turn_id is None or item.get("turn_id") == turn_id:
+                        selected.append(item)
+        except OSError:
+            return []
+        return list(selected)
+
+    def summarize(self, turn_id: str) -> dict[str, Any]:
+        events = self.recent(turn_id=turn_id, limit=10_000)
+        durations: dict[str, list[float]] = {}
+        gpu_values: dict[str, list[float]] = {
+            "gpu_utilization_percent": [],
+            "memory_utilization_percent": [],
+            "power_draw_w": [],
+            "sm_clock_mhz": [],
+        }
+        for item in events:
+            duration = item.get("duration_ms")
+            if isinstance(duration, (int, float)):
+                durations.setdefault(str(item.get("event")), []).append(float(duration))
+            if item.get("event") == "gpu.sample":
+                details = item.get("details") or {}
+                for key in gpu_values:
+                    value = details.get(key)
+                    if isinstance(value, (int, float)):
+                        gpu_values[key].append(float(value))
+        phase_totals_ms = {key: round(sum(values), 3) for key, values in durations.items()}
+        def summarize_gpu(values_by_key: dict[str, list[float]]) -> dict[str, dict[str, Any]]:
+            return {
+                key: {
+                    "samples": len(values),
+                    "average": round(sum(values) / len(values), 3) if values else None,
+                    "peak": round(max(values), 3) if values else None,
+                }
+                for key, values in values_by_key.items()
+            }
+
+        gpu_summary = summarize_gpu(gpu_values)
+        inference_intervals = [
+            (
+                int(item["monotonic_ns"]) - int(item["duration_ns"]),
+                int(item["monotonic_ns"]),
+            )
+            for item in events
+            if item.get("event") == "inference.request"
+            and isinstance(item.get("monotonic_ns"), int)
+            and isinstance(item.get("duration_ns"), int)
+        ]
+        inference_gpu_values: dict[str, list[float]] = {
+            key: [] for key in gpu_values
+        }
+        for item in events:
+            if item.get("event") != "gpu.sample":
+                continue
+            instant = item.get("monotonic_ns")
+            if not isinstance(instant, int) or not any(
+                started <= instant <= ended for started, ended in inference_intervals
+            ):
+                continue
+            details = item.get("details") or {}
+            for key in inference_gpu_values:
+                value = details.get(key)
+                if isinstance(value, (int, float)):
+                    inference_gpu_values[key].append(float(value))
+        inference_gpu_summary = summarize_gpu(inference_gpu_values)
+
+        turn_started_ns = next(
+            (
+                item.get("monotonic_ns")
+                for item in events
+                if item.get("event") == "turn.started"
+            ),
+            None,
+        )
+        first_audio_ns = next(
+            (
+                item.get("monotonic_ns")
+                for item in events
+                if item.get("event") == "audio.playback.started"
+            ),
+            None,
+        )
+        time_to_first_audio_ms = (
+            (first_audio_ns - turn_started_ns) / 1_000_000
+            if isinstance(first_audio_ns, int) and isinstance(turn_started_ns, int)
+            else None
+        )
+        inference_records = [
+            item for item in events if item.get("event") == "inference.request"
+        ]
+        tool_calls = [
+            item.get("details", {}).get("tool_call")
+            for item in inference_records
+            if item.get("details", {}).get("tool_call")
+        ]
+        generated_audio_ms = sum(
+            float(item.get("details", {}).get("audio_duration_ms") or 0)
+            for item in events
+            if item.get("event") == "tts.synthesis"
+        )
+        observations: list[str] = []
+        inference_ms = sum(
+            value for key, value in phase_totals_ms.items() if key == "inference.request"
+        )
+        first_token = next(
+            (
+                item.get("details", {}).get("time_to_first_text_ms")
+                for item in reversed(events)
+                if item.get("event") == "inference.request"
+            ),
+            None,
+        )
+        average_gpu = inference_gpu_summary["gpu_utilization_percent"]["average"]
+        if len(inference_records) > 1:
+            observations.append(
+                f"The model required {len(inference_records)} inference passes; the first selected "
+                f"tool(s) {tool_calls or ['unknown']}, so a second completion delayed speech."
+            )
+        if isinstance(first_token, (int, float)) and first_token > 1500:
+            observations.append(
+                "Most perceived delay before speech is time-to-first-text: prompt ingestion, "
+                "audio projection, and model prefill occur before the first speakable sentence."
+            )
+        if inference_ms and isinstance(average_gpu, (int, float)):
+            if average_gpu < 35:
+                observations.append(
+                    "GPU utilization was low during the inference intervals; CPU-side request, audio "
+                    "projection, synchronization, or sampling gaps likely dominate part of latency."
+                )
+            elif average_gpu > 75:
+                observations.append(
+                    "GPU utilization was high during the turn, consistent with model prefill/decode "
+                    "being a material latency source."
+                )
+        if phase_totals_ms.get("tts.synthesis", 0) > inference_ms:
+            observations.append("Kokoro synthesis took longer than measured model inference.")
+        if phase_totals_ms.get("audio.playback", 0) > inference_ms:
+            observations.append(
+                "Playback duration dominates the completed turn; this is generated speech length, "
+                "not inference latency."
+            )
+        if not observations:
+            observations.append(
+                "Use the phase durations and GPU samples directly; this turn does not support a "
+                "single dominant inference bottleneck classification."
+            )
+        return {
+            "schema": "wendy.modcon.trace-summary.v1",
+            "turn_id": turn_id,
+            "event_count": len(events),
+            "first_wall_time_utc": events[0].get("wall_time_utc") if events else None,
+            "last_wall_time_utc": events[-1].get("wall_time_utc") if events else None,
+            "phase_totals_ms": phase_totals_ms,
+            "time_to_first_audio_ms": (
+                round(time_to_first_audio_ms, 3)
+                if isinstance(time_to_first_audio_ms, (int, float))
+                else None
+            ),
+            "inference_passes": len(inference_records),
+            "tool_calls": tool_calls,
+            "generated_audio_ms": round(generated_audio_ms, 3),
+            "gpu": gpu_summary,
+            "gpu_during_inference": inference_gpu_summary,
+            "observations": observations,
+        }
+
+    def _read_gpu(self, process: subprocess.Popen[str]) -> None:
+        if process.stdout is None:
+            return
+        while not self._stopping.is_set():
+            line = process.stdout.readline()
+            if not line:
+                return
+            values = [part.strip() for part in line.split(",")]
+            if len(values) != len(self.GPU_FIELDS):
+                continue
+            details: dict[str, Any] = {"gpu_name": values[0]}
+            for key, value in zip(self.GPU_FIELDS[1:], values[1:]):
+                details[key] = _number(value)
+            try:
+                memory = {
+                    line.split(":", 1)[0]: int(line.split()[1]) / 1024
+                    for line in Path("/proc/meminfo").read_text(encoding="utf-8").splitlines()
+                    if line.startswith(("MemTotal:", "MemAvailable:"))
+                }
+            except (OSError, ValueError, IndexError):
+                memory = {}
+            details["unified_memory_total_mib"] = memory.get("MemTotal")
+            details["unified_memory_available_mib"] = memory.get("MemAvailable")
+            for turn_id in self.active_turns():
+                self.record(
+                    turn_id,
+                    "gpu.sample",
+                    component="nvidia-smi",
+                    kind="sample",
+                    details=details,
+                )
+
+    def _append_locked(self, item: dict[str, Any]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            if self.path.stat().st_size >= self._max_bytes:
+                rotated = self.path.with_suffix(self.path.suffix + ".1")
+                try:
+                    rotated.unlink()
+                except FileNotFoundError:
+                    pass
+                self.path.replace(rotated)
+        except FileNotFoundError:
+            pass
+        encoded = json.dumps(
+            item, sort_keys=True, separators=(",", ":"), default=str
+        )
+        with self.path.open("a", encoding="utf-8") as output:
+            output.write(encoded + "\n")

--- a/Examples/CUDASpeechLLM/voice_server.py
+++ b/Examples/CUDASpeechLLM/voice_server.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import array
 import base64
 import collections
+import hashlib
 import io
 import json
 import math
@@ -20,10 +21,14 @@ import threading
 import time
 import urllib.error
 import urllib.request
+import uuid
 import wave
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
+
+from g1_tools import G1ControlClient, G1ToolError, TOOL_SCHEMAS
+from trace_recorder import TraceRecorder
 
 
 PUBLIC_DIR = Path(os.environ.get("VOICE_WEB_ROOT", "/app/web")).resolve()
@@ -39,6 +44,29 @@ TTS_SPEAKER_ID = int(os.environ.get("TTS_SPEAKER_ID", "3"))
 TTS_SPEED = float(os.environ.get("TTS_SPEED", "1.04"))
 TTS_THREADS = int(os.environ.get("TTS_THREADS", "8"))
 ALSA_PLAYBACK_DEVICE = os.environ.get("ALSA_PLAYBACK_DEVICE", "default")
+SYSTEM_PROMPT_PATH = Path(os.environ.get("SYSTEM_PROMPT_PATH", "/app/SOUL.md"))
+KNOWLEDGE_DIR = Path(os.environ.get("KNOWLEDGE_DIR", "/app/knowledge"))
+KNOWLEDGE_MAX_CHARS = int(os.environ.get("KNOWLEDGE_MAX_CHARS", "30000"))
+TTS_CHUNK_MIN_CHARS = int(os.environ.get("TTS_CHUNK_MIN_CHARS", "24"))
+TTS_CHUNK_QUEUE_SIZE = int(os.environ.get("TTS_CHUNK_QUEUE_SIZE", "8"))
+MIN_AUDIO_RMS = float(os.environ.get("MIN_AUDIO_RMS", "0.002"))
+RUNAWAY_VOICE_LIMIT = int(os.environ.get("RUNAWAY_VOICE_LIMIT", "3"))
+RUNAWAY_VOICE_WINDOW_SECONDS = float(
+    os.environ.get("RUNAWAY_VOICE_WINDOW_SECONDS", "10")
+)
+AUTO_RESUME_COOLDOWN_SECONDS = float(
+    os.environ.get("AUTO_RESUME_COOLDOWN_SECONDS", "3")
+)
+AUTO_RESUME_QUIET_SECONDS = float(
+    os.environ.get("AUTO_RESUME_QUIET_SECONDS", "1")
+)
+AUTO_RESUME_MAX_SECONDS = float(
+    os.environ.get("AUTO_RESUME_MAX_SECONDS", "12")
+)
+TRACE_LOG_PATH = os.environ.get(
+    "TRACE_LOG_PATH", "/models/traces/speechllm-trace.jsonl"
+)
+TRACE_GPU_INTERVAL_MS = int(os.environ.get("TRACE_GPU_INTERVAL_MS", "250"))
 AUTO_LISTEN = os.environ.get("AUTO_LISTEN", "true").lower() not in {
     "0",
     "false",
@@ -46,7 +74,7 @@ AUTO_LISTEN = os.environ.get("AUTO_LISTEN", "true").lower() not in {
     "off",
 }
 
-SYSTEM_PROMPT = (
+DEFAULT_SYSTEM_PROMPT = (
     "You are a warm, quick voice assistant in a live conversation. Listen "
     "carefully to each audio turn and reply naturally in one to three short "
     "sentences. Do not describe your process, mention transcription, or use "
@@ -54,9 +82,191 @@ SYSTEM_PROMPT = (
 )
 
 
+def load_system_prompt(
+    soul_path: Path = SYSTEM_PROMPT_PATH,
+    knowledge_dir: Path = KNOWLEDGE_DIR,
+) -> str:
+    """Load Walter's identity and bounded conference reference material."""
+    parts: list[str] = []
+    try:
+        soul = soul_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        soul = ""
+    remaining = max(0, KNOWLEDGE_MAX_CHARS)
+    if remaining and knowledge_dir.is_dir():
+        for path in sorted(knowledge_dir.glob("*.md")):
+            try:
+                text = path.read_text(encoding="utf-8").strip()
+            except OSError:
+                continue
+            if not text:
+                continue
+            excerpt = text[:remaining]
+            parts.append(f"Reference: {path.stem}\n{excerpt}")
+            remaining -= len(excerpt)
+            if remaining <= 0:
+                break
+
+    # Put behavioral and identity instructions after reference material so a
+    # small local model sees the decision policy closest to the user turn.
+    if soul:
+        parts.append(f"Final identity and conversation policy:\n{soul}")
+
+    return "\n\n".join(parts) if parts else DEFAULT_SYSTEM_PROMPT
+
+
+SYSTEM_PROMPT = load_system_prompt()
+G1_CLIENT = G1ControlClient.from_env()
+TRACE = TraceRecorder(
+    TRACE_LOG_PATH,
+    device=os.environ.get("TRACE_DEVICE_NAME", "spark-3011"),
+    gpu_interval_ms=TRACE_GPU_INTERVAL_MS,
+)
+TRACE_THREAD = threading.local()
+
+
+def runtime_system_prompt(
+    base_prompt: str = SYSTEM_PROMPT, *, g1_tools_enabled: bool | None = None
+) -> str:
+    """Describe the live robot boundary without inviting unavailable tool calls."""
+    enabled = G1_CLIENT.enabled if g1_tools_enabled is None else g1_tools_enabled
+    if enabled:
+        return base_prompt
+    return (
+        f"{base_prompt}\n\n"
+        "Live operator state: G1 control is offline and robot tools are disabled. "
+        "Do not call, retry, or suggest a G1 task. If asked for robot status or "
+        "motion, state the unavailability once in one short sentence, then continue "
+        "with non-robot conversation."
+    )
+
+
+class GestureCommandGate:
+    """Require current-turn command evidence before a gesture can schedule."""
+
+    _DENIED_TEXT = re.compile(
+        r"\b(?:hypothetical|hypothetically|example|explain|describe|discuss|"
+        r"what\s+(?:would|will)\s+happen|if\s+(?:someone|somebody|a person)|"
+        r"do\s+not|don't|dont|without\s+(?:moving|doing\s+it))\b",
+        re.IGNORECASE,
+    )
+    _DIRECT_TEXT = {
+        "raise_hand": re.compile(
+            r"\b(?:raise|lift|put)\s+(?:your\s+)?(?:right\s+)?hand(?:\s+up)?\b",
+            re.IGNORECASE,
+        ),
+        "wave_hand": re.compile(
+            r"\bwave(?:\s+(?:your\s+)?hand)?(?:\s+(?:to|at)\s+(?:me|us|the\s+audience))?\b",
+            re.IGNORECASE,
+        ),
+        "shake_hand": re.compile(
+            r"\b(?:shake\s+(?:my|our|the|your)\s+hand|handshake)\b",
+            re.IGNORECASE,
+        ),
+        "stop": re.compile(
+            r"\b(?:stop|cancel|halt|hold\s+still|release)\b",
+            re.IGNORECASE,
+        ),
+    }
+    _SPOKEN_DIRECT_TEXT = {
+        "raise_hand": re.compile(
+            r"^(?:hey\s+)?walter[,\s]+(?:please\s+)?"
+            r"(?:raise|lift|put)\s+(?:your\s+)?(?:right\s+)?hand(?:\s+up)?"
+            r"(?:\s+(?:now|please))?[.!?]*$",
+            re.IGNORECASE,
+        ),
+        "wave_hand": re.compile(
+            r"^(?:hey\s+)?walter[,\s]+(?:please\s+)?wave"
+            r"(?:\s+(?:your\s+)?hand)?"
+            r"(?:\s+(?:to|at)\s+(?:me|us|the\s+audience))?"
+            r"(?:\s+(?:now|please))?[.!?]*$",
+            re.IGNORECASE,
+        ),
+        "shake_hand": re.compile(
+            r"^(?:hey\s+)?walter[,\s]+(?:please\s+)?"
+            r"(?:shake\s+(?:my|our)\s+hand|give\s+me\s+a\s+handshake|handshake)"
+            r"(?:\s+(?:now|please))?[.!?]*$",
+            re.IGNORECASE,
+        ),
+        # A false stop is safer than ignoring an urgent stop, so it does not
+        # require the Walter address that motion-starting commands require.
+        "stop": re.compile(
+            r"^(?:(?:hey\s+)?walter[,\s]+)?(?:please\s+)?"
+            r"(?:stop|cancel|halt|hold\s+still|release)"
+            r"(?:\s+(?:now|please))?[.!?]*$",
+            re.IGNORECASE,
+        ),
+    }
+
+    @staticmethod
+    def _text(user_message: dict) -> str | None:
+        content = user_message.get("content")
+        return content if isinstance(content, str) else None
+
+    def clear(self) -> None:
+        """Retained for reset/interrupt symmetry; direct mode has no armed state."""
+
+    @staticmethod
+    def _rejection(error: str) -> tuple[str, dict]:
+        return (
+            "reject",
+            {"success": False, "accepted": False, "error": error},
+        )
+
+    def evaluate(
+        self,
+        user_message: dict,
+        action: str,
+        *,
+        command_text: str | None = None,
+    ) -> tuple[str, dict]:
+        """Return execute or reject using evidence from only the current turn."""
+        text = self._text(user_message)
+        if text is not None:
+            if self._DENIED_TEXT.search(text):
+                return self._rejection(
+                    "gesture request was hypothetical, explanatory, or negated"
+                )
+            pattern = self._DIRECT_TEXT.get(action)
+            if pattern is None or pattern.search(text) is None:
+                return self._rejection(
+                    "gesture was not an explicit direct command in this turn"
+                )
+            self.clear()
+            return "execute", {}
+
+        # A model-selected tool is not sufficient authorization for microphone
+        # input. Require the same tool call to carry current-turn command words,
+        # and accept only a narrow, addressed imperative that agrees with the
+        # selected action. This rejects Walter's declarative TTS, actuator noise,
+        # unrelated speech, explanations, and stale/partial tool arguments.
+        if not isinstance(action, str):
+            return self._rejection("spoken tool selected an invalid action")
+        if not isinstance(command_text, str) or not command_text.strip():
+            return self._rejection("no current-turn spoken command evidence")
+        normalized = " ".join(command_text.split())
+        if self._DENIED_TEXT.search(normalized):
+            return self._rejection(
+                "spoken gesture request was hypothetical, explanatory, or negated"
+            )
+        pattern = self._SPOKEN_DIRECT_TEXT.get(action)
+        if pattern is None or pattern.fullmatch(normalized) is None:
+            return self._rejection(
+                "spoken command was not an exact addressed imperative for this action"
+            )
+        self.clear()
+        return "execute", {}
+
+
+GESTURE_GATE = GestureCommandGate()
+
+
 class VoiceState:
     def __init__(self) -> None:
         self.lock = threading.RLock()
+        self.turn_idle = threading.Condition(self.lock)
+        self.turn_active = False
+        self.active_turn_id: str | None = None
         self.listening = AUTO_LISTEN
         self.speaking = False
         self.generating = False
@@ -67,23 +277,50 @@ class VoiceState:
         self.level = 0.0
         self.last_error = ""
         self.history: list[dict] = []
+        self.recent_spoken_sentences: collections.deque[str] = collections.deque(
+            maxlen=12
+        )
+        self.recent_audio_digests: collections.deque[str] = collections.deque(
+            maxlen=12
+        )
+        self.unusable_voice_turns: collections.deque[float] = collections.deque()
+        self.listen_pause_reason = ""
+        self.auto_resume_pending = False
+        self.auto_resume_not_before = 0.0
+        self.auto_resume_force_at = 0.0
+        self.auto_resume_quiet_since: float | None = None
+        self.auto_resume_turn_id: str | None = None
         self.subscribers: list[queue.Queue] = []
         self.stop = threading.Event()
         self.wake = threading.Event()
         self.cancel_generation = threading.Event()
+        self.active_speech_queue: queue.Queue | None = None
 
     def snapshot(self) -> dict:
         with self.lock:
+            now = time.monotonic()
+            resume_in_ms = (
+                max(0, round((self.auto_resume_not_before - now) * 1000))
+                if self.auto_resume_pending
+                else 0
+            )
             return {
                 "listening": self.listening,
                 "speaking": self.speaking,
                 "generating": self.generating,
+                "turn_active": self.turn_active,
+                "active_turn_id": self.active_turn_id,
                 "model_ready": self.model_ready,
                 "phase": self.phase,
                 "capture_backend": self.capture_backend,
                 "capture_source": self.capture_source,
                 "level": self.level,
                 "model": MODEL_ALIAS,
+                "g1_tools_enabled": G1_CLIENT.enabled,
+                "trace_log_path": TRACE_LOG_PATH,
+                "listen_pause_reason": self.listen_pause_reason,
+                "auto_resume_pending": self.auto_resume_pending,
+                "auto_resume_in_ms": resume_in_ms,
                 "last_error": self.last_error,
             }
 
@@ -115,6 +352,47 @@ TTS_INIT_LOCK = threading.Lock()
 TTS_GENERATE_LOCK = threading.Lock()
 PLAYBACK_LOCK = threading.Lock()
 PLAYBACK_PROCESS: subprocess.Popen | None = None
+
+
+class RepeatedFirstSentenceError(RuntimeError):
+    """The model tried to start a microphone reply with recent spoken output."""
+
+    def __init__(self, sentence: str) -> None:
+        super().__init__("model repeated a recently spoken first sentence")
+        self.sentence = sentence
+
+
+def _trace_turn() -> str | None:
+    value = getattr(TRACE_THREAD, "turn_id", None)
+    if value:
+        return str(value)
+    with STATE.lock:
+        return STATE.active_turn_id
+
+
+def _trace_event(
+    event: str,
+    *,
+    component: str,
+    turn_id: str | None = None,
+    monotonic_ns: int | None = None,
+    duration_ns: int | None = None,
+    details: dict | None = None,
+) -> None:
+    current = turn_id or _trace_turn()
+    if not current:
+        return
+    try:
+        TRACE.record(
+            current,
+            event,
+            component=component,
+            monotonic_ns=monotonic_ns,
+            duration_ns=duration_ns,
+            details=details,
+        )
+    except OSError as exc:
+        print(f"Trace write failed: {exc}", flush=True)
 
 
 def api_ready(timeout: float = 0.7) -> bool:
@@ -195,13 +473,44 @@ def synthesize_speech(text: str) -> bytes:
     generation.sid = TTS_SPEAKER_ID
     generation.speed = TTS_SPEED
     generation.silence_scale = 0.18
-    started = time.monotonic()
-    with TTS_GENERATE_LOCK:
-        audio = engine.generate(text, generation)
+    started_ns = time.monotonic_ns()
+    _trace_event(
+        "tts.synthesis.started",
+        component="kokoro",
+        monotonic_ns=started_ns,
+        details={"characters": len(text), "chunk_index": getattr(TRACE_THREAD, "chunk_index", None)},
+    )
+    try:
+        with TTS_GENERATE_LOCK:
+            audio = engine.generate(text, generation)
+    except Exception as exc:
+        ended_ns = time.monotonic_ns()
+        _trace_event(
+            "tts.synthesis.failed",
+            component="kokoro",
+            monotonic_ns=ended_ns,
+            duration_ns=ended_ns - started_ns,
+            details={"error": str(exc)},
+        )
+        raise
     if len(audio.samples) == 0:
         raise RuntimeError("Kokoro produced no audio")
     duration = len(audio.samples) / audio.sample_rate
-    elapsed = time.monotonic() - started
+    ended_ns = time.monotonic_ns()
+    elapsed = (ended_ns - started_ns) / 1_000_000_000
+    _trace_event(
+        "tts.synthesis",
+        component="kokoro",
+        monotonic_ns=ended_ns,
+        duration_ns=ended_ns - started_ns,
+        details={
+            "characters": len(text),
+            "audio_duration_ms": duration * 1000,
+            "realtime_factor": elapsed / duration,
+            "chunk_index": getattr(TRACE_THREAD, "chunk_index", None),
+            "threads": TTS_THREADS,
+        },
+    )
     print(
         f"Kokoro synthesized {duration:.2f}s in {elapsed:.2f}s "
         f"(RTF {elapsed / duration:.2f})",
@@ -210,17 +519,40 @@ def synthesize_speech(text: str) -> bytes:
     return samples_to_wav(audio.samples, audio.sample_rate)
 
 
+def prewarm_tts() -> None:
+    """Load Kokoro during startup so the first spoken turn is low latency."""
+    try:
+        kokoro_engine()
+    except Exception as exc:
+        print(f"Kokoro TTS prewarm failed: {exc}", flush=True)
+
+
 def play_wav_alsa(wav: bytes) -> None:
     """Play a complete WAV through ALSA, without a browser audio stack."""
     global PLAYBACK_PROCESS
     if not shutil.which("aplay"):
         raise RuntimeError("aplay is not installed")
 
+    started_ns = time.monotonic_ns()
     process = subprocess.Popen(
         ["aplay", "-q", "-D", ALSA_PLAYBACK_DEVICE, "-t", "wav"],
         stdin=subprocess.PIPE,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.PIPE,
+    )
+    STATE.publish(
+        "playback_start",
+        {"device": ALSA_PLAYBACK_DEVICE, "monotonic_ns": started_ns},
+    )
+    _trace_event(
+        "audio.playback.started",
+        component="alsa",
+        monotonic_ns=started_ns,
+        details={
+            "device": ALSA_PLAYBACK_DEVICE,
+            "wav_bytes": len(wav),
+            "chunk_index": getattr(TRACE_THREAD, "chunk_index", None),
+        },
     )
     with PLAYBACK_LOCK:
         PLAYBACK_PROCESS = process
@@ -230,6 +562,19 @@ def play_wav_alsa(wav: bytes) -> None:
         with PLAYBACK_LOCK:
             if PLAYBACK_PROCESS is process:
                 PLAYBACK_PROCESS = None
+    ended_ns = time.monotonic_ns()
+    _trace_event(
+        "audio.playback",
+        component="alsa",
+        monotonic_ns=ended_ns,
+        duration_ns=ended_ns - started_ns,
+        details={
+            "device": ALSA_PLAYBACK_DEVICE,
+            "return_code": process.returncode,
+            "cancelled": STATE.cancel_generation.is_set(),
+            "chunk_index": getattr(TRACE_THREAD, "chunk_index", None),
+        },
+    )
     if process.returncode:
         detail = stderr.decode("utf-8", "replace").strip()
         raise RuntimeError(
@@ -238,8 +583,12 @@ def play_wav_alsa(wav: bytes) -> None:
         )
 
 
-def speak_alsa(text: str) -> None:
+def speak_alsa(text: str, before_playback=None) -> None:
     wav = synthesize_speech(text)
+    if STATE.cancel_generation.is_set():
+        return
+    if before_playback is not None:
+        before_playback()
     if STATE.cancel_generation.is_set():
         return
     started = time.monotonic()
@@ -260,7 +609,68 @@ def stop_playback() -> None:
     with PLAYBACK_LOCK:
         process = PLAYBACK_PROCESS
     if process is not None and process.poll() is None:
+        _trace_event(
+            "audio.playback.interrupt_requested",
+            component="alsa",
+            details={"pid": process.pid},
+        )
         process.terminate()
+
+
+def discard_queued_speech(speech_queue: queue.Queue | None) -> int:
+    """Remove synthesized-but-not-started speech after an interruption."""
+    if speech_queue is None:
+        return 0
+    dropped = 0
+    saw_sentinel = False
+    while True:
+        try:
+            item = speech_queue.get_nowait()
+        except queue.Empty:
+            if saw_sentinel:
+                # The worker still needs its end-of-stream marker; dropping it
+                # here would leave generate_reply blocked in join forever.
+                speech_queue.put_nowait(None)
+            return dropped
+        if item is None:
+            saw_sentinel = True
+        else:
+            dropped += 1
+
+
+def interrupt_for_barge_in(
+    *, monotonic_ns: int | None = None, next_turn_id: str | None = None
+) -> bool:
+    """Cancel the active reply immediately on a confirmed microphone onset."""
+    with STATE.lock:
+        if not (STATE.turn_active or STATE.generating or STATE.speaking):
+            return False
+        interrupted_turn_id = STATE.active_turn_id
+        STATE.cancel_generation.set()
+        speech_queue = STATE.active_speech_queue
+    stop_playback()
+    dropped = discard_queued_speech(speech_queue)
+    STATE.publish(
+        "barge_in",
+        {
+            "monotonic_ns": time.monotonic_ns()
+            if monotonic_ns is None
+            else monotonic_ns,
+            "queued_chunks_discarded": dropped,
+        },
+    )
+    if interrupted_turn_id:
+        _trace_event(
+            "conversation.barge_in",
+            component="vad",
+            turn_id=interrupted_turn_id,
+            monotonic_ns=monotonic_ns,
+            details={
+                "next_turn_id": next_turn_id,
+                "queued_chunks_discarded": dropped,
+            },
+        )
+    return True
 
 
 def normalized_rms(frame: bytes) -> float:
@@ -343,12 +753,78 @@ def start_capture() -> subprocess.Popen | None:
 
 def should_capture() -> bool:
     with STATE.lock:
-        return (
-            STATE.model_ready
-            and STATE.listening
-            and not STATE.speaking
-            and not STATE.generating
+        # The PowerConf remains open while Walter thinks and speaks so a human
+        # voice can interrupt without waiting for the current turn to finish.
+        # During an automatic runaway cooldown it also stays open for level-only
+        # observation so quiet can re-arm listening without a process restart.
+        return STATE.model_ready and (
+            STATE.listening or STATE.auto_resume_pending
         )
+
+
+def should_begin_audio_turn() -> bool:
+    """Do not let room noise supersede a turn that has not started speaking."""
+    with STATE.lock:
+        return (
+            not STATE.auto_resume_pending
+            and (not STATE.generating or STATE.speaking)
+        )
+
+
+def observe_auto_resume(
+    level: float,
+    threshold: float,
+    *,
+    now: float | None = None,
+) -> bool:
+    """Re-arm a runaway pause after quiet, with a bounded forced retry.
+
+    Inference stays disabled while this function observes microphone levels.
+    Sustained quiet is preferred so room noise does not immediately create
+    another empty turn. The maximum timeout guarantees that an unlucky noisy
+    sample can never leave the conference demo permanently paused.
+    """
+    timestamp = time.monotonic() if now is None else now
+    resumed_by = ""
+    resume_turn_id: str | None = None
+    with STATE.lock:
+        if not STATE.auto_resume_pending:
+            return False
+        quiet = level < threshold * 0.72
+        if quiet:
+            if STATE.auto_resume_quiet_since is None:
+                STATE.auto_resume_quiet_since = timestamp
+        else:
+            STATE.auto_resume_quiet_since = None
+        quiet_ready = (
+            STATE.auto_resume_quiet_since is not None
+            and timestamp >= STATE.auto_resume_not_before
+            and timestamp - STATE.auto_resume_quiet_since
+            >= AUTO_RESUME_QUIET_SECONDS
+        )
+        forced = timestamp >= STATE.auto_resume_force_at
+        if not quiet_ready and not forced:
+            return False
+        resumed_by = "quiet" if quiet_ready else "maximum_cooldown"
+        resume_turn_id = STATE.auto_resume_turn_id
+        STATE.listening = True
+        STATE.phase = "listening"
+        STATE.listen_pause_reason = ""
+        STATE.unusable_voice_turns.clear()
+        STATE.auto_resume_pending = False
+        STATE.auto_resume_not_before = 0.0
+        STATE.auto_resume_force_at = 0.0
+        STATE.auto_resume_quiet_since = None
+        STATE.auto_resume_turn_id = None
+    _trace_event(
+        "listening.auto_resumed",
+        component="speechllm",
+        turn_id=resume_turn_id,
+        details={"reason": resumed_by, "level": level, "threshold": threshold},
+    )
+    STATE.wake.set()
+    STATE.publish("listening_auto_resumed", {"reason": resumed_by})
+    return True
 
 
 def capture_loop() -> None:
@@ -356,6 +832,8 @@ def capture_loop() -> None:
     process: subprocess.Popen | None = None
     buffer = bytearray()
     utterance: list[bytes] = []
+    utterance_turn_id: str | None = None
+    utterance_started_ns: int | None = None
     in_speech = False
     hot_frames = 0
     silent_frames = 0
@@ -382,7 +860,9 @@ def capture_loop() -> None:
                 STATE.set_phase("error", "No ALSA capture source is available")
                 time.sleep(2)
                 continue
-            STATE.set_phase("listening")
+            with STATE.lock:
+                starting_in_cooldown = STATE.auto_resume_pending
+            STATE.set_phase("cooldown" if starting_in_cooldown else "listening")
 
         assert process.stdout is not None
         try:
@@ -400,6 +880,8 @@ def capture_loop() -> None:
             buffer.clear()
             pre_roll.clear()
             utterance = []
+            utterance_turn_id = None
+            utterance_started_ns = None
             in_speech = False
             hot_frames = 0
             silent_frames = 0
@@ -423,14 +905,37 @@ def capture_loop() -> None:
                 noise_floor = noise_floor * 0.9 + level * 0.1
                 calibration_frames -= 1
                 if calibration_frames == 74:
-                    STATE.set_phase("calibrating")
+                    with STATE.lock:
+                        calibrating_in_cooldown = STATE.auto_resume_pending
+                    STATE.set_phase(
+                        "cooldown" if calibrating_in_cooldown else "calibrating"
+                    )
                 if calibration_frames == 0:
-                    STATE.set_phase("listening")
+                    with STATE.lock:
+                        calibrated_in_cooldown = STATE.auto_resume_pending
+                    STATE.set_phase(
+                        "cooldown" if calibrated_in_cooldown else "listening"
+                    )
                 pre_roll.clear()
                 continue
 
             threshold = max(0.012, noise_floor * 1.8)
+            with STATE.lock:
+                auto_resume_pending = STATE.auto_resume_pending
+            if auto_resume_pending:
+                # Track a bounded room-noise estimate while inference is gated.
+                # Clipping prevents nearby speech from teaching the detector that
+                # a human voice is background noise.
+                noise_floor = noise_floor * 0.96 + min(level, 0.025) * 0.04
+                observe_auto_resume(level, max(0.012, noise_floor * 1.8), now=now)
+                hot_frames = 0
+                pre_roll.clear()
+                continue
             if not in_speech:
+                if not should_begin_audio_turn():
+                    hot_frames = 0
+                    pre_roll.clear()
+                    continue
                 if level < threshold:
                     noise_floor = noise_floor * 0.96 + min(level, 0.025) * 0.04
                 pre_roll.append(frame)
@@ -439,6 +944,28 @@ def capture_loop() -> None:
                     in_speech = True
                     silent_frames = 0
                     utterance = list(pre_roll)
+                    onset_confirmed_ns = time.monotonic_ns()
+                    utterance_turn_id = f"voice-{uuid.uuid4().hex}"
+                    utterance_started_ns = onset_confirmed_ns - (
+                        len(utterance) * FRAME_MS * 1_000_000
+                    )
+                    _trace_event(
+                        "input.speech.started",
+                        component="powerconf-vad",
+                        turn_id=utterance_turn_id,
+                        monotonic_ns=utterance_started_ns,
+                        details={
+                            "onset_confirmed_ns": onset_confirmed_ns,
+                            "confirmation_frames": 3,
+                            "frame_ms": FRAME_MS,
+                            "threshold": threshold,
+                            "level": level,
+                        },
+                    )
+                    interrupt_for_barge_in(
+                        monotonic_ns=onset_confirmed_ns,
+                        next_turn_id=utterance_turn_id,
+                    )
                     STATE.set_phase("hearing")
             else:
                 utterance.append(frame)
@@ -451,15 +978,40 @@ def capture_loop() -> None:
                     duration = len(usable) * FRAME_MS / 1000
                     if duration >= 0.35:
                         raw = b"".join(usable)
+                        input_ended_ns = time.monotonic_ns()
+                        input_started_ns = utterance_started_ns or (
+                            input_ended_ns - int(duration * 1_000_000_000)
+                        )
+                        turn_id = utterance_turn_id or f"voice-{uuid.uuid4().hex}"
+                        _trace_event(
+                            "input.speech.ended",
+                            component="powerconf-vad",
+                            turn_id=turn_id,
+                            monotonic_ns=input_ended_ns,
+                            duration_ns=input_ended_ns - input_started_ns,
+                            details={
+                                "audio_duration_ms": duration * 1000,
+                                "pcm_bytes": len(raw),
+                                "end_silence_frames": trailing,
+                            },
+                        )
                         threading.Thread(
                             target=generate_audio_reply,
-                            args=(raw, duration),
+                            args=(
+                                raw,
+                                duration,
+                                input_started_ns,
+                                input_ended_ns,
+                                turn_id,
+                            ),
                             daemon=True,
                         ).start()
                     in_speech = False
                     hot_frames = 0
                     silent_frames = 0
                     utterance = []
+                    utterance_turn_id = None
+                    utterance_started_ns = None
                     pre_roll.clear()
                     break
 
@@ -470,57 +1022,470 @@ def trim_history() -> None:
             STATE.history = STATE.history[-6:]
 
 
-def generate_audio_reply(raw_pcm: bytes, duration: float) -> None:
+def canonical_sentence(text: str) -> str:
+    """Normalize a spoken sentence for deterministic replay detection."""
+    return " ".join(re.findall(r"\w+", text.casefold(), flags=re.UNICODE))
+
+
+def replay_guard_sentences(state: VoiceState) -> set[str]:
+    """Return recent assistant sentences that a new mic turn must not replay."""
+    blocked = {
+        canonical_sentence(sentence) for sentence in state.recent_spoken_sentences
+    }
+    for message in state.history:
+        if message.get("role") != "assistant":
+            continue
+        content = message.get("content")
+        if not isinstance(content, str):
+            continue
+        chunks, _ = extract_tts_chunks(content, final=True)
+        blocked.update(canonical_sentence(chunk) for chunk in chunks)
+    blocked.discard("")
+    return blocked
+
+
+VOICE_BLOCKED_FIRST_SENTENCES = {
+    canonical_sentence("What do you need it for?"),
+    canonical_sentence("What kind of implementation do you want to use it for?"),
+    canonical_sentence(
+        "Are you interested in the architecture, deployment workflow, or robot behavior?"
+    ),
+}
+
+
+def record_unusable_voice_turn(
+    turn_id: str,
+    reason: str,
+    *,
+    now: float | None = None,
+) -> bool:
+    """Enter a self-clearing cooldown instead of an unbounded inference loop."""
+    timestamp = time.monotonic() if now is None else now
+    with STATE.lock:
+        cutoff = timestamp - RUNAWAY_VOICE_WINDOW_SECONDS
+        while STATE.unusable_voice_turns and STATE.unusable_voice_turns[0] < cutoff:
+            STATE.unusable_voice_turns.popleft()
+        STATE.unusable_voice_turns.append(timestamp)
+        count = len(STATE.unusable_voice_turns)
+        paused = count >= RUNAWAY_VOICE_LIMIT
+        if paused:
+            STATE.listening = False
+            STATE.phase = "cooldown"
+            STATE.listen_pause_reason = "repeated_unusable_voice_turns"
+            STATE.auto_resume_pending = True
+            STATE.auto_resume_not_before = (
+                timestamp + AUTO_RESUME_COOLDOWN_SECONDS
+            )
+            STATE.auto_resume_force_at = timestamp + AUTO_RESUME_MAX_SECONDS
+            STATE.auto_resume_quiet_since = None
+            STATE.auto_resume_turn_id = turn_id
+    if paused:
+        _trace_event(
+            "listening.auto_paused",
+            component="speechllm",
+            turn_id=turn_id,
+            details={
+                "reason": reason,
+                "turn_count": count,
+                "minimum_cooldown_seconds": AUTO_RESUME_COOLDOWN_SECONDS,
+                "quiet_seconds": AUTO_RESUME_QUIET_SECONDS,
+                "maximum_cooldown_seconds": AUTO_RESUME_MAX_SECONDS,
+            },
+        )
+        STATE.wake.set()
+        STATE.publish(
+            "listening_auto_paused",
+            {"reason": reason, "turn_count": count, "turn_id": turn_id},
+        )
+    return paused
+
+
+def remember_spoken_sentence(sentence: str) -> None:
+    if not canonical_sentence(sentence):
+        return
+    with STATE.lock:
+        STATE.recent_spoken_sentences.append(sentence)
+
+
+def accept_audio_turn(raw_pcm: bytes, duration: float) -> tuple[bool, str, float]:
+    """Reject empty, silent, or byte-identical stale microphone submissions."""
+    rms = normalized_rms(raw_pcm) if raw_pcm else 0.0
+    if duration < 0.35 or len(raw_pcm) < FRAME_BYTES:
+        return False, "too_short", rms
+    if rms < MIN_AUDIO_RMS:
+        return False, "silent", rms
+    digest = hashlib.sha256(raw_pcm).hexdigest()
+    with STATE.lock:
+        if digest in STATE.recent_audio_digests:
+            return False, "duplicate_pcm", rms
+        STATE.recent_audio_digests.append(digest)
+    return True, "accepted", rms
+
+
+def retain_history_turn(
+    history: list[dict], user_message: dict, reply: str, action: str | None
+) -> None:
+    """Retain context without ever replaying a prior microphone command."""
+    if action is not None:
+        # A completed action turn is intentionally non-conversational state.
+        # Clear both its raw audio and any earlier action-biased history so a
+        # later utterance can never inherit or replay the command.
+        history.clear()
+        return
+    content = user_message.get("content")
+    if isinstance(content, list) and any(
+        isinstance(item, dict) and item.get("type") == "input_audio"
+        for item in content
+    ):
+        # Ultravox does not expose an authenticated transcript. Keeping only the
+        # assistant half of a voice exchange anchors later audio to Walter's own
+        # topic. Voice turns stay stateless until both sides can be retained.
+        return
+    history.extend([user_message, {"role": "assistant", "content": reply}])
+
+
+def extract_tts_chunks(buffer: str, final: bool = False) -> tuple[list[str], str]:
+    """Split streamed model text into speakable sentence-sized chunks."""
+    chunks: list[str] = []
+    pending = buffer
+    while pending:
+        match = re.match(r'^(.+?[.!?]+["\']?)(?=\s|$)', pending, re.DOTALL)
+        if match is None:
+            break
+        sentence = match.group(1).strip()
+        pending = pending[match.end() :].lstrip()
+        if sentence:
+            if len(sentence) < TTS_CHUNK_MIN_CHARS and pending and chunks:
+                chunks[-1] = f"{chunks[-1]} {sentence}"
+            elif len(sentence) < TTS_CHUNK_MIN_CHARS and pending:
+                next_match = re.match(
+                    r'^(.+?[.!?]+["\']?)(?=\s|$)', pending, re.DOTALL
+                )
+                if next_match is None:
+                    pending = f"{sentence} {pending}".strip()
+                    break
+                chunks.append(f"{sentence} {next_match.group(1).strip()}")
+                pending = pending[next_match.end() :].lstrip()
+            else:
+                chunks.append(sentence)
+    if final and pending.strip():
+        chunks.append(pending.strip())
+        pending = ""
+    return chunks, pending
+
+
+def stream_speech_worker(
+    speech_queue: queue.Queue,
+    errors: list[str],
+    action_context: dict,
+) -> None:
+    chunk_index = 0
+    TRACE_THREAD.turn_id = str(action_context["turn_id"])
+    while True:
+        chunk = speech_queue.get()
+        if chunk is None:
+            break
+        if STATE.cancel_generation.is_set():
+            continue
+        chunk_index += 1
+        TRACE_THREAD.chunk_index = chunk_index
+        _trace_event(
+            "speech.chunk.started",
+            component="speech-worker",
+            details={"chunk_index": chunk_index, "characters": len(chunk)},
+        )
+        with STATE.lock:
+            STATE.speaking = True
+            STATE.phase = "speaking"
+        STATE.wake.set()
+        STATE.publish(
+            "speech_chunk_start",
+            {"index": chunk_index, "text": chunk},
+        )
+        print(
+            f"Streaming TTS chunk {chunk_index}: {len(chunk)} characters",
+            flush=True,
+        )
+        try:
+            before_playback = None
+            if action_context.get("action") and not action_context.get("attempted"):
+                action_context["attempted"] = True
+
+                def schedule_action() -> None:
+                    turn_id = str(action_context["turn_id"])
+                    action = str(action_context["action"])
+                    schedule_started_ns = time.monotonic_ns()
+                    _trace_event(
+                        "g1.schedule.started",
+                        component="spark-orchestrator",
+                        turn_id=turn_id,
+                        monotonic_ns=schedule_started_ns,
+                        details={"action": action},
+                    )
+                    plan = G1_CLIENT.schedule(turn_id, action)
+                    schedule_ended_ns = time.monotonic_ns()
+                    _trace_event(
+                        "g1.schedule",
+                        component="spark-orchestrator",
+                        turn_id=turn_id,
+                        monotonic_ns=schedule_ended_ns,
+                        duration_ns=schedule_ended_ns - schedule_started_ns,
+                        details={"action": action, "plan": plan},
+                    )
+                    action_context["plan"] = plan
+                    prepare_wait_started_ns = time.monotonic_ns()
+                    prepared = G1_CLIENT.wait_until_prepared(turn_id, plan)
+                    prepare_wait_ended_ns = time.monotonic_ns()
+                    _trace_event(
+                        "g1.prepare_wait",
+                        component="g1-sync-gateway",
+                        turn_id=turn_id,
+                        monotonic_ns=prepare_wait_ended_ns,
+                        duration_ns=prepare_wait_ended_ns - prepare_wait_started_ns,
+                        details={"action": action, "timing": prepared},
+                    )
+                    action_context["prepared"] = prepared
+                    playback_wait_started_ns = time.monotonic_ns()
+                    G1_CLIENT.wait_until_playback(plan)
+                    playback_wait_ended_ns = time.monotonic_ns()
+                    _trace_event(
+                        "g1.playback_alignment_wait",
+                        component="spark-orchestrator",
+                        turn_id=turn_id,
+                        monotonic_ns=playback_wait_ended_ns,
+                        duration_ns=playback_wait_ended_ns - playback_wait_started_ns,
+                        details={"action": action},
+                    )
+                    G1_CLIENT.record_event(turn_id, "output.speech_started")
+                    action_context["scheduled"] = True
+                    STATE.publish(
+                        "g1_action_scheduled",
+                        {
+                            "turn_id": turn_id,
+                            "action": action,
+                            "g1_execute_at_ns": plan.get("g1_execute_at_ns"),
+                        },
+                    )
+
+                before_playback = schedule_action
+            if before_playback is None:
+                speak_alsa(chunk)
+            else:
+                speak_alsa(chunk, before_playback=before_playback)
+            # Record output even if barge-in terminated playback partway through.
+            # The next mic turn waits for this worker to finish, so an acoustic
+            # echo cannot race ahead of the replay guard.
+            remember_spoken_sentence(chunk)
+        except G1ToolError as exc:
+            error = f"G1 action scheduling failed: {exc}"
+            errors.append(error)
+            action_context["error"] = str(exc)
+            print(error, flush=True)
+            turn_id = action_context.get("turn_id")
+            if action_context.get("plan") and turn_id:
+                try:
+                    G1_CLIENT.cancel(str(turn_id))
+                except G1ToolError:
+                    pass
+            try:
+                failure = "I couldn't safely start that gesture. Please check the G1 status."
+                wav = synthesize_speech(failure)
+                play_wav_alsa(wav)
+            except Exception as speech_error:
+                print(f"G1 failure announcement failed: {speech_error}", flush=True)
+            STATE.cancel_generation.set()
+            stop_playback()
+        except Exception as exc:
+            error = f"Kokoro/ALSA output failed: {exc}"
+            errors.append(error)
+            print(error, flush=True)
+            STATE.cancel_generation.set()
+            stop_playback()
+
+        _trace_event(
+            "speech.chunk.finished",
+            component="speech-worker",
+            details={
+                "chunk_index": chunk_index,
+                "cancelled": STATE.cancel_generation.is_set(),
+            },
+        )
+
+    with STATE.lock:
+        STATE.speaking = False
+        STATE.phase = (
+            "thinking"
+            if STATE.generating
+            else (
+                "cooldown"
+                if STATE.auto_resume_pending
+                else "paused"
+                if STATE.listen_pause_reason
+                else ("listening" if STATE.listening else "ready")
+            )
+        )
+    STATE.wake.set()
+    TRACE_THREAD.turn_id = None
+    TRACE_THREAD.chunk_index = None
+
+
+def generate_audio_reply(
+    raw_pcm: bytes,
+    duration: float,
+    input_started_ns: int | None = None,
+    input_ended_ns: int | None = None,
+    turn_id: str | None = None,
+) -> None:
+    turn_id = turn_id or f"voice-{uuid.uuid4().hex}"
+    accepted, reason, rms = accept_audio_turn(raw_pcm, duration)
+    if not accepted:
+        _trace_event(
+            "input.audio.dropped",
+            component="speechllm",
+            turn_id=turn_id,
+            details={
+                "reason": reason,
+                "duration_ms": duration * 1000,
+                "pcm_bytes": len(raw_pcm),
+                "rms": rms,
+            },
+        )
+        STATE.publish(
+            "input_ignored",
+            {"kind": "audio", "reason": reason, "turn_id": turn_id},
+        )
+        return
+    encode_started_ns = time.monotonic_ns()
     audio = base64.b64encode(wav_bytes(raw_pcm)).decode("ascii")
+    encode_ended_ns = time.monotonic_ns()
+    _trace_event(
+        "input.audio.encoded",
+        component="speechllm",
+        turn_id=turn_id,
+        monotonic_ns=encode_ended_ns,
+        duration_ns=encode_ended_ns - encode_started_ns,
+        details={"pcm_bytes": len(raw_pcm), "base64_bytes": len(audio)},
+    )
     user_message = {
         "role": "user",
         "content": [
             {"type": "input_audio", "input_audio": {"data": audio, "format": "wav"}},
-            {"type": "text", "text": "Reply directly and conversationally to this voice message."},
+            {
+                "type": "text",
+                "text": (
+                    "This is a live voice turn. Reply directly in one to three "
+                    "short sentences. Never ask what the person needs it for or "
+                    "ask a generic implementation question. For an explicit G1 "
+                    "gesture request, call the matching tool before speaking."
+                ),
+            },
         ],
     }
     STATE.publish("user_turn", {"kind": "audio", "duration": round(duration, 1)})
-    generate_reply(user_message)
+    generate_reply(
+        user_message,
+        turn_id=turn_id,
+        input_started_ns=input_started_ns,
+        input_ended_ns=input_ended_ns,
+        wait_for_idle=True,
+    )
 
 
-def generate_text_reply(text: str) -> None:
+def generate_text_reply(text: str, turn_id: str | None = None) -> None:
+    turn_id = turn_id or f"typed-{uuid.uuid4().hex}"
+    _trace_event(
+        "input.text.accepted",
+        component="voice-http",
+        turn_id=turn_id,
+        details={"characters": len(text)},
+    )
     STATE.publish("user_turn", {"kind": "text", "text": text})
-    generate_reply({"role": "user", "content": text})
+    generate_reply(
+        {"role": "user", "content": text},
+        turn_id=turn_id,
+    )
 
 
-def generate_reply(user_message: dict) -> None:
-    with STATE.lock:
-        if STATE.generating or STATE.speaking:
-            return
-        STATE.generating = True
-        STATE.phase = "thinking"
-        STATE.cancel_generation.clear()
-        messages = [{"role": "system", "content": SYSTEM_PROMPT}, *STATE.history, user_message]
-    STATE.wake.set()
-    STATE.publish("assistant_start")
-
-    body = json.dumps(
-        {
-            "model": MODEL_ALIAS,
-            "messages": messages,
-            "stream": True,
-            "max_tokens": 192,
-            "temperature": 0.45,
-            "top_p": 0.9,
-        }
-    ).encode("utf-8")
+def _stream_completion(
+    messages: list[dict],
+    speech_queue: queue.Queue,
+    *,
+    allow_tools: bool,
+    turn_id: str,
+    pass_index: int,
+    blocked_first_sentences: set[str] | None = None,
+) -> tuple[str, str, dict | None]:
+    payload: dict = {
+        "model": MODEL_ALIAS,
+        "messages": messages,
+        "stream": True,
+        "max_tokens": 192,
+        "temperature": 0.45,
+        "top_p": 0.9,
+    }
+    if allow_tools and G1_CLIENT.enabled:
+        payload["tools"] = TOOL_SCHEMAS
+        payload["tool_choice"] = "auto"
     request = urllib.request.Request(
         f"{LLAMA_URL}/v1/chat/completions",
-        data=body,
+        data=json.dumps(payload).encode("utf-8"),
         headers={"Content-Type": "application/json"},
         method="POST",
     )
     reply = ""
-    error = ""
+    speech_buffer = ""
+    queued_chunks = 0
+    tool_call: dict | None = None
+    request_started_ns = time.monotonic_ns()
+    connected_ns: int | None = None
+    first_event_ns: int | None = None
+    first_text_ns: int | None = None
+    first_chunk_ns: int | None = None
+    stream_events = 0
+    outcome = "ok"
+    first_sentence_checked = False
+    first_text_published = False
+
+    def enqueue_chunks(chunks: list[str]) -> None:
+        nonlocal queued_chunks, first_chunk_ns, first_sentence_checked
+        for chunk in chunks:
+            if not first_sentence_checked:
+                first_sentence_checked = True
+                normalized = canonical_sentence(chunk)
+                if normalized and normalized in (blocked_first_sentences or set()):
+                    raise RepeatedFirstSentenceError(chunk)
+            speech_queue.put(chunk)
+            queued_chunks += 1
+            if first_chunk_ns is None:
+                first_chunk_ns = time.monotonic_ns()
+                _trace_event(
+                    "inference.first_speech_chunk",
+                    component="llama.cpp",
+                    turn_id=turn_id,
+                    monotonic_ns=first_chunk_ns,
+                    details={
+                        "pass_index": pass_index,
+                        "characters": len(chunk),
+                    },
+                )
+    _trace_event(
+        "inference.request.started",
+        component="llama.cpp",
+        turn_id=turn_id,
+        monotonic_ns=request_started_ns,
+        details={
+            "pass_index": pass_index,
+            "message_count": len(messages),
+            "allow_tools": allow_tools,
+            "model": MODEL_ALIAS,
+        },
+    )
     try:
         with urllib.request.urlopen(request, timeout=180) as response:
+            connected_ns = time.monotonic_ns()
             for raw_line in response:
                 if STATE.cancel_generation.is_set():
+                    outcome = "cancelled"
                     break
                 line = raw_line.decode("utf-8", "replace").strip()
                 if not line.startswith("data:"):
@@ -530,42 +1495,461 @@ def generate_reply(user_message: dict) -> None:
                     break
                 try:
                     event = json.loads(data)
-                    delta = event["choices"][0].get("delta", {}).get("content") or ""
+                    delta_object = event["choices"][0].get("delta", {})
                 except (KeyError, IndexError, json.JSONDecodeError):
                     continue
+                stream_events += 1
+                if first_event_ns is None:
+                    first_event_ns = time.monotonic_ns()
+                for fragment in delta_object.get("tool_calls") or []:
+                    if queued_chunks or reply.strip():
+                        raise G1ToolError("model emitted a gesture tool after spoken content")
+                    if int(fragment.get("index", 0)) != 0:
+                        raise G1ToolError("only one G1 tool call is allowed per turn")
+                    if tool_call is None:
+                        tool_call = {
+                            "id": "",
+                            "type": "function",
+                            "function": {"name": "", "arguments": ""},
+                        }
+                    tool_call["id"] += str(fragment.get("id") or "")
+                    function = fragment.get("function") or {}
+                    tool_call["function"]["name"] += str(function.get("name") or "")
+                    tool_call["function"]["arguments"] += str(
+                        function.get("arguments") or ""
+                    )
+                delta = delta_object.get("content") or ""
                 if delta:
+                    now_ns = time.monotonic_ns()
+                    if first_text_ns is None:
+                        first_text_ns = now_ns
+                    if tool_call is not None:
+                        raise G1ToolError("model mixed a G1 tool call with spoken content")
                     reply += delta
-                    STATE.publish("assistant_delta", {"text": delta})
-    except (OSError, urllib.error.URLError, urllib.error.HTTPError) as exc:
+                    speech_buffer += delta
+                    chunks, speech_buffer = extract_tts_chunks(speech_buffer)
+                    if chunks:
+                        # Validate a complete first sentence before either the
+                        # UI or Kokoro can replay it. Later deltas keep streaming.
+                        enqueue_chunks(chunks)
+                        if not first_text_published:
+                            STATE.publish("assistant_delta", {"text": reply})
+                            first_text_published = True
+                    elif first_text_published:
+                        STATE.publish("assistant_delta", {"text": delta})
+            if tool_call is None and reply and not STATE.cancel_generation.is_set():
+                chunks, speech_buffer = extract_tts_chunks(speech_buffer, final=True)
+                if chunks:
+                    enqueue_chunks(chunks)
+                    if not first_text_published:
+                        STATE.publish("assistant_delta", {"text": reply})
+                        first_text_published = True
+    except RepeatedFirstSentenceError:
+        outcome = "replay_suppressed"
+        raise
+    except Exception:
+        outcome = "error"
+        raise
+    finally:
+        ended_ns = time.monotonic_ns()
+        _trace_event(
+            "inference.request",
+            component="llama.cpp",
+            turn_id=turn_id,
+            monotonic_ns=ended_ns,
+            duration_ns=ended_ns - request_started_ns,
+            details={
+                "pass_index": pass_index,
+                "outcome": outcome,
+                "http_connect_ms": (
+                    None
+                    if connected_ns is None
+                    else (connected_ns - request_started_ns) / 1_000_000
+                ),
+                "time_to_first_event_ms": (
+                    None
+                    if first_event_ns is None
+                    else (first_event_ns - request_started_ns) / 1_000_000
+                ),
+                "time_to_first_text_ms": (
+                    None
+                    if first_text_ns is None
+                    else (first_text_ns - request_started_ns) / 1_000_000
+                ),
+                "time_to_first_speech_chunk_ms": (
+                    None
+                    if first_chunk_ns is None
+                    else (first_chunk_ns - request_started_ns) / 1_000_000
+                ),
+                "stream_events": stream_events,
+                "output_characters": len(reply),
+                "queued_speech_chunks": queued_chunks,
+                "tool_call": None
+                if tool_call is None
+                else tool_call.get("function", {}).get("name"),
+            },
+        )
+    return reply, speech_buffer, tool_call
+
+
+def _resolve_tool_call(
+    tool_call: dict, user_message: dict
+) -> tuple[dict, str | None]:
+    function = tool_call.get("function") or {}
+    name = str(function.get("name") or "")
+    try:
+        arguments = json.loads(function.get("arguments") or "{}")
+        if not isinstance(arguments, dict):
+            raise ValueError("tool arguments must be an object")
+        if name == "g1_gesture":
+            if set(arguments) != {"action", "command_text"}:
+                raise ValueError(
+                    "g1_gesture requires only action and current-turn command_text"
+                )
+            action = arguments.get("action")
+            decision, gate_result = GESTURE_GATE.evaluate(
+                user_message,
+                action,
+                command_text=arguments.get("command_text"),
+            )
+            if decision != "execute":
+                result = gate_result
+                action = None
+            else:
+                result, action = G1_CLIENT.admit_tool(name, {"action": action})
+        else:
+            result, action = G1_CLIENT.admit_tool(name, arguments)
+    except (G1ToolError, ValueError, json.JSONDecodeError) as exc:
+        result = {"success": False, "accepted": False, "error": str(exc)}
+        action = None
+    STATE.publish(
+        "g1_tool_result",
+        {"tool": name, "action": action, "result": result},
+    )
+    return result, action
+
+
+def record_g1_action_completion(turn_id: str, action: str) -> None:
+    """Append terminal G1 evidence without delaying Walter's next voice turn."""
+    started_ns = time.monotonic_ns()
+    deadline = time.monotonic() + 30.0
+    last: dict = {}
+    terminal_states = {
+        "released",
+        "released_by_action",
+        "cancelled",
+        "cancelled_before_dispatch",
+        "release_failed",
+        "failed",
+        "prepare_failed",
+    }
+    while time.monotonic() < deadline and not STATE.stop.is_set():
+        try:
+            response = G1_CLIENT.timing(turn_id)
+        except G1ToolError as exc:
+            last = {"ok": False, "error": str(exc)}
+            time.sleep(0.2)
+            continue
+        timing = response.get("timing") or {}
+        if isinstance(timing, dict):
+            last = timing
+        if str(last.get("state") or "") in terminal_states:
+            ended_ns = time.monotonic_ns()
+            action_duration_ns = last.get("request_to_action_complete_ns")
+            _trace_event(
+                "g1.action.completed",
+                component="g1-action-runtime",
+                turn_id=turn_id,
+                monotonic_ns=ended_ns,
+                duration_ns=(
+                    action_duration_ns
+                    if isinstance(action_duration_ns, int)
+                    else ended_ns - started_ns
+                ),
+                details={"action": action, "timing": last},
+            )
+            try:
+                alignment = G1_CLIENT.alignment_timing(turn_id)
+            except G1ToolError as exc:
+                alignment = {"ok": False, "error": str(exc)}
+            _trace_event(
+                "g1.action.final_alignment",
+                component="spark-orchestrator",
+                turn_id=turn_id,
+                details={"action": action, "timing": alignment},
+            )
+            return
+        time.sleep(0.2)
+    ended_ns = time.monotonic_ns()
+    _trace_event(
+        "g1.action.completion_timeout",
+        component="g1-action-runtime",
+        turn_id=turn_id,
+        monotonic_ns=ended_ns,
+        duration_ns=ended_ns - started_ns,
+        details={"action": action, "last_timing": last},
+    )
+
+
+def generate_reply(
+    user_message: dict,
+    *,
+    turn_id: str | None = None,
+    input_started_ns: int | None = None,
+    input_ended_ns: int | None = None,
+    wait_for_idle: bool = False,
+) -> None:
+    turn_id = turn_id or f"turn-{uuid.uuid4().hex}"
+    queued_ns = time.monotonic_ns()
+    _trace_event(
+        "turn.queued",
+        component="speechllm",
+        turn_id=turn_id,
+        monotonic_ns=queued_ns,
+        details={"wait_for_idle": wait_for_idle},
+    )
+    with STATE.turn_idle:
+        while STATE.turn_active:
+            if not wait_for_idle or STATE.stop.is_set():
+                _trace_event(
+                    "turn.dropped",
+                    component="speechllm",
+                    turn_id=turn_id,
+                    details={"reason": "another turn is active"},
+                )
+                return
+            STATE.turn_idle.wait(timeout=0.5)
+        turn_started_ns = time.monotonic_ns()
+        STATE.turn_active = True
+        STATE.active_turn_id = turn_id
+        STATE.generating = True
+        STATE.phase = "thinking"
+        STATE.cancel_generation.clear()
+        messages = [
+            {"role": "system", "content": runtime_system_prompt()},
+            *STATE.history,
+            user_message,
+        ]
+        is_audio_turn = isinstance(user_message.get("content"), list)
+        blocked_first_sentences = (
+            replay_guard_sentences(STATE) | VOICE_BLOCKED_FIRST_SENTENCES
+            if is_audio_turn
+            else set()
+        )
+    TRACE.activate(turn_id)
+    _trace_event(
+        "turn.started",
+        component="speechllm",
+        turn_id=turn_id,
+        monotonic_ns=turn_started_ns,
+        duration_ns=turn_started_ns - queued_ns,
+        details={
+            "queue_wait_ms": (turn_started_ns - queued_ns) / 1_000_000,
+            "history_messages": max(0, len(messages) - 2),
+            "input_kind": "audio"
+            if isinstance(user_message.get("content"), list)
+            else "text",
+        },
+    )
+    STATE.wake.set()
+    STATE.publish("assistant_start", {"turn_id": turn_id})
+
+    if G1_CLIENT.enabled:
+        for event_name, event_time in (
+            ("input.speech_started", input_started_ns),
+            ("input.speech_ended", input_ended_ns),
+        ):
+            if event_time is None:
+                continue
+            try:
+                G1_CLIENT.record_event(
+                    turn_id, event_name, monotonic_ns=event_time
+                )
+            except G1ToolError as exc:
+                print(f"G1 timing event failed: {exc}", flush=True)
+
+    speech_queue: queue.Queue = queue.Queue(maxsize=TTS_CHUNK_QUEUE_SIZE)
+    with STATE.lock:
+        STATE.active_speech_queue = speech_queue
+    speech_errors: list[str] = []
+    action_context = {
+        "turn_id": turn_id,
+        "action": None,
+        "attempted": False,
+        "scheduled": False,
+    }
+    speech_thread = threading.Thread(
+        target=stream_speech_worker,
+        args=(speech_queue, speech_errors, action_context),
+        daemon=True,
+    )
+    speech_thread.start()
+
+    reply = ""
+    speech_buffer = ""
+    error = ""
+    replay_suppressed = False
+    try:
+        reply, speech_buffer, tool_call = _stream_completion(
+            messages,
+            speech_queue,
+            allow_tools=True,
+            turn_id=turn_id,
+            pass_index=1,
+            blocked_first_sentences=blocked_first_sentences,
+        )
+        if tool_call is not None and not STATE.cancel_generation.is_set():
+            result, action = _resolve_tool_call(tool_call, user_message)
+            action_context["action"] = action
+            if not tool_call.get("id"):
+                tool_call["id"] = f"call-{uuid.uuid4().hex}"
+            messages.extend(
+                [
+                    {"role": "assistant", "content": None, "tool_calls": [tool_call]},
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_call["id"],
+                        "name": tool_call["function"]["name"],
+                        "content": json.dumps(result, separators=(",", ":")),
+                    },
+                ]
+            )
+            reply, speech_buffer, repeated_tool = _stream_completion(
+                messages,
+                speech_queue,
+                allow_tools=False,
+                turn_id=turn_id,
+                pass_index=2,
+                # Repeated short acknowledgements such as "Okay" are valid for
+                # independently authorized action turns.
+                blocked_first_sentences=set(),
+            )
+            if repeated_tool is not None:
+                raise G1ToolError("model repeated a G1 tool call")
+    except RepeatedFirstSentenceError as exc:
+        replay_suppressed = True
+        reply = ""
+        speech_buffer = ""
+        _trace_event(
+            "response.replay_suppressed",
+            component="speechllm",
+            turn_id=turn_id,
+            details={"sentence": exc.sentence},
+        )
+        if is_audio_turn:
+            record_unusable_voice_turn(turn_id, "blocked_first_sentence")
+    except (OSError, urllib.error.URLError, urllib.error.HTTPError, G1ToolError) as exc:
         error = str(exc)
 
     cancelled = STATE.cancel_generation.is_set()
+    speech_queue.put(None)
+
     with STATE.lock:
         if reply and not error and not cancelled:
-            STATE.history.extend([user_message, {"role": "assistant", "content": reply}])
+            retain_history_turn(
+                STATE.history,
+                user_message,
+                reply,
+                action_context.get("action"),
+            )
+            if is_audio_turn:
+                STATE.unusable_voice_turns.clear()
         STATE.generating = False
-        STATE.speaking = bool(reply and not error and not cancelled)
         STATE.phase = (
             "speaking"
             if STATE.speaking
-            else ("listening" if STATE.listening else "ready")
+            else (
+                "cooldown"
+                if STATE.auto_resume_pending
+                else "paused"
+                if STATE.listen_pause_reason
+                else ("listening" if STATE.listening else "ready")
+            )
         )
         STATE.last_error = error
     trim_history()
     STATE.wake.set()
     if not error:
-        STATE.publish("assistant_done", {"text": reply, "cancelled": cancelled})
-        if reply and not cancelled:
-            try:
-                speak_alsa(reply)
-            except Exception as exc:
-                error = f"Kokoro/ALSA output failed: {exc}"
-                print(error, flush=True)
+        STATE.publish(
+            "assistant_done",
+            {
+                "text": reply,
+                "cancelled": cancelled,
+                "suppressed": replay_suppressed,
+                "turn_id": turn_id,
+                "action": action_context.get("action"),
+            },
+        )
+    speech_thread.join()
+    if speech_errors and not error:
+        error = speech_errors[0]
 
-    with STATE.lock:
+    if action_context.get("scheduled"):
+        try:
+            timing = G1_CLIENT.timing(turn_id)
+        except G1ToolError as exc:
+            timing = {"ok": False, "error": str(exc)}
+        STATE.publish(
+            "g1_action_result",
+            {
+                "turn_id": turn_id,
+                "action": action_context.get("action"),
+                "timing": timing,
+            },
+        )
+        _trace_event(
+            "g1.action.runtime_timing",
+            component="g1-action-runtime",
+            turn_id=turn_id,
+            details={"action": action_context.get("action"), "timing": timing},
+        )
+        try:
+            alignment_timing = G1_CLIENT.alignment_timing(turn_id)
+        except G1ToolError as exc:
+            alignment_timing = {"ok": False, "error": str(exc)}
+        _trace_event(
+            "g1.action.alignment",
+            component="spark-orchestrator",
+            turn_id=turn_id,
+            details={"action": action_context.get("action"), "timing": alignment_timing},
+        )
+        threading.Thread(
+            target=record_g1_action_completion,
+            args=(turn_id, str(action_context["action"])),
+            daemon=True,
+        ).start()
+
+    with STATE.turn_idle:
         STATE.speaking = False
-        STATE.phase = "listening" if STATE.listening else "ready"
+        STATE.turn_active = False
+        STATE.active_turn_id = None
+        if STATE.active_speech_queue is speech_queue:
+            STATE.active_speech_queue = None
+        STATE.phase = (
+            "cooldown"
+            if STATE.auto_resume_pending
+            else "paused"
+            if STATE.listen_pause_reason
+            else ("listening" if STATE.listening else "ready")
+        )
         STATE.last_error = error
+        STATE.turn_idle.notify_all()
+    turn_ended_ns = time.monotonic_ns()
+    _trace_event(
+        "turn.finished",
+        component="speechllm",
+        turn_id=turn_id,
+        monotonic_ns=turn_ended_ns,
+        duration_ns=turn_ended_ns - turn_started_ns,
+        details={
+            "cancelled": cancelled,
+            "replay_suppressed": replay_suppressed,
+            "error": error or None,
+            "reply_characters": len(reply),
+            "action": action_context.get("action"),
+        },
+    )
+    TRACE.deactivate(turn_id)
     STATE.wake.set()
     if error:
         STATE.publish("error", {"message": error})
@@ -603,7 +1987,8 @@ class VoiceHandler(BaseHTTPRequestHandler):
         return json.loads(self.rfile.read(length).decode("utf-8"))
 
     def do_GET(self) -> None:  # noqa: N802
-        path = urlparse(self.path).path
+        parsed = urlparse(self.path)
+        path = parsed.path
         if path == "/health":
             ready = api_ready()
             if ready:
@@ -623,6 +2008,26 @@ class VoiceHandler(BaseHTTPRequestHandler):
         if path == "/api/events":
             self.send_events()
             return
+        if path == "/api/traces":
+            query = parse_qs(parsed.query)
+            turn_id = (query.get("turn_id") or [None])[0]
+            try:
+                limit = int((query.get("limit") or ["1000"])[0])
+            except ValueError:
+                self.json_response({"error": "limit must be an integer"}, 400)
+                return
+            self.json_response(
+                {"turn_id": turn_id, "events": TRACE.recent(turn_id=turn_id, limit=limit)}
+            )
+            return
+        if path == "/api/trace-summary":
+            query = parse_qs(parsed.query)
+            turn_id = str((query.get("turn_id") or [""])[0])
+            if not turn_id:
+                self.json_response({"error": "turn_id is required"}, 400)
+                return
+            self.json_response(TRACE.summarize(turn_id))
+            return
         self.send_static(path)
 
     def do_POST(self) -> None:  # noqa: N802
@@ -638,6 +2043,13 @@ class VoiceHandler(BaseHTTPRequestHandler):
             with STATE.lock:
                 STATE.listening = enabled
                 STATE.phase = "listening" if enabled else "ready"
+                STATE.unusable_voice_turns.clear()
+                STATE.listen_pause_reason = ""
+                STATE.auto_resume_pending = False
+                STATE.auto_resume_not_before = 0.0
+                STATE.auto_resume_force_at = 0.0
+                STATE.auto_resume_quiet_since = None
+                STATE.auto_resume_turn_id = None
             STATE.wake.set()
             STATE.publish("state")
             self.json_response(STATE.snapshot())
@@ -652,8 +2064,11 @@ class VoiceHandler(BaseHTTPRequestHandler):
             if not text:
                 self.json_response({"error": "Message is empty"}, 400)
                 return
-            threading.Thread(target=generate_text_reply, args=(text,), daemon=True).start()
-            self.json_response({"accepted": True}, 202)
+            turn_id = f"typed-{uuid.uuid4().hex}"
+            threading.Thread(
+                target=generate_text_reply, args=(text, turn_id), daemon=True
+            ).start()
+            self.json_response({"accepted": True, "turn_id": turn_id}, 202)
             return
         if path == "/api/tts":
             text = str(payload.get("text", "")).strip()
@@ -671,14 +2086,25 @@ class VoiceHandler(BaseHTTPRequestHandler):
             return
         if path == "/api/interrupt":
             STATE.cancel_generation.set()
+            GESTURE_GATE.clear()
             stop_playback()
             self.json_response({"interrupted": True})
             return
         if path == "/api/reset":
             STATE.cancel_generation.set()
+            GESTURE_GATE.clear()
             stop_playback()
             with STATE.lock:
                 STATE.history.clear()
+                STATE.recent_spoken_sentences.clear()
+                STATE.recent_audio_digests.clear()
+                STATE.unusable_voice_turns.clear()
+                STATE.listen_pause_reason = ""
+                STATE.auto_resume_pending = False
+                STATE.auto_resume_not_before = 0.0
+                STATE.auto_resume_force_at = 0.0
+                STATE.auto_resume_quiet_since = None
+                STATE.auto_resume_turn_id = None
             STATE.publish("reset")
             self.json_response({"reset": True})
             return
@@ -753,7 +2179,9 @@ def wait_for_model() -> None:
 
 
 def main() -> None:
+    TRACE.start_gpu_sampler()
     threading.Thread(target=wait_for_model, daemon=True).start()
+    threading.Thread(target=prewarm_tts, daemon=True).start()
     threading.Thread(target=capture_loop, daemon=True).start()
     server = ThreadingHTTPServer(("0.0.0.0", VOICE_PORT), VoiceHandler)
     print(f"Optional status/control API on 0.0.0.0:{VOICE_PORT}", flush=True)
@@ -764,6 +2192,7 @@ def main() -> None:
     finally:
         STATE.stop.set()
         STATE.wake.set()
+        TRACE.close()
         server.server_close()
 
 

--- a/Examples/CUDASpeechLLM/voice_server.py
+++ b/Examples/CUDASpeechLLM/voice_server.py
@@ -44,6 +44,9 @@ TTS_SPEAKER_ID = int(os.environ.get("TTS_SPEAKER_ID", "3"))
 TTS_SPEED = float(os.environ.get("TTS_SPEED", "1.04"))
 TTS_THREADS = int(os.environ.get("TTS_THREADS", "8"))
 ALSA_PLAYBACK_DEVICE = os.environ.get("ALSA_PLAYBACK_DEVICE", "default")
+ALSA_PLAYBACK_PREROLL_MS = max(
+    0, int(os.environ.get("ALSA_PLAYBACK_PREROLL_MS", "300"))
+)
 SYSTEM_PROMPT_PATH = Path(os.environ.get("SYSTEM_PROMPT_PATH", "/app/SOUL.md"))
 KNOWLEDGE_DIR = Path(os.environ.get("KNOWLEDGE_DIR", "/app/knowledge"))
 KNOWLEDGE_MAX_CHARS = int(os.environ.get("KNOWLEDGE_MAX_CHARS", "30000"))
@@ -432,6 +435,34 @@ def samples_to_wav(samples, sample_rate: int) -> bytes:
     return output.getvalue()
 
 
+def add_wav_preroll(wav_data: bytes, preroll_ms: int) -> bytes:
+    """Prepend silence so a newly opened USB playback path cannot eat speech."""
+    if preroll_ms <= 0:
+        return wav_data
+
+    source = io.BytesIO(wav_data)
+    with wave.open(source, "rb") as wav:
+        channels = wav.getnchannels()
+        sample_width = wav.getsampwidth()
+        sample_rate = wav.getframerate()
+        compression = wav.getcomptype()
+        compression_name = wav.getcompname()
+        frames = wav.readframes(wav.getnframes())
+
+    silent_frame_count = round(sample_rate * preroll_ms / 1000)
+    silent_sample = b"\x80" if sample_width == 1 else b"\x00" * sample_width
+    silence = silent_sample * channels * silent_frame_count
+
+    output = io.BytesIO()
+    with wave.open(output, "wb") as wav:
+        wav.setnchannels(channels)
+        wav.setsampwidth(sample_width)
+        wav.setframerate(sample_rate)
+        wav.setcomptype(compression, compression_name)
+        wav.writeframes(silence + frames)
+    return output.getvalue()
+
+
 def kokoro_engine():
     global TTS_ENGINE, TTS_MODULE
     if TTS_ENGINE is not None:
@@ -533,6 +564,7 @@ def play_wav_alsa(wav: bytes) -> None:
     if not shutil.which("aplay"):
         raise RuntimeError("aplay is not installed")
 
+    playback_wav = add_wav_preroll(wav, ALSA_PLAYBACK_PREROLL_MS)
     started_ns = time.monotonic_ns()
     process = subprocess.Popen(
         ["aplay", "-q", "-D", ALSA_PLAYBACK_DEVICE, "-t", "wav"],
@@ -550,14 +582,16 @@ def play_wav_alsa(wav: bytes) -> None:
         monotonic_ns=started_ns,
         details={
             "device": ALSA_PLAYBACK_DEVICE,
-            "wav_bytes": len(wav),
+            "wav_bytes": len(playback_wav),
+            "source_wav_bytes": len(wav),
+            "preroll_ms": ALSA_PLAYBACK_PREROLL_MS,
             "chunk_index": getattr(TRACE_THREAD, "chunk_index", None),
         },
     )
     with PLAYBACK_LOCK:
         PLAYBACK_PROCESS = process
     try:
-        _, stderr = process.communicate(input=wav)
+        _, stderr = process.communicate(input=playback_wav)
     finally:
         with PLAYBACK_LOCK:
             if PLAYBACK_PROCESS is process:
@@ -1790,14 +1824,47 @@ def generate_reply(
     error = ""
     replay_suppressed = False
     try:
-        reply, speech_buffer, tool_call = _stream_completion(
-            messages,
-            speech_queue,
-            allow_tools=True,
-            turn_id=turn_id,
-            pass_index=1,
-            blocked_first_sentences=blocked_first_sentences,
-        )
+        response_pass_index = 1
+        while True:
+            try:
+                reply, speech_buffer, tool_call = _stream_completion(
+                    messages,
+                    speech_queue,
+                    allow_tools=True,
+                    turn_id=turn_id,
+                    pass_index=response_pass_index,
+                    blocked_first_sentences=blocked_first_sentences,
+                )
+                break
+            except RepeatedFirstSentenceError as exc:
+                if response_pass_index >= 2 or not is_audio_turn:
+                    raise
+                _trace_event(
+                    "response.replay_retry",
+                    component="speechllm",
+                    turn_id=turn_id,
+                    details={"sentence": exc.sentence},
+                )
+                # Reuse the same current-turn audio, but make the retry answer
+                # its content instead of falling back to a generic phrase. The
+                # normal tool gate and G1 preflight still apply unchanged.
+                messages = [
+                    *messages,
+                    {
+                        "role": "system",
+                        "content": (
+                            "Your previous attempt began with a recently spoken "
+                            "sentence and was not delivered. Listen to the current "
+                            "visitor audio again and answer its actual request. Do "
+                            "not begin with a generic acknowledgment such as Okay "
+                            "or Hello. If the audio is unclear, ask the visitor to "
+                            "repeat it in one short sentence. If and only if this "
+                            "audio contains an explicit addressed G1 gesture "
+                            "command, call the matching tool before speaking."
+                        ),
+                    },
+                ]
+                response_pass_index += 1
         if tool_call is not None and not STATE.cancel_generation.is_set():
             result, action = _resolve_tool_call(tool_call, user_message)
             action_context["action"] = action
@@ -1819,7 +1886,7 @@ def generate_reply(
                 speech_queue,
                 allow_tools=False,
                 turn_id=turn_id,
-                pass_index=2,
+                pass_index=response_pass_index + 1,
                 # Repeated short acknowledgements such as "Okay" are valid for
                 # independently authorized action turns.
                 blocked_first_sentences=set(),

--- a/Examples/CUDASpeechLLM/web/app.js
+++ b/Examples/CUDASpeechLLM/web/app.js
@@ -27,6 +27,7 @@ function phaseCopy(phase) {
     loading: ["Loading model", "The voice service will unlock automatically"],
     ready: ["Ready when you are", "Press the orb to use the Spark microphone"],
     calibrating: ["Calibrating the room", "A quiet second helps detect natural turns"],
+    cooldown: ["Listening will resume automatically", "Waiting briefly for quieter room audio"],
     listening: ["Listening", "Speak naturally—silence ends your turn"],
     hearing: ["I hear you", "Keep talking"],
     thinking: ["Thinking", "Understanding your voice turn"],
@@ -44,7 +45,9 @@ function renderState(next) {
   elements.listen.setAttribute("aria-pressed", String(Boolean(state.listening)));
   elements.listen.classList.toggle("active", Boolean(state.listening));
   elements.body.classList.toggle("listening", Boolean(state.listening));
-  elements.orbLabel.textContent = state.listening ? "Stop listening" : "Start listening";
+  elements.orbLabel.textContent = state.auto_resume_pending
+    ? "Resuming automatically"
+    : state.listening ? "Stop listening" : "Start listening";
   const sourceReady = state.capture_backend && !["detecting", "unavailable"].includes(state.capture_backend);
   elements.source.textContent = sourceReady
     ? `${state.capture_backend} · ${state.capture_source || "default mic"}`
@@ -89,6 +92,7 @@ function handleEvent(message) {
     assistantBubble.classList.add("thinking");
     elements.conversation.scrollTop = elements.conversation.scrollHeight;
   } else if (event === "assistant_done") {
+    if (data.suppressed || !assistantText.trim()) assistantBubble?.closest(".message")?.remove();
     assistantBubble?.classList.remove("thinking");
     assistantBubble = null;
   } else if (event === "error") {


### PR DESCRIPTION
## What changed

- adds interruptible PowerConf capture with onset-time barge-in, streaming Kokoro TTS, and bounded automatic listening recovery
- rejects silent, too-short, duplicate-audio, repeated-first-sentence, and repeated-action turns deterministically
- keeps voice history turn-scoped so stale audio context is not replayed
- adds allowlisted G1 action tooling and synchronized dispatch contracts while leaving G1 action tools disabled in the Spark stagefile
- adds correlated Spark/G1 wall-clock, monotonic, phase, action, and GPU JSONL traces plus trace APIs
- adds Walter's ModCon soul and WendyOS, SSH, G1/Spark, and Border Collie reference material
- updates the PowerConf ALSA configuration, UI recovery state, README, stagefile lock, and unit coverage

## Why

The live demo could capture echo or unusable microphone turns as new requests, repeat previous language or G1 work, and eventually remain paused. Long responses also waited too long before speaking, and the existing telemetry could not explain latency across inference, TTS, dispatch, and physical-motion observation.

## Impact

The Spark voice loop now starts speaking sentence-by-sentence, can be interrupted by a visitor, recovers automatically from runaway-input cooldowns, and records evidence for each stage of a turn. Offline G1 actions remain fail-closed.

No Spark or G1 deployment is performed by this PR.

## Validation

- `python3 -m unittest -v test_voice_server.py` — 48 passed
- `python3 -m py_compile voice_server.py g1_tools.py trace_recorder.py`
- `node --check web/app.js`
- `git diff --cached --check`
