### PR TITLE
WDY-2476/WDY-2478/WDY-2479: CLI and docs cleanups — TTY-gated attach resize, skills-doc dedupe, truthful pipeline tutorial

### DIFF
--- a/go/internal/cli/assets/docs/guides/tutorials/python/webcam-streaming.mdx
+++ b/go/internal/cli/assets/docs/guides/tutorials/python/webcam-streaming.mdx
@@ -66,12 +66,12 @@ The complete sample is available in the [samples repository](https://github.com/
 
 ### Understanding the Architecture
 
-This sample uses a **slim Debian base image** (`debian:bookworm-slim`) with GStreamer and its Python bindings installed. Most USB webcams output **MJPEG natively**, so the app streams those JPEG frames straight through to the browser without re-encoding.
+This sample uses a **slim Debian base image** (`debian:bookworm-slim`) with GStreamer and its Python bindings installed. Most USB webcams output **MJPEG natively**; the app still decodes and re-encodes those frames to a standard JPEG bitstream by default (`jpegdec ! jpegenc quality=85`) — Safari is stricter than Chrome about webcam-native MJPEG — and only passes frames through untouched as a last resort.
 
 The streaming pipeline works as follows:
 
 1. **GStreamer** captures frames from the webcam via V4L2 (`v4l2src`)
-2. The app tries several pipelines in order, preferring native MJPEG passthrough and falling back to `jpegenc` software encoding when needed
+2. The app tries several pipelines in order: re-encoded MJPEG first (a standard JPEG bitstream every browser accepts), then `jpegenc` software encoding for raw-output cameras, with native MJPEG passthrough as the final fallback
 3. **FastAPI** serves a WebSocket endpoint that broadcasts JPEG frames to all connected browsers
 4. The **HTML5 frontend** renders each frame by setting the `src` of an `<img>` element to a base64 data URL
 
@@ -111,7 +111,7 @@ The camera pipeline starts lazily when the first client connects and stops when 
 
     **GStreamer Pipeline**
 
-    The `MJPEGCamera` class builds a capture pipeline. It prefers passing the camera's native MJPEG straight through and falls back to software JPEG encoding, trying each candidate until one reaches the `PAUSED` state:
+    The `MJPEGCamera` class builds a capture pipeline. It prefers decoding and re-encoding the camera's native MJPEG (for cross-browser compatibility) and keeps untouched passthrough as the last resort, trying each candidate until one reaches the `PAUSED` state:
 
     ```python
     class MJPEGCamera:
@@ -145,8 +145,8 @@ The camera pipeline starts lazily when the first client connects and stops when 
 
     **How it works:**
     - `v4l2src` captures frames from the USB webcam (the device defaults to `/dev/video0`)
-    - The last two pipelines pass the camera's native `image/jpeg` straight through with no re-encoding
-    - The earlier pipelines decode and re-encode (`jpegdec ! jpegenc`) or convert raw frames (`videoconvert ! jpegenc`) as fallbacks
+    - The first two pipelines decode and re-encode the camera's native `image/jpeg` (`jpegdec ! jpegenc quality=85`) — Safari rejects some webcam MJPEG bitstreams that Chrome tolerates, so a clean re-encode is tried first
+    - The third pipeline encodes raw (non-MJPEG) camera output (`videoconvert ! jpegenc quality=70`); the last two pass native `image/jpeg` straight through with no re-encoding — the last resort
     - `appsink` with `max-buffers=2 drop=true` prevents frame buildup if clients are slow
 
     **WebSocket Frame Broadcasting**

--- a/go/internal/cli/assets/skills/wendy/references/wendy.json.md
+++ b/go/internal/cli/assets/skills/wendy/references/wendy.json.md
@@ -118,17 +118,17 @@ Present to a locally-attached monitor as a Wayland client (GPU-accelerated).
 { "type": "display" }
 ```
 
-When enabled:
-- `/dev/dri` (GPU render nodes); cgroup access is `rw`, no `mknod`
-- Membership in the `video` and `render` groups
-- The WendyOS compositor's Wayland socket, exposed via `WAYLAND_DISPLAY` / `XDG_RUNTIME_DIR`
+The container receives:
+- `/dev/dri` (GPU render nodes); cgroup access is `rw`, no `mknod`.
+- Membership in the `video` group, plus the `render` group when the host has one.
+- The WendyOS compositor's Wayland socket, exposed via `WAYLAND_DISPLAY` / `XDG_RUNTIME_DIR`.
 
-On NVIDIA Jetson the GL/EGL userspace is injected from the host through CDI; on Raspberry Pi the app's own mesa works against the vc4 kernel driver.
+On NVIDIA Jetson the GL/EGL userspace is injected from the host through the same CDI path as `gpu`; on Raspberry Pi the app's own mesa works against the vc4 kernel driver.
 
 | Constraint | |
 |------------|--|
 | At most one `display` per app | enforced at validation |
-| Display-enabled image | the Wayland socket is present only on display-enabled WendyOS images |
+| Display-enabled image | the Wayland socket is present only on display-enabled WendyOS images; on a headless image the entitlement is accepted but nothing renders |
 
 > **Security:** apps **without** `display` never receive `/dev/dri` — the default GPU/display sandbox is unchanged.
 
@@ -179,28 +179,6 @@ Allows communication with Bluetooth devices.
 **bluez mode** provides:
 - BlueZ D-Bus interface access
 - Interaction with paired devices and Bluetooth profiles
-
-### Display Entitlement
-
-Present to a locally-attached monitor as a Wayland client (GPU-accelerated).
-
-```json
-{ "type": "display" }
-```
-
-The container receives:
-- `/dev/dri` (GPU render nodes); cgroup access is `rw`, no `mknod`.
-- Membership in the `video` group, plus the `render` group when the host has one.
-- The WendyOS compositor's Wayland socket, exposed via `WAYLAND_DISPLAY` / `XDG_RUNTIME_DIR`.
-
-On NVIDIA Jetson the GL/EGL userspace is injected from the host through the same CDI path as `gpu`; on Raspberry Pi the app's own mesa works against the vc4 kernel driver.
-
-| Constraint | |
-|------------|--|
-| At most one `display` per app | enforced at validation |
-| Display-enabled image | the Wayland socket is present only on display-enabled WendyOS images; on a headless image the entitlement is accepted but nothing renders |
-
-> **Security:** apps **without** `display` never receive `/dev/dri` — the default GPU/display sandbox is unchanged.
 
 ### Notifications Entitlement
 
@@ -261,7 +239,7 @@ Grants `CAP_SYS_ADMIN` and un-denies the `unshare` / `clone(CLONE_NEWUSER)` sysc
   "version": "1.0.0",
   "entitlements": [
     { "type": "network", "mode": "host" },
-    { "type": "video" }
+    { "type": "camera" }
   ]
 }
 ```
@@ -287,7 +265,7 @@ Grants `CAP_SYS_ADMIN` and un-denies the `unshare` / `clone(CLONE_NEWUSER)` sysc
   "version": "1.0.0",
   "entitlements": [
     { "type": "gpu" },
-    { "type": "video" }
+    { "type": "camera" }
   ]
 }
 ```
@@ -323,7 +301,7 @@ Grants `CAP_SYS_ADMIN` and un-denies the `unshare` / `clone(CLONE_NEWUSER)` sysc
 wendy project entitlements add network --mode host
 wendy project entitlements add network --mode none
 wendy project entitlements add gpu
-wendy project entitlements add video
+wendy project entitlements add camera
 wendy project entitlements add audio
 wendy project entitlements add notifications
 wendy project entitlements add bluetooth --mode kernel

--- a/go/internal/cli/commands/device_attach.go
+++ b/go/internal/cli/commands/device_attach.go
@@ -91,24 +91,18 @@ func runDeviceAttach(cmd *cobra.Command, app string, execCmd []string) error {
 		return fmt.Errorf("sending exec start: %w", err)
 	}
 
-	if term.IsTerminal(fd) {
+	interactive := term.IsTerminal(fd)
+	if interactive {
 		oldState, rawErr := term.MakeRaw(fd)
 		if rawErr == nil {
 			defer func() { _ = term.Restore(fd, oldState) }()
 		}
-	}
 
-	// Terminal resize -> resize frames. Only wired up on Unix (SIGWINCH);
-	// a no-op on Windows, which has no equivalent signal.
-	winch := make(chan os.Signal, 1)
-	stopResize := notifyTerminalResize(winch)
-	defer stopResize()
-	go func() {
-		for range winch {
-			r, c := termSize(fd)
-			_ = send(winSizeFrame(r, c))
-		}
-	}()
+		// Terminal resize -> resize frames (SIGWINCH on Unix; no-op on
+		// Windows). Only meaningful when we actually own a terminal.
+		stop := watchTerminalResize(fd, func(r, c uint32) { _ = send(winSizeFrame(r, c)) })
+		defer stop()
+	}
 
 	// stdin -> stream.
 	go func() {

--- a/go/internal/cli/commands/device_shell.go
+++ b/go/internal/cli/commands/device_shell.go
@@ -101,15 +101,8 @@ func runDeviceShell(cmd *cobra.Command, shellCmd []string) error {
 
 		// Terminal resize -> resize frames (SIGWINCH on Unix; no-op on
 		// Windows). Only meaningful when we actually own a terminal.
-		winch := make(chan os.Signal, 1)
-		stopResize := notifyTerminalResize(winch)
-		defer stopResize()
-		go func() {
-			for range winch {
-				r, c := termSize(fd)
-				_ = send(shellWinSizeFrame(r, c))
-			}
-		}()
+		stop := watchTerminalResize(fd, func(r, c uint32) { _ = send(shellWinSizeFrame(r, c)) })
+		defer stop()
 	}
 
 	// stdin -> stream.

--- a/go/internal/cli/commands/terminal_resize.go
+++ b/go/internal/cli/commands/terminal_resize.go
@@ -1,0 +1,34 @@
+package commands
+
+import (
+	"os"
+	"sync"
+)
+
+// watchTerminalResize wires terminal-resize notifications (SIGWINCH via
+// notifyTerminalResize on Unix; a no-op on Windows) to sendResize, reporting
+// the new size from termSize(fd). Callers gate on term.IsTerminal: a
+// non-terminal stdin has no real size, so a stray SIGWINCH would report the
+// 24x80 fallback and clobber the remote PTY (WDY-2478). The returned stop
+// detaches the handler and ends the watcher goroutine; safe to call twice.
+func watchTerminalResize(fd int, sendResize func(rows, cols uint32)) (stop func()) {
+	winch := make(chan os.Signal, 1)
+	stopNotify := notifyTerminalResize(winch)
+
+	go func() {
+		for range winch {
+			sendResize(termSize(fd))
+		}
+	}()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			// signal.Stop (inside stopNotify) guarantees no further sends
+			// once it returns, so closing here is safe and lets the watcher
+			// goroutine above exit instead of leaking.
+			stopNotify()
+			close(winch)
+		})
+	}
+}

--- a/go/internal/cli/commands/terminal_resize_test.go
+++ b/go/internal/cli/commands/terminal_resize_test.go
@@ -1,0 +1,81 @@
+//go:build !windows
+
+package commands
+
+import (
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestWatchTerminalResize_DeliversAndStops exercises the watcher end-to-end.
+// SIGWINCH's default disposition is ignore, so self-signaling the test
+// process is safe under `go test` (nothing crashes, no other handler is
+// disturbed).
+func TestWatchTerminalResize_DeliversAndStops(t *testing.T) {
+	fd := int(os.Stdin.Fd())
+
+	// Test stdin isn't a real terminal, so termSize(fd) is the 24x80
+	// fallback; pin that down here (locking the fallback contract) and reuse
+	// it below so the delivery assertion doesn't hardcode a second copy of
+	// the constant.
+	wantRows, wantCols := termSize(fd)
+	if wantRows != 24 || wantCols != 80 {
+		t.Fatalf("termSize(fd) = %d,%d, want the 24x80 fallback (stdin unexpectedly a terminal under go test)", wantRows, wantCols)
+	}
+
+	got := make(chan [2]uint32, 4)
+	stop := watchTerminalResize(fd, func(rows, cols uint32) {
+		got <- [2]uint32{rows, cols}
+	})
+	t.Cleanup(stop)
+
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGWINCH); err != nil {
+		t.Fatalf("raising SIGWINCH: %v", err)
+	}
+
+	select {
+	case size := <-got:
+		if size[0] != wantRows || size[1] != wantCols {
+			t.Fatalf("delivered size = %v, want [%d %d]", size, wantRows, wantCols)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for resize delivery")
+	}
+
+	stop()
+
+	// Drain any delivery already in flight before re-raising, then confirm
+	// stop actually detached the handler: no further delivery arrives.
+	select {
+	case <-got:
+	default:
+	}
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGWINCH); err != nil {
+		t.Fatalf("raising SIGWINCH: %v", err)
+	}
+	select {
+	case size := <-got:
+		t.Fatalf("got delivery after stop: %v", size)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	stop() // idempotent: a second call must not panic (e.g. double close).
+}
+
+// TestTermSizeFallback locks termSize's non-terminal fallback against a fd
+// that is never a terminal, independent of whatever os.Stdin happens to be
+// under the test harness.
+func TestTermSizeFallback(t *testing.T) {
+	f, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("opening %s: %v", os.DevNull, err)
+	}
+	defer f.Close()
+
+	rows, cols := termSize(int(f.Fd()))
+	if rows != 24 || cols != 80 {
+		t.Fatalf("termSize(non-tty fd) = %d,%d, want 24,80 fallback", rows, cols)
+	}
+}


### PR DESCRIPTION
Three small cleanups from the WDY-2430 burn-down follow-ups, stacked on #1704 (parallel to #1721; GitHub retargets when the stack merges).

- **WDY-2478** — `device attach`'s SIGWINCH watcher now only runs on a real terminal, matching `device shell`'s gating: with piped stdin, a window resize used to send the 24x80 `termSize` fallback and clobber the remote PTY. Both commands now share a new `watchTerminalResize` helper (so they can't drift again), whose `sync.Once` stop also closes the signal channel — fixing a pre-existing watcher-goroutine leak.
- **WDY-2479** — the skills-mirror `references/wendy.json.md` had two `### Display Entitlement` sections (kept the richer body, first position) and three live examples still using the deprecated `video` entitlement type (now `camera`; the Video deprecation section itself is untouched). The `docs/apps` sibling was verified clean and left alone.
- **WDY-2476 (docs half)** — `webcam-streaming.mdx` claimed MJPEG passthrough-first while quoting a ladder that re-encodes first (`jpegdec ! jpegenc quality=85`, a deliberate Safari-compatibility ordering); all four narrative sites now match the ladder. The template-docstring half of WDY-2476 already landed on templates#83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGVBA3ePkCsNG8xbbuLTYf