### PR TITLE
Add exact Jetson recovery target selection

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -297,12 +297,19 @@ CLI prints a warning; don't use them in production.
 | `--storage <nvme\|sd\|emmc>` | Target storage medium |
 | `--no-bmap` | Disable bmap-accelerated flashing (useful when debugging a flaky flash) |
 | `--rootfs-only` | Jetson Orin: write only the SD/NVMe rootfs, skip QSPI boot firmware |
+| `--expected-recovery-ecid-sha256 sha256:<64-hex>` + `--recovery-usb-path <path>` | Pin a full Jetson recovery to one chip and controller USB path; both flags are required together |
 | `--force`, `--yes-overwrite-internal` | Skip confirmations / allow internal-drive writes |
 
 Notes:
 
 - `os install` needs local elevation to write the disk (and, for Thor recovery,
   to claim the USB device) — it will prompt for `sudo`.
+- Recovery ECIDs are never accepted raw on the command line or written to logs.
+  The selector digest is SHA-256 of ASCII
+  `wendyos-recovery-ecid-v1\n` followed by the canonical 32-character,
+  lowercase NVIDIA BR_CID (no `0x`). Exact-selector mode also disables the
+  single off-port USB-gadget fallback and fails before a raw write if topology
+  changes.
 - `os update --pr N` re-applies even when the device already reports that
   version, because a PR's version tag is constant across rebuilds — so pushing a
   new commit and re-running picks up the new build instead of silently no-op'ing.

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/os/install.md
@@ -27,6 +27,11 @@ wendy install --device-type jetson-agx-thor
 # Orin Nano: full QSPI + NVMe recovery (macOS or Linux)
 wendy install --device-type jetson-orin-nano
 
+# Automation: require both the expected chip digest and controller USB path
+wendy install --device-type jetson-orin-nano \
+  --expected-recovery-ecid-sha256 "$RECOVERY_ECID_SHA256" \
+  --recovery-usb-path 1-2
+
 # AGX Orin: storage is mandatory non-interactively
 wendy install --device-type jetson-agx-orin --storage nvme
 wendy install --device-type jetson-agx-orin --storage emmc
@@ -39,6 +44,15 @@ wendy install path/to/image.img /dev/disk4 --force
 ```
 
 > **Note:** `--device-type` is not supported for ESP32 targets. Use the interactive picker to flash an ESP32.
+
+For unattended Jetson recovery, `--expected-recovery-ecid-sha256` and
+`--recovery-usb-path` must be supplied together. The digest is SHA-256 over the
+ASCII domain `wendyos-recovery-ecid-v1\n` followed by NVIDIA's canonical
+32-character lowercase BR_CID (without `0x`). Pass only the digest to Wendy;
+raw ECIDs are intentionally not accepted in argv or emitted in errors/logs.
+The CLI rechecks identity, product, and controller path on the recovery-device
+reopen. Exact-selector mode does not use the legacy unique off-port gadget
+fallback, so a USB topology change stops before the first raw write.
 
 ---
 

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -27,6 +27,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/rcm"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 	"github.com/wendylabsinc/wendy/go/internal/shared/discovery"
@@ -37,15 +38,16 @@ import (
 type preEnrollMode int
 
 type t234InstallOptions struct {
-	DeviceType    string
-	DeviceName    string
-	Version       string
-	Storage       string
-	Artifact      *recoveryFlashpackInfo
-	Force         bool
-	WiFi          wifiCLIOptions
-	RequestedName string
-	PreEnroll     preEnrollOptions
+	DeviceType     string
+	DeviceName     string
+	Version        string
+	Storage        string
+	Artifact       *recoveryFlashpackInfo
+	Force          bool
+	WiFi           wifiCLIOptions
+	RequestedName  string
+	PreEnroll      preEnrollOptions
+	RecoveryTarget rcm.RecoverySelector
 }
 
 const (
@@ -72,6 +74,8 @@ func newOSInstallCmd() *cobra.Command {
 	var deviceName string
 	var enrollCloudGRPC string
 	var prNumber int
+	var expectedRecoveryECIDDigest string
+	var recoveryUSBPath string
 
 	cmd := &cobra.Command{
 		Use:   "install [image] [drive]",
@@ -102,6 +106,10 @@ Flags can be provided progressively — omitted values trigger interactive picke
 			}
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			recoveryTarget, err := rcm.NewRecoverySelector(recoveryUSBPath, expectedRecoveryECIDDigest)
+			if err != nil {
+				return err
+			}
 			if rootfsOnly && len(args) > 0 {
 				return fmt.Errorf("--rootfs-only cannot be combined with positional [image] [drive] arguments")
 			}
@@ -112,8 +120,8 @@ Flags can be provided progressively — omitted values trigger interactive picke
 				fmt.Fprintln(cmd.ErrOrStderr(), tui.WarningMessage("PR images are unhardened debug builds (passwordless root, SSH on). Do not use in production."))
 			}
 			// Positional direct-install mode is incompatible with manifest-backed flags.
-			if len(args) > 0 && (deviceType != "" || versionFlag != "" || driveFlag != "" || wifiSSID != "" || wifiPassword != "" || len(wifiEntries) > 0 || noWifi || deviceName != "" || enrollCloudGRPC != "") {
-				return fmt.Errorf("positional [image] [drive] arguments cannot be combined with --device-type, --version, --drive, --wifi-ssid, --wifi-password, --wifi, --no-wifi, --device-name, or --cloud-grpc")
+			if len(args) > 0 && (deviceType != "" || versionFlag != "" || driveFlag != "" || wifiSSID != "" || wifiPassword != "" || len(wifiEntries) > 0 || noWifi || deviceName != "" || enrollCloudGRPC != "" || !recoveryTarget.IsZero()) {
+				return fmt.Errorf("positional [image] [drive] arguments cannot be combined with --device-type, --version, --drive, --wifi-ssid, --wifi-password, --wifi, --no-wifi, --device-name, --cloud-grpc, --expected-recovery-ecid-sha256, or --recovery-usb-path")
 			}
 			if nightly && versionFlag != "" {
 				return fmt.Errorf("--nightly and --version are mutually exclusive")
@@ -138,7 +146,7 @@ Flags can be provided progressively — omitted values trigger interactive picke
 				}
 			}
 			rootfsOnlyExplicit := cmd.Flags().Changed("rootfs-only")
-			return runOSInstall(cmd.Context(), nightly, deviceType, versionFlag, driveFlag, force, yesOverwriteInternal, noBmap, rootfsOnly, rootfsOnlyExplicit, storageOverride, opts, deviceName, preEnrollOptions{mode: mode, cloudGRPC: enrollCloudGRPC}, prNumber)
+			return runOSInstall(cmd.Context(), nightly, deviceType, versionFlag, driveFlag, force, yesOverwriteInternal, noBmap, rootfsOnly, rootfsOnlyExplicit, storageOverride, recoveryTarget, opts, deviceName, preEnrollOptions{mode: mode, cloudGRPC: enrollCloudGRPC}, prNumber)
 		},
 	}
 
@@ -159,6 +167,8 @@ Flags can be provided progressively — omitted values trigger interactive picke
 	cmd.Flags().BoolVar(&preEnroll, "pre-enroll", false, "Pre-enroll this device with Wendy Cloud during imaging (requires 'wendy auth login')")
 	cmd.Flags().StringVar(&enrollCloudGRPC, "cloud-grpc", "", "Cloud gRPC endpoint of the auth session to use for pre-enrollment (optional when a default is set via 'wendy auth use')")
 	cmd.Flags().IntVar(&prNumber, "pr", 0, "Install the image built by wendyos-builder PR #N (debug build; mutually exclusive with --nightly, --version, and positional [image] [drive])")
+	cmd.Flags().StringVar(&expectedRecoveryECIDDigest, "expected-recovery-ecid-sha256", "", "Require the exact Jetson recovery ECID digest (sha256:<64 hex>, domain wendyos-recovery-ecid-v1); must be paired with --recovery-usb-path")
+	cmd.Flags().StringVar(&recoveryUSBPath, "recovery-usb-path", "", "Require the exact controller USB topology path; must be paired with --expected-recovery-ecid-sha256")
 
 	return cmd
 }
@@ -271,7 +281,15 @@ func pickLinuxDevice() (string, deviceInfo, error) {
 	return key, deviceMap[key], nil
 }
 
-func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion, flagDrive string, force bool, yesOverwriteInternal bool, noBmap, rootfsOnly, rootfsOnlyExplicit bool, storageOverride string, wifi wifiCLIOptions, deviceName string, preOpts preEnrollOptions, prNumber int) error {
+func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion, flagDrive string, force bool, yesOverwriteInternal bool, noBmap, rootfsOnly, rootfsOnlyExplicit bool, storageOverride string, recoveryTarget rcm.RecoverySelector, wifi wifiCLIOptions, deviceName string, preOpts preEnrollOptions, prNumber int) error {
+	if !recoveryTarget.IsZero() {
+		if rootfsOnly {
+			return fmt.Errorf("recovery identity selectors require full Jetson USB recovery and cannot be combined with --rootfs-only")
+		}
+		if flagDeviceType != "" && flagDeviceType != thorDeviceType && !isT234RecoveryDevice(flagDeviceType) {
+			return fmt.Errorf("recovery identity selectors apply only to Jetson Thor/Orin full USB recovery")
+		}
+	}
 	if storageOverride != "" && storageOverride != "nvme" && storageOverride != "sd" && storageOverride != "emmc" {
 		return fmt.Errorf("invalid --storage %q: must be \"nvme\", \"sd\", or \"emmc\" (jetson-agx-orin only)", storageOverride)
 	}
@@ -299,7 +317,7 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 		if storageOverride != "" {
 			return fmt.Errorf("--storage does not apply to Jetson AGX Thor recovery")
 		}
-		return installThor(ctx, flagVersion, nightly, force, wifi, deviceName, preOpts, prNumber)
+		return installThor(ctx, flagVersion, nightly, force, wifi, deviceName, preOpts, prNumber, recoveryTarget)
 	}
 	fmt.Println("Fetching available devices...")
 
@@ -439,7 +457,10 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 		if storageOverride != "" {
 			return fmt.Errorf("--storage does not apply to Jetson AGX Thor recovery")
 		}
-		return installThor(ctx, flagVersion, nightly, force, wifi, deviceName, preOpts, prNumber)
+		return installThor(ctx, flagVersion, nightly, force, wifi, deviceName, preOpts, prNumber, recoveryTarget)
+	}
+	if !recoveryTarget.IsZero() && !isT234RecoveryDevice(selected) {
+		return fmt.Errorf("recovery identity selectors apply only to Jetson Thor/Orin full USB recovery")
 	}
 
 	if selected == linuxDesktopValue {
@@ -474,6 +495,9 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 		return fmt.Errorf("version %s does not publish an eMMC recovery flashpack", selectedVersion)
 	}
 	if isT234RecoveryDevice(selected) && ver.InstallMode != "recovery" && !rootfsOnly {
+		if !recoveryTarget.IsZero() {
+			return fmt.Errorf("recovery identity selectors require a version with a full recovery flashpack")
+		}
 		// The version has no recovery flashpack, so its legacy SD/NVMe image is
 		// the only way to install it. Fall back to rootfs-only imaging instead
 		// of making the user rediscover the flag — unless they explicitly
@@ -512,6 +536,9 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 			}
 		}
 	}
+	if !recoveryTarget.IsZero() && rootfsOnly {
+		return fmt.Errorf("recovery identity selectors require full Jetson USB recovery and cannot be combined with rootfs-only imaging")
+	}
 	if isT234RecoveryDevice(selected) && ver.InstallMode == "recovery" && !rootfsOnly {
 		if err := rejectRecoveryDriveFlags(flagDrive, noBmap, yesOverwriteInternal); err != nil {
 			return err
@@ -537,7 +564,7 @@ func runOSInstall(ctx context.Context, nightly bool, flagDeviceType, flagVersion
 		return installOrin(ctx, t234InstallOptions{
 			DeviceType: selected, DeviceName: device.Name, Version: selectedVersion,
 			Storage: storage, Artifact: artifact, Force: force, WiFi: wifi,
-			RequestedName: deviceName, PreEnroll: preOpts,
+			RequestedName: deviceName, PreEnroll: preOpts, RecoveryTarget: recoveryTarget,
 		})
 	}
 	if isT234RecoveryDevice(selected) && rootfsOnly {

--- a/go/internal/cli/commands/os_install_orin.go
+++ b/go/internal/cli/commands/os_install_orin.go
@@ -38,6 +38,7 @@ const (
 // Per-OS seams: pickOrinRecoveryDevice, orinStageOne, and runT234Helper
 // (os_install_orin_unix.go / os_install_orin_windows.go).
 func installOrin(ctx context.Context, opts t234InstallOptions) error {
+	requireExactRecoveryPort := !opts.RecoveryTarget.IsZero()
 	cacheDir, err := osCacheDir()
 	if err != nil {
 		return fmt.Errorf("resolving cache dir: %w", err)
@@ -86,6 +87,10 @@ func installOrin(ctx context.Context, opts t234InstallOptions) error {
 	dev, err := pickOrinRecoveryDevice(opts)
 	if err != nil {
 		return err
+	}
+	pinnedTarget, err := dev.PinnedSelector()
+	if err != nil {
+		return fmt.Errorf("cannot pin the selected Orin: %w", err)
 	}
 	fmt.Printf("\n%s %s\n", tui.Dim("Target:"), tui.Device(dev.Describe()))
 
@@ -164,7 +169,7 @@ func installOrin(ctx context.Context, opts t234InstallOptions) error {
 			target := fp.Manifest.Target
 			massStorage = &t234.Stage2{
 				FlashPackagePath: fp.FlashPackageImage(), LayoutPath: layoutPath, ImagesDir: workspace,
-				Plan: flashPlan, PortPath: dev.PathKey,
+				Plan: flashPlan, PortPath: pinnedTarget.PathKey, RequireExactPort: requireExactRecoveryPort,
 				StatusPath: fp.Manifest.Layout.FlashPackageStatus, LogsPath: fp.Manifest.Layout.FlashPackageLogs,
 				ExpectedIdentity: t234.IdentityExpectation{ModuleID: target.ModuleID, ModuleSKU: target.ModuleSKU, CarrierID: target.CarrierID, CarrierSKU: target.CarrierSKU},
 				Out:              out, Detail: detail, RunHelper: runT234Helper, TempDir: handoffDir,
@@ -172,7 +177,7 @@ func installOrin(ctx context.Context, opts t234InstallOptions) error {
 			return false, nil
 		}},
 		{id: orinStepRCMBoot, label: "Stage 1  RCM boot", run: func(out io.Writer, _ func(string)) (bool, error) {
-			return false, orinStageOne(fp, dev, out)
+			return false, orinStageOne(fp, pinnedTarget, dev, out)
 		}},
 		{id: orinStepCommands, label: "Stage 2  verify target + hand off recovery", abortWarning: boundaryWarning, run: func(out io.Writer, detail func(string)) (bool, error) {
 			massStorage.Out, massStorage.Detail = out, detail

--- a/go/internal/cli/commands/os_install_orin_unix.go
+++ b/go/internal/cli/commands/os_install_orin_unix.go
@@ -27,18 +27,18 @@ import (
 // pickOrinRecoveryDevice lists T234 modules in recovery mode and selects one,
 // filtered to the install's module family.
 func pickOrinRecoveryDevice(opts t234InstallOptions) (rcm.RecoveryDevice, error) {
-	return pickUnixRecoveryDevice(orinRecoveryHints(opts), orinRecoveryMatch(opts.DeviceType))
+	return pickUnixRecoveryDevice(orinRecoveryHints(opts), orinRecoveryMatch(opts.DeviceType), opts.RecoveryTarget)
 }
 
 // orinStageOne performs the stage-1 RCM boot over gousb with the file chain
 // declared by the flashpack manifest.
-func orinStageOne(fp *flashpack.Flashpack, dev rcm.RecoveryDevice, out io.Writer) error {
+func orinStageOne(fp *flashpack.Flashpack, target rcm.RecoverySelector, dev rcm.RecoveryDevice, out io.Writer) error {
 	order, memBCT, blob, err := t234RCMFiles(fp)
 	if err != nil {
 		return err
 	}
-	return bringup.Run(bringup.Options{Dir: fp.Root, MemBCT: memBCT, Blob: blob, DevicePath: dev.PathKey,
-		ExpectedProduct: dev.Product, SendOrder: order, Out: out})
+	return bringup.Run(bringup.Options{Dir: fp.Root, MemBCT: memBCT, Blob: blob, DevicePath: target.PathKey,
+		ExpectedProduct: dev.Product, ExpectedECIDDigest: target.ExpectedECIDDigest, SendOrder: order, Out: out})
 }
 
 // isWinRawDiskAccessError is Windows-only (errno-matched there); never true

--- a/go/internal/cli/commands/os_install_orin_windows.go
+++ b/go/internal/cli/commands/os_install_orin_windows.go
@@ -38,13 +38,44 @@ func pickOrinRecoveryDevice(opts t234InstallOptions) (rcm.RecoveryDevice, error)
 		if err != nil {
 			return nil, err
 		}
+		var allRecovery []rcm.RecoveryDevice
 		var recovery []winusb.Device
 		for _, d := range devs {
+			if d.IsRecovery() {
+				allRecovery = append(allRecovery, d.RecoveryDevice())
+			}
 			if d.IsT234() && match(d.RecoveryDevice()) {
 				recovery = append(recovery, d)
 			}
 		}
+		if err := rcm.ValidateRecoveryDeviceCount(allRecovery); err != nil {
+			return nil, err
+		}
 		return recovery, nil
+	}
+	if !opts.RecoveryTarget.IsZero() {
+		recovery, err := scan()
+		if err != nil {
+			return rcm.RecoveryDevice{}, err
+		}
+		candidates := make([]rcm.RecoveryDevice, 0, len(recovery))
+		for _, dev := range recovery {
+			candidates = append(candidates, dev.RecoveryDevice())
+		}
+		selected, err := rcm.SelectRecoveryDevice(candidates, opts.RecoveryTarget)
+		if err != nil {
+			return rcm.RecoveryDevice{}, err
+		}
+		for _, dev := range recovery {
+			if dev.InstanceID != selected.Instance {
+				continue
+			}
+			if err := ensureOrinDriver(dev); err != nil {
+				return rcm.RecoveryDevice{}, err
+			}
+			return selected, nil
+		}
+		return rcm.RecoveryDevice{}, fmt.Errorf("the selected recovery device disappeared before the RCM handoff")
 	}
 	for {
 		recovery, err := scan()
@@ -64,19 +95,19 @@ func pickOrinRecoveryDevice(opts t234InstallOptions) (rcm.RecoveryDevice, error)
 		case 1:
 			chosen = recovery[0]
 		default:
-			// Keyed by InstanceID — always present and unique. LocationPath is
-			// best-effort (empty under USB redirection) and empty/duplicate keys
-			// would collapse picker rows, resolving a destructive selection to
-			// the wrong board.
+			// Keep raw PnP instance IDs out of picker values and sort keys: those
+			// identifiers contain the bootROM's reversed ECID on Windows. Opaque
+			// per-scan keys preserve duplicate location rows without exposing it.
 			var items []tui.PickerItem
 			byKey := map[string]winusb.Device{}
-			for _, d := range recovery {
-				byKey[d.InstanceID] = d
+			for i, d := range recovery {
+				key := fmt.Sprintf("recovery-%d", i)
+				byKey[key] = d
 				items = append(items, tui.PickerItem{
 					Name:    d.Describe(),
 					Section: "Recovery devices",
-					SortKey: d.InstanceID,
-					Value:   d.InstanceID,
+					SortKey: fmt.Sprintf("%s-%06d", d.Describe(), i),
+					Value:   key,
 				})
 			}
 			sel, err := pickFromItems("Select the "+opts.DeviceName+" to flash", items)
@@ -117,20 +148,21 @@ func ensureOrinDriver(d winusb.Device) error {
 
 // orinStageOne performs the stage-1 RCM boot over WinUSB with the file chain
 // declared by the flashpack manifest.
-func orinStageOne(fp *flashpack.Flashpack, dev rcm.RecoveryDevice, out io.Writer) error {
+func orinStageOne(fp *flashpack.Flashpack, target rcm.RecoverySelector, dev rcm.RecoveryDevice, out io.Writer) error {
 	order, memBCT, blob, err := t234RCMFiles(fp)
 	if err != nil {
 		return err
 	}
 	return winusb.StageOneBoot(winusb.StageOneOptions{
-		Stage1Dir:       fp.Root,
-		MemBCT:          memBCT,
-		Blob:            blob,
-		SendOrder:       order,
-		Location:        dev.PathKey,
-		Instance:        dev.Instance,
-		ExpectedProduct: dev.Product,
-		Out:             out,
+		Stage1Dir:          fp.Root,
+		MemBCT:             memBCT,
+		Blob:               blob,
+		SendOrder:          order,
+		Location:           target.PathKey,
+		Instance:           dev.Instance,
+		ExpectedProduct:    dev.Product,
+		ExpectedECIDDigest: target.ExpectedECIDDigest,
+		Out:                out,
 	})
 }
 

--- a/go/internal/cli/commands/os_install_recovery_test.go
+++ b/go/internal/cli/commands/os_install_recovery_test.go
@@ -12,12 +12,18 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/rcm"
 )
 
+const testRecoveryECIDDigest = "sha256:52c5b9de12b1f1943a441df0ecdea9f3eb94c7f64b98968855390f14c6e6e05c"
+
 func TestRecoveryFlagCombinationsFailBeforeManifestLookup(t *testing.T) {
 	tests := [][]string{
 		{"--device-type", orinDeviceType, "--drive", "/dev/disk9"},
 		{"--device-type", orinNanoDeviceType, "--no-bmap"},
 		{"--device-type", orinDeviceType, "--yes-overwrite-internal"},
 		{"--device-type", orinDeviceType, "--rootfs-only", "--storage", "emmc"},
+		{"--device-type", orinNanoDeviceType, "--recovery-usb-path", "1-2"},
+		{"--device-type", orinNanoDeviceType, "--expected-recovery-ecid-sha256", testRecoveryECIDDigest},
+		{"--device-type", orinNanoDeviceType, "--rootfs-only", "--recovery-usb-path", "1-2", "--expected-recovery-ecid-sha256", testRecoveryECIDDigest},
+		{"--device-type", "raspberry-pi-5", "--recovery-usb-path", "1-2", "--expected-recovery-ecid-sha256", testRecoveryECIDDigest},
 	}
 	for _, args := range tests {
 		cmd := newOSInstallCmd()
@@ -25,6 +31,20 @@ func TestRecoveryFlagCombinationsFailBeforeManifestLookup(t *testing.T) {
 		if err := cmd.Execute(); err == nil {
 			t.Fatalf("args %v unexpectedly accepted", args)
 		}
+	}
+}
+
+func TestRecoverySelectorCLIExposesDigestNotRawECID(t *testing.T) {
+	cmd := newOSInstallCmd()
+	if cmd.Flags().Lookup("expected-recovery-ecid-sha256") == nil || cmd.Flags().Lookup("recovery-usb-path") == nil {
+		t.Fatal("exact recovery selector flags are missing")
+	}
+	if cmd.Flags().Lookup("expected-recovery-ecid") != nil {
+		t.Fatal("raw ECID flag must never be exposed")
+	}
+	cmd.SetArgs([]string{"--expected-recovery-ecid", "80012641783de2442400000016ff80c0"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("raw ECID flag unexpectedly accepted")
 	}
 }
 

--- a/go/internal/cli/commands/os_install_test.go
+++ b/go/internal/cli/commands/os_install_test.go
@@ -91,7 +91,7 @@ func TestNewOSInstallCmd_PositionalArgsIncompatibleWithFlags(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected error when positional args are combined with manifest flags")
 			}
-			expected := "positional [image] [drive] arguments cannot be combined with --device-type, --version, --drive, --wifi-ssid, --wifi-password, --wifi, --no-wifi, --device-name, or --cloud-grpc"
+			expected := "positional [image] [drive] arguments cannot be combined with --device-type, --version, --drive, --wifi-ssid, --wifi-password, --wifi, --no-wifi, --device-name, --cloud-grpc, --expected-recovery-ecid-sha256, or --recovery-usb-path"
 			if got := err.Error(); got != expected {
 				t.Errorf("unexpected error: %q; want %q", got, expected)
 			}

--- a/go/internal/cli/commands/os_install_thor_hw_unix.go
+++ b/go/internal/cli/commands/os_install_thor_hw_unix.go
@@ -34,21 +34,35 @@ func thorPrepareHost(out io.Writer) error {
 
 // pickThorRecoveryDevice lists Jetsons in recovery mode and selects one, with a
 // rescan loop and USB-access guidance.
-func pickThorRecoveryDevice() (thorDevice, error) {
-	dev, err := pickUnixRecoveryDevice(thorRecoveryHints(), func(d rcm.RecoveryDevice) bool { return d.IsThor() })
+func pickThorRecoveryDevice(target rcm.RecoverySelector) (thorDevice, error) {
+	dev, err := pickUnixRecoveryDevice(thorRecoveryHints(), func(d rcm.RecoveryDevice) bool { return d.IsThor() }, target)
 	if err != nil {
 		return thorDevice{}, err
 	}
-	return thorDevice{PathKey: dev.PathKey, Label: dev.Describe()}, nil
+	pinned, err := dev.PinnedSelector()
+	if err != nil {
+		return thorDevice{}, fmt.Errorf("cannot pin the selected Thor: %w", err)
+	}
+	return thorDevice{RecoveryTarget: pinned, Label: dev.Describe(), RequireExactPath: !target.IsZero()}, nil
 }
 
 // pickUnixRecoveryDevice selects only devices matching the requested family.
 // Filtering happens before the single-device fast path and on every rescan, so
 // an attached Orin can never be selected by a Thor installation (or vice versa).
-func pickUnixRecoveryDevice(hints recoveryWaitHints, match func(rcm.RecoveryDevice) bool) (rcm.RecoveryDevice, error) {
+func pickUnixRecoveryDevice(hints recoveryWaitHints, match func(rcm.RecoveryDevice) bool, target rcm.RecoverySelector) (rcm.RecoveryDevice, error) {
 	scan := func() ([]rcm.RecoveryDevice, error) {
 		devs, err := rcm.ListRecoveryDevices()
+		if countErr := rcm.ValidateRecoveryDeviceCount(devs); countErr != nil {
+			return nil, countErr
+		}
 		return filterRecoveryDevices(devs, match), err
+	}
+	if !target.IsZero() {
+		devs, err := scan()
+		if err != nil {
+			return rcm.RecoveryDevice{}, err
+		}
+		return rcm.SelectRecoveryDevice(devs, target)
 	}
 	for {
 		devs, err := scan()
@@ -138,12 +152,13 @@ func diskAvailBytes(path string) (avail int64, ok bool) {
 // thorStageOne performs the stage-1 RCM boot over gousb.
 func thorStageOne(fp *flashpack.Flashpack, dev thorDevice, out io.Writer) error {
 	return bringup.Run(bringup.Options{
-		Dir:             fp.Stage1Dir(),
-		MemBCT:          fp.MemBCT(),
-		DevicePath:      dev.PathKey,
-		ExpectedProduct: uint16(rcm.ProductThor),
-		SendOrder:       fp.Manifest.Stage1SendOrder,
-		Out:             out,
+		Dir:                fp.Stage1Dir(),
+		MemBCT:             fp.MemBCT(),
+		DevicePath:         dev.RecoveryTarget.PathKey,
+		ExpectedProduct:    uint16(rcm.ProductThor),
+		ExpectedECIDDigest: dev.RecoveryTarget.ExpectedECIDDigest,
+		SendOrder:          fp.Manifest.Stage1SendOrder,
+		Out:                out,
 	})
 }
 
@@ -151,8 +166,15 @@ func thorStageOne(fp *flashpack.Flashpack, dev thorDevice, out io.Writer) error 
 // pinning the selected device via WENDY_ADB_PATH and retrying while it
 // re-enumerates after stage-1.
 func thorOpenGadget(dev thorDevice, out io.Writer) (flashengine.Transport, func(), error) {
-	if dev.PathKey != "" {
-		os.Setenv("WENDY_ADB_PATH", dev.PathKey)
+	if dev.RecoveryTarget.PathKey != "" {
+		os.Setenv("WENDY_ADB_PATH", dev.RecoveryTarget.PathKey)
+	} else {
+		os.Unsetenv("WENDY_ADB_PATH")
+	}
+	if dev.RequireExactPath {
+		os.Setenv("WENDY_ADB_REQUIRE_PATH", "1")
+	} else {
+		os.Unsetenv("WENDY_ADB_REQUIRE_PATH")
 	}
 	deadline := time.Now().Add(60 * time.Second)
 	var lastErr error

--- a/go/internal/cli/commands/os_install_thor_hw_windows.go
+++ b/go/internal/cli/commands/os_install_thor_hw_windows.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/flashengine"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/flashpack"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/rcm"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/winusb"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 )
@@ -51,19 +52,46 @@ func thorPrepareHost(out io.Writer) error {
 
 // pickThorRecoveryDevice lists NVIDIA recovery devices via SetupAPI and selects
 // one, rescanning until a Thor/Orin in recovery appears.
-func pickThorRecoveryDevice() (thorDevice, error) {
+func pickThorRecoveryDevice(target rcm.RecoverySelector) (thorDevice, error) {
 	scanRecovery := func() ([]winusb.Device, error) {
 		devs, err := winusb.ListDevices()
 		if err != nil {
 			return nil, err
 		}
+		var allRecovery []rcm.RecoveryDevice
 		var recovery []winusb.Device
 		for _, d := range devs {
+			if d.IsRecovery() {
+				allRecovery = append(allRecovery, d.RecoveryDevice())
+			}
 			if d.IsThor() {
 				recovery = append(recovery, d)
 			}
 		}
+		if err := rcm.ValidateRecoveryDeviceCount(allRecovery); err != nil {
+			return nil, err
+		}
 		return recovery, nil
+	}
+	if !target.IsZero() {
+		recovery, err := scanRecovery()
+		if err != nil {
+			return thorDevice{}, err
+		}
+		candidates := make([]rcm.RecoveryDevice, 0, len(recovery))
+		for _, dev := range recovery {
+			candidates = append(candidates, dev.RecoveryDevice())
+		}
+		selected, err := rcm.SelectRecoveryDevice(candidates, target)
+		if err != nil {
+			return thorDevice{}, err
+		}
+		for _, dev := range recovery {
+			if dev.InstanceID == selected.Instance {
+				return windowsThorDevice(dev, true)
+			}
+		}
+		return thorDevice{}, fmt.Errorf("the selected recovery device disappeared before the RCM handoff")
 	}
 	for {
 		recovery, err := scanRecovery()
@@ -80,26 +108,35 @@ func pickThorRecoveryDevice() (thorDevice, error) {
 		}
 		switch len(recovery) {
 		case 1:
-			return thorDevice{PathKey: recovery[0].LocationPath, Label: recovery[0].Describe()}, nil
+			return windowsThorDevice(recovery[0], false)
 		default:
 			var items []tui.PickerItem
 			byKey := map[string]winusb.Device{}
-			for _, d := range recovery {
-				byKey[d.LocationPath] = d
+			for i, d := range recovery {
+				key := fmt.Sprintf("recovery-%d", i)
+				byKey[key] = d
 				items = append(items, tui.PickerItem{
 					Name:    d.Describe(),
 					Section: "Recovery devices",
-					SortKey: d.LocationPath,
-					Value:   d.LocationPath,
+					SortKey: fmt.Sprintf("%s-%06d", d.Describe(), i),
+					Value:   key,
 				})
 			}
 			sel, err := pickFromItems("Select the Thor to flash", items)
 			if err != nil {
 				return thorDevice{}, err
 			}
-			return thorDevice{PathKey: byKey[sel].LocationPath, Label: byKey[sel].Describe()}, nil
+			return windowsThorDevice(byKey[sel], false)
 		}
 	}
+}
+
+func windowsThorDevice(dev winusb.Device, requireExactPath bool) (thorDevice, error) {
+	pinned, err := dev.RecoveryDevice().PinnedSelector()
+	if err != nil {
+		return thorDevice{}, fmt.Errorf("cannot pin the selected Thor: %w", err)
+	}
+	return thorDevice{RecoveryTarget: pinned, Instance: dev.InstanceID, Label: dev.Describe(), RequireExactPath: requireExactPath}, nil
 }
 
 // thorIsUSBAccessErr reports whether err is the OS denying wendy access to the
@@ -131,12 +168,14 @@ func diskAvailBytes(path string) (int64, bool) {
 // thorStageOne performs the stage-1 RCM boot over WinUSB.
 func thorStageOne(fp *flashpack.Flashpack, dev thorDevice, out io.Writer) error {
 	return winusb.StageOneBoot(winusb.StageOneOptions{
-		Stage1Dir:       fp.Stage1Dir(),
-		MemBCT:          fp.MemBCT(),
-		SendOrder:       fp.Manifest.Stage1SendOrder,
-		Location:        dev.PathKey,
-		ExpectedProduct: winusb.ProductThor,
-		Out:             out,
+		Stage1Dir:          fp.Stage1Dir(),
+		MemBCT:             fp.MemBCT(),
+		SendOrder:          fp.Manifest.Stage1SendOrder,
+		Location:           dev.RecoveryTarget.PathKey,
+		Instance:           dev.Instance,
+		ExpectedProduct:    winusb.ProductThor,
+		ExpectedECIDDigest: dev.RecoveryTarget.ExpectedECIDDigest,
+		Out:                out,
 	})
 }
 
@@ -146,8 +185,9 @@ func thorOpenGadget(dev thorDevice, out io.Writer) (flashengine.Transport, func(
 	deadline := time.Now().Add(60 * time.Second)
 	var lastErr error
 	for time.Now().Before(deadline) {
-		// Pin the chosen board by physical location across the re-enumeration.
-		d, err := winusb.Open(dev.PathKey)
+		// Pin the chosen board by physical location and require the stage-2
+		// gadget product across the re-enumeration.
+		d, err := winusb.OpenExpected(dev.RecoveryTarget.PathKey, winusb.ProductGadget)
 		if err == nil {
 			a, aerr := winusb.NewADB(d)
 			if aerr == nil {

--- a/go/internal/cli/commands/os_install_thor_shared.go
+++ b/go/internal/cli/commands/os_install_thor_shared.go
@@ -28,6 +28,7 @@ import (
 	"github.com/diskfs/go-diskfs/filesystem"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/flashengine"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/flashpack"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/rcm"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 	"github.com/wendylabsinc/wendy/go/internal/shared/wendyconf"
@@ -51,8 +52,10 @@ var errGadgetUnreachable = errors.New("thor flashing gadget did not appear over 
 // PathKey is the stable physical-location key used to re-find the device across
 // the RCM→gadget re-enumeration; Label is a human description.
 type thorDevice struct {
-	PathKey string
-	Label   string
+	RecoveryTarget   rcm.RecoverySelector
+	Instance         string
+	Label            string
+	RequireExactPath bool
 }
 
 // installThor flashes a Jetson AGX Thor over USB recovery: plan the flashpack,
@@ -60,7 +63,7 @@ type thorDevice struct {
 // the device, then run download → stage-1 RCM boot → stage-2 partition flash as a
 // BuildKit-style step list. Stage-2 is the shared Go engine (flashengine) on all
 // platforms.
-func installThor(ctx context.Context, version string, nightly, force bool, wifi wifiCLIOptions, deviceName string, preOpts preEnrollOptions, prNumber int) error {
+func installThor(ctx context.Context, version string, nightly, force bool, wifi wifiCLIOptions, deviceName string, preOpts preEnrollOptions, prNumber int, recoveryTarget rcm.RecoverySelector) error {
 	// Thor's USB recovery access is an in-process libusb handle, so the whole
 	// process must be root on macOS/Linux — caching the sudo timestamp is not
 	// enough. Elevate up front, before the briefing, so a missing-permission
@@ -121,7 +124,7 @@ func installThor(ctx context.Context, version string, nightly, force bool, wifi 
 		return err
 	}
 
-	dev, err := pickThorRecoveryDevice()
+	dev, err := pickThorRecoveryDevice(recoveryTarget)
 	if err != nil {
 		return err
 	}

--- a/go/internal/cli/tegraflash/adb/adb.go
+++ b/go/internal/cli/tegraflash/adb/adb.go
@@ -109,6 +109,7 @@ func openOnce() (*Device, error) {
 	// NOT pre-filter by WENDY_ADB_PATH here because the flashing gadget can
 	// re-enumerate at a different USB location than the RCM device was selected at.
 	wantPath := os.Getenv("WENDY_ADB_PATH")
+	requirePath := os.Getenv("WENDY_ADB_REQUIRE_PATH") == "1"
 	devs, err := ctx.OpenDevices(func(desc *gousb.DeviceDesc) bool {
 		_, _, _, ok := findADBInterface(desc)
 		return ok
@@ -131,28 +132,23 @@ func openOnce() (*Device, error) {
 	// flashing gadget often re-enumerates at a *different* port than the RCM device:
 	// on macOS the RCM device is USB-2 Hi-Speed while the ADB gadget is USB-3
 	// SuperSpeed, which lands on the companion port (e.g. 1-1 -> 1-2). So when the pin
-	// matches nothing but exactly one ADB device is present, fall back to it.
-	sel := 0
-	if wantPath != "" {
-		sel = -1
-		for i, d := range devs {
-			if adbPortKey(d.Desc) == wantPath {
-				sel = i
-				break
-			}
+	// matches nothing but exactly one ADB device is present, the interactive
+	// compatibility path falls back to it. Exact controller selection sets
+	// WENDY_ADB_REQUIRE_PATH and refuses that off-port fallback before writes.
+	paths := make([]string, len(devs))
+	for i, dev := range devs {
+		paths[i] = adbPortKey(dev.Desc)
+	}
+	sel, fellBack, selectErr := selectADBPath(paths, wantPath, requirePath)
+	if selectErr != nil {
+		for _, d := range devs {
+			d.Close()
 		}
-		if sel == -1 {
-			if len(devs) == 1 {
-				sel = 0
-				fmt.Fprintf(os.Stderr, "wendy adb: no ADB device at usb %s; using the only ADB device present (usb %s)\n", wantPath, adbPortKey(devs[0].Desc))
-			} else {
-				for _, d := range devs {
-					d.Close()
-				}
-				ctx.Close()
-				return nil, fmt.Errorf("no ADB device at usb %s among %d ADB devices present", wantPath, len(devs))
-			}
-		}
+		ctx.Close()
+		return nil, selectErr
+	}
+	if fellBack {
+		fmt.Fprintf(os.Stderr, "wendy adb: selected recovery path did not re-enumerate; using the only ADB device present\n")
 	}
 	dev := devs[sel]
 	for i, d := range devs {

--- a/go/internal/cli/tegraflash/adb/adb_test.go
+++ b/go/internal/cli/tegraflash/adb/adb_test.go
@@ -1,0 +1,27 @@
+package adb
+
+import "testing"
+
+func TestSelectADBPathExactModeNeverFallsBack(t *testing.T) {
+	if index, fallback, err := selectADBPath([]string{"1-2"}, "1-1", false); err != nil || index != 0 || !fallback {
+		t.Fatalf("legacy unique fallback = index %d fallback %v err %v", index, fallback, err)
+	}
+	if _, _, err := selectADBPath([]string{"1-2"}, "1-1", true); err == nil {
+		t.Fatal("exact mode accepted an off-port gadget")
+	}
+	if index, fallback, err := selectADBPath([]string{"1-2", "1-1"}, "1-1", true); err != nil || index != 1 || fallback {
+		t.Fatalf("exact match = index %d fallback %v err %v", index, fallback, err)
+	}
+	if _, _, err := selectADBPath([]string{"1-2", "3-2"}, "1-1", false); err == nil {
+		t.Fatal("ambiguous legacy selection accepted")
+	}
+	if _, _, err := selectADBPath([]string{"1-1", "1-1"}, "1-1", true); err == nil {
+		t.Fatal("duplicate exact path accepted")
+	}
+	if _, _, err := selectADBPath([]string{"1-1"}, "", true); err == nil {
+		t.Fatal("exact mode accepted an empty controller path")
+	}
+	if _, _, err := selectADBPath(make([]string, maxADBDevices+1), "1-1", true); err == nil {
+		t.Fatal("oversized ADB discovery accepted")
+	}
+}

--- a/go/internal/cli/tegraflash/adb/select.go
+++ b/go/internal/cli/tegraflash/adb/select.go
@@ -1,0 +1,38 @@
+package adb
+
+import "fmt"
+
+const maxADBDevices = 32
+
+// selectADBPath is kept platform-neutral so exact target selection can be
+// exhaustively tested without opening a USB device or requiring libusb.
+func selectADBPath(paths []string, wantPath string, requirePath bool) (index int, fellBack bool, err error) {
+	if len(paths) > maxADBDevices {
+		return -1, false, fmt.Errorf("refusing ADB discovery with %d devices (maximum %d)", len(paths), maxADBDevices)
+	}
+	if len(paths) == 0 {
+		return -1, false, fmt.Errorf("no ADB devices are present")
+	}
+	if wantPath == "" {
+		if requirePath {
+			return -1, false, fmt.Errorf("an exact ADB controller USB path is required")
+		}
+		return 0, false, nil
+	}
+	match := -1
+	for i, path := range paths {
+		if path == wantPath {
+			if match != -1 {
+				return -1, false, fmt.Errorf("multiple ADB devices matched the required recovery USB path")
+			}
+			match = i
+		}
+	}
+	if match != -1 {
+		return match, false, nil
+	}
+	if len(paths) == 1 && !requirePath {
+		return 0, true, nil
+	}
+	return -1, false, fmt.Errorf("no ADB device at the required recovery USB path among %d ADB devices present", len(paths))
+}

--- a/go/internal/cli/tegraflash/bringup/bringup.go
+++ b/go/internal/cli/tegraflash/bringup/bringup.go
@@ -54,6 +54,10 @@ type Options struct {
 	// ExpectedProduct pins the selected Jetson family across the re-open. This
 	// prevents a different Jetson on the same host from satisfying the wait.
 	ExpectedProduct uint16
+	// ExpectedECIDDigest pins the exact chip without exposing its raw ECID. It
+	// must be paired with DevicePath; recovery installers populate both from the
+	// selected device immediately before this non-persistent RCM handoff.
+	ExpectedECIDDigest string
 	// SendOrder is the bootROM image filenames to send, in order. Empty uses the
 	// built-in default (bct_br → mb1 → psc_bl1 → bct_mb1). Driving this from the
 	// flashpack manifest lets a future BSP reorder the chain without a code change.
@@ -67,6 +71,16 @@ var DefaultSendOrder = []string{FileBctBR, FileMB1, FilePSCBL1, FileBctMB1}
 // Run executes the stage-1 RCM boot. On success the device has booted the blob and
 // is re-enumerating as the initrd-flash ADB gadget.
 func Run(opts Options) error {
+	if opts.ExpectedProduct == 0 {
+		return fmt.Errorf("an expected Jetson recovery product is required before RCM handoff")
+	}
+	selector, err := rcm.NewRecoverySelector(opts.DevicePath, opts.ExpectedECIDDigest)
+	if err != nil {
+		return fmt.Errorf("validating recovery target selector: %w", err)
+	}
+	if selector.IsZero() {
+		return fmt.Errorf("recovery target identity and USB path are required before RCM handoff")
+	}
 	out := opts.Out
 	if out == nil {
 		out = os.Stdout
@@ -102,7 +116,7 @@ func Run(opts Options) error {
 	}
 
 	fmt.Fprintln(out, "Waiting for Jetson in USB recovery mode...")
-	dev, err := rcm.WaitForDeviceAt(opts.DevicePath, opts.ExpectedProduct)
+	dev, err := rcm.WaitForDevice(selector, opts.ExpectedProduct)
 	if err != nil {
 		return fmt.Errorf("waiting for device: %w", err)
 	}

--- a/go/internal/cli/tegraflash/bringup/bringup_test.go
+++ b/go/internal/cli/tegraflash/bringup/bringup_test.go
@@ -1,0 +1,34 @@
+package bringup
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/rcm"
+)
+
+func TestRunRequiresExactRecoveryHandoffBeforeReadingArtifacts(t *testing.T) {
+	const digest = "sha256:52c5b9de12b1f1943a441df0ecdea9f3eb94c7f64b98968855390f14c6e6e05c"
+	tests := []struct {
+		name string
+		opts Options
+		want string
+	}{
+		{"missing product", Options{}, "expected Jetson recovery product"},
+		{"missing both selectors", Options{ExpectedProduct: rcm.ProductThor}, "identity and USB path are required"},
+		{"path only", Options{ExpectedProduct: rcm.ProductThor, DevicePath: "1-2"}, "must be supplied together"},
+		{"digest only", Options{ExpectedProduct: rcm.ProductThor, ExpectedECIDDigest: digest}, "must be supplied together"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.opts.Dir = t.TempDir()
+			err := Run(tc.opts)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Run error = %v, want %q", err, tc.want)
+			}
+			if strings.Contains(err.Error(), "artifact") {
+				t.Fatalf("target validation happened after artifact access: %v", err)
+			}
+		})
+	}
+}

--- a/go/internal/cli/tegraflash/rcm/constants.go
+++ b/go/internal/cli/tegraflash/rcm/constants.go
@@ -17,7 +17,9 @@ const (
 	ProductThor = 0x7026 // T264 (AGX Thor); confirmed on live hardware
 )
 
-// t234Modules maps each T234 recovery PID to its module name.
+// t234Modules maps documented T234 recovery products to display/driver-package
+// names. These names are routing hints only, never module/carrier attestation;
+// destructive recovery verifies the board identity from the recovery initrd.
 var t234Modules = map[uint16]string{
 	ProductOrinAGX32: "AGX Orin 32GB",
 	ProductOrinAGX64: "AGX Orin 64GB",
@@ -33,7 +35,8 @@ func IsT234RecoveryPID(pid uint16) bool {
 	return ok
 }
 
-// T234ModuleName names the Orin-family module behind a recovery PID.
+// T234ModuleName returns the documented product label for a recovery PID. It
+// must not be used as physical module/carrier attestation.
 func T234ModuleName(pid uint16) (string, bool) {
 	name, ok := t234Modules[pid]
 	return name, ok

--- a/go/internal/cli/tegraflash/rcm/device.go
+++ b/go/internal/cli/tegraflash/rcm/device.go
@@ -188,15 +188,3 @@ func parseChipIDDescriptor(buf []byte, n int) (string, error) {
 	}
 	return reverseASCII(sb.String()), nil
 }
-
-func isHexDigit(c byte) bool {
-	return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f')
-}
-
-func reverseASCII(s string) string {
-	b := []byte(s)
-	for i, j := 0, len(b)-1; i < j; i, j = i+1, j-1 {
-		b[i], b[j] = b[j], b[i]
-	}
-	return string(b)
-}

--- a/go/internal/cli/tegraflash/rcm/recovery.go
+++ b/go/internal/cli/tegraflash/rcm/recovery.go
@@ -1,8 +1,12 @@
 package rcm
 
 import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 )
 
 // ErrUSBAccess reports that a Jetson in recovery mode is present but the OS
@@ -12,6 +16,177 @@ import (
 // the gousb-tagged files) so the shared install flow can classify it on every
 // OS, including Windows.
 var ErrUSBAccess = errors.New("USB device access denied")
+
+const (
+	// MaxRecoveryDevices bounds the structured recovery-device set accepted by
+	// selectors. A larger set is almost certainly a broken/hostile USB view, and
+	// must not be partially filtered into a seemingly unambiguous flash target.
+	MaxRecoveryDevices = 32
+
+	recoveryECIDDigestDomain = "wendyos-recovery-ecid-v1\n"
+	maxRecoveryPathBytes     = 512
+)
+
+// RecoverySelector pins a recovery target without placing its raw ECID in the
+// process list, shell history, errors, picker labels, or flash logs. The digest
+// is SHA-256 over recoveryECIDDigestDomain followed by the normalized (lowercase,
+// 32-hex-character) ECID.
+type RecoverySelector struct {
+	PathKey            string
+	ExpectedECIDDigest string
+}
+
+// NewRecoverySelector validates the two controller-supplied target selectors.
+// Both may be empty for the backward-compatible interactive picker; an explicit
+// automation target must provide both identity and physical-location pins.
+func NewRecoverySelector(pathKey, expectedECIDDigest string) (RecoverySelector, error) {
+	if pathKey != "" {
+		if len(pathKey) > maxRecoveryPathBytes || strings.TrimSpace(pathKey) != pathKey {
+			return RecoverySelector{}, fmt.Errorf("recovery USB path must be a non-whitespace ASCII value of at most %d bytes", maxRecoveryPathBytes)
+		}
+		for i := 0; i < len(pathKey); i++ {
+			if pathKey[i] < 0x21 || pathKey[i] > 0x7e {
+				return RecoverySelector{}, fmt.Errorf("recovery USB path must be a non-whitespace ASCII value of at most %d bytes", maxRecoveryPathBytes)
+			}
+		}
+	}
+	digest, err := normalizeRecoveryECIDDigest(expectedECIDDigest)
+	if err != nil {
+		return RecoverySelector{}, err
+	}
+	if (pathKey == "") != (digest == "") {
+		return RecoverySelector{}, fmt.Errorf("expected recovery ECID digest and recovery USB path must be supplied together")
+	}
+	return RecoverySelector{PathKey: pathKey, ExpectedECIDDigest: digest}, nil
+}
+
+// IsZero reports whether no explicit target constraint was supplied.
+func (s RecoverySelector) IsZero() bool {
+	return s.PathKey == "" && s.ExpectedECIDDigest == ""
+}
+
+// ValidateRecoveryDeviceCount fails before family/selector filtering so an
+// oversized discovery result cannot be collapsed into one apparently safe row.
+func ValidateRecoveryDeviceCount(devs []RecoveryDevice) error {
+	if len(devs) > MaxRecoveryDevices {
+		return fmt.Errorf("refusing recovery discovery with %d devices (maximum %d)", len(devs), MaxRecoveryDevices)
+	}
+	return nil
+}
+
+// SelectRecoveryDevice applies an explicit selector to an already family-
+// filtered, bounded discovery result. It never includes ECIDs or their digests
+// in errors. Zero, multiple, missing-identity, and mismatch cases all fail
+// closed rather than falling back to the first device.
+func SelectRecoveryDevice(devs []RecoveryDevice, selector RecoverySelector) (RecoveryDevice, error) {
+	normalized, err := NewRecoverySelector(selector.PathKey, selector.ExpectedECIDDigest)
+	if err != nil {
+		return RecoveryDevice{}, err
+	}
+	selector = normalized
+	if selector.IsZero() {
+		return RecoveryDevice{}, fmt.Errorf("an explicit recovery selector is required")
+	}
+	if err := ValidateRecoveryDeviceCount(devs); err != nil {
+		return RecoveryDevice{}, err
+	}
+	if len(devs) == 0 {
+		return RecoveryDevice{}, fmt.Errorf("no recovery device is present for the requested target family")
+	}
+
+	matches := make([]RecoveryDevice, 0, 1)
+	identityUnavailable := false
+	for _, dev := range devs {
+		if selector.PathKey != "" && dev.PathKey != selector.PathKey {
+			continue
+		}
+		if selector.ExpectedECIDDigest != "" {
+			got := dev.ECIDDigest()
+			if got == "" {
+				identityUnavailable = true
+				continue
+			}
+			if subtle.ConstantTimeCompare([]byte(got), []byte(selector.ExpectedECIDDigest)) != 1 {
+				continue
+			}
+		}
+		matches = append(matches, dev)
+	}
+
+	switch len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
+		if selector.ExpectedECIDDigest != "" && identityUnavailable {
+			return RecoveryDevice{}, fmt.Errorf("a recovery device did not expose a valid ECID; refusing an identity-unverified flash")
+		}
+		return RecoveryDevice{}, fmt.Errorf("no recovery device matched the expected identity and USB path")
+	default:
+		return RecoveryDevice{}, fmt.Errorf("multiple recovery devices matched the expected identity and USB path")
+	}
+}
+
+// RecoveryECIDDigest returns the domain-separated digest used by
+// --expected-recovery-ecid-sha256. Invalid/raw descriptor values return an
+// empty string so callers can fail closed without reflecting them in errors.
+func RecoveryECIDDigest(ecid string) string {
+	normalized, ok := normalizeRecoveryECID(ecid)
+	if !ok {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(recoveryECIDDigestDomain + normalized))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// RecoveryECIDFromUSBSerial converts the reversed 32-hex USB serial exposed by
+// NVIDIA's bootROM into the canonical ECID used by tegrarcm. It is primarily
+// used by Windows SetupAPI enumeration; Linux/macOS parse the same descriptor
+// directly over EP0.
+func RecoveryECIDFromUSBSerial(serial string) string {
+	normalized, ok := normalizeRecoveryECID(serial)
+	if !ok {
+		return ""
+	}
+	return reverseASCII(normalized)
+}
+
+func normalizeRecoveryECID(ecid string) (string, bool) {
+	if len(ecid) != 32 {
+		return "", false
+	}
+	for i := 0; i < len(ecid); i++ {
+		if !isHexDigit(ecid[i]) {
+			return "", false
+		}
+	}
+	return strings.ToLower(ecid), true
+}
+
+func isHexDigit(c byte) bool {
+	return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f')
+}
+
+func reverseASCII(s string) string {
+	b := []byte(s)
+	for i, j := 0, len(b)-1; i < j; i, j = i+1, j-1 {
+		b[i], b[j] = b[j], b[i]
+	}
+	return string(b)
+}
+
+func normalizeRecoveryECIDDigest(digest string) (string, error) {
+	if digest == "" {
+		return "", nil
+	}
+	if len(digest) != len("sha256:")+sha256.Size*2 || !strings.HasPrefix(digest, "sha256:") {
+		return "", fmt.Errorf("expected recovery ECID digest must be sha256:<64 hexadecimal characters>")
+	}
+	hexPart := digest[len("sha256:"):]
+	if _, err := hex.DecodeString(hexPart); err != nil {
+		return "", fmt.Errorf("expected recovery ECID digest must be sha256:<64 hexadecimal characters>")
+	}
+	return "sha256:" + strings.ToLower(hexPart), nil
+}
 
 // RecoveryDevice identifies a Jetson sitting in USB recovery mode. PathKey is the
 // physical USB location (bus + parent-port chain); it is stable across the
@@ -26,6 +201,23 @@ type RecoveryDevice struct {
 	// (redirected/virtualized USB may report no location path at all). Empty on
 	// gousb platforms, where PathKey (bus + port chain) is always present.
 	Instance string
+}
+
+// ECIDDigest returns a stable, non-raw identity for exact selection. Empty
+// means the device did not expose a valid canonical ECID.
+func (r RecoveryDevice) ECIDDigest() string { return RecoveryECIDDigest(r.ECID) }
+
+// PinnedSelector captures both selectors observable for this device. It never
+// silently degrades to a path-only or identity-only pin.
+func (r RecoveryDevice) PinnedSelector() (RecoverySelector, error) {
+	if r.PathKey == "" {
+		return RecoverySelector{}, fmt.Errorf("recovery device has no stable controller USB path")
+	}
+	digest := r.ECIDDigest()
+	if digest == "" {
+		return RecoverySelector{}, fmt.Errorf("recovery device did not expose a valid ECID")
+	}
+	return NewRecoverySelector(r.PathKey, digest)
 }
 
 // IsThor reports whether the device is a T264 (AGX Thor).
@@ -45,17 +237,20 @@ func (r RecoveryDevice) IsOrinNano() bool {
 	return r.Product == uint16(ProductOrinNano8) || r.Product == uint16(ProductOrinNano4)
 }
 
-// Describe returns a one-line human label for pickers/logs.
+// Describe returns a one-line human label for pickers/logs. Raw ECIDs and their
+// stable digests are deliberately omitted: both are durable hardware identifiers.
 func (r RecoveryDevice) Describe() string {
 	chip := "Jetson"
 	if r.IsThor() {
 		chip = "AGX Thor (T264)"
-	} else if name, ok := T234ModuleName(r.Product); ok {
-		chip = name + " (T234)"
+	} else if r.IsOrin() {
+		// A recovery PID is a transport/product continuity check, not physical
+		// module/carrier attestation. The recovery initrd verifies those later.
+		chip = fmt.Sprintf("Jetson T234 recovery (USB product 0x%04x)", r.Product)
 	}
-	ecid := r.ECID
-	if ecid == "" {
-		ecid = "unknown"
+	identity := "ECID unavailable"
+	if r.ECIDDigest() != "" {
+		identity = "ECID available"
 	}
-	return fmt.Sprintf("%s  [usb %s, ECID %s]", chip, r.PathKey, ecid)
+	return fmt.Sprintf("%s  [usb %s, %s]", chip, r.PathKey, identity)
 }

--- a/go/internal/cli/tegraflash/rcm/recovery_test.go
+++ b/go/internal/cli/tegraflash/rcm/recovery_test.go
@@ -5,21 +5,22 @@ import (
 	"testing"
 )
 
+const testCanonicalECID = "80012641783de2442400000016ff80c0"
+
 // The T234 family enumerates one recovery PID per module SKU (0x7<module>23).
 // Detection must accept all of them — matching only the AGX Orin PID made an
 // Orin Nano in recovery mode invisible to the CLI (WDY-1888).
 func TestT234FamilyRecoveryPIDs(t *testing.T) {
 	tests := []struct {
 		pid       uint16
-		module    string
 		agx, nano bool
 	}{
-		{ProductOrinAGX32, "AGX Orin 32GB", true, false},
-		{ProductOrinAGX64, "AGX Orin 64GB", true, false},
-		{ProductOrinNX16, "Orin NX 16GB", false, false},
-		{ProductOrinNX8, "Orin NX 8GB", false, false},
-		{ProductOrinNano8, "Orin Nano 8GB", false, true},
-		{ProductOrinNano4, "Orin Nano 4GB", false, true},
+		{ProductOrinAGX32, true, false},
+		{ProductOrinAGX64, true, false},
+		{ProductOrinNX16, false, false},
+		{ProductOrinNX8, false, false},
+		{ProductOrinNano8, false, true},
+		{ProductOrinNano4, false, true},
 	}
 	for _, tc := range tests {
 		d := RecoveryDevice{Product: tc.pid}
@@ -32,8 +33,8 @@ func TestT234FamilyRecoveryPIDs(t *testing.T) {
 		if d.IsOrinAGX() != tc.agx || d.IsOrinNano() != tc.nano {
 			t.Errorf("PID 0x%04x: IsOrinAGX=%v IsOrinNano=%v, want %v/%v", tc.pid, d.IsOrinAGX(), d.IsOrinNano(), tc.agx, tc.nano)
 		}
-		if got := d.Describe(); !strings.Contains(got, tc.module) {
-			t.Errorf("Describe() for PID 0x%04x = %q, want module %q", tc.pid, got, tc.module)
+		if got := d.Describe(); !strings.Contains(got, "T234 recovery") || strings.Contains(got, "Nano 8GB") || strings.Contains(got, "AGX Orin") {
+			t.Errorf("Describe() for PID 0x%04x made a SKU claim: %q", tc.pid, got)
 		}
 	}
 }
@@ -45,5 +46,120 @@ func TestNonT234PIDsRejected(t *testing.T) {
 	}
 	if IsT234RecoveryPID(ProductThor) || IsT234RecoveryPID(0x7123) || IsT234RecoveryPID(0x0104) {
 		t.Error("non-T234 PID accepted as T234 recovery PID")
+	}
+}
+
+func TestRecoveryECIDDigestIsCanonicalAndDomainSeparated(t *testing.T) {
+	want := RecoveryECIDDigest(testCanonicalECID)
+	const literal = "sha256:52c5b9de12b1f1943a441df0ecdea9f3eb94c7f64b98968855390f14c6e6e05c"
+	if want != literal {
+		t.Fatalf("domain-separated digest = %q, want %q", want, literal)
+	}
+	if got := RecoveryECIDDigest(strings.ToUpper(testCanonicalECID)); got != want {
+		t.Fatalf("uppercase ECID digest = %q, want %q", got, want)
+	}
+	if got := RecoveryECIDDigest("wendyos-recovery-ecid-v1\n" + testCanonicalECID); got != "" {
+		t.Fatalf("non-ECID input unexpectedly hashed: %q", got)
+	}
+	if got := RecoveryECIDFromUSBSerial("0C08FF6100000042442ED38714621008"); got != testCanonicalECID {
+		t.Fatalf("USB serial normalized to %q, want %q", got, testCanonicalECID)
+	}
+}
+
+func TestRecoverySelectorValidation(t *testing.T) {
+	digest := RecoveryECIDDigest(testCanonicalECID)
+	selector, err := NewRecoverySelector("1-2.3", strings.ToUpper(digest[:7])+digest[7:])
+	if err == nil {
+		// The algorithm prefix is deliberately canonical/lowercase. This keeps
+		// the external contract exact and avoids multiple serialized spellings.
+		t.Fatalf("uppercase digest prefix accepted: %+v", selector)
+	}
+	selector, err = NewRecoverySelector("1-2.3", "sha256:"+strings.ToUpper(digest[len("sha256:"):]))
+	if err != nil || selector.ExpectedECIDDigest != digest {
+		t.Fatalf("uppercase hex normalization = %+v, %v", selector, err)
+	}
+	for _, path := range []string{" 1-2", "1-2\n", strings.Repeat("x", maxRecoveryPathBytes+1)} {
+		if _, err := NewRecoverySelector(path, digest); err == nil {
+			t.Errorf("unsafe path accepted (length %d)", len(path))
+		}
+	}
+	if _, err := NewRecoverySelector("1-2", "sha256:not-a-digest"); err == nil {
+		t.Fatal("invalid digest accepted")
+	}
+	if _, err := NewRecoverySelector("1-2", ""); err == nil {
+		t.Fatal("path-only selector accepted")
+	}
+	if _, err := NewRecoverySelector("", digest); err == nil {
+		t.Fatal("digest-only selector accepted")
+	}
+	if selector, err := NewRecoverySelector("", ""); err != nil || !selector.IsZero() {
+		t.Fatalf("empty interactive selector = %+v, %v", selector, err)
+	}
+}
+
+func TestSelectRecoveryDeviceFailsClosed(t *testing.T) {
+	wanted := RecoveryDevice{PathKey: "1-2", Product: ProductOrinNano8, ECID: testCanonicalECID}
+	other := RecoveryDevice{PathKey: "1-3", Product: ProductOrinNano8, ECID: "10012641783de2442400000016ff80c0"}
+	selector, err := NewRecoverySelector(wanted.PathKey, wanted.ECIDDigest())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := SelectRecoveryDevice([]RecoveryDevice{other, wanted}, selector)
+	if err != nil || got.PathKey != wanted.PathKey {
+		t.Fatalf("selection = %+v, %v", got, err)
+	}
+
+	cases := []struct {
+		name string
+		devs []RecoveryDevice
+		sel  RecoverySelector
+	}{
+		{"zero", nil, selector},
+		{"mismatch", []RecoveryDevice{other}, selector},
+		{"missing ECID", []RecoveryDevice{{PathKey: wanted.PathKey, Product: ProductOrinNano8}}, selector},
+		{"multiple", []RecoveryDevice{wanted, wanted}, selector},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := SelectRecoveryDevice(tc.devs, tc.sel)
+			if err == nil {
+				t.Fatal("expected fail-closed selection error")
+			}
+			if strings.Contains(strings.ToLower(err.Error()), testCanonicalECID) || strings.Contains(err.Error(), wanted.ECIDDigest()) {
+				t.Fatalf("identity leaked in error: %v", err)
+			}
+		})
+	}
+
+	tooMany := make([]RecoveryDevice, MaxRecoveryDevices+1)
+	if _, err := SelectRecoveryDevice(tooMany, selector); err == nil {
+		t.Fatal("oversized discovery result accepted")
+	}
+}
+
+func TestDescribeNeverExposesRecoveryIdentity(t *testing.T) {
+	d := RecoveryDevice{PathKey: "1-2", Product: ProductThor, ECID: testCanonicalECID}
+	got := d.Describe()
+	if strings.Contains(strings.ToLower(got), testCanonicalECID) || strings.Contains(got, d.ECIDDigest()) {
+		t.Fatalf("Describe leaked hardware identity: %q", got)
+	}
+	if !strings.Contains(got, "ECID available") {
+		t.Fatalf("Describe lost availability signal: %q", got)
+	}
+}
+
+func TestPinnedSelectorNeverDegrades(t *testing.T) {
+	valid := RecoveryDevice{PathKey: "1-2", Product: ProductThor, ECID: testCanonicalECID}
+	selector, err := valid.PinnedSelector()
+	if err != nil || selector.PathKey == "" || selector.ExpectedECIDDigest == "" {
+		t.Fatalf("valid pin = %+v, %v", selector, err)
+	}
+	for _, dev := range []RecoveryDevice{
+		{Product: ProductThor, ECID: testCanonicalECID},
+		{PathKey: "1-2", Product: ProductThor},
+	} {
+		if _, err := dev.PinnedSelector(); err == nil {
+			t.Fatalf("partial device pin accepted: %+v", dev)
+		}
 	}
 }

--- a/go/internal/cli/tegraflash/rcm/select_other.go
+++ b/go/internal/cli/tegraflash/rcm/select_other.go
@@ -13,3 +13,8 @@ func ListRecoveryDevices() ([]RecoveryDevice, error) {
 func WaitForDeviceAt(string, uint16) (*Device, error) {
 	return nil, fmt.Errorf("Jetson USB recovery flashing is not supported on this platform")
 }
+
+// WaitForDevice is unsupported off macOS/Linux.
+func WaitForDevice(RecoverySelector, uint16) (*Device, error) {
+	return nil, fmt.Errorf("Jetson USB recovery flashing is not supported on this platform")
+}

--- a/go/internal/cli/tegraflash/rcm/select_usb.go
+++ b/go/internal/cli/tegraflash/rcm/select_usb.go
@@ -44,19 +44,30 @@ func ListRecoveryDevices() ([]RecoveryDevice, error) {
 	if errors.Is(err, gousb.ErrorAccess) {
 		accessErr = fmt.Errorf("%w: a Jetson in recovery mode is connected but could not be opened: %v", ErrUSBAccess, err)
 	}
+	if len(devs) > MaxRecoveryDevices {
+		for _, dev := range devs {
+			dev.Close()
+		}
+		return nil, fmt.Errorf("refusing recovery discovery with %d devices (maximum %d)", len(devs), MaxRecoveryDevices)
+	}
 	var out []RecoveryDevice
 	for _, dev := range devs {
-		rd := RecoveryDevice{PathKey: portKey(dev.Desc), Product: uint16(dev.Desc.Product)}
-		buf := make([]byte, 96)
-		if n, err := dev.Control(0x80, 0x06, 0x0303, 0x0000, buf); err == nil {
-			if id, err := parseChipIDDescriptor(buf, n); err == nil {
-				rd.ECID = id
-			}
-		}
+		rd := describeRecoveryDevice(dev)
 		out = append(out, rd)
 		dev.Close()
 	}
 	return out, accessErr
+}
+
+func describeRecoveryDevice(dev *gousb.Device) RecoveryDevice {
+	rd := RecoveryDevice{PathKey: portKey(dev.Desc), Product: uint16(dev.Desc.Product)}
+	buf := make([]byte, 96)
+	if n, err := dev.Control(0x80, 0x06, 0x0303, 0x0000, buf); err == nil {
+		if id, err := parseChipIDDescriptor(buf, n); err == nil {
+			rd.ECID = id
+		}
+	}
+	return rd
 }
 
 // WaitForDeviceAt blocks until the Jetson at pathKey (from ListRecoveryDevices)
@@ -64,31 +75,107 @@ func ListRecoveryDevices() ([]RecoveryDevice, error) {
 // physical port; an expectedProduct of zero retains the legacy any-Jetson
 // behavior. Recovery installers must always pass the product they selected.
 func WaitForDeviceAt(pathKey string, expectedProduct uint16) (*Device, error) {
+	return waitForDevice(RecoverySelector{PathKey: pathKey}, expectedProduct, false)
+}
+
+// WaitForDevice re-opens and identity-checks the selected recovery device on
+// the same handle that will receive the RCM payload. This is the final check
+// before the non-persistent recovery handoff; a missing/mismatched ECID never
+// falls back to another device at the same port or of the same product family.
+func WaitForDevice(selector RecoverySelector, expectedProduct uint16) (*Device, error) {
+	normalized, err := NewRecoverySelector(selector.PathKey, selector.ExpectedECIDDigest)
+	if err != nil {
+		return nil, err
+	}
+	if normalized.IsZero() {
+		return nil, fmt.Errorf("an exact recovery selector is required before the RCM handoff")
+	}
+	return waitForDevice(normalized, expectedProduct, true)
+}
+
+func waitForDevice(selector RecoverySelector, expectedProduct uint16, exact bool) (*Device, error) {
 	ctx := gousb.NewContext()
 	ctx.Debug(0)
 
 	deadline := time.Now().Add(60 * time.Second)
 	for time.Now().Before(deadline) {
 		devs, err := ctx.OpenDevices(func(d *gousb.DeviceDesc) bool {
-			return d.Vendor == gousb.ID(VendorNVIDIA) && isRecoveryPID(d.Product) &&
-				(expectedProduct == 0 || uint16(d.Product) == expectedProduct) &&
-				(pathKey == "" || portKey(d) == pathKey)
+			// Enumerate and bound the entire recovery set before applying path,
+			// product, or ECID filters. A hostile oversized view must not collapse
+			// into one apparently safe target after filtering.
+			return d.Vendor == gousb.ID(VendorNVIDIA) && isRecoveryPID(d.Product)
 		})
 		// Access denied won't heal within the wait window; fail now with the
 		// classified error instead of spinning to a misleading timeout.
-		if len(devs) == 0 && errors.Is(err, gousb.ErrorAccess) {
+		if errors.Is(err, gousb.ErrorAccess) {
+			for _, dev := range devs {
+				dev.Close()
+			}
 			ctx.Close()
 			return nil, fmt.Errorf("%w: %v", ErrUSBAccess, err)
 		}
-		var chosen *gousb.Device
-		for i, dev := range devs {
-			if i == 0 {
-				chosen = dev
-			} else {
+		if len(devs) > MaxRecoveryDevices {
+			for _, dev := range devs {
 				dev.Close()
 			}
+			ctx.Close()
+			return nil, fmt.Errorf("refusing recovery discovery with %d devices (maximum %d)", len(devs), MaxRecoveryDevices)
 		}
+
+		candidates := make([]RecoveryDevice, 0, len(devs))
+		candidateHandles := make([]*gousb.Device, 0, len(devs))
+		productChangedAtPinnedPath := false
+		for _, dev := range devs {
+			rd := describeRecoveryDevice(dev)
+			if expectedProduct != 0 && rd.Product != expectedProduct {
+				if selector.PathKey != "" && rd.PathKey == selector.PathKey {
+					productChangedAtPinnedPath = true
+				}
+				continue
+			}
+			if !exact && selector.PathKey != "" && rd.PathKey != selector.PathKey {
+				continue
+			}
+			candidates = append(candidates, rd)
+			candidateHandles = append(candidateHandles, dev)
+		}
+		if productChangedAtPinnedPath {
+			for _, dev := range devs {
+				dev.Close()
+			}
+			ctx.Close()
+			return nil, fmt.Errorf("the recovery device at the selected USB path changed product; refusing the RCM handoff")
+		}
+
+		var chosen *gousb.Device
+		if exact {
+			selected, selectErr := SelectRecoveryDevice(candidates, selector)
+			if selectErr == nil {
+				for i, candidate := range candidates {
+					if candidate.PathKey == selected.PathKey && candidate.Product == selected.Product && candidate.ECID == selected.ECID {
+						chosen = candidateHandles[i]
+						break
+					}
+				}
+			} else if len(candidates) > 0 {
+				for _, dev := range devs {
+					dev.Close()
+				}
+				ctx.Close()
+				return nil, selectErr
+			}
+		} else if len(candidates) > 0 {
+			// Backward-compatible internal API behavior. Recovery install flows
+			// use WaitForDevice with identity + path instead.
+			chosen = candidateHandles[0]
+		}
+
 		if chosen != nil {
+			for _, dev := range devs {
+				if dev != chosen {
+					dev.Close()
+				}
+			}
 			d, err := openDevice(ctx, chosen)
 			if err != nil {
 				chosen.Close()
@@ -97,8 +184,11 @@ func WaitForDeviceAt(pathKey string, expectedProduct uint16) (*Device, error) {
 			}
 			return d, nil
 		}
+		for _, dev := range devs {
+			dev.Close()
+		}
 		time.Sleep(500 * time.Millisecond)
 	}
 	ctx.Close()
-	return nil, fmt.Errorf("timed out waiting for Jetson product 0x%04x at usb %s in recovery mode", expectedProduct, pathKey)
+	return nil, fmt.Errorf("timed out waiting for the selected Jetson product 0x%04x in recovery mode", expectedProduct)
 }

--- a/go/internal/cli/tegraflash/t234/disk.go
+++ b/go/internal/cli/tegraflash/t234/disk.go
@@ -23,7 +23,10 @@ const (
 // splits it back into the export name and session serial via splitInquiry.
 const FlashpkgVendor = "flashpkg"
 
-const sessionSerialLen = 8
+const (
+	sessionSerialLen = 8
+	maxUMSDisks      = 32
+)
 
 // splitInquiry recovers the export name and session id after SCSI splits the
 // gadget inquiry string across its fixed-width vendor and product fields.
@@ -84,8 +87,8 @@ func observedUMSHint() string {
 func tegraUSBLabel(vendor, product uint16) string {
 	switch {
 	case vendor == 0x0955:
-		if name, ok := rcm.T234ModuleName(product); ok {
-			return fmt.Sprintf("0955:%04x (%s APX recovery)", product, name)
+		if rcm.IsT234RecoveryPID(product) {
+			return fmt.Sprintf("0955:%04x (NVIDIA T234 recovery; product only, not module/carrier attestation)", product)
 		}
 		return fmt.Sprintf("0955:%04x (NVIDIA recovery)", product)
 	case vendor == GadgetVendorID && product == GadgetProductID:
@@ -110,6 +113,9 @@ func WaitForUMSDiskAt(ctx context.Context, selector LUNSelector, timeout time.Du
 	for {
 		disks, err := scanUMSDisks()
 		if err == nil {
+			if len(disks) > maxUMSDisks {
+				return UMSDisk{}, fmt.Errorf("refusing USB storage discovery with %d disks (maximum %d)", len(disks), maxUMSDisks)
+			}
 			var matches []UMSDisk
 			for _, d := range disks {
 				if d.Vendor != selector.Vendor {

--- a/go/internal/cli/tegraflash/t234/flash.go
+++ b/go/internal/cli/tegraflash/t234/flash.go
@@ -41,6 +41,10 @@ type Stage2 struct {
 	ImagesDir        string
 	Plan             *Plan
 	PortPath         string
+	// RequireExactPort disables the legacy single-device off-port fallback.
+	// Automation that supplies an external ECID digest + controller path sets
+	// this so a topology change fails before the first raw write.
+	RequireExactPort bool
 	Session          string
 	StatusPath       string
 	LogsPath         string
@@ -94,7 +98,7 @@ func (s *Stage2) SendFlashPackage(ctx context.Context) error {
 	// than the bootROM's recovery device, which moves it to the connector's
 	// other root-hub port (e.g. recovery high-speed at usb 1-1, SuperSpeed
 	// gadget at usb 1-2 — seen live on an Orin Nano on macOS).
-	disk, err := WaitForUMSDiskAt(ctx, LUNSelector{Vendor: FlashpkgVendor, PortPath: s.PortPath, PortHint: true}, flashpkgWait)
+	disk, err := WaitForUMSDiskAt(ctx, s.flashPackageSelector(), flashpkgWait)
 	if err != nil {
 		return err
 	}
@@ -117,6 +121,10 @@ func (s *Stage2) SendFlashPackage(ctx context.Context) error {
 		return err
 	}
 	return s.release(ctx, disk)
+}
+
+func (s *Stage2) flashPackageSelector() LUNSelector {
+	return LUNSelector{Vendor: FlashpkgVendor, PortPath: s.PortPath, PortHint: !s.RequireExactPort}
 }
 
 // adoptGadget re-pins stage-2 correlation to the identity-verified gadget LUN:

--- a/go/internal/cli/tegraflash/t234/recovery_state_test.go
+++ b/go/internal/cli/tegraflash/t234/recovery_state_test.go
@@ -61,6 +61,16 @@ func TestWaitForUMSDiskAtRejectsAmbiguity(t *testing.T) {
 	}
 }
 
+func TestWaitForUMSDiskAtRejectsOversizedDiscoveryBeforeFiltering(t *testing.T) {
+	withUMSScan(t, func() ([]UMSDisk, error) {
+		return make([]UMSDisk, maxUMSDisks+1), nil
+	})
+	_, err := WaitForUMSDiskAt(context.Background(), LUNSelector{Vendor: FlashpkgVendor, PortPath: "1-3"}, time.Second)
+	if err == nil || !strings.Contains(err.Error(), "refusing USB storage discovery") {
+		t.Fatalf("oversized-discovery error = %v", err)
+	}
+}
+
 func TestValidateDeviceIdentity(t *testing.T) {
 	want := IdentityExpectation{ModuleID: "3701", ModuleSKU: "0005", CarrierID: "3737", CarrierSKU: "0000"}
 	got := DeviceIdentity{Protocol: DeviceIdentityProtocol, SessionID: "ABCDEF12", ModuleID: "3701", ModuleSKU: "0005", CarrierID: "3737", CarrierSKU: "0000"}
@@ -243,5 +253,16 @@ func TestAdoptGadgetRepinsPortAndSession(t *testing.T) {
 	s.adoptGadget(UMSDisk{DevPath: "/dev/disk6", Vendor: FlashpkgVendor, PortPath: "1-2", Serial: "f3885343"})
 	if s.PortPath != "1-2" || s.Session != "f3885343" {
 		t.Fatalf("adopted state: port=%q session=%q", s.PortPath, s.Session)
+	}
+}
+
+func TestFlashPackageSelectorCanRequireExactControllerPort(t *testing.T) {
+	legacy := (&Stage2{PortPath: "1-2"}).flashPackageSelector()
+	if !legacy.PortHint {
+		t.Fatal("interactive compatibility path lost its unique off-port fallback")
+	}
+	exact := (&Stage2{PortPath: "1-2", RequireExactPort: true}).flashPackageSelector()
+	if exact.PortHint || exact.PortPath != "1-2" || exact.Vendor != FlashpkgVendor {
+		t.Fatalf("exact flash-package selector = %+v", exact)
 	}
 }

--- a/go/internal/cli/tegraflash/winusb/enumerate_windows.go
+++ b/go/internal/cli/tegraflash/winusb/enumerate_windows.go
@@ -89,7 +89,15 @@ func (d Device) IsGadget() bool { return d.PID == ProductGadget }
 // (the bootROM reports the chip ECID there) becomes the ECID, and the PnP
 // instance ID rides along as the exact devnode handle for the stage-1 open.
 func (d Device) RecoveryDevice() rcm.RecoveryDevice {
-	return rcm.RecoveryDevice{PathKey: d.LocationPath, Product: d.PID, ECID: d.Serial, Instance: d.InstanceID}
+	return rcm.RecoveryDevice{
+		PathKey: d.LocationPath,
+		Product: d.PID,
+		// NVIDIA exposes the USB serial in reverse-nibble order. Canonicalize it
+		// to the same BR_CID display order used by tegrarcm and the gousb path.
+		// Windows-generated composite IDs contain '&' and fail strict parsing.
+		ECID:     rcm.RecoveryECIDFromUSBSerial(d.Serial),
+		Instance: d.InstanceID,
+	}
 }
 
 // Describe returns a one-line human label for pickers and logs.
@@ -99,10 +107,7 @@ func (d Device) Describe() string {
 	case d.PID == ProductThor:
 		kind = "AGX Thor (T264) recovery"
 	case d.IsT234():
-		kind = "Orin (T234) recovery"
-		if name, ok := rcm.T234ModuleName(d.PID); ok {
-			kind = name + " (T234) recovery"
-		}
+		kind = fmt.Sprintf("Jetson T234 recovery (USB product 0x%04x)", d.PID)
 	case d.PID == ProductGadget:
 		kind = "initrd-flash gadget"
 	default:

--- a/go/internal/cli/tegraflash/winusb/enumerate_windows_test.go
+++ b/go/internal/cli/tegraflash/winusb/enumerate_windows_test.go
@@ -2,7 +2,11 @@
 
 package winusb
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/rcm"
+)
 
 // These helpers are shared with package t234's gadget-disk discovery and USB
 // release; both sides must extract identity from PnP instance IDs identically.
@@ -31,5 +35,28 @@ func TestInstanceSerial(t *testing.T) {
 	}
 	if got := InstanceSerial("no-backslash"); got != "" {
 		t.Fatalf("malformed id = %q", got)
+	}
+}
+
+func TestRecoveryDeviceCanonicalizesUSBSerialLikeGousb(t *testing.T) {
+	d := Device{
+		InstanceID:   `USB\VID_0955&PID_7026\0C08FF6100000042442ED38714621008`,
+		PID:          ProductThor,
+		Serial:       "0C08FF6100000042442ED38714621008",
+		LocationPath: "PCIROOT(0)#USBROOT(0)#USB(2)",
+	}
+	rd := d.RecoveryDevice()
+	if rd.ECID != "80012641783de2442400000016ff80c0" {
+		t.Fatalf("canonical ECID = %q", rd.ECID)
+	}
+	// Cross-OS fixture: Linux/macOS parse the reversed descriptor into this
+	// canonical BR_CID, so both paths must derive the exact same digest.
+	if got, want := rd.ECIDDigest(), rcm.RecoveryECIDDigest("80012641783DE2442400000016FF80C0"); got == "" || got != want {
+		t.Fatalf("Windows digest = %q, gousb digest = %q", got, want)
+	}
+
+	d.Serial = `7&2C54F607&0&0000`
+	if got := d.RecoveryDevice().ECID; got != "" {
+		t.Fatalf("composite/generated instance id accepted as ECID: %q", got)
 	}
 }

--- a/go/internal/cli/tegraflash/winusb/rcmboot_windows.go
+++ b/go/internal/cli/tegraflash/winusb/rcmboot_windows.go
@@ -13,6 +13,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/rcm"
 )
 
 // StageOneOptions controls a Windows stage-1 RCM boot.
@@ -24,7 +26,10 @@ type StageOneOptions struct {
 	Location        string   // optional location path to pin the device
 	Instance        string   // optional PnP instance ID pinning the exact devnode (wins over Location)
 	ExpectedProduct uint16
-	Out             io.Writer
+	// ExpectedECIDDigest is the domain-separated canonical BR_CID digest. It
+	// must be paired with Location; raw ECIDs are never accepted or logged.
+	ExpectedECIDDigest string
+	Out                io.Writer
 }
 
 // bootROM image filenames (mirror of package bringup).
@@ -41,6 +46,16 @@ var defaultSendOrder = []string{fileBctBR, fileMB1, filePSCBL1, fileBctMB1}
 // StageOneBoot performs the stage-1 RCM boot. On success the device has booted
 // the blob and is re-enumerating as the initrd-flash ADB gadget (0955:7100).
 func StageOneBoot(opts StageOneOptions) error {
+	if opts.ExpectedProduct == 0 {
+		return fmt.Errorf("an expected Jetson recovery product is required before RCM handoff")
+	}
+	selector, err := rcm.NewRecoverySelector(opts.Location, opts.ExpectedECIDDigest)
+	if err != nil {
+		return fmt.Errorf("validating recovery target selector: %w", err)
+	}
+	if selector.IsZero() {
+		return fmt.Errorf("recovery target identity and USB path are required before RCM handoff")
+	}
 	out := opts.Out
 	if out == nil {
 		out = os.Stdout
@@ -73,12 +88,17 @@ func StageOneBoot(opts StageOneOptions) error {
 	}
 
 	fmt.Fprintln(out, "Opening Jetson in recovery mode over WinUSB…")
-	var dev *USBDevice
-	if opts.Instance != "" {
-		dev, err = OpenInstance(opts.Instance, opts.ExpectedProduct)
-	} else {
-		dev, err = OpenExpected(opts.Location, opts.ExpectedProduct)
+	present, err := ListDevices()
+	if err != nil {
+		return fmt.Errorf("re-enumerating recovery devices: %w", err)
 	}
+	selected, err := selectStageOneRecoveryDevice(present, opts)
+	if err != nil {
+		return err
+	}
+	// Open the exact devnode just verified. A replacement at the same port has
+	// a different instance ID/ECID and cannot satisfy this call.
+	dev, err := OpenInstance(selected.InstanceID, opts.ExpectedProduct)
 	if err != nil {
 		return err
 	}
@@ -118,6 +138,52 @@ func StageOneBoot(opts StageOneOptions) error {
 	fmt.Fprintf(out, "  blob sent in %v; mb1 is booting the payload.\n", time.Since(t0).Round(time.Millisecond))
 	readResponse(out, dev)
 	return nil
+}
+
+// selectStageOneRecoveryDevice is the pure, testable half of the final Windows
+// identity check. SetupAPI supplies both the controller path and reversed USB
+// serial; Device.RecoveryDevice canonicalizes the latter before hashing.
+func selectStageOneRecoveryDevice(devices []Device, opts StageOneOptions) (Device, error) {
+	if opts.ExpectedProduct == 0 {
+		return Device{}, fmt.Errorf("an expected Jetson recovery product is required before RCM handoff")
+	}
+	selector, err := rcm.NewRecoverySelector(opts.Location, opts.ExpectedECIDDigest)
+	if err != nil {
+		return Device{}, fmt.Errorf("validating recovery target selector: %w", err)
+	}
+	if selector.IsZero() {
+		return Device{}, fmt.Errorf("recovery target identity and USB path are required before RCM handoff")
+	}
+
+	allRecovery := make([]rcm.RecoveryDevice, 0, len(devices))
+	for _, dev := range devices {
+		if dev.IsRecovery() {
+			allRecovery = append(allRecovery, dev.RecoveryDevice())
+		}
+	}
+	if err := rcm.ValidateRecoveryDeviceCount(allRecovery); err != nil {
+		return Device{}, err
+	}
+
+	productCandidates := make([]rcm.RecoveryDevice, 0, len(allRecovery))
+	for _, dev := range allRecovery {
+		if opts.ExpectedProduct == 0 || dev.Product == opts.ExpectedProduct {
+			productCandidates = append(productCandidates, dev)
+		}
+	}
+	selected, err := rcm.SelectRecoveryDevice(productCandidates, selector)
+	if err != nil {
+		return Device{}, err
+	}
+	if opts.Instance != "" && selected.Instance != opts.Instance {
+		return Device{}, fmt.Errorf("the recovery device changed since selection; refusing the RCM handoff")
+	}
+	for _, dev := range devices {
+		if dev.InstanceID == selected.Instance {
+			return dev, nil
+		}
+	}
+	return Device{}, fmt.Errorf("the selected recovery device disappeared before the RCM handoff")
 }
 
 // readResponse does a tolerant bulk-IN read of any status the device returns.

--- a/go/internal/cli/tegraflash/winusb/rcmboot_windows_test.go
+++ b/go/internal/cli/tegraflash/winusb/rcmboot_windows_test.go
@@ -1,0 +1,88 @@
+//go:build windows
+
+package winusb
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tegraflash/rcm"
+)
+
+func TestSelectStageOneRecoveryDeviceFailsClosed(t *testing.T) {
+	const (
+		path     = "PCIROOT(0)#USBROOT(0)#USB(2)"
+		serial   = "0C08FF6100000042442ED38714621008"
+		instance = `USB\VID_0955&PID_7026\0C08FF6100000042442ED38714621008`
+	)
+	wanted := Device{InstanceID: instance, PID: ProductThor, Serial: serial, LocationPath: path}
+	digest := wanted.RecoveryDevice().ECIDDigest()
+	opts := StageOneOptions{Location: path, Instance: instance, ExpectedProduct: ProductThor, ExpectedECIDDigest: digest}
+
+	got, err := selectStageOneRecoveryDevice([]Device{wanted}, opts)
+	if err != nil || got.InstanceID != instance {
+		t.Fatalf("selected = %+v, %v", got, err)
+	}
+
+	tests := []struct {
+		name    string
+		devices []Device
+		mutate  func(*StageOneOptions)
+	}{
+		{"zero", nil, nil},
+		{"identity mismatch", []Device{{InstanceID: `USB\VID_0955&PID_7026\10000000000000000000000000000000`, PID: ProductThor, Serial: "10000000000000000000000000000000", LocationPath: path}}, nil},
+		{"instance changed", []Device{wanted}, func(o *StageOneOptions) { o.Instance = `USB\VID_0955&PID_7026\DIFFERENT` }},
+		{"missing identity", []Device{{InstanceID: `USB\VID_0955&PID_7026\7&ABC`, PID: ProductThor, Serial: "7&ABC", LocationPath: path}}, nil},
+		{"multiple", []Device{wanted, wanted}, nil},
+		{"missing product", []Device{wanted}, func(o *StageOneOptions) { o.ExpectedProduct = 0 }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			candidate := opts
+			if tc.mutate != nil {
+				tc.mutate(&candidate)
+			}
+			_, err := selectStageOneRecoveryDevice(tc.devices, candidate)
+			if err == nil {
+				t.Fatal("expected fail-closed error")
+			}
+			if strings.Contains(strings.ToLower(err.Error()), "80012641783de2442400000016ff80c0") || strings.Contains(err.Error(), digest) {
+				t.Fatalf("identity leaked in error: %v", err)
+			}
+		})
+	}
+
+	tooMany := make([]Device, rcm.MaxRecoveryDevices+1)
+	for i := range tooMany {
+		tooMany[i] = wanted
+		tooMany[i].InstanceID += string(rune('a' + i%26))
+	}
+	if _, err := selectStageOneRecoveryDevice(tooMany, opts); err == nil {
+		t.Fatal("oversized recovery discovery accepted")
+	}
+}
+
+func TestRecoveryOpenErrorsNeverExposeInstanceIdentifiers(t *testing.T) {
+	const (
+		reversed  = "0C08FF6100000042442ED38714621008"
+		canonical = "80012641783DE2442400000016FF80C0"
+	)
+	instance := `USB\VID_0955&PID_7523\` + reversed
+	_, productErr := OpenInstance(instance, ProductThor) // pure mismatch: no OS access
+	errs := []error{
+		productErr,
+		noRecoveryInterfaceError(),
+		wrapRecoveryInterfaceOpenError(errors.New("access denied")),
+	}
+	for _, err := range errs {
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		for _, forbidden := range []string{instance, reversed, canonical} {
+			if strings.Contains(strings.ToUpper(err.Error()), strings.ToUpper(forbidden)) {
+				t.Fatalf("recovery identity leaked in error: %v", err)
+			}
+		}
+	}
+}

--- a/go/internal/cli/tegraflash/winusb/winusb_windows.go
+++ b/go/internal/cli/tegraflash/winusb/winusb_windows.go
@@ -152,6 +152,9 @@ func OpenExpected(locationPath string, expectedProduct uint16) (*USBDevice, erro
 	if err != nil {
 		return nil, err
 	}
+	if len(paths) > 32 {
+		return nil, fmt.Errorf("refusing WinUSB discovery with %d interfaces (maximum 32)", len(paths))
+	}
 	if len(paths) == 0 {
 		return nil, fmt.Errorf("no Jetson WinUSB device found (is the driver installed and the device connected?)")
 	}
@@ -164,15 +167,25 @@ func OpenExpected(locationPath string, expectedProduct uint16) (*USBDevice, erro
 	if err != nil {
 		return nil, err
 	}
+	if len(devs) > 32 {
+		return nil, fmt.Errorf("refusing Jetson USB discovery with %d devices (maximum 32)", len(devs))
+	}
+	var selectedPath string
 	for _, d := range devs {
 		if d.LocationPath != locationPath || (expectedProduct != 0 && d.PID != expectedProduct) {
 			continue
 		}
 		if p := devInterfacePath(d.InstanceID); p != "" {
-			return openPath(p)
+			if selectedPath != "" {
+				return nil, fmt.Errorf("multiple Jetson WinUSB devices matched the required controller path and product")
+			}
+			selectedPath = p
 		}
 	}
-	return nil, fmt.Errorf("no Jetson WinUSB product 0x%04x at location %q among %d present (is our driver bound to it?)", expectedProduct, locationPath, len(paths))
+	if selectedPath != "" {
+		return openPath(selectedPath)
+	}
+	return nil, fmt.Errorf("no matching Jetson WinUSB product 0x%04x among %d present devices (is our driver bound to it?)", expectedProduct, len(paths))
 }
 
 // OpenInstance opens the exact devnode named by its PnP instance ID — stronger
@@ -182,12 +195,12 @@ func OpenExpected(locationPath string, expectedProduct uint16) (*USBDevice, erro
 func OpenInstance(instanceID string, expectedProduct uint16) (*USBDevice, error) {
 	if expectedProduct != 0 {
 		if _, pid, ok := ParseVIDPID(instanceID); !ok || pid != expectedProduct {
-			return nil, fmt.Errorf("device %s is not USB product 0x%04x", instanceID, expectedProduct)
+			return nil, wrongRecoveryProductError(expectedProduct)
 		}
 	}
 	p := devInterfacePath(instanceID)
 	if p == "" {
-		return nil, fmt.Errorf("device %s does not expose the Jetson WinUSB interface (is our driver bound to it?)", instanceID)
+		return nil, noRecoveryInterfaceError()
 	}
 	return openPath(p)
 }
@@ -243,7 +256,7 @@ func openPath(devPath string) (*USBDevice, error) {
 		0,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("CreateFile(%s): %w", devPath, err)
+		return nil, wrapRecoveryInterfaceOpenError(err)
 	}
 	d := &USBDevice{handle: h}
 	if r, _, e := procWinUsbInitialize.Call(uintptr(h), uintptr(unsafe.Pointer(&d.winusb))); r == 0 {
@@ -255,6 +268,18 @@ func openPath(devPath string) (*USBDevice, error) {
 		return nil, err
 	}
 	return d, nil
+}
+
+func wrongRecoveryProductError(expectedProduct uint16) error {
+	return fmt.Errorf("selected Jetson is not USB product 0x%04x", expectedProduct)
+}
+
+func noRecoveryInterfaceError() error {
+	return fmt.Errorf("selected Jetson does not expose the Wendy WinUSB interface (is our driver bound to it?)")
+}
+
+func wrapRecoveryInterfaceOpenError(err error) error {
+	return fmt.Errorf("opening selected Jetson WinUSB interface: %w", err)
 }
 
 // discoverPipes queries the interface's endpoints and records the bulk IN/OUT

--- a/go/internal/shared/config/config.go
+++ b/go/internal/shared/config/config.go
@@ -145,8 +145,8 @@ func LogDir() (string, error) {
 		return "", fmt.Errorf("determining log directory: %w", err)
 	}
 	logDir := filepath.Join(dir, "wendy", "logs")
-	// 0o700: flash logs can contain hardware identifiers (e.g. the device ECID),
-	// so keep them readable only by the owner.
+	// 0o700: flash logs can contain sensitive host/device diagnostics. Raw ECIDs
+	// are deliberately excluded, but the remaining support data stays private.
 	if err := os.MkdirAll(logDir, 0o700); err != nil {
 		return "", fmt.Errorf("creating log directory: %w", err)
 	}


### PR DESCRIPTION
## Summary

This adds an optional fail-closed target selector for full Jetson USB-recovery installs:

- `--expected-recovery-ecid-sha256 sha256:<64-hex>`
- `--recovery-usb-path <controller-topology-path>`

The flags must be supplied together. Wendy selects the matching recovery device and revalidates the expected USB product, physical path, and domain-separated ECID digest immediately before the RCM handoff. Orin and Thor flows carry the selected path into stage two and exact mode disables the legacy off-port fallback before raw writes.

## Privacy and safety

- Raw BR_CID/ECID values are not accepted in argv or written to logs/errors/picker keys.
- The digest contract is `SHA256("wendyos-recovery-ecid-v1\n" + canonical-lowercase-32-hex-BR_CID)`.
- Windows normalizes NVIDIA's reversed USB serial into the same canonical BR_CID order used by the gousb path.
- Recovery, ADB, WinUSB, and USB-storage discovery sets are bounded before filtering.
- Zero, duplicate, partial-selector, missing-identity, product/path change, and identity-mismatch cases fail closed.
- Recovery PID labels are treated as family/routing hints, not module or carrier attestation.

The normal interactive picker remains available when the new flags are omitted. A selected board must expose a valid ECID before Wendy proceeds with destructive recovery.

## Validation

Run against current Wendy `main` with checksum-verified Go 1.26.6:

```
go test ./go/internal/cli/tegraflash/rcm \
        ./go/internal/cli/tegraflash/bringup \
        ./go/internal/cli/tegraflash/adb \
        ./go/internal/cli/tegraflash/t234 \
        ./go/internal/cli/tegraflash/winusb -count=1

go test ./go/internal/cli/commands \
  -run 'TestRecovery|TestNewOSInstallCmd_PositionalArgsIncompatibleWithFlags' \
  -count=1

go vet ./go/internal/cli/tegraflash/rcm \
       ./go/internal/cli/tegraflash/bringup \
       ./go/internal/cli/tegraflash/adb \
       ./go/internal/cli/tegraflash/t234 \
       ./go/internal/cli/commands
```

All commands above pass. `git diff --check` is clean. A separate static security/privacy review found no P0/P1 blocker.

## Deliberate draft limitations

- No physical flash was run for this change.
- Linux/libusb coverage still needs upstream CI and physical multi-device/re-enumeration validation.
- ECID cannot yet be cryptographically carried across the RCM-to-gadget transition. Exact mode therefore requires the controller topology path to remain unchanged and safely stops if the gadget moves to a USB2/USB3 companion path.
- A public structured recovery-discovery command is intentionally out of scope.
- A nonce-bound gadget attestation and tested recovery/rollback flow remain prerequisites for unattended physical flashing.