### PR TITLE
Check the Docker daemon before the build progress UI starts

### DIFF
--- a/go/internal/cli/commands/ocilayers.go
+++ b/go/internal/cli/commands/ocilayers.go
@@ -448,6 +448,16 @@ func readOCILayoutDirLayers(dir, platform string) ([]localLayer, []byte, error) 
 // ("tar") instead of the persistent layout directory. Escape hatch only.
 const chunkExportModeEnv = "WENDY_CHUNK_EXPORT"
 
+// resolveOCIExportBuilder resolves the builder an OCI-layout export will use,
+// applying the on-device BuildKit default that an unset --builder gets when no
+// docker is present. Returns normalizeImageBuilder's error for unknown builders.
+func resolveOCIExportBuilder(builder string) (string, error) {
+	if !imageBuilderWasExplicit(builder) && shouldUseBuildkitOnDevice() {
+		builder = imageBuilderBuildkit
+	}
+	return normalizeImageBuilder(builder)
+}
+
 // chunkExportPlan decides how the chunk-diff deploy exports the built image:
 // "dir" — persistent OCI layout directory (buildx tar=false, blob-deduped) —
 // for the docker backend, "tar" for backends that can only emit a tar
@@ -458,10 +468,7 @@ func chunkExportPlan(builder string) string {
 	if os.Getenv(chunkExportModeEnv) == "tar" {
 		return "tar"
 	}
-	if !imageBuilderWasExplicit(builder) && shouldUseBuildkitOnDevice() {
-		return "tar"
-	}
-	normalized, err := normalizeImageBuilder(builder)
+	normalized, err := resolveOCIExportBuilder(builder)
 	if err != nil || normalized != imageBuilderDocker {
 		return "tar"
 	}
@@ -944,10 +951,7 @@ func buildImageToOCILayoutWithBuildkit(ctx context.Context, cwd, dockerfile, pla
 // It mirrors the flag/cache/env setup of buildAndPushImage but skips registry
 // push entirely.
 func buildImageToOCILayout(ctx context.Context, cwd, dockerfile, platform string, buildArgs map[string]string, builder, dest, cacheKey string, stdout, stderr io.Writer) error {
-	if !imageBuilderWasExplicit(builder) && shouldUseBuildkitOnDevice() {
-		builder = imageBuilderBuildkit
-	}
-	normalized, err := normalizeImageBuilder(builder)
+	normalized, err := resolveOCIExportBuilder(builder)
 	if err != nil {
 		return err
 	}

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -1741,6 +1741,20 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 		return err
 	}
 
+	chunkDiffWillRun := !isDarwinAgent && !opts.deploy && opts.chunking != chunkingOff
+
+	// The daemon check prompts on macOS. Run it here: once the build progress UI
+	// owns the terminal it repaints over any prompt, so the CLI waits on input the
+	// user cannot see.
+	// An unknown builder is left for the build below to report.
+	if chunkDiffWillRun {
+		if b, err := resolveOCIExportBuilder(opts.builder); err == nil && b == imageBuilderDocker {
+			if err := ensureDockerDaemon(ctx); err != nil {
+				return err
+			}
+		}
+	}
+
 	// The fast chunk-diff (CDC) deploy path handles attached (default) and
 	// detached (--detach) runs. Deploy-only (--deploy) is excluded because it
 	// must create the container WITHOUT starting it, whereas RunContainer always
@@ -1749,7 +1763,7 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 	// --chunking gates this path: "off" skips it entirely (registry push only),
 	// while "force" uses it with no registry-push fallback on failure.
 	var ociHint *ociReuseHint
-	if !isDarwinAgent && !opts.deploy && opts.chunking != chunkingOff {
+	if chunkDiffWillRun {
 		diffIDs, hint, err := deployByChunkDiff(ctx, conn, cwd, appCfg, platform, opts.dockerfile, buildArgs, deployEnv, opts)
 		ociHint = hint
 		if err == nil {


### PR DESCRIPTION
Closes WDY-2509

## Problem

`wendy run` seemed to hang when the Docker daemon was not running. The spinner stayed on `Building image (OCI layout) for linux/arm64...` and the command did not return. Ctrl-C then showed the real cause:

```
Cause: docker daemon is not running — please start Docker Desktop and try again
```

## Cause

`ensureDockerDaemon` prompts the user on macOS before it opens Docker Desktop. That check ran from inside the build, after the build progress UI had taken the terminal. The UI repaints its two-line frame in place, so the next frame painted over the prompt. The CLI then waited for input that the user could not see.

## Change

Check the daemon before the chunk-diff deploy starts, next to the Apple Container check that already runs at that point. The prompt then renders on a clean terminal, and the later check inside the build is a no-op.

`chunkExportPlan` and `buildImageToOCILayout` each held a copy of the same builder resolution, and the check needs the same answer. That is now `resolveOCIExportBuilder`.

## Testing

Tested on a Raspberry Pi 4 running WendyOS 0.18.2, from macOS, with a Swift project targeting `linux/arm64`.