### PR TITLE
Explain what `wendy auth use <org>` actually failed to find

### DIFF
--- a/go/internal/cli/commands/auth.go
+++ b/go/internal/cli/commands/auth.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -841,6 +842,11 @@ func authConfigToJSON(auth *config.AuthConfig) ([]byte, error) {
 // An all-digit selector matches a certificate OrganizationID; otherwise it is a
 // case-insensitive substring of the gRPC endpoint or dashboard URL. It errors
 // when nothing matches or when more than one session matches.
+//
+// Matching is purely local: it only ever sees orgs this machine holds a
+// certificate for. Asking for an org that exists in the cloud but was never
+// logged into here is the common no-match case, so the error says so and points
+// at 'wendy auth login' rather than implying the org does not exist.
 func matchAuthSelector(cfg *config.Config, selector string) (*config.AuthConfig, error) {
 	selector = strings.TrimSpace(selector)
 	if selector == "" {
@@ -867,7 +873,7 @@ func matchAuthSelector(cfg *config.Config, selector string) (*config.AuthConfig,
 	}
 	switch len(matches) {
 	case 0:
-		return nil, fmt.Errorf("no auth session matches %q", selector)
+		return nil, noSessionMatchError(cfg, selector)
 	case 1:
 		return matches[0], nil
 	default:
@@ -877,6 +883,41 @@ func matchAuthSelector(cfg *config.Config, selector string) (*config.AuthConfig,
 		}
 		return nil, fmt.Errorf("selector %q matches multiple sessions:%s", selector, b.String())
 	}
+}
+
+// noSessionMatchError explains a failed selector lookup. `wendy auth use` only
+// searches locally stored certificates, so "no match" almost always means "you
+// are not logged into that org on this machine" — not that the org is missing
+// or the selector is malformed. The error therefore names what IS available and
+// gives the exact command that fixes it.
+func noSessionMatchError(cfg *config.Config, selector string) error {
+	var b strings.Builder
+	if orgID, err := strconv.Atoi(selector); err == nil {
+		fmt.Fprintf(&b, "not logged in to org %d on this machine", orgID)
+	} else {
+		fmt.Fprintf(&b, "no auth session matches %q", selector)
+	}
+
+	if labels := authSessionLabels(cfg); len(labels) > 0 {
+		b.WriteString("\n\nSessions stored here:")
+		for _, l := range labels {
+			fmt.Fprintf(&b, "\n  - %s", l)
+		}
+	}
+
+	b.WriteString("\n\n'wendy auth use' only selects between orgs this machine already holds a")
+	b.WriteString("\ncertificate for; it does not query the cloud. To add another org, run")
+	b.WriteString("\n'wendy auth login' and pick it in the browser — existing sessions are kept.")
+	return errors.New(b.String())
+}
+
+// authSessionLabels lists every stored session, most useful identifier first.
+func authSessionLabels(cfg *config.Config) []string {
+	labels := make([]string, 0, len(cfg.Auth))
+	for i := range cfg.Auth {
+		labels = append(labels, authSessionLabel(&cfg.Auth[i]))
+	}
+	return labels
 }
 
 func newAuthUseCmd() *cobra.Command {

--- a/go/internal/cli/commands/auth_default_test.go
+++ b/go/internal/cli/commands/auth_default_test.go
@@ -36,6 +36,47 @@ func TestMatchAuthSelectorNoMatch(t *testing.T) {
 	}
 }
 
+// An org ID the user is not logged into is the common failure (the org exists
+// in the cloud, just not on this machine), so the error must not read as
+// "no such org" — it names the stored sessions and the command that fixes it.
+func TestMatchAuthSelectorUnknownOrgIDExplainsLogin(t *testing.T) {
+	_, err := matchAuthSelector(selectorConfig(), "75")
+	if err == nil {
+		t.Fatal("want error for an org with no stored session")
+	}
+	got := err.Error()
+	for _, want := range []string{
+		"not logged in to org 75",
+		"wendy auth login",
+		"org 7 — prod.example.com:443",
+		"org 1 — localhost:50051",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("error missing %q:\n%s", want, got)
+		}
+	}
+	// It must not claim the org does not exist: this command never asks the cloud.
+	if strings.Contains(got, "does not exist") {
+		t.Errorf("error should not assert the org is missing:\n%s", got)
+	}
+}
+
+// A non-numeric selector is an endpoint substring, so the wording stays as a
+// selector miss rather than a login problem — but it still lists what exists.
+func TestMatchAuthSelectorUnknownSubstringListsSessions(t *testing.T) {
+	_, err := matchAuthSelector(selectorConfig(), "nope")
+	if err == nil {
+		t.Fatal("want error for an unmatched substring")
+	}
+	got := err.Error()
+	if !strings.Contains(got, `no auth session matches "nope"`) {
+		t.Errorf("want selector-miss wording, got:\n%s", got)
+	}
+	if !strings.Contains(got, "prod.example.com:443") {
+		t.Errorf("error should list stored sessions, got:\n%s", got)
+	}
+}
+
 func TestMatchAuthSelectorAmbiguous(t *testing.T) {
 	cfg := selectorConfig()
 	cfg.Auth[1].Certificates[0].OrganizationID = 7 // two sessions in org 7


### PR DESCRIPTION
`wendy auth use 75` reports `no auth session matches "75"`, which reads as "org 75 doesn't exist" or "bad selector." Neither is true — `matchAuthSelector` only searches certificates stored on the local machine, so the real meaning is "you've never logged into org 75 here."

### Before

```
✗ no auth session matches "75"
```

### After

```
✗ not logged in to org 75 on this machine

Sessions stored here:
  - org 2 — wendy-cloud-services-114319063177.us-central1.run.app:443
  - org 9 — wendy-cloud-services-114319063177.us-central1.run.app:443

'wendy auth use' only selects between orgs this machine already holds a
certificate for; it does not query the cloud. To add another org, run
'wendy auth login' and pick it in the browser — existing sessions are kept.
```

The numeric and substring cases are worded differently on purpose: an all-digit selector is almost always "I'm not logged into that org," while a non-numeric one is a genuine endpoint-substring miss, so that case keeps `no auth session matches "nope"` and just gains the session list. The wording deliberately avoids claiming the org doesn't exist, since the command never asks the cloud.

Local-only change to one error path; no behavior change on success or on the ambiguous-match path.

### Verification

- 6/6 `TestMatchAuthSelector*` tests pass, including 2 new ones covering the unknown-org and unknown-substring wording
- Full `internal/cli/commands` package passes
- `gofmt -l -s .` clean, `go build ./...` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)