### PR TITLE
Give the build-host connection the cloud fallback its doc claims

### DIFF
--- a/go/internal/cli/commands/buildhost.go
+++ b/go/internal/cli/commands/buildhost.go
@@ -256,8 +256,18 @@ func runRemoteBuild(
 // connectBuildHost resolves and connects to the build host by name, reusing the
 // same connect machinery as --device so LKG cache, mDNS and cloud fallback all
 // apply unchanged.
+//
+// The cloud fallback is what makes this feature usable by the developer it was
+// written for. resolveTarget alone is direct/LAN only, so a remote developer --
+// precisely the person who does not want to build locally -- could never reach
+// a build host, while the deploy target resolved over the tunnel in the same
+// command. `wendy cloud run --build-host` was the only working spelling, and it
+// prints a deprecation notice pointing back at this one.
+//
+// host is passed explicitly: the fallback must not read --device, which names
+// the TARGET. See resolveWithCloudFallback.
 func connectBuildHost(ctx context.Context, host string) (*grpcclient.AgentConnection, error) {
-	sel, err := resolveTarget(ctx, SelectDevice(host), NonInteractive(), SuppressUpdateCheck())
+	sel, err := resolveWithCloudFallback(ctx, host, SelectDevice(host), NonInteractive(), SuppressUpdateCheck())
 	if err != nil {
 		return nil, err
 	}

--- a/go/internal/cli/commands/buildhost_test.go
+++ b/go/internal/cli/commands/buildhost_test.go
@@ -333,3 +333,30 @@ func TestRejectUnsupportedBuildHostProject(t *testing.T) {
 		t.Fatalf("got %v, want a clear remote-build support boundary", err)
 	}
 }
+
+// TestCloudFallbackDeviceName_ExplicitWinsOverDeviceFlag is the contract that
+// keeps `wendy run --build-host` honest. Two devices are in flight -- the build
+// host and the deploy target -- and --device names the TARGET. If the cloud
+// fallback preferred the flag, connectBuildHost would tunnel to the target and
+// build there, putting the image on the machine the developer meant to deploy
+// to while reporting success.
+func TestCloudFallbackDeviceName_ExplicitWinsOverDeviceFlag(t *testing.T) {
+	got := cloudFallbackDeviceName("spark-office", "ccr2", "some-default")
+	if got != "spark-office" {
+		t.Fatalf("got %q, want the explicit build host to win over --device", got)
+	}
+}
+
+// A caller with no explicit name is resolving the deploy target itself, where
+// --device IS the device being resolved.
+func TestCloudFallbackDeviceName_FallsBackToFlagThenDefault(t *testing.T) {
+	if got := cloudFallbackDeviceName("", "ccr2", "some-default"); got != "ccr2" {
+		t.Fatalf("got %q, want the --device flag", got)
+	}
+	if got := cloudFallbackDeviceName("", "", "some-default"); got != "some-default" {
+		t.Fatalf("got %q, want the configured default", got)
+	}
+	if got := cloudFallbackDeviceName("", "", ""); got != "" {
+		t.Fatalf("got %q, want empty so the caller reports the original error", got)
+	}
+}

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -655,6 +655,38 @@ func runWithInterruptChannel(parent context.Context, sigCh <-chan os.Signal, run
 // exist, it retries via the cloud tunnel using the device name from --device
 // or the configured default.
 func resolveRunTarget(ctx context.Context, opts ...resolveOption) (*SelectedDevice, error) {
+	return resolveWithCloudFallback(ctx, "", opts...)
+}
+
+// cloudFallbackDeviceName picks which device the cloud tunnel should dial.
+//
+// An explicit name always wins, and must never be silently replaced by
+// deviceFlag: those name two different machines during `wendy run --build-host`,
+// and preferring the flag would build on the deploy target.
+func cloudFallbackDeviceName(explicit, flagValue, configDefault string) string {
+	if explicit != "" {
+		return explicit
+	}
+	if flagValue != "" {
+		return flagValue
+	}
+	return configDefault
+}
+
+// resolveWithCloudFallback is resolveRunTarget with the cloud-tunnel device name
+// stated explicitly rather than read from the --device flag.
+//
+// cloudName must be set by any caller connecting to a device that is NOT the
+// deploy target. `wendy run --build-host` has two devices in flight, and the
+// fallback name is not interchangeable between them: with cloudName empty this
+// falls back to deviceFlag, so a build-host caller would tunnel to the TARGET
+// and build on the machine it meant to deploy to — landing the image on the
+// wrong device while reporting success, which is the exact failure mode the
+// two-explicit-flags design exists to prevent.
+//
+// An empty cloudName preserves the original behaviour for the deploy target,
+// where --device IS the device being resolved.
+func resolveWithCloudFallback(ctx context.Context, cloudName string, opts ...resolveOption) (*SelectedDevice, error) {
 	target, err := resolveTarget(ctx, opts...)
 	if err == nil {
 		return target, nil
@@ -668,10 +700,7 @@ func resolveRunTarget(ctx context.Context, opts ...resolveOption) (*SelectedDevi
 		return nil, err
 	}
 
-	deviceName := deviceFlag
-	if deviceName == "" {
-		deviceName = cfg.DefaultDevice
-	}
+	deviceName := cloudFallbackDeviceName(cloudName, deviceFlag, cfg.DefaultDevice)
 	if deviceName == "" {
 		return nil, err
 	}


### PR DESCRIPTION
## The bug

`connectBuildHost` documents that it reuses the `--device` connect machinery *"so LKG cache, mDNS and cloud fallback all apply unchanged"* — but it calls `resolveTarget`, which is direct/LAN only. The cloud fallback lives in `resolveRunTarget`, and only the deploy target gets it.

So one command resolves its two devices by different rules:

| Connection | Resolver | Cloud fallback |
|---|---|---|
| Target device | `resolveRunTarget` | yes |
| **Build host** | `resolveTarget` | **no** |

For a remote developer the build host is unreachable — and that is the developer this feature exists for, since the whole premise is that a laptop need not be the machine that builds. The only working spelling was `wendy cloud run --build-host`, which prints a deprecation notice pointing back at `wendy run`.

## Measured

Builder `Spark3`, target `ccr2`, from a laptop on neither network. Before:

```
Connecting to ccr2 via cloud tunnel...        <- target resolved
✗ connecting to build host Spark3: device "Spark3" is pinned to an enrolled
  identity and no authenticated endpoint answered at any address it resolves to
```

Both halves of the failure are visible in one run: the target tunnelled, the build host did not.

After:

```
Connecting to ccr2 via cloud tunnel...
Connecting to Spark3 via cloud tunnel...
✓ Built & pushed (1 cached, 1 rebuilt) in 3.957s
Application sh.wendy.probe.buildhost running in detached mode.
```

App confirmed present on `ccr2` and absent from `Spark3`, then removed.

## The subtlety

The fallback name is passed explicitly rather than read from `deviceFlag`. `--device` names the **target**, so a build-host caller reusing it would tunnel to the target and build on the machine it meant to deploy to — landing the image on the wrong device while reporting success. That is the failure mode the two-explicit-flags design exists to prevent, so `cloudFallbackDeviceName` is split out and a test holds the ordering.

`resolveRunTarget` keeps its exact previous behaviour by passing an empty name.

## Test plan

- `go test ./internal/cli/commands` — new tests cover explicit-wins-over-flag and the unchanged target path (flag, then configured default, then empty).
- Verified on hardware as above, US build host to a device in Canada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)