### PR TITLE
Say what to install when a build host has no BuildKit

### DIFF
--- a/go/internal/cli/commands/buildhost.go
+++ b/go/internal/cli/commands/buildhost.go
@@ -169,7 +169,11 @@ func checkBuildHostCapabilities(host string, resp *agentpbv2.GetBuildCapabilitie
 		if strings.EqualFold(resp.GetOs(), "darwin") {
 			return fmt.Errorf("%s has no BuildKit daemon: macOS hosts run containers through Apple Container, which has no BuildKit underneath, so a Mac cannot be a build host", host)
 		}
-		return fmt.Errorf("%s has no BuildKit daemon and cannot build", host)
+		// Say what to do, not only what is wrong. The agent's own refusal names
+		// the socket and the daemon -- but this check runs first, before any
+		// context is transferred, so that wording is unreachable in practice and
+		// the developer lands on this line instead.
+		return fmt.Errorf("%s has no BuildKit daemon and cannot build; install buildkitd on it and start it on unix:///run/buildkit/buildkitd.sock, or omit --build-host to build locally", host)
 	}
 	if slices.Contains(resp.GetNativePlatforms(), platform) {
 		return nil

--- a/go/internal/cli/commands/buildhost_test.go
+++ b/go/internal/cli/commands/buildhost_test.go
@@ -490,3 +490,64 @@ func TestDeliveryOutcome_RecordsFailureReason(t *testing.T) {
 		t.Errorf("the reason must survive; got %q", bad.GetError())
 	}
 }
+
+// TestBuildkitAbsentNotice_SilentWhenBuildable: enabling on a working build host
+// must stay quiet. A note that fires when nothing is wrong trains people to
+// ignore the one that matters.
+func TestBuildkitAbsentNotice_SilentWhenBuildable(t *testing.T) {
+	if got := buildkitAbsentNotice(true, "linux"); got != nil {
+		t.Fatalf("got %v, want no notice when BuildKit is available", got)
+	}
+	if got := buildkitAbsentNotice(true, "darwin"); got != nil {
+		t.Fatalf("got %v, want no notice when BuildKit is available", got)
+	}
+}
+
+// TestBuildkitAbsentNotice_TellsLinuxHostsWhatToInstall covers the case that
+// motivated this: `enable` reports success and points at `wendy run
+// --build-host`, but the device has no build engine.
+func TestBuildkitAbsentNotice_TellsLinuxHostsWhatToInstall(t *testing.T) {
+	got := buildkitAbsentNotice(false, "linux")
+	if len(got) == 0 {
+		t.Fatal("want a notice when BuildKit is absent")
+	}
+	joined := strings.Join(got, "\n")
+	if !strings.Contains(joined, "buildkitd") {
+		t.Errorf("notice must name the daemon to install; got %q", joined)
+	}
+	if !strings.Contains(joined, "unix:///run/buildkit/buildkitd.sock") {
+		t.Errorf("notice must name the socket the agent looks at; got %q", joined)
+	}
+}
+
+// A Mac cannot have BuildKit at all, so it must not be told to install one.
+func TestBuildkitAbsentNotice_DoesNotSendMacsAfterADaemon(t *testing.T) {
+	joined := strings.Join(buildkitAbsentNotice(false, "darwin"), "\n")
+	if joined == "" {
+		t.Fatal("want a notice explaining why a Mac cannot build")
+	}
+	if strings.Contains(joined, "Install buildkitd") {
+		t.Errorf("must not tell a Mac to install buildkitd; got %q", joined)
+	}
+	if !strings.Contains(joined, "Apple Container") {
+		t.Errorf("should say why; got %q", joined)
+	}
+}
+
+// TestCheckBuildHostCapabilities_NamesTheRemedy: this is the message a developer
+// actually lands on. The agent's own refusal names the socket and says what to
+// install, but the CLI refuses first -- before any context transfer -- so that
+// more useful wording is unreachable in practice.
+func TestCheckBuildHostCapabilities_NamesTheRemedy(t *testing.T) {
+	err := checkBuildHostCapabilities("spark-office", &agentpbv2.GetBuildCapabilitiesResponse{
+		BuilderEnabled:    true,
+		BuildkitAvailable: false,
+		Os:                "linux",
+	}, "linux/arm64")
+	if err == nil {
+		t.Fatal("a host with no BuildKit must be refused")
+	}
+	if !strings.Contains(err.Error(), "buildkitd") || !strings.Contains(err.Error(), "unix:///run/buildkit/buildkitd.sock") {
+		t.Errorf("the error must say what to install and where; got %q", err)
+	}
+}

--- a/go/internal/cli/commands/device_buildhost.go
+++ b/go/internal/cli/commands/device_buildhost.go
@@ -1,10 +1,12 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
 
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
 )
@@ -54,11 +56,56 @@ func newDeviceBuildHostSetCmd(use, short string, enabled bool) *cobra.Command {
 			}
 			if resp.GetEnabled() {
 				cliSuccess("Build host enabled. Target it with %s.", tui.Value("wendy run --build-host <device>"))
+				warnIfCannotBuild(ctx, target.Agent)
 			} else {
 				cliSuccess("Build host disabled. This device will refuse remote builds.")
 			}
 			return nil
 		},
+	}
+}
+
+// warnIfCannotBuild says so when the role was just enabled on a device that has
+// no build engine.
+//
+// Enabling only writes the opt-in marker; the agent does not check for buildkitd
+// and should not, since the role is a policy decision that can legitimately
+// precede installing one. But the success line above tells the developer to go
+// and target this host, and without this the next thing they see is a build
+// failing with FailedPrecondition -- so the message would be a promise the
+// device cannot keep.
+//
+// Advisory only. The role IS enabled, the capability probe is best-effort, and a
+// probe that cannot answer must not make a successful enable look failed.
+func warnIfCannotBuild(ctx context.Context, agent *grpcclient.AgentConnection) {
+	caps, err := agent.BuildService.GetBuildCapabilities(ctx, &agentpbv2.GetBuildCapabilitiesRequest{})
+	if err != nil {
+		return
+	}
+	for _, line := range buildkitAbsentNotice(caps.GetBuildkitAvailable(), caps.GetOs()) {
+		cliLogln("%s", line)
+	}
+}
+
+// buildkitAbsentNotice returns the lines to print after enabling the role, or
+// nothing when the device can actually build.
+//
+// darwin gets a different message because it is not a fixable omission: the Mac
+// agent runs containers through Apple Container, which has no BuildKit under it,
+// so telling someone to install a daemon would send them after something that
+// does not exist for their platform.
+func buildkitAbsentNotice(buildkitAvailable bool, os string) []string {
+	if buildkitAvailable {
+		return nil
+	}
+	if os == "darwin" {
+		return []string{
+			"Note: This device has no BuildKit: macOS runs containers through Apple Container, which has none, so it cannot serve remote builds.",
+		}
+	}
+	return []string{
+		"Note: This device has no BuildKit daemon yet, so builds sent here will be refused.",
+		"      Install buildkitd and start it on unix:///run/buildkit/buildkitd.sock before targeting this host.",
 	}
 }
 


### PR DESCRIPTION
Rebased on current `main`. Two related gaps, both about a build host that is opted in but cannot build.

## 1. `enable` promises something the device cannot do

`build-host enable` writes the opt-in marker and prints:

```
Build host enabled. Target it with wendy run --build-host <device>.
```

It never checks that the device has a build engine. Hit twice while setting up a DGX Spark: `enable` reported success, and `status` then read `BuildKit: unavailable`.

Now, when the role is enabled on a host with no BuildKit:

```
Build host enabled. Target it with wendy run --build-host <device>.
Note: This device has no BuildKit daemon yet, so builds sent here will be refused.
      Install buildkitd and start it on unix:///run/buildkit/buildkitd.sock before targeting this host.
```

Silent again once the daemon is started. Verified on a real build host by stopping and restarting buildkitd.

## 2. The refusal a developer actually reads doesn't say what to fix

This is a correction to how the original PR described the problem, after reading `main` properly.

There are two refusals, and **the more useful one is unreachable**:

| Where | Message | Says what to do? |
|---|---|---|
| Agent, `BuildImage` | *"this build host has no buildkit daemon at `unix:///run/buildkit/buildkitd.sock`; install and start buildkitd there, or build elsewhere"* | yes |
| CLI, `checkBuildHostCapabilities` | *"spark-office has no BuildKit daemon and cannot build"* | **no** |

The CLI checks capabilities **before** transferring any context — deliberately, so a doomed build fails cheaply — which means it refuses first and the agent's better wording never reaches the developer. So the message people land on is correct about the problem and silent about the fix.

Both now carry the remedy, so it no longer depends on which layer happens to refuse first.

## What this deliberately does not change

The agent is untouched. `SetBuildHostEnabled` still succeeds without buildkitd, because the role is a policy decision that can legitimately precede installing a daemon, and the probe is best-effort — one that cannot answer must not make a successful enable look failed. This is advisory output, not a new refusal.

`darwin` gets its own wording: there it is not a fixable omission, since the Mac agent runs containers through Apple Container, which has no BuildKit underneath. Telling someone to install a daemon would send them after something that does not exist for their platform.

## Test plan

- `go test ./internal/cli/commands` — full suite green.
- Covers: silence when buildable, naming both the daemon and the socket on linux, not sending a Mac after a daemon it cannot have, and that the CLI-side refusal now names the remedy.
- Verified on hardware by stopping and restarting buildkitd on a real build host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)