### PR TITLE
cli: speak the fleet delivery protocol, with one device in the fleet

### DIFF
--- a/go/internal/cli/commands/buildhost.go
+++ b/go/internal/cli/commands/buildhost.go
@@ -93,6 +93,21 @@ func rejectUnsupportedBuildHostProject(host, project string) error {
 // transferred. Every failure names the host, and none falls back to a local
 // build: a long build the developer believed was running on the Spark is worse
 // than an error.
+// checkFleetDeliverySupported refuses a fleet build against a build host that
+// would silently drop the extra devices.
+//
+// proto3 discards unknown fields, so an agent predating push_targets receives a
+// spec whose fleet it cannot see and whose single target is empty. It would
+// build and deliver nowhere while this CLI reported a fleet deploy. Refusing is
+// the only safe answer: degrading to the first device would deploy to one
+// machine and claim several, which is worse than an error and invisible.
+func checkFleetDeliverySupported(host string, resp *agentpbv2.GetBuildCapabilitiesResponse, deviceCount int) error {
+	if deviceCount <= 1 || resp.GetMultiTargetDelivery() {
+		return nil
+	}
+	return fmt.Errorf("build host %s cannot deliver one build to several devices; update its agent, or deploy to one device at a time", host)
+}
+
 func checkBuildHostCapabilities(host string, resp *agentpbv2.GetBuildCapabilitiesResponse, platform string) error {
 	if !resp.GetBuilderEnabled() {
 		return fmt.Errorf("%s is not configured as a build host; enable the builder role on that device, or omit --build-host to build locally", host)
@@ -215,6 +230,14 @@ func runRemoteBuild(
 	if err != nil {
 		return err
 	}
+	// One entry today; the fleet flag lengthens it. Kept as a slice from here on
+	// so the delivery path, the capability guard and the reporting are the same
+	// code for one device as for ten -- a fleet path that only runs when someone
+	// passes several devices is a fleet path nobody has tested.
+	pushTargets := []*agentpbv2.PushTarget{pushTarget}
+	if err := checkFleetDeliverySupported(host, caps, len(pushTargets)); err != nil {
+		return err
+	}
 
 	buildTitle := fmt.Sprintf("Building on %s for %s...", tui.Value(host), tui.Value(platform))
 	if err := runBuildWithProgress(ctx, buildTitle, dumpRawAlways, func(buildCtx context.Context, stream, logw io.Writer) error {
@@ -222,18 +245,29 @@ func runRemoteBuild(
 		if err != nil {
 			return err
 		}
-		return streamRemoteBuild(buildCtx, builder, &agentpbv2.BuildSpec{
-			AppId:      appCfg.AppID,
-			Platform:   platform,
-			PushTarget: pushTarget,
-			Context:    manifest,
+		// A single device keeps using the original field. The fleet field is
+		// invisible to an agent that predates it -- proto3 drops unknown fields
+		// -- so sending it for a one-device build would break exactly the case
+		// that works today, against exactly the agents most likely to be in the
+		// field. checkFleetDeliverySupported above is what allows the other
+		// branch.
+		spec := &agentpbv2.BuildSpec{
+			AppId:    appCfg.AppID,
+			Platform: platform,
+			Context:  manifest,
 			Definition: &agentpbv2.BuildSpec_DockerfileBuild{
 				DockerfileBuild: &agentpbv2.DockerfileBuild{
 					Dockerfile: resolved,
 					BuildArgs:  buildArgs,
 				},
 			},
-		}, stream)
+		}
+		if len(pushTargets) == 1 {
+			spec.PushTarget = pushTargets[0]
+		} else {
+			spec.PushTargets = pushTargets
+		}
+		return streamRemoteBuild(buildCtx, builder, spec, stream)
 	}); err != nil {
 		return classifyRemoteBuildError(host, err)
 	}
@@ -251,6 +285,48 @@ func runRemoteBuild(
 		Env:           deployEnv,
 	}
 	return startAndStreamContainer(ctx, target, appCfg, createReq, opts)
+}
+
+// fleetDeliveryReport turns the agent's per-device outcomes into what the
+// developer reads, and into the exit status.
+//
+// It exists as a pure function because the rule it encodes is the one worth
+// testing: a run where some devices missed the image is NOT a success. Every
+// other failure mode in this feature has been a wrong outcome reported as a
+// right one, and a fleet deploy is the easiest place yet to hide one — the
+// build succeeds, most devices update, and nobody looks at the tail of the
+// output.
+func fleetDeliveryReport(deliveries []*agentpbv2.DeliveryResult, nameOf map[int32]string) (lines []string, failed int) {
+	for _, d := range deliveries {
+		name := nameOf[d.GetAssetId()]
+		if name == "" {
+			name = fmt.Sprintf("asset %d", d.GetAssetId())
+		}
+		if d.GetDelivered() {
+			lines = append(lines, fmt.Sprintf("  %-24s delivered", name))
+			continue
+		}
+		failed++
+		reason := d.GetError()
+		if reason == "" {
+			// An agent that reports a failure without saying why still must not
+			// be summarised as "fine".
+			reason = "delivery failed (no reason reported)"
+		}
+		lines = append(lines, fmt.Sprintf("  %-24s FAILED: %s", name, reason))
+	}
+	return lines, failed
+}
+
+// errPartialFleetDeploy is returned when the image reached some devices and not
+// others. Named so the exit path cannot accidentally treat it as success.
+type errPartialFleetDeploy struct {
+	failed, total int
+}
+
+func (e *errPartialFleetDeploy) Error() string {
+	return fmt.Sprintf("deployed to %d of %d devices; %d failed — see the report above",
+		e.total-e.failed, e.total, e.failed)
 }
 
 // connectBuildHost resolves and connects to the build host by name, reusing the

--- a/go/internal/cli/commands/buildhost_test.go
+++ b/go/internal/cli/commands/buildhost_test.go
@@ -360,3 +360,64 @@ func TestCloudFallbackDeviceName_FallsBackToFlagThenDefault(t *testing.T) {
 		t.Fatalf("got %q, want empty so the caller reports the original error", got)
 	}
 }
+
+// TestCheckFleetDeliverySupported_RefusesOldAgent: proto3 drops unknown fields,
+// so an agent predating push_targets would receive a spec whose fleet it cannot
+// see and deliver nowhere, while the CLI reported a fleet deploy. Degrading to
+// the first device would be worse: deploying to one machine and claiming
+// several.
+func TestCheckFleetDeliverySupported_RefusesOldAgent(t *testing.T) {
+	old := &agentpbv2.GetBuildCapabilitiesResponse{MultiTargetDelivery: false}
+	if err := checkFleetDeliverySupported("spark-office", old, 3); err == nil {
+		t.Fatal("want a refusal when several devices are requested of an agent that cannot deliver to them")
+	}
+	// One device needs nothing new, so an older agent stays usable.
+	if err := checkFleetDeliverySupported("spark-office", old, 1); err != nil {
+		t.Fatalf("single-device builds must still work against an older agent: %v", err)
+	}
+	newer := &agentpbv2.GetBuildCapabilitiesResponse{MultiTargetDelivery: true}
+	if err := checkFleetDeliverySupported("spark-office", newer, 3); err != nil {
+		t.Fatalf("a capable agent must be accepted: %v", err)
+	}
+}
+
+// TestFleetDeliveryReport_CountsFailures is the rule that keeps a partial fleet
+// deploy from reading as a success.
+func TestFleetDeliveryReport_CountsFailures(t *testing.T) {
+	names := map[int32]string{1: "ccr1", 2: "ccr2", 3: "theta"}
+	lines, failed := fleetDeliveryReport([]*agentpbv2.DeliveryResult{
+		{AssetId: 1, Delivered: true},
+		{AssetId: 2, Delivered: false, Error: "mesh dial failed"},
+		{AssetId: 3, Delivered: true},
+	}, names)
+	if failed != 1 {
+		t.Fatalf("failed = %d, want 1", failed)
+	}
+	joined := strings.Join(lines, "\n")
+	for _, want := range []string{"ccr1", "ccr2", "theta", "mesh dial failed", "FAILED"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("report missing %q; got:\n%s", want, joined)
+		}
+	}
+}
+
+// An agent that reports a failure without a reason must still not be summarised
+// as fine.
+func TestFleetDeliveryReport_FailureWithoutReasonStillFails(t *testing.T) {
+	lines, failed := fleetDeliveryReport([]*agentpbv2.DeliveryResult{
+		{AssetId: 9, Delivered: false},
+	}, nil)
+	if failed != 1 {
+		t.Fatalf("failed = %d, want 1", failed)
+	}
+	if !strings.Contains(strings.Join(lines, "\n"), "asset 9") {
+		t.Errorf("an unnamed device must still be identifiable; got %v", lines)
+	}
+}
+
+func TestPartialFleetDeployError_StatesTheSplit(t *testing.T) {
+	err := &errPartialFleetDeploy{failed: 1, total: 3}
+	if !strings.Contains(err.Error(), "2 of 3") {
+		t.Errorf("the message must say how many succeeded; got %q", err.Error())
+	}
+}


### PR DESCRIPTION
**Stack 3/3.** Based on #1732 (agent) → #1731 (proto). Retarget down the stack as they merge.

## Scope

This lands the CLI decisions worth reviewing on their own. **The `--device a,b,c` flag is deliberately not here** — see "What's next".

The delivery target becomes a slice at the point it is resolved, so the capability guard, the wire encoding and the reporting are the same code for one device as for ten. A fleet path that only runs when someone passes several devices is a fleet path nobody has tested.

## The three decisions

**1. Refuse, never degrade.** `checkFleetDeliverySupported` rejects a fleet build against an agent that would silently drop the extra devices. proto3 discards unknown fields, so an agent predating `push_targets` receives a spec whose fleet it cannot see and whose single target is empty — it builds and delivers nowhere while the CLI reports a fleet deploy. Degrading to the first device would be worse: deploying to one machine and claiming several.

**2. A single device still sends `push_target`.** Sending the new field for a one-device build would break exactly the case that works today, against exactly the agents most likely to be in the field. The guard above is what permits the other branch.

**3. Partial is not success.** `fleetDeliveryReport` and `errPartialFleetDeploy` encode that a run where some devices missed the image is not a success, and that a failure reported *without* a reason is still a failure.

That third one is the reason this is split out. Every wrong outcome this feature has produced so far was reported as a right one — a deploy landing on the build host, an image reaching the wrong peer — and a fleet deploy is the easiest place yet to hide one: the build succeeds, most devices update, and nobody reads the tail of the output.

## Test plan

- `go test ./internal/cli/commands` — full suite green (29.7s).
- New tests: old agent refused for a fleet and still accepted for one device, a capable agent accepted, failures counted and named, an unnamed device still identifiable, a reasonless failure still counted, and the partial-deploy message stating how many succeeded.
- Single-device `wendy run --build-host` is unchanged on the wire; verified by build and the existing suite.

## What's next (not in this stack)

- `--device a,b,c` fan-out: resolve N connections, require platform agreement across them, create the container on each, render the report, exit non-zero on partial. Needs `--detach` for N > 1, since streaming logs from several devices is meaningless.
- Per-device configuration (`Env` is already carried by `CreateContainerRequest`; the CLI surface is the open design question — flag pairing is fragile, a fleet manifest is probably right).

## Not yet verified on hardware

The agent side has no end-to-end run against real devices yet. The natural test is a throwaway app built on a Spark and delivered to two cameras, checking both received it and that killing one mid-deploy produces a partial report with a non-zero exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)