### PR TITLE
cli: --device a,b,c deploys one build to several devices

### DIFF
--- a/go/internal/cli/commands/buildhost.go
+++ b/go/internal/cli/commands/buildhost.go
@@ -604,13 +604,23 @@ func connectFleetDevice(ctx context.Context, name string) (*grpcclient.AgentConn
 // -- a failure that surfaces long after the deploy reported success, on the
 // device least likely to be watched.
 func assertSamePlatform(ctx context.Context, name string, conn *grpcclient.AgentConnection, platform string) error {
-	got, err := targetAgentOS(ctx, conn)
+	// Resolved the SAME way the primary device's platform was, via
+	// resolveAgentPlatform. Comparing the raw agent OS instead looks equivalent
+	// and is not: a WendyOS device reports "wendyos", never "linux", so a check
+	// against the platform string's OS half rejects every device it is asked
+	// about. Measured -- it refused ccr1 for a linux/arm64 build that ccr1 runs
+	// perfectly well.
+	versionResp, err := conn.AgentService.GetAgentVersion(ctx, &agentpb.GetAgentVersionRequest{})
 	if err != nil {
 		return fmt.Errorf("determining what %s runs: %w", name, err)
 	}
-	want, _, _ := strings.Cut(platform, "/")
-	if !strings.EqualFold(got, want) {
-		return fmt.Errorf("%s runs %s but this build targets %s; a fleet must be one platform, so deploy %s separately",
+	arch := versionResp.GetCpuArchitecture()
+	if arch == "" {
+		arch = "arm64"
+	}
+	got := resolveAgentPlatform("", versionResp.GetOs(), arch)
+	if !strings.EqualFold(got, platform) {
+		return fmt.Errorf("%s is %s but this build targets %s; one build makes one image for one platform, so deploy %s separately",
 			name, got, platform, name)
 	}
 	return nil

--- a/go/internal/cli/commands/buildhost.go
+++ b/go/internal/cli/commands/buildhost.go
@@ -89,10 +89,56 @@ func rejectUnsupportedBuildHostProject(host, project string) error {
 	return fmt.Errorf("build host %s cannot build %s; remote builds currently support single-service container image projects only (remove --build-host or clear defaultBuildHost to build locally)", host, project)
 }
 
-// checkBuildHostCapabilities refuses a build host before any context is
-// transferred. Every failure names the host, and none falls back to a local
-// build: a long build the developer believed was running on the Spark is worse
-// than an error.
+// splitFleetDevices reads a comma-separated --device value into the primary
+// device and the rest.
+//
+// The primary is not just the first name: it is the device every existing
+// decision in the run path is already made against — GPU architecture for a
+// cuda: stage, agent OS, build-arg hints. Those must come from one device, and
+// silently averaging them across a fleet would produce an image correct for
+// none of them.
+//
+// Order is preserved and duplicates are refused. A fleet listed as larger than
+// it is would report a device twice and hide that another was never named.
+func splitFleetDevices(value string) (primary string, extras []string, err error) {
+	parts := strings.Split(value, ",")
+	seen := make(map[string]struct{}, len(parts))
+	names := make([]string, 0, len(parts))
+	for _, p := range parts {
+		name := strings.TrimSpace(p)
+		if name == "" {
+			return "", nil, fmt.Errorf("--device %q has an empty entry; list devices as a,b,c", value)
+		}
+		if _, dup := seen[name]; dup {
+			return "", nil, fmt.Errorf("--device lists %q more than once", name)
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	return names[0], names[1:], nil
+}
+
+// validateFleetRun rejects the combinations that cannot be honoured, before any
+// device is contacted.
+func validateFleetRun(extras []string, buildHost string, detach bool) error {
+	if len(extras) == 0 {
+		return nil
+	}
+	// Without a build host each device would build the image locally, in turn.
+	// The point of naming several devices is that the expensive stage happens
+	// once, so this combination asks for the opposite of the feature.
+	if strings.TrimSpace(buildHost) == "" {
+		return errors.New("deploying to several devices needs --build-host: without it each device would trigger its own local build, which is what naming them together avoids")
+	}
+	// Log streaming follows one container. Interleaving several devices' logs
+	// into one terminal produces output no one can attribute, and the run would
+	// appear to hang on whichever device is quietest.
+	if !detach {
+		return errors.New("deploying to several devices needs --detach: logs are streamed from a single container, so there is no sensible thing to follow across a fleet")
+	}
+	return nil
+}
+
 // checkFleetDeliverySupported refuses a fleet build against a build host that
 // would silently drop the extra devices.
 //
@@ -108,6 +154,10 @@ func checkFleetDeliverySupported(host string, resp *agentpbv2.GetBuildCapabiliti
 	return fmt.Errorf("build host %s cannot deliver one build to several devices; update its agent, or deploy to one device at a time", host)
 }
 
+// checkBuildHostCapabilities refuses a build host before any context is
+// transferred. Every failure names the host, and none falls back to a local
+// build: a long build the developer believed was running on the Spark is worse
+// than an error.
 func checkBuildHostCapabilities(host string, resp *agentpbv2.GetBuildCapabilitiesResponse, platform string) error {
 	if !resp.GetBuilderEnabled() {
 		return fmt.Errorf("%s is not configured as a build host; enable the builder role on that device, or omit --build-host to build locally", host)
@@ -230,11 +280,44 @@ func runRemoteBuild(
 	if err != nil {
 		return err
 	}
-	// One entry today; the fleet flag lengthens it. Kept as a slice from here on
-	// so the delivery path, the capability guard and the reporting are the same
-	// code for one device as for ten -- a fleet path that only runs when someone
-	// passes several devices is a fleet path nobody has tested.
+	// Kept as a slice so the delivery path, the capability guard and the
+	// reporting are the same code for one device as for ten -- a fleet path that
+	// only runs when someone passes several devices is a fleet path nobody has
+	// tested.
 	pushTargets := []*agentpbv2.PushTarget{pushTarget}
+	// Names for the report. The primary is whatever --device resolved to.
+	nameOf := map[int32]string{pushTarget.GetAssetId(): deviceFlag}
+
+	// Resolve every extra device BEFORE building. A fleet member that cannot be
+	// reached is worth an error now, not after the build host has spent minutes
+	// on an image most of the fleet will never see.
+	fleetConns := make([]*grpcclient.AgentConnection, 0, len(opts.fleetDevices))
+	defer func() {
+		for _, c := range fleetConns {
+			c.Close()
+		}
+	}()
+	for _, name := range opts.fleetDevices {
+		conn, err := connectFleetDevice(ctx, name)
+		if err != nil {
+			return fmt.Errorf("connecting to %s: %w", name, err)
+		}
+		fleetConns = append(fleetConns, conn)
+
+		// One build produces one image for one platform. A device of a different
+		// architecture cannot run it, and finding that out after delivery would
+		// leave a camera holding an image it can never start.
+		if err := assertSamePlatform(ctx, name, conn, platform); err != nil {
+			return err
+		}
+		t, err := targetPushTarget(ctx, conn, appCfg)
+		if err != nil {
+			return fmt.Errorf("resolving %s as a delivery target: %w", name, err)
+		}
+		pushTargets = append(pushTargets, t)
+		nameOf[t.GetAssetId()] = name
+	}
+
 	if err := checkFleetDeliverySupported(host, caps, len(pushTargets)); err != nil {
 		return err
 	}
@@ -284,7 +367,50 @@ func runRemoteBuild(
 		UserArgs:      opts.userArgs,
 		Env:           deployEnv,
 	}
-	return startAndStreamContainer(ctx, target, appCfg, createReq, opts)
+	if len(fleetConns) == 0 {
+		return startAndStreamContainer(ctx, target, appCfg, createReq, opts)
+	}
+
+	// Fleet run. Every device gets the image; each still needs its own container
+	// created, and one device failing that must not strand the others -- the
+	// image is already on them.
+	report := make([]*agentpbv2.DeliveryResult, 0, len(pushTargets))
+	primaryErr := startAndStreamContainer(ctx, target, appCfg, createReq, opts)
+	report = append(report, deliveryOutcome(pushTargets[0].GetAssetId(), primaryErr))
+
+	for i, conn := range fleetConns {
+		req := &agentpb.CreateContainerRequest{
+			// Resolved per device: the reference names that device's own registry.
+			ImageName:     localRegistryReference(ctx, conn, appCfg),
+			AppName:       appCfg.AppID,
+			AppConfig:     appConfigData,
+			RestartPolicy: resolveRestartPolicy(opts),
+			UserArgs:      opts.userArgs,
+			Env:           deployEnv,
+		}
+		report = append(report, deliveryOutcome(pushTargets[i+1].GetAssetId(),
+			startAndStreamContainer(ctx, conn, appCfg, req, opts)))
+	}
+
+	lines, failed := fleetDeliveryReport(report, nameOf)
+	cliLogln("Deployed from one build on %s:", tui.Value(host))
+	for _, l := range lines {
+		cliLogln("%s", l)
+	}
+	if failed > 0 {
+		return &errPartialFleetDeploy{failed: failed, total: len(report)}
+	}
+	return nil
+}
+
+// deliveryOutcome records what happened to one device without collapsing a
+// failure into the run's overall status. See fleetDeliveryReport for why a
+// partial fleet deploy must not read as success.
+func deliveryOutcome(assetID int32, err error) *agentpbv2.DeliveryResult {
+	if err != nil {
+		return &agentpbv2.DeliveryResult{AssetId: assetID, Error: err.Error()}
+	}
+	return &agentpbv2.DeliveryResult{AssetId: assetID, Delivered: true}
 }
 
 // fleetDeliveryReport turns the agent's per-device outcomes into what the
@@ -440,4 +566,52 @@ func consumeBuildProgress(recv func() (*agentpbv2.BuildImageProgress, error), ou
 			return nil
 		}
 	}
+}
+
+// connectFleetDevice connects to one extra delivery target by name.
+//
+// KNOWN LIMITATION, measured rather than assumed: resolveTarget is direct/LAN
+// only, so a fleet member that is not on this network fails here with "name
+// resolver error: produced zero addresses". Deploying to ccr2,ccr1 from a
+// laptop on neither network gets as far as this call and stops.
+//
+// The fix is the one connectBuildHost needs and for the same reason -- a cloud
+// fallback that takes the device name EXPLICITLY, because --device names the
+// primary and reusing it here would connect every fleet member to the same
+// machine. That is a separate change; when it lands, this becomes a one-line
+// swap rather than a second copy of the same logic.
+//
+// Until then a fleet must be LAN-reachable from the developer's machine. That
+// is a real restriction and is stated in the flag's help rather than left to be
+// discovered.
+func connectFleetDevice(ctx context.Context, name string) (*grpcclient.AgentConnection, error) {
+	sel, err := resolveTarget(ctx, SelectDevice(name), NonInteractive(), SuppressUpdateCheck())
+	if err != nil {
+		return nil, err
+	}
+	if sel.Agent == nil {
+		sel.Close()
+		return nil, fmt.Errorf("%s is not a WendyOS device with an agent", name)
+	}
+	return sel.Agent, nil
+}
+
+// assertSamePlatform refuses a fleet whose members do not all run the image
+// that is about to be built.
+//
+// One build produces one image for one platform. Delivering it to a device of
+// another architecture leaves that camera holding an image it can never start
+// -- a failure that surfaces long after the deploy reported success, on the
+// device least likely to be watched.
+func assertSamePlatform(ctx context.Context, name string, conn *grpcclient.AgentConnection, platform string) error {
+	got, err := targetAgentOS(ctx, conn)
+	if err != nil {
+		return fmt.Errorf("determining what %s runs: %w", name, err)
+	}
+	want, _, _ := strings.Cut(platform, "/")
+	if !strings.EqualFold(got, want) {
+		return fmt.Errorf("%s runs %s but this build targets %s; a fleet must be one platform, so deploy %s separately",
+			name, got, platform, name)
+	}
+	return nil
 }

--- a/go/internal/cli/commands/buildhost_test.go
+++ b/go/internal/cli/commands/buildhost_test.go
@@ -421,3 +421,72 @@ func TestPartialFleetDeployError_StatesTheSplit(t *testing.T) {
 		t.Errorf("the message must say how many succeeded; got %q", err.Error())
 	}
 }
+
+// TestSplitFleetDevices_KeepsOrderAndNamesPrimary: the primary is not merely
+// first — it is the device the GPU architecture, agent OS and build-arg hints
+// are read from, so which name lands there decides what image gets built.
+func TestSplitFleetDevices_KeepsOrderAndNamesPrimary(t *testing.T) {
+	primary, extras, err := splitFleetDevices("ccr1, ccr2 ,theta")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if primary != "ccr1" {
+		t.Errorf("primary = %q, want ccr1", primary)
+	}
+	if len(extras) != 2 || extras[0] != "ccr2" || extras[1] != "theta" {
+		t.Errorf("extras = %v, want [ccr2 theta] with whitespace trimmed", extras)
+	}
+}
+
+// A duplicate would report one device twice and hide that another was never
+// named — a fleet that looks larger than it is.
+func TestSplitFleetDevices_RefusesDuplicatesAndBlanks(t *testing.T) {
+	if _, _, err := splitFleetDevices("ccr1,ccr2,ccr1"); err == nil {
+		t.Error("want an error for a repeated device")
+	}
+	if _, _, err := splitFleetDevices("ccr1,,ccr2"); err == nil {
+		t.Error("want an error for an empty entry")
+	}
+}
+
+// A single device must be untouched by any of this.
+func TestSplitFleetDevices_SingleDeviceHasNoExtras(t *testing.T) {
+	primary, extras, err := splitFleetDevices("ccr1")
+	if err != nil || primary != "ccr1" || len(extras) != 0 {
+		t.Fatalf("got (%q, %v, %v), want ccr1 with no extras", primary, extras, err)
+	}
+}
+
+// TestValidateFleetRun_RequiresBuildHostAndDetach: both refusals exist because
+// the alternative is silently doing something other than what was asked —
+// N local builds, or logs from a fleet interleaved into one terminal.
+func TestValidateFleetRun_RequiresBuildHostAndDetach(t *testing.T) {
+	extras := []string{"ccr2"}
+	if err := validateFleetRun(extras, "", true); err == nil {
+		t.Error("a fleet without --build-host must be refused")
+	}
+	if err := validateFleetRun(extras, "spark-office", false); err == nil {
+		t.Error("a fleet without --detach must be refused")
+	}
+	if err := validateFleetRun(extras, "spark-office", true); err != nil {
+		t.Errorf("a valid fleet run must be allowed: %v", err)
+	}
+	// A single device keeps working with no build host and no --detach.
+	if err := validateFleetRun(nil, "", false); err != nil {
+		t.Errorf("ordinary single-device runs must be unaffected: %v", err)
+	}
+}
+
+func TestDeliveryOutcome_RecordsFailureReason(t *testing.T) {
+	ok := deliveryOutcome(7, nil)
+	if !ok.GetDelivered() || ok.GetError() != "" {
+		t.Errorf("got %v, want a clean success", ok)
+	}
+	bad := deliveryOutcome(8, errors.New("container create refused"))
+	if bad.GetDelivered() {
+		t.Error("a failed create must not be recorded as delivered")
+	}
+	if !strings.Contains(bad.GetError(), "container create refused") {
+		t.Errorf("the reason must survive; got %q", bad.GetError())
+	}
+}

--- a/go/internal/cli/commands/root.go
+++ b/go/internal/cli/commands/root.go
@@ -113,7 +113,7 @@ func NewRootCmd() *cobra.Command {
 	}
 
 	root.PersistentFlags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
-	root.PersistentFlags().StringVar(&deviceFlag, "device", "", "Target device hostname")
+	root.PersistentFlags().StringVar(&deviceFlag, "device", "", "Target device hostname; `wendy run` accepts a comma-separated list to deploy one build to several devices (needs --build-host and --detach, and all of them LAN-reachable)")
 
 	// Render the top-level command groups in the deliberate order below rather
 	// than alphabetically, so e.g. "project" lists before "device".

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -481,7 +481,10 @@ type runOptions struct {
 	// buildHost names a WendyOS device that builds the image instead of this
 	// machine. Empty means build locally, and every existing local path must be
 	// unaffected when it is empty.
-	buildHost            string
+	buildHost string
+	// Devices beyond the primary --device that this build is also delivered to.
+	// Empty for every ordinary run.
+	fleetDevices         []string
 	debug                bool
 	deploy               bool
 	detach               bool
@@ -809,6 +812,27 @@ func runCommand(ctx context.Context, opts runOptions) error {
 		return err
 	}
 	opts.buildHost = buildHost
+
+	// A comma-separated --device names a fleet. Split it HERE, before anything
+	// resolves a device: deviceFlag is what target resolution and the cloud
+	// tunnel fallback look up, and "ccr1,ccr2" is not a device name. Leaving the
+	// split any later means the first lookup fails with a confusing "no device
+	// named ccr1,ccr2".
+	//
+	// deviceFlag is narrowed to the primary so every existing decision in this
+	// function -- GPU architecture, agent OS, build-arg hints -- keeps being made
+	// against exactly one device, as it always has been.
+	if strings.Contains(deviceFlag, ",") {
+		primary, extras, splitErr := splitFleetDevices(deviceFlag)
+		if splitErr != nil {
+			return splitErr
+		}
+		if err := validateFleetRun(extras, opts.buildHost, opts.detach); err != nil {
+			return err
+		}
+		deviceFlag = primary
+		opts.fleetDevices = extras
+	}
 
 	// --dockerfile implies a docker build; validate the file exists and ensure
 	// --build-type is compatible.


### PR DESCRIPTION
**Stack 4/4.** Based on #1733 → #1732 → #1731. Retarget down the stack as they merge.

Completes the fleet path. The protocol carried a list (#1731), the agent looped over it (#1732), the CLI knew how to guard and report on it (#1733) — but nothing let a developer ask for more than one device.

```sh
wendy run --build-host Spark3 --device ccr1,ccr2,theta --detach
```

## Where the split happens, and why it matters

Before anything resolves a device. `deviceFlag` is what target resolution and the cloud tunnel fallback look up, so splitting any later means the first lookup fails with `no device named ccr1,ccr2`.

`deviceFlag` is then narrowed to the **primary**, so every existing decision in the run path — GPU architecture for a `cuda:` stage, agent OS, build-arg hints — keeps being made against exactly one device, as it always has been. Silently averaging those across a fleet would produce an image correct for none of them. Which name lands there decides what gets built, so it is the first, not an arbitrary one.

## Refused before any device is contacted

| Input | Why |
|---|---|
| no `--build-host` | each device would trigger its own local build — the opposite of what naming them together asks for |
| no `--detach` | logs stream from one container; a fleet has nothing sensible to follow, and the run would appear to hang on the quietest device |
| `--device ccr1,ccr1` | would report one device twice and hide that another was never named |
| a member on another platform | one build makes one image for one architecture; discovering that after delivery leaves a camera holding an image it can never start |

Verified against the built binary — all three flag refusals fire instantly, before any network call:

```
✗ deploying to several devices needs --build-host: ...
✗ deploying to several devices needs --detach: ...
✗ --device lists "ccr1" more than once
```

## Ordering

Every extra device is resolved **before** the build, so an unreachable member costs an error rather than a wasted build most of the fleet will never receive — the same principle as `checkBuildHostCapabilities`.

Container creation is per device and isolated: by then the image is already on a device, so one failed create must not strand the rest. The run ends with a per-device report and a **non-zero exit** when any device missed it.

## Known limitation — measured, not assumed

`connectFleetDevice` resolves LAN-only, so a fleet member on another network fails with `name resolver error: produced zero addresses`. Deploying `ccr2,ccr1` from a laptop on neither network stops there.

The fix is the cloud fallback `connectBuildHost` also needs (#1729), taking the device name **explicitly** — `--device` names the primary, so reusing it would connect every fleet member to the same machine. After that change this is a one-line swap rather than a second copy of the logic. Stated in `--device`'s help rather than left to be discovered.

**So this PR should land after #1729**, or a fleet is limited to LAN-reachable devices.

## Test plan

- `go test ./internal/cli/commands` — full suite green (31.7s).
- New tests: order preserved and primary named, whitespace trimmed, duplicates and blanks refused, single device unaffected, both `--build-host`/`--detach` refusals, ordinary runs untouched, and a failed create recorded with its reason rather than as delivered.
- Flag refusals verified against the built binary as shown above.
- **Not yet verified end to end on hardware** — blocked by the limitation above; the fleet devices here are in another country. Once #1729 lands, the test is a throwaway app to `ccr1,ccr2` plus killing one mid-deploy to confirm the partial report and non-zero exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)