### PR TITLE
agent: share a claimed camera instead of failing with a generic error

### DIFF
--- a/go/internal/agent/audio/camera.go
+++ b/go/internal/agent/audio/camera.go
@@ -1,0 +1,42 @@
+package audio
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// FindCameraSource returns the object.serial of the PipeWire node publishing devicePath.
+// Serial, not node.name: a multi-interface UVC camera publishes one node per V4L2 device
+// under a single name, so the name resolves to the wrong one.
+func FindCameraSource(ctx context.Context, devicePath string) (uint64, bool) {
+	out, err := DumpRun(ctx)
+	if err != nil {
+		return 0, false
+	}
+	return parseCameraSource(out, devicePath)
+}
+
+// parseCameraSource finds the Video/Source node for devicePath in a pw-dump.
+func parseCameraSource(data []byte, devicePath string) (uint64, bool) {
+	var objects []pwObject
+	if err := json.Unmarshal(data, &objects); err != nil {
+		return 0, false
+	}
+	for _, o := range objects {
+		// Device and Port objects carry media.class and api.v4l2.path too, but
+		// only a Node can be streamed.
+		if o.Type != "PipeWire:Interface:Node" {
+			continue
+		}
+		if propString(o.Info.Props, "media.class") != "Video/Source" {
+			continue
+		}
+		if propString(o.Info.Props, "api.v4l2.path") != devicePath {
+			continue
+		}
+		if serial := propUint(o.Info.Props, "object.serial"); serial != 0 {
+			return serial, true
+		}
+	}
+	return 0, false
+}

--- a/go/internal/agent/audio/camera.go
+++ b/go/internal/agent/audio/camera.go
@@ -17,6 +17,12 @@ func FindCameraSource(ctx context.Context, devicePath string) (uint64, bool) {
 }
 
 // parseCameraSource finds the Video/Source node for devicePath in a pw-dump.
+//
+// Matching on api.v4l2.path assumes WirePlumber's v4l2 monitor publishes a node for every
+// camera we capture from. That holds today: WendyOS requires monitor.v4l2, and although the
+// libcamera monitor also runs and publishes its own api.libcamera.path nodes, WirePlumber
+// ships no cross-monitor dedup, so the v4l2 node always coexists. A version that started
+// hiding it in favour of the libcamera node would silently break this lookup.
 func parseCameraSource(data []byte, devicePath string) (uint64, bool) {
 	var objects []pwObject
 	if err := json.Unmarshal(data, &objects); err != nil {

--- a/go/internal/agent/audio/camera.go
+++ b/go/internal/agent/audio/camera.go
@@ -1,9 +1,6 @@
 package audio
 
-import (
-	"context"
-	"encoding/json"
-)
+import "context"
 
 // FindCameraSource returns the object.serial of the PipeWire node publishing devicePath.
 // Serial, not node.name: a multi-interface UVC camera publishes one node per V4L2 device
@@ -18,29 +15,20 @@ func FindCameraSource(ctx context.Context, devicePath string) (uint64, bool) {
 
 // parseCameraSource finds the Video/Source node for devicePath in a pw-dump.
 //
-// Matching on api.v4l2.path assumes WirePlumber's v4l2 monitor publishes a node for every
-// camera we capture from. That holds today: WendyOS requires monitor.v4l2, and although the
-// libcamera monitor also runs and publishes its own api.libcamera.path nodes, WirePlumber
-// ships no cross-monitor dedup, so the v4l2 node always coexists. A version that started
-// hiding it in favour of the libcamera node would silently break this lookup.
+// Matching api.v4l2.path assumes the v4l2 monitor publishes a node for every camera. It holds
+// because WendyOS requires monitor.v4l2 and WirePlumber has no cross-monitor dedup, so the
+// v4l2 node coexists with libcamera's; a version that deduped them would break this silently.
 func parseCameraSource(data []byte, devicePath string) (uint64, bool) {
-	var objects []pwObject
-	if err := json.Unmarshal(data, &objects); err != nil {
+	objects, err := decodeDump(data)
+	if err != nil {
 		return 0, false
 	}
 	for _, o := range objects {
-		// Device and Port objects carry media.class and api.v4l2.path too, but
-		// only a Node can be streamed.
-		if o.Type != "PipeWire:Interface:Node" {
+		props, _, ok := nodeProps(o, "Video/Source")
+		if !ok || propString(props, "api.v4l2.path") != devicePath {
 			continue
 		}
-		if propString(o.Info.Props, "media.class") != "Video/Source" {
-			continue
-		}
-		if propString(o.Info.Props, "api.v4l2.path") != devicePath {
-			continue
-		}
-		if serial := propUint(o.Info.Props, "object.serial"); serial != 0 {
+		if serial := propUint(props, "object.serial"); serial != 0 {
 			return serial, true
 		}
 	}

--- a/go/internal/agent/audio/camera_test.go
+++ b/go/internal/agent/audio/camera_test.go
@@ -1,0 +1,74 @@
+package audio
+
+import "testing"
+
+// cameraDump is a trimmed pw-dump from an AGX Thor with a Logitech BRIO: two
+// V4L2 sources sharing one node.name, the Device object that shares the id
+// space, and an audio node that must not match.
+const cameraDump = `[
+  {"id": 31, "type": "PipeWire:Interface:Device",
+   "info": {"props": {"media.class": "Video/Device", "api.v4l2.path": "/dev/video0",
+                      "object.serial": 60}}},
+  {"id": 63, "type": "PipeWire:Interface:Node",
+   "info": {"props": {"media.class": "Video/Source", "api.v4l2.path": "/dev/video0",
+                      "object.serial": 68,
+                      "node.name": "v4l2_input.platform-a80aa10000.usb-usb-0_3.2_1.0"}}},
+  {"id": 61, "type": "PipeWire:Interface:Node",
+   "info": {"props": {"media.class": "Video/Source", "api.v4l2.path": "/dev/video2",
+                      "object.serial": 65,
+                      "node.name": "v4l2_input.platform-a80aa10000.usb-usb-0_3.2_1.0"}}},
+  {"id": 51, "type": "PipeWire:Interface:Node",
+   "info": {"props": {"media.class": "Audio/Source", "object.serial": 51,
+                      "node.name": "alsa_input.platform-sound.analog-stereo"}}}
+]`
+
+func TestParseCameraSource(t *testing.T) {
+	tests := []struct {
+		name       string
+		devicePath string
+		want       uint64
+	}{
+		// Both cameras share one node.name, so only the serial tells them apart.
+		{"first camera", "/dev/video0", 68},
+		{"second camera", "/dev/video2", 65},
+		{"device object only", "/dev/video1", 0},
+		{"absent device", "/dev/video9", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseCameraSource([]byte(cameraDump), tt.devicePath)
+			if (tt.want != 0) != ok {
+				t.Fatalf("ok = %v, want %v", ok, tt.want != 0)
+			}
+			if got != tt.want {
+				t.Errorf("serial = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// A node without object.serial must not abandon the scan: a later entry for the
+// same device is still usable, and giving up sends the caller to the device the
+// graph could have shared.
+func TestParseCameraSource_SkipsNodeMissingSerial(t *testing.T) {
+	dump := `[
+	  {"id": 1, "type": "PipeWire:Interface:Node",
+	   "info": {"props": {"media.class": "Video/Source", "api.v4l2.path": "/dev/video0"}}},
+	  {"id": 2, "type": "PipeWire:Interface:Node",
+	   "info": {"props": {"media.class": "Video/Source", "api.v4l2.path": "/dev/video0",
+	                      "object.serial": 99}}}
+	]`
+	got, ok := parseCameraSource([]byte(dump), "/dev/video0")
+	if !ok || got != 99 {
+		t.Errorf("serial = %d, ok = %v; want 99, true", got, ok)
+	}
+}
+
+// A malformed dump leaves the caller on the device rather than failing a stream.
+func TestParseCameraSource_MalformedDump(t *testing.T) {
+	for _, dump := range []string{"", "not json", "{}", "[]"} {
+		if _, ok := parseCameraSource([]byte(dump), "/dev/video0"); ok {
+			t.Errorf("dump %q: reported a node that does not exist", dump)
+		}
+	}
+}

--- a/go/internal/agent/audio/pipewire.go
+++ b/go/internal/agent/audio/pipewire.go
@@ -18,6 +18,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -236,11 +237,33 @@ func propUint(props map[string]json.RawMessage, key string) uint64 {
 	return v
 }
 
-// parseDump extracts audio sinks and sources, and the current defaults.
-func parseDump(data []byte) ([]Node, Defaults, error) {
+// decodeDump unmarshals pw-dump output into the objects both scans below walk.
+func decodeDump(data []byte) ([]pwObject, error) {
 	var objects []pwObject
 	if err := json.Unmarshal(data, &objects); err != nil {
-		return nil, Defaults{}, fmt.Errorf("parsing pw-dump output: %w", err)
+		return nil, fmt.Errorf("parsing pw-dump output: %w", err)
+	}
+	return objects, nil
+}
+
+// nodeProps returns o's properties and media.class if o is a Node of one of classes. Device
+// and Port objects share the id space and carry media.class too, but only a Node is streamable.
+func nodeProps(o pwObject, classes ...string) (map[string]json.RawMessage, string, bool) {
+	if o.Type != "PipeWire:Interface:Node" {
+		return nil, "", false
+	}
+	class := propString(o.Info.Props, "media.class")
+	if !slices.Contains(classes, class) {
+		return nil, "", false
+	}
+	return o.Info.Props, class, true
+}
+
+// parseDump extracts audio sinks and sources, and the current defaults.
+func parseDump(data []byte) ([]Node, Defaults, error) {
+	objects, err := decodeDump(data)
+	if err != nil {
+		return nil, Defaults{}, err
 	}
 
 	var nodes []Node
@@ -265,29 +288,23 @@ func parseDump(data []byte) ([]Node, Defaults, error) {
 			continue
 		}
 
-		// Only Node objects are addressable by wpctl and pw-record; Device and
-		// Port objects share the id space and can carry a media.class.
-		if o.Type != "PipeWire:Interface:Node" {
+		// Exactly "Audio/Sink" or "Audio/Source": monitor and virtual nodes carry a
+		// further suffix and are not devices anyone chose to install.
+		props, class, ok := nodeProps(o, "Audio/Sink", "Audio/Source")
+		if !ok {
 			continue
 		}
-
-		// Exactly "Audio/Sink" or "Audio/Source". Monitor and virtual nodes
-		// carry a further suffix and are not devices anyone chose to install.
-		class := propString(o.Info.Props, "media.class")
-		if class != "Audio/Sink" && class != "Audio/Source" {
-			continue
-		}
-		name := propString(o.Info.Props, "node.name")
+		name := propString(props, "node.name")
 		if name == "" {
 			continue
 		}
-		description := propString(o.Info.Props, "node.description")
+		description := propString(props, "node.description")
 		if description == "" {
 			description = name
 		}
 		nodes = append(nodes, Node{
 			ID:          o.ID,
-			Serial:      propUint(o.Info.Props, "object.serial"),
+			Serial:      propUint(props, "object.serial"),
 			Name:        name,
 			Description: description,
 			IsSink:      class == "Audio/Sink",

--- a/go/internal/agent/services/camera_stream_error.go
+++ b/go/internal/agent/services/camera_stream_error.go
@@ -1,0 +1,171 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// reasonCameraInUse is the ErrorInfo reason for a camera another process holds AND that
+// could not be read through the PipeWire graph either -- reaching it means sharing was
+// unavailable, not that a camera inherently allows one consumer.
+const reasonCameraInUse = "CAMERA_IN_USE"
+
+// errCameraInUse reports contention as a FailedPrecondition: the device is
+// healthy, its state is wrong, and the caller can retry once the holder stops.
+func errCameraInUse(devicePath string) error {
+	st := status.New(codes.FailedPrecondition,
+		fmt.Sprintf("camera %s is already in use by another application on this device", devicePath))
+	detailed, err := st.WithDetails(&errdetails.ErrorInfo{
+		Reason:   reasonCameraInUse,
+		Metadata: map[string]string{"device": devicePath},
+	})
+	if err != nil {
+		return st.Err()
+	}
+	return detailed.Err()
+}
+
+// isCameraInUse reports whether err is the contention error above.
+func isCameraInUse(err error) bool {
+	st, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+	for _, d := range st.Details() {
+		if info, ok := d.(*errdetails.ErrorInfo); ok && info.GetReason() == reasonCameraInUse {
+			return true
+		}
+	}
+	return false
+}
+
+// isBusyErrno reports whether a syscall failed because the device is claimed.
+func isBusyErrno(err error) bool {
+	return errors.Is(err, unix.EBUSY)
+}
+
+// retryWhileBusy re-runs op briefly while it reports EBUSY: a reconnect can land while the
+// agent's own previous producer still holds the device, which is not another application.
+func retryWhileBusy(ctx context.Context, op func() unix.Errno) unix.Errno {
+	const (
+		attempts = 4
+		delay    = 150 * time.Millisecond
+	)
+	errno := op()
+	for i := 0; i < attempts && isBusyErrno(errno); i++ {
+		select {
+		case <-ctx.Done():
+			return errno
+		case <-time.After(delay):
+		}
+		errno = op()
+	}
+	return errno
+}
+
+// busyPhrases are how the capture elements word contention. GStreamer reports it
+// only as prose on stderr, and each library words it differently.
+var busyPhrases = []string{
+	"resource busy",               // kernel EBUSY text
+	"is busy",                     // v4l2src: Device '/dev/video0' is busy
+	"already in use",              // libcamera, Argus
+	"failed to acquire camera",    // libcamera
+	"cannot create camera device", // nvargus, sensor already claimed
+}
+
+// captureElements name the sources that read a camera. An encoder returns EBUSY in the
+// same wording, so a busy phrase alone would blame the camera for a contended encoder.
+var captureElements = []string{"v4l2src", "libcamerasrc", "nvarguscamerasrc", "pipewiresrc", "argus"}
+
+// isBusyStderr reports whether captured stderr describes camera contention. Per error
+// record: gst splits one failure across its "from element" line and the debug block below,
+// while a warning it recovered from must not lend its element name to a later failure.
+func isBusyStderr(stderr, devicePath string) bool {
+	device := strings.ToLower(devicePath)
+	for _, record := range errorRecords(strings.ToLower(stderr)) {
+		if !containsAny(record, busyPhrases) {
+			continue
+		}
+		if namesDevice(record, device) || containsAny(record, captureElements) {
+			return true
+		}
+	}
+	return false
+}
+
+// exitedOnError reports whether the process failed by itself rather than being killed
+// during teardown. streamGStreamer always signals the pipeline, so a non-nil Wait error
+// proves nothing on its own.
+func exitedOnError(err error) bool {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
+	}
+	ws, ok := exitErr.Sys().(syscall.WaitStatus)
+	if !ok {
+		return false
+	}
+	return !ws.Signaled() || ws.Signal() != syscall.SIGKILL
+}
+
+// errorRecords splits already-lowercased gst stderr at each error or warning marker,
+// keeping a message and the debug block that explains it together as one unit.
+func errorRecords(stderr string) []string {
+	var records []string
+	var cur strings.Builder
+	for _, line := range strings.Split(stderr, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "error") || strings.HasPrefix(trimmed, "warn") {
+			if cur.Len() > 0 {
+				records = append(records, cur.String())
+				cur.Reset()
+			}
+		}
+		cur.WriteString(line)
+		cur.WriteByte('\n')
+	}
+	if cur.Len() > 0 {
+		records = append(records, cur.String())
+	}
+	return records
+}
+
+// namesDevice reports whether s mentions exactly devicePath. A plain substring test
+// would let /dev/video1 match /dev/video11 — on a Pi that is the H.264 encoder, so a
+// contended encoder would be blamed on the camera.
+func namesDevice(s, devicePath string) bool {
+	if devicePath == "" {
+		return false
+	}
+	for i := 0; i+len(devicePath) <= len(s); {
+		j := strings.Index(s[i:], devicePath)
+		if j < 0 {
+			return false
+		}
+		end := i + j + len(devicePath)
+		if end == len(s) || s[end] < '0' || s[end] > '9' {
+			return true
+		}
+		i = end
+	}
+	return false
+}
+
+func containsAny(s string, subs []string) bool {
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/go/internal/agent/services/camera_stream_error.go
+++ b/go/internal/agent/services/camera_stream_error.go
@@ -54,18 +54,22 @@ func isBusyErrno(err error) bool {
 	return errors.Is(err, unix.EBUSY)
 }
 
-// retryWhileBusy re-runs op briefly while it reports EBUSY: a reconnect can land while the
-// agent's own previous producer still holds the device, which is not another application.
+// retryWhileBusy re-runs op briefly while it reports EBUSY, covering the lag between a dying
+// producer's hub closing and its deferred fd close actually running. The substantive wait for
+// that race belongs to getOrCreateHub (maxHubRetries x hubTeardownTimeout), so this stays at
+// one retry: when another application holds the camera it can never succeed, and every extra
+// attempt only delays the fallback and the answer.
 func retryWhileBusy(ctx context.Context, op func() unix.Errno) unix.Errno {
 	const (
-		attempts = 4
-		delay    = 150 * time.Millisecond
+		retries = 1
+		delay   = 150 * time.Millisecond
 	)
 	errno := op()
-	for i := 0; i < attempts && isBusyErrno(errno); i++ {
+	for i := 0; i < retries && isBusyErrno(errno); i++ {
 		select {
 		case <-ctx.Done():
-			return errno
+			// Not the stale EBUSY: a shutdown mid-retry must not read as contention.
+			return unix.ECANCELED
 		case <-time.After(delay):
 		}
 		errno = op()
@@ -93,6 +97,12 @@ var captureElements = []string{"v4l2src", "libcamerasrc", "nvarguscamerasrc", "p
 func isBusyStderr(stderr, devicePath string) bool {
 	device := strings.ToLower(devicePath)
 	for _, record := range errorRecords(strings.ToLower(stderr)) {
+		// A warning gst recovered from is not why the pipeline died: it prints "Device or
+		// resource busy" while probing modes and carries on. Records with no marker at all
+		// stay eligible -- bare tool output is often the only evidence there is.
+		if strings.HasPrefix(strings.TrimSpace(record), "warn") {
+			continue
+		}
 		if !containsAny(record, busyPhrases) {
 			continue
 		}
@@ -120,6 +130,10 @@ func exitedOnError(err error) bool {
 
 // errorRecords splits already-lowercased gst stderr at each error or warning marker,
 // keeping a message and the debug block that explains it together as one unit.
+//
+// An unprefixed line joins whichever record precedes it. That is deliberate -- gst's
+// "Additional debug info" block carries the decisive text and has no marker of its own -- and
+// it is why a record can be evidence without being prefixed at all.
 func errorRecords(stderr string) []string {
 	var records []string
 	var cur strings.Builder

--- a/go/internal/agent/services/camera_stream_error.go
+++ b/go/internal/agent/services/camera_stream_error.go
@@ -10,43 +10,27 @@ import (
 	"time"
 
 	"golang.org/x/sys/unix"
-	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/streamreason"
 )
 
 // reasonCameraInUse is the ErrorInfo reason for a camera another process holds AND that
 // could not be read through the PipeWire graph either -- reaching it means sharing was
 // unavailable, not that a camera inherently allows one consumer.
-const reasonCameraInUse = "CAMERA_IN_USE"
+const reasonCameraInUse = streamreason.CameraInUse
 
 // errCameraInUse reports contention as a FailedPrecondition: the device is
 // healthy, its state is wrong, and the caller can retry once the holder stops.
 func errCameraInUse(devicePath string) error {
-	st := status.New(codes.FailedPrecondition,
-		fmt.Sprintf("camera %s is already in use by another application on this device", devicePath))
-	detailed, err := st.WithDetails(&errdetails.ErrorInfo{
-		Reason:   reasonCameraInUse,
-		Metadata: map[string]string{"device": devicePath},
-	})
-	if err != nil {
-		return st.Err()
-	}
-	return detailed.Err()
+	return streamreason.New(codes.FailedPrecondition,
+		fmt.Sprintf("camera %s is already in use by another application on this device", devicePath),
+		reasonCameraInUse, map[string]string{"device": devicePath})
 }
 
 // isCameraInUse reports whether err is the contention error above.
 func isCameraInUse(err error) bool {
-	st, ok := status.FromError(err)
-	if !ok {
-		return false
-	}
-	for _, d := range st.Details() {
-		if info, ok := d.(*errdetails.ErrorInfo); ok && info.GetReason() == reasonCameraInUse {
-			return true
-		}
-	}
-	return false
+	return streamreason.Has(err, reasonCameraInUse)
 }
 
 // isBusyErrno reports whether a syscall failed because the device is claimed.
@@ -54,11 +38,9 @@ func isBusyErrno(err error) bool {
 	return errors.Is(err, unix.EBUSY)
 }
 
-// retryWhileBusy re-runs op briefly while it reports EBUSY, covering the lag between a dying
-// producer's hub closing and its deferred fd close actually running. The substantive wait for
-// that race belongs to getOrCreateHub (maxHubRetries x hubTeardownTimeout), so this stays at
-// one retry: when another application holds the camera it can never succeed, and every extra
-// attempt only delays the fallback and the answer.
+// retryWhileBusy re-runs op briefly while it reports EBUSY, covering the gap between a dying
+// producer's hub closing and its deferred fd close running. One retry only: getOrCreateHub
+// does the substantive waiting, and against another application retrying cannot succeed.
 func retryWhileBusy(ctx context.Context, op func() unix.Errno) unix.Errno {
 	const (
 		retries = 1
@@ -97,9 +79,8 @@ var captureElements = []string{"v4l2src", "libcamerasrc", "nvarguscamerasrc", "p
 func isBusyStderr(stderr, devicePath string) bool {
 	device := strings.ToLower(devicePath)
 	for _, record := range errorRecords(strings.ToLower(stderr)) {
-		// A warning gst recovered from is not why the pipeline died: it prints "Device or
-		// resource busy" while probing modes and carries on. Records with no marker at all
-		// stay eligible -- bare tool output is often the only evidence there is.
+		// A warning gst recovered from did not kill the pipeline; only marked errors and
+		// marker-less records (often the only evidence there is) can convict.
 		if strings.HasPrefix(strings.TrimSpace(record), "warn") {
 			continue
 		}
@@ -131,9 +112,8 @@ func exitedOnError(err error) bool {
 // errorRecords splits already-lowercased gst stderr at each error or warning marker,
 // keeping a message and the debug block that explains it together as one unit.
 //
-// An unprefixed line joins whichever record precedes it. That is deliberate -- gst's
-// "Additional debug info" block carries the decisive text and has no marker of its own -- and
-// it is why a record can be evidence without being prefixed at all.
+// An unprefixed line joins the record before it: gst's "Additional debug info" block carries
+// the decisive text and has no marker of its own.
 func errorRecords(stderr string) []string {
 	var records []string
 	var cur strings.Builder

--- a/go/internal/agent/services/camera_stream_error_test.go
+++ b/go/internal/agent/services/camera_stream_error_test.go
@@ -1,0 +1,182 @@
+package services
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Capture failures used to collapse into "GStreamer pipeline failed", which tells an
+// operator nothing; the commonest cause is another process holding the camera.
+func TestCameraInUseError_IsActionableAndMachineReadable(t *testing.T) {
+	err := errCameraInUse("/dev/video0")
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected a gRPC status, got %v", err)
+	}
+	// FailedPrecondition, not Internal: the device is fine, its state is wrong.
+	if st.Code() != codes.FailedPrecondition {
+		t.Errorf("code = %v, want FailedPrecondition", st.Code())
+	}
+	if !strings.Contains(st.Message(), "already in use") {
+		t.Errorf("message must say what is wrong, got %q", st.Message())
+	}
+
+	var info *errdetails.ErrorInfo
+	for _, d := range st.Details() {
+		if got, ok := d.(*errdetails.ErrorInfo); ok {
+			info = got
+		}
+	}
+	if info == nil {
+		t.Fatal("no ErrorInfo attached; clients cannot tell this apart from any other failure")
+	}
+	if info.GetReason() != reasonCameraInUse {
+		t.Errorf("reason = %q, want %q", info.GetReason(), reasonCameraInUse)
+	}
+	// The device path is what the operator needs to find the process holding it.
+	if got := info.GetMetadata()["device"]; got != "/dev/video0" {
+		t.Errorf("metadata device = %q, want /dev/video0", got)
+	}
+}
+
+func TestIsBusyErrno(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"EBUSY", unix.EBUSY, true},
+		{"wrapped EBUSY", errors.New("open: " + unix.EBUSY.Error()), false},
+		{"EACCES", unix.EACCES, false},
+		{"nil", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isBusyErrno(tt.err); got != tt.want {
+				t.Errorf("isBusyErrno(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// GStreamer reports contention only in prose on stderr, and the wording differs
+// per element. These are the strings observed from the elements the agent uses.
+func TestIsBusyStderr(t *testing.T) {
+	busy := []string{
+		"ERROR: from element /GstPipeline:pipeline0/GstV4l2Src:v4l2src0: Device '/dev/video0' is busy",
+		"v4l2src: Call to S_FMT failed for MJPG @ 640x480: Device or resource busy",
+		"libcamerasrc: Failed to acquire camera",
+		"nvarguscamerasrc: cannot create camera device",
+		"/dev/video0 is already in use by another process",
+	}
+	for _, msg := range busy {
+		if !isBusyStderr(msg, "/dev/video0") {
+			t.Errorf("should be recognised as contention: %q", msg)
+		}
+	}
+
+	notBusy := []string{
+		"ERROR: could not link videoconvert0 to nvv4l2h264enc0",
+		"WARNING: erroneous pipeline: no element \"pipewiresrc\"",
+		"streaming stopped, reason not-negotiated (-4)",
+		"",
+	}
+	for _, msg := range notBusy {
+		if isBusyStderr(msg, "/dev/video0") {
+			t.Errorf("must not be misreported as contention: %q", msg)
+		}
+	}
+}
+
+// An encoder can return EBUSY in the same words as the camera. Blaming the
+// camera sends the operator hunting a process that does not hold it.
+func TestIsBusyStderr_EncoderContentionIsNotTheCamera(t *testing.T) {
+	msg := "ERROR: from element /GstPipeline:pipeline0/v4l2h264enc0: Device or resource busy"
+	if isBusyStderr(msg, "/dev/video0") {
+		t.Errorf("a busy encoder must not be reported as a busy camera: %q", msg)
+	}
+}
+
+// On a Pi the H.264 encoder is /dev/video10-12, so a substring match on the
+// camera path claims a busy encoder as a busy camera.
+func TestIsBusyStderr_SiblingDeviceNodeIsNotTheCamera(t *testing.T) {
+	msg := "ERROR: from element /GstPipeline:pipeline0/GstV4l2H264Enc:v4l2h264enc0: Device '/dev/video11' is busy"
+	if isBusyStderr(msg, "/dev/video1") {
+		t.Errorf("/dev/video11 must not match /dev/video1: %q", msg)
+	}
+	if !isBusyStderr("Device '/dev/video1' is busy", "/dev/video1") {
+		t.Error("the camera's own node must still match")
+	}
+}
+
+// streamGStreamer always signals the pipeline on the way out, so a non-nil Wait error
+// cannot by itself tell a run that failed from one that was torn down.
+func TestExitedOnError(t *testing.T) {
+	if !exitedOnError(exec.Command("false").Run()) {
+		t.Error("a process that exited non-zero by itself must count as failed")
+	}
+	if exitedOnError(exec.Command("true").Run()) {
+		t.Error("a clean exit must not count as failed")
+	}
+
+	killed := exec.Command("sleep", "30")
+	if err := killed.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if err := killed.Process.Kill(); err != nil {
+		t.Fatalf("kill: %v", err)
+	}
+	if exitedOnError(killed.Wait()) {
+		t.Error("a pipeline killed during teardown must not count as failed")
+	}
+}
+
+// GStreamer splits one failure across the "ERROR: from element" line and its
+// "Additional debug info" block, so the phrase and the element land on different
+// lines of the same record.
+func TestIsBusyStderr_MatchesAcrossOneErrorRecord(t *testing.T) {
+	msg := "ERROR: from element /GstPipeline:pipeline0/GstV4l2Src:v4l2src0: Could not read from resource.\n" +
+		"Additional debug info:\n" +
+		"gstv4l2bufferpool.c(848): gst_v4l2_buffer_pool_start (): /GstPipeline:pipeline0/GstV4l2Src:v4l2src0:\n" +
+		"failed to activate bufferpool: Device or resource busy"
+	if !isBusyStderr(msg, "/dev/video0") {
+		t.Errorf("busy evidence in the debug block must still count: %q", msg)
+	}
+}
+
+// The stderr buffer holds the whole run, so a busy warning gst recovered from at
+// startup must not pair with a source element named much later.
+func TestIsBusyStderr_MatchesWithinOneRecord(t *testing.T) {
+	msg := "WARN: v4l2src0: reading modes\n" +
+		"ERROR: from element /GstPipeline:pipeline0/nvv4l2h264enc0: Device or resource busy"
+	if isBusyStderr(msg, "/dev/video0") {
+		t.Errorf("a busy encoder must not borrow a capture element from another line: %q", msg)
+	}
+}
+
+// Matching is case-insensitive because the wording comes from several different
+// libraries, each with its own capitalisation.
+func TestIsBusyStderr_CaseInsensitive(t *testing.T) {
+	if !isBusyStderr("DEVICE '/DEV/VIDEO0' IS BUSY", "/dev/video0") {
+		t.Error("uppercase stderr must still be recognised")
+	}
+}
+
+func TestIsCameraInUse(t *testing.T) {
+	if !isCameraInUse(errCameraInUse("/dev/video0")) {
+		t.Error("the contention error must be recognised by its reason")
+	}
+	for _, err := range []error{nil, errors.New("plain"), status.Error(codes.Internal, "other")} {
+		if isCameraInUse(err) {
+			t.Errorf("must not match: %v", err)
+		}
+	}
+}

--- a/go/internal/agent/services/camera_stream_error_test.go
+++ b/go/internal/agent/services/camera_stream_error_test.go
@@ -9,9 +9,10 @@ import (
 
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
-	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/streamreason"
 )
 
 // Capture failures used to collapse into "GStreamer pipeline failed", which tells an
@@ -31,12 +32,7 @@ func TestCameraInUseError_IsActionableAndMachineReadable(t *testing.T) {
 		t.Errorf("message must say what is wrong, got %q", st.Message())
 	}
 
-	var info *errdetails.ErrorInfo
-	for _, d := range st.Details() {
-		if got, ok := d.(*errdetails.ErrorInfo); ok {
-			info = got
-		}
-	}
+	info := streamreason.Info(err)
 	if info == nil {
 		t.Fatal("no ErrorInfo attached; clients cannot tell this apart from any other failure")
 	}
@@ -183,9 +179,8 @@ func TestIsCameraInUse(t *testing.T) {
 	}
 }
 
-// The kernel refuses a second consumer at different ioctls depending on the driver:
-// uvcvideo at S_FMT, vb2 drivers (bcm2835-camera, tegra-video) at REQBUFS or STREAMON.
-// Every setup site must therefore reach CAMERA_IN_USE, or sharing never engages on them.
+// Which ioctl refuses a second consumer is driver- and timing-dependent, so every setup site
+// must reach CAMERA_IN_USE, not just S_FMT.
 func TestErrCaptureSetup_ClassifiesBusyAtEverySite(t *testing.T) {
 	svc := NewVideoService(context.Background(), zap.NewNop())
 	for _, ioctl := range []string{
@@ -214,9 +209,8 @@ func TestErrCaptureSetup_OtherErrnosStayInternal(t *testing.T) {
 	}
 }
 
-// gst prints "Device or resource busy" while probing modes and then carries on. Such a
-// warning must not convict the camera when the pipeline later dies of something else --
-// the operator would be sent to stop an application that does not hold anything.
+// gst prints "Device or resource busy" while probing modes and carries on. Convicting on
+// that sends the operator to stop an application that holds nothing.
 func TestIsBusyStderr_RecoveredWarningIsNotContention(t *testing.T) {
 	msg := "WARNING: from element /GstPipeline:pipeline0/GstV4l2Src:v4l2src0: Cannot set S_PARM: Device or resource busy\n" +
 		"Additional debug info:\n" +

--- a/go/internal/agent/services/camera_stream_error_test.go
+++ b/go/internal/agent/services/camera_stream_error_test.go
@@ -1,11 +1,13 @@
 package services
 
 import (
+	"context"
 	"errors"
 	"os/exec"
 	"strings"
 	"testing"
 
+	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
@@ -178,5 +180,92 @@ func TestIsCameraInUse(t *testing.T) {
 		if isCameraInUse(err) {
 			t.Errorf("must not match: %v", err)
 		}
+	}
+}
+
+// The kernel refuses a second consumer at different ioctls depending on the driver:
+// uvcvideo at S_FMT, vb2 drivers (bcm2835-camera, tegra-video) at REQBUFS or STREAMON.
+// Every setup site must therefore reach CAMERA_IN_USE, or sharing never engages on them.
+func TestErrCaptureSetup_ClassifiesBusyAtEverySite(t *testing.T) {
+	svc := NewVideoService(context.Background(), zap.NewNop())
+	for _, ioctl := range []string{
+		"VIDIOC_REQBUFS", "VIDIOC_QUERYBUF", "VIDIOC_QBUF", "VIDIOC_STREAMON", "VIDIOC_DQBUF",
+	} {
+		if err := svc.errCaptureSetup(ioctl, "/dev/video0", unix.EBUSY); !isCameraInUse(err) {
+			t.Errorf("%s: EBUSY must be reported as CAMERA_IN_USE, got %v", ioctl, err)
+		}
+	}
+}
+
+func TestErrCaptureSetup_OtherErrnosStayInternal(t *testing.T) {
+	svc := NewVideoService(context.Background(), zap.NewNop())
+	for _, errno := range []unix.Errno{unix.EINVAL, unix.ENOMEM, unix.ENODEV} {
+		err := svc.errCaptureSetup("VIDIOC_REQBUFS", "/dev/video0", errno)
+		if isCameraInUse(err) {
+			t.Errorf("%v must not be reported as contention", errno)
+		}
+		if got := status.Code(err); got != codes.Internal {
+			t.Errorf("%v: want codes.Internal, got %v", errno, got)
+		}
+		// The errno must not reach the client: it lets a caller enumerate the system.
+		if strings.Contains(err.Error(), errno.Error()) {
+			t.Errorf("%v: errno text leaked into the response: %q", errno, err.Error())
+		}
+	}
+}
+
+// gst prints "Device or resource busy" while probing modes and then carries on. Such a
+// warning must not convict the camera when the pipeline later dies of something else --
+// the operator would be sent to stop an application that does not hold anything.
+func TestIsBusyStderr_RecoveredWarningIsNotContention(t *testing.T) {
+	msg := "WARNING: from element /GstPipeline:pipeline0/GstV4l2Src:v4l2src0: Cannot set S_PARM: Device or resource busy\n" +
+		"Additional debug info:\n" +
+		"gstv4l2object.c(1234): gst_v4l2_object_set_format ():\n" +
+		"ERROR: from element /GstPipeline:pipeline0/x264enc0: Could not negotiate format\n" +
+		"Additional debug info:\n" +
+		"gstvideoencoder.c(999): failed to negotiate"
+	if isBusyStderr(msg, "/dev/video0") {
+		t.Errorf("an encoder failure must not be reported as camera contention: %q", msg)
+	}
+}
+
+// The counterpart: a genuine busy ERROR must still be recognised, including when the
+// evidence sits in the debug block rather than the message line.
+func TestIsBusyStderr_FatalBusyStillCounts(t *testing.T) {
+	msg := "WARNING: from element /GstPipeline:pipeline0/GstV4l2Src:v4l2src0: Cannot set S_PARM: Device or resource busy\n" +
+		"ERROR: from element /GstPipeline:pipeline0/GstV4l2Src:v4l2src0: Could not read from resource.\n" +
+		"Additional debug info:\n" +
+		"gstv4l2bufferpool.c(848): failed to activate bufferpool: Device or resource busy"
+	if !isBusyStderr(msg, "/dev/video0") {
+		t.Errorf("a fatal busy record must still be recognised: %q", msg)
+	}
+}
+
+// The loop must run exactly one retry, and a cancellation must not be reported as EBUSY --
+// otherwise a shutdown landing mid-retry manufactures a CAMERA_IN_USE verdict.
+func TestRetryWhileBusy(t *testing.T) {
+	calls := 0
+	if got := retryWhileBusy(context.Background(), func() unix.Errno {
+		calls++
+		return unix.EBUSY
+	}); got != unix.EBUSY {
+		t.Errorf("want EBUSY passed through, got %v", got)
+	}
+	if calls != 2 {
+		t.Errorf("want one initial call plus one retry, got %d calls", calls)
+	}
+
+	calls = 0
+	if got := retryWhileBusy(context.Background(), func() unix.Errno {
+		calls++
+		return 0
+	}); got != 0 || calls != 1 {
+		t.Errorf("a free device must cost exactly one ioctl: errno=%v calls=%d", got, calls)
+	}
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if got := retryWhileBusy(cancelled, func() unix.Errno { return unix.EBUSY }); isBusyErrno(got) {
+		t.Errorf("a cancelled context must not report contention, got %v", got)
 	}
 }

--- a/go/internal/agent/services/tegra_camera_preflight.go
+++ b/go/internal/agent/services/tegra_camera_preflight.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 
 	"go.uber.org/zap"
-	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/streamreason"
 )
 
-const tegraFirmwareMismatchReason = "TEGRA_FIRMWARE_MISMATCH"
+const tegraFirmwareMismatchReason = streamreason.TegraFirmwareMismatch
 
 var (
 	tegraReleaseFamilyRE = regexp.MustCompile(`(?i)\bR([0-9]{2})\b`)
@@ -60,19 +60,11 @@ func (s *VideoService) preflightTegraCSI(ctx context.Context) error {
 	if versions.RootfsFamily == versions.BootFamily {
 		return nil
 	}
-	st := status.New(codes.FailedPrecondition, fmt.Sprintf(
+	return streamreason.New(codes.FailedPrecondition, fmt.Sprintf(
 		"Jetson rootfs %s does not match boot firmware %s; CSI camera drivers cannot be initialized safely",
-		versions.RootfsVersion, versions.BootVersion))
-	withInfo, err := st.WithDetails(&errdetails.ErrorInfo{
-		Reason: tegraFirmwareMismatchReason,
-		Domain: "wendy.dev",
-		Metadata: map[string]string{
+		versions.RootfsVersion, versions.BootVersion),
+		tegraFirmwareMismatchReason, map[string]string{
 			"rootfs_l4t":        versions.RootfsVersion,
 			"boot_firmware_l4t": versions.BootVersion,
-		},
-	})
-	if err != nil {
-		return st.Err()
-	}
-	return withInfo.Err()
+		})
 }

--- a/go/internal/agent/services/tegra_camera_preflight_test.go
+++ b/go/internal/agent/services/tegra_camera_preflight_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 
 	"go.uber.org/zap"
-	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/streamreason"
 )
 
 func TestParseTegraVersions(t *testing.T) {
@@ -27,15 +28,15 @@ func TestTegraCSIPreflightMismatchHasErrorInfo(t *testing.T) {
 	if st.Code() != codes.FailedPrecondition {
 		t.Fatalf("code = %v, want FailedPrecondition", st.Code())
 	}
-	for _, detail := range st.Details() {
-		if info, ok := detail.(*errdetails.ErrorInfo); ok {
-			if info.Reason != tegraFirmwareMismatchReason || info.Metadata["rootfs_l4t"] != "R38.2.0" || info.Metadata["boot_firmware_l4t"] != "R36.4.3" {
-				t.Fatalf("unexpected ErrorInfo: %+v", info)
-			}
-			return
-		}
+	info := streamreason.Info(err)
+	if info == nil {
+		t.Fatal("missing ErrorInfo")
 	}
-	t.Fatal("missing ErrorInfo")
+	if info.GetReason() != tegraFirmwareMismatchReason ||
+		info.GetMetadata()["rootfs_l4t"] != "R38.2.0" ||
+		info.GetMetadata()["boot_firmware_l4t"] != "R36.4.3" {
+		t.Fatalf("unexpected ErrorInfo: %+v", info)
+	}
 }
 
 func TestTegraCSIPreflightUnknownDoesNotBlock(t *testing.T) {

--- a/go/internal/agent/services/video_framesize_test.go
+++ b/go/internal/agent/services/video_framesize_test.go
@@ -86,7 +86,7 @@ func TestBuildGStreamerArgs_USB_PrefersMJPEG(t *testing.T) {
 	withMJPEGProbe(t, func(path string, w, h uint32) bool { return w == 1280 && h == 720 })
 	req := &agentpb.StreamVideoRequest{Width: 1280, Height: 720}
 	args, err := buildGStreamerArgs("/usr/bin/gst-launch-1.0", "/dev/video9", req,
-		"x264enc", true, camera.TransportUSB, "", map[string]bool{"jpegdec": true})
+		"x264enc", true, camera.TransportUSB, "", pipeWireSource{}, map[string]bool{"jpegdec": true})
 	if err != nil {
 		t.Fatalf("buildGStreamerArgs: %v", err)
 	}
@@ -108,7 +108,7 @@ func TestBuildGStreamerArgs_USB_RawWhenNoMJPEG(t *testing.T) {
 	withMJPEGProbe(t, func(string, uint32, uint32) bool { return false })
 	req := &agentpb.StreamVideoRequest{Width: 640, Height: 480}
 	args, err := buildGStreamerArgs("/usr/bin/gst-launch-1.0", "/dev/video9", req,
-		"x264enc", true, camera.TransportUSB, "", map[string]bool{"jpegdec": true})
+		"x264enc", true, camera.TransportUSB, "", pipeWireSource{}, map[string]bool{"jpegdec": true})
 	if err != nil {
 		t.Fatalf("buildGStreamerArgs: %v", err)
 	}
@@ -127,7 +127,7 @@ func TestBuildGStreamerArgs_USB_RawWhenNoJpegdec(t *testing.T) {
 	withMJPEGProbe(t, func(string, uint32, uint32) bool { return true })
 	req := &agentpb.StreamVideoRequest{Width: 1280, Height: 720}
 	args, err := buildGStreamerArgs("/usr/bin/gst-launch-1.0", "/dev/video9", req,
-		"x264enc", true, camera.TransportUSB, "", map[string]bool{"x264enc": true})
+		"x264enc", true, camera.TransportUSB, "", pipeWireSource{}, map[string]bool{"x264enc": true})
 	if err != nil {
 		t.Fatalf("buildGStreamerArgs: %v", err)
 	}

--- a/go/internal/agent/services/video_pipewire_test.go
+++ b/go/internal/agent/services/video_pipewire_test.go
@@ -1,0 +1,189 @@
+package services
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/camera"
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+const testPWSerial uint64 = 68
+
+// pipewireElements is defaultElements plus the GStreamer PipeWire plugin, which
+// ships in its own package (gstreamer1.0-pipewire) and so must be probed for.
+func pipewireElements() map[string]bool {
+	e := defaultElements()
+	e["pipewiresrc"] = true
+	return e
+}
+
+func TestBuildSourceElement_UsesPipeWireNodeWhenPresent(t *testing.T) {
+	src := buildSourceElement("/dev/video9", camera.TransportUSB, "", pipeWireSource{serial: testPWSerial}, pipewireElements())
+	if src != fmt.Sprintf("pipewiresrc target-object=%d", testPWSerial) {
+		t.Errorf("expected pipewiresrc on the node, got %q", src)
+	}
+}
+
+func TestBuildSourceElement_NoNodeKeepsV4L2(t *testing.T) {
+	src := buildSourceElement("/dev/video9", camera.TransportUSB, "", pipeWireSource{}, pipewireElements())
+	if src != "v4l2src device=/dev/video9" {
+		t.Errorf("no node must leave the direct source in place, got %q", src)
+	}
+}
+
+// On CSI the ISP source is the only one producing usable frames, so a node for
+// the same device must not displace it.
+func TestBuildSourceElement_CSIKeepsLibcamerasrc(t *testing.T) {
+	src := buildSourceElement("/dev/video9", camera.TransportCSI, "/base/soc/i2c0mux/imx708@1a", pipeWireSource{serial: testPWSerial}, pipewireElements())
+	if !strings.HasPrefix(src, "libcamerasrc") {
+		t.Errorf("CSI must stay on libcamerasrc, got %q", src)
+	}
+}
+
+// Pinning a dimension on pipewiresrc trips "assertion 'gst_caps_is_fixed' failed" once
+// another client is streaming, so size goes through videoscale and rate through videorate.
+func TestBuildGStreamerArgs_PipeWireConvertsInsteadOfConstraining(t *testing.T) {
+	args, err := buildGStreamerArgs("gst", "/dev/video9",
+		&agentpb.StreamVideoRequest{Width: 640, Height: 480, Framerate: 30},
+		"x264enc", true, camera.TransportUSB, "", pipeWireSource{serial: testPWSerial}, pipewireElements())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "videoscale ! video/x-raw,width=640,height=480") {
+		t.Errorf("size must go through videoscale: %v", args)
+	}
+	if !strings.Contains(joined, "videorate max-rate=30") {
+		t.Errorf("rate must go through videorate: %v", args)
+	}
+	if strings.Contains(joined, fmt.Sprintf("pipewiresrc target-object=%d", testPWSerial)+" ! video/x-raw") {
+		t.Errorf("no capsfilter may sit directly on pipewiresrc: %v", args)
+	}
+	if strings.Contains(joined, "framerate=30/1") {
+		t.Errorf("framerate must not reach a source capsfilter: %v", args)
+	}
+}
+
+// With nothing requested the source is left completely unconstrained.
+func TestBuildGStreamerArgs_PipeWireDefaultsAddNoCaps(t *testing.T) {
+	withMJPEGProbe(t, func(string, uint32, uint32) bool { return true })
+
+	args, err := buildGStreamerArgs("gst", "/dev/video9", &agentpb.StreamVideoRequest{},
+		"x264enc", true, camera.TransportUSB, "", pipeWireSource{serial: testPWSerial}, pipewireElements())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "videoscale") || strings.Contains(joined, "videorate") {
+		t.Errorf("nothing was requested, so nothing should be converted: %v", args)
+	}
+	if strings.Contains(joined, "width=") || strings.Contains(joined, "height=") {
+		t.Errorf("no size may be pinned on the graph: %v", args)
+	}
+}
+
+// A backlog must be shed before any scale work is spent on it.
+func TestBuildGStreamerArgs_PipeWireQueuesBeforeConverting(t *testing.T) {
+	args, err := buildGStreamerArgs("gst", "/dev/video9",
+		&agentpb.StreamVideoRequest{Width: 640, Height: 480, Framerate: 30},
+		"x264enc", true, camera.TransportUSB, "", pipeWireSource{serial: testPWSerial}, pipewireElements())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	joined := strings.Join(args, " ")
+	if strings.Index(joined, "leaky=downstream") > strings.Index(joined, "videoscale") {
+		t.Errorf("the leaky queue must precede videoscale: %v", args)
+	}
+}
+
+// PipeWire's V4L2 source decodes MJPEG itself and publishes raw video, so an
+// image/jpeg capsfilter on pipewiresrc cannot negotiate.
+func TestBuildGStreamerArgs_PipeWireSkipsMJPEG(t *testing.T) {
+	withMJPEGProbe(t, func(string, uint32, uint32) bool { return true })
+
+	elements := pipewireElements()
+	elements["jpegdec"] = true
+	args, err := buildGStreamerArgs("gst", "/dev/video9",
+		&agentpb.StreamVideoRequest{Width: 1280, Height: 720},
+		"x264enc", true, camera.TransportUSB, "", pipeWireSource{serial: testPWSerial}, elements)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "image/jpeg") || strings.Contains(joined, "jpegdec") {
+		t.Errorf("pipewiresrc cannot deliver MJPEG: %v", args)
+	}
+}
+
+// The direct V4L2 path negotiates size and rate fine and must keep doing so.
+func TestBuildGStreamerArgs_V4L2KeepsCapsBehaviour(t *testing.T) {
+	withMJPEGProbe(t, func(string, uint32, uint32) bool { return false })
+
+	args, err := buildGStreamerArgs("gst", "/dev/video9",
+		&agentpb.StreamVideoRequest{Width: 640, Height: 480, Framerate: 30},
+		"x264enc", true, camera.TransportUSB, "", pipeWireSource{}, pipewireElements())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "video/x-raw,width=640,height=480,framerate=30/1") {
+		t.Errorf("v4l2src must still pin size and rate in caps: %v", args)
+	}
+	if strings.Contains(joined, "videoscale") || strings.Contains(joined, "videorate") {
+		t.Errorf("v4l2src needs no conversion stages: %v", args)
+	}
+}
+
+// The graph serves one format per camera, picked by whichever client got there
+// first. When that is MJPEG the type must be named and decoded — videoconvert
+// cannot take compressed input, and unnamed caps trip pipewiresrc's assertion.
+func TestBuildGStreamerArgs_PipeWireDecodesMJPEGNode(t *testing.T) {
+	elements := pipewireElements()
+	elements["jpegdec"] = true
+	args, err := buildGStreamerArgs("gst", "/dev/video9", &agentpb.StreamVideoRequest{},
+		"x264enc", true, camera.TransportUSB, "", pipeWireSource{serial: testPWSerial, jpeg: true}, elements)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "image/jpeg") || !strings.Contains(joined, "jpegdec") {
+		t.Errorf("an MJPEG node must be named and decoded: %v", args)
+	}
+}
+
+// jpeg describes a graph node, so it must not reach a pipeline that ended up on
+// another source: a jpeg capsfilter behind libcamerasrc cannot link, and the raw
+// side would lose the leaky queue that sheds its backlog.
+func TestBuildGStreamerArgs_JPEGNodeDoesNotSteerAnotherSource(t *testing.T) {
+	elements := pipewireElements()
+	elements["jpegdec"] = true
+	args, err := buildGStreamerArgs("gst", "/dev/video9", &agentpb.StreamVideoRequest{},
+		"x264enc", true, camera.TransportCSI, "/base/soc/i2c0mux/imx708@1a",
+		pipeWireSource{serial: testPWSerial, jpeg: true}, elements)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "image/jpeg") || strings.Contains(joined, "jpegdec") {
+		t.Errorf("libcamerasrc serves raw; no jpeg stage may appear: %v", args)
+	}
+	if !strings.Contains(joined, "leaky=downstream") {
+		t.Errorf("the raw path must keep its leaky queue: %v", args)
+	}
+}
+
+// videorate drops frames videoscale would otherwise resize for nothing.
+func TestBuildGStreamerArgs_PipeWireRatesBeforeScaling(t *testing.T) {
+	args, err := buildGStreamerArgs("gst", "/dev/video9",
+		&agentpb.StreamVideoRequest{Width: 640, Height: 480, Framerate: 15},
+		"x264enc", true, camera.TransportUSB, "", pipeWireSource{serial: testPWSerial}, pipewireElements())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	joined := strings.Join(args, " ")
+	if strings.Index(joined, "videorate") > strings.Index(joined, "videoscale") {
+		t.Errorf("videorate must precede videoscale: %v", args)
+	}
+}

--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -1004,6 +1004,14 @@ func (s *VideoService) captureLocalCamera(ctx context.Context, broadcast func([]
 	return err
 }
 
+// gstInspectTimeout bounds the element listing fork.
+const gstInspectTimeout = 10 * time.Second
+
+// firstFrameTimeout bounds the wait for a pipeline's first chunk. It has to clear the whole
+// device-side cold start -- element listing, PipeWire lookup, camera and encoder warm-up --
+// which on a loaded Pi or Jetson runs to several seconds.
+const firstFrameTimeout = 20 * time.Second
+
 // pipeWireProbeTimeout bounds the format probe below. A raw node yields nothing
 // to a JPEG request, so the probe ends by deadline rather than by error.
 const pipeWireProbeTimeout = 2 * time.Second
@@ -1011,25 +1019,31 @@ const pipeWireProbeTimeout = 2 * time.Second
 // nodeServesJPEG reports whether the graph is sending MJPEG for this node. pw-dump
 // advertises only what the device supports, not what the first client negotiated, and a
 // mismatched pipeline stalls rather than fails — so the live format is read, not guessed.
-func (s *VideoService) nodeServesJPEG(ctx context.Context, gstPath string, serial uint64) bool {
-	ctx, cancel := context.WithTimeout(ctx, pipeWireProbeTimeout)
+// The second return distinguishes a definite answer from an inconclusive one. A deadline or a
+// missing session is not evidence of a raw node, and reporting it as one used to build a
+// pipeline that stalled forever. Callers can now say so rather than guess silently.
+func (s *VideoService) nodeServesJPEG(ctx context.Context, gstPath string, serial uint64) (jpeg, known bool) {
+	probeCtx, cancel := context.WithTimeout(ctx, pipeWireProbeTimeout)
 	defer cancel()
-	cmd, err := audio.Command(ctx, gstPath, "-q",
+	cmd, err := audio.Command(probeCtx, gstPath, "-q",
 		"pipewiresrc", fmt.Sprintf("target-object=%d", serial), "num-buffers=1",
 		"!", "image/jpeg", "!", "fakesink")
 	if err != nil {
-		return false
+		s.logger.Debug("PipeWire format probe could not start",
+			zap.Uint64("node_serial", serial), zap.Error(err))
+		return false, false
 	}
 	if runErr := cmd.Run(); runErr != nil {
-		// A deadline here is inconclusive rather than a "no", and the raw pipeline it
-		// selects stalls silently on an MJPEG node, so record which of the two happened.
-		s.logger.Debug("PipeWire format probe found no MJPEG",
-			zap.Uint64("node_serial", serial),
-			zap.Bool("timed_out", ctx.Err() != nil),
-			zap.Error(runErr))
-		return false
+		// Only a clean refusal is evidence. If our own deadline killed the probe, or the
+		// parent context went away, the format is simply unknown.
+		if probeCtx.Err() != nil || ctx.Err() != nil {
+			s.logger.Debug("PipeWire format probe was inconclusive",
+				zap.Uint64("node_serial", serial), zap.Error(runErr))
+			return false, false
+		}
+		return false, true
 	}
-	return true
+	return true, true
 }
 
 // pipeWireSource names the graph node a pipeline reads, and how.
@@ -1317,6 +1331,20 @@ func (s *VideoService) runIPProducer(ctx context.Context, broadcast func([]byte,
 	})
 }
 
+// errCaptureSetup classifies a buffer-setup or streaming ioctl failure. EBUSY here is the
+// same contention S_FMT reports elsewhere: vb2 drivers enforce queue ownership at REQBUFS
+// and STREAMON rather than at S_FMT, so without this the sharing fallback never runs on them.
+// The errno is logged rather than returned, matching the deliberately opaque open/S_FMT
+// messages -- returning it lets an authenticated client enumerate the system.
+func (s *VideoService) errCaptureSetup(ioctl, path string, errno unix.Errno) error {
+	if isBusyErrno(errno) {
+		return errCameraInUse(path)
+	}
+	s.logger.Error("V4L2 capture setup failed",
+		zap.String("device", path), zap.String("ioctl", ioctl), zap.Error(errno))
+	return status.Errorf(codes.Internal, "failed to start video capture")
+}
+
 // streamV4L2Native opens the V4L2 device, configures H.264 output via VIDIOC_S_FMT,
 // allocates mmap buffers, and streams frames until ctx is cancelled or an error occurs.
 // Each captured frame is delivered via the broadcast callback; if the callback returns
@@ -1366,8 +1394,9 @@ func (s *VideoService) streamV4L2Native(ctx context.Context, broadcast func([]by
 			return nativeH264NotSupported{msg: fmt.Sprintf("VIDIOC_S_FMT H264 rejected: %v", errno)}
 		}
 		s.logger.Error("VIDIOC_S_FMT failed", zap.String("device", path), zap.Error(errno))
-		// Opening a V4L2 node always succeeds — the kernel only refuses the
-		// second *streaming* consumer, and it does so here, at S_FMT.
+		// Where the kernel refuses a second consumer is driver-dependent: uvcvideo
+		// refuses at S_FMT, while vb2 drivers enforce queue ownership later, at
+		// REQBUFS or STREAMON. Every such site classifies EBUSY, not just this one.
 		if isBusyErrno(errno) {
 			return errCameraInUse(path)
 		}
@@ -1390,7 +1419,7 @@ func (s *VideoService) streamV4L2Native(ctx context.Context, broadcast func([]by
 	req4.Memory = v4l2MemoryMmap
 
 	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), vidiocReqbufs, uintptr(unsafe.Pointer(&req4))); errno != 0 {
-		return status.Errorf(codes.Internal, "VIDIOC_REQBUFS: %v", errno)
+		return s.errCaptureSetup("VIDIOC_REQBUFS", path, errno)
 	}
 	if req4.Count < 2 {
 		return status.Errorf(codes.Internal, "insufficient buffer memory on device")
@@ -1406,7 +1435,7 @@ func (s *VideoService) streamV4L2Native(ctx context.Context, broadcast func([]by
 		qbuf.setMemory(v4l2MemoryMmap)
 
 		if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), vidiocQuerybuf, uintptr(unsafe.Pointer(&qbuf))); errno != 0 {
-			return status.Errorf(codes.Internal, "VIDIOC_QUERYBUF[%d]: %v", i, errno)
+			return s.errCaptureSetup("VIDIOC_QUERYBUF", path, errno)
 		}
 
 		length := uint32(*(*uint32)(unsafe.Pointer(&qbuf[72]))) // length at offset 72 in v4l2_buffer
@@ -1417,7 +1446,7 @@ func (s *VideoService) streamV4L2Native(ctx context.Context, broadcast func([]by
 		mapped[i] = data
 
 		if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), vidiocQbuf, uintptr(unsafe.Pointer(&qbuf))); errno != 0 {
-			return status.Errorf(codes.Internal, "VIDIOC_QBUF[%d]: %v", i, errno)
+			return s.errCaptureSetup("VIDIOC_QBUF", path, errno)
 		}
 	}
 	defer func() {
@@ -1429,7 +1458,7 @@ func (s *VideoService) streamV4L2Native(ctx context.Context, broadcast func([]by
 	// Start streaming.
 	bufType := uint32(v4l2BufTypeVideoCapture)
 	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), vidiocStreamon, uintptr(unsafe.Pointer(&bufType))); errno != 0 {
-		return status.Errorf(codes.Internal, "VIDIOC_STREAMON: %v", errno)
+		return s.errCaptureSetup("VIDIOC_STREAMON", path, errno)
 	}
 	defer func() {
 		unix.Syscall(unix.SYS_IOCTL, uintptr(fd), vidiocStreamoff, uintptr(unsafe.Pointer(&bufType))) //nolint:errcheck
@@ -1468,12 +1497,18 @@ func (s *VideoService) streamV4L2Native(ctx context.Context, broadcast func([]by
 			if errno == unix.EINTR || errno == unix.EAGAIN {
 				continue
 			}
+			// Contention first: EBUSY here is a held camera, not a device that cannot
+			// encode H264, so it must reach the sharing fallback rather than the
+			// software-encoder one below.
+			if isBusyErrno(errno) {
+				return errCameraInUse(path)
+			}
 			// Device accepted H264 format but failed before delivering any frame —
 			// signal the caller to fall back to the GStreamer software encoder.
 			if framesSent == 0 {
 				return nativeH264NotSupported{msg: fmt.Sprintf("VIDIOC_DQBUF failed before first frame: %v", errno)}
 			}
-			return status.Errorf(codes.Internal, "VIDIOC_DQBUF: %v", errno)
+			return s.errCaptureSetup("VIDIOC_DQBUF", path, errno)
 		}
 
 		idx := dqbuf.index()
@@ -1501,7 +1536,7 @@ func (s *VideoService) streamV4L2Native(ctx context.Context, broadcast func([]by
 		qbuf.setType(v4l2BufTypeVideoCapture)
 		qbuf.setMemory(v4l2MemoryMmap)
 		if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), vidiocQbuf, uintptr(unsafe.Pointer(&qbuf))); errno != 0 {
-			return status.Errorf(codes.Internal, "VIDIOC_QBUF requeue[%d]: %v", idx, errno)
+			return s.errCaptureSetup("VIDIOC_QBUF", path, errno)
 		}
 	}
 }
@@ -1637,7 +1672,17 @@ func (s *VideoService) streamGStreamer(ctx context.Context, broadcast func([]byt
 		// Probe here, not at the call site: the element set is what says whether a
 		// jpegdec stage can be built at all, and an absent one must not reach the
 		// pipeline. Also keeps the 2s probe off the path that rejects pipewiresrc.
-		pw.jpeg = available["jpegdec"] && s.nodeServesJPEG(ctx, gstPath, pw.serial)
+		if available["jpegdec"] {
+			jpeg, known := s.nodeServesJPEG(ctx, gstPath, pw.serial)
+			pw.jpeg = jpeg
+			if !known {
+				// Treated as raw, but say so: a wrong guess costs the first-frame
+				// deadline below, after which the caller reports the contention that
+				// sent us here rather than a graph error nobody asked about.
+				s.logger.Info("PipeWire node format unknown; assuming raw",
+					zap.String("device", path), zap.Uint64("node_serial", pw.serial))
+			}
+		}
 	}
 
 	enc, err := findGStreamerEncoderFromSet(available)
@@ -1728,6 +1773,19 @@ func (s *VideoService) streamGStreamer(ctx context.Context, broadcast func([]byt
 	const chunkSize = 256 * 1024
 	buf := make([]byte, chunkSize)
 
+	// A mismatched pipeline does not fail, it stalls: gst stays alive producing nothing,
+	// stdout.Read blocks on a pipe with no deadline, and nothing above this loop bounds it --
+	// so `camera view` hangs with no frame and no error. Kill the pipeline instead and report
+	// it. Set below the dashboard player's own 25s budget so this specific error wins the race.
+	var timedOut atomic.Bool
+	firstChunk := time.AfterFunc(firstFrameTimeout, func() {
+		timedOut.Store(true)
+		if cmd.Process != nil {
+			cmd.Process.Kill() //nolint:errcheck
+		}
+	})
+	defer firstChunk.Stop()
+
 	// gstMaxFrameRate is the maximum number of frame allocations per second from
 	// the GStreamer read loop. A misbehaving or adversarially replaced gst-launch
 	// binary could write at arbitrarily high rate; bounding the allocation rate
@@ -1746,6 +1804,7 @@ func (s *VideoService) streamGStreamer(ctx context.Context, broadcast func([]byt
 
 		n, readErr := stdout.Read(buf)
 		if n > 0 {
+			firstChunk.Stop()
 			now := time.Now()
 			passFrame := lastFrameTime.IsZero() || now.Sub(lastFrameTime) >= minFrameInterval
 			lastFrameTime = now // always update to prevent burst bypass after a gap
@@ -1761,6 +1820,10 @@ func (s *VideoService) streamGStreamer(ctx context.Context, broadcast func([]byt
 			}
 		}
 		if readErr != nil {
+			if timedOut.Load() {
+				return status.Errorf(codes.DeadlineExceeded,
+					"camera produced no video within %s", firstFrameTimeout)
+			}
 			if readErr == io.EOF {
 				return nil // normal termination; defer surfaces stderr/exit errors
 			}
@@ -1900,7 +1963,11 @@ func findGStreamerEncoderFromSet(available map[string]bool) (gstEncoderResult, e
 // listGSTElements runs gst-inspect-1.0 once and returns a set of all available element names.
 // Each output line has the form "plugin:  element: description".
 func listGSTElements(inspectPath string) (map[string]bool, error) {
-	out, err := exec.Command(inspectPath).Output()
+	// Bounded: this walks the whole plugin registry, runs on the contended-camera path where
+	// the operator is already waiting, and an unbounded fork here would hang that path.
+	ctx, cancel := context.WithTimeout(context.Background(), gstInspectTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, inspectPath).Output()
 	if err != nil {
 		return nil, fmt.Errorf("gst-inspect-1.0: %w", err)
 	}

--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unsafe"
 
@@ -24,6 +25,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/wendylabsinc/wendy/go/internal/agent/audio"
 	"github.com/wendylabsinc/wendy/go/internal/agent/board"
 	"github.com/wendylabsinc/wendy/go/internal/agent/camera"
 	"github.com/wendylabsinc/wendy/go/internal/agent/ipcam"
@@ -478,8 +480,11 @@ type VideoService struct {
 	classifyTransport  func(base string) (camera.Transport, string)
 	enumerateLibcamera func(ctx context.Context) (map[string]string, error)
 	isJetson           func() bool
-	readTegraRelease   func() ([]byte, error)
-	dumpBootSlots      func(context.Context) ([]byte, error)
+	// findCameraSource resolves a device path to its PipeWire node serial. A
+	// seam so tests do not fork pw-dump at the host's session.
+	findCameraSource func(ctx context.Context, devicePath string) (uint64, bool)
+	readTegraRelease func() ([]byte, error)
+	dumpBootSlots    func(context.Context) ([]byte, error)
 
 	ctx    context.Context    // cancelled on Shutdown; hub contexts are derived from this
 	cancel context.CancelFunc // cancels ctx
@@ -520,6 +525,7 @@ func NewVideoService(ctx context.Context, logger *zap.Logger) *VideoService {
 		},
 		classifyTransport:  camera.Classify,
 		enumerateLibcamera: camera.EnumerateLibcamera,
+		findCameraSource:   audio.FindCameraSource,
 		isJetson:           func() bool { return board.Detect().IsJetson() },
 		readTegraRelease:   func() ([]byte, error) { return os.ReadFile("/etc/nv_tegra_release") },
 		dumpBootSlots: func(ctx context.Context) ([]byte, error) {
@@ -917,16 +923,12 @@ func (s *VideoService) runProducer(ctx context.Context, h *deviceHub, path strin
 
 		// CSI/ribbon sensors emit raw Bayer/RGB, not encoded H.264 — skip the native
 		// V4L2 H.264 path entirely and capture via GStreamer (libcamerasrc, or
-		// nvarguscamerasrc on Jetson). USB/unknown cameras keep native-H.264-first.
+		// nvarguscamerasrc on Jetson).
 		if transport == camera.TransportCSI {
 			s.logger.Info("CSI camera detected, using GStreamer", zap.String("device", path))
-			err = s.streamGStreamer(ctx, broadcast, path, req, transport, libcameraID)
+			err = s.streamGStreamer(ctx, broadcast, path, req, transport, libcameraID, pipeWireSource{})
 		} else {
-			err = s.streamV4L2Native(ctx, broadcast, path, req)
-			if _, ok := err.(nativeH264NotSupported); ok {
-				s.logger.Info("native H.264 not supported, falling back to GStreamer", zap.String("device", path))
-				err = s.streamGStreamer(ctx, broadcast, path, req, transport, libcameraID)
-			}
+			err = s.captureLocalCamera(ctx, broadcast, path, req, transport, libcameraID)
 		}
 	}
 	if err != nil && ctx.Err() == nil {
@@ -957,6 +959,83 @@ func (s *VideoService) runProducer(ctx context.Context, h *deviceHub, path strin
 	// Signal that the device fd is fully released. getOrCreateHub waits on
 	// this before opening a new producer to avoid EBUSY on reconnect.
 	close(h.done)
+}
+
+// captureLocalCamera reads a USB/unknown camera, preferring the cheapest source: raw V4L2
+// keeps MJPEG capture and the best-mode probe, so the graph is only worth its
+// raw-plus-re-encode cost once the device refuses a second streaming consumer.
+func (s *VideoService) captureLocalCamera(ctx context.Context, broadcast func([]byte, uint64, agentpb.VideoCodec) bool, path string, req *agentpb.StreamVideoRequest, transport camera.Transport, libcameraID string) error {
+	// A second source may only take over before a frame has reached subscribers: restarting
+	// mid-stream splices a new resolution and SPS into what downstream reads as one timeline.
+	var delivered atomic.Bool
+	send := func(data []byte, tsNs uint64, codec agentpb.VideoCodec) bool {
+		ok := broadcast(data, tsNs, codec)
+		if ok && !delivered.Load() {
+			delivered.Store(true)
+		}
+		return ok
+	}
+
+	err := s.streamV4L2Native(ctx, send, path, req)
+	if _, ok := err.(nativeH264NotSupported); ok {
+		s.logger.Info("native H.264 not supported, falling back to GStreamer", zap.String("device", path))
+		err = s.streamGStreamer(ctx, send, path, req, transport, libcameraID, pipeWireSource{})
+	}
+	if !isCameraInUse(err) || delivered.Load() || ctx.Err() != nil {
+		return err
+	}
+
+	serial, ok := s.findCameraSource(ctx, path)
+	if !ok {
+		return err
+	}
+	s.logger.Info("camera held by another client, capturing through PipeWire",
+		zap.String("device", path), zap.Uint64("node_serial", serial))
+
+	// Contention stays the answer when sharing fails outright: it is the cause an operator
+	// can act on, and a graph error names a pipeline they did not ask for. Once the shared
+	// stream has shipped frames the camera is demonstrably readable, so its own error wins.
+	pwErr := s.streamGStreamer(ctx, send, path, req, transport, libcameraID, pipeWireSource{serial: serial})
+	if pwErr == nil || ctx.Err() != nil || isCameraInUse(pwErr) || delivered.Load() {
+		return pwErr
+	}
+	s.logger.Warn("PipeWire capture failed for a held camera",
+		zap.String("device", path), zap.Error(pwErr))
+	return err
+}
+
+// pipeWireProbeTimeout bounds the format probe below. A raw node yields nothing
+// to a JPEG request, so the probe ends by deadline rather than by error.
+const pipeWireProbeTimeout = 2 * time.Second
+
+// nodeServesJPEG reports whether the graph is sending MJPEG for this node. pw-dump
+// advertises only what the device supports, not what the first client negotiated, and a
+// mismatched pipeline stalls rather than fails — so the live format is read, not guessed.
+func (s *VideoService) nodeServesJPEG(ctx context.Context, gstPath string, serial uint64) bool {
+	ctx, cancel := context.WithTimeout(ctx, pipeWireProbeTimeout)
+	defer cancel()
+	cmd, err := audio.Command(ctx, gstPath, "-q",
+		"pipewiresrc", fmt.Sprintf("target-object=%d", serial), "num-buffers=1",
+		"!", "image/jpeg", "!", "fakesink")
+	if err != nil {
+		return false
+	}
+	if runErr := cmd.Run(); runErr != nil {
+		// A deadline here is inconclusive rather than a "no", and the raw pipeline it
+		// selects stalls silently on an MJPEG node, so record which of the two happened.
+		s.logger.Debug("PipeWire format probe found no MJPEG",
+			zap.Uint64("node_serial", serial),
+			zap.Bool("timed_out", ctx.Err() != nil),
+			zap.Error(runErr))
+		return false
+	}
+	return true
+}
+
+// pipeWireSource names the graph node a pipeline reads, and how.
+type pipeWireSource struct {
+	serial uint64
+	jpeg   bool
 }
 
 // maxVideoDeviceID is the upper bound for accepted device IDs.
@@ -1247,6 +1326,9 @@ func (s *VideoService) streamV4L2Native(ctx context.Context, broadcast func([]by
 	fd, err := unix.Open(path, unix.O_RDWR|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
 	if err != nil {
 		s.logger.Error("failed to open video device", zap.String("device", path), zap.Error(err))
+		if isBusyErrno(err) {
+			return errCameraInUse(path)
+		}
 		return status.Errorf(codes.Internal, "failed to open video device")
 	}
 	defer unix.Close(fd) //nolint:errcheck
@@ -1275,11 +1357,20 @@ func (s *VideoService) streamV4L2Native(ctx context.Context, broadcast func([]by
 	vfmt.PixelFormat = v4l2PixFmtH264
 	vfmt.Field = v4l2FieldNone
 
-	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), vidiocSFmt, uintptr(unsafe.Pointer(&vfmt))); errno != 0 {
+	sfmt := func() unix.Errno {
+		_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), vidiocSFmt, uintptr(unsafe.Pointer(&vfmt)))
+		return errno
+	}
+	if errno := retryWhileBusy(ctx, sfmt); errno != 0 {
 		if errno == unix.EINVAL {
 			return nativeH264NotSupported{msg: fmt.Sprintf("VIDIOC_S_FMT H264 rejected: %v", errno)}
 		}
 		s.logger.Error("VIDIOC_S_FMT failed", zap.String("device", path), zap.Error(errno))
+		// Opening a V4L2 node always succeeds — the kernel only refuses the
+		// second *streaming* consumer, and it does so here, at S_FMT.
+		if isBusyErrno(errno) {
+			return errCameraInUse(path)
+		}
 		return status.Errorf(codes.Internal, "failed to configure video device")
 	}
 	if vfmt.PixelFormat != v4l2PixFmtH264 {
@@ -1511,7 +1602,7 @@ func resolveGSTBinary(name string) (string, error) {
 
 // streamGStreamer spawns gst-launch-1.0 on the device to encode via the best available
 // encoder and pipes the resulting stream back as videoFrame chunks via the broadcast callback.
-func (s *VideoService) streamGStreamer(ctx context.Context, broadcast func([]byte, uint64, agentpb.VideoCodec) bool, path string, req *agentpb.StreamVideoRequest, transport camera.Transport, libcameraID string) (runErr error) {
+func (s *VideoService) streamGStreamer(ctx context.Context, broadcast func([]byte, uint64, agentpb.VideoCodec) bool, path string, req *agentpb.StreamVideoRequest, transport camera.Transport, libcameraID string, pw pipeWireSource) (runErr error) {
 	gstPath, err := resolveGSTBinary("gst-launch-1.0")
 	if err != nil {
 		return status.Errorf(codes.FailedPrecondition, "%v", err)
@@ -1528,6 +1619,25 @@ func (s *VideoService) streamGStreamer(ctx context.Context, broadcast func([]byt
 		// findGStreamerEncoderFromSet handles a nil set by attempting x264enc.
 		s.logger.Debug("gst-inspect listing failed", zap.Error(listErr))
 		available = nil
+	}
+
+	if pw.serial != 0 {
+		if listErr != nil {
+			// A listing failure is not contention; saying so would send the operator
+			// after a process that does not hold the camera.
+			return status.Errorf(codes.Internal, "cannot check for gstreamer1.0-pipewire: %v", listErr)
+		}
+		// Name the missing package rather than silently opening the device this
+		// call was chosen to avoid: pipewiresrc ships separately from the daemon.
+		if !available["pipewiresrc"] {
+			s.logger.Warn("gstreamer1.0-pipewire is missing; cannot read a camera another client holds",
+				zap.String("device", path))
+			return errCameraInUse(path)
+		}
+		// Probe here, not at the call site: the element set is what says whether a
+		// jpegdec stage can be built at all, and an absent one must not reach the
+		// pipeline. Also keeps the 2s probe off the path that rejects pipewiresrc.
+		pw.jpeg = available["jpegdec"] && s.nodeServesJPEG(ctx, gstPath, pw.serial)
 	}
 
 	enc, err := findGStreamerEncoderFromSet(available)
@@ -1558,12 +1668,26 @@ func (s *VideoService) streamGStreamer(ctx context.Context, broadcast func([]byt
 			zap.Int("sensor_id", sensorID), zap.String("encoder", enc.element))
 		args = buildArgusGStreamerArgs(gstPath, req, sensorID, enc.element, enc.hasH264Parse, available)
 	} else {
-		args, err = buildGStreamerArgs(gstPath, path, req, enc.element, enc.hasH264Parse, transport, libcameraID, available)
+		args, err = buildGStreamerArgs(gstPath, path, req, enc.element, enc.hasH264Parse, transport, libcameraID, pw, available)
 		if err != nil {
 			return status.Errorf(codes.Internal, "failed to build GStreamer pipeline: %v", err)
 		}
 	}
-	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	var cmd *exec.Cmd
+	if pw.serial != 0 {
+		// The agent runs as root outside any session, so a PipeWire client it
+		// spawns must be pointed at the wendy session. Without it the client
+		// reaches the system-wide daemon, whose graph is empty.
+		var envErr error
+		if cmd, envErr = audio.Command(ctx, args[0], args[1:]...); envErr != nil {
+			return status.Errorf(codes.Unavailable, "PipeWire session unavailable: %v", envErr)
+		}
+	} else {
+		cmd = exec.CommandContext(ctx, args[0], args[1:]...)
+	}
+	// The busy classifier reads gst's prose. LC_ALL=C is the one value glibc short-circuits
+	// ahead of LANGUAGE, so messages cannot come back translated; exec keeps the last entry.
+	cmd.Env = append(cmd.Environ(), "LC_ALL=C")
 	stderrBuf := &limitedBuffer{limit: maxStderrBytes}
 	cmd.Stderr = stderrBuf
 
@@ -1587,7 +1711,14 @@ func (s *VideoService) streamGStreamer(ctx context.Context, broadcast func([]byt
 			msg := strings.TrimSpace(stderrBuf.buf.String())
 			if msg != "" {
 				s.logger.Error("GStreamer pipeline failed", zap.String("device", path), zap.String("stderr", msg))
-				runErr = status.Errorf(codes.Internal, "GStreamer pipeline failed; see agent logs for details")
+				// Contention is the one cause an operator can act on, and it is only ever
+				// reported as prose on stderr. Gated on the pipeline failing by itself: gst
+				// also prints busy warnings while probing modes it then recovers from.
+				if exitedOnError(waitErr) && isBusyStderr(msg, path) {
+					runErr = errCameraInUse(path)
+				} else {
+					runErr = status.Errorf(codes.Internal, "GStreamer pipeline failed; see agent logs for details")
+				}
 			} else if waitErr != nil {
 				runErr = status.Errorf(codes.Internal, "GStreamer pipeline failed; see agent logs for details")
 			}
@@ -1813,7 +1944,7 @@ const leakyRawQueue = "queue max-size-buffers=2 max-size-bytes=0 max-size-time=0
 // Returns an error if any interpolated string contains GStreamer pipeline injection
 // tokens — making the security property a hard failure at construction time rather
 // than relying solely on caller-side allowlist validation.
-func buildGStreamerArgs(gstPath, devicePath string, req *agentpb.StreamVideoRequest, encoder string, hasH264Parse bool, transport camera.Transport, libcameraID string, available map[string]bool) ([]string, error) {
+func buildGStreamerArgs(gstPath, devicePath string, req *agentpb.StreamVideoRequest, encoder string, hasH264Parse bool, transport camera.Transport, libcameraID string, pw pipeWireSource, available map[string]bool) ([]string, error) {
 	// Validate numeric request parameters here (not only at StreamVideo entry) so
 	// buildGStreamerArgs is safe regardless of call site — prevents injection via
 	// unbounded width/height/framerate values if called from a different path.
@@ -1831,7 +1962,10 @@ func buildGStreamerArgs(gstPath, devicePath string, req *agentpb.StreamVideoRequ
 	// For CSI cameras the source is libcamerasrc (with a validated camera-name);
 	// otherwise v4l2src on the device path. libcameraID is validated inside
 	// buildSourceElement, so it is not subject to the devicePath/encoder check above.
-	src := buildSourceElement(devicePath, transport, libcameraID, available)
+	src := buildSourceElement(devicePath, transport, libcameraID, pw, available)
+	usingPipeWire := strings.HasPrefix(src, "pipewiresrc")
+	// GOP is in frames. On the PipeWire path videorate only caps the rate, so a
+	// graph running slower than requested spaces keyframes further apart in time.
 	gop := keyframeIntervalFrames(req.GetFramerate())
 
 	// libcamerasrc (CSI/PiSP) must be pinned to a processed format or it
@@ -1846,28 +1980,44 @@ func buildGStreamerArgs(gstPath, devicePath string, req *agentpb.StreamVideoRequ
 	if strings.HasPrefix(src, "libcamerasrc") {
 		capsParts = append(capsParts, "format=NV12")
 	}
-	// Same "default must not mean smallest" rule as the native path: with no
-	// width/height in the caps the source negotiates its first mode, which on UVC
-	// is the smallest. Ask the device what it has and pin the best.
-	capW, capH := req.GetWidth(), req.GetHeight()
-	if (capW == 0 || capH == 0) && !strings.HasPrefix(src, "libcamerasrc") {
-		if bw, bh := bestDefaultFrameSizeForDevice(devicePath); bw > 0 && bh > 0 {
-			if capW == 0 {
-				capW = bw
-			}
-			if capH == 0 {
-				capH = bh
+	// No dimension may be pinned on pipewiresrc: once another client is streaming, that
+	// trips "assertion 'gst_caps_is_fixed' failed". Naming the media type alone is fine.
+	// Convert after the queue instead, where videoscale and videorate take what they get.
+	var capW, capH uint32
+	var convertStages []string
+	if usingPipeWire {
+		// Rate first: the graph serves whatever the first client negotiated, so
+		// scaling ahead of videorate pays for frames it is about to drop.
+		if req.GetFramerate() > 0 {
+			convertStages = append(convertStages, fmt.Sprintf("videorate max-rate=%d", req.GetFramerate()))
+		}
+		if req.GetWidth() > 0 && req.GetHeight() > 0 {
+			convertStages = append(convertStages, "videoscale",
+				fmt.Sprintf("video/x-raw,width=%d,height=%d", req.GetWidth(), req.GetHeight()))
+		}
+	} else {
+		// "Default" must not mean "smallest": with no width/height the source
+		// negotiates its first mode, which on UVC is the smallest.
+		capW, capH = req.GetWidth(), req.GetHeight()
+		if (capW == 0 || capH == 0) && !strings.HasPrefix(src, "libcamerasrc") {
+			if bw, bh := bestDefaultFrameSizeForDevice(devicePath); bw > 0 && bh > 0 {
+				if capW == 0 {
+					capW = bw
+				}
+				if capH == 0 {
+					capH = bh
+				}
 			}
 		}
-	}
-	if capW > 0 {
-		capsParts = append(capsParts, fmt.Sprintf("width=%d", capW))
-	}
-	if capH > 0 {
-		capsParts = append(capsParts, fmt.Sprintf("height=%d", capH))
-	}
-	if req.GetFramerate() > 0 {
-		capsParts = append(capsParts, fmt.Sprintf("framerate=%d/1", req.GetFramerate()))
+		if capW > 0 {
+			capsParts = append(capsParts, fmt.Sprintf("width=%d", capW))
+		}
+		if capH > 0 {
+			capsParts = append(capsParts, fmt.Sprintf("height=%d", capH))
+		}
+		if req.GetFramerate() > 0 {
+			capsParts = append(capsParts, fmt.Sprintf("framerate=%d/1", req.GetFramerate()))
+		}
 	}
 
 	// Prefer compressed (MJPEG) capture from USB cameras when the device offers
@@ -1878,21 +2028,33 @@ func buildGStreamerArgs(gstPath, devicePath string, req *agentpb.StreamVideoRequ
 	// 720p). jpegdec is cheap relative to the H.264 encode that follows. The
 	// leaky queue sits on the compressed side so backlog is dropped before,
 	// not after, the decode work is spent.
-	useMJPEG := !strings.HasPrefix(src, "libcamerasrc") &&
+	//
+	// The PipeWire path negotiates whatever the graph serves, so it selects no
+	// capture format of its own.
+	useMJPEG := !strings.HasPrefix(src, "libcamerasrc") && !usingPipeWire &&
 		capW > 0 && capH > 0 &&
 		available["jpegdec"] &&
 		deviceSupportsMJPEGSize(devicePath, capW, capH)
 
-	var pipeline string
-	if useMJPEG {
-		caps := "image/jpeg," + strings.Join(capsParts, ",")
-		pipeline = fmt.Sprintf("%s ! %s ! %s ! jpegdec ! %s ! fdsink fd=1", src, caps, leakyRawQueue, encoderSegment(encoder, hasH264Parse, gop))
-	} else if len(capsParts) > 0 {
-		caps := "video/x-raw," + strings.Join(capsParts, ",")
-		pipeline = fmt.Sprintf("%s ! %s ! %s ! %s ! fdsink fd=1", src, caps, leakyRawQueue, encoderSegment(encoder, hasH264Parse, gop))
-	} else {
-		pipeline = fmt.Sprintf("%s ! %s ! %s ! fdsink fd=1", src, leakyRawQueue, encoderSegment(encoder, hasH264Parse, gop))
+	// The leaky queue goes as early as the source allows, so a backlog is shed
+	// before any decode or scale work is spent on it. pw.jpeg only describes a
+	// graph node, so it may not steer a pipeline that ended up on another source.
+	stages := []string{src}
+	switch {
+	case useMJPEG:
+		stages = append(stages, "image/jpeg,"+strings.Join(capsParts, ","), leakyRawQueue, "jpegdec")
+	case usingPipeWire && pw.jpeg:
+		// Name the type and decode it: videoconvert cannot take compressed input.
+		stages = append(stages, "image/jpeg", leakyRawQueue, "jpegdec")
+	default:
+		if len(capsParts) > 0 {
+			stages = append(stages, "video/x-raw,"+strings.Join(capsParts, ","))
+		}
+		stages = append(stages, leakyRawQueue)
 	}
+	stages = append(stages, convertStages...)
+	stages = append(stages, encoderSegment(encoder, hasH264Parse, gop), "fdsink fd=1")
+	pipeline := strings.Join(stages, " ! ")
 	// -q suppresses gst-launch's status messages (e.g. "Setting pipeline to PLAYING")
 	// from being written to stdout and corrupting the binary H264 stream.
 	return append([]string{gstPath, "-q"}, strings.Fields(pipeline)...), nil
@@ -1952,12 +2114,17 @@ func (s *VideoService) lookupLibcameraID(ctx context.Context, transport camera.T
 // injection sink. An ID that fails validation is dropped and libcamerasrc
 // auto-selects instead. (devicePath is always "/dev/video%d" formatted from a
 // uint32 device id, so it cannot contain whitespace or pipeline separators.)
-func buildSourceElement(devicePath string, transport camera.Transport, libcameraID string, available map[string]bool) string {
+func buildSourceElement(devicePath string, transport camera.Transport, libcameraID string, pw pipeWireSource, available map[string]bool) string {
 	if transport == camera.TransportCSI && available != nil && available["libcamerasrc"] {
 		if camera.IsValidLibcameraID(libcameraID) {
 			return fmt.Sprintf("libcamerasrc camera-name=%s", libcameraID)
 		}
 		return "libcamerasrc"
+	}
+	// pipewiresrc reads the camera through the graph, so the device node stays free for
+	// other consumers. streamGStreamer checks the element ships before setting pw.serial.
+	if pw.serial != 0 {
+		return fmt.Sprintf("pipewiresrc target-object=%d", pw.serial)
 	}
 	return fmt.Sprintf("v4l2src device=%s", devicePath)
 }

--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -20,7 +20,6 @@ import (
 
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
-	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -29,6 +28,7 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/agent/board"
 	"github.com/wendylabsinc/wendy/go/internal/agent/camera"
 	"github.com/wendylabsinc/wendy/go/internal/agent/ipcam"
+	"github.com/wendylabsinc/wendy/go/internal/shared/streamreason"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
 
@@ -443,7 +443,7 @@ const ipHubKeyPrefix = "ip:"
 // reasonIPCameraNoCredentials is the ErrorInfo reason for a network camera with
 // no stored login. The command-line interface turns it into a camera login hint,
 // the same way TEGRA_FIRMWARE_MISMATCH becomes an os install hint.
-const reasonIPCameraNoCredentials = "IP_CAMERA_NO_CREDENTIALS"
+const reasonIPCameraNoCredentials = streamreason.IPCameraNoCredentials
 
 // State paths for network cameras, under the agent's existing state directory.
 // Declared as vars so tests can point them at a temporary directory.
@@ -784,16 +784,9 @@ func (s *VideoService) ipCameraCredentials(cam ipcam.Camera) (ipcam.Credential, 
 			return cred, nil
 		}
 	}
-	st := status.New(codes.FailedPrecondition,
-		fmt.Sprintf("camera %d has no stored credentials", cam.ID))
-	detailed, err := st.WithDetails(&errdetails.ErrorInfo{
-		Reason:   reasonIPCameraNoCredentials,
-		Metadata: map[string]string{"device_id": fmt.Sprintf("%d", cam.ID)},
-	})
-	if err != nil {
-		return ipcam.Credential{}, st.Err()
-	}
-	return ipcam.Credential{}, detailed.Err()
+	return ipcam.Credential{}, streamreason.New(codes.FailedPrecondition,
+		fmt.Sprintf("camera %d has no stored credentials", cam.ID),
+		reasonIPCameraNoCredentials, map[string]string{"device_id": fmt.Sprintf("%d", cam.ID)})
 }
 
 // maxHubRetries is the maximum number of times getOrCreateHub will retry after
@@ -967,12 +960,12 @@ func (s *VideoService) runProducer(ctx context.Context, h *deviceHub, path strin
 func (s *VideoService) captureLocalCamera(ctx context.Context, broadcast func([]byte, uint64, agentpb.VideoCodec) bool, path string, req *agentpb.StreamVideoRequest, transport camera.Transport, libcameraID string) error {
 	// A second source may only take over before a frame has reached subscribers: restarting
 	// mid-stream splices a new resolution and SPS into what downstream reads as one timeline.
-	var delivered atomic.Bool
+	// Plain bool, not atomic: send runs on this producer goroutine's capture loop, and every
+	// read below happens after that loop has returned.
+	var delivered bool
 	send := func(data []byte, tsNs uint64, codec agentpb.VideoCodec) bool {
 		ok := broadcast(data, tsNs, codec)
-		if ok && !delivered.Load() {
-			delivered.Store(true)
-		}
+		delivered = delivered || ok
 		return ok
 	}
 
@@ -981,7 +974,7 @@ func (s *VideoService) captureLocalCamera(ctx context.Context, broadcast func([]
 		s.logger.Info("native H.264 not supported, falling back to GStreamer", zap.String("device", path))
 		err = s.streamGStreamer(ctx, send, path, req, transport, libcameraID, pipeWireSource{})
 	}
-	if !isCameraInUse(err) || delivered.Load() || ctx.Err() != nil {
+	if !isCameraInUse(err) || delivered || ctx.Err() != nil {
 		return err
 	}
 
@@ -996,7 +989,7 @@ func (s *VideoService) captureLocalCamera(ctx context.Context, broadcast func([]
 	// can act on, and a graph error names a pipeline they did not ask for. Once the shared
 	// stream has shipped frames the camera is demonstrably readable, so its own error wins.
 	pwErr := s.streamGStreamer(ctx, send, path, req, transport, libcameraID, pipeWireSource{serial: serial})
-	if pwErr == nil || ctx.Err() != nil || isCameraInUse(pwErr) || delivered.Load() {
+	if pwErr == nil || ctx.Err() != nil || isCameraInUse(pwErr) || delivered {
 		return pwErr
 	}
 	s.logger.Warn("PipeWire capture failed for a held camera",
@@ -1007,9 +1000,8 @@ func (s *VideoService) captureLocalCamera(ctx context.Context, broadcast func([]
 // gstInspectTimeout bounds the element listing fork.
 const gstInspectTimeout = 10 * time.Second
 
-// firstFrameTimeout bounds the wait for a pipeline's first chunk. It has to clear the whole
-// device-side cold start -- element listing, PipeWire lookup, camera and encoder warm-up --
-// which on a loaded Pi or Jetson runs to several seconds.
+// firstFrameTimeout bounds the wait for a pipeline's first chunk. Generous because it must
+// clear the whole cold start: element listing, PipeWire lookup, camera and encoder warm-up.
 const firstFrameTimeout = 20 * time.Second
 
 // pipeWireProbeTimeout bounds the format probe below. A raw node yields nothing
@@ -1019,9 +1011,8 @@ const pipeWireProbeTimeout = 2 * time.Second
 // nodeServesJPEG reports whether the graph is sending MJPEG for this node. pw-dump
 // advertises only what the device supports, not what the first client negotiated, and a
 // mismatched pipeline stalls rather than fails — so the live format is read, not guessed.
-// The second return distinguishes a definite answer from an inconclusive one. A deadline or a
-// missing session is not evidence of a raw node, and reporting it as one used to build a
-// pipeline that stalled forever. Callers can now say so rather than guess silently.
+// The second return separates a definite "raw" from an inconclusive probe: a deadline or a
+// missing session is not evidence, and treating it as one built a pipeline that stalled.
 func (s *VideoService) nodeServesJPEG(ctx context.Context, gstPath string, serial uint64) (jpeg, known bool) {
 	probeCtx, cancel := context.WithTimeout(ctx, pipeWireProbeTimeout)
 	defer cancel()
@@ -1331,11 +1322,9 @@ func (s *VideoService) runIPProducer(ctx context.Context, broadcast func([]byte,
 	})
 }
 
-// errCaptureSetup classifies a buffer-setup or streaming ioctl failure. EBUSY here is the
-// same contention S_FMT reports elsewhere: vb2 drivers enforce queue ownership at REQBUFS
-// and STREAMON rather than at S_FMT, so without this the sharing fallback never runs on them.
-// The errno is logged rather than returned, matching the deliberately opaque open/S_FMT
-// messages -- returning it lets an authenticated client enumerate the system.
+// errCaptureSetup classifies a buffer-setup or streaming ioctl failure. Which ioctl refuses a
+// second consumer is driver- and timing-dependent: S_FMT only refuses once the holder has
+// allocated buffers. The errno is logged, not returned -- it would let a client probe the host.
 func (s *VideoService) errCaptureSetup(ioctl, path string, errno unix.Errno) error {
 	if isBusyErrno(errno) {
 		return errCameraInUse(path)
@@ -1394,9 +1383,7 @@ func (s *VideoService) streamV4L2Native(ctx context.Context, broadcast func([]by
 			return nativeH264NotSupported{msg: fmt.Sprintf("VIDIOC_S_FMT H264 rejected: %v", errno)}
 		}
 		s.logger.Error("VIDIOC_S_FMT failed", zap.String("device", path), zap.Error(errno))
-		// Where the kernel refuses a second consumer is driver-dependent: uvcvideo
-		// refuses at S_FMT, while vb2 drivers enforce queue ownership later, at
-		// REQBUFS or STREAMON. Every such site classifies EBUSY, not just this one.
+		// Refuses only once the holder has allocated buffers; later sites cover the rest.
 		if isBusyErrno(errno) {
 			return errCameraInUse(path)
 		}
@@ -1497,9 +1484,8 @@ func (s *VideoService) streamV4L2Native(ctx context.Context, broadcast func([]by
 			if errno == unix.EINTR || errno == unix.EAGAIN {
 				continue
 			}
-			// Contention first: EBUSY here is a held camera, not a device that cannot
-			// encode H264, so it must reach the sharing fallback rather than the
-			// software-encoder one below.
+			// Before the H264 fallback below: EBUSY is a held camera, not a device that
+			// cannot encode, so it must reach the sharing path, not the software encoder.
 			if isBusyErrno(errno) {
 				return errCameraInUse(path)
 			}
@@ -1676,9 +1662,8 @@ func (s *VideoService) streamGStreamer(ctx context.Context, broadcast func([]byt
 			jpeg, known := s.nodeServesJPEG(ctx, gstPath, pw.serial)
 			pw.jpeg = jpeg
 			if !known {
-				// Treated as raw, but say so: a wrong guess costs the first-frame
-				// deadline below, after which the caller reports the contention that
-				// sent us here rather than a graph error nobody asked about.
+				// Treated as raw. A wrong guess costs the first-frame deadline below,
+				// after which the caller reports the contention that sent us here.
 				s.logger.Info("PipeWire node format unknown; assuming raw",
 					zap.String("device", path), zap.Uint64("node_serial", pw.serial))
 			}
@@ -1773,10 +1758,9 @@ func (s *VideoService) streamGStreamer(ctx context.Context, broadcast func([]byt
 	const chunkSize = 256 * 1024
 	buf := make([]byte, chunkSize)
 
-	// A mismatched pipeline does not fail, it stalls: gst stays alive producing nothing,
-	// stdout.Read blocks on a pipe with no deadline, and nothing above this loop bounds it --
-	// so `camera view` hangs with no frame and no error. Kill the pipeline instead and report
-	// it. Set below the dashboard player's own 25s budget so this specific error wins the race.
+	// A mismatched pipeline stalls rather than fails: gst stays alive producing nothing and
+	// stdout.Read blocks on a pipe with no deadline, so `camera view` hung with no frame and no
+	// error. Kept under the dashboard player's 25s budget so this error wins that race.
 	var timedOut atomic.Bool
 	firstChunk := time.AfterFunc(firstFrameTimeout, func() {
 		timedOut.Store(true)
@@ -1820,7 +1804,7 @@ func (s *VideoService) streamGStreamer(ctx context.Context, broadcast func([]byt
 			}
 		}
 		if readErr != nil {
-			if timedOut.Load() {
+			if timedOut.Load() && lastFrameTime.IsZero() {
 				return status.Errorf(codes.DeadlineExceeded,
 					"camera produced no video within %s", firstFrameTimeout)
 			}
@@ -1963,8 +1947,7 @@ func findGStreamerEncoderFromSet(available map[string]bool) (gstEncoderResult, e
 // listGSTElements runs gst-inspect-1.0 once and returns a set of all available element names.
 // Each output line has the form "plugin:  element: description".
 func listGSTElements(inspectPath string) (map[string]bool, error) {
-	// Bounded: this walks the whole plugin registry, runs on the contended-camera path where
-	// the operator is already waiting, and an unbounded fork here would hang that path.
+	// Bounded: this walks the whole plugin registry on a path an operator is already waiting on.
 	ctx, cancel := context.WithTimeout(context.Background(), gstInspectTimeout)
 	defer cancel()
 	out, err := exec.CommandContext(ctx, inspectPath).Output()

--- a/go/internal/agent/services/video_service_ipcam_test.go
+++ b/go/internal/agent/services/video_service_ipcam_test.go
@@ -9,12 +9,12 @@ import (
 	"time"
 
 	"go.uber.org/zap"
-	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/wendylabsinc/wendy/go/internal/agent/ipcam"
+	"github.com/wendylabsinc/wendy/go/internal/shared/streamreason"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
 
@@ -41,19 +41,6 @@ func (f *fakeVideoStream) Send(frame *agentpb.VideoFrame) error {
 	defer f.mu.Unlock()
 	f.frames = append(f.frames, frame.GetData())
 	return nil
-}
-
-func hasErrorReason(err error, reason string) bool {
-	st, ok := status.FromError(err)
-	if !ok {
-		return false
-	}
-	for _, detail := range st.Details() {
-		if info, ok := detail.(*errdetails.ErrorInfo); ok && info.GetReason() == reason {
-			return true
-		}
-	}
-	return false
 }
 
 // newIPTestService returns a service with state under a temporary directory and
@@ -266,7 +253,7 @@ func TestStreamVideoWithoutCredentials(t *testing.T) {
 	if status.Code(err) != codes.FailedPrecondition {
 		t.Fatalf("code = %v, want FailedPrecondition", status.Code(err))
 	}
-	if !hasErrorReason(err, reasonIPCameraNoCredentials) {
+	if !streamreason.Has(err, reasonIPCameraNoCredentials) {
 		t.Fatalf("error %v missing reason %s", err, reasonIPCameraNoCredentials)
 	}
 }

--- a/go/internal/agent/services/video_service_test.go
+++ b/go/internal/agent/services/video_service_test.go
@@ -23,7 +23,7 @@ import (
 // directly with a CSI transport.
 func mustBuildGStreamerArgs(t *testing.T, gstPath, devicePath string, req *agentpb.StreamVideoRequest, encoder string, hasH264Parse bool) []string {
 	t.Helper()
-	args, err := buildGStreamerArgs(gstPath, devicePath, req, encoder, hasH264Parse, camera.TransportUSB, "", nil)
+	args, err := buildGStreamerArgs(gstPath, devicePath, req, encoder, hasH264Parse, camera.TransportUSB, "", pipeWireSource{}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error from buildGStreamerArgs: %v", err)
 	}
@@ -46,6 +46,7 @@ func newTestVideoService(glob func() ([]string, error), readName func(string) (s
 	svc.classifyTransport = func(string) (camera.Transport, string) { return camera.TransportUnknown, "" }
 	svc.enumerateLibcamera = func(context.Context) (map[string]string, error) { return nil, nil }
 	svc.isJetson = func() bool { return false }
+	svc.findCameraSource = func(context.Context, string) (uint64, bool) { return 0, false }
 	return svc
 }
 
@@ -675,7 +676,7 @@ func TestStreamGStreamer_MissingGStreamer(t *testing.T) {
 	gstFallbackDirs = nil
 	t.Cleanup(func() { gstFallbackDirs = prev })
 	svc := NewVideoService(context.Background(), zap.NewNop())
-	err := svc.streamGStreamer(context.Background(), nil, "/dev/video0", &agentpb.StreamVideoRequest{}, camera.TransportUSB, "")
+	err := svc.streamGStreamer(context.Background(), nil, "/dev/video0", &agentpb.StreamVideoRequest{}, camera.TransportUSB, "", pipeWireSource{})
 	if err == nil {
 		t.Fatal("expected error when gst-launch-1.0 not found")
 	}
@@ -844,7 +845,7 @@ func defaultElements() map[string]bool {
 // for injection-token / invalid-parameter inputs).
 func mustCSIArgs(t *testing.T, devicePath string, req *agentpb.StreamVideoRequest, encoder string, hasH264Parse bool, transport camera.Transport, libcameraID string, available map[string]bool) []string {
 	t.Helper()
-	args, err := buildGStreamerArgs("gst", devicePath, req, encoder, hasH264Parse, transport, libcameraID, available)
+	args, err := buildGStreamerArgs("gst", devicePath, req, encoder, hasH264Parse, transport, libcameraID, pipeWireSource{}, available)
 	if err != nil {
 		t.Fatalf("unexpected error from buildGStreamerArgs: %v", err)
 	}
@@ -1030,7 +1031,7 @@ func TestBuildGStreamerArgs_USB_DoesNotForceNV12SourceFormat(t *testing.T) {
 }
 
 func TestBuildSourceElement_NilAvailableMapTreatedAsLibcamerasrcAbsent(t *testing.T) {
-	src := buildSourceElement("/dev/video0", camera.TransportCSI, "/cam", nil)
+	src := buildSourceElement("/dev/video0", camera.TransportCSI, "/cam", pipeWireSource{}, nil)
 	if src != "v4l2src device=/dev/video0" {
 		t.Errorf("nil availability must degrade CSI to v4l2src, got %q", src)
 	}
@@ -1041,7 +1042,7 @@ func TestBuildSourceElement_NilAvailableMapTreatedAsLibcamerasrcAbsent(t *testin
 // libcamerasrc auto-select instead of interpolating camera-name=<hostile>.
 func TestBuildSourceElement_RejectsInjectableLibcameraID(t *testing.T) {
 	hostile := "/cam ! filesink location=/etc/passwd"
-	src := buildSourceElement("/dev/video0", camera.TransportCSI, hostile, defaultElements())
+	src := buildSourceElement("/dev/video0", camera.TransportCSI, hostile, pipeWireSource{}, defaultElements())
 	if src != "libcamerasrc" {
 		t.Errorf("hostile libcamera id must degrade to plain libcamerasrc, got %q", src)
 	}

--- a/go/internal/cli/commands/camera.go
+++ b/go/internal/cli/commands/camera.go
@@ -338,6 +338,9 @@ func cameraStreamDiagnostic(err error) error {
 		case "IP_CAMERA_NO_CREDENTIALS":
 			id := info.GetMetadata()["device_id"]
 			return fmt.Errorf("camera %s has no stored credentials. Run `wendy device camera login %s`", id, id)
+		case "CAMERA_IN_USE":
+			device := info.GetMetadata()["device"]
+			return fmt.Errorf("camera %s is held by another application on this device and could not be shared with it. Stop the app holding it, then retry", device)
 		}
 	}
 	return err

--- a/go/internal/cli/commands/camera.go
+++ b/go/internal/cli/commands/camera.go
@@ -15,9 +15,8 @@ import (
 	"golang.org/x/term"
 
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+	"github.com/wendylabsinc/wendy/go/internal/shared/streamreason"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
-	"google.golang.org/genproto/googleapis/rpc/errdetails"
-	"google.golang.org/grpc/status"
 )
 
 func newCameraCmd() *cobra.Command {
@@ -322,26 +321,20 @@ func (s *cameraDiagnosticStream) Recv() (*agentpb.VideoFrame, error) {
 // cameraStreamDiagnostic turns machine-readable agent errors into the action the
 // operator should take. Every reason the agent can attach names its own fix.
 func cameraStreamDiagnostic(err error) error {
-	st, ok := status.FromError(err)
-	if !ok {
+	info := streamreason.Info(err)
+	if info == nil {
 		return err
 	}
-	for _, detail := range st.Details() {
-		info, ok := detail.(*errdetails.ErrorInfo)
-		if !ok {
-			continue
-		}
-		switch info.GetReason() {
-		case "TEGRA_FIRMWARE_MISMATCH":
-			rootfs, boot := info.GetMetadata()["rootfs_l4t"], info.GetMetadata()["boot_firmware_l4t"]
-			return fmt.Errorf("Jetson CSI camera is unavailable because the rootfs (%s) and boot firmware (%s) are from different L4T families. Run `wendy os install`, choose this Jetson, and perform full USB recovery (do not use --rootfs-only)", rootfs, boot)
-		case "IP_CAMERA_NO_CREDENTIALS":
-			id := info.GetMetadata()["device_id"]
-			return fmt.Errorf("camera %s has no stored credentials. Run `wendy device camera login %s`", id, id)
-		case "CAMERA_IN_USE":
-			device := info.GetMetadata()["device"]
-			return fmt.Errorf("camera %s is held by another application on this device and could not be shared with it. Stop the app holding it, then retry", device)
-		}
+	switch info.GetReason() {
+	case streamreason.TegraFirmwareMismatch:
+		rootfs, boot := info.GetMetadata()["rootfs_l4t"], info.GetMetadata()["boot_firmware_l4t"]
+		return fmt.Errorf("Jetson CSI camera is unavailable because the rootfs (%s) and boot firmware (%s) are from different L4T families. Run `wendy os install`, choose this Jetson, and perform full USB recovery (do not use --rootfs-only)", rootfs, boot)
+	case streamreason.IPCameraNoCredentials:
+		id := info.GetMetadata()["device_id"]
+		return fmt.Errorf("camera %s has no stored credentials. Run `wendy device camera login %s`", id, id)
+	case streamreason.CameraInUse:
+		device := info.GetMetadata()["device"]
+		return fmt.Errorf("camera %s is held by another application on this device and could not be shared with it. Stop the app holding it, then retry", device)
 	}
 	return err
 }

--- a/go/internal/cli/commands/camera_credentials.go
+++ b/go/internal/cli/commands/camera_credentials.go
@@ -9,10 +9,9 @@ import (
 
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
-	"google.golang.org/genproto/googleapis/rpc/errdetails"
-	"google.golang.org/grpc/status"
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	"github.com/wendylabsinc/wendy/go/internal/shared/streamreason"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
 
@@ -50,22 +49,15 @@ func cameraCredentialsFromConfig(dir string) (user, password string, found bool)
 // It is the agent's machine-readable signal, so a stream that failed for any other
 // reason is left alone.
 func cameraNeedsCredentials(err error) (uint32, bool) {
-	st, ok := status.FromError(err)
-	if !ok {
+	info := streamreason.Info(err)
+	if info == nil || info.GetReason() != streamreason.IPCameraNoCredentials {
 		return 0, false
 	}
-	for _, detail := range st.Details() {
-		info, ok := detail.(*errdetails.ErrorInfo)
-		if !ok || info.GetReason() != "IP_CAMERA_NO_CREDENTIALS" {
-			continue
-		}
-		id, parseErr := parseCameraID(info.GetMetadata()["device_id"])
-		if parseErr != nil {
-			return 0, false
-		}
-		return id, true
+	id, parseErr := parseCameraID(info.GetMetadata()["device_id"])
+	if parseErr != nil {
+		return 0, false
 	}
-	return 0, false
+	return id, true
 }
 
 // streamVideoWithCredentialRetry starts a camera stream and resolves a missing

--- a/go/internal/cli/commands/camera_credentials_test.go
+++ b/go/internal/cli/commands/camera_credentials_test.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/wendylabsinc/wendy/go/internal/shared/streamreason"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
 
@@ -76,7 +77,7 @@ func credentialsNeededError(t *testing.T, deviceID string) error {
 	t.Helper()
 	st := status.New(codes.FailedPrecondition, "camera has no stored credentials")
 	detailed, err := st.WithDetails(&errdetails.ErrorInfo{
-		Reason:   "IP_CAMERA_NO_CREDENTIALS",
+		Reason:   streamreason.IPCameraNoCredentials,
 		Metadata: map[string]string{"device_id": deviceID},
 	})
 	if err != nil {

--- a/go/internal/cli/commands/camera_test.go
+++ b/go/internal/cli/commands/camera_test.go
@@ -14,6 +14,8 @@ import (
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/streamreason"
 )
 
 // Annex-B NAL header bytes (forbidden_zero | nal_ref_idc | nal_unit_type).
@@ -178,7 +180,7 @@ func TestPlayVideoWithGStreamer_RemoteStreamErrorPrecedesMissingGStreamer(t *tes
 func firmwareMismatchError(t *testing.T) error {
 	t.Helper()
 	st := status.New(codes.FailedPrecondition, "firmware mismatch")
-	with, err := st.WithDetails(&errdetails.ErrorInfo{Reason: "TEGRA_FIRMWARE_MISMATCH", Metadata: map[string]string{
+	with, err := st.WithDetails(&errdetails.ErrorInfo{Reason: streamreason.TegraFirmwareMismatch, Metadata: map[string]string{
 		"rootfs_l4t": "R38.2.0", "boot_firmware_l4t": "R36.4.3",
 	}})
 	if err != nil {

--- a/go/internal/shared/streamreason/streamreason.go
+++ b/go/internal/shared/streamreason/streamreason.go
@@ -1,0 +1,56 @@
+// Package streamreason holds the machine-readable reasons the agent attaches to camera and
+// stream failures, plus the one place that builds and reads them. Spelling them out on both
+// sides of the boundary let a rename silently degrade the CLI's diagnostic to a raw error.
+package streamreason
+
+import (
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Reasons carried in google.rpc.ErrorInfo. Renaming one is a breaking change for any client
+// that switches on it, so treat these as the wire contract they are.
+const (
+	CameraInUse           = "CAMERA_IN_USE"
+	IPCameraNoCredentials = "IP_CAMERA_NO_CREDENTIALS"
+	TegraFirmwareMismatch = "TEGRA_FIRMWARE_MISMATCH"
+)
+
+// Domain scopes the reasons to us, so a client can tell ours from a third party's.
+const Domain = "wendy.dev"
+
+// New returns an error carrying reason and metadata as an ErrorInfo detail. If the detail
+// cannot be attached, the plain status still goes out: the operator keeps the message.
+func New(code codes.Code, msg, reason string, metadata map[string]string) error {
+	st := status.New(code, msg)
+	detailed, err := st.WithDetails(&errdetails.ErrorInfo{
+		Reason:   reason,
+		Domain:   Domain,
+		Metadata: metadata,
+	})
+	if err != nil {
+		return st.Err()
+	}
+	return detailed.Err()
+}
+
+// Info returns the ErrorInfo err carries, or nil.
+func Info(err error) *errdetails.ErrorInfo {
+	st, ok := status.FromError(err)
+	if !ok {
+		return nil
+	}
+	for _, d := range st.Details() {
+		if info, ok := d.(*errdetails.ErrorInfo); ok {
+			return info
+		}
+	}
+	return nil
+}
+
+// Has reports whether err carries the given reason.
+func Has(err error, reason string) bool {
+	info := Info(err)
+	return info != nil && info.GetReason() == reason
+}

--- a/go/internal/shared/streamreason/streamreason_test.go
+++ b/go/internal/shared/streamreason/streamreason_test.go
@@ -1,0 +1,68 @@
+package streamreason
+
+import (
+	"errors"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestNewCarriesReasonDomainAndMetadata(t *testing.T) {
+	err := New(codes.FailedPrecondition, "camera /dev/video0 is already in use",
+		CameraInUse, map[string]string{"device": "/dev/video0"})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("not a gRPC status: %v", err)
+	}
+	if st.Code() != codes.FailedPrecondition {
+		t.Errorf("code = %v, want FailedPrecondition", st.Code())
+	}
+	info := Info(err)
+	if info == nil {
+		t.Fatal("no ErrorInfo attached")
+	}
+	if info.GetReason() != CameraInUse {
+		t.Errorf("reason = %q, want %q", info.GetReason(), CameraInUse)
+	}
+	// Domain drifted between the three hand-rolled constructions this replaced.
+	if info.GetDomain() != Domain {
+		t.Errorf("domain = %q, want %q", info.GetDomain(), Domain)
+	}
+	if got := info.GetMetadata()["device"]; got != "/dev/video0" {
+		t.Errorf("metadata device = %q, want /dev/video0", got)
+	}
+}
+
+func TestInfoAndHasIgnoreUnrelatedErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"nil", nil},
+		{"plain error", errors.New("boom")},
+		{"status without ErrorInfo", status.Error(codes.Internal, "failed to start video capture")},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if info := Info(c.err); info != nil {
+				t.Errorf("Info = %v, want nil", info)
+			}
+			if Has(c.err, CameraInUse) {
+				t.Error("Has = true, want false")
+			}
+		})
+	}
+}
+
+func TestHasDistinguishesReasons(t *testing.T) {
+	err := New(codes.FailedPrecondition, "no credentials", IPCameraNoCredentials, nil)
+	if !Has(err, IPCameraNoCredentials) {
+		t.Error("Has(IPCameraNoCredentials) = false, want true")
+	}
+	// The reasons are a switch key on the CLI side, so a near miss must not match.
+	if Has(err, CameraInUse) {
+		t.Error("Has(CameraInUse) = true, want false")
+	}
+}


### PR DESCRIPTION
The kernel allows one consumer per V4L2 node. Read a held camera through the PipeWire graph, and where that cannot work, name the app holding it.

Refs: WDY-1994