### PR TITLE
Show native OTel logs in wendy run

### DIFF
--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -2343,11 +2343,12 @@ func buildROS2Env(appCfg *appconfig.AppConfig, appID, serviceName string) ([]str
 
 // injectOTELEnvIfNeeded appends OTEL exporter env vars to env when host
 // networking is in effect and the endpoint is not already configured. Besides
-// the endpoint and protocol, it sets OTEL_SERVICE_NAME and
-// OTEL_RESOURCE_ATTRIBUTES (wendy.app.name) to the appId so that telemetry
-// exported by the app matches `wendy device logs --app <id>`, which filters on
-// those resource attributes. It must be called after the image env has been
-// merged so that image-set values take precedence.
+// the endpoint and protocol, it sets OTEL_SERVICE_NAME to the single-container
+// app ID or multi-service container name, and OTEL_RESOURCE_ATTRIBUTES
+// (wendy.app.name) to the owning app ID. This keeps services distinguishable
+// while allowing `wendy device logs --app <id>` to select the whole app. It
+// must be called after the image env has been merged so that image-set values
+// take precedence.
 //
 // appID is passed explicitly (rather than read from appCfg.AppID) so the
 // caller's AppConfig struct is never mutated, which would affect concurrent or
@@ -2390,7 +2391,11 @@ func injectOTELEnvIfNeeded(env []string, appCfg *appconfig.AppConfig, appID stri
 	// Image-set values still take precedence.
 	if appID != "" {
 		if !hasServiceName {
-			env = append(env, "OTEL_SERVICE_NAME="+appID)
+			serviceName := appID
+			if appCfg.ServiceName != "" {
+				serviceName = ContainerName(appID, appCfg.ServiceName)
+			}
+			env = append(env, "OTEL_SERVICE_NAME="+serviceName)
 		}
 		if !hasResourceAttrs {
 			env = append(env, "OTEL_RESOURCE_ATTRIBUTES=wendy.app.name="+appID)

--- a/go/internal/agent/containerd/client_test.go
+++ b/go/internal/agent/containerd/client_test.go
@@ -597,6 +597,20 @@ func TestInjectOTELEnvSetsServiceNameAndResourceAttrs(t *testing.T) {
 	}
 }
 
+func TestInjectOTELEnvUsesContainerNameForMultiServiceIdentity(t *testing.T) {
+	cfg := hostNetworkCfgWithID("robot")
+	cfg.ServiceName = "listener"
+
+	env := injectOTELEnvIfNeeded(nil, cfg, "robot")
+
+	if !slices.Contains(env, "OTEL_SERVICE_NAME=robot_listener") {
+		t.Errorf("env missing multi-service OTEL_SERVICE_NAME; got %v", env)
+	}
+	if !slices.Contains(env, "OTEL_RESOURCE_ATTRIBUTES=wendy.app.name=robot") {
+		t.Errorf("env missing owning app resource attribute; got %v", env)
+	}
+}
+
 func TestInjectOTELEnvSetsIdentityWhenEndpointPreset(t *testing.T) {
 	// An image that presets only the endpoint should still get identity vars so
 	// its direct OTLP logs remain filterable by `wendy device logs --app <id>`.

--- a/go/internal/cli/assets/docs/cloud/telemetry.md
+++ b/go/internal/cli/assets/docs/cloud/telemetry.md
@@ -32,7 +32,7 @@ left untouched if the image already sets it, so image-provided values win:
 |---|---|---|
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://127.0.0.1:4317` (port from `WENDY_OTEL_PORT`, default `4317`) | Only set if the image hasn't configured an endpoint. |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` | Only set together with the default endpoint above (i.e. when the image hasn't set an endpoint) and only if absent. An image that sets its own endpoint keeps full control of the protocol. |
-| `OTEL_SERVICE_NAME` | `<appId>` | Only set if absent and `appId` is non-empty. |
+| `OTEL_SERVICE_NAME` | `<appId>` for a single-container app; `<appId>_<serviceName>` for a multi-service app | Only set if absent and `appId` is non-empty. |
 | `OTEL_RESOURCE_ATTRIBUTES` | `wendy.app.name=<appId>` | Only set if absent and `appId` is non-empty. |
 
 `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES` set the `service.name` and

--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -1520,6 +1520,12 @@ func composeStartDetached(ctx, runCtx context.Context, conn *grpcclient.AgentCon
 // runCancel) stays with the caller and its ordering is unchanged.
 func composeStartAndStream(runCtx context.Context, runCancel context.CancelFunc, conn *grpcclient.AgentConnection, ordered []string, svcCfgs, svcLifecycleCfgs map[string]*appconfig.AppConfig, appLevelCfg *appconfig.AppConfig, stdoutWriters, stderrWriters map[string]*serviceLogWriter) error {
 	runner := &serviceHookRunner{conn: conn}
+	var appName string
+	if len(ordered) > 0 && svcCfgs[ordered[0]] != nil {
+		appName = svcCfgs[ordered[0]].AppID
+	}
+	logSub := startRunLogSubscription(runCtx, conn, appName, os.Stdout, runLogStreamWarning)
+	defer logSub.stop()
 
 	var wg sync.WaitGroup
 	errCh := make(chan error, len(ordered))

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -1508,6 +1508,10 @@ func printLogRecordJSON(service string, lr *logspb.LogRecord) {
 }
 
 func printLogRecord(service string, lr *logspb.LogRecord) {
+	writeLogRecord(os.Stdout, service, lr)
+}
+
+func writeLogRecord(w io.Writer, service string, lr *logspb.LogRecord) {
 	ts := time.Unix(0, int64(lr.GetTimeUnixNano())).Local().Format("15:04:05.000")
 	label, style := severityLabel(lr.GetSeverityNumber())
 
@@ -1537,7 +1541,7 @@ func printLogRecord(service string, lr *logspb.LogRecord) {
 		}
 	}
 
-	fmt.Println(b.String())
+	fmt.Fprintln(w, b.String())
 }
 
 func newDeviceTelemetryStreamCmd() *cobra.Command {

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -1102,6 +1102,8 @@ func runMacOSNativeContainer(ctx context.Context, conn *grpcclient.AgentConnecti
 
 	runCtx, runCancel := context.WithCancel(ctx)
 	defer runCancel()
+	logSub := startRunLogSubscription(runCtx, conn, appCfg.AppID, os.Stdout, runLogStreamWarning)
+	defer logSub.stop()
 
 	stream, err := conn.ContainerService.StartContainer(contextWithPostStartAgentHook(runCtx, appCfg), &agentpb.StartContainerRequest{
 		AppName: appCfg.ContainerName(),
@@ -2043,6 +2045,8 @@ func startAndStreamContainer(ctx context.Context, conn *grpcclient.AgentConnecti
 	// Start and stream output using AttachContainer so stdin is forwarded.
 	runCtx, runCancel := context.WithCancel(ctx)
 	defer runCancel()
+	logSub := startRunLogSubscription(runCtx, conn, appCfg.AppID, os.Stdout, runLogStreamWarning)
+	defer logSub.stop()
 
 	outStream, stdinAttempted, err := openContainerStream(runCtx, conn.ContainerService, appCfg.ContainerName(), appCfg)
 	if err != nil {
@@ -2708,6 +2712,11 @@ func deployByChunkDiff(ctx context.Context, conn *grpcclient.AgentConnection, cw
 	// Carry the post-start agent-hook metadata so the agent runs the in-container
 	// hook on start, matching the registry path's StartContainer call.
 	runCtx := contextWithPostStartAgentHook(ctx, appCfg)
+	var logSub *runLogSubscription
+	if !opts.deploy && !opts.detach {
+		logSub = startRunLogSubscription(ctx, conn, appCfg.AppID, os.Stdout, runLogStreamWarning)
+		defer logSub.stop()
+	}
 	stream, err := conn.ContainerService.RunContainer(runCtx, &agentpb.RunContainerLayersRequest{
 		ImageName:      imageName,
 		AppName:        appCfg.AppID,

--- a/go/internal/cli/commands/run_logs.go
+++ b/go/internal/cli/commands/run_logs.go
@@ -1,0 +1,109 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	logspb "go.opentelemetry.io/proto/otlp/logs/v1"
+)
+
+// runLogSubscription adds native OTLP application logs to an attached
+// `wendy run`. Container stdout and stderr continue to travel over the
+// container RPC and are written raw by their existing code paths.
+type runLogSubscription struct {
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+func startRunLogSubscription(ctx context.Context, conn *grpcclient.AgentConnection, appName string, output io.Writer, onError func(error)) *runLogSubscription {
+	if conn == nil || conn.TelemetryService == nil || appName == "" {
+		return nil
+	}
+
+	streamCtx, cancel := context.WithCancel(ctx)
+	lastN := int32(0)
+	stream, err := conn.TelemetryService.StreamLogs(streamCtx, &agentpb.StreamLogsRequest{
+		AppName: &appName,
+		LastN:   &lastN,
+	})
+	if err != nil {
+		cancel()
+		if onError != nil {
+			onError(err)
+		}
+		return nil
+	}
+
+	sub := &runLogSubscription{cancel: cancel, done: make(chan struct{})}
+	go func() {
+		defer close(sub.done)
+		for {
+			resp, recvErr := stream.Recv()
+			if recvErr != nil {
+				if !errors.Is(recvErr, io.EOF) && streamCtx.Err() == nil && onError != nil {
+					onError(recvErr)
+				}
+				return
+			}
+			writeRunLogResponse(output, resp)
+		}
+	}()
+	return sub
+}
+
+func (s *runLogSubscription) stop() {
+	if s == nil {
+		return
+	}
+	s.cancel()
+	<-s.done
+}
+
+// writeRunLogResponse writes only native application records. The agent also
+// adapts stdout/stderr into OTLP under the wendy.container scope; those records
+// are deliberately skipped because the container RPC already preserves and
+// displays their original bytes and stream identity.
+func writeRunLogResponse(w io.Writer, resp *agentpb.StreamLogsResponse) {
+	if resp == nil || resp.GetIsHistory() {
+		return
+	}
+	logs := resp.GetLogs()
+	if logs == nil {
+		return
+	}
+	for _, rl := range logs.GetResourceLogs() {
+		service := resourceServiceName(rl.GetResource())
+		for _, sl := range rl.GetScopeLogs() {
+			for _, lr := range sl.GetLogRecords() {
+				if isContainerStreamLog(sl.GetScope(), lr) {
+					continue
+				}
+				writeLogRecord(w, service, lr)
+			}
+		}
+	}
+}
+
+func isContainerStreamLog(scope *commonpb.InstrumentationScope, record *logspb.LogRecord) bool {
+	if scope.GetName() != "wendy.container" {
+		return false
+	}
+	for _, attr := range record.GetAttributes() {
+		if attr.GetKey() != "stream" {
+			continue
+		}
+		switch attr.GetValue().GetStringValue() {
+		case "stdout", "stderr":
+			return true
+		}
+	}
+	return false
+}
+
+func runLogStreamWarning(err error) {
+	cliNotice("Notice: native application logs unavailable (%v)", err)
+}

--- a/go/internal/cli/commands/run_logs_test.go
+++ b/go/internal/cli/commands/run_logs_test.go
@@ -1,0 +1,283 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	logspb "go.opentelemetry.io/proto/otlp/logs/v1"
+	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
+	"google.golang.org/grpc"
+)
+
+func TestWriteRunLogResponseShowsNativeLogsWithoutDuplicatingContainerStreams(t *testing.T) {
+	native := testLogRecord("native hello")
+	stdoutCopy := testLogRecord("raw stdout duplicate")
+	stdoutCopy.Attributes = []*commonpb.KeyValue{testStringAttribute("stream", "stdout")}
+	stderrCopy := testLogRecord("raw stderr duplicate")
+	stderrCopy.Attributes = []*commonpb.KeyValue{testStringAttribute("stream", "stderr")}
+	unspecifiedContainerRecord := testLogRecord("container scope without stream")
+	legacyUnscopedRecord := testLogRecord("unscoped stream attribute")
+	legacyUnscopedRecord.Attributes = []*commonpb.KeyValue{testStringAttribute("stream", "stdout")}
+
+	resp := testRunLogsResponse(false,
+		&logspb.ScopeLogs{
+			Scope:      &commonpb.InstrumentationScope{Name: "wendy.container"},
+			LogRecords: []*logspb.LogRecord{stdoutCopy, stderrCopy, unspecifiedContainerRecord},
+		},
+		&logspb.ScopeLogs{
+			Scope:      &commonpb.InstrumentationScope{Name: "swift-otel"},
+			LogRecords: []*logspb.LogRecord{native, legacyUnscopedRecord},
+		},
+	)
+
+	var output bytes.Buffer
+	writeRunLogResponse(&output, resp)
+	got := output.String()
+	if strings.Contains(got, "raw stdout duplicate") || strings.Contains(got, "raw stderr duplicate") {
+		t.Fatalf("adapter copies must not be rendered by the OTel path: %q", got)
+	}
+	if !strings.Contains(got, "native hello") {
+		t.Fatalf("native OTel record missing from output: %q", got)
+	}
+	if !strings.Contains(got, "container scope without stream") {
+		t.Fatalf("scope alone must not suppress a record: %q", got)
+	}
+	if !strings.Contains(got, "unscoped stream attribute") {
+		t.Fatalf("stream attribute alone must not suppress a native record: %q", got)
+	}
+}
+
+func TestWriteRunLogResponseSkipsHistory(t *testing.T) {
+	var output bytes.Buffer
+	writeRunLogResponse(&output, testRunLogsResponse(true, &logspb.ScopeLogs{
+		Scope:      &commonpb.InstrumentationScope{Name: "swift-otel"},
+		LogRecords: []*logspb.LogRecord{testLogRecord("previous run")},
+	}))
+	if output.Len() != 0 {
+		t.Fatalf("history output = %q, want empty", output.String())
+	}
+}
+
+func TestStartRunLogSubscriptionRequestsLiveAppLogsAndStopsCleanly(t *testing.T) {
+	stream := &runLogsFakeStream{delivered: make(chan struct{}), response: testRunLogsResponse(false, &logspb.ScopeLogs{
+		Scope:      &commonpb.InstrumentationScope{Name: "swift-otel"},
+		LogRecords: []*logspb.LogRecord{testLogRecord("subscribed")},
+	})}
+	client := &runLogsFakeClient{stream: stream}
+	conn := &grpcclient.AgentConnection{TelemetryService: client}
+
+	var output bytes.Buffer
+	var streamErr error
+	sub := startRunLogSubscription(context.Background(), conn, "camera", &output, func(err error) {
+		streamErr = err
+	})
+	if sub == nil {
+		t.Fatal("startRunLogSubscription returned nil")
+	}
+
+	select {
+	case <-stream.delivered:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for native log delivery")
+	}
+	sub.stop()
+
+	if streamErr != nil {
+		t.Fatalf("stream error callback = %v", streamErr)
+	}
+	if client.request == nil || client.request.GetAppName() != "camera" {
+		t.Fatalf("app filter = %v, want camera", client.request)
+	}
+	if client.request.LastN == nil || client.request.GetLastN() != 0 {
+		t.Fatalf("last_n = %v, want explicitly-set zero", client.request.LastN)
+	}
+	if !strings.Contains(output.String(), "subscribed") {
+		t.Fatalf("native stream output = %q", output.String())
+	}
+}
+
+func TestStartRunLogSubscriptionIsDisabledWithoutRequiredInputs(t *testing.T) {
+	tests := map[string]struct {
+		conn    *grpcclient.AgentConnection
+		appName string
+	}{
+		"nil connection": {conn: nil, appName: "camera"},
+		"nil telemetry client": {
+			conn:    &grpcclient.AgentConnection{},
+			appName: "camera",
+		},
+		"empty app name": {
+			conn: &grpcclient.AgentConnection{
+				TelemetryService: &runLogsFakeClient{},
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if sub := startRunLogSubscription(context.Background(), tt.conn, tt.appName, io.Discard, nil); sub != nil {
+				t.Fatal("startRunLogSubscription returned a subscription")
+			}
+		})
+	}
+}
+
+func TestStartRunLogSubscriptionReportsOpenError(t *testing.T) {
+	wantErr := errors.New("stream unavailable")
+	client := &runLogsFakeClient{openErr: wantErr}
+	conn := &grpcclient.AgentConnection{TelemetryService: client}
+	var gotErr error
+
+	sub := startRunLogSubscription(context.Background(), conn, "camera", io.Discard, func(err error) {
+		gotErr = err
+	})
+
+	if sub != nil {
+		t.Fatal("startRunLogSubscription returned a subscription after an open error")
+	}
+	if !errors.Is(gotErr, wantErr) {
+		t.Fatalf("error callback = %v, want %v", gotErr, wantErr)
+	}
+}
+
+func TestStartRunLogSubscriptionReportsReceiveError(t *testing.T) {
+	wantErr := errors.New("stream interrupted")
+	stream := &runLogsFakeStream{receiveErr: wantErr}
+	client := &runLogsFakeClient{stream: stream}
+	conn := &grpcclient.AgentConnection{TelemetryService: client}
+	errCh := make(chan error, 1)
+
+	sub := startRunLogSubscription(context.Background(), conn, "camera", io.Discard, func(err error) {
+		errCh <- err
+	})
+	if sub == nil {
+		t.Fatal("startRunLogSubscription returned nil")
+	}
+
+	select {
+	case gotErr := <-errCh:
+		if !errors.Is(gotErr, wantErr) {
+			t.Fatalf("error callback = %v, want %v", gotErr, wantErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for receive error callback")
+	}
+	sub.stop()
+}
+
+func TestStartRunLogSubscriptionTreatsEOFAsCleanShutdown(t *testing.T) {
+	stream := &runLogsFakeStream{receiveErr: io.EOF}
+	client := &runLogsFakeClient{stream: stream}
+	conn := &grpcclient.AgentConnection{TelemetryService: client}
+	errCh := make(chan error, 1)
+
+	sub := startRunLogSubscription(context.Background(), conn, "camera", io.Discard, func(err error) {
+		errCh <- err
+	})
+	if sub == nil {
+		t.Fatal("startRunLogSubscription returned nil")
+	}
+	<-sub.done
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("unexpected error callback: %v", err)
+	default:
+	}
+	sub.stop()
+}
+
+type runLogsFakeClient struct {
+	agentpb.WendyTelemetryServiceClient
+	request *agentpb.StreamLogsRequest
+	stream  *runLogsFakeStream
+	openErr error
+}
+
+func (c *runLogsFakeClient) StreamLogs(ctx context.Context, req *agentpb.StreamLogsRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[agentpb.StreamLogsResponse], error) {
+	c.request = req
+	if c.openErr != nil {
+		return nil, c.openErr
+	}
+	c.stream.ctx = ctx
+	return c.stream, nil
+}
+
+type runLogsFakeStream struct {
+	grpc.ServerStreamingClient[agentpb.StreamLogsResponse]
+
+	mu         sync.Mutex
+	ctx        context.Context
+	response   *agentpb.StreamLogsResponse
+	delivered  chan struct{}
+	sent       bool
+	receiveErr error
+}
+
+func (s *runLogsFakeStream) Recv() (*agentpb.StreamLogsResponse, error) {
+	s.mu.Lock()
+	if !s.sent {
+		s.sent = true
+		if s.response == nil && s.receiveErr != nil {
+			err := s.receiveErr
+			s.mu.Unlock()
+			return nil, err
+		}
+		response := s.response
+		delivered := s.delivered
+		s.mu.Unlock()
+		if delivered != nil {
+			close(delivered)
+		}
+		return response, nil
+	}
+	if s.receiveErr != nil {
+		err := s.receiveErr
+		s.mu.Unlock()
+		return nil, err
+	}
+	ctx := s.ctx
+	s.mu.Unlock()
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func testRunLogsResponse(history bool, scopeLogs ...*logspb.ScopeLogs) *agentpb.StreamLogsResponse {
+	return &agentpb.StreamLogsResponse{
+		IsHistory: history,
+		Logs: &collogspb.ExportLogsServiceRequest{ResourceLogs: []*logspb.ResourceLogs{{
+			Resource: &resourcepb.Resource{Attributes: []*commonpb.KeyValue{
+				testStringAttribute("service.name", "camera"),
+			}},
+			ScopeLogs: scopeLogs,
+		}}},
+	}
+}
+
+func testLogRecord(body string) *logspb.LogRecord {
+	return &logspb.LogRecord{
+		TimeUnixNano:   uint64(time.Date(2026, 8, 20, 12, 0, 0, 0, time.Local).UnixNano()),
+		SeverityNumber: logspb.SeverityNumber_SEVERITY_NUMBER_INFO,
+		SeverityText:   "INFO",
+		Body:           &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: body}},
+	}
+}
+
+func testStringAttribute(key, value string) *commonpb.KeyValue {
+	return &commonpb.KeyValue{
+		Key: key,
+		Value: &commonpb.AnyValue{
+			Value: &commonpb.AnyValue_StringValue{StringValue: value},
+		},
+	}
+}

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift
@@ -27,6 +27,7 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
     private let blobsDirectory: String
     private let broadcaster: TelemetryBroadcaster
     private let infoFileURL: URL
+    private let otelPort: Int
     private let onAppsChanged: @Sendable ([WendyAppInfo]) async -> Void
     private typealias NativeLaunchInfo = WendyApp.NativeMetadata
 
@@ -60,6 +61,7 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
         linuxBackend: (any LinuxContainerBackend)? = nil,
         linuxUnavailableMessage: String =
             "No Linux container runtime found. Install Apple's `container` (recommended) or Docker on the Mac agent.",
+        otelPort: Int = 4317,
         supervisorInterval: Duration = .seconds(15),
         restartFloor: Duration = .seconds(10),
         pidExecutablePath: @escaping PIDExecutablePathLookup = {
@@ -74,6 +76,7 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
         self.sandboxProfilePath = sandboxProfilePath
         self.linuxBackend = linuxBackend
         self.linuxUnavailableMessage = linuxUnavailableMessage
+        self.otelPort = otelPort
         self.supervisorInterval = supervisorInterval
         self.restartFloorSeconds = Self.seconds(restartFloor)
         self.pidExecutablePath = pidExecutablePath
@@ -1180,6 +1183,44 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
         return environment
     }
 
+    /// Builds the environment for a native app process. Native apps share the
+    /// host network namespace with the agent, so point their OTLP exporter at
+    /// the agent's loopback receiver and stamp the resource identity used by
+    /// `wendy device logs --app` and attached `wendy run` subscriptions.
+    nonisolated static func nativeAppEnvironment(
+        appName: String,
+        otelPort: Int,
+        source: [String: String] = ProcessInfo.processInfo.environment
+    ) -> [String: String] {
+        var environment = source
+        environment["NSUnbufferedIO"] = "YES"
+        environment["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://127.0.0.1:\(otelPort)"
+        environment["OTEL_EXPORTER_OTLP_PROTOCOL"] = "grpc"
+        for signal in ["LOGS", "METRICS", "TRACES"] {
+            environment.removeValue(forKey: "OTEL_EXPORTER_OTLP_\(signal)_ENDPOINT")
+            environment.removeValue(forKey: "OTEL_EXPORTER_OTLP_\(signal)_PROTOCOL")
+        }
+        environment["OTEL_SERVICE_NAME"] = appName
+
+        let appAttribute = "wendy.app.name=\(appName)"
+        if let attributes = environment["OTEL_RESOURCE_ATTRIBUTES"], !attributes.isEmpty {
+            var foundAppAttribute = false
+            let merged = attributes.split(separator: ",").map { attribute -> String in
+                let key = attribute.split(separator: "=", maxSplits: 1).first.map(String.init)
+                guard key == "wendy.app.name" else { return String(attribute) }
+                foundAppAttribute = true
+                return appAttribute
+            }
+            environment["OTEL_RESOURCE_ATTRIBUTES"] =
+                (foundAppAttribute
+                ? merged
+                : merged + [appAttribute]).joined(separator: ",")
+        } else {
+            environment["OTEL_RESOURCE_ATTRIBUTES"] = appAttribute
+        }
+        return environment
+    }
+
     nonisolated static func brewBundleFailureMessage(status: Int32) -> String {
         "brew bundle failed with exit code \(status). Run 'wendy device logs --tail 100 --level info' for Homebrew output."
     }
@@ -1727,13 +1768,14 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
         }
 
         let process = Foundation.Process()
-        var environment = ProcessInfo.processInfo.environment
         // Child stdout/stderr are connected to pipes, not a TTY. Without
         // unbuffered I/O, Swift's `print()` output may sit in stdio buffers for
         // a long time (or until exit), which makes `wendy run` appear silent
         // for long-running native macOS apps like HelloMLX.
-        environment["NSUnbufferedIO"] = "YES"
-        process.environment = environment
+        process.environment = Self.nativeAppEnvironment(
+            appName: appName,
+            otelPort: self.otelPort
+        )
         if let profilePath {
             process.executableURL = URL(fileURLWithPath: "/usr/bin/sandbox-exec")
             process.arguments = ["-f", profilePath, binaryPath] + processArgs
@@ -2308,6 +2350,27 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
         severity: Opentelemetry_Proto_Logs_V1_SeverityNumber
     ) async {
         let timestamp = UInt64(Date().timeIntervalSince1970 * 1_000_000_000)
+        await broadcaster.broadcastLogs(
+            Self.containerLogRequest(
+                appName: appName,
+                text: text,
+                stream: stream,
+                severity: severity,
+                timestamp: timestamp
+            )
+        )
+    }
+
+    /// Produces the canonical OTLP representation of adapted process output.
+    /// The instrumentation scope is the discriminator CLI clients use to avoid
+    /// displaying this record once from the process stream and again from OTLP.
+    nonisolated static func containerLogRequest(
+        appName: String,
+        text: String,
+        stream: String,
+        severity: Opentelemetry_Proto_Logs_V1_SeverityNumber,
+        timestamp: UInt64
+    ) -> Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceRequest {
 
         var logRecord = Opentelemetry_Proto_Logs_V1_LogRecord()
         logRecord.timeUnixNano = timestamp
@@ -2323,6 +2386,7 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
         )
 
         var scopeLogs = Opentelemetry_Proto_Logs_V1_ScopeLogs()
+        scopeLogs.scope.name = "wendy.container"
         scopeLogs.logRecords = [logRecord]
 
         var resourceLogs = Opentelemetry_Proto_Logs_V1_ResourceLogs()
@@ -2340,11 +2404,9 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
             }
         )
 
-        await broadcaster.broadcastLogs(
-            Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceRequest.with {
-                $0.resourceLogs = [resourceLogs]
-            }
-        )
+        return Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceRequest.with {
+            $0.resourceLogs = [resourceLogs]
+        }
     }
 }
 

--- a/swift/WendyAgentCore/Sources/WendyAgent/WendyAgent.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/WendyAgent.swift
@@ -305,6 +305,7 @@ public actor WendyAgent {
             stateDirectory: stateDirectory,
             appsBase: appsBase,
             linuxBackend: linuxBackend,
+            otelPort: self.configuration.otelPort,
             onAppsChanged: { [weak self] apps in
                 await self?.updateApps(apps)
             }

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/ContainerServiceTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/ContainerServiceTests.swift
@@ -2,6 +2,7 @@ import Crypto
 import Darwin
 import Foundation
 import GRPCCore
+import OpenTelemetryGRPC
 import Testing
 import WendyAgentGRPC
 
@@ -739,6 +740,80 @@ struct ContainerServiceTests {
 
         #expect(environment["USER"] == "wendy")
         #expect(environment["LOGNAME"] == "wendy")
+    }
+
+    @Test("Native app environment routes OTLP to the agent and stamps app identity")
+    func nativeAppEnvironmentRoutesOTLPToAgent() {
+        let environment = ContainerService.nativeAppEnvironment(
+            appName: "camera",
+            otelPort: 54321,
+            source: [
+                "PATH": "/usr/bin:/bin",
+                "OTEL_EXPORTER_OTLP_ENDPOINT": "https://inherited.invalid:4317",
+                "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
+                "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT": "https://inherited.invalid/v1/logs",
+                "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL": "http/protobuf",
+                "OTEL_SERVICE_NAME": "inherited-agent-name",
+                "OTEL_RESOURCE_ATTRIBUTES": "deployment.environment.name=test",
+            ]
+        )
+
+        #expect(environment["PATH"] == "/usr/bin:/bin")
+        #expect(environment["NSUnbufferedIO"] == "YES")
+        #expect(environment["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://127.0.0.1:54321")
+        #expect(environment["OTEL_EXPORTER_OTLP_PROTOCOL"] == "grpc")
+        #expect(environment["OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"] == nil)
+        #expect(environment["OTEL_EXPORTER_OTLP_LOGS_PROTOCOL"] == nil)
+        #expect(environment["OTEL_SERVICE_NAME"] == "camera")
+        #expect(
+            environment["OTEL_RESOURCE_ATTRIBUTES"]
+                == "deployment.environment.name=test,wendy.app.name=camera"
+        )
+    }
+
+    @Test("Native app environment corrects an inherited Wendy app resource attribute")
+    func nativeAppEnvironmentCorrectsInheritedAppAttribute() {
+        let environment = ContainerService.nativeAppEnvironment(
+            appName: "camera",
+            otelPort: 4317,
+            source: ["OTEL_RESOURCE_ATTRIBUTES": "wendy.app.name=custom,region=au"]
+        )
+
+        #expect(environment["OTEL_RESOURCE_ATTRIBUTES"] == "wendy.app.name=camera,region=au")
+    }
+
+    @Test("Adapted native process output uses the canonical container log scope")
+    func adaptedNativeOutputUsesContainerScope() throws {
+        let request = ContainerService.containerLogRequest(
+            appName: "camera",
+            text: "hello",
+            stream: "stderr",
+            severity: .warn,
+            timestamp: 123
+        )
+        let resourceLogs = try #require(request.resourceLogs.first)
+        let scopeLogs = try #require(resourceLogs.scopeLogs.first)
+        let record = try #require(scopeLogs.logRecords.first)
+
+        #expect(scopeLogs.scope.name == "wendy.container")
+        #expect(record.body.stringValue == "hello")
+        #expect(record.severityNumber == .warn)
+        #expect(record.timeUnixNano == 123)
+        #expect(
+            record.attributes.contains { attribute in
+                attribute.key == "stream" && attribute.value.stringValue == "stderr"
+            }
+        )
+        #expect(
+            resourceLogs.resource.attributes.contains { attribute in
+                attribute.key == "service.name" && attribute.value.stringValue == "camera"
+            }
+        )
+        #expect(
+            resourceLogs.resource.attributes.contains { attribute in
+                attribute.key == "wendy.app.name" && attribute.value.stringValue == "camera"
+            }
+        )
     }
 
     @Test("Real user name resolves to an existing account")


### PR DESCRIPTION
Swift applications using the supported OTel logger currently appear silent during `wendy run`, even though their logs are available through `wendy device logs`. This makes those native OTel records appear live in the attached run output alongside the existing raw stdout/stderr output.

The run command subscribes to logs for the current app across container, compose, chunk-diff, and native macOS paths. It uses the existing `wendy device logs` formatter and filters the agent-generated `wendy.container` stdout/stderr records so users do not see those streams twice.

Fixes [WDY-2012](https://linear.app/wendylabsinc/issue/WDY-2012/swift-templates-no-application-logs-appear-in-wendy-run-otel-routes).

Accepted for now:

- Raw stdout/stderr remain on the byte-oriented container RPC; this PR does not consolidate console output onto OTel.
- Raw output and native OTel use independent streams, so their relative ordering is best-effort.
- Existing bounded telemetry queues can drop records under sustained backpressure; reliable console transport is separate follow-up work.
- There is no subscription-ready handshake before app start, leaving a narrow race for the earliest OTel records.
- Native OTel output intentionally uses the existing verbose `wendy device logs` human formatter.
- Swift OTel bootstrap diagnostics remain raw console output and can still be noisy.
- [PR #1736](https://github.com/wendylabsinc/WendyOS/pull/1736) correctly marks cached recent records as `is_history`; this PR filters those records to provide a live-only run view and should land with or after that fix.

Validation:

- Go CLI and agent test suites
- Go race and vet checks for the affected packages
- WendyAgentCore test suite
- Raspberry Pi 4 runs covering native Swift OTel, Python stdout/stderr, and short-lived Swift output