### PR TITLE
Skip single-option pickers in wendy init

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/init.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/init.md
@@ -26,9 +26,9 @@ An `[app-id]` argument (or `--app-id`) always creates a new subdirectory of that
 
 ## What it produces
 
-1. Picks the **target**, so template and language choices can be filtered to what that target supports.
+1. Picks the **target**, so template and language choices can be filtered to what that target supports. A concrete `--template <name>` resolves first instead: when the template supports exactly one target, the question is skipped and the target is inferred with a notice; when it supports several, the picker is narrowed to those.
 2. Picks a **template** (`--template`), or continues with the plain wizard.
-3. Picks the **language**.
+3. Picks the **language**. Skipped with a notice when the chosen template offers exactly one language.
 4. Collects **entitlements** — the capabilities the app needs. See [Entitlements](../../../apps/wendy.json.md#entitlements-1).
 5. Collects **framework** configuration — currently ROS 2. See [Frameworks](#frameworks).
 6. Writes `wendy.json` and scaffolds the project files.
@@ -59,7 +59,7 @@ Templates may offer additional languages (for example `rust`, `node`, or `cpp`) 
 
 | Flag | Description |
 |---|---|
-| `--template [<name>]` | Scaffold from a template. Passing it **without** a value opens a picker filtered by target. |
+| `--template [<name>]` | Scaffold from a template. Passing it **without** a value opens a picker filtered by target, auto-selecting when only one template exists for the target. With a value, `--target` becomes optional: it is inferred when the template's metadata maps to exactly one target. |
 | `--branch <name>` | Branch of the templates repo to read templates from. |
 | `--var KEY=VALUE` | Override a template variable. Repeatable. |
 
@@ -149,8 +149,9 @@ Entitlement and framework flags are merged into the template's own `wendy.json` 
 
 `wendy init` detects whether a real terminal is attached. In CI, in scripts, and under AI agents there is none, so the interactive pickers are skipped rather than failing on a TTY that cannot be opened. Instead the CLI prints the choices as plain text and exits with an error naming the flag to pass:
 
-- **No `--target`** — prints the available targets, then errors with `--target is required when running non-interactively`.
-- **Bare `--template` with no value** — prints the templates available for the selected target, then errors with `--template requires a value when running non-interactively`. If the target has no templates at all, it errors with `no templates available for <target>` instead.
+- **No `--target`** — prints the available targets, then errors with `--target is required when running non-interactively`. With `--template <name>`, the target is inferred when the template's metadata maps to exactly one target; otherwise the error lists only that template's targets.
+- **Bare `--template` with no value** — prints the templates available for the selected target, then errors with `--template requires a value when running non-interactively`. If the target has exactly one template it is auto-selected instead; if it has none, the error is `no templates available for <target>`.
+- **Template with several languages and no `--language`** — prints the languages available for the template, then errors with `--language is required when running non-interactively`. A single-language template is auto-selected with a notice.
 - **No app ID** — errors with `an app ID is required when running non-interactively`; pass `--app-id` or the `[app-id]` argument.
 
 So discovering the valid values is a matter of running the command and reading the list:
@@ -186,6 +187,10 @@ wendy init \
 ```sh
 # Scaffold from a template, picking the language interactively
 wendy init --template simple-api
+
+# Target and language inferred from the template's metadata
+# (go2-rc supports only WendyOS + Python, so neither is asked)
+wendy init go2-app --template go2-rc
 
 # Non-interactive template scaffold with a variable override
 wendy init --app-id my-api --template simple-api --language rust --var PORT=8080

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -32,6 +32,11 @@ const (
 	assistantClaude = "claude"
 	assistantCodex  = "codex"
 	assistantSkip   = "skip"
+
+	// bareTemplatePickSentinel is the value rewriteBareTemplateFlag injects for
+	// a bare --template so cobra can parse it; the wizard treats it as "show
+	// the template picker".
+	bareTemplatePickSentinel = "_pick"
 )
 
 // Languages available per target platform.
@@ -281,7 +286,7 @@ func rewriteBareTemplateFlag() {
 			}
 			// If --template is last arg or next arg is another flag, inject sentinel.
 			if next == "" || strings.HasPrefix(next, "-") {
-				os.Args[i] = "--template=_pick"
+				os.Args[i] = "--template=" + bareTemplatePickSentinel
 			}
 		}
 	}
@@ -414,7 +419,7 @@ func resolveInitTemplateForTarget(target string, opts initOptions) (string, *rep
 			return "", nil, err
 		}
 
-		if tmpl == "_pick" {
+		if tmpl == bareTemplatePickSentinel {
 			// Bare --template (no value): show interactive picker filtered by target.
 			name, err := resolveBareTemplatePick(target, meta)
 			return name, meta, err
@@ -467,6 +472,22 @@ func templateTargetMatch(t repoMetaTemplate, target string) bool {
 		}
 	}
 	return false
+}
+
+// templateTargets returns the targets a template supports, restricted to the
+// targets `wendy init` knows about. Mirrors templateTargetMatch: an empty
+// Targets list means WendyOS only.
+func templateTargets(t repoMetaTemplate) []string {
+	if len(t.Targets) == 0 {
+		return []string{targetWendyOS}
+	}
+	var targets []string
+	for _, tgt := range t.Targets {
+		if isValidInitTarget(tgt) {
+			targets = append(targets, tgt)
+		}
+	}
+	return targets
 }
 
 // templateItemsForTarget builds the picker items for the templates available
@@ -1008,6 +1029,32 @@ var initTargetItems = []tui.PickerItem{
 	{Name: "WendyOS", Description: "Full Linux-based edge device (Jetson, Raspberry Pi, ...)", Value: targetWendyOS, SortKey: "0"},
 	{Name: "macOS", Description: "Native macOS app deployed to Wendy Agent for Mac", Value: targetDarwin, SortKey: "1"},
 	{Name: "Wendy Lite", Description: "Microcontroller running WASM (ESP32)", Value: targetWendyLite, SortKey: "2"},
+}
+
+// initTargetItemsFor filters the shared initTargetItems so a narrowed target
+// picker keeps the canonical names, descriptions, and sort order.
+func initTargetItemsFor(targets []string) []tui.PickerItem {
+	var items []tui.PickerItem
+	for _, item := range initTargetItems {
+		for _, target := range targets {
+			if item.Value.(string) == target {
+				items = append(items, item)
+				break
+			}
+		}
+	}
+	return items
+}
+
+// initTargetDisplayName maps a target value ("wendyos") to its picker display
+// name ("WendyOS"); unknown values pass through unchanged.
+func initTargetDisplayName(target string) string {
+	for _, item := range initTargetItems {
+		if item.Value.(string) == target {
+			return item.Name
+		}
+	}
+	return target
 }
 
 func resolveInitTarget(opts initOptions) (string, error) {

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -627,15 +627,28 @@ func resolveTemplateLanguage(target, tmpl string, meta *repoMeta, opts initOptio
 		return lang, nil
 	}
 
+	if len(languages) == 1 {
+		cliNotice("Template %q uses %s.", tmpl, languages[0].Name)
+		return languages[0].Key, nil
+	}
+
+	items := templateLanguageItems(languages)
+	if !isInteractiveTerminal() {
+		printPickerItemsPlainText("Available languages for template "+tmpl, items)
+		return "", fmt.Errorf("--language is required when running non-interactively (valid for template %q: %s)",
+			tmpl, repoMetaLanguageKeys(languages))
+	}
+
 	fmt.Println()
+	return pickFromItems("What language will you use?", items)
+}
+
+func templateLanguageItems(languages []repoMetaLanguage) []tui.PickerItem {
 	var items []tui.PickerItem
 	for _, l := range languages {
-		items = append(items, tui.PickerItem{
-			Name:  l.Name,
-			Value: l.Key,
-		})
+		items = append(items, tui.PickerItem{Name: l.Name, Value: l.Key})
 	}
-	return pickFromItems("What language will you use?", items)
+	return items
 }
 
 func templateLanguageAvailable(language string, languages []repoMetaLanguage) bool {

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -302,14 +302,9 @@ func runInitWizard(args []string, opts initOptions) error {
 		return err
 	}
 
-	// Step 1: Pick target device first so template filtering works.
-	target, err := resolveInitTarget(opts)
-	if err != nil {
-		return err
-	}
-
-	// Template flow: offer templates filtered by target, or use --template flag.
-	tmpl, meta, err := resolveInitTemplateForTarget(target, opts)
+	// Steps 1-2: target and template resolve together — a concrete --template
+	// can pin or narrow the target from registry metadata.
+	target, tmpl, meta, err := resolveInitTargetAndTemplate(opts)
 	if err != nil {
 		return err
 	}
@@ -404,6 +399,37 @@ func runInitWizard(args []string, opts initOptions) error {
 	}
 
 	return nil
+}
+
+// resolveInitTargetAndTemplate resolves steps 1 and 2 of the wizard together:
+// a concrete --template can pin or narrow the target from registry metadata,
+// so the target question is asked only when the answer is genuinely open.
+// Meta is fetched at most once on either path.
+func resolveInitTargetAndTemplate(opts initOptions) (string, string, *repoMeta, error) {
+	if opts.templateSet && !opts.targetSet {
+		if name := normalizeInitChoice(opts.template); name != bareTemplatePickSentinel {
+			meta, err := fetchRepoMetaWithUI(opts.branch)
+			if err != nil {
+				return "", "", nil, err
+			}
+			t, ok := templateByName(meta, name)
+			if !ok {
+				return "", "", nil, fmt.Errorf("unknown template %q (available: %s)", opts.template, metaTemplateNames(meta))
+			}
+			target, err := resolveInitTargetForTemplate(*t)
+			if err != nil {
+				return "", "", nil, err
+			}
+			return target, name, meta, nil
+		}
+	}
+
+	target, err := resolveInitTarget(opts)
+	if err != nil {
+		return "", "", nil, err
+	}
+	tmpl, meta, err := resolveInitTemplateForTarget(target, opts)
+	return target, tmpl, meta, err
 }
 
 // resolveInitTemplateForTarget determines which template to use, filtering by target.

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -549,15 +549,19 @@ func pickTemplateNameForTarget(target string, meta *repoMeta) (string, error) {
 // list as plain text instead of failing on the picker's TTY open. Without
 // this, a headless caller (script, CI, or an AI agent) hit
 // "picker: could not open a new TTY" with no way to discover what templates
-// exist at all.
+// exist at all. When exactly one template exists for the target it is
+// auto-selected with a notice, TTY or not.
 func resolveBareTemplatePick(target string, meta *repoMeta) (string, error) {
+	items := templateItemsForTarget(target, meta)
+	if len(items) == 0 {
+		return "", fmt.Errorf("no templates available for %s", target)
+	}
+	if len(items) == 1 {
+		name := items[0].Value.(string)
+		cliNotice("Template %q is the only template for %s.", name, initTargetDisplayName(target))
+		return name, nil
+	}
 	if !isInteractiveTerminal() {
-		// Report "no templates" the same way the picker path does rather than
-		// printing an empty list and then blaming the missing --template value.
-		items := templateItemsForTarget(target, meta)
-		if len(items) == 0 {
-			return "", fmt.Errorf("no templates available for %s", target)
-		}
 		printPickerItemsPlainText("Available templates for "+target, items)
 		return "", fmt.Errorf("--template requires a value when running non-interactively; pass --template=<name> using one of the templates listed above")
 	}

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -145,6 +145,10 @@ func newInitCmd() *cobra.Command {
   # Scaffold from a template (interactive language picker)
   wendy init --template simple-api
 
+  # Create a project from a template; target and language are inferred
+  # from the template's metadata when it supports exactly one of each
+  wendy init go2-app --template go2-rc
+
   # Non-interactive template scaffold with variable overrides
   wendy init --app-id my-api --template simple-api --language rust --var PORT=8080
 

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -616,7 +616,9 @@ func metaTemplateNames(meta *repoMeta) string {
 	return strings.Join(names, ", ")
 }
 
-func fetchRepoMetaWithUI(branch string) (*repoMeta, error) {
+// fetchRepoMetaWithUI is a variable so tests can substitute a canned registry
+// (the real fetch hits the network).
+var fetchRepoMetaWithUI = func(branch string) (*repoMeta, error) {
 	if !isInteractiveTerminal() {
 		cliLogln("Fetching template registry...")
 		return fetchRepoMeta(context.Background(), branch)

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -1075,6 +1075,31 @@ func resolveInitTarget(opts initOptions) (string, error) {
 	return pickFromItems("What is your target device?", initTargetItems)
 }
 
+// resolveInitTargetForTemplate resolves the target when a concrete --template
+// was given without --target: a single-target template pins the answer, a
+// multi-target template narrows the picker to its targets.
+func resolveInitTargetForTemplate(t repoMetaTemplate) (string, error) {
+	targets := templateTargets(t)
+	switch len(targets) {
+	case 0:
+		return "", fmt.Errorf("template %q is not available for any supported target (valid: %s, %s, %s)",
+			t.Name, targetWendyOS, targetWendyLite, targetDarwin)
+	case 1:
+		cliNotice("Template %q targets %s.", t.Name, initTargetDisplayName(targets[0]))
+		return targets[0], nil
+	}
+
+	items := initTargetItemsFor(targets)
+	if !isInteractiveTerminal() {
+		printPickerItemsPlainText("Available targets for template "+t.Name, items)
+		return "", fmt.Errorf("--target is required when running non-interactively (valid for template %q: %s)",
+			t.Name, strings.Join(targets, ", "))
+	}
+
+	fmt.Println()
+	return pickFromItems("What is your target device?", items)
+}
+
 // printPickerItemsPlainText renders picker items as a plain-text list. Used
 // as the non-interactive fallback for choices that would otherwise require a
 // Bubble Tea picker, which fails ungracefully ("could not open a new TTY")

--- a/go/internal/cli/commands/init_cmd_test.go
+++ b/go/internal/cli/commands/init_cmd_test.go
@@ -1600,3 +1600,36 @@ func TestInitCommand_NoFrameworkFlagsLeavesFrameworksNil(t *testing.T) {
 		t.Fatalf("Frameworks = %+v, want nil when no --framework flags were passed", cfg.Frameworks)
 	}
 }
+
+func TestTemplateTargets_DefaultsToWendyOS(t *testing.T) {
+	targets := templateTargets(repoMetaTemplate{Name: "go2-rc"})
+	if len(targets) != 1 || targets[0] != targetWendyOS {
+		t.Fatalf("expected [%s], got %v", targetWendyOS, targets)
+	}
+}
+
+func TestTemplateTargets_DropsUnknownTargets(t *testing.T) {
+	targets := templateTargets(repoMetaTemplate{Name: "x", Targets: []string{"windows", targetDarwin}})
+	if len(targets) != 1 || targets[0] != targetDarwin {
+		t.Fatalf("expected [%s], got %v", targetDarwin, targets)
+	}
+}
+
+func TestInitTargetItemsFor_ReusesSharedItems(t *testing.T) {
+	items := initTargetItemsFor([]string{targetWendyOS, targetDarwin})
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+	if items[0].Name != "WendyOS" || items[1].Name != "macOS" {
+		t.Fatalf("expected canonical initTargetItems entries, got %+v", items)
+	}
+}
+
+func TestInitTargetDisplayName(t *testing.T) {
+	if got := initTargetDisplayName(targetWendyOS); got != "WendyOS" {
+		t.Fatalf("expected WendyOS, got %q", got)
+	}
+	if got := initTargetDisplayName("weird"); got != "weird" {
+		t.Fatalf("expected raw passthrough, got %q", got)
+	}
+}

--- a/go/internal/cli/commands/init_cmd_test.go
+++ b/go/internal/cli/commands/init_cmd_test.go
@@ -1107,9 +1107,11 @@ func TestResolveBareTemplatePick_NonInteractivePrintsListAndErrors(t *testing.T)
 	isInteractiveTerminalFn = func() bool { return false }
 	t.Cleanup(func() { isInteractiveTerminalFn = orig })
 
+	// Two wendyos templates, so the single-template auto-select cannot kick in.
 	meta := &repoMeta{
 		Templates: []repoMetaTemplate{
 			{Name: "simple-api", Description: "Minimal HTTP API"},
+			{Name: "fullstack", Description: "Full-stack starter"},
 			{Name: "mac-llm", Description: "macOS-only template", Targets: []string{targetDarwin}},
 		},
 	}
@@ -1120,6 +1122,18 @@ func TestResolveBareTemplatePick_NonInteractivePrintsListAndErrors(t *testing.T)
 	}
 	if !strings.Contains(err.Error(), "--template requires a value") {
 		t.Fatalf("error = %q, want mention of --template", err)
+	}
+}
+
+func TestResolveBareTemplatePick_SingleTemplateAutoSelected(t *testing.T) {
+	stubNonInteractive(t)
+	meta := &repoMeta{Templates: []repoMetaTemplate{{Name: "go2-rc", Description: "Go2 remote control"}}}
+	name, err := resolveBareTemplatePick(targetWendyOS, meta)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "go2-rc" {
+		t.Fatalf("expected go2-rc, got %q", name)
 	}
 }
 

--- a/go/internal/cli/commands/init_cmd_test.go
+++ b/go/internal/cli/commands/init_cmd_test.go
@@ -1745,3 +1745,33 @@ func TestResolveInitTargetAndTemplate_TargetFlagKeepsExistingValidation(t *testi
 		t.Fatalf("expected existing target-mismatch error, got: %v", err)
 	}
 }
+
+func TestResolveTemplateLanguage_SingleLanguageAutoSelected(t *testing.T) {
+	stubNonInteractive(t) // success while non-interactive proves no picker ran
+	meta := &repoMeta{
+		Templates: []repoMetaTemplate{{Name: "go2-rc", Languages: []string{"python"}}},
+		Languages: []repoMetaLanguage{{Key: "python", Name: "Python"}},
+	}
+	lang, err := resolveTemplateLanguage(targetWendyOS, "go2-rc", meta, initOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if lang != langPython {
+		t.Fatalf("expected python, got %q", lang)
+	}
+}
+
+func TestResolveTemplateLanguage_NonInteractiveMultiLanguageRequiresFlag(t *testing.T) {
+	stubNonInteractive(t)
+	meta := &repoMeta{
+		Templates: []repoMetaTemplate{{Name: "multi", Languages: []string{"python", "rust"}}},
+		Languages: []repoMetaLanguage{{Key: "python", Name: "Python"}, {Key: "rust", Name: "Rust"}},
+	}
+	_, err := resolveTemplateLanguage(targetWendyOS, "multi", meta, initOptions{})
+	if err == nil || !strings.Contains(err.Error(), "--language is required when running non-interactively") {
+		t.Fatalf("expected --language required error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "python") || !strings.Contains(err.Error(), "rust") {
+		t.Fatalf("error should list the template's languages, got: %v", err)
+	}
+}

--- a/go/internal/cli/commands/init_cmd_test.go
+++ b/go/internal/cli/commands/init_cmd_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -1671,5 +1672,76 @@ func TestResolveInitTargetForTemplate_MultiTargetNonInteractiveRequiresTarget(t 
 	}
 	if !strings.Contains(err.Error(), targetWendyOS) || !strings.Contains(err.Error(), targetDarwin) {
 		t.Fatalf("error should list the template's targets, got: %v", err)
+	}
+}
+
+// stubFetchRepoMeta replaces the template-registry fetch with a canned result
+// so tests never hit the network.
+func stubFetchRepoMeta(t *testing.T, meta *repoMeta, err error) {
+	t.Helper()
+	orig := fetchRepoMetaWithUI
+	fetchRepoMetaWithUI = func(branch string) (*repoMeta, error) { return meta, err }
+	t.Cleanup(func() { fetchRepoMetaWithUI = orig })
+}
+
+func TestResolveInitTargetAndTemplate_SingleTargetTemplateInfersTarget(t *testing.T) {
+	stubNonInteractive(t)
+	meta := &repoMeta{
+		Templates: []repoMetaTemplate{{Name: "go2-rc", Languages: []string{"python"}}},
+		Languages: []repoMetaLanguage{{Key: "python", Name: "Python"}},
+	}
+	stubFetchRepoMeta(t, meta, nil)
+
+	target, tmpl, gotMeta, err := resolveInitTargetAndTemplate(initOptions{template: "go2-rc", templateSet: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if target != targetWendyOS || tmpl != "go2-rc" || gotMeta != meta {
+		t.Fatalf("expected (wendyos, go2-rc, meta), got (%q, %q, %v)", target, tmpl, gotMeta)
+	}
+}
+
+func TestResolveInitTargetAndTemplate_MetaFetchErrorFails(t *testing.T) {
+	stubNonInteractive(t)
+	stubFetchRepoMeta(t, nil, fmt.Errorf("registry unreachable"))
+	_, _, _, err := resolveInitTargetAndTemplate(initOptions{template: "go2-rc", templateSet: true})
+	if err == nil || !strings.Contains(err.Error(), "registry unreachable") {
+		t.Fatalf("expected fetch error to propagate, got: %v", err)
+	}
+}
+
+func TestResolveInitTargetAndTemplate_UnknownTemplateFailsBeforeTargetPrompt(t *testing.T) {
+	stubNonInteractive(t)
+	stubFetchRepoMeta(t, &repoMeta{
+		Templates: []repoMetaTemplate{{Name: "go2-rc"}},
+	}, nil)
+	_, _, _, err := resolveInitTargetAndTemplate(initOptions{template: "nope", templateSet: true})
+	if err == nil || !strings.Contains(err.Error(), `unknown template "nope"`) {
+		t.Fatalf("expected unknown-template error, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "--target is required") {
+		t.Fatalf("unknown template must be reported before any target requirement, got: %v", err)
+	}
+}
+
+func TestResolveInitTargetAndTemplate_BareTemplateStillResolvesTargetFirst(t *testing.T) {
+	stubNonInteractive(t)
+	_, _, _, err := resolveInitTargetAndTemplate(initOptions{template: bareTemplatePickSentinel, templateSet: true})
+	if err == nil || !strings.Contains(err.Error(), "--target is required when running non-interactively") {
+		t.Fatalf("bare --template must fall through to target resolution, got: %v", err)
+	}
+}
+
+func TestResolveInitTargetAndTemplate_TargetFlagKeepsExistingValidation(t *testing.T) {
+	stubNonInteractive(t)
+	stubFetchRepoMeta(t, &repoMeta{
+		Templates: []repoMetaTemplate{{Name: "go2-rc"}}, // WendyOS-only
+	}, nil)
+	_, _, _, err := resolveInitTargetAndTemplate(initOptions{
+		template: "go2-rc", templateSet: true,
+		target: targetDarwin, targetSet: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "is not available for target") {
+		t.Fatalf("expected existing target-mismatch error, got: %v", err)
 	}
 }

--- a/go/internal/cli/commands/init_cmd_test.go
+++ b/go/internal/cli/commands/init_cmd_test.go
@@ -1775,6 +1775,26 @@ func TestResolveTemplateLanguage_SingleLanguageAutoSelected(t *testing.T) {
 	}
 }
 
+func TestInitCommand_NonInteractiveTemplateInfersTarget(t *testing.T) {
+	stubNonInteractive(t)
+	stubFetchRepoMeta(t, &repoMeta{
+		Templates: []repoMetaTemplate{{Name: "go2-rc", Languages: []string{"python"}}},
+		Languages: []repoMetaLanguage{{Key: "python", Name: "Python"}},
+	}, nil)
+
+	cmd := newInitCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--template", "go2-rc"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected an app-ID error, got success")
+	}
+	if !strings.Contains(err.Error(), "an app ID is required") {
+		t.Fatalf("expected the run to reach the app-ID step (target inferred, no --target error), got: %v", err)
+	}
+}
+
 func TestResolveTemplateLanguage_NonInteractiveMultiLanguageRequiresFlag(t *testing.T) {
 	stubNonInteractive(t)
 	meta := &repoMeta{

--- a/go/internal/cli/commands/init_cmd_test.go
+++ b/go/internal/cli/commands/init_cmd_test.go
@@ -1633,3 +1633,43 @@ func TestInitTargetDisplayName(t *testing.T) {
 		t.Fatalf("expected raw passthrough, got %q", got)
 	}
 }
+
+func TestResolveInitTargetForTemplate_SingleTargetSkipsPicker(t *testing.T) {
+	stubNonInteractive(t) // success while non-interactive proves no picker ran
+	target, err := resolveInitTargetForTemplate(repoMetaTemplate{Name: "go2-rc"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if target != targetWendyOS {
+		t.Fatalf("expected %s, got %q", targetWendyOS, target)
+	}
+}
+
+func TestResolveInitTargetForTemplate_ExplicitSingleTarget(t *testing.T) {
+	stubNonInteractive(t)
+	target, err := resolveInitTargetForTemplate(repoMetaTemplate{Name: "mac-llm", Targets: []string{targetDarwin}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if target != targetDarwin {
+		t.Fatalf("expected %s, got %q", targetDarwin, target)
+	}
+}
+
+func TestResolveInitTargetForTemplate_NoSupportedTargetsErrors(t *testing.T) {
+	_, err := resolveInitTargetForTemplate(repoMetaTemplate{Name: "x", Targets: []string{"windows"}})
+	if err == nil || !strings.Contains(err.Error(), "not available for any supported target") {
+		t.Fatalf("expected unsupported-target error, got: %v", err)
+	}
+}
+
+func TestResolveInitTargetForTemplate_MultiTargetNonInteractiveRequiresTarget(t *testing.T) {
+	stubNonInteractive(t)
+	_, err := resolveInitTargetForTemplate(repoMetaTemplate{Name: "x", Targets: []string{targetWendyOS, targetDarwin}})
+	if err == nil || !strings.Contains(err.Error(), "--target is required") {
+		t.Fatalf("expected --target required error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), targetWendyOS) || !strings.Contains(err.Error(), targetDarwin) {
+		t.Fatalf("error should list the template's targets, got: %v", err)
+	}
+}

--- a/go/internal/cli/commands/template.go
+++ b/go/internal/cli/commands/template.go
@@ -133,8 +133,8 @@ type templateVariable struct {
 // If ctx is cancelled, the in-flight request is aborted.
 func fetchRepoMeta(ctx context.Context, branch string) (*repoMeta, error) {
 	branch = resolveTemplateBranch(branch)
-	url := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/meta.json",
-		templateRepoOwner, templateRepoName, branch)
+	url := fmt.Sprintf("%s/%s/%s/%s/meta.json",
+		strings.TrimRight(templateRawBaseURL, "/"), templateRepoOwner, templateRepoName, branch)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {


### PR DESCRIPTION
Fixes WDY-2540

When `wendy init` can determine a choice from a template's registry metadata, it no longer shows a picker for it:

- **`--template <name>` without `--target`** now fetches the registry first and infers the target when the template supports exactly one (e.g. `wendy init go2-app --template go2-rc` → WendyOS, no target prompt). Multi-target templates narrow the picker to their targets; non-interactive runs get an error listing only those targets.
- **The template-flow language picker** is skipped with a notice when the template offers exactly one language (go2-rc → Python). It also gains a non-interactive fallback: headless multi-language runs now print the language list and a `--language is required` error instead of dying on the picker's raw TTY failure.
- **Bare `--template`** auto-selects when only one template exists for the target.

Each skipped step prints a `cliNotice` explaining the forced choice, following the existing `pickInitLanguage` convention; the skips run before the TTY check, per the `pickBuildOptionWithTitle` precedent.

Explicit flags keep their existing validation: `--target` + `--template` mismatches, `--language` conflicts, and unknown template names error as before (unknown templates are now reported before any target prompt).

## Testing

- 16 new unit tests (target inference, language auto-select, non-interactive fallbacks, orchestrator edge cases, command-level inference proxy) using new no-network seams: `fetchRepoMetaWithUI` is now a swappable `var`, and `fetchRepoMeta` builds its URL from `templateRawBaseURL`.
- Full `go/internal/cli/...` suite green; `gofmt`/`go vet` clean.
- Live smoke against the real registry: `wendy init --template go2-rc` infers WendyOS and proceeds to the app-ID requirement; `--target wendy-lite` mismatch and unknown-template errors unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)