### PR TITLE
Let a fleet member be reached over the cloud tunnel

### DIFF
--- a/go/internal/cli/commands/buildhost.go
+++ b/go/internal/cli/commands/buildhost.go
@@ -570,22 +570,19 @@ func consumeBuildProgress(recv func() (*agentpbv2.BuildImageProgress, error), ou
 
 // connectFleetDevice connects to one extra delivery target by name.
 //
-// KNOWN LIMITATION, measured rather than assumed: resolveTarget is direct/LAN
-// only, so a fleet member that is not on this network fails here with "name
-// resolver error: produced zero addresses". Deploying to ccr2,ccr1 from a
-// laptop on neither network gets as far as this call and stops.
+// The name is passed EXPLICITLY, and that is the whole subtlety. The cloud
+// fallback otherwise reads --device, which after the fleet split names the
+// PRIMARY -- so every member of the fleet would tunnel to the same machine, and
+// a deploy meant for three cameras would build one image and hand it to one
+// device three times while reporting three deliveries.
 //
-// The fix is the one connectBuildHost needs and for the same reason -- a cloud
-// fallback that takes the device name EXPLICITLY, because --device names the
-// primary and reusing it here would connect every fleet member to the same
-// machine. That is a separate change; when it lands, this becomes a one-line
-// swap rather than a second copy of the same logic.
-//
-// Until then a fleet must be LAN-reachable from the developer's machine. That
-// is a real restriction and is stated in the flag's help rather than left to be
-// discovered.
+// Before this, a fleet member not on the developer's network failed with "name
+// resolver error: produced zero addresses". Measured on main: deploying
+// ccr2,ccr1 from a laptop on neither network connected the primary and the
+// build host over the tunnel, then stopped here -- three devices, three
+// resolvers, and only this one direct-only.
 func connectFleetDevice(ctx context.Context, name string) (*grpcclient.AgentConnection, error) {
-	sel, err := resolveTarget(ctx, SelectDevice(name), NonInteractive(), SuppressUpdateCheck())
+	sel, err := resolveWithCloudFallback(ctx, name, SelectDevice(name), NonInteractive(), SuppressUpdateCheck())
 	if err != nil {
 		return nil, err
 	}

--- a/go/internal/cli/commands/root.go
+++ b/go/internal/cli/commands/root.go
@@ -113,7 +113,7 @@ func NewRootCmd() *cobra.Command {
 	}
 
 	root.PersistentFlags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
-	root.PersistentFlags().StringVar(&deviceFlag, "device", "", "Target device hostname; `wendy run` accepts a comma-separated list to deploy one build to several devices (needs --build-host and --detach, and all of them LAN-reachable)")
+	root.PersistentFlags().StringVar(&deviceFlag, "device", "", "Target device hostname; `wendy run` accepts a comma-separated list to deploy one build to several devices (needs --build-host and --detach)")
 
 	// Render the top-level command groups in the deliberate order below rather
 	// than alphabetically, so e.g. "project" lists before "device".


### PR DESCRIPTION
Follow-up to #1734, using the helper #1729 added.

## The problem

`wendy run --device a,b,c` resolves its devices three different ways, and the fleet members get the only one without a cloud fallback. Measured on current `main`, deploying `ccr2,ccr1` from a laptop on neither network:

```
Connecting to ccr2 via cloud tunnel...      <- primary, resolveRunTarget
Connecting to Spark3 via cloud tunnel...    <- build host, resolveWithCloudFallback (#1729)
✗ connecting to ccr1: device "ccr1" is pinned to an enrolled identity and no
  authenticated endpoint answered ... (name resolver error: produced zero addresses)
```

The primary tunnels. The build host tunnels. The fleet member is direct-only.

So `--device a,b,c` works for a fleet on the developer's LAN and for nothing else — which removes most of the reason to have a build host at all. The devices this was built for are in another country from the machine that builds for them.

## The change

One line, plus the comment that described this as pending. `connectFleetDevice` now uses `resolveWithCloudFallback`, exactly as `connectBuildHost` does.

The name is passed **explicitly**, which is the subtlety it shares with the build host: the fallback otherwise reads `--device`, which after the fleet split names the **primary**. Every member would then tunnel to the same machine, and a deploy meant for three cameras would hand one image to one device three times while reporting three deliveries.

## Verified end to end

Before, on stock `main`: fails at `ccr1` as above.

After, first attempt:

```
Deployed from one build on Spark3:
  ccr2                     delivered
  ccr1                     delivered
```

One build on a DGX Spark in the US, delivered to two Jetson camera boxes in Canada. Confirmed by inspection rather than by trusting the summary: the app present on **both** devices, **zero** copies on Spark3, then removed and both devices confirmed clean.

`--device`'s help no longer claims the fleet must be LAN-reachable, because it no longer must be.

## Test plan

- `go test ./internal/cli/commands` — full suite green.
- Behaviour verified on hardware, before and after, as above.
- Single-device `wendy run` is untouched: this function is only reached for devices beyond the primary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)