### PR TITLE
cli: preserve args for custom flag parsers

### DIFF
--- a/go/internal/cli/commands/root.go
+++ b/go/internal/cli/commands/root.go
@@ -270,12 +270,14 @@ func NewRootCmd() *cobra.Command {
 // A command is only treated as argument-free when its Use string declares no
 // placeholder. Anything documenting a positional, such as "logs [app]" or
 // "record [topics...]", already states its own contract and is left alone, as is
-// any command that already sets Args.
+// any command that already sets Args. Commands that disable Cobra's flag parser
+// are also left alone: their remaining argv is an application-defined protocol,
+// not a list of positional arguments for Cobra to reject.
 func rejectStrayArguments(cmd *cobra.Command) {
 	for _, child := range cmd.Commands() {
 		rejectStrayArguments(child)
 	}
-	if !cmd.Runnable() || cmd.Args != nil {
+	if !cmd.Runnable() || cmd.Args != nil || cmd.DisableFlagParsing {
 		return
 	}
 	for _, token := range strings.Fields(cmd.Use)[1:] {

--- a/go/internal/cli/commands/stray_arguments_test.go
+++ b/go/internal/cli/commands/stray_arguments_test.go
@@ -15,7 +15,7 @@ func TestNoCommandSilentlyAcceptsStrayArguments(t *testing.T) {
 	var walk func(cmd *cobra.Command)
 	walk = func(cmd *cobra.Command) {
 		for _, c := range cmd.Commands() {
-			if c.Runnable() && !declaresPositionals(c.Use) {
+			if c.Runnable() && !c.DisableFlagParsing && !declaresPositionals(c.Use) {
 				if c.Args == nil || c.Args(c, []string{"zzstray"}) == nil {
 					unguarded = append(unguarded, c.CommandPath())
 				}
@@ -28,6 +28,18 @@ func TestNoCommandSilentlyAcceptsStrayArguments(t *testing.T) {
 	if len(unguarded) > 0 {
 		t.Errorf("%d command(s) silently accept a stray positional argument:\n  %s",
 			len(unguarded), strings.Join(unguarded, "\n  "))
+	}
+}
+
+// A command that disables Cobra flag parsing owns its complete argv. The
+// central stray-argument sweep must not reject that argv before the command's
+// parser sees it. This is the sudo re-exec boundary used by Orin recovery.
+func TestDisableFlagParsingCommandReceivesItsArguments(t *testing.T) {
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"__t234-write", "--bogus"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), `unknown __t234-write flag "--bogus"`) {
+		t.Fatalf("Execute() error = %v; want error from __t234-write argument parser", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- exempt commands with custom flag parsing from the global stray-argument validator
- allow the Orin recovery helper to receive its private writer flags
- add an end-to-end regression test covering argument delivery to the helper parser

## Root cause
The stray-argument sweep assigned cobra.NoArgs to the hidden T234 writer helper even though it disables Cobra flag parsing. Valid flags such as --unmount and --device were therefore rejected before the helper parser ran, stopping AGX Orin recovery before device identity verification.

## Test plan
- go test ./internal/cli/commands ./internal/cli/tegraflash/t234