### PR TITLE
feat(data): per-source capture config, upload policy, fair eviction, per-campaign episodes

### DIFF
--- a/Examples/WendyDataCampaign/campaign.yaml
+++ b/Examples/WendyDataCampaign/campaign.yaml
@@ -1,10 +1,29 @@
+# The campaign schema version this file is written against. Required; this
+# release of the agent supports version 1.
+version: 1
+
 name: forklift-failures
 fleet: warehouse-west
 
 sources:
+  # Per-source capture policy is optional; without one a source records
+  # continuously. Modes other than continuous are validated and stored, but
+  # the capture adapters do not implement them yet: deployment warns and the
+  # source records continuously for now.
   - camera: front
+    capture:
+      mode: snapshot
+      interval: 2s
+      max_resolution: 1280x720
   - ros2: /lidar/points
   - ros2: /vehicle/odometry
+  # An audio source kind does not exist yet. Once it does, a threshold
+  # capture policy will look like this:
+  # - audio: cabin-mic
+  #   capture:
+  #     mode: threshold
+  #     trigger: "level_db > -20"
+  #     fragment: 30s
 
 capture:
   buffer: 10s
@@ -14,8 +33,17 @@ capture:
     - model.uncertainty: "> 0.65"
 
 upload:
+  # One of always, wifi, or manual.
   when: wifi
-  destination: s3://acme-ml/forklift
+  # Optional logical dataset name the fleet backend maps to storage. This is
+  # not a URL; devices never receive bucket layouts or credentials.
+  destination: forklift-episodes
+  # Optional device-side bandwidth cap for uploads.
+  max_rate: 5MB/s
+
+retention:
+  # Optional cap for on-device episode storage.
+  local_quota: 10GiB
 
 export:
   annotation: cvat

--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -292,6 +292,7 @@ func main() {
 	dataManager.SetConsensusProvider(func(ctx context.Context) (timesync.Consensus, error) {
 		return timesync.QueryConsensus(ctx, timesync.Servers)
 	})
+	dataManager.SetWarnLogger(func(msg string) { logger.Warn(msg) })
 	dataSvc := services.NewDataService(dataManager)
 	// ROS 2 inspection requires the containerd-backed sidecar runtime; the
 	// service is only registered when containerd connected (WDY-1332).

--- a/go/internal/agent/data/adversarial_test.go
+++ b/go/internal/agent/data/adversarial_test.go
@@ -1,0 +1,644 @@
+package data
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// legacyCampaignJSON is the exact persisted shape written by the previous
+// agent release (before per-source capture, upload policy, and retention
+// existed). Upgraded agents must keep loading and triggering these plans.
+const legacyCampaignJSON = `{
+  "version": 1,
+  "name": "legacy-flight",
+  "sources": [
+    {"telemetry": true}
+  ],
+  "capture": {
+    "buffer": "10ms",
+    "after_trigger": "30ms",
+    "triggers": [
+      {"event": "emergency_stop"}
+    ]
+  },
+  "upload": {
+    "when": "wifi",
+    "destination": "s3://acme-ml/forklift"
+  },
+  "export": {"annotation": "cvat"},
+  "models": {},
+  "privacy": [],
+  "state": "armed",
+  "revision": "0123456789abcdef0123456789abcdef",
+  "deployed_unix_nanos": 12345,
+  "warnings": null
+}`
+
+func writeCampaignFile(t *testing.T, m *Manager, name, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(m.campaignDir(), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(m.campaignDir(), name+".json"), []byte(contents), 0o640); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPersistedCampaignsFromOlderAgentsSurviveUpgrade(t *testing.T) {
+	root := t.TempDir()
+	m, err := NewManager(filepath.Join(root, "episodes"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeCampaignFile(t, m, "legacy-flight", legacyCampaignJSON)
+	// A plan persisted without any version field (or hand-recovered state) must
+	// also keep loading: reload is trusted durable state, not author input.
+	noVersion := strings.Replace(legacyCampaignJSON, "\"version\": 1,\n  ", "", 1)
+	noVersion = strings.Replace(noVersion, "legacy-flight", "legacy-zero", 1)
+	writeCampaignFile(t, m, "legacy-zero", noVersion)
+
+	campaigns, err := m.Campaigns()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(campaigns) != 2 {
+		t.Fatalf("campaigns = %d, want 2 (old persisted plans must reload): %+v", len(campaigns), campaigns)
+	}
+	for _, campaign := range campaigns {
+		if campaign.State != "armed" {
+			t.Fatalf("campaign %s state = %q, want armed", campaign.Name, campaign.State)
+		}
+		if campaign.Revision != "0123456789abcdef0123456789abcdef" {
+			t.Fatalf("campaign %s revision was not preserved verbatim: %q", campaign.Name, campaign.Revision)
+		}
+		reason, expression, matched := campaign.Match(ApplicationRecord{Version: 1, Type: "event", Name: "emergency_stop"})
+		if !matched || reason == "" || expression == "" {
+			t.Fatalf("campaign %s no longer matches its trigger after upgrade", campaign.Name)
+		}
+		if _, _, err := m.ResolveCampaignSources(campaign); err != nil {
+			t.Fatalf("campaign %s sources no longer resolve: %v", campaign.Name, err)
+		}
+	}
+	// The full trigger path still works for a legacy plan.
+	legacy, err := m.Campaign("legacy-flight")
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := m.Start(StartOptions{Sources: []string{"applications", "telemetry"}, Trigger: EpisodeTrigger{Reason: "event:emergency_stop", CampaignName: legacy.Name, CampaignRevision: legacy.Revision}})
+	if err != nil {
+		t.Fatalf("legacy campaign can no longer start an episode: %v", err)
+	}
+	stopped, err := m.Stop(legacy.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stopped.ID != started.ID || stopped.Trigger.CampaignRevision != legacy.Revision {
+		t.Fatalf("legacy campaign episode lost identity: %+v", stopped.Trigger)
+	}
+}
+
+func TestCampaignRevisionDeterministicAndPreservedOnReload(t *testing.T) {
+	yaml := []byte(`version: 1
+name: rev-check
+sources:
+  - telemetry: true
+capture:
+  buffer: 10ms
+  after_trigger: 30ms
+  triggers:
+    - event: emergency_stop
+upload:
+  when: wifi
+  max_rate: 5MB/s
+retention:
+  local_quota: 10GiB
+export:
+  annotation: cvat
+models:
+  detector: v4
+  planner: v9
+`)
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := m.DeployCampaign(yaml)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := m.DeployCampaign(yaml)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Revision == "" || first.Revision != second.Revision {
+		t.Fatalf("same plan produced different revisions: %q vs %q", first.Revision, second.Revision)
+	}
+	reloaded, err := m.Campaign("rev-check")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloaded.Revision != first.Revision {
+		t.Fatalf("reload recomputed or lost the revision: %q vs %q", reloaded.Revision, first.Revision)
+	}
+	parsed, err := ParseCampaign(yaml)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Revision != first.Revision {
+		t.Fatalf("ParseCampaign revision differs from deploy: %q vs %q", parsed.Revision, first.Revision)
+	}
+}
+
+func TestParseByteSizeAndRateEdgeCases(t *testing.T) {
+	sizes := []struct {
+		raw     string
+		want    int64
+		wantErr bool
+	}{
+		{"500", 500, false},
+		{"1.5MB", 1500000, false},
+		{"10GiB", 10 << 30, false},
+		{"10 GiB", 10 << 30, false},
+		{"512KiB", 512 << 10, false},
+		{"2TB", 2e12, false},
+		{"0", 0, true},
+		{"0MB", 0, true},
+		{"-1GiB", 0, true},
+		{"5MBps", 0, true},
+		{"1PB", 0, true},
+		{"MB", 0, true},
+		{"", 0, true},
+		{"1..5MB", 0, true},
+		// Values that overflow int64 must be rejected, not silently converted
+		// to an implementation-defined (possibly negative) quota.
+		{"999999999999999999GiB", 0, true},
+		{"16EiB", 0, true},
+		{"9300000000000000000", 0, true},
+	}
+	for _, c := range sizes {
+		got, err := parseByteSize(c.raw)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("parseByteSize(%q) = %d, want error", c.raw, got)
+			}
+			continue
+		}
+		if err != nil || got != c.want {
+			t.Errorf("parseByteSize(%q) = %d, %v, want %d", c.raw, got, err, c.want)
+		}
+	}
+	rates := []struct {
+		raw     string
+		want    int64
+		wantErr bool
+	}{
+		{"5MB/s", 5e6, false},
+		{"5mb/s", 5e6, false},
+		{"5MB", 5e6, false},
+		{"1GiB/s", 1 << 30, false},
+		{"250000", 250000, false},
+		{"5MBps", 0, true},
+		{"-5MB/s", 0, true},
+		{"/s", 0, true},
+	}
+	for _, c := range rates {
+		got, err := parseByteRate(c.raw)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("parseByteRate(%q) = %d, want error", c.raw, got)
+			}
+			continue
+		}
+		if err != nil || got != c.want {
+			t.Errorf("parseByteRate(%q) = %d, %v, want %d", c.raw, got, err, c.want)
+		}
+	}
+}
+
+func TestValidationErrorsNameTheField(t *testing.T) {
+	base := `version: 1
+name: field-names
+sources:
+  - telemetry: true
+capture:
+  buffer: 10ms
+  after_trigger: 30ms
+  triggers:
+    - event: emergency_stop
+upload:
+  when: wifi
+%s
+export:
+  annotation: cvat
+`
+	cases := []struct {
+		fragment string
+		field    string
+	}{
+		{"  max_rate: 5MBps\n", "upload.max_rate"},
+		{"  max_rate: -1MB/s\n", "upload.max_rate"},
+		{"retention:\n  local_quota: banana\n", "retention.local_quota"},
+		{"retention:\n  local_quota: \"0\"\n", "retention.local_quota"},
+	}
+	for _, c := range cases {
+		_, err := ParseCampaign([]byte(fmt.Sprintf(base, c.fragment)))
+		if err == nil || !strings.Contains(err.Error(), c.field) {
+			t.Errorf("fragment %q: error %v does not name field %s", c.fragment, err, c.field)
+		}
+	}
+}
+
+func TestThresholdParserEdgeCases(t *testing.T) {
+	cases := []struct {
+		expression string
+		field      string
+		operator   string
+		value      float64
+		wantErr    bool
+	}{
+		{"level_db > -20", "level_db", ">", -20, false},
+		{"level_db>-20", "level_db", ">", -20, false},
+		{"  model.uncertainty   >   0.9  ", "model.uncertainty", ">", 0.9, false},
+		{"model.uncertainty > .9", "model.uncertainty", ">", 0.9, false},
+		{"model.uncertainty >= 0", "model.uncertainty", ">=", 0, false},
+		{"model.uncertainty <= 1", "model.uncertainty", "<=", 1, false},
+		{"model.uncertainty == 0.5", "model.uncertainty", "==", 0.5, false},
+		{"model.uncertainty > 1.5", "", "", 0, true},
+		{"model.uncertainty < -0.1", "", "", 0, true},
+		{"level dB > 3", "", "", 0, true},
+		{"garbage", "", "", 0, true},
+		{"> 5", "", "", 0, true},
+		{"level_db >", "", "", 0, true},
+		// NaN and infinities are not comparable thresholds; accepting them
+		// arms a trigger that can never fire (NaN) or always fires (Inf).
+		{"model.uncertainty > NaN", "", "", 0, true},
+		{"level_db > NaN", "", "", 0, true},
+		{"level_db < +Inf", "", "", 0, true},
+		{"level_db > -Inf", "", "", 0, true},
+	}
+	for _, c := range cases {
+		field, operator, value, err := parseFieldThreshold(c.expression)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("parseFieldThreshold(%q) = %s %s %g, want error", c.expression, field, operator, value)
+			}
+			continue
+		}
+		if err != nil || field != c.field || operator != c.operator || value != c.value {
+			t.Errorf("parseFieldThreshold(%q) = %s %s %g, %v; want %s %s %g", c.expression, field, operator, value, err, c.field, c.operator, c.value)
+		}
+	}
+	// The campaign-level trigger keeps the original strict 0..1 rejection for
+	// model.uncertainty (a behavior the previous release enforced too).
+	if _, _, err := parseThreshold("model.uncertainty", "> 1.5"); err == nil {
+		t.Error("campaign trigger accepted model.uncertainty > 1.5")
+	}
+	if _, _, err := parseThreshold("model.uncertainty", "> NaN"); err == nil {
+		t.Error("campaign trigger accepted model.uncertainty > NaN")
+	}
+}
+
+func TestQuotaEvictionEdgeCases(t *testing.T) {
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var warnings []string
+	m.SetWarnLogger(func(msg string) { warnings = append(warnings, msg) })
+
+	first := recordEpisode(t, m, StartOptions{Sources: []string{"applications"}, Trigger: EpisodeTrigger{Reason: "event:a", CampaignName: "camp-a"}})
+	second := recordEpisode(t, m, StartOptions{Sources: []string{"applications"}, Trigger: EpisodeTrigger{Reason: "event:b", CampaignName: "camp-b"}})
+	third := recordEpisode(t, m, StartOptions{Sources: []string{"applications"}, Trigger: EpisodeTrigger{Reason: "event:c", CampaignName: "camp-c"}})
+	for id, campaign := range map[string]string{first.ID: "camp-a", second.ID: "camp-b", third.ID: "camp-c"} {
+		setUploadState(t, m, id, "pending", campaign)
+	}
+	// Equal start timestamps must not break the ordering.
+	for _, id := range []string{first.ID, second.ID} {
+		dir, err := m.episodeDir(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mf, err := readManifest(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mf.StartedUnixNanos = 42
+		if err := writeManifest(dir, mf); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Every candidate awaits upload and the quota holds roughly one episode:
+	// eviction must still make room, warn once per sacrificed episode, and
+	// never fail to start the new capture.
+	m.quotaForTest = episodeSize(t, m, third.ID) + 1
+	fourth := recordEpisode(t, m, StartOptions{Sources: []string{"applications"}})
+	if _, err := m.episodeDir(fourth.ID); err != nil {
+		t.Fatal(err)
+	}
+	evicted := 0
+	for _, id := range []string{first.ID, second.ID, third.ID} {
+		if _, err := m.episodeDir(id); err != nil {
+			evicted++
+		}
+	}
+	if evicted == 0 {
+		t.Fatal("no pending episode was evicted despite an overflowing quota")
+	}
+	if len(warnings) != evicted {
+		t.Fatalf("warnings = %d, want exactly one per evicted episode (%d): %v", len(warnings), evicted, warnings)
+	}
+	// A quota smaller than any single episode evicts everything sealed and
+	// still admits the new episode rather than deadlocking capture.
+	warnings = warnings[:0]
+	m.quotaForTest = 1
+	fifth, err := m.Start(StartOptions{Sources: []string{"applications"}})
+	if err != nil {
+		t.Fatalf("start under minimal quota: %v", err)
+	}
+	if _, err := m.Stop(AdHocEpisodeKey); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.episodeDir(fourth.ID); err == nil {
+		t.Fatal("sealed episode survived a quota that cannot hold it")
+	}
+	_ = fifth
+}
+
+func TestRecordsRouteOnlyToEpisodesCapturingApplications(t *testing.T) {
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	telemetryOnly, err := m.Start(StartOptions{Sources: []string{"telemetry"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	withApps, err := m.Start(StartOptions{Sources: []string{"applications"}, Trigger: EpisodeTrigger{Reason: "event:x", CampaignName: "apps"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := m.RecordApplication("test.app", ApplicationRecord{Version: 1, Type: "event", Name: "shared"})
+	if err != nil || state != "recorded" {
+		t.Fatalf("record state = %q, %v", state, err)
+	}
+	telemetryManifest, err := m.Stop(AdHocEpisodeKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	appsManifest, err := m.Stop("apps")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if telemetryManifest.ID != telemetryOnly.ID || appsManifest.ID != withApps.ID {
+		t.Fatal("episode identity mixed up across stops")
+	}
+	for _, file := range telemetryManifest.Files {
+		if file.Path != "events.jsonl" {
+			continue
+		}
+		if file.Size != 0 {
+			t.Fatalf("episode that excluded the applications source captured application records: %+v", file)
+		}
+	}
+	found := false
+	for _, file := range appsManifest.Files {
+		if file.Path == "events.jsonl" && file.Size > 0 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("episode with the applications source did not capture the record: %+v", appsManifest.Files)
+	}
+}
+
+func TestRecoverMultiplePartialsAcrossCampaigns(t *testing.T) {
+	root := t.TempDir()
+	m, err := NewManager(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	episodes := map[string]Manifest{}
+	for _, campaign := range []string{"camp-a", "camp-b", ""} {
+		upload := WorkflowState{State: "local"}
+		if campaign != "" {
+			upload = WorkflowState{State: "pending", Destination: "example-episodes"}
+		}
+		started, err := m.Start(StartOptions{Sources: []string{"applications"}, Trigger: EpisodeTrigger{Reason: "event:crash", CampaignName: campaign}, Upload: upload})
+		if err != nil {
+			t.Fatal(err)
+		}
+		episodes[campaign] = started
+	}
+	// Simulate an agent crash: a fresh manager over the same root must
+	// finalize every partial from every campaign, not just one.
+	recovered, err := NewManager(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if keys := recovered.ActiveEpisodeKeys(); len(keys) != 0 {
+		t.Fatalf("recovered manager reports active episodes: %v", keys)
+	}
+	list, err := recovered.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 3 {
+		t.Fatalf("recovered episodes = %d, want 3", len(list))
+	}
+	for campaign, started := range episodes {
+		mf, _, err := recovered.Inspect(started.ID, true)
+		if err != nil {
+			t.Fatalf("campaign %q episode not recovered: %v", campaign, err)
+		}
+		if mf.State != "interrupted" || mf.Interruption != "agent_restart" {
+			t.Fatalf("campaign %q episode state = %s/%s", campaign, mf.State, mf.Interruption)
+		}
+		if mf.Trigger.CampaignName != campaign {
+			t.Fatalf("campaign association lost: %q vs %q", mf.Trigger.CampaignName, campaign)
+		}
+		wantUpload := "local"
+		if campaign != "" {
+			wantUpload = "pending"
+		}
+		if mf.Upload.State != wantUpload {
+			t.Fatalf("campaign %q upload state = %q, want %q", campaign, mf.Upload.State, wantUpload)
+		}
+	}
+	// Recovered pending-upload episodes keep their eviction protection.
+	var warnings []string
+	recovered.SetWarnLogger(func(msg string) { warnings = append(warnings, msg) })
+	recovered.quotaForTest = 1
+	if _, err := recovered.Start(StartOptions{Sources: []string{"applications"}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := recovered.Stop(AdHocEpisodeKey); err != nil {
+		t.Fatal(err)
+	}
+	protectedWarnings := 0
+	for _, warning := range warnings {
+		if strings.Contains(warning, "camp-a") || strings.Contains(warning, "camp-b") {
+			protectedWarnings++
+		}
+	}
+	if protectedWarnings != 2 {
+		t.Fatalf("recovered pending episodes were evicted without warnings: %v", warnings)
+	}
+}
+
+func TestManagerConcurrentLifecycleStress(t *testing.T) {
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.SetWarnLogger(func(string) {})
+	keys := []string{AdHocEpisodeKey, "stress-a", "stress-b", "stress-c"}
+	var wg sync.WaitGroup
+	for _, key := range keys {
+		key := key
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 15; i++ {
+				if _, err := m.Start(StartOptions{Sources: []string{"applications"}, Trigger: EpisodeTrigger{Reason: "stress", CampaignName: key}}); err != nil {
+					continue
+				}
+				if i%3 == 0 {
+					_, _ = m.Interrupt(key, "stress")
+				} else {
+					_, _ = m.Stop(key)
+				}
+			}
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			_, _ = m.RecordApplication("stress.app", ApplicationRecord{Version: 1, Type: "event", Name: "stress"})
+		}
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			for _, key := range keys {
+				_, _ = m.Stop(key)
+			}
+			_ = m.Status()
+			_ = m.ActiveEpisodeKeys()
+			_, _ = m.List()
+		}
+	}()
+	wg.Wait()
+	for _, key := range keys {
+		_, _ = m.Stop(key)
+	}
+	if keys := m.ActiveEpisodeKeys(); len(keys) != 0 {
+		t.Fatalf("episodes leaked after stress: %v", keys)
+	}
+	list, err := m.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[string]bool{}
+	for _, episode := range list {
+		if seen[episode.ID] {
+			t.Fatalf("episode %s sealed twice", episode.ID)
+		}
+		seen[episode.ID] = true
+		if episode.State != "complete" && episode.State != "interrupted" {
+			t.Fatalf("episode %s in state %q after stress", episode.ID, episode.State)
+		}
+	}
+	entries, err := os.ReadDir(m.root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if strings.HasSuffix(entry.Name(), ".partial") {
+			t.Fatalf("partial episode %s left behind", entry.Name())
+		}
+	}
+}
+
+// TestUploadStateVocabularyMatchesEviction pins the awaitingUpload state set
+// against the states the agent actually writes, so a renamed workflow state
+// cannot silently revert eviction to oldest-first.
+func TestUploadStateVocabularyMatchesEviction(t *testing.T) {
+	// States produced by this agent today: "local" (ad-hoc default) and
+	// "pending" (campaign episodes). "uploaded" is written by the future
+	// transfer worker. Anything unknown must stay protected (fail-safe).
+	for state, awaiting := range map[string]bool{
+		"":          false,
+		"local":     false,
+		"uploaded":  false,
+		"pending":   true,
+		"uploading": true,
+		"failed":    true,
+	} {
+		if got := awaitingUpload(state); got != awaiting {
+			t.Errorf("awaitingUpload(%q) = %v, want %v", state, got, awaiting)
+		}
+	}
+	var manifest Manifest
+	if err := json.Unmarshal([]byte(`{"upload":{"state":"pending"}}`), &manifest); err != nil {
+		t.Fatal(err)
+	}
+	if !awaitingUpload(manifest.Upload.State) {
+		t.Fatal("persisted pending state lost eviction protection")
+	}
+}
+
+func TestCampaignConcurrentDeployAndReload(t *testing.T) {
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	yaml := `version: 1
+name: deploy-%d
+sources:
+  - telemetry: true
+capture:
+  buffer: 10ms
+  after_trigger: 30ms
+  triggers:
+    - event: emergency_stop
+upload:
+  when: wifi
+export:
+  annotation: cvat
+`
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 10; j++ {
+				if _, err := m.DeployCampaign([]byte(fmt.Sprintf(yaml, i))); err != nil {
+					t.Errorf("deploy %d: %v", i, err)
+					return
+				}
+				if _, err := m.Campaigns(); err != nil {
+					t.Errorf("list during deploy: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	campaigns, err := m.Campaigns()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(campaigns) != 8 {
+		t.Fatalf("campaigns = %d, want 8", len(campaigns))
+	}
+	_ = time.Now()
+}

--- a/go/internal/agent/data/campaign.go
+++ b/go/internal/agent/data/campaign.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -281,6 +282,9 @@ func (m *Manager) DeployCampaign(contents []byte) (Campaign, error) {
 	if len(pendingModes) > 0 {
 		campaign.Warnings = append(campaign.Warnings, "capture modes other than continuous are not implemented yet; these sources record continuously for now: "+strings.Join(pendingModes, ", "))
 	}
+	if campaign.Retention.LocalQuota != "" {
+		campaign.Warnings = append(campaign.Warnings, "retention.local_quota is recorded with the plan, but this release enforces only the device-wide storage quota")
+	}
 	dir := m.campaignDir()
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return Campaign{}, err
@@ -470,6 +474,11 @@ func parseThreshold(field, expression string) (string, float64, error) {
 			if err != nil {
 				return "", 0, fmt.Errorf("%s must compare with a number", field)
 			}
+			// strconv accepts NaN and infinities; a NaN threshold never fires
+			// and an infinite one always or never fires. Reject both.
+			if math.IsNaN(value) || math.IsInf(value, 0) {
+				return "", 0, fmt.Errorf("%s must compare with a finite number", field)
+			}
 			if field == "model.uncertainty" && (value < 0 || value > 1) {
 				return "", 0, errors.New("model.uncertainty must compare with a number from 0 through 1")
 			}
@@ -646,6 +655,11 @@ func parseByteSize(raw string) (int64, error) {
 	total := value * multiplier
 	if total <= 0 {
 		return 0, fmt.Errorf("%q must be a positive byte size", raw)
+	}
+	// Converting a float beyond int64 range is implementation-defined in Go;
+	// reject instead of storing a garbage (possibly negative) byte count.
+	if total >= float64(math.MaxInt64) {
+		return 0, fmt.Errorf("%q is too large for a byte size", raw)
 	}
 	return int64(total), nil
 }

--- a/go/internal/agent/data/campaign.go
+++ b/go/internal/agent/data/campaign.go
@@ -20,11 +20,56 @@ import (
 
 const CampaignVersion = 1
 
+// SourceCapture is an optional per-source capture policy. Only the
+// "continuous" mode is implemented by the capture adapters today; the other
+// modes are validated so authored plans are portable, and deployment reports
+// them as not yet implemented rather than silently recording continuously.
+type SourceCapture struct {
+	// Mode is one of continuous (default), snapshot, fragment, or threshold.
+	Mode string `json:"mode,omitempty" yaml:"mode,omitempty"`
+	// Interval is the snapshot period (snapshot mode only).
+	Interval string `json:"interval,omitempty" yaml:"interval,omitempty"`
+	// Rate caps the capture rate in hertz (continuous mode only).
+	Rate float64 `json:"rate,omitempty" yaml:"rate,omitempty"`
+	// Pre and Post bound a fragment around an occurrence (fragment mode only).
+	Pre  string `json:"pre,omitempty" yaml:"pre,omitempty"`
+	Post string `json:"post,omitempty" yaml:"post,omitempty"`
+	// Trigger is a field threshold expression such as "model.uncertainty > 0.9"
+	// or "level_db > -20" (threshold mode only). The 0..1 range applies only to
+	// model.uncertainty; other fields carry their own units.
+	Trigger string `json:"trigger,omitempty" yaml:"trigger,omitempty"`
+	// Fragment is the captured duration per threshold crossing (threshold mode only).
+	Fragment string `json:"fragment,omitempty" yaml:"fragment,omitempty"`
+	// MaxResolution caps camera capture as WxH, for example 1280x720 (camera sources only).
+	MaxResolution string `json:"max_resolution,omitempty" yaml:"max_resolution,omitempty"`
+}
+
+// EffectiveMode returns the declared capture mode, defaulting to continuous.
+func (sc *SourceCapture) EffectiveMode() string {
+	if sc == nil || sc.Mode == "" {
+		return "continuous"
+	}
+	return sc.Mode
+}
+
 type CampaignSource struct {
-	Camera      string `json:"camera,omitempty" yaml:"camera,omitempty"`
-	ROS2        string `json:"ros2,omitempty" yaml:"ros2,omitempty"`
-	Telemetry   bool   `json:"telemetry,omitempty" yaml:"telemetry,omitempty"`
-	Calibration string `json:"calibration_revision,omitempty" yaml:"calibration_revision,omitempty"`
+	Camera      string         `json:"camera,omitempty" yaml:"camera,omitempty"`
+	ROS2        string         `json:"ros2,omitempty" yaml:"ros2,omitempty"`
+	Telemetry   bool           `json:"telemetry,omitempty" yaml:"telemetry,omitempty"`
+	Calibration string         `json:"calibration_revision,omitempty" yaml:"calibration_revision,omitempty"`
+	Capture     *SourceCapture `json:"capture,omitempty" yaml:"capture,omitempty"`
+}
+
+func (s CampaignSource) describe() string {
+	switch {
+	case s.Camera != "":
+		return "camera:" + s.Camera
+	case s.ROS2 != "":
+		return "ros2:" + s.ROS2
+	case s.Telemetry:
+		return "telemetry"
+	}
+	return "unknown"
 }
 
 type CampaignTrigger struct {
@@ -39,8 +84,21 @@ type CampaignCapture struct {
 }
 
 type CampaignUpload struct {
-	When        string `json:"when" yaml:"when"`
-	Destination string `json:"destination" yaml:"destination"`
+	// When is one of always, wifi, or manual.
+	When string `json:"when" yaml:"when"`
+	// Destination is an optional logical dataset name the fleet backend maps
+	// to storage. It is not a URL; devices never receive storage credentials
+	// or bucket layouts through campaign plans.
+	Destination string `json:"destination,omitempty" yaml:"destination,omitempty"`
+	// MaxRate caps upload bandwidth in bytes per second. Plain integers and
+	// human-readable rates such as "5MB/s" are accepted.
+	MaxRate string `json:"max_rate,omitempty" yaml:"max_rate,omitempty"`
+}
+
+type CampaignRetention struct {
+	// LocalQuota bounds on-device episode storage in bytes. Plain integers and
+	// human-readable sizes such as "10GiB" are accepted.
+	LocalQuota string `json:"local_quota,omitempty" yaml:"local_quota,omitempty"`
 }
 
 type CampaignExport struct {
@@ -56,12 +114,13 @@ type CampaignPrivacy struct {
 // triggers; it does not require the configured sensors or network destination
 // to be online at deployment time.
 type Campaign struct {
-	Version           int               `json:"version" yaml:"-"`
+	Version           int               `json:"version" yaml:"version"`
 	Name              string            `json:"name" yaml:"name"`
 	Fleet             string            `json:"fleet,omitempty" yaml:"fleet,omitempty"`
 	Sources           []CampaignSource  `json:"sources" yaml:"sources"`
 	Capture           CampaignCapture   `json:"capture" yaml:"capture"`
 	Upload            CampaignUpload    `json:"upload" yaml:"upload"`
+	Retention         CampaignRetention `json:"retention,omitempty" yaml:"retention,omitempty"`
 	Export            CampaignExport    `json:"export" yaml:"export"`
 	Models            map[string]string `json:"models" yaml:"models,omitempty"`
 	Privacy           []CampaignPrivacy `json:"privacy" yaml:"privacy,omitempty"`
@@ -85,7 +144,6 @@ func ParseCampaign(contents []byte) (Campaign, error) {
 	if err := campaign.validate(); err != nil {
 		return Campaign{}, err
 	}
-	campaign.Version = CampaignVersion
 	campaign.State = "armed"
 	if campaign.Models == nil {
 		campaign.Models = map[string]string{}
@@ -102,12 +160,21 @@ func ParseCampaign(contents []byte) (Campaign, error) {
 	return campaign, nil
 }
 
+// planOnly strips deployment state before hashing. The author-declared
+// schema version and every plan field, including per-source capture policy,
+// upload policy, and retention, feed the revision digest.
 func (c Campaign) planOnly() Campaign {
-	c.Version, c.State, c.Revision, c.DeployedUnixNanos, c.Warnings = 0, "", "", 0, nil
+	c.State, c.Revision, c.DeployedUnixNanos, c.Warnings = "", "", 0, nil
 	return c
 }
 
 func (c Campaign) validate() error {
+	if c.Version == 0 {
+		return fmt.Errorf("version is required; this agent supports campaign version %d", CampaignVersion)
+	}
+	if c.Version != CampaignVersion {
+		return fmt.Errorf("campaign version %d is not supported; this agent supports up to version %d", c.Version, CampaignVersion)
+	}
 	if c.Name == "" || safeName(c.Name) != c.Name || len(c.Name) > 128 {
 		return errors.New("campaign name must use only letters, numbers, '.', '-' or '_'")
 	}
@@ -128,6 +195,9 @@ func (c Campaign) validate() error {
 		if kinds != 1 {
 			return fmt.Errorf("sources[%d] must select exactly one of camera, ros2, or telemetry", i)
 		}
+		if err := validateSourceCapture(source); err != nil {
+			return fmt.Errorf("sources[%d].capture: %w", i, err)
+		}
 	}
 	buffer, err := time.ParseDuration(c.Capture.Buffer)
 	if err != nil || buffer < 0 || buffer > preRollWindow {
@@ -145,16 +215,25 @@ func (c Campaign) validate() error {
 			return fmt.Errorf("capture.triggers[%d] must define exactly one event or model.uncertainty", i)
 		}
 		if trigger.ModelUncertainty != "" {
-			if _, _, err := parseThreshold(trigger.ModelUncertainty); err != nil {
+			if _, _, err := parseThreshold("model.uncertainty", trigger.ModelUncertainty); err != nil {
 				return fmt.Errorf("capture.triggers[%d]: %w", i, err)
 			}
 		}
 	}
-	if c.Upload.When == "" {
-		return errors.New("upload.when is required")
+	switch c.Upload.When {
+	case "always", "wifi", "manual":
+	default:
+		return errors.New("upload.when must be one of always, wifi, or manual")
 	}
-	if c.Upload.Destination == "" {
-		return errors.New("upload.destination is required")
+	if c.Upload.MaxRate != "" {
+		if _, err := parseByteRate(c.Upload.MaxRate); err != nil {
+			return fmt.Errorf("upload.max_rate: %w", err)
+		}
+	}
+	if c.Retention.LocalQuota != "" {
+		if _, err := parseByteSize(c.Retention.LocalQuota); err != nil {
+			return fmt.Errorf("retention.local_quota: %w", err)
+		}
 	}
 	if c.Export.Annotation == "" {
 		return errors.New("export.annotation is required")
@@ -192,6 +271,15 @@ func (m *Manager) DeployCampaign(contents []byte) (Campaign, error) {
 				break
 			}
 		}
+	}
+	var pendingModes []string
+	for i, source := range campaign.Sources {
+		if mode := source.Capture.EffectiveMode(); !implementedCaptureModes[mode] {
+			pendingModes = append(pendingModes, fmt.Sprintf("sources[%d] (%s, mode %s)", i, source.describe(), mode))
+		}
+	}
+	if len(pendingModes) > 0 {
+		campaign.Warnings = append(campaign.Warnings, "capture modes other than continuous are not implemented yet; these sources record continuously for now: "+strings.Join(pendingModes, ", "))
 	}
 	dir := m.campaignDir()
 	if err := os.MkdirAll(dir, 0o750); err != nil {
@@ -334,7 +422,7 @@ func (c Campaign) Match(record ApplicationRecord) (string, string, bool) {
 			if !ok {
 				continue
 			}
-			op, threshold, _ := parseThreshold(trigger.ModelUncertainty)
+			op, threshold, _ := parseThreshold("model.uncertainty", trigger.ModelUncertainty)
 			if compareThreshold(value, op, threshold) {
 				return fmt.Sprintf("model_uncertainty:%g", value), "model.uncertainty " + trigger.ModelUncertainty, true
 			}
@@ -370,18 +458,224 @@ func numericValue(value any) (float64, bool) {
 	}
 }
 
-func parseThreshold(expression string) (string, float64, error) {
+// parseThreshold parses an "<operator> <number>" expression for the named
+// field. Value ranges are field dependent: model.uncertainty is a probability
+// clamped to 0..1, while fields such as an audio level_db are legitimately
+// negative and carry no fixed range.
+func parseThreshold(field, expression string) (string, float64, error) {
 	expression = strings.TrimSpace(expression)
 	for _, operator := range []string{"<=", ">=", "==", "<", ">"} {
 		if strings.HasPrefix(expression, operator) {
 			value, err := strconv.ParseFloat(strings.TrimSpace(strings.TrimPrefix(expression, operator)), 64)
-			if err != nil || value < 0 || value > 1 {
+			if err != nil {
+				return "", 0, fmt.Errorf("%s must compare with a number", field)
+			}
+			if field == "model.uncertainty" && (value < 0 || value > 1) {
 				return "", 0, errors.New("model.uncertainty must compare with a number from 0 through 1")
 			}
 			return operator, value, nil
 		}
 	}
-	return "", 0, errors.New("model.uncertainty must begin with <, <=, ==, >=, or >")
+	return "", 0, fmt.Errorf("%s must begin with <, <=, ==, >=, or >", field)
+}
+
+// parseFieldThreshold parses a "<field> <operator> <number>" expression such
+// as "model.uncertainty > 0.9" or "level_db > -20".
+func parseFieldThreshold(expression string) (string, string, float64, error) {
+	expression = strings.TrimSpace(expression)
+	split := strings.IndexAny(expression, "<>=")
+	if split <= 0 {
+		return "", "", 0, errors.New("threshold trigger must have the form \"<field> <operator> <number>\", for example \"model.uncertainty > 0.9\"")
+	}
+	field := strings.TrimSpace(expression[:split])
+	for _, r := range field {
+		if !(r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '.' || r == '_') {
+			return "", "", 0, fmt.Errorf("threshold trigger field %q must use only letters, numbers, '.' or '_'", field)
+		}
+	}
+	operator, value, err := parseThreshold(field, expression[split:])
+	if err != nil {
+		return "", "", 0, err
+	}
+	return field, operator, value, nil
+}
+
+// validCaptureModes lists the campaign schema's per-source capture modes. The
+// schema accepts them all; DeployCampaign reports which ones the installed
+// adapters do not implement yet.
+var validCaptureModes = []string{"continuous", "snapshot", "fragment", "threshold"}
+
+// implementedCaptureModes is what capture adapters actually honor today.
+var implementedCaptureModes = map[string]bool{"continuous": true}
+
+func validateSourceCapture(source CampaignSource) error {
+	capture := source.Capture
+	if capture == nil {
+		return nil
+	}
+	mode := capture.EffectiveMode()
+	type field struct {
+		name  string
+		set   bool
+		modes []string
+	}
+	fields := []field{
+		{"interval", capture.Interval != "", []string{"snapshot"}},
+		{"rate", capture.Rate != 0, []string{"continuous"}},
+		{"pre", capture.Pre != "", []string{"fragment"}},
+		{"post", capture.Post != "", []string{"fragment"}},
+		{"trigger", capture.Trigger != "", []string{"threshold"}},
+		{"fragment", capture.Fragment != "", []string{"threshold"}},
+	}
+	valid := false
+	for _, candidate := range validCaptureModes {
+		valid = valid || candidate == mode
+	}
+	if !valid {
+		return fmt.Errorf("mode must be one of %s", strings.Join(validCaptureModes, ", "))
+	}
+	for _, f := range fields {
+		if !f.set {
+			continue
+		}
+		allowed := false
+		for _, m := range f.modes {
+			allowed = allowed || m == mode
+		}
+		if !allowed {
+			return fmt.Errorf("%s applies only to %s mode, not %s mode", f.name, strings.Join(f.modes, "/"), mode)
+		}
+	}
+	switch mode {
+	case "continuous":
+		if capture.Rate < 0 {
+			return errors.New("rate must be a positive capture frequency in hertz")
+		}
+	case "snapshot":
+		interval, err := time.ParseDuration(capture.Interval)
+		if capture.Interval == "" || err != nil || interval <= 0 {
+			return errors.New("snapshot mode requires a positive interval duration")
+		}
+	case "fragment":
+		if capture.Pre == "" && capture.Post == "" {
+			return errors.New("fragment mode requires pre and/or post durations")
+		}
+		for name, raw := range map[string]string{"pre": capture.Pre, "post": capture.Post} {
+			if raw == "" {
+				continue
+			}
+			if d, err := time.ParseDuration(raw); err != nil || d < 0 {
+				return fmt.Errorf("%s must be a non-negative duration", name)
+			}
+		}
+	case "threshold":
+		if capture.Trigger == "" {
+			return errors.New("threshold mode requires a trigger expression")
+		}
+		if _, _, _, err := parseFieldThreshold(capture.Trigger); err != nil {
+			return fmt.Errorf("trigger: %w", err)
+		}
+		if capture.Fragment != "" {
+			if d, err := time.ParseDuration(capture.Fragment); err != nil || d <= 0 {
+				return errors.New("fragment must be a positive duration")
+			}
+		}
+	}
+	if capture.MaxResolution != "" {
+		if source.Camera == "" {
+			return errors.New("max_resolution applies only to camera sources")
+		}
+		if err := validateResolution(capture.MaxResolution); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateResolution(resolution string) error {
+	width, height, found := strings.Cut(resolution, "x")
+	w, errW := strconv.Atoi(width)
+	h, errH := strconv.Atoi(height)
+	if !found || errW != nil || errH != nil || w <= 0 || h <= 0 {
+		return fmt.Errorf("max_resolution %q must be WxH, for example 1280x720", resolution)
+	}
+	return nil
+}
+
+// parseByteSize parses a byte count. Plain integers are bytes; decimal (KB,
+// MB, GB, TB) and binary (KiB, MiB, GiB, TiB) suffixes follow the convention
+// used elsewhere in this repository.
+func parseByteSize(raw string) (int64, error) {
+	s := strings.TrimSpace(raw)
+	cut := len(s)
+	for cut > 0 {
+		r := s[cut-1]
+		if r >= '0' && r <= '9' || r == '.' {
+			break
+		}
+		cut--
+	}
+	number := strings.TrimSpace(s[:cut])
+	unit := strings.TrimSpace(s[cut:])
+	value, err := strconv.ParseFloat(number, 64)
+	if err != nil || value < 0 {
+		return 0, fmt.Errorf("%q is not a byte size; use bytes or a unit such as 500MB or 10GiB", raw)
+	}
+	multiplier := float64(1)
+	switch strings.ToLower(unit) {
+	case "", "b":
+	case "kb":
+		multiplier = 1e3
+	case "kib":
+		multiplier = 1 << 10
+	case "mb":
+		multiplier = 1e6
+	case "mib":
+		multiplier = 1 << 20
+	case "gb":
+		multiplier = 1e9
+	case "gib":
+		multiplier = 1 << 30
+	case "tb":
+		multiplier = 1e12
+	case "tib":
+		multiplier = 1 << 40
+	default:
+		return 0, fmt.Errorf("%q is not a byte size; use bytes or a unit such as 500MB or 10GiB", raw)
+	}
+	total := value * multiplier
+	if total <= 0 {
+		return 0, fmt.Errorf("%q must be a positive byte size", raw)
+	}
+	return int64(total), nil
+}
+
+// parseByteRate parses a bytes-per-second rate such as "5MB/s", "5MB", or a
+// plain integer byte count per second.
+func parseByteRate(raw string) (int64, error) {
+	s := strings.TrimSpace(raw)
+	s = strings.TrimSuffix(s, "/s")
+	return parseByteSize(s)
+}
+
+// UploadMaxRateBytes returns the validated upload bandwidth cap in bytes per
+// second, or 0 when unlimited.
+func (c Campaign) UploadMaxRateBytes() int64 {
+	if c.Upload.MaxRate == "" {
+		return 0
+	}
+	rate, _ := parseByteRate(c.Upload.MaxRate)
+	return rate
+}
+
+// LocalQuotaBytes returns the validated on-device retention quota in bytes,
+// or 0 when the device-wide default applies.
+func (c Campaign) LocalQuotaBytes() int64 {
+	if c.Retention.LocalQuota == "" {
+		return 0
+	}
+	quota, _ := parseByteSize(c.Retention.LocalQuota)
+	return quota
 }
 
 func compareThreshold(value float64, operator string, threshold float64) bool {

--- a/go/internal/agent/data/campaign_test.go
+++ b/go/internal/agent/data/campaign_test.go
@@ -2,13 +2,20 @@ package data
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 )
 
-const exampleCampaignYAML = `name: forklift-failures
+const exampleCampaignYAML = `version: 1
+name: forklift-failures
 fleet: warehouse-west
 sources:
   - camera: front
+    capture:
+      mode: snapshot
+      interval: 2s
+      max_resolution: 1280x720
   - ros2: /lidar/points
   - ros2: /vehicle/odometry
 capture:
@@ -19,7 +26,10 @@ capture:
     - model.uncertainty: "> 0.65"
 upload:
   when: wifi
-  destination: s3://acme-ml/forklift
+  destination: forklift-episodes
+  max_rate: 5MB/s
+retention:
+  local_quota: 10GiB
 export:
   annotation: cvat
 models:
@@ -53,17 +63,129 @@ func TestParseCampaignRejectsUnknownFieldsAndBadThresholds(t *testing.T) {
 	if _, err := ParseCampaign([]byte(badField)); err == nil {
 		t.Fatal("unknown field was accepted")
 	}
-	badThreshold := []byte(`name: bad
+	badThreshold := []byte(`version: 1
+name: bad
 sources: [{telemetry: true}]
 capture:
   buffer: 1s
   after_trigger: 1s
   triggers: [{model.uncertainty: "> 2"}]
-upload: {when: wifi, destination: s3://bucket/path}
+upload: {when: wifi}
 export: {annotation: cvat}
 `)
 	if _, err := ParseCampaign(badThreshold); err == nil {
 		t.Fatal("out-of-range threshold was accepted")
+	}
+}
+
+const minimalCampaignFormat = `version: %d
+name: minimal
+sources:
+  - %s
+capture:
+  buffer: 1s
+  after_trigger: 1s
+  triggers: [{event: go}]
+upload: {when: %s}
+export: {annotation: cvat}
+`
+
+func minimalCampaign(version int, source, when string) []byte {
+	return []byte(fmt.Sprintf(minimalCampaignFormat, version, source, when))
+}
+
+func TestParseCampaignRequiresAuthorDeclaredVersion(t *testing.T) {
+	missing := []byte(strings.Replace(string(minimalCampaign(1, "telemetry: true", "wifi")), "version: 1\n", "", 1))
+	if _, err := ParseCampaign(missing); err == nil || !strings.Contains(err.Error(), "version is required") {
+		t.Fatalf("missing version accepted: %v", err)
+	}
+	if _, err := ParseCampaign(minimalCampaign(2, "telemetry: true", "wifi")); err == nil || !strings.Contains(err.Error(), "supports up to version 1") {
+		t.Fatalf("future version accepted: %v", err)
+	}
+	if _, err := ParseCampaign(minimalCampaign(1, "telemetry: true", "wifi")); err != nil {
+		t.Fatalf("supported version rejected: %v", err)
+	}
+}
+
+func TestUploadPolicyValidation(t *testing.T) {
+	if _, err := ParseCampaign(minimalCampaign(1, "telemetry: true", "sometimes")); err == nil || !strings.Contains(err.Error(), "always, wifi, or manual") {
+		t.Fatalf("invalid upload.when accepted: %v", err)
+	}
+	// destination is optional: minimalCampaign has none.
+	campaign, err := ParseCampaign(minimalCampaign(1, "telemetry: true", "manual"))
+	if err != nil {
+		t.Fatalf("campaign without destination rejected: %v", err)
+	}
+	if campaign.Upload.Destination != "" {
+		t.Fatalf("unexpected destination: %q", campaign.Upload.Destination)
+	}
+	rated := []byte(strings.Replace(string(minimalCampaign(1, "telemetry: true", "wifi")), "upload: {when: wifi}", "upload: {when: wifi, max_rate: 5MB/s}\nretention: {local_quota: 10GiB}", 1))
+	campaign, err = ParseCampaign(rated)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if campaign.UploadMaxRateBytes() != 5_000_000 || campaign.LocalQuotaBytes() != 10<<30 {
+		t.Fatalf("rate=%d quota=%d", campaign.UploadMaxRateBytes(), campaign.LocalQuotaBytes())
+	}
+	badRate := []byte(strings.Replace(string(minimalCampaign(1, "telemetry: true", "wifi")), "upload: {when: wifi}", "upload: {when: wifi, max_rate: fast}", 1))
+	if _, err = ParseCampaign(badRate); err == nil || !strings.Contains(err.Error(), "max_rate") {
+		t.Fatalf("invalid max_rate accepted: %v", err)
+	}
+	badQuota := []byte(string(minimalCampaign(1, "telemetry: true", "wifi")) + "retention: {local_quota: \"-5\"}\n")
+	if _, err = ParseCampaign(badQuota); err == nil || !strings.Contains(err.Error(), "local_quota") {
+		t.Fatalf("invalid local_quota accepted: %v", err)
+	}
+}
+
+func TestSourceCaptureValidation(t *testing.T) {
+	reject := map[string]string{
+		"snapshot without interval":    "camera: front\n    capture: {mode: snapshot}",
+		"threshold without trigger":    "camera: front\n    capture: {mode: threshold}",
+		"unknown mode":                 "camera: front\n    capture: {mode: burst}",
+		"field from another mode":      "camera: front\n    capture: {mode: snapshot, interval: 2s, rate: 5}",
+		"trigger outside threshold":    "camera: front\n    capture: {mode: continuous, trigger: \"level_db > -20\"}",
+		"max_resolution on non-camera": "telemetry: true\n    capture: {mode: continuous, max_resolution: 1280x720}",
+		"malformed max_resolution":     "camera: front\n    capture: {mode: continuous, max_resolution: huge}",
+		"uncertainty above range":      "camera: front\n    capture: {mode: threshold, trigger: \"model.uncertainty > 2\"}",
+		"fragment without pre or post": "camera: front\n    capture: {mode: fragment}",
+	}
+	for name, source := range reject {
+		if _, err := ParseCampaign(minimalCampaign(1, source, "wifi")); err == nil {
+			t.Errorf("%s was accepted", name)
+		}
+	}
+	accept := map[string]string{
+		"default continuous":         "camera: front\n    capture: {rate: 5}",
+		"snapshot with interval":     "camera: front\n    capture: {mode: snapshot, interval: 30s, max_resolution: 1920x1080}",
+		"fragment with pre and post": "ros2: /lidar/points\n    capture: {mode: fragment, pre: 5s, post: 10s}",
+		"negative decibel threshold": "camera: front\n    capture: {mode: threshold, trigger: \"level_db > -20\", fragment: 10s}",
+		"uncertainty threshold":      "camera: front\n    capture: {mode: threshold, trigger: \"model.uncertainty > 0.9\"}",
+	}
+	for name, source := range accept {
+		if _, err := ParseCampaign(minimalCampaign(1, source, "wifi")); err != nil {
+			t.Errorf("%s was rejected: %v", name, err)
+		}
+	}
+}
+
+func TestRevisionHashCoversCaptureUploadAndRetention(t *testing.T) {
+	base, err := ParseCampaign(minimalCampaign(1, "telemetry: true", "wifi"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	variants := []string{
+		strings.Replace(string(minimalCampaign(1, "telemetry: true", "wifi")), "telemetry: true", "telemetry: true\n    capture: {mode: snapshot, interval: 2s}", 1),
+		strings.Replace(string(minimalCampaign(1, "telemetry: true", "wifi")), "upload: {when: wifi}", "upload: {when: wifi, max_rate: 5MB/s}", 1),
+		string(minimalCampaign(1, "telemetry: true", "wifi")) + "retention: {local_quota: 10GiB}\n",
+	}
+	for i, variant := range variants {
+		changed, err := ParseCampaign([]byte(variant))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if changed.Revision == base.Revision {
+			t.Errorf("variant %d did not change the revision hash", i)
+		}
 	}
 }
 
@@ -81,6 +203,13 @@ func TestCampaignPersistsAndResolvesSemanticSources(t *testing.T) {
 	campaign, err := manager.DeployCampaign([]byte(exampleCampaignYAML))
 	if err != nil {
 		t.Fatal(err)
+	}
+	modeWarning := false
+	for _, warning := range campaign.Warnings {
+		modeWarning = modeWarning || strings.Contains(warning, "not implemented yet") && strings.Contains(warning, "camera:front")
+	}
+	if !modeWarning {
+		t.Fatalf("snapshot mode deploy warning missing: %v", campaign.Warnings)
 	}
 	stored, err := manager.Campaign(campaign.Name)
 	if err != nil {

--- a/go/internal/agent/data/manager.go
+++ b/go/internal/agent/data/manager.go
@@ -125,6 +125,9 @@ type activeEpisode struct {
 	manifest Manifest
 	cancel   context.CancelFunc
 	done     chan struct{}
+	// capturesApplications reports whether the applications source was
+	// selected; episodes that excluded it receive no application records.
+	capturesApplications bool
 }
 
 func NewManager(root string) (*Manager, error) {
@@ -317,9 +320,15 @@ func (m *Manager) Start(opts StartOptions) (Manifest, error) {
 			manifest.Calibrations = append(manifest.Calibrations, Calibration{Source: source, Revision: revision})
 		}
 	}
-	if err := os.WriteFile(filepath.Join(dir, "events.jsonl"), nil, 0o640); err != nil {
-		_ = os.RemoveAll(dir)
-		return Manifest{}, err
+	capturesApplications := false
+	for _, source := range selected {
+		capturesApplications = capturesApplications || source.ID == "applications"
+	}
+	if capturesApplications {
+		if err := os.WriteFile(filepath.Join(dir, "events.jsonl"), nil, 0o640); err != nil {
+			_ = os.RemoveAll(dir)
+			return Manifest{}, err
+		}
 	}
 	for _, source := range selected {
 		if source.ID == "telemetry" {
@@ -330,27 +339,29 @@ func (m *Manager) Start(opts StartOptions) (Manifest, error) {
 			break
 		}
 	}
-	manifest.PreRollLost = m.preRollLost
-	preRollCount, earliestPreRoll, err := m.flushPreRoll(dir, origin, opts.PreRollDuration)
-	if err != nil {
-		_ = os.RemoveAll(dir)
-		return Manifest{}, err
-	}
-	for i := range manifest.Sources {
-		if manifest.Sources[i].Source.ID != "applications" {
-			continue
+	if capturesApplications {
+		manifest.PreRollLost = m.preRollLost
+		preRollCount, earliestPreRoll, err := m.flushPreRoll(dir, origin, opts.PreRollDuration)
+		if err != nil {
+			_ = os.RemoveAll(dir)
+			return Manifest{}, err
 		}
-		manifest.Sources[i].Count += preRollCount
-		manifest.Sources[i].DropAccounting = "exact"
-		if earliestPreRoll != nil {
-			manifest.Sources[i].ActualOffset = *earliestPreRoll
+		for i := range manifest.Sources {
+			if manifest.Sources[i].Source.ID != "applications" {
+				continue
+			}
+			manifest.Sources[i].Count += preRollCount
+			manifest.Sources[i].DropAccounting = "exact"
+			if earliestPreRoll != nil {
+				manifest.Sources[i].ActualOffset = *earliestPreRoll
+			}
 		}
 	}
 	if err := writeManifest(dir, manifest); err != nil {
 		_ = os.RemoveAll(dir)
 		return Manifest{}, err
 	}
-	a := &activeEpisode{key: key, dir: dir, manifest: manifest}
+	a := &activeEpisode{key: key, dir: dir, manifest: manifest, capturesApplications: capturesApplications}
 	ctx, cancel := context.WithCancel(context.Background())
 	a.cancel = cancel
 	a.done = make(chan struct{})
@@ -633,9 +644,13 @@ func (m *Manager) RecordApplication(appID string, record ApplicationRecord) (str
 		stamp = record.ClientBootNanos
 	}
 	stored := storedApplicationRecord{ApplicationRecord: record, AppID: appID, AgentReceiptBootNanos: receipt, ClientTimestampAccepted: accepted, TimestampUncertaintyNanos: (after - before + 1) / 2}
-	// Every active episode receives the record on its own timeline.
+	// Every active episode that selected the applications source receives the
+	// record on its own timeline; episodes that excluded it are skipped.
 	recorded := false
 	for _, a := range m.active {
+		if !a.capturesApplications {
+			continue
+		}
 		stored.EpisodeNanos = stamp - a.manifest.RequestBootNanos
 		b, _ := json.Marshal(stored)
 		if err := appendJSONL(filepath.Join(a.dir, "events.jsonl"), b); err != nil {

--- a/go/internal/agent/data/manager.go
+++ b/go/internal/agent/data/manager.go
@@ -31,10 +31,15 @@ const (
 
 var ErrNoActiveEpisode = errors.New("no active episode")
 
+// AdHocEpisodeKey is the reserved concurrency key for episodes started
+// without a campaign (for example `wendy data record`). Each campaign may run
+// one active episode at a time, and one ad-hoc episode may run beside them.
+const AdHocEpisodeKey = ""
+
 type Manager struct {
 	mu             sync.Mutex
 	root           string
-	active         *activeEpisode
+	active         map[string]*activeEpisode
 	consensus      func(context.Context) (timesync.Consensus, error)
 	preRoll        []bufferedRecord
 	preRollBytes   int
@@ -42,6 +47,22 @@ type Manager struct {
 	downloads      map[string]int
 	sourceProvider func(context.Context) []Source
 	appObserver    func(string, ApplicationRecord)
+	warn           func(string)
+	quotaForTest   int64
+}
+
+// SetWarnLogger routes operational warnings (for example evicting an episode
+// that has not been uploaded yet) to the agent's logger.
+func (m *Manager) SetWarnLogger(warn func(string)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.warn = warn
+}
+
+func (m *Manager) warnf(format string, args ...any) {
+	if m.warn != nil {
+		m.warn(fmt.Sprintf(format, args...))
+	}
 }
 
 // SetSourceProvider adds device-backed sources discovered by capture adapters.
@@ -99,6 +120,7 @@ func (m *Manager) SetConsensusProvider(provider func(context.Context) (timesync.
 }
 
 type activeEpisode struct {
+	key      string
 	dir      string
 	manifest Manifest
 	cancel   context.CancelFunc
@@ -123,7 +145,7 @@ func NewManager(root string) (*Manager, error) {
 			return nil, errors.Join(err, fallbackErr)
 		}
 	}
-	m := &Manager{root: root, downloads: make(map[string]int)}
+	m := &Manager{root: root, downloads: make(map[string]int), active: make(map[string]*activeEpisode)}
 	if err := m.recoverPartials(); err != nil {
 		return nil, err
 	}
@@ -180,11 +202,18 @@ func observeUTC(origin int64, _ string, source string) (UTCObservation, error) {
 	}, nil
 }
 
+// Start begins one episode. Concurrency is keyed per campaign: each campaign
+// may record one active episode at a time, and one ad-hoc (campaign-less)
+// episode may record beside them.
 func (m *Manager) Start(opts StartOptions) (Manifest, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if m.active != nil {
-		return Manifest{}, errors.New("an episode is already active")
+	key := opts.Trigger.CampaignName
+	if m.active[key] != nil {
+		if key == AdHocEpisodeKey {
+			return Manifest{}, errors.New("an episode is already active")
+		}
+		return Manifest{}, fmt.Errorf("an episode is already active for campaign %s", key)
 	}
 	if err := m.enforceQuota(); err != nil {
 		return Manifest{}, err
@@ -321,13 +350,22 @@ func (m *Manager) Start(opts StartOptions) (Manifest, error) {
 		_ = os.RemoveAll(dir)
 		return Manifest{}, err
 	}
-	a := &activeEpisode{dir: dir, manifest: manifest}
+	a := &activeEpisode{key: key, dir: dir, manifest: manifest}
 	ctx, cancel := context.WithCancel(context.Background())
 	a.cancel = cancel
 	a.done = make(chan struct{})
 	go m.sampleEpisode(ctx, a)
-	m.active = a
-	return manifest, nil
+	m.active[key] = a
+	return snapshotManifest(manifest), nil
+}
+
+// snapshotManifest returns a copy whose Sources slice does not share a
+// backing array with the live episode manifest, which the manager keeps
+// mutating (source counters, adapter results) under its lock while callers
+// read the returned value without it.
+func snapshotManifest(v Manifest) Manifest {
+	v.Sources = append([]SourceStats(nil), v.Sources...)
+	return v
 }
 
 // SetApplicationObserver receives validated entitled application records after
@@ -340,27 +378,44 @@ func (m *Manager) SetApplicationObserver(observer func(string, ApplicationRecord
 }
 
 // ActiveSession returns the immutable filesystem and clock context for capture
-// adapters. It is valid only while an episode is recording.
-func (m *Manager) ActiveSession() (CaptureSession, bool) {
+// adapters for the episode keyed by the given campaign name (AdHocEpisodeKey
+// for campaign-less episodes). It is valid only while that episode is recording.
+func (m *Manager) ActiveSession(key string) (CaptureSession, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if m.active == nil {
+	a := m.active[key]
+	if a == nil {
 		return CaptureSession{}, false
 	}
-	return CaptureSession{ID: m.active.manifest.ID, Directory: m.active.dir, RequestBootNanos: m.active.manifest.RequestBootNanos, BootID: m.active.manifest.BootID}, true
+	return CaptureSession{ID: a.manifest.ID, Directory: a.dir, RequestBootNanos: a.manifest.RequestBootNanos, BootID: a.manifest.BootID}, true
+}
+
+// ActiveEpisodeKeys returns the sorted concurrency keys of active episodes.
+// AdHocEpisodeKey marks a campaign-less episode; every other key is a
+// campaign name.
+func (m *Manager) ActiveEpisodeKeys() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	keys := make([]string, 0, len(m.active))
+	for key := range m.active {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // ApplyCaptureResults merges final adapter counters and mapping summaries before
 // sealing. Unknown drops remain absent rather than being rendered as zero.
-func (m *Manager) ApplyCaptureResults(results []CaptureResult) error {
+func (m *Manager) ApplyCaptureResults(key string, results []CaptureResult) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if m.active == nil {
+	a := m.active[key]
+	if a == nil {
 		return ErrNoActiveEpisode
 	}
 	for _, result := range results {
-		for i := range m.active.manifest.Sources {
-			stats := &m.active.manifest.Sources[i]
+		for i := range a.manifest.Sources {
+			stats := &a.manifest.Sources[i]
 			if stats.Source.ID != result.SourceID {
 				continue
 			}
@@ -383,18 +438,18 @@ func (m *Manager) ApplyCaptureResults(results []CaptureResult) error {
 			stats.Mappings = append([]ClockMapping(nil), result.Mappings...)
 		}
 	}
-	return writeManifest(m.active.dir, m.active.manifest)
+	return writeManifest(a.dir, a.manifest)
 }
 
 // Interrupt finalizes an active episode after adapter startup failed. Existing
 // monotonic data is retained for auditability and is never silently deleted.
-func (m *Manager) Interrupt(reason string) (Manifest, error) {
+func (m *Manager) Interrupt(key, reason string) (Manifest, error) {
 	m.mu.Lock()
-	if m.active == nil {
+	a := m.active[key]
+	if a == nil {
 		m.mu.Unlock()
 		return Manifest{}, ErrNoActiveEpisode
 	}
-	a := m.active
 	if a.cancel != nil {
 		a.cancel()
 	}
@@ -404,10 +459,10 @@ func (m *Manager) Interrupt(reason string) (Manifest, error) {
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if m.active != a {
+	if m.active[key] != a {
 		return Manifest{}, ErrNoActiveEpisode
 	}
-	return m.finalizeLocked("interrupted", reason)
+	return m.finalizeLocked(a, "interrupted", reason)
 }
 
 func (m *Manager) sampleEpisode(ctx context.Context, a *activeEpisode) {
@@ -429,7 +484,7 @@ func (m *Manager) sampleEpisode(ctx context.Context, a *activeEpisode) {
 			b, _ := json.Marshal(sample)
 			if err = appendJSONL(filepath.Join(a.dir, "telemetry.jsonl"), b); err == nil {
 				m.mu.Lock()
-				if m.active == a {
+				if m.active[a.key] == a {
 					for i := range a.manifest.Sources {
 						if a.manifest.Sources[i].Source.ID == "telemetry" {
 							a.manifest.Sources[i].Count++
@@ -449,7 +504,7 @@ func (m *Manager) sampleEpisode(ctx context.Context, a *activeEpisode) {
 				continue
 			}
 			m.mu.Lock()
-			if m.active == a {
+			if m.active[a.key] == a {
 				a.manifest.Roughtime = append(a.manifest.Roughtime, c)
 				_ = writeManifest(a.dir, a.manifest)
 			}
@@ -469,9 +524,15 @@ func (m *Manager) enforceQuota() error {
 	if quota > maxQuotaBytes {
 		quota = maxQuotaBytes
 	}
+	reserve := reserveBytes
+	if m.quotaForTest > 0 {
+		quota, reserve = m.quotaForTest, 0
+	}
 	type candidate struct {
 		path          string
 		started, size int64
+		id, campaign  string
+		awaitUpload   bool
 	}
 	var candidates []candidate
 	var used int64
@@ -499,13 +560,23 @@ func (m *Manager) enforceQuota() error {
 		})
 		used += size
 		if m.downloads[mf.ID] == 0 {
-			candidates = append(candidates, candidate{dir, mf.StartedUnixNanos, size})
+			candidates = append(candidates, candidate{dir, mf.StartedUnixNanos, size, mf.ID, mf.Trigger.CampaignName, awaitingUpload(mf.Upload.State)})
 		}
 	}
-	sort.Slice(candidates, func(i, j int) bool { return candidates[i].started < candidates[j].started })
+	// Episodes that still await upload are evicted only after every uploaded or
+	// local-only episode; within each group the oldest goes first.
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].awaitUpload != candidates[j].awaitUpload {
+			return !candidates[i].awaitUpload
+		}
+		return candidates[i].started < candidates[j].started
+	})
 	for _, c := range candidates {
-		if used <= quota && free >= reserveBytes {
+		if used <= quota && free >= reserve {
 			break
+		}
+		if c.awaitUpload {
+			m.warnf("evicting episode %s (campaign %s) before its upload completed to preserve the data quota", c.id, c.campaign)
 		}
 		if err := os.RemoveAll(c.path); err != nil {
 			return fmt.Errorf("evicting %s: %w", filepath.Base(c.path), err)
@@ -513,10 +584,21 @@ func (m *Manager) enforceQuota() error {
 		used -= c.size
 		free += c.size
 	}
-	if used > quota || free < reserveBytes {
+	if used > quota || free < reserve {
 		return fmt.Errorf("data quota cannot preserve %d GiB free", reserveBytes>>30)
 	}
 	return nil
+}
+
+// awaitingUpload reports whether an episode's payload has not reached its
+// upload destination yet. Local-only episodes ("local" or empty) never upload
+// and are evictable; "uploaded" episodes already have a durable remote copy.
+func awaitingUpload(state string) bool {
+	switch state {
+	case "", "local", "uploaded":
+		return false
+	}
+	return true
 }
 
 func (m *Manager) BeginDownload(id string) { m.mu.Lock(); defer m.mu.Unlock(); m.downloads[id]++ }
@@ -551,25 +633,25 @@ func (m *Manager) RecordApplication(appID string, record ApplicationRecord) (str
 		stamp = record.ClientBootNanos
 	}
 	stored := storedApplicationRecord{ApplicationRecord: record, AppID: appID, AgentReceiptBootNanos: receipt, ClientTimestampAccepted: accepted, TimestampUncertaintyNanos: (after - before + 1) / 2}
-	if m.active != nil {
-		stored.EpisodeNanos = stamp - m.active.manifest.RequestBootNanos
+	// Every active episode receives the record on its own timeline.
+	recorded := false
+	for _, a := range m.active {
+		stored.EpisodeNanos = stamp - a.manifest.RequestBootNanos
 		b, _ := json.Marshal(stored)
-		if err := appendJSONL(filepath.Join(m.active.dir, "events.jsonl"), b); err != nil {
+		if err := appendJSONL(filepath.Join(a.dir, "events.jsonl"), b); err != nil {
 			m.mu.Unlock()
 			return "rejected", err
 		}
-		for i := range m.active.manifest.Sources {
-			if m.active.manifest.Sources[i].Source.ID == "applications" {
-				m.active.manifest.Sources[i].Count++
+		for i := range a.manifest.Sources {
+			if a.manifest.Sources[i].Source.ID == "applications" {
+				a.manifest.Sources[i].Count++
 			}
 		}
-		observer := m.appObserver
-		m.mu.Unlock()
-		if observer != nil {
-			observer(appID, record)
-		}
-		return "recorded", nil
+		recorded = true
 	}
+	// The pre-roll ring buffer is maintained continuously so an episode that
+	// starts later still receives its full pre-trigger window, even when
+	// another campaign's episode was recording at the time.
 	stored.EpisodeNanos = 0
 	b, err := json.Marshal(stored)
 	if err != nil {
@@ -584,6 +666,9 @@ func (m *Manager) RecordApplication(appID string, record ApplicationRecord) (str
 	if observer != nil {
 		observer(appID, record)
 	}
+	if recorded {
+		return "recorded", nil
+	}
 	return "buffered", nil
 }
 
@@ -595,6 +680,11 @@ func (m *Manager) evictPreRoll(now int64) {
 		m.preRollLost++
 	}
 }
+
+// flushPreRoll copies the buffered records inside the requested window into a
+// starting episode. The ring buffer is not consumed: with per-campaign
+// concurrency another campaign's later episode is entitled to the same
+// pre-trigger records on its own timeline.
 func (m *Manager) flushPreRoll(dir string, origin int64, requested time.Duration) (uint64, *int64, error) {
 	window := preRollWindow
 	if requested > 0 && requested < window {
@@ -604,7 +694,7 @@ func (m *Manager) flushPreRoll(dir string, origin int64, requested time.Duration
 	var count uint64
 	var earliest *int64
 	for _, r := range m.preRoll {
-		if r.bootNanos < cutoff {
+		if r.bootNanos < cutoff || r.bootNanos > origin {
 			continue
 		}
 		var stored storedApplicationRecord
@@ -622,8 +712,6 @@ func (m *Manager) flushPreRoll(dir string, origin int64, requested time.Duration
 		}
 		count++
 	}
-	m.preRoll = nil
-	m.preRollBytes = 0
 	return count, earliest, nil
 }
 func appendJSONL(path string, b []byte) error {
@@ -644,13 +732,15 @@ func abs64(v int64) int64 {
 	return v
 }
 
-func (m *Manager) Stop() (Manifest, error) {
+// Stop finalizes the episode keyed by the given campaign name
+// (AdHocEpisodeKey for campaign-less episodes).
+func (m *Manager) Stop(key string) (Manifest, error) {
 	m.mu.Lock()
-	if m.active == nil {
+	a := m.active[key]
+	if a == nil {
 		m.mu.Unlock()
 		return Manifest{}, ErrNoActiveEpisode
 	}
-	a := m.active
 	if a.cancel != nil {
 		a.cancel()
 	}
@@ -660,14 +750,13 @@ func (m *Manager) Stop() (Manifest, error) {
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if m.active != a {
+	if m.active[key] != a {
 		return Manifest{}, ErrNoActiveEpisode
 	}
-	return m.finalizeLocked("complete", "")
+	return m.finalizeLocked(a, "complete", "")
 }
 
-func (m *Manager) finalizeLocked(state, reason string) (Manifest, error) {
-	a := m.active
+func (m *Manager) finalizeLocked(a *activeEpisode, state, reason string) (Manifest, error) {
 	now, err := readBootTime()
 	if err != nil {
 		return Manifest{}, err
@@ -701,17 +790,30 @@ func (m *Manager) finalizeLocked(state, reason string) (Manifest, error) {
 	if err := os.Rename(a.dir, final); err != nil {
 		return Manifest{}, err
 	}
-	m.active = nil
+	delete(m.active, a.key)
 	return a.manifest, nil
 }
 
+// Status reports one active episode for status displays: the ad-hoc episode
+// when present, otherwise the earliest-started campaign episode. Use
+// ActiveEpisodeKeys and ActiveSession to enumerate concurrent episodes.
 func (m *Manager) Status() *Manifest {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if m.active == nil {
+	if a := m.active[AdHocEpisodeKey]; a != nil {
+		v := snapshotManifest(a.manifest)
+		return &v
+	}
+	var earliest *activeEpisode
+	for _, a := range m.active {
+		if earliest == nil || a.manifest.StartedUnixNanos < earliest.manifest.StartedUnixNanos {
+			earliest = a
+		}
+	}
+	if earliest == nil {
 		return nil
 	}
-	v := m.active.manifest
+	v := snapshotManifest(earliest.manifest)
 	return &v
 }
 

--- a/go/internal/agent/data/manager_test.go
+++ b/go/internal/agent/data/manager_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestEpisodeLifecycleUsesBoottimeAndSealsFiles(t *testing.T) {
@@ -23,7 +25,7 @@ func TestEpisodeLifecycleUsesBoottimeAndSealsFiles(t *testing.T) {
 	if len(started.UTCObservations) != 1 || started.UTCObservations[0].UncertaintyNanos < 0 {
 		t.Fatalf("bad UTC interval: %+v", started.UTCObservations)
 	}
-	stopped, err := m.Stop()
+	stopped, err := m.Stop(AdHocEpisodeKey)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +67,7 @@ func TestApplicationPreRollHasNegativeCanonicalOffsets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err = m.Stop(); err != nil {
+	if _, err = m.Stop(AdHocEpisodeKey); err != nil {
 		t.Fatal(err)
 	}
 	dir, err := m.episodeDir(started.ID)
@@ -138,7 +140,7 @@ func TestInspectDetectsChecksumCorruption(t *testing.T) {
 	if e != nil {
 		t.Fatal(e)
 	}
-	done, e := m.Stop()
+	done, e := m.Stop(AdHocEpisodeKey)
 	if e != nil {
 		t.Fatal(e)
 	}
@@ -155,6 +157,175 @@ func TestInspectDetectsChecksumCorruption(t *testing.T) {
 	}
 	if len(fail) == 0 {
 		t.Fatal("expected corruption failure")
+	}
+}
+
+func setUploadState(t *testing.T, m *Manager, id, uploadState, campaignName string) {
+	t.Helper()
+	dir, err := m.episodeDir(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mf, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mf.Upload.State = uploadState
+	mf.Trigger.CampaignName = campaignName
+	if err := writeManifest(dir, mf); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func episodeSize(t *testing.T, m *Manager, id string) int64 {
+	t.Helper()
+	dir, err := m.episodeDir(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var size int64
+	err = filepath.WalkDir(dir, func(_ string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !d.IsDir() {
+			info, infoErr := d.Info()
+			if infoErr != nil {
+				return infoErr
+			}
+			size += info.Size()
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return size
+}
+
+func recordEpisode(t *testing.T, m *Manager, opts StartOptions) Manifest {
+	t.Helper()
+	started, err := m.Start(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stopped, err := m.Stop(opts.Trigger.CampaignName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if started.ID != stopped.ID {
+		t.Fatal("id changed across stop")
+	}
+	return stopped
+}
+
+func TestEnforceQuotaEvictsUploadedBeforePendingUpload(t *testing.T) {
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var warnings []string
+	m.SetWarnLogger(func(msg string) { warnings = append(warnings, msg) })
+	pending := recordEpisode(t, m, StartOptions{Sources: []string{"applications"}, Trigger: EpisodeTrigger{Reason: "event:test", CampaignName: "forklift"}})
+	time.Sleep(2 * time.Millisecond)
+	uploaded := recordEpisode(t, m, StartOptions{Sources: []string{"applications"}})
+	setUploadState(t, m, pending.ID, "pending", "forklift")
+	setUploadState(t, m, uploaded.ID, "uploaded", "")
+	// The quota can hold the pending episode alone. The pending episode is the
+	// OLDER of the two, so the previous strictly oldest-first order would have
+	// evicted it; upload-state ordering must sacrifice the newer uploaded
+	// episode instead.
+	m.quotaForTest = episodeSize(t, m, pending.ID) + 1
+	final := recordEpisode(t, m, StartOptions{Sources: []string{"applications"}})
+	if _, err = m.episodeDir(uploaded.ID); err == nil {
+		t.Fatal("uploaded episode was not evicted")
+	}
+	if _, err = m.episodeDir(pending.ID); err != nil {
+		t.Fatal("pending episode did not survive eviction")
+	}
+	if _, err = m.episodeDir(final.ID); err != nil {
+		t.Fatal(err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+	// Force the pending episode out as well: the quota can no longer hold it,
+	// and the eviction must warn, naming the episode and campaign.
+	m.quotaForTest = 1
+	if _, err = m.Start(StartOptions{Sources: []string{"applications"}}); err == nil {
+		if _, stopErr := m.Stop(AdHocEpisodeKey); stopErr != nil {
+			t.Fatal(stopErr)
+		}
+	}
+	if _, err = m.episodeDir(pending.ID); err == nil {
+		t.Fatal("pending episode survived a quota that cannot hold it")
+	}
+	warned := false
+	for _, warning := range warnings {
+		warned = warned || strings.Contains(warning, pending.ID) && strings.Contains(warning, "forklift")
+	}
+	if !warned {
+		t.Fatalf("missing eviction warning naming episode and campaign: %v", warnings)
+	}
+}
+
+func TestPerCampaignEpisodeConcurrency(t *testing.T) {
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := m.Start(StartOptions{Sources: []string{"applications"}, Trigger: EpisodeTrigger{Reason: "event:a", CampaignName: "campaign-a"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := m.Start(StartOptions{Sources: []string{"applications"}, Trigger: EpisodeTrigger{Reason: "event:b", CampaignName: "campaign-b"}})
+	if err != nil {
+		t.Fatalf("second campaign could not capture concurrently: %v", err)
+	}
+	adHoc, err := m.Start(StartOptions{Sources: []string{"applications"}})
+	if err != nil {
+		t.Fatalf("ad-hoc episode could not run beside campaigns: %v", err)
+	}
+	if _, err = m.Start(StartOptions{Sources: []string{"applications"}, Trigger: EpisodeTrigger{Reason: "event:a", CampaignName: "campaign-a"}}); err == nil || !strings.Contains(err.Error(), "campaign-a") {
+		t.Fatalf("second episode for the same campaign was accepted: %v", err)
+	}
+	if _, err = m.Start(StartOptions{Sources: []string{"applications"}}); err == nil || err.Error() != "an episode is already active" {
+		t.Fatalf("second ad-hoc episode was accepted: %v", err)
+	}
+	// A record lands in every concurrently active episode.
+	if _, err = m.RecordApplication("test.app", ApplicationRecord{Version: 1, Type: "event", Name: "shared"}); err != nil {
+		t.Fatal(err)
+	}
+	keys := m.ActiveEpisodeKeys()
+	if len(keys) != 3 || keys[0] != AdHocEpisodeKey || keys[1] != "campaign-a" || keys[2] != "campaign-b" {
+		t.Fatalf("active keys: %v", keys)
+	}
+	for key, id := range map[string]string{"campaign-a": first.ID, "campaign-b": second.ID, AdHocEpisodeKey: adHoc.ID} {
+		session, ok := m.ActiveSession(key)
+		if !ok || session.ID != id {
+			t.Fatalf("session for %q = %+v, want %s", key, session, id)
+		}
+		manifest, err := m.Stop(key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		counted := false
+		for _, source := range manifest.Sources {
+			if source.Source.ID == "applications" && source.Count == 1 {
+				counted = true
+			}
+		}
+		if !counted {
+			t.Fatalf("episode %s did not record the shared application record: %+v", id, manifest.Sources)
+		}
+	}
+	// Quota accounting spans the episodes of every campaign and the ad-hoc one.
+	episodes, err := m.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(episodes) != 3 {
+		t.Fatalf("episodes = %d, want 3", len(episodes))
 	}
 }
 

--- a/go/internal/agent/services/app_data_socket_test.go
+++ b/go/internal/agent/services/app_data_socket_test.go
@@ -74,7 +74,7 @@ func TestAppDataSocketIsPrivateAndRecordsIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err = capture.Stop(); err != nil {
+	if _, err = capture.Stop(data.AdHocEpisodeKey); err != nil {
 		t.Fatal(err)
 	}
 	manifest, failures, err := capture.Inspect(started.ID, true)

--- a/go/internal/agent/services/data_service.go
+++ b/go/internal/agent/services/data_service.go
@@ -19,12 +19,14 @@ import (
 
 type DataService struct {
 	agentpbv2.UnimplementedDataServiceServer
-	manager        *data.Manager
-	adapterMu      sync.RWMutex
-	adapters       []dataCaptureAdapter
-	captureMu      sync.Mutex
-	activeCaptures []runningDataCapture
-	autoStopCancel context.CancelFunc
+	manager   *data.Manager
+	adapterMu sync.RWMutex
+	adapters  []dataCaptureAdapter
+	captureMu sync.Mutex
+	// Concurrency is keyed per campaign name; data.AdHocEpisodeKey holds the
+	// campaign-less episode started through the Start RPC.
+	activeCaptures map[string][]runningDataCapture
+	autoStopCancel map[string]context.CancelFunc
 }
 
 type dataCaptureAdapter interface {
@@ -37,7 +39,7 @@ type runningDataCapture interface {
 }
 
 func NewDataService(m *data.Manager) *DataService {
-	s := &DataService{manager: m}
+	s := &DataService{manager: m, activeCaptures: make(map[string][]runningDataCapture), autoStopCancel: make(map[string]context.CancelFunc)}
 	m.SetSourceProvider(s.discoverAdapterSources)
 	m.SetApplicationObserver(s.observeApplicationRecord)
 	return s
@@ -97,11 +99,12 @@ func (s *DataService) Start(ctx context.Context, req *agentpbv2.DataStartRequest
 func (s *DataService) startCapture(ctx context.Context, opts data.StartOptions) (*agentpbv2.DataEpisode, error) {
 	s.captureMu.Lock()
 	defer s.captureMu.Unlock()
+	key := opts.Trigger.CampaignName
 	m, err := s.manager.Start(opts)
 	if err != nil {
 		return nil, status.Error(codes.FailedPrecondition, err.Error())
 	}
-	session, ok := s.manager.ActiveSession()
+	session, ok := s.manager.ActiveSession(key)
 	if !ok {
 		return nil, status.Error(codes.Internal, "episode session disappeared during capture startup")
 	}
@@ -123,44 +126,61 @@ func (s *DataService) startCapture(ctx context.Context, opts data.StartOptions) 
 			r, _ := captures[i].Stop(context.Background())
 			results = append(results, r...)
 		}
-		_ = s.manager.ApplyCaptureResults(results)
-		_, _ = s.manager.Interrupt("capture_adapter_start_failed")
+		_ = s.manager.ApplyCaptureResults(key, results)
+		_, _ = s.manager.Interrupt(key, "capture_adapter_start_failed")
 		return nil, status.Error(codes.FailedPrecondition, fmt.Sprintf("starting capture adapter: %v", startErr))
 	}
-	s.activeCaptures = captures
+	s.activeCaptures[key] = captures
 	return manifestEpisode(m), nil
 }
 
 func (s *DataService) Stop(ctx context.Context, _ *agentpbv2.DataStopRequest) (*agentpbv2.DataEpisode, error) {
-	return s.stopCapture(ctx)
+	// The Stop RPC names no episode. Prefer the ad-hoc episode; otherwise stop
+	// the single active campaign episode, and refuse when that is ambiguous.
+	keys := s.manager.ActiveEpisodeKeys()
+	key := data.AdHocEpisodeKey
+	adHoc := false
+	for _, active := range keys {
+		adHoc = adHoc || active == data.AdHocEpisodeKey
+	}
+	if !adHoc {
+		if len(keys) > 1 {
+			return nil, status.Error(codes.FailedPrecondition, "multiple campaign episodes are active; wait for their after_trigger windows or trigger-specific tooling to finish them")
+		}
+		if len(keys) == 1 {
+			key = keys[0]
+		}
+	}
+	return s.stopCapture(ctx, key)
 }
 
-func (s *DataService) stopCapture(ctx context.Context) (*agentpbv2.DataEpisode, error) {
+func (s *DataService) stopCapture(ctx context.Context, key string) (*agentpbv2.DataEpisode, error) {
 	s.captureMu.Lock()
 	defer s.captureMu.Unlock()
-	if s.autoStopCancel != nil {
-		s.autoStopCancel()
-		s.autoStopCancel = nil
+	if cancel := s.autoStopCancel[key]; cancel != nil {
+		cancel()
+		delete(s.autoStopCancel, key)
 	}
 	var results []data.CaptureResult
 	var captureErrs []error
-	for i := len(s.activeCaptures) - 1; i >= 0; i-- {
-		r, err := s.activeCaptures[i].Stop(ctx)
+	captures := s.activeCaptures[key]
+	for i := len(captures) - 1; i >= 0; i-- {
+		r, err := captures[i].Stop(ctx)
 		results = append(results, r...)
 		if err != nil {
 			captureErrs = append(captureErrs, err)
 		}
 	}
-	s.activeCaptures = nil
+	delete(s.activeCaptures, key)
 	if len(results) > 0 {
-		_ = s.manager.ApplyCaptureResults(results)
+		_ = s.manager.ApplyCaptureResults(key, results)
 	}
 	var m data.Manifest
 	var err error
 	if len(captureErrs) > 0 {
-		m, err = s.manager.Interrupt("capture_adapter_failed")
+		m, err = s.manager.Interrupt(key, "capture_adapter_failed")
 	} else {
-		m, err = s.manager.Stop()
+		m, err = s.manager.Stop(key)
 	}
 	if errors.Is(err, data.ErrNoActiveEpisode) {
 		return nil, status.Error(codes.FailedPrecondition, err.Error())
@@ -272,7 +292,10 @@ func (s *DataService) triggerCampaign(ctx context.Context, campaign data.Campaig
 	}
 	timerContext, cancel := context.WithCancel(context.Background())
 	s.captureMu.Lock()
-	s.autoStopCancel = cancel
+	if previous := s.autoStopCancel[campaign.Name]; previous != nil {
+		previous()
+	}
+	s.autoStopCancel[campaign.Name] = cancel
 	s.captureMu.Unlock()
 	go func(episodeID string, after time.Duration) {
 		timer := time.NewTimer(after)
@@ -281,31 +304,37 @@ func (s *DataService) triggerCampaign(ctx context.Context, campaign data.Campaig
 		case <-timerContext.Done():
 			return
 		case <-timer.C:
-			active := s.manager.Status()
-			if active == nil || active.ID != episodeID {
+			session, ok := s.manager.ActiveSession(campaign.Name)
+			if !ok || session.ID != episodeID {
 				return
 			}
-			_, _ = s.stopCapture(context.Background())
+			_, _ = s.stopCapture(context.Background(), campaign.Name)
 		}
 	}(episode.GetId(), campaign.AfterTriggerDuration())
 	return episode, nil
 }
 
 func (s *DataService) observeApplicationRecord(_ string, record data.ApplicationRecord) {
-	if s.manager.Status() != nil {
-		return
+	// Triggers are dropped only for campaigns that already have an active
+	// episode; other campaigns (and ad-hoc recordings) capture independently.
+	activeKeys := map[string]bool{}
+	for _, key := range s.manager.ActiveEpisodeKeys() {
+		activeKeys[key] = true
 	}
 	campaigns, err := s.manager.Campaigns()
 	if err != nil {
 		return
 	}
 	for _, campaign := range campaigns {
-		reason, expression, matched := campaign.Match(record)
-		if !matched || campaign.State != "armed" {
+		if campaign.State != "armed" || activeKeys[campaign.Name] {
 			continue
 		}
+		reason, expression, matched := campaign.Match(record)
+		if !matched {
+			continue
+		}
+		campaign := campaign
 		go func() { _, _ = s.triggerCampaign(context.Background(), campaign, reason, expression) }()
-		return
 	}
 }
 

--- a/go/internal/agent/services/data_service.go
+++ b/go/internal/agent/services/data_service.go
@@ -157,6 +157,24 @@ func (s *DataService) Stop(ctx context.Context, _ *agentpbv2.DataStopRequest) (*
 func (s *DataService) stopCapture(ctx context.Context, key string) (*agentpbv2.DataEpisode, error) {
 	s.captureMu.Lock()
 	defer s.captureMu.Unlock()
+	return s.stopCaptureLocked(ctx, key)
+}
+
+// stopCaptureIfCurrent finalizes the episode keyed by key only while the
+// given episode is still the active one. The check runs under captureMu so a
+// stale auto-stop timer that raced a manual stop plus an immediate re-trigger
+// cannot finalize the campaign's new episode.
+func (s *DataService) stopCaptureIfCurrent(ctx context.Context, key, episodeID string) {
+	s.captureMu.Lock()
+	defer s.captureMu.Unlock()
+	session, ok := s.manager.ActiveSession(key)
+	if !ok || session.ID != episodeID {
+		return
+	}
+	_, _ = s.stopCaptureLocked(ctx, key)
+}
+
+func (s *DataService) stopCaptureLocked(ctx context.Context, key string) (*agentpbv2.DataEpisode, error) {
 	if cancel := s.autoStopCancel[key]; cancel != nil {
 		cancel()
 		delete(s.autoStopCancel, key)
@@ -304,11 +322,7 @@ func (s *DataService) triggerCampaign(ctx context.Context, campaign data.Campaig
 		case <-timerContext.Done():
 			return
 		case <-timer.C:
-			session, ok := s.manager.ActiveSession(campaign.Name)
-			if !ok || session.ID != episodeID {
-				return
-			}
-			_, _ = s.stopCapture(context.Background(), campaign.Name)
+			s.stopCaptureIfCurrent(context.Background(), campaign.Name, episodeID)
 		}
 	}(episode.GetId(), campaign.AfterTriggerDuration())
 	return episode, nil

--- a/go/internal/agent/services/data_service_adversarial_test.go
+++ b/go/internal/agent/services/data_service_adversarial_test.go
@@ -1,0 +1,290 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/data"
+	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestLegacyPersistedCampaignStillTriggersAfterUpgrade simulates an agent
+// upgrade: a campaign persisted by the previous release (no version stamping
+// at parse time, no capture/upload-policy/retention fields) must keep
+// auto-triggering through the full service path without redeployment.
+func TestLegacyPersistedCampaignStillTriggersAfterUpgrade(t *testing.T) {
+	root := t.TempDir()
+	legacy := `{
+  "version": 1,
+  "name": "legacy-flight",
+  "sources": [
+    {"telemetry": true}
+  ],
+  "capture": {
+    "buffer": "10ms",
+    "after_trigger": "30ms",
+    "triggers": [
+      {"event": "emergency_stop"}
+    ]
+  },
+  "upload": {
+    "when": "wifi",
+    "destination": "s3://acme-ml/forklift"
+  },
+  "export": {"annotation": "cvat"},
+  "models": {},
+  "privacy": [],
+  "state": "armed",
+  "revision": "0123456789abcdef0123456789abcdef",
+  "deployed_unix_nanos": 12345,
+  "warnings": null
+}`
+	campaignsDir := filepath.Join(root, "campaigns")
+	if err := os.MkdirAll(campaignsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(campaignsDir, "legacy-flight.json"), []byte(legacy), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	manager, err := data.NewManager(filepath.Join(root, "episodes"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := NewDataService(manager)
+	listed, err := service.Campaigns(context.Background(), &agentpbv2.DataCampaignsRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listed.GetCampaigns()) != 1 || listed.GetCampaigns()[0].GetRevision() != "0123456789abcdef0123456789abcdef" {
+		t.Fatalf("legacy campaign not listed intact: %+v", listed.GetCampaigns())
+	}
+	if _, err := manager.RecordApplication("test.app", data.ApplicationRecord{Version: 1, Type: "event", Name: "emergency_stop"}); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		list, listErr := manager.List()
+		if listErr != nil {
+			t.Fatal(listErr)
+		}
+		if len(list) == 1 {
+			manifest, _, inspectErr := manager.Inspect(list[0].ID, false)
+			if inspectErr != nil {
+				t.Fatal(inspectErr)
+			}
+			if manifest.Trigger.CampaignName != "legacy-flight" || manifest.Trigger.CampaignRevision != "0123456789abcdef0123456789abcdef" {
+				t.Fatalf("legacy campaign identity lost on triggered episode: %+v", manifest.Trigger)
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("legacy persisted campaign no longer triggers after the upgrade")
+}
+
+func deployTestCampaign(t *testing.T, service *DataService, name, afterTrigger string) {
+	t.Helper()
+	yaml := fmt.Sprintf(`version: 1
+name: %s
+sources:
+  - telemetry: true
+capture:
+  buffer: 10ms
+  after_trigger: %s
+  triggers:
+    - event: trigger-%s
+upload:
+  when: manual
+export:
+  annotation: cvat
+`, name, afterTrigger, name)
+	if _, err := service.CampaignDeploy(context.Background(), &agentpbv2.DataCampaignDeployRequest{CampaignYaml: []byte(yaml)}); err != nil {
+		t.Fatalf("deploying %s: %v", name, err)
+	}
+}
+
+func TestStopPrefersAdHocThenRefusesAmbiguousCampaigns(t *testing.T) {
+	manager, err := data.NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := NewDataService(manager)
+	deployTestCampaign(t, service, "stop-a", "10s")
+	deployTestCampaign(t, service, "stop-b", "10s")
+	first, err := service.CampaignTrigger(context.Background(), &agentpbv2.DataCampaignTriggerRequest{Name: "stop-a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := service.CampaignTrigger(context.Background(), &agentpbv2.DataCampaignTriggerRequest{Name: "stop-b"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	adHoc, err := service.Start(context.Background(), &agentpbv2.DataStartRequest{Sources: []string{"applications"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stopped, err := service.Stop(context.Background(), &agentpbv2.DataStopRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stopped.GetId() != adHoc.GetId() {
+		t.Fatalf("Stop finalized %s, want the ad-hoc episode %s", stopped.GetId(), adHoc.GetId())
+	}
+	// Two campaign episodes remain and no ad-hoc: Stop must refuse.
+	if _, err = service.Stop(context.Background(), &agentpbv2.DataStopRequest{}); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("ambiguous Stop returned %v, want FailedPrecondition", err)
+	}
+	// A stale auto-stop guard must not finalize a different episode.
+	service.stopCaptureIfCurrent(context.Background(), "stop-a", "not-the-active-episode")
+	if session, ok := manager.ActiveSession("stop-a"); !ok || session.ID != first.GetId() {
+		t.Fatal("stale auto-stop guard finalized the wrong episode")
+	}
+	// With the right episode it stops exactly that campaign's episode.
+	service.stopCaptureIfCurrent(context.Background(), "stop-a", first.GetId())
+	if _, ok := manager.ActiveSession("stop-a"); ok {
+		t.Fatal("stopCaptureIfCurrent did not finalize the current episode")
+	}
+	// One campaign episode remains: Stop now finalizes it.
+	stopped, err = service.Stop(context.Background(), &agentpbv2.DataStopRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stopped.GetId() != second.GetId() {
+		t.Fatalf("Stop finalized %s, want %s", stopped.GetId(), second.GetId())
+	}
+	if keys := manager.ActiveEpisodeKeys(); len(keys) != 0 {
+		t.Fatalf("episodes still active: %v", keys)
+	}
+}
+
+func TestServiceConcurrentTriggerRecordAndStopStress(t *testing.T) {
+	manager, err := data.NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager.SetWarnLogger(func(string) {})
+	service := NewDataService(manager)
+	campaigns := []string{"stress-x", "stress-y", "stress-z"}
+	for _, name := range campaigns {
+		deployTestCampaign(t, service, name, "40ms")
+	}
+	var wg sync.WaitGroup
+	// Records that match every campaign trigger, arriving concurrently.
+	for worker := 0; worker < 3; worker++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 30; i++ {
+				for _, name := range campaigns {
+					_, _ = manager.RecordApplication("stress.app", data.ApplicationRecord{Version: 1, Type: "event", Name: "trigger-" + name})
+				}
+				time.Sleep(time.Millisecond)
+			}
+		}()
+	}
+	// Manual triggers racing the automatic ones.
+	for _, name := range campaigns {
+		name := name
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 10; i++ {
+				_, _ = service.CampaignTrigger(context.Background(), &agentpbv2.DataCampaignTriggerRequest{Name: name})
+				time.Sleep(2 * time.Millisecond)
+			}
+		}()
+	}
+	// Ad-hoc episodes and Stop RPCs racing the campaign lifecycle.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 20; i++ {
+			_, _ = service.Start(context.Background(), &agentpbv2.DataStartRequest{Sources: []string{"applications"}})
+			_, _ = service.Stop(context.Background(), &agentpbv2.DataStopRequest{})
+			time.Sleep(2 * time.Millisecond)
+		}
+	}()
+	wg.Wait()
+	// Quiesce: pending observer goroutines and after_trigger timers drain.
+	deadline := time.Now().Add(5 * time.Second)
+	stable := 0
+	for time.Now().Before(deadline) && stable < 3 {
+		if len(manager.ActiveEpisodeKeys()) == 0 {
+			stable++
+		} else {
+			stable = 0
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if keys := manager.ActiveEpisodeKeys(); len(keys) != 0 {
+		t.Fatalf("episodes still active after stress: %v", keys)
+	}
+	list, err := manager.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	valid := map[string]bool{"": true}
+	for _, name := range campaigns {
+		valid[name] = true
+	}
+	seen := map[string]bool{}
+	for _, episode := range list {
+		if seen[episode.ID] {
+			t.Fatalf("episode %s appears twice", episode.ID)
+		}
+		seen[episode.ID] = true
+		if episode.State != "complete" && episode.State != "interrupted" {
+			t.Fatalf("episode %s in state %q", episode.ID, episode.State)
+		}
+		manifest, _, err := manager.Inspect(episode.ID, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !valid[manifest.Trigger.CampaignName] {
+			t.Fatalf("episode %s attributed to unknown campaign %q", episode.ID, manifest.Trigger.CampaignName)
+		}
+	}
+}
+
+func TestCampaignDeployWarnsAboutUnenforcedRetentionQuota(t *testing.T) {
+	manager, err := data.NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := NewDataService(manager)
+	yaml := []byte(`version: 1
+name: quota-warn
+sources:
+  - telemetry: true
+capture:
+  buffer: 10ms
+  after_trigger: 30ms
+  triggers:
+    - event: emergency_stop
+upload:
+  when: wifi
+retention:
+  local_quota: 10GiB
+export:
+  annotation: cvat
+`)
+	campaign, err := service.CampaignDeploy(context.Background(), &agentpbv2.DataCampaignDeployRequest{CampaignYaml: yaml})
+	if err != nil {
+		t.Fatal(err)
+	}
+	warned := false
+	for _, warning := range campaign.GetWarnings() {
+		warned = warned || strings.Contains(warning, "retention.local_quota")
+	}
+	if !warned {
+		t.Fatalf("deploy accepted an unenforced retention.local_quota without warning: %v", campaign.GetWarnings())
+	}
+}

--- a/go/internal/agent/services/data_service_test.go
+++ b/go/internal/agent/services/data_service_test.go
@@ -26,7 +26,8 @@ func TestCampaignDeployTriggerAndTimedFinalization(t *testing.T) {
 	service := NewDataService(manager)
 	adapter := &fakeDataAdapter{}
 	service.addAdapter(adapter)
-	yaml := []byte(`name: test-flight
+	yaml := []byte(`version: 1
+name: test-flight
 fleet: test-lab
 sources:
   - camera: front
@@ -37,7 +38,7 @@ capture:
     - event: emergency_stop
 upload:
   when: wifi
-  destination: s3://example/episodes
+  destination: example-episodes
 export:
   annotation: cvat
 `)
@@ -69,7 +70,7 @@ export:
 	if len(failures) != 0 {
 		t.Fatalf("verification failures: %v", failures)
 	}
-	if manifest.Trigger.CampaignName != "test-flight" || manifest.Trigger.Reason != "hardware_test" || manifest.Upload.Destination != "s3://example/episodes" || manifest.Labeling.Destination != "cvat" {
+	if manifest.Trigger.CampaignName != "test-flight" || manifest.Trigger.Reason != "hardware_test" || manifest.Upload.Destination != "example-episodes" || manifest.Labeling.Destination != "cvat" {
 		t.Fatalf("campaign metadata missing from episode: %+v", manifest)
 	}
 	if manifest.CollectorVersion == "" || manifest.Device.ID == "" {
@@ -88,7 +89,8 @@ func TestCampaignApplicationEventAutomaticallyTriggers(t *testing.T) {
 		t.Fatal(err)
 	}
 	service := NewDataService(manager)
-	yaml := []byte(`name: event-flight
+	yaml := []byte(`version: 1
+name: event-flight
 sources:
   - telemetry: true
 capture:
@@ -96,7 +98,7 @@ capture:
   after_trigger: 30ms
   triggers:
     - event: emergency_stop
-upload: {when: wifi, destination: s3://example/episodes}
+upload: {when: wifi, destination: example-episodes}
 export: {annotation: cvat}
 `)
 	if _, err = service.CampaignDeploy(context.Background(), &agentpbv2.DataCampaignDeployRequest{CampaignYaml: yaml}); err != nil {
@@ -130,6 +132,112 @@ export: {annotation: cvat}
 	}
 	t.Fatal("application event did not produce a finalized episode")
 }
+func deployEventCampaign(t *testing.T, service *DataService, name, event string) {
+	t.Helper()
+	yaml := []byte(`version: 1
+name: ` + name + `
+sources:
+  - telemetry: true
+capture:
+  buffer: 1s
+  after_trigger: 150ms
+  triggers:
+    - event: ` + event + `
+upload: {when: wifi, destination: example-episodes}
+export: {annotation: cvat}
+`)
+	if _, err := service.CampaignDeploy(context.Background(), &agentpbv2.DataCampaignDeployRequest{CampaignYaml: yaml}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func waitForFinalizedEpisodes(t *testing.T, manager *data.Manager, want int) []data.EpisodeInfo {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		list, err := manager.List()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(list) >= want && len(manager.ActiveEpisodeKeys()) == 0 {
+			return list
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d finalized episodes", want)
+	return nil
+}
+
+func TestTwoCampaignsCaptureConcurrently(t *testing.T) {
+	manager, err := data.NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := NewDataService(manager)
+	deployEventCampaign(t, service, "campaign-a", "event_a")
+	deployEventCampaign(t, service, "campaign-b", "event_b")
+	if _, err = manager.RecordApplication("test.app", data.ApplicationRecord{Version: 1, Type: "event", Name: "event_a"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = manager.RecordApplication("test.app", data.ApplicationRecord{Version: 1, Type: "event", Name: "event_b"}); err != nil {
+		t.Fatal(err)
+	}
+	// Both campaigns must be recording at the same time before either
+	// finalizes; after_trigger leaves a wide window for this.
+	deadline := time.Now().Add(2 * time.Second)
+	concurrent := false
+	for !concurrent && time.Now().Before(deadline) {
+		keys := manager.ActiveEpisodeKeys()
+		concurrent = len(keys) == 2
+		time.Sleep(2 * time.Millisecond)
+	}
+	if !concurrent {
+		t.Fatal("campaigns did not capture concurrently")
+	}
+	episodes := waitForFinalizedEpisodes(t, manager, 2)
+	campaigns := map[string]bool{}
+	for _, episode := range episodes {
+		manifest, _, err := manager.Inspect(episode.ID, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		campaigns[manifest.Trigger.CampaignName] = true
+	}
+	if len(episodes) != 2 || !campaigns["campaign-a"] || !campaigns["campaign-b"] {
+		t.Fatalf("episodes=%d campaigns=%v", len(episodes), campaigns)
+	}
+}
+
+func TestSameCampaignTriggerDroppedWhileActive(t *testing.T) {
+	manager, err := data.NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := NewDataService(manager)
+	deployEventCampaign(t, service, "single-flight", "event_x")
+	if _, err = manager.RecordApplication("test.app", data.ApplicationRecord{Version: 1, Type: "event", Name: "event_x"}); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	active := false
+	for !active && time.Now().Before(deadline) {
+		_, active = manager.ActiveSession("single-flight")
+		time.Sleep(2 * time.Millisecond)
+	}
+	if !active {
+		t.Fatal("first trigger did not start an episode")
+	}
+	// A second trigger for the SAME campaign while its episode is active must
+	// be dropped rather than queueing or interrupting the recording.
+	if _, err = manager.RecordApplication("test.app", data.ApplicationRecord{Version: 1, Type: "event", Name: "event_x"}); err != nil {
+		t.Fatal(err)
+	}
+	episodes := waitForFinalizedEpisodes(t, manager, 1)
+	if len(episodes) != 1 {
+		t.Fatalf("episodes = %d, want exactly 1", len(episodes))
+	}
+}
+
 func (f *fakeDataAdapter) Start(_ context.Context, _ data.CaptureSession, selected []data.Source) (runningDataCapture, error) {
 	for _, source := range selected {
 		if source.ID == "fake:camera" {

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
@@ -119,7 +119,7 @@ The `upload` and `retention` blocks:
 | `upload.when` | yes | One of `always`, `wifi`, or `manual`. |
 | `upload.destination` | no | Logical dataset name the fleet backend maps to storage. Not a URL; devices never receive bucket layouts or credentials through campaign plans. |
 | `upload.max_rate` | no | Upload bandwidth cap in bytes per second; plain integers and rates such as `5MB/s` are accepted. |
-| `retention.local_quota` | no | On-device episode storage bound in bytes; plain integers and sizes such as `10GiB` are accepted. |
+| `retention.local_quota` | no | Declared on-device episode storage bound in bytes; plain integers and sizes such as `10GiB` are accepted. Stored with the plan; this release enforces only the device-wide quota and deployment prints a warning. |
 
 ```yaml
 version: 1
@@ -183,6 +183,8 @@ warning in the agent log naming the Episode and campaign.
   transfer worker.
 - Per-source capture modes other than `continuous` are validated and stored,
   but the adapters record continuously; deployment warns per source.
+- `retention.local_quota` is validated and stored, but eviction currently
+  applies only the device-wide quota; deployment warns when it is set.
 - `export.annotation` is stored as labeling lifecycle state, but this release
   does not create CVAT tasks.
 - Fleet catalog search, replay, evaluation, and model redeployment are later

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
@@ -57,11 +57,13 @@ rejected.
 
 | Top-level field | Required | Description |
 |---|---|---|
+| `version` | yes | Campaign schema version the author wrote the file against. This release supports version `1`; higher versions are a deploy-time error. |
 | `name` | yes | Unique device-local name using letters, numbers, `.`, `-`, or `_`; maximum 128 characters. |
 | `fleet` | no | Fleet selector retained with the plan. A direct device deployment applies to the connected device. |
 | `sources` | yes | One or more source entries. |
 | `capture` | yes | Buffer, post-trigger duration, and triggers. |
-| `upload` | yes | Upload condition and destination lifecycle intent. |
+| `upload` | yes | Upload condition, optional logical destination, and optional rate cap. |
+| `retention` | no | Optional on-device storage bounds. |
 | `export` | yes | Annotation integration lifecycle intent. |
 | `models` | no | Map of model name to deployed version, copied into Episodes. |
 | `privacy` | no | List of declared transforms with optional revisions. |
@@ -78,6 +80,26 @@ An optional `calibration_revision` can accompany a source. Application records
 are included automatically because they carry campaign trigger evidence and
 pre-roll.
 
+### Per-source capture policy
+
+Each source may carry an optional `capture` block declaring how it records.
+Fields belonging to a different mode than the declared one are rejected.
+
+| Field | Mode | Description |
+|---|---|---|
+| `mode` | | One of `continuous` (default), `snapshot`, `fragment`, or `threshold`. |
+| `rate` | `continuous` | Optional capture frequency cap in hertz. |
+| `interval` | `snapshot` | Required snapshot period, for example `2s`. |
+| `pre`, `post` | `fragment` | Durations bounding a fragment around an occurrence; at least one is required. |
+| `trigger` | `threshold` | Required expression `<field> <op> <number>`, for example `model.uncertainty > 0.9` or `level_db > -20`. Only `model.uncertainty` is bounded to 0 through 1; other fields carry their own units. |
+| `fragment` | `threshold` | Optional captured duration per threshold crossing. |
+| `max_resolution` | any | Camera sources only: `WxH` cap such as `1280x720`. |
+
+Only `continuous` is implemented by the capture adapters today. Other modes
+validate and deploy, and deployment prints a warning naming each source whose
+requested mode is not implemented yet; those sources record continuously for
+now.
+
 `capture.buffer` must be a Go-style duration from `0s` through `5m`.
 `capture.after_trigger` must be greater than `0s` and no more than `24h`. At
 least one trigger is required, and each trigger selects exactly one condition:
@@ -90,12 +112,26 @@ least one trigger is required, and each trigger selects exactly one condition:
 Prediction uncertainty is read from the structured `uncertainty` attribute
 when present, otherwise from the prediction value.
 
+The `upload` and `retention` blocks:
+
+| Field | Required | Description |
+|---|---|---|
+| `upload.when` | yes | One of `always`, `wifi`, or `manual`. |
+| `upload.destination` | no | Logical dataset name the fleet backend maps to storage. Not a URL; devices never receive bucket layouts or credentials through campaign plans. |
+| `upload.max_rate` | no | Upload bandwidth cap in bytes per second; plain integers and rates such as `5MB/s` are accepted. |
+| `retention.local_quota` | no | On-device episode storage bound in bytes; plain integers and sizes such as `10GiB` are accepted. |
+
 ```yaml
+version: 1
 name: forklift-failures
 fleet: warehouse-west
 
 sources:
   - camera: front
+    capture:
+      mode: snapshot
+      interval: 2s
+      max_resolution: 1280x720
   - ros2: /lidar/points
   - ros2: /vehicle/odometry
 
@@ -108,7 +144,11 @@ capture:
 
 upload:
   when: wifi
-  destination: s3://acme-ml/forklift
+  destination: forklift-episodes
+  max_rate: 5MB/s
+
+retention:
+  local_quota: 10GiB
 
 export:
   annotation: cvat
@@ -123,10 +163,26 @@ and the achieved offset; campaign deployment prints a warning when sensor
 pre-roll was requested. Unknown drop counts are displayed as unknown, never as
 zero.
 
+## Concurrency and retention
+
+Each campaign records at most one active Episode at a time; a second trigger
+for the same campaign while its Episode is active is dropped. Different
+campaigns capture concurrently, and one ad-hoc `wendy data record` Episode can
+run beside them. `wendy data stop` finalizes the ad-hoc Episode when one is
+running, otherwise the single active campaign Episode.
+
+When the device storage quota is exceeded, the oldest Episodes that are
+already uploaded or were recorded without an upload policy are evicted first.
+Episodes still awaiting upload are evicted only as a last resort, with a
+warning in the agent log naming the Episode and campaign.
+
 ## Current layer boundaries
 
-- `upload.when` and `upload.destination` are stored as durable pending state,
-  but this release does not run an S3 or cloud transfer worker.
+- Upload policy (`upload.when`, `upload.destination`, `upload.max_rate`) is
+  stored as durable pending state, but this release does not run a cloud
+  transfer worker.
+- Per-source capture modes other than `continuous` are validated and stored,
+  but the adapters record continuously; deployment warns per source.
 - `export.annotation` is stored as labeling lifecycle state, but this release
   does not create CVAT tasks.
 - Fleet catalog search, replay, evaluation, and model redeployment are later


### PR DESCRIPTION
## Problem

The freshly rebased Wendy Data episode-capture subsystem carried device-lane schema and behavior gaps against the committed platform design (docs/specs/2026-08-22-wendy-data-platform-design.md in the cloud repository):

1. Capture policy was campaign-wide only; there was no way to declare per-source behavior such as a snapshot camera or a threshold-gated stream, and the model-uncertainty threshold parser clamped every value to 0..1, which cannot express negative audio decibel thresholds.
2. The campaign schema version was stamped by device code rather than declared by the author, so a device could not honestly reject a plan written against a newer schema.
3. `upload.when` was accepted as any non-empty string, there was no upload rate cap or local retention bound, and `upload.destination` was a required field documented by example as a storage URL, leaking storage layout concerns into device plans.
4. Quota eviction removed the oldest finalized episodes regardless of upload state, so an episode still awaiting upload could be silently destroyed while an already-uploaded copy of older data survived.
5. The manager enforced one active episode per device, so any recording (including an ad-hoc one) suppressed every campaign trigger fleet-wide on that device.

## Cause

The subsystem was built before the platform design settled these contracts; the initial cut favored a single-episode invariant and a permissive upload schema.

## Solution

- **Per-source capture blocks.** `CampaignSource` gains an optional `capture` block with `mode` (`continuous` default, `snapshot`, `fragment`, `threshold`) and mode-scoped fields (`interval`, `rate`, `pre`/`post`, `trigger`, `fragment`, `max_resolution`), each validated per mode and rejected outside it. Adapters only implement `continuous` today, so deployment emits a warning naming every source whose requested mode is not implemented yet, mirroring the existing pre-roll warning. `parseThreshold` is generalized: the 0..1 clamp applies only to `model.uncertainty`.
- **Author-declared schema version.** A required top-level `version: 1` is now written by the author; missing or higher versions are a deploy-time error naming the maximum supported version.
- **Upload policy.** `upload.when` is an enum (`always`, `wifi`, `manual`) with an error listing valid values. New optional `upload.max_rate` (bytes per second, human-readable rates such as `5MB/s`, following the byte-unit convention already used by the build progress parser) and `retention.local_quota` (bytes, human-readable sizes). `upload.destination` is optional and documented as a logical dataset name, not a URL.
- **Eviction respects upload state.** `enforceQuota` evicts episodes awaiting upload only after every uploaded or local-only episode, and evicting one logs a warning naming the episode and campaign (wired to the agent logger via a new `SetWarnLogger` hook).
- **Per-campaign episode concurrency.** The manager keys active episodes by campaign name; ad-hoc `wendy data record` episodes keep the old single-episode behavior under a reserved empty key. `observeApplicationRecord` drops triggers only for campaigns whose own episode is active. Application records land in every concurrently active episode on each episode's own timeline, and the pre-roll ring buffer is maintained continuously and flushed by copy so a later-starting episode still receives its full pre-trigger window. Sealing, crash recovery, and per-episode auto-stop timers are preserved per episode.
- The campaign revision hash now covers the new fields (and the author-declared version).
- Fixed a latent data race the new concurrency tests exposed: manifests returned by `Start`/`Status` shared their `Sources` slice backing array with the live manifest the manager mutates.
- Updated the example campaign (`Examples/WendyDataCampaign/campaign.yaml`, with the audio threshold source commented out because the audio source kind does not exist yet) and the `wendy data` Command Line Interface (CLI) documentation.

## Testing

`CC=/usr/bin/clang go build ./... && go test ./internal/agent/data/... ./internal/agent/services/... ./internal/cli/...` is green with no skips; the two changed packages also pass under `-race` and the new timing-sensitive tests pass with `-count=3`. New tests: `TestParseCampaignRequiresAuthorDeclaredVersion`, `TestUploadPolicyValidation`, `TestSourceCaptureValidation`, `TestRevisionHashCoversCaptureUploadAndRetention`, `TestEnforceQuotaEvictsUploadedBeforePendingUpload`, `TestPerCampaignEpisodeConcurrency`, `TestTwoCampaignsCaptureConcurrently`, `TestSameCampaignTriggerDroppedWhileActive`.