### PR TITLE
feat(data): snapshot capture mode and camera rate/resolution caps

### DIFF
--- a/go/internal/agent/data/adversarial_test.go
+++ b/go/internal/agent/data/adversarial_test.go
@@ -81,7 +81,7 @@ func TestPersistedCampaignsFromOlderAgentsSurviveUpgrade(t *testing.T) {
 		if !matched || reason == "" || expression == "" {
 			t.Fatalf("campaign %s no longer matches its trigger after upgrade", campaign.Name)
 		}
-		if _, _, err := m.ResolveCampaignSources(campaign); err != nil {
+		if _, _, _, err := m.ResolveCampaignSources(campaign); err != nil {
 			t.Fatalf("campaign %s sources no longer resolve: %v", campaign.Name, err)
 		}
 	}

--- a/go/internal/agent/data/campaign.go
+++ b/go/internal/agent/data/campaign.go
@@ -21,10 +21,11 @@ import (
 
 const CampaignVersion = 1
 
-// SourceCapture is an optional per-source capture policy. Only the
-// "continuous" mode is implemented by the capture adapters today; the other
-// modes are validated so authored plans are portable, and deployment reports
-// them as not yet implemented rather than silently recording continuously.
+// SourceCapture is an optional per-source capture policy. The camera adapter
+// implements the "continuous" (default) and "snapshot" modes; other
+// combinations are validated so authored plans are portable, and deployment
+// reports them as not yet implemented rather than silently recording
+// continuously.
 type SourceCapture struct {
 	// Mode is one of continuous (default), snapshot, fragment, or threshold.
 	Mode string `json:"mode,omitempty" yaml:"mode,omitempty"`
@@ -53,6 +54,33 @@ func (sc *SourceCapture) EffectiveMode() string {
 	return sc.Mode
 }
 
+// IntervalDuration returns the validated snapshot interval, or zero when the
+// policy declares none.
+func (sc *SourceCapture) IntervalDuration() time.Duration {
+	if sc == nil || sc.Interval == "" {
+		return 0
+	}
+	d, err := time.ParseDuration(sc.Interval)
+	if err != nil || d <= 0 {
+		return 0
+	}
+	return d
+}
+
+// MaxResolutionPixels returns the validated WxH resolution cap.
+func (sc *SourceCapture) MaxResolutionPixels() (uint32, uint32, bool) {
+	if sc == nil || sc.MaxResolution == "" {
+		return 0, 0, false
+	}
+	width, height, found := strings.Cut(sc.MaxResolution, "x")
+	w, errW := strconv.Atoi(width)
+	h, errH := strconv.Atoi(height)
+	if !found || errW != nil || errH != nil || w <= 0 || h <= 0 {
+		return 0, 0, false
+	}
+	return uint32(w), uint32(h), true
+}
+
 type CampaignSource struct {
 	Camera      string         `json:"camera,omitempty" yaml:"camera,omitempty"`
 	ROS2        string         `json:"ros2,omitempty" yaml:"ros2,omitempty"`
@@ -67,6 +95,18 @@ func (s CampaignSource) describe() string {
 		return "camera:" + s.Camera
 	case s.ROS2 != "":
 		return "ros2:" + s.ROS2
+	case s.Telemetry:
+		return "telemetry"
+	}
+	return "unknown"
+}
+
+func (s CampaignSource) kind() string {
+	switch {
+	case s.Camera != "":
+		return "camera"
+	case s.ROS2 != "":
+		return "ros2"
 	case s.Telemetry:
 		return "telemetry"
 	}
@@ -275,12 +315,12 @@ func (m *Manager) DeployCampaign(contents []byte) (Campaign, error) {
 	}
 	var pendingModes []string
 	for i, source := range campaign.Sources {
-		if mode := source.Capture.EffectiveMode(); !implementedCaptureModes[mode] {
+		if mode := source.Capture.EffectiveMode(); !implementedCaptureModes[source.kind()][mode] {
 			pendingModes = append(pendingModes, fmt.Sprintf("sources[%d] (%s, mode %s)", i, source.describe(), mode))
 		}
 	}
 	if len(pendingModes) > 0 {
-		campaign.Warnings = append(campaign.Warnings, "capture modes other than continuous are not implemented yet; these sources record continuously for now: "+strings.Join(pendingModes, ", "))
+		campaign.Warnings = append(campaign.Warnings, "these capture modes are not implemented yet for their source kind; the sources record continuously for now: "+strings.Join(pendingModes, ", "))
 	}
 	if campaign.Retention.LocalQuota != "" {
 		campaign.Warnings = append(campaign.Warnings, "retention.local_quota is recorded with the plan, but this release enforces only the device-wide storage quota")
@@ -344,9 +384,13 @@ func (m *Manager) Campaigns() ([]Campaign, error) {
 // ResolveCampaignSources maps semantic campaign selectors onto the current
 // device source inventory. ROS topic selectors intentionally select the local
 // ROS graph recorder, which preserves the requested topics in the manifest.
-func (m *Manager) ResolveCampaignSources(campaign Campaign) ([]string, []string, error) {
+// Camera capture policies are returned keyed by resolved source ID so the
+// capture adapter can honor them; ROS 2 and telemetry policies are not plumbed
+// because those adapters implement only continuous capture (deployment warns).
+func (m *Manager) ResolveCampaignSources(campaign Campaign) ([]string, []string, map[string]*SourceCapture, error) {
 	all := m.Sources(context.Background())
 	selected := map[string]bool{"applications": true}
+	captures := map[string]*SourceCapture{}
 	var topics []string
 	for _, requested := range campaign.Sources {
 		switch {
@@ -361,14 +405,17 @@ func (m *Manager) ResolveCampaignSources(campaign Campaign) ([]string, []string,
 				}
 			}
 			if !found {
-				return nil, nil, fmt.Errorf("no healthy ROS 2 graph is available for topic %s", requested.ROS2)
+				return nil, nil, nil, fmt.Errorf("no healthy ROS 2 graph is available for topic %s", requested.ROS2)
 			}
 		case requested.Camera != "":
 			id, err := resolveCameraSelector(all, requested.Camera)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 			selected[id] = true
+			if requested.Capture != nil {
+				captures[id] = requested.Capture
+			}
 		}
 	}
 	ids := make([]string, 0, len(selected))
@@ -377,7 +424,7 @@ func (m *Manager) ResolveCampaignSources(campaign Campaign) ([]string, []string,
 	}
 	sort.Strings(ids)
 	sort.Strings(topics)
-	return ids, topics, nil
+	return ids, topics, captures, nil
 }
 
 func resolveCameraSelector(all []Source, selector string) (string, error) {
@@ -514,8 +561,15 @@ func parseFieldThreshold(expression string) (string, string, float64, error) {
 // adapters do not implement yet.
 var validCaptureModes = []string{"continuous", "snapshot", "fragment", "threshold"}
 
-// implementedCaptureModes is what capture adapters actually honor today.
-var implementedCaptureModes = map[string]bool{"continuous": true}
+// implementedCaptureModes is what capture adapters actually honor today, by
+// campaign source kind. The camera adapter implements snapshot capture; the
+// ROS 2 and telemetry paths still record continuously regardless of mode, so
+// snapshot deploy-warns for them.
+var implementedCaptureModes = map[string]map[string]bool{
+	"camera":    {"continuous": true, "snapshot": true},
+	"ros2":      {"continuous": true},
+	"telemetry": {"continuous": true},
+}
 
 func validateSourceCapture(source CampaignSource) error {
 	capture := source.Capture

--- a/go/internal/agent/data/campaign.go
+++ b/go/internal/agent/data/campaign.go
@@ -26,6 +26,16 @@ const CampaignVersion = 1
 // combinations are validated so authored plans are portable, and deployment
 // reports them as not yet implemented rather than silently recording
 // continuously.
+//
+// Snapshot stills and the continuous-mode rate cap additionally require a
+// camera transport that delivers whole encoded access units, which today
+// means a local V4L2 camera with native H.264 output. IP cameras and
+// GStreamer-encoded pipelines (CSI sensors, USB cameras without native H.264)
+// deliver byte-stream chunks that cannot be cut into standalone files without
+// corruption, so those sources record continuously at the stream rate and the
+// episode manifest's source detail records that the policy was not applied.
+// Which case applies is only knowable once the stream is running, so this is
+// reported per episode rather than warned at deployment.
 type SourceCapture struct {
 	// Mode is one of continuous (default), snapshot, fragment, or threshold.
 	Mode string `json:"mode,omitempty" yaml:"mode,omitempty"`

--- a/go/internal/agent/data/campaign_test.go
+++ b/go/internal/agent/data/campaign_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 )
 
 const exampleCampaignYAML = `version: 1
@@ -204,12 +205,10 @@ func TestCampaignPersistsAndResolvesSemanticSources(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	modeWarning := false
 	for _, warning := range campaign.Warnings {
-		modeWarning = modeWarning || strings.Contains(warning, "not implemented yet") && strings.Contains(warning, "camera:front")
-	}
-	if !modeWarning {
-		t.Fatalf("snapshot mode deploy warning missing: %v", campaign.Warnings)
+		if strings.Contains(warning, "not implemented yet") && strings.Contains(warning, "camera:front") {
+			t.Fatalf("camera snapshot mode still deploy-warns: %v", campaign.Warnings)
+		}
 	}
 	stored, err := manager.Campaign(campaign.Name)
 	if err != nil {
@@ -218,7 +217,7 @@ func TestCampaignPersistsAndResolvesSemanticSources(t *testing.T) {
 	if stored.Revision != campaign.Revision || stored.DeployedUnixNanos == 0 {
 		t.Fatalf("campaign was not durably stored: %+v", stored)
 	}
-	sources, topics, err := manager.ResolveCampaignSources(stored)
+	sources, topics, captures, err := manager.ResolveCampaignSources(stored)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -228,5 +227,41 @@ func TestCampaignPersistsAndResolvesSemanticSources(t *testing.T) {
 	}
 	if len(wantSources) != 0 || len(topics) != 2 {
 		t.Fatalf("sources=%v topics=%v missing=%v", sources, topics, wantSources)
+	}
+	capture := captures["v4l2:/dev/video2"]
+	if capture == nil || capture.EffectiveMode() != "snapshot" || capture.IntervalDuration() != 2*time.Second {
+		t.Fatalf("camera capture policy was not resolved: %+v", capture)
+	}
+	if w, h, ok := capture.MaxResolutionPixels(); !ok || w != 1280 || h != 720 {
+		t.Fatalf("max_resolution not resolved: %dx%d %v", w, h, ok)
+	}
+}
+
+func TestDeployWarnsUnimplementedModesPerSourceKind(t *testing.T) {
+	manager, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	warned := func(source string) []string {
+		campaign, err := manager.DeployCampaign(minimalCampaign(1, source, "wifi"))
+		if err != nil {
+			t.Fatalf("%s: %v", source, err)
+		}
+		var modeWarnings []string
+		for _, warning := range campaign.Warnings {
+			if strings.Contains(warning, "not implemented yet") {
+				modeWarnings = append(modeWarnings, warning)
+			}
+		}
+		return modeWarnings
+	}
+	if warnings := warned("camera: front\n    capture: {mode: snapshot, interval: 2s}"); len(warnings) != 0 {
+		t.Fatalf("camera snapshot mode deploy-warns although the camera adapter implements it: %v", warnings)
+	}
+	if warnings := warned("ros2: /lidar/points\n    capture: {mode: snapshot, interval: 2s}"); len(warnings) != 1 || !strings.Contains(warnings[0], "ros2:/lidar/points") {
+		t.Fatalf("ros2 snapshot mode must still deploy-warn: %v", warnings)
+	}
+	if warnings := warned("camera: front\n    capture: {mode: threshold, trigger: \"model.uncertainty > 0.9\"}"); len(warnings) != 1 {
+		t.Fatalf("camera threshold mode must still deploy-warn: %v", warnings)
 	}
 }

--- a/go/internal/agent/data/manager.go
+++ b/go/internal/agent/data/manager.go
@@ -262,6 +262,11 @@ func (m *Manager) Start(opts StartOptions) (Manifest, error) {
 		_ = os.Remove(dir)
 		return Manifest{}, err
 	}
+	for i := range selected {
+		if capture := opts.SourceCaptures[selected[i].ID]; capture != nil {
+			selected[i].Capture = capture
+		}
+	}
 	currentBootID := bootID()
 	trigger := opts.Trigger
 	if trigger.Reason == "" {

--- a/go/internal/agent/data/model.go
+++ b/go/internal/agent/data/model.go
@@ -39,6 +39,11 @@ type Source struct {
 	ClockDomain string `json:"clock_domain"`
 	Healthy     bool   `json:"healthy"`
 	Detail      string `json:"detail,omitempty"`
+	// Capture is the per-episode capture policy a campaign attached to this
+	// source, nil when none applies. It is deliberately excluded from the
+	// manifest: the policy lives in the campaign plan, while the manifest
+	// records the behavior the adapter actually achieved.
+	Capture *SourceCapture `json:"-"`
 }
 
 type SourceStats struct {
@@ -174,9 +179,12 @@ type Manifest struct {
 }
 
 type StartOptions struct {
-	Name                  string
-	Sources               []string
-	ExcludeSources        []string
+	Name           string
+	Sources        []string
+	ExcludeSources []string
+	// SourceCaptures carries per-source capture policies keyed by resolved
+	// source ID (see Manager.ResolveCampaignSources).
+	SourceCaptures        map[string]*SourceCapture
 	RequireUTCUncertainty time.Duration
 	Calibrations          map[string][]byte
 	CalibrationRevisions  map[string]string

--- a/go/internal/agent/services/data_camera_adapter.go
+++ b/go/internal/agent/services/data_camera_adapter.go
@@ -14,9 +14,16 @@ import (
 
 	"github.com/wendylabsinc/wendy/go/internal/agent/data"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const cameraSegmentDuration = 10 * time.Second
+
+// captureModeSnapshot is the camera capture mode producing one standalone
+// decodable still per campaign-declared interval. Every other declared mode
+// records continuously (deployment already warned for the unimplemented ones).
+const captureModeSnapshot = "snapshot"
 
 var errAwaitCameraRandomAccess = errors.New("waiting for a decodable random-access unit")
 
@@ -99,6 +106,19 @@ func (a *cameraDataAdapter) startOne(ctx context.Context, session data.CaptureSe
 			return nil, err
 		}
 	}
+	mode := "continuous"
+	var interval time.Duration
+	capture := source.Capture
+	if capture.EffectiveMode() == captureModeSnapshot {
+		if d := capture.IntervalDuration(); d > 0 {
+			mode, interval = captureModeSnapshot, d
+		}
+	}
+	var rateCap float64
+	if capture != nil && capture.Rate > 0 {
+		rateCap = capture.Rate
+	}
+	req, notes := buildStreamRequest(devID, src, capture)
 	dir := filepath.Join(session.Directory, "cameras", safeCaptureName(source.ID))
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return nil, err
@@ -112,15 +132,19 @@ func (a *cameraDataAdapter) startOne(ctx context.Context, session data.CaptureSe
 		index.Close()
 		return nil, err
 	}
-	req := &agentpb.StreamVideoRequest{DeviceId: devID}
-	hub, subID, frames, err := a.video.getOrCreateHub(ctx, src.key, req)
+	hub, subID, frames, achievedW, achievedH, achievedFPS, err := a.subscribeHub(ctx, src.key, req)
 	if err != nil {
 		index.Close()
 		mappings.Close()
 		return nil, err
 	}
+	if achievedW != req.GetWidth() || achievedH != req.GetHeight() || achievedFPS != req.GetFramerate() {
+		notes = append(notes, fmt.Sprintf("stream already active with different parameters; requested %s, capturing at %s",
+			describeStreamParams(req.GetWidth(), req.GetHeight(), req.GetFramerate()),
+			describeStreamParams(achievedW, achievedH, achievedFPS)))
+	}
 	captureCtx, cancel := context.WithCancel(context.Background())
-	c := &cameraCapture{source: source, session: session, dir: dir, hub: hub, subID: subID, frames: frames, index: index, mappingFile: mappings, ctx: captureCtx, cancel: cancel, done: make(chan struct{}), ready: make(chan error, 1)}
+	c := &cameraCapture{source: source, session: session, dir: dir, hub: hub, subID: subID, frames: frames, index: index, mappingFile: mappings, ctx: captureCtx, cancel: cancel, done: make(chan struct{}), ready: make(chan error, 1), mode: mode, interval: interval.Nanoseconds(), rateCap: rateCap, notes: notes, lastSnapshotIdx: -1}
 	go c.run()
 	select {
 	case err := <-c.ready:
@@ -139,6 +163,89 @@ func (a *cameraDataAdapter) startOne(ctx context.Context, session data.CaptureSe
 		<-c.done
 		return nil, errors.New("timed out waiting for first encoded camera frame")
 	}
+}
+
+// buildStreamRequest translates a campaign capture policy into stream
+// parameters the video pipeline will accept. Caps that cannot be requested at
+// the source are recorded as honesty notes and reconciled adapter-side (rate)
+// or reported (resolution) instead of failing the episode.
+func buildStreamRequest(devID uint32, src videoSource, capture *data.SourceCapture) (*agentpb.StreamVideoRequest, []string) {
+	req := &agentpb.StreamVideoRequest{DeviceId: devID}
+	if capture == nil {
+		return req, nil
+	}
+	var notes []string
+	if w, h, ok := capture.MaxResolutionPixels(); ok {
+		if src.kind == sourceV4L2 {
+			req.Width, req.Height = w, h
+		} else {
+			// On network cameras, width selects which pre-configured stream to
+			// open rather than sizing frames, so the cap is not requestable.
+			notes = append(notes, fmt.Sprintf("max_resolution %s cannot be requested from a network camera; recording its configured stream", capture.MaxResolution))
+		}
+	}
+	if capture.Rate > 0 && src.kind == sourceV4L2 {
+		req.Framerate = sourceFramerateAtOrBelow(capture.Rate)
+	}
+	if src.kind == sourceV4L2 && req.GetWidth() != 0 {
+		// The framerate always comes from the accepted set, so a validation
+		// failure here can only be the resolution.
+		if err := validateStreamParams(src.path, req); err != nil {
+			notes = append(notes, fmt.Sprintf("max_resolution %s is not a mode this camera advertises; recording at the stream default", capture.MaxResolution))
+			req.Width, req.Height = 0, 0
+		}
+	}
+	return req, notes
+}
+
+// sourceFramerateAtOrBelow maps a capture rate cap onto the discrete
+// framerates the stream pipeline accepts (see validateStreamParams). Zero
+// means the cap cannot be requested at the source; the adapter-side
+// group-of-pictures gate still enforces it.
+func sourceFramerateAtOrBelow(rate float64) uint32 {
+	best := uint32(0)
+	for _, fps := range []uint32{15, 24, 25, 30, 60, 90, 120} {
+		if float64(fps) <= rate && fps > best {
+			best = fps
+		}
+	}
+	return best
+}
+
+func describeStreamParams(w, h, fps uint32) string {
+	size := "default resolution"
+	if w != 0 || h != 0 {
+		size = fmt.Sprintf("%dx%d", w, h)
+	}
+	if fps != 0 {
+		return fmt.Sprintf("%s at %d fps", size, fps)
+	}
+	return size + " at default rate"
+}
+
+// subscribeHub joins the device's frame hub. When the hub already runs with
+// different stream parameters (for example a live dashboard viewer), the
+// episode must not fail: fall back to subscribing at the existing parameters
+// and let the capture reconcile adapter-side, reporting requested-vs-achieved.
+func (a *cameraDataAdapter) subscribeHub(ctx context.Context, key string, req *agentpb.StreamVideoRequest) (*deviceHub, int, chan *videoFrame, uint32, uint32, uint32, error) {
+	for attempt := 0; attempt < maxHubRetries; attempt++ {
+		hub, id, ch, err := a.video.getOrCreateHub(ctx, key, req)
+		if err == nil {
+			return hub, id, ch, req.GetWidth(), req.GetHeight(), req.GetFramerate(), nil
+		}
+		if status.Code(err) != codes.InvalidArgument {
+			return nil, 0, nil, 0, 0, 0, err
+		}
+		hub, id, ch, w, h, fps, ok, err := a.video.subscribeExistingHub(key)
+		if err != nil {
+			return nil, 0, nil, 0, 0, 0, err
+		}
+		if ok {
+			return hub, id, ch, w, h, fps, nil
+		}
+		// The conflicting hub disappeared between the two calls; retry.
+	}
+	return nil, 0, nil, 0, 0, 0, status.Error(codes.Unavailable, "video device hub churned during capture start")
 }
 
 type cameraCaptureGroup struct{ captures []*cameraCapture }
@@ -188,6 +295,33 @@ type cameraCapture struct {
 	mappingSummaries   []data.ClockMapping
 	maxCanonicalError  int64
 	observedDomains    map[string]bool
+	// mode is "continuous" or captureModeSnapshot; interval is the snapshot
+	// period in nanoseconds; rateCap is the campaign's continuous-mode capture
+	// rate cap in hertz (0 when uncapped).
+	mode     string
+	interval int64
+	rateCap  float64
+	// captureReceipt is a test seam over data.CaptureReceipt (see receiptNow).
+	captureReceipt func() (int64, int64, int64, error)
+	// notes accumulates honesty notes folded into the result's source detail.
+	notes []string
+	// Snapshot state: the interval index of the last written snapshot (-1
+	// before the first) and intervals that produced no still.
+	lastSnapshotIdx int64
+	snapshotNumber  int
+	missedIntervals uint64
+	// Rate-cap state: receipts of the first and last written frames, and
+	// whether the current group of pictures is being skipped.
+	rateStart int64
+	rateLast  int64
+	skipGOP   bool
+}
+
+func (c *cameraCapture) receiptNow() (int64, int64, int64, error) {
+	if c.captureReceipt != nil {
+		return c.captureReceipt()
+	}
+	return data.CaptureReceipt()
 }
 
 type cameraIndexRecord struct {
@@ -221,14 +355,27 @@ func (c *cameraCapture) run() {
 		}
 		if c.result.ClockDomain == "CLOCK_REALTIME_AGENT_CAPTURE" {
 			c.result.ClockDomain = "GSTREAMER_PIPE/AGENT_RECEIPT"
-			c.result.SourceDetail = c.source.Detail + " (pipeline PTS unavailable; canonical time uses bounded agent receipt)"
+			c.notes = append([]string{"pipeline PTS unavailable; canonical time uses bounded agent receipt"}, c.notes...)
 		}
-		drops := c.hub.unsubscribe(c.subID)
-		if c.result.Drops != nil {
-			drops += *c.result.Drops
+		subscriberDrops := c.hub.unsubscribe(c.subID)
+		if c.mode == captureModeSnapshot {
+			// Discarding frames between intervals is the normal snapshot
+			// workflow, so subscriber-channel drops are not data loss here;
+			// the honest loss unit is an interval that produced no still.
+			end := int64(0)
+			if _, receipt, _, err := c.receiptNow(); err == nil {
+				end = receipt
+			}
+			c.finishSnapshotAccounting(end)
+		} else {
+			drops := subscriberDrops
+			if c.result.Drops != nil {
+				drops += *c.result.Drops
+			}
+			c.result.Drops = &drops
+			c.result.DropAccounting = "partial_known_driver_and_subscriber"
 		}
-		c.result.Drops = &drops
-		c.result.DropAccounting = "partial_known_driver_and_subscriber"
+		c.finishResultDetail()
 		c.finishMapping(c.result.Count)
 		c.result.Mappings = append([]data.ClockMapping(nil), c.mappingSummaries...)
 		if c.maxCanonicalError > 0 {
@@ -259,7 +406,7 @@ func (c *cameraCapture) run() {
 				c.signalReady(c.runErr)
 				return
 			}
-			if err := c.writeFrame(frame); errors.Is(err, errAwaitCameraRandomAccess) {
+			if err := c.handleFrame(frame); errors.Is(err, errAwaitCameraRandomAccess) {
 				continue
 			} else if err != nil {
 				c.runErr = err
@@ -271,22 +418,32 @@ func (c *cameraCapture) run() {
 	}
 }
 
-func (c *cameraCapture) writeFrame(frame *videoFrame) error {
+// handleFrame dispatches one hub frame to the active capture mode.
+func (c *cameraCapture) handleFrame(frame *videoFrame) error {
+	if c.mode == captureModeSnapshot {
+		return c.writeSnapshot(frame)
+	}
+	return c.writeFrame(frame)
+}
+
+// canonicalTime stamps one frame on the canonical CLOCK_BOOTTIME episode
+// timeline, maintaining the native-clock mapping segments as a side effect.
+func (c *cameraCapture) canonicalTime(frame *videoFrame) (canonical, uncertainty int64, mappingID string, receipt int64, err error) {
 	if c.observedDomains == nil {
 		c.observedDomains = make(map[string]bool)
 	}
 	c.observedDomains[frame.nativeClock] = true
-	before, receipt, after, err := data.CaptureReceipt()
+	before, receipt, after, err := c.receiptNow()
 	if err != nil {
-		return err
+		return 0, 0, "", 0, err
 	}
-	canonical := receipt
-	uncertainty := (after - before + 1) / 2
-	mappingID := "receipt-bracket-v1"
+	canonical = receipt
+	uncertainty = (after - before + 1) / 2
+	mappingID = "receipt-bracket-v1"
 	if frame.nativeClock == "CLOCK_MONOTONIC_V4L2" {
 		if !c.haveMapping || receipt-c.lastMapping.BootAfterNanos >= int64(time.Second) {
 			if err := c.sampleMapping(receipt); err != nil {
-				return err
+				return 0, 0, "", 0, err
 			}
 		}
 		offset := c.lastMapping.OffsetLowerNanos + (c.lastMapping.OffsetUpperNanos-c.lastMapping.OffsetLowerNanos)/2
@@ -305,6 +462,52 @@ func (c *cameraCapture) writeFrame(frame *videoFrame) error {
 	}
 	if uncertainty > c.maxCanonicalError {
 		c.maxCanonicalError = uncertainty
+	}
+	return canonical, uncertainty, mappingID, receipt, nil
+}
+
+// frameRandomAccess reports whether a frame can start decoding on its own, and
+// the byte offset of the decodable unit. H.264 requires an SPS/PPS/IDR access
+// unit; VP8 marks keyframes in the frame tag (bit 0 of the first byte is zero
+// for keyframes). Other codecs are treated as independently decodable per
+// frame, matching how the segmenter already treats them.
+func frameRandomAccess(frame *videoFrame) (int, bool) {
+	switch frame.codec {
+	case agentpb.VideoCodec_VIDEO_CODEC_H264:
+		return h264RandomAccessOffset(frame.data)
+	case agentpb.VideoCodec_VIDEO_CODEC_VP8:
+		return 0, len(frame.data) > 0 && frame.data[0]&0x01 == 0
+	default:
+		return 0, len(frame.data) > 0
+	}
+}
+
+// gateGOP applies the campaign's capture rate cap adapter-side by admitting or
+// skipping whole groups of pictures (GOPs). H.264 inter frames reference
+// earlier frames, so dropping below GOP granularity would corrupt the stream:
+// the cap is therefore best-effort at GOP granularity, and the achieved rate
+// is recorded honestly in the capture result (see finishResultDetail).
+// Intentionally skipped GOPs are not counted as drops.
+func (c *cameraCapture) gateGOP(frame *videoFrame, receipt int64) (skip bool) {
+	if _, randomAccess := frameRandomAccess(frame); randomAccess {
+		if c.result.Count == 0 {
+			// Always admit the first GOP so the capture starts promptly.
+			c.skipGOP = false
+		} else {
+			elapsed := float64(receipt-c.rateStart) / float64(time.Second)
+			c.skipGOP = elapsed <= 0 || float64(c.result.Count) > c.rateCap*elapsed
+		}
+	}
+	return c.skipGOP
+}
+
+func (c *cameraCapture) writeFrame(frame *videoFrame) error {
+	canonical, uncertainty, mappingID, receipt, err := c.canonicalTime(frame)
+	if err != nil {
+		return err
+	}
+	if c.rateCap > 0 && c.gateGOP(frame, receipt) {
+		return nil
 	}
 	trim, err := c.ensureSegment(frame.codec, canonical, frame.data)
 	if err != nil {
@@ -339,11 +542,126 @@ func (c *cameraCapture) writeFrame(frame *videoFrame) error {
 		return err
 	}
 	c.result.Count++
+	if c.result.Count == 1 {
+		c.rateStart = receipt
+	}
+	c.rateLast = receipt
 	if c.result.ActualOffset == nil {
 		actual := canonical - c.session.RequestBootNanos
 		c.result.ActualOffset = &actual
 	}
 	return nil
+}
+
+// writeSnapshot implements snapshot capture: one standalone decodable still
+// per campaign interval.
+//
+// Format choice: snapshots are written as single H.264 random-access units
+// (snapshot-<n>.h264) rather than JPEG. The producer pipelines deliver encoded
+// H.264 (or VP8) frames only, and every H.264 keyframe here already carries
+// the SPS/PPS parameter sets needed to decode it standalone, so keyframe
+// stills need no new GStreamer JPEG pipeline; the episode file inventory
+// already classifies .h264 payloads. VP8 streams follow the segmenter's
+// existing .webm naming convention.
+//
+// Between intervals the capture stays subscribed and discards frames instead
+// of unsubscribing: receiving and dropping a shared frame pointer is a channel
+// receive, while hub churn closes the device file descriptor, restarts the
+// producer pipeline, and rejoining races hub teardown (bounded by
+// maxHubRetries * hubTeardownTimeout) and then waits a full group of pictures
+// for the next keyframe.
+func (c *cameraCapture) writeSnapshot(frame *videoFrame) error {
+	offset, randomAccess := frameRandomAccess(frame)
+	if !randomAccess {
+		if c.result.Count == 0 {
+			return errAwaitCameraRandomAccess
+		}
+		return nil
+	}
+	canonical, uncertainty, mappingID, receipt, err := c.canonicalTime(frame)
+	if err != nil {
+		return err
+	}
+	idx := (receipt - c.session.RequestBootNanos) / c.interval
+	if idx <= c.lastSnapshotIdx {
+		// This interval already has its still; discard cheaply.
+		return nil
+	}
+	// Intervals that elapsed without a decodable unit are honest losses.
+	c.missedIntervals += uint64(idx - c.lastSnapshotIdx - 1)
+	c.lastSnapshotIdx = idx
+	c.snapshotNumber++
+	ext := ".h264"
+	if frame.codec == agentpb.VideoCodec_VIDEO_CODEC_VP8 {
+		ext = ".webm"
+	}
+	name := fmt.Sprintf("snapshot-%06d%s", c.snapshotNumber, ext)
+	f, err := os.OpenFile(filepath.Join(c.dir, name), os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o640)
+	if err != nil {
+		return err
+	}
+	payload := frame.data[offset:]
+	n, err := f.Write(payload)
+	if err == nil && n != len(payload) {
+		err = ioErrShortWrite(n, len(payload))
+	}
+	if syncErr := f.Sync(); err == nil {
+		err = syncErr
+	}
+	if closeErr := f.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return err
+	}
+	var seq *uint32
+	if frame.sequenceValid {
+		v := frame.sequence
+		seq = &v
+	}
+	rel := filepath.ToSlash(filepath.Join("cameras", safeCaptureName(c.source.ID), name))
+	record := cameraIndexRecord{CanonicalEpisodeNanos: canonical - c.session.RequestBootNanos, CanonicalUncertaintyNanos: uncertainty, NativeTimestampNanos: frame.nativeNs, NativeClockDomain: frame.nativeClock, NativeTimestampFlags: frame.nativeFlags, AgentCaptureRealtimeNanos: frame.tsNs, AgentReceiptBootNanos: receipt, MappingSegment: mappingID, Segment: rel, ByteOffset: 0, ByteSize: n, Codec: frame.codec.String(), Sequence: seq}
+	b, _ := json.Marshal(record)
+	if _, err := c.index.Write(append(b, '\n')); err != nil {
+		return err
+	}
+	c.result.Count++
+	if c.result.ActualOffset == nil {
+		actual := canonical - c.session.RequestBootNanos
+		c.result.ActualOffset = &actual
+	}
+	return nil
+}
+
+// finishSnapshotAccounting reports missed snapshot intervals as the capture's
+// drop count: every fully elapsed interval that produced no still, including
+// the tail after the last snapshot up to end (a receipt on CLOCK_BOOTTIME;
+// zero skips the tail when no end receipt is available).
+func (c *cameraCapture) finishSnapshotAccounting(end int64) {
+	if c.interval > 0 && end > c.session.RequestBootNanos {
+		endIdx := (end - c.session.RequestBootNanos) / c.interval
+		if tail := endIdx - 1 - c.lastSnapshotIdx; tail > 0 {
+			c.missedIntervals += uint64(tail)
+		}
+	}
+	missed := c.missedIntervals
+	c.result.Drops = &missed
+	c.result.DropAccounting = "missed_snapshot_intervals"
+}
+
+// finishResultDetail folds accumulated honesty notes, including the achieved
+// rate under a capture rate cap, into the reported source detail.
+func (c *cameraCapture) finishResultDetail() {
+	if c.rateCap > 0 {
+		note := fmt.Sprintf("rate cap %.3g Hz applied at GOP granularity (best effort)", c.rateCap)
+		if c.result.Count > 1 && c.rateLast > c.rateStart {
+			note += fmt.Sprintf("; achieved %.3g Hz", float64(c.result.Count-1)/(float64(c.rateLast-c.rateStart)/float64(time.Second)))
+		}
+		c.notes = append(c.notes, note)
+	}
+	if len(c.notes) > 0 {
+		c.result.SourceDetail = strings.TrimSpace(c.source.Detail + " (" + strings.Join(c.notes, "; ") + ")")
+	}
 }
 
 func (c *cameraCapture) ensureSegment(codec agentpb.VideoCodec, canonical int64, payload []byte) (int, error) {

--- a/go/internal/agent/services/data_camera_adapter.go
+++ b/go/internal/agent/services/data_camera_adapter.go
@@ -108,17 +108,22 @@ func (a *cameraDataAdapter) startOne(ctx context.Context, session data.CaptureSe
 	}
 	mode := "continuous"
 	var interval time.Duration
+	var notes []string
 	capture := source.Capture
 	if capture.EffectiveMode() == captureModeSnapshot {
 		if d := capture.IntervalDuration(); d > 0 {
 			mode, interval = captureModeSnapshot, d
+			notes = append(notes, fmt.Sprintf("snapshot mode: one still per %s", d))
+		} else {
+			notes = append(notes, "snapshot mode requested without a valid interval; recording continuously")
 		}
 	}
 	var rateCap float64
 	if capture != nil && capture.Rate > 0 {
 		rateCap = capture.Rate
 	}
-	req, notes := buildStreamRequest(devID, src, capture)
+	req, requestNotes := buildStreamRequest(devID, src, capture)
+	notes = append(notes, requestNotes...)
 	dir := filepath.Join(session.Directory, "cameras", safeCaptureName(source.ID))
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return nil, err
@@ -297,10 +302,13 @@ type cameraCapture struct {
 	observedDomains    map[string]bool
 	// mode is "continuous" or captureModeSnapshot; interval is the snapshot
 	// period in nanoseconds; rateCap is the campaign's continuous-mode capture
-	// rate cap in hertz (0 when uncapped).
-	mode     string
-	interval int64
-	rateCap  float64
+	// rate cap in hertz (0 when uncapped). alignmentKnown records that the
+	// first frame has classified the transport as access-unit aligned or
+	// byte-chunked (see handleFrame).
+	mode           string
+	interval       int64
+	rateCap        float64
+	alignmentKnown bool
 	// captureReceipt is a test seam over data.CaptureReceipt (see receiptNow).
 	captureReceipt func() (int64, int64, int64, error)
 	// notes accumulates honesty notes folded into the result's source detail.
@@ -358,14 +366,14 @@ func (c *cameraCapture) run() {
 			c.notes = append([]string{"pipeline PTS unavailable; canonical time uses bounded agent receipt"}, c.notes...)
 		}
 		subscriberDrops := c.hub.unsubscribe(c.subID)
+		end := int64(0)
+		if _, receipt, _, err := c.receiptNow(); err == nil {
+			end = receipt
+		}
 		if c.mode == captureModeSnapshot {
 			// Discarding frames between intervals is the normal snapshot
 			// workflow, so subscriber-channel drops are not data loss here;
 			// the honest loss unit is an interval that produced no still.
-			end := int64(0)
-			if _, receipt, _, err := c.receiptNow(); err == nil {
-				end = receipt
-			}
 			c.finishSnapshotAccounting(end)
 		} else {
 			drops := subscriberDrops
@@ -375,7 +383,7 @@ func (c *cameraCapture) run() {
 			c.result.Drops = &drops
 			c.result.DropAccounting = "partial_known_driver_and_subscriber"
 		}
-		c.finishResultDetail()
+		c.finishResultDetail(end)
 		c.finishMapping(c.result.Count)
 		c.result.Mappings = append([]data.ClockMapping(nil), c.mappingSummaries...)
 		if c.maxCanonicalError > 0 {
@@ -419,7 +427,29 @@ func (c *cameraCapture) run() {
 }
 
 // handleFrame dispatches one hub frame to the active capture mode.
+//
+// Frame-boundary-sensitive behavior (snapshot stills, GOP-granularity rate
+// capping) requires access-unit-aligned frames, which only the native V4L2
+// producer delivers; the GStreamer and IP camera producers emit arbitrary
+// byte-stream chunks (see videoFrame.auAligned). A producer's alignment is a
+// property of its pipeline and never changes mid-stream, so the first frame
+// decides: on a chunked transport snapshot mode degrades to continuous
+// recording and the rate cap is disabled, each with an honesty note that ends
+// up in the manifest's source detail.
 func (c *cameraCapture) handleFrame(frame *videoFrame) error {
+	if !c.alignmentKnown {
+		c.alignmentKnown = true
+		if !frame.auAligned {
+			if c.mode == captureModeSnapshot {
+				c.mode = "continuous"
+				c.notes = append(c.notes, "snapshot stills require a transport that delivers whole access units (native V4L2 H.264); this stream arrives as byte chunks, so the source records continuously instead")
+			}
+			if c.rateCap > 0 {
+				c.notes = append(c.notes, fmt.Sprintf("rate cap %.3g Hz cannot be enforced at GOP granularity on this transport's byte-chunked stream without corrupting it; recording at the stream rate", c.rateCap))
+				c.rateCap = 0
+			}
+		}
+	}
 	if c.mode == captureModeSnapshot {
 		return c.writeSnapshot(frame)
 	}
@@ -488,8 +518,13 @@ func frameRandomAccess(frame *videoFrame) (int, bool) {
 // the cap is therefore best-effort at GOP granularity, and the achieved rate
 // is recorded honestly in the capture result (see finishResultDetail).
 // Intentionally skipped GOPs are not counted as drops.
+//
+// The admit/skip decision toggles only on whole random-access units: the cap
+// is disabled outright on byte-chunked transports (see handleFrame), and a
+// frame truncated by the maxFrameBytes cap keeps the current decision, since
+// its parsed prefix does not prove a GOP boundary.
 func (c *cameraCapture) gateGOP(frame *videoFrame, receipt int64) (skip bool) {
-	if _, randomAccess := frameRandomAccess(frame); randomAccess {
+	if _, randomAccess := frameRandomAccess(frame); randomAccess && frame.auAligned {
 		if c.result.Count == 0 {
 			// Always admit the first GOP so the capture starts promptly.
 			c.skipGOP = false
@@ -557,12 +592,18 @@ func (c *cameraCapture) writeFrame(frame *videoFrame) error {
 // per campaign interval.
 //
 // Format choice: snapshots are written as single H.264 random-access units
-// (snapshot-<n>.h264) rather than JPEG. The producer pipelines deliver encoded
-// H.264 (or VP8) frames only, and every H.264 keyframe here already carries
-// the SPS/PPS parameter sets needed to decode it standalone, so keyframe
-// stills need no new GStreamer JPEG pipeline; the episode file inventory
-// already classifies .h264 payloads. VP8 streams follow the segmenter's
-// existing .webm naming convention.
+// (snapshot-<n>.h264) rather than JPEG, so keyframe stills need no new
+// GStreamer JPEG pipeline; the episode file inventory already classifies
+// .h264 payloads.
+//
+// Decodability rests on two checks, both required. handleFrame only routes
+// access-unit-aligned frames here (native V4L2 H.264, one whole encoded frame
+// per buffer — byte-chunked transports degrade to continuous recording), and
+// frameRandomAccess then verifies the unit carries its own SPS/PPS/IDR trio.
+// Together they guarantee a written still is a complete, self-contained
+// access unit; a keyframe whose parameter sets the camera firmware did not
+// inline is skipped and its interval is reported as missed rather than filled
+// with an undecodable file.
 //
 // Between intervals the capture stays subscribed and discards frames instead
 // of unsubscribing: receiving and dropping a shared frame pointer is a channel
@@ -572,7 +613,9 @@ func (c *cameraCapture) writeFrame(frame *videoFrame) error {
 // for the next keyframe.
 func (c *cameraCapture) writeSnapshot(frame *videoFrame) error {
 	offset, randomAccess := frameRandomAccess(frame)
-	if !randomAccess {
+	// A frame truncated by the maxFrameBytes cap loses its alignment promise
+	// mid-stream; it must not become a still even when its head parses as one.
+	if !randomAccess || !frame.auAligned {
 		if c.result.Count == 0 {
 			return errAwaitCameraRandomAccess
 		}
@@ -651,11 +694,22 @@ func (c *cameraCapture) finishSnapshotAccounting(end int64) {
 
 // finishResultDetail folds accumulated honesty notes, including the achieved
 // rate under a capture rate cap, into the reported source detail.
-func (c *cameraCapture) finishResultDetail() {
+//
+// The achieved rate is computed over the span from the first written frame to
+// the capture's end receipt, not to the last written frame: frames arrive in
+// GOP bursts, so a capture that admitted a single GOP and then skipped to the
+// end would otherwise report the encoder's intra-GOP rate (say 30 Hz) rather
+// than the delivered rate the cap actually produced.
+func (c *cameraCapture) finishResultDetail(end int64) {
 	if c.rateCap > 0 {
 		note := fmt.Sprintf("rate cap %.3g Hz applied at GOP granularity (best effort)", c.rateCap)
-		if c.result.Count > 1 && c.rateLast > c.rateStart {
-			note += fmt.Sprintf("; achieved %.3g Hz", float64(c.result.Count-1)/(float64(c.rateLast-c.rateStart)/float64(time.Second)))
+		span := end - c.rateStart
+		if end == 0 || span <= 0 {
+			// No end receipt: fall back to the written-frame span.
+			span = c.rateLast - c.rateStart
+		}
+		if c.result.Count > 0 && span > 0 {
+			note += fmt.Sprintf("; achieved %.3g Hz", float64(c.result.Count)/(float64(span)/float64(time.Second)))
 		}
 		c.notes = append(c.notes, note)
 	}
@@ -699,9 +753,14 @@ func (c *cameraCapture) ensureSegment(codec agentpb.VideoCodec, canonical int64,
 	return 0, nil
 }
 
-// h264RandomAccessUnit reports an Annex-B access unit that includes SPS, PPS,
-// and IDR NALs. h264parse config-interval=-1 emits this trio at every keyframe,
-// so starting segments only here makes each file independently decodable.
+// h264RandomAccessOffset reports an Annex-B payload position where SPS, PPS,
+// and IDR NALs appear in order. The GStreamer pipelines emit this trio at
+// every keyframe (h264parse config-interval=-1) and UVC H.264 firmware
+// commonly inlines it too, so starting segments only here makes each file
+// begin independently decodable. Note this inspects only the bytes it is
+// given: on a byte-chunked transport a reported unit may still be truncated
+// at the payload's end, which is why snapshot stills additionally require an
+// access-unit-aligned frame (see handleFrame).
 func h264RandomAccessOffset(payload []byte) (offset int, found bool) {
 	spsOffset, ppsOffset := -1, -1
 	for i := 0; i+3 < len(payload); {

--- a/go/internal/agent/services/data_camera_adapter_test.go
+++ b/go/internal/agent/services/data_camera_adapter_test.go
@@ -5,13 +5,17 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/wendylabsinc/wendy/go/internal/agent/data"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	"go.uber.org/zap"
 )
 
 func TestCameraDeviceID(t *testing.T) {
@@ -99,6 +103,244 @@ func TestH264SegmentsWaitForSelfContainedRandomAccessUnit(t *testing.T) {
 	}
 	if offset, found := h264RandomAccessOffset(key); !found || offset != 3 {
 		t.Fatal("SPS/PPS/IDR access unit not recognized")
+	}
+}
+
+// fakeReceipt is a deterministic CLOCK_BOOTTIME source for capture tests.
+type fakeReceipt struct{ now int64 }
+
+func (f *fakeReceipt) fn() (int64, int64, int64, error) { return f.now, f.now, f.now, nil }
+
+var (
+	// testRAUFrame is an Annex-B SPS/PPS/IDR access unit (decodable standalone).
+	testRAUFrame = []byte{0, 0, 0, 1, 0x67, 1, 0, 0, 0, 1, 0x68, 2, 0, 0, 0, 1, 0x65, 3}
+	// testInterFrame is a non-IDR slice that references earlier frames.
+	testInterFrame = []byte{0, 0, 0, 1, 0x41, 1}
+)
+
+func testH264Frame(payload []byte) *videoFrame {
+	return &videoFrame{data: payload, nativeClock: "CLOCK_REALTIME_AGENT_CAPTURE", codec: agentpb.VideoCodec_VIDEO_CODEC_H264}
+}
+
+func newTestCameraCapture(t *testing.T, clock *fakeReceipt) *cameraCapture {
+	t.Helper()
+	dir := t.TempDir()
+	index, err := os.OpenFile(filepath.Join(dir, "index.jsonl"), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mappings, err := os.OpenFile(filepath.Join(dir, "clock_samples.jsonl"), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { index.Close(); mappings.Close() })
+	return &cameraCapture{source: data.Source{ID: "v4l2:/dev/video2"}, session: data.CaptureSession{RequestBootNanos: 0}, dir: dir, index: index, mappingFile: mappings, captureReceipt: clock.fn, lastSnapshotIdx: -1}
+}
+
+func TestSnapshotModeWritesOneStillPerInterval(t *testing.T) {
+	clock := &fakeReceipt{}
+	c := newTestCameraCapture(t, clock)
+	c.mode, c.interval = captureModeSnapshot, int64(time.Second)
+
+	clock.now = 100 * int64(time.Millisecond)
+	if err := c.handleFrame(testH264Frame(testInterFrame)); !errors.Is(err, errAwaitCameraRandomAccess) {
+		t.Fatalf("inter frame before the first still: %v", err)
+	}
+	if err := c.handleFrame(testH264Frame(testRAUFrame)); err != nil {
+		t.Fatal(err)
+	}
+	clock.now = 500 * int64(time.Millisecond)
+	if err := c.handleFrame(testH264Frame(testRAUFrame)); err != nil {
+		t.Fatal(err) // same interval: discarded, not written
+	}
+	clock.now = 1300 * int64(time.Millisecond)
+	if err := c.handleFrame(testH264Frame(testInterFrame)); err != nil {
+		t.Fatal(err) // not decodable standalone: discarded
+	}
+	if err := c.handleFrame(testH264Frame(testRAUFrame)); err != nil {
+		t.Fatal(err)
+	}
+
+	if c.result.Count != 2 {
+		t.Fatalf("count = %d, want 2", c.result.Count)
+	}
+	for n := 1; n <= 2; n++ {
+		media, err := os.ReadFile(filepath.Join(c.dir, fmt.Sprintf("snapshot-%06d.h264", n)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(media, testRAUFrame) {
+			t.Fatalf("snapshot %d = %x", n, media)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(c.dir, "snapshot-000003.h264")); err == nil {
+		t.Fatal("extra snapshot written within an interval")
+	}
+	if err := c.index.Sync(); err != nil {
+		t.Fatal(err)
+	}
+	contents, err := os.ReadFile(filepath.Join(c.dir, "index.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := bytes.Split(bytes.TrimSpace(contents), []byte("\n"))
+	if len(lines) != 2 {
+		t.Fatalf("index lines = %d, want 2", len(lines))
+	}
+	for i, line := range lines {
+		var record cameraIndexRecord
+		if err := json.Unmarshal(line, &record); err != nil {
+			t.Fatal(err)
+		}
+		if record.ByteOffset != 0 || record.ByteSize != len(testRAUFrame) || record.MappingSegment == "" {
+			t.Fatalf("bad snapshot index record %d: %+v", i, record)
+		}
+		want := fmt.Sprintf("snapshot-%06d.h264", i+1)
+		if !strings.HasSuffix(record.Segment, want) {
+			t.Fatalf("record %d segment = %q, want suffix %q", i, record.Segment, want)
+		}
+	}
+}
+
+func TestSnapshotModeCountsMissedIntervals(t *testing.T) {
+	clock := &fakeReceipt{}
+	c := newTestCameraCapture(t, clock)
+	c.mode, c.interval = captureModeSnapshot, int64(time.Second)
+
+	clock.now = 2500 * int64(time.Millisecond) // intervals 0 and 1 elapsed before any decodable unit
+	if err := c.handleFrame(testH264Frame(testRAUFrame)); err != nil {
+		t.Fatal(err)
+	}
+	clock.now = 5100 * int64(time.Millisecond) // intervals 3 and 4 got no still
+	if err := c.handleFrame(testH264Frame(testRAUFrame)); err != nil {
+		t.Fatal(err)
+	}
+	c.finishSnapshotAccounting(8200 * int64(time.Millisecond)) // intervals 6 and 7 elapsed after the last still
+
+	if c.result.Count != 2 {
+		t.Fatalf("count = %d, want 2", c.result.Count)
+	}
+	if c.result.Drops == nil || *c.result.Drops != 6 {
+		t.Fatalf("drops = %v, want 6 missed intervals", c.result.Drops)
+	}
+	if c.result.DropAccounting != "missed_snapshot_intervals" {
+		t.Fatalf("drop accounting = %q", c.result.DropAccounting)
+	}
+}
+
+func TestContinuousRateCapDropsWholeGOPs(t *testing.T) {
+	clock := &fakeReceipt{}
+	c := newTestCameraCapture(t, clock)
+	c.rateCap = 1 // hertz
+
+	written := func(at time.Duration, payload []byte) uint64 {
+		clock.now = int64(at)
+		if err := c.handleFrame(testH264Frame(payload)); err != nil {
+			t.Fatalf("frame at %s: %v", at, err)
+		}
+		return c.result.Count
+	}
+	if got := written(0, testRAUFrame); got != 1 {
+		t.Fatalf("first GOP not admitted: count %d", got)
+	}
+	if got := written(100*time.Millisecond, testInterFrame); got != 2 {
+		t.Fatalf("inter frame of the admitted GOP was dropped: count %d", got)
+	}
+	if got := written(250*time.Millisecond, testRAUFrame); got != 2 {
+		t.Fatalf("over-cap GOP admitted: count %d", got)
+	}
+	if got := written(300*time.Millisecond, testInterFrame); got != 2 {
+		t.Fatalf("inter frame of a skipped GOP written: count %d", got)
+	}
+	if got := written(2*time.Second, testRAUFrame); got != 3 {
+		t.Fatalf("back-under-cap GOP not admitted: count %d", got)
+	}
+	if c.result.Drops != nil {
+		t.Fatalf("intentionally skipped GOPs must not count as drops: %v", *c.result.Drops)
+	}
+	c.finishResultDetail()
+	if !strings.Contains(c.result.SourceDetail, "rate cap 1 Hz") || !strings.Contains(c.result.SourceDetail, "achieved 1 Hz") {
+		t.Fatalf("achieved rate not recorded: %q", c.result.SourceDetail)
+	}
+}
+
+func TestHubCollisionFallsBackToExistingParameters(t *testing.T) {
+	video := NewVideoService(context.Background(), zap.NewNop())
+	hctx, hcancel := context.WithCancel(context.Background())
+	existing := &deviceHub{subs: make(map[int]chan *videoFrame), subDrops: make(map[int]uint64), ctx: hctx, cancel: hcancel, done: make(chan struct{}), width: 1920, height: 1080, framerate: 30}
+	viewerID, _, err := existing.subscribe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	video.hubs["/dev/video0"] = existing
+	adapter := &cameraDataAdapter{video: video}
+
+	req := &agentpb.StreamVideoRequest{DeviceId: 0, Width: 1280, Height: 720, Framerate: 15}
+	hub, id, ch, w, h, fps, err := adapter.subscribeHub(context.Background(), "/dev/video0", req)
+	if err != nil {
+		t.Fatalf("collision failed the episode: %v", err)
+	}
+	if hub != existing || ch == nil {
+		t.Fatal("did not join the existing hub")
+	}
+	if w != 1920 || h != 1080 || fps != 30 {
+		t.Fatalf("achieved parameters = %dx%d@%d, want the existing hub's 1920x1080@30", w, h, fps)
+	}
+	hub.unsubscribe(id)
+	existing.unsubscribe(viewerID)
+}
+
+func TestStartOneRecordsRequestedVersusAchievedOnCollision(t *testing.T) {
+	video := NewVideoService(context.Background(), zap.NewNop())
+	hctx, hcancel := context.WithCancel(context.Background())
+	existing := &deviceHub{subs: make(map[int]chan *videoFrame), subDrops: make(map[int]uint64), ctx: hctx, cancel: hcancel, done: make(chan struct{}), width: 1920, height: 1080, framerate: 30}
+	viewerID, _, err := existing.subscribe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer existing.unsubscribe(viewerID)
+	video.hubs["/dev/video0"] = existing
+	adapter := &cameraDataAdapter{video: video}
+
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			case <-time.After(5 * time.Millisecond):
+				existing.broadcast(testH264Frame(testRAUFrame))
+			}
+		}
+	}()
+
+	_, origin, _, err := data.CaptureReceipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	session := data.CaptureSession{Directory: t.TempDir(), RequestBootNanos: origin}
+	source := data.Source{ID: "v4l2:/dev/video0", Kind: "camera", Capture: &data.SourceCapture{Rate: 15, MaxResolution: "1280x720"}}
+	capture, err := adapter.startOne(context.Background(), session, source, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	results, err := capture.Stop(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results = %d", len(results))
+	}
+	detail := results[0].SourceDetail
+	if !strings.Contains(detail, "capturing at 1920x1080 at 30 fps") || !strings.Contains(detail, "requested") {
+		t.Fatalf("requested-vs-achieved resolution not recorded: %q", detail)
+	}
+	if !strings.Contains(detail, "rate cap 15 Hz") {
+		t.Fatalf("rate cap note not recorded: %q", detail)
+	}
+	if results[0].Count == 0 {
+		t.Fatal("no frames captured through the existing hub")
 	}
 }
 

--- a/go/internal/agent/services/data_camera_adapter_test.go
+++ b/go/internal/agent/services/data_camera_adapter_test.go
@@ -118,7 +118,14 @@ var (
 	testInterFrame = []byte{0, 0, 0, 1, 0x41, 1}
 )
 
+// testH264Frame models a native V4L2 frame: one whole access unit per frame.
 func testH264Frame(payload []byte) *videoFrame {
+	return &videoFrame{data: payload, nativeClock: "CLOCK_REALTIME_AGENT_CAPTURE", codec: agentpb.VideoCodec_VIDEO_CODEC_H264, auAligned: true}
+}
+
+// testChunkedH264Frame models a GStreamer or IP camera frame: an arbitrary
+// slice of the encoded byte stream with no access-unit alignment.
+func testChunkedH264Frame(payload []byte) *videoFrame {
 	return &videoFrame{data: payload, nativeClock: "CLOCK_REALTIME_AGENT_CAPTURE", codec: agentpb.VideoCodec_VIDEO_CODEC_H264}
 }
 
@@ -258,9 +265,121 @@ func TestContinuousRateCapDropsWholeGOPs(t *testing.T) {
 	if c.result.Drops != nil {
 		t.Fatalf("intentionally skipped GOPs must not count as drops: %v", *c.result.Drops)
 	}
-	c.finishResultDetail()
+	c.finishResultDetail(3 * int64(time.Second))
 	if !strings.Contains(c.result.SourceDetail, "rate cap 1 Hz") || !strings.Contains(c.result.SourceDetail, "achieved 1 Hz") {
 		t.Fatalf("achieved rate not recorded: %q", c.result.SourceDetail)
+	}
+}
+
+func TestAchievedRateIsComputedOverTheCaptureSpanNotTheWrittenBurst(t *testing.T) {
+	clock := &fakeReceipt{}
+	c := newTestCameraCapture(t, clock)
+	c.rateCap = 1 // hertz
+
+	// One admitted GOP: a keyframe and four inter frames inside 400ms. Every
+	// later GOP stays over the cap and is skipped until the capture ends.
+	for i, payload := range [][]byte{testRAUFrame, testInterFrame, testInterFrame, testInterFrame, testInterFrame} {
+		clock.now = int64(i) * 100 * int64(time.Millisecond)
+		if err := c.handleFrame(testH264Frame(payload)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	clock.now = 2 * int64(time.Second)
+	if err := c.handleFrame(testH264Frame(testRAUFrame)); err != nil {
+		t.Fatal(err)
+	}
+	if c.result.Count != 5 {
+		t.Fatalf("count = %d, want the single admitted GOP's 5 frames", c.result.Count)
+	}
+
+	c.finishResultDetail(10 * int64(time.Second))
+	if !strings.Contains(c.result.SourceDetail, "achieved 0.5 Hz") {
+		t.Fatalf("achieved rate must cover the whole capture span (5 frames / 10s), got %q", c.result.SourceDetail)
+	}
+}
+
+func TestSnapshotModeDegradesToContinuousOnByteChunkedTransport(t *testing.T) {
+	clock := &fakeReceipt{now: 100 * int64(time.Millisecond)}
+	c := newTestCameraCapture(t, clock)
+	c.mode, c.interval = captureModeSnapshot, int64(time.Second)
+
+	// The chunk parses as a random-access prefix, but chunk boundaries are
+	// arbitrary: the same bytes could be the head of a truncated keyframe.
+	if err := c.handleFrame(testChunkedH264Frame(testRAUFrame)); err != nil {
+		t.Fatal(err)
+	}
+	if c.mode != "continuous" {
+		t.Fatalf("mode = %q, want degrade to continuous", c.mode)
+	}
+	if _, err := os.Stat(filepath.Join(c.dir, "snapshot-000001.h264")); err == nil {
+		t.Fatal("a byte-stream chunk was written as a snapshot still")
+	}
+	if _, err := os.Stat(filepath.Join(c.dir, "segment-000001.h264")); err != nil {
+		t.Fatalf("degraded capture did not record continuously: %v", err)
+	}
+	c.finishResultDetail(0)
+	if !strings.Contains(c.result.SourceDetail, "records continuously instead") {
+		t.Fatalf("degrade note missing from source detail: %q", c.result.SourceDetail)
+	}
+}
+
+func TestRateCapIsDisabledOnByteChunkedTransport(t *testing.T) {
+	clock := &fakeReceipt{}
+	c := newTestCameraCapture(t, clock)
+	c.rateCap = 1 // hertz
+
+	// Chunks of a byte stream cannot be skipped at GOP granularity: dropping
+	// them corrupts the stream. All three must be written despite the cap.
+	for i, payload := range [][]byte{testRAUFrame, testInterFrame, testRAUFrame} {
+		clock.now = int64(i) * 100 * int64(time.Millisecond)
+		if err := c.handleFrame(testChunkedH264Frame(payload)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if c.result.Count != 3 {
+		t.Fatalf("count = %d, want all 3 chunks written", c.result.Count)
+	}
+	if c.rateCap != 0 {
+		t.Fatalf("rate cap still armed on a chunked transport: %v", c.rateCap)
+	}
+	c.finishResultDetail(0)
+	if !strings.Contains(c.result.SourceDetail, "rate cap 1 Hz cannot be enforced") {
+		t.Fatalf("disabled-cap note missing: %q", c.result.SourceDetail)
+	}
+}
+
+func TestSnapshotSkipsTruncatedFrameOnAlignedTransport(t *testing.T) {
+	clock := &fakeReceipt{now: 100 * int64(time.Millisecond)}
+	c := newTestCameraCapture(t, clock)
+	c.mode, c.interval = captureModeSnapshot, int64(time.Second)
+
+	if err := c.handleFrame(testH264Frame(testRAUFrame)); err != nil {
+		t.Fatal(err)
+	}
+	// A single frame truncated by the maxFrameBytes cap: its head still parses
+	// as SPS/PPS/IDR, but it must not become a still, and it must not degrade
+	// the whole capture either.
+	clock.now = 1500 * int64(time.Millisecond)
+	truncated := testChunkedH264Frame(testRAUFrame)
+	if err := c.handleFrame(truncated); err != nil {
+		t.Fatal(err)
+	}
+	if c.result.Count != 1 {
+		t.Fatalf("count = %d after truncated frame, want 1", c.result.Count)
+	}
+	clock.now = 1700 * int64(time.Millisecond)
+	if err := c.handleFrame(testH264Frame(testRAUFrame)); err != nil {
+		t.Fatal(err)
+	}
+	if c.mode != captureModeSnapshot || c.result.Count != 2 {
+		t.Fatalf("mode = %q count = %d, want snapshot mode intact with 2 stills", c.mode, c.result.Count)
+	}
+	media, err := os.ReadFile(filepath.Join(c.dir, "snapshot-000002.h264"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(media, testRAUFrame) {
+		t.Fatalf("snapshot 2 = %x", media)
 	}
 }
 

--- a/go/internal/agent/services/data_service.go
+++ b/go/internal/agent/services/data_service.go
@@ -270,7 +270,7 @@ func (s *DataService) CampaignTrigger(ctx context.Context, req *agentpbv2.DataCa
 }
 
 func (s *DataService) triggerCampaign(ctx context.Context, campaign data.Campaign, reason, expression string) (*agentpbv2.DataEpisode, error) {
-	sources, topics, err := s.manager.ResolveCampaignSources(campaign)
+	sources, topics, captures, err := s.manager.ResolveCampaignSources(campaign)
 	if err != nil {
 		return nil, status.Error(codes.FailedPrecondition, err.Error())
 	}
@@ -295,6 +295,7 @@ func (s *DataService) triggerCampaign(ctx context.Context, campaign data.Campaig
 	episode, err := s.startCapture(ctx, data.StartOptions{
 		Name:                 campaign.Name,
 		Sources:              sources,
+		SourceCaptures:       captures,
 		PreRollDuration:      campaign.BufferDuration(),
 		Trigger:              data.EpisodeTrigger{Reason: reason, CampaignName: campaign.Name, CampaignRevision: campaign.Revision, Expression: expression},
 		CollectorVersion:     version.Version,

--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -932,6 +932,31 @@ func (s *VideoService) getOrCreateHub(ctx context.Context, path string, req *age
 	return h, id, ch, nil
 }
 
+// subscribeExistingHub joins the live hub for path at whatever stream
+// parameters it is already running with, asserting none of its own. It returns
+// ok=false (and no error) when no live hub exists or the hub is shutting down,
+// in which case the caller should create one via getOrCreateHub. Episode
+// capture uses this to coexist with a live viewer instead of failing the
+// episode when the viewer's stream parameters differ from the campaign's caps.
+func (s *VideoService) subscribeExistingHub(path string) (h *deviceHub, id int, ch chan *videoFrame, width, height, framerate uint32, ok bool, err error) {
+	s.mu.Lock()
+	h, exists := s.hubs[path]
+	if !exists || h.ctx.Err() != nil {
+		s.mu.Unlock()
+		return nil, 0, nil, 0, 0, 0, false, nil
+	}
+	id, ch, err = h.subscribe()
+	s.mu.Unlock()
+	if err != nil {
+		if st, _ := status.FromError(err); st.Code() == codes.Unavailable {
+			// The hub began shutting down between the map lookup and subscribe.
+			return nil, 0, nil, 0, 0, 0, false, nil
+		}
+		return nil, 0, nil, 0, 0, 0, false, err
+	}
+	return h, id, ch, h.width, h.height, h.framerate, true, nil
+}
+
 // runProducer drives the capture loop for a single device hub.
 // It tries native V4L2 H.264 first, falling back to GStreamer when unsupported.
 // When the hub loses its last subscriber the context is cancelled and this goroutine exits.

--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -326,6 +326,15 @@ type videoFrame struct {
 	nativeFlags   uint32
 	sequence      uint32
 	sequenceValid bool
+	// auAligned reports that data holds exactly one whole encoded access unit.
+	// Only the native V4L2 path delivers this (one V4L2 buffer per encoded
+	// frame); the GStreamer and IP camera producers read a byte stream from a
+	// pipe, so their frames are arbitrary chunk-sized slices of the stream that
+	// can begin or end mid-access-unit. Consumers that cut the stream at frame
+	// boundaries (snapshot stills, GOP-granularity rate capping) must require
+	// this flag: a chunk that merely contains an SPS/PPS/IDR prefix may still
+	// be truncated mid-IDR.
+	auAligned bool
 }
 
 type frameTimestamp struct {
@@ -335,6 +344,7 @@ type frameTimestamp struct {
 	nativeFlags   uint32
 	sequence      uint32
 	sequenceValid bool
+	auAligned     bool
 }
 
 func realtimeFrameTimestamp(now time.Time) frameTimestamp {
@@ -963,7 +973,7 @@ func (s *VideoService) subscribeExistingHub(path string) (h *deviceHub, id int, 
 func (s *VideoService) runProducer(ctx context.Context, h *deviceHub, path string, req *agentpb.StreamVideoRequest) {
 	defer s.wg.Done()
 	broadcast := func(payload []byte, stamp frameTimestamp, codec agentpb.VideoCodec) bool {
-		return h.broadcast(&videoFrame{data: payload, tsNs: stamp.wallNs, codec: codec, nativeNs: stamp.nativeNs, nativeClock: stamp.nativeClock, nativeFlags: stamp.nativeFlags, sequence: stamp.sequence, sequenceValid: stamp.sequenceValid})
+		return h.broadcast(&videoFrame{data: payload, tsNs: stamp.wallNs, codec: codec, nativeNs: stamp.nativeNs, nativeClock: stamp.nativeClock, nativeFlags: stamp.nativeFlags, sequence: stamp.sequence, sequenceValid: stamp.sequenceValid, auAligned: stamp.auAligned})
 	}
 
 	// The hub key carries the source kind: network cameras key on "ip:<id>" and
@@ -1463,6 +1473,12 @@ func (s *VideoService) streamV4L2Native(ctx context.Context, broadcast func([]by
 			stamp.nativeFlags = dqbuf.flags()
 			stamp.sequence = dqbuf.sequence()
 			stamp.sequenceValid = true
+			// V4L2 compressed capture delivers exactly one encoded frame per
+			// dequeued buffer, so this is the one producer whose frames are
+			// whole access units. The maxFrameBytes cap below can truncate a
+			// pathologically large frame, in which case the alignment promise
+			// no longer holds.
+			stamp.auAligned = n == dqbuf.bytesUsed()
 			const v4l2TimestampMask = uint32(0x0000e000)
 			const v4l2TimestampMonotonic = uint32(0x00002000)
 			if stamp.nativeFlags&v4l2TimestampMask == v4l2TimestampMonotonic {


### PR DESCRIPTION
## Problem

Campaigns validate per-source capture policies (mode, interval, rate, max_resolution) since the capture-config deliverable, but the camera adapter ignored all of them: every camera source recorded continuously at whatever the device defaulted to, and any mode other than continuous only produced a deploy warning. A campaign author asking for one still every 30 seconds, or a 5 hertz cap on a 30 hertz camera, silently got full-rate continuous video.

## Cause

The adapter built its StreamVideoRequest with only the device identifier, never setting framerate, width, or height even though the protocol supports them, and had a single continuous write path with no notion of the per-source policy. The policy also had no route from the campaign plan to the adapter: sources arrive as plain identifiers through StartOptions.

## Solution

**Plumbing.** ResolveCampaignSources now also returns capture policies keyed by resolved source identifier; they travel through StartOptions.SourceCaptures onto data.Source (excluded from the manifest via `json:"-"`; the plan holds the policy, the manifest records achieved behavior).

**Caps for continuous mode.** capture.rate maps to the largest pipeline-accepted framerate at or below the cap, and capture.max_resolution to width/height when the device advertises that mode. Caps the pipeline cannot accept do not fail the episode: the rate cap is enforced adapter-side by admitting or skipping whole groups of pictures (GOP) - sub-GOP dropping would corrupt H.264, so capping is documented as best-effort at GOP granularity and the achieved rate is recorded in the capture result. If the device hub is already streaming with different parameters (for example a live dashboard viewer), the episode subscribes at the existing parameters via a new subscribeExistingHub instead of failing, and records requested-versus-achieved in the source detail.

**Snapshot mode.** `mode: snapshot, interval: T` writes one standalone decodable still per interval as a single H.264 random-access unit (snapshot-<n>.h264: SPS/PPS/IDR, decodable on its own). JPEG was deliberately not added: the producer pipelines emit encoded H.264/VP8 only, so keyframe stills are the least-invention path and need no new GStreamer pipeline. Each snapshot gets an index entry with canonical timestamp and clock mapping exactly like segments. Between intervals the capture stays subscribed and discards frames (hub churn would close the device, restart the encoder, and wait a GOP for the next keyframe). Intervals that produce no still - including head and tail gaps - are counted as drops under the accounting label missed_snapshot_intervals.

**Deploy warnings.** implementedCaptureModes is now per source kind: camera implements continuous and snapshot; ros2 and telemetry snapshot still deploy-warn.

## Tests

- Snapshot writes one still per interval with one random-access unit each, plus index entries; extra frames and inter frames are discarded.
- Missed-interval drop accounting including head and tail gaps.
- Rate cap admits/skips whole GOPs, never counts intentional skips as drops, and records the achieved rate.
- Hub-collision fallback joins the existing hub and reports its parameters; a full startOne/Stop pass records requested-versus-achieved detail.
- Campaign deploy: camera snapshot no longer warns, ros2 snapshot and camera threshold still do.

Verified with `CC=/usr/bin/clang go build ./...` and `go test` (including -race) on internal/agent/data, internal/agent/services, and internal/cli.