### PR TITLE
feat(examples): WendyDataModelApp reference app for the model harness

### DIFF
--- a/Examples/WendyDataModelApp/Dockerfile
+++ b/Examples/WendyDataModelApp/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1.6
+#
+# A Dockerfile rather than a Stagefile because the model is produced by a
+# build step (an Ultralytics ONNX export) that the Stagefile DSL has no
+# instruction for. The export stage is build-time only: ultralytics and
+# torch never enter the runtime image, which carries just onnxruntime,
+# OpenCV, and NumPy on the CPU.
+#
+# Jetson GPU variant: see README.md. The runtime stage swaps
+# onnxruntime for the onnxruntime-gpu wheel from the Jetson wheel index
+# (the same wheel HelloONNX's Stagefile resolves with `cuda: true`).
+
+FROM python:3.11-slim-bookworm AS export
+# Pin the Ultralytics release; it is the model version reported in every
+# prediction record (WENDY_MODEL_VERSION) and pinned in campaign.yaml.
+RUN pip install --no-cache-dir "ultralytics==8.3.63" "onnx<2" onnxruntime
+WORKDIR /export
+# Downloads the pinned yolov8n.pt weights and exports yolov8n.onnx.
+# opset 12 keeps the graph loadable by every onnxruntime this app targets.
+RUN yolo export model=yolov8n.pt format=onnx imgsz=640 opset=12
+
+FROM python:3.11-slim-bookworm
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libglib2.0-0 \
+    && rm -rf /var/lib/apt/lists/*
+RUN pip install --no-cache-dir onnxruntime opencv-python-headless "numpy<3"
+WORKDIR /app
+COPY --from=export /export/yolov8n.onnx ./yolov8n.onnx
+COPY app.py wendydata.py ./
+ENV PYTHONUNBUFFERED=1 \
+    WENDY_MODEL_VERSION=8.3.63
+CMD ["python3", "app.py"]

--- a/Examples/WendyDataModelApp/README.md
+++ b/Examples/WendyDataModelApp/README.md
@@ -1,0 +1,151 @@
+# WendyDataModelApp — reference app for the model harness
+
+The smallest complete app that proves the three model-harness contracts on
+WendyOS, so a Wendy Arm demo needs nothing beyond `wendy run` and
+`wendy data campaign deploy campaign.yaml`.
+
+| Contract | Mechanism in this app |
+|---|---|
+| Sensors in | Webcam frames via Open Computer Vision (OpenCV) over Video4Linux2 (V4L2), granted by the `camera` entitlement |
+| Predictions out | One `prediction` record per processed frame, plus a `person_detected` event, over the app-private data socket granted by the `data` entitlement (`WENDY_DATA_SOCKET`) |
+| Actuation out | A Robot Operating System 2 (ROS 2) `geometry_msgs/Twist` on `/cmd_vel` when ROS 2 is enabled; the identical control decision is logged when it is not |
+
+```
+WendyDataModelApp/
+├── wendy.json          ← camera + data entitlements
+├── Dockerfile          ← build-time YOLOv8n ONNX export, CPU runtime
+├── app.py              ← capture, detect, record, actuate loop
+├── wendydata.py        ← data socket client (standard library only)
+├── test_wendydata.py   ← unit tests for framing + uncertainty formula
+└── campaign.yaml       ← flight-recorder plan armed by the app's records
+```
+
+## What the app does
+
+Every loop iteration (at most 5 per second, see rate limiting below):
+
+1. Grabs a frame from `/dev/video0` (override with `WENDY_CAMERA_DEVICE`).
+2. Runs YOLOv8n, exported to Open Neural Network Exchange (ONNX) at image
+   build time, through onnxruntime.
+3. Sends a `prediction` record: model `yolov8n`, the pinned model version,
+   the frame's uncertainty score, and the top detections in attributes.
+4. Sends a `person_detected` event when a person newly enters the view
+   (edge-triggered, so a person standing still fires the campaign once).
+5. Computes an actuation decision — turn towards the largest person and
+   creep forward when centered — and publishes it as a Twist (ROS 2 mode)
+   or logs it (default mode).
+
+### The uncertainty formula
+
+```
+uncertainty = 1 - max(confidence over detections >= threshold)
+            = 1.0 when nothing was detected above the threshold
+```
+
+Clamped to 0..1. A frame the model is sure about scores near 0; an empty
+or ambiguous frame scores 1.0. That makes `model.uncertainty > 0.65` in
+the campaign collect exactly the frames worth labeling: the ones the
+current model cannot explain. The formula lives in
+`wendydata.uncertainty_score` and is unit-tested.
+
+### Prediction rate limiting
+
+The agent rejects more than 200 records per second per connection. This
+app stays far below it by frame sampling: it processes at most
+`WENDY_PREDICTIONS_PER_SECOND` frames per second (default 5) and sends one
+prediction per processed frame. Acknowledgements are honored:
+`buffered` and `recorded` are success, `rejected` is logged with the
+agent's reason, and the client reconnects and retries once when the
+socket drops.
+
+## Run on a dev box (no GPU, no ROS 2)
+
+The default image is CPU-only and needs no ROS 2 stack:
+
+```sh
+cd Examples/WendyDataModelApp
+wendy run
+```
+
+The build's export stage installs Ultralytics (pinned to 8.3.63), exports
+`yolov8n.onnx` at opset 12, and discards itself; the runtime image carries
+only onnxruntime, OpenCV, and NumPy. Without a data socket (running
+outside WendyOS, or without the `data` entitlement) the app keeps running
+and logs each dropped record; without ROS 2 it logs each actuation
+decision. Nothing hard-requires the harness, the GPU, or a robot.
+
+Unit tests (no camera or agent needed):
+
+```sh
+python3 -m unittest discover Examples/WendyDataModelApp
+```
+
+## Run on a Jetson with the arm (GPU, ROS 2 on)
+
+Two independent switches:
+
+**GPU**: swap the runtime wheel for the Jetson build of onnxruntime. In
+the Dockerfile's runtime stage replace `onnxruntime` with
+`onnxruntime-gpu` resolved against the Jetson wheel index — the same
+wheel `Examples/HelloONNX` resolves with the Stagefile's `cuda: true` GPU
+profile — and add the `gpu` entitlement to `wendy.json`. The app already
+passes `ort.get_available_providers()`, so the CUDA (Compute Unified
+Device Architecture) provider is picked up automatically when present.
+
+**ROS 2 actuation**: build from a ROS base image so `rclpy` is importable
+(for example `ros:humble` plus this Dockerfile's pip packages), set the
+environment gate, and declare the ROS 2 framework so the agent injects the
+Data Distribution Service (DDS) domain:
+
+```jsonc
+// wendy.json additions for the ROS 2 variant
+"env": { "WENDY_MODEL_APP_ROS2": "1" },
+"frameworks": {
+  "ros2": { "domainId": 42, "rmw": "rmw_cyclonedds_cpp", "distro": "humble" }
+}
+```
+
+See `Examples/ROS2` for what `frameworks.ros2` injects
+(`ROS_DOMAIN_ID`, `RMW_IMPLEMENTATION`) and the shared-ipc isolation a
+multi-container ROS graph wants. With the gate off, or with `rclpy`
+missing, the app logs the same decisions it would have published, so the
+demo works on a plain Jetson without any ROS 2 stack.
+
+## Deploy the campaign
+
+```sh
+wendy data campaign deploy campaign.yaml
+wendy data campaign list
+```
+
+`campaign.yaml` arms two triggers — the `person_detected` event and
+`model.uncertainty > 0.65` — and snapshots the camera every 30 seconds.
+The `applications` source is always captured; it does not appear under
+`sources:` because it cannot be deselected.
+
+To fire an episode without waiting for a trigger:
+
+```sh
+wendy data campaign trigger model-harness-demo --reason commissioning
+```
+
+## What to expect in an episode
+
+```sh
+wendy data episodes
+wendy data inspect <episode-id>
+```
+
+- `events.jsonl` — the application records: the app's `prediction`
+  records (model, model_version, uncertainty, top detections) and any
+  `person_detected` events, each stamped with agent receipt time and
+  clock-uncertainty metadata. Records honor the 10-second pre-trigger
+  buffer.
+- Camera snapshot stills at the 30-second interval (on a camera transport
+  that delivers whole encoded access units; other transports record
+  continuously and the manifest's source detail says so).
+- A manifest tying sources, trigger reason (`event:person_detected` or
+  `model_uncertainty:<value>`), and the campaign revision together.
+
+With `upload.when: always`, finished episodes upload whenever the device
+has connectivity.

--- a/Examples/WendyDataModelApp/app.py
+++ b/Examples/WendyDataModelApp/app.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Reference model app for the Wendy model harness.
+
+Demonstrates the three harness contracts end to end:
+
+  1. Sensors in    — webcam frames via Open Computer Vision (OpenCV) and
+                     Video4Linux2 (V4L2), granted by the camera entitlement.
+  2. Predictions out — one "prediction" record per processed frame, plus a
+                     "person_detected" event, over the app-private data
+                     socket granted by the data entitlement.
+  3. Actuation out — a Robot Operating System 2 (ROS 2) Twist command on
+                     /cmd_vel when ROS 2 is available and enabled; the
+                     same decision is logged when it is not.
+
+The detector is YOLOv8n exported to Open Neural Network Exchange (ONNX)
+at image build time and run with onnxruntime on the Central Processing
+Unit (CPU) by default, so the app runs on any dev box. See README.md for
+the Jetson Graphics Processing Unit (GPU) wheel path.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import time
+
+import cv2
+import numpy as np
+import onnxruntime as ort
+
+import wendydata
+
+log = logging.getLogger("model-app")
+
+MODEL_NAME = "yolov8n"
+# Pinned in the Dockerfile export stage; keep the two in sync.
+MODEL_VERSION = os.environ.get("WENDY_MODEL_VERSION", "8.3.63")
+MODEL_PATH = os.environ.get("WENDY_MODEL_PATH", os.path.join(os.path.dirname(__file__), "yolov8n.onnx"))
+CAMERA_DEVICE = os.environ.get("WENDY_CAMERA_DEVICE", "/dev/video0")
+CONFIDENCE_THRESHOLD = float(os.environ.get("WENDY_CONFIDENCE_THRESHOLD", "0.25"))
+IOU_THRESHOLD = float(os.environ.get("WENDY_IOU_THRESHOLD", "0.45"))
+# Rate-limit friendliness: the agent caps a connection at 200 records per
+# second; this app samples frames so it sends at most this many
+# predictions per second (default 5).
+PREDICTIONS_PER_SECOND = float(os.environ.get("WENDY_PREDICTIONS_PER_SECOND", "5"))
+# Actuation is optional: a plain Jetson demo has no ROS 2 stack. Set
+# WENDY_MODEL_APP_ROS2=1 (and run an image with rclpy) to publish Twists.
+ROS2_REQUESTED = os.environ.get("WENDY_MODEL_APP_ROS2", "0") == "1"
+ACTUATION_TOPIC = os.environ.get("WENDY_ACTUATION_TOPIC", "/cmd_vel")
+INPUT_SIZE = 640
+PERSON_CLASS_ID = 0
+TOP_DETECTIONS = 5
+
+COCO_CLASSES = [
+    "person", "bicycle", "car", "motorcycle", "airplane", "bus", "train", "truck", "boat",
+    "traffic light", "fire hydrant", "stop sign", "parking meter", "bench", "bird", "cat",
+    "dog", "horse", "sheep", "cow", "elephant", "bear", "zebra", "giraffe", "backpack",
+    "umbrella", "handbag", "tie", "suitcase", "frisbee", "skis", "snowboard", "sports ball",
+    "kite", "baseball bat", "baseball glove", "skateboard", "surfboard", "tennis racket",
+    "bottle", "wine glass", "cup", "fork", "knife", "spoon", "bowl", "banana", "apple",
+    "sandwich", "orange", "broccoli", "carrot", "hot dog", "pizza", "donut", "cake", "chair",
+    "couch", "potted plant", "bed", "dining table", "toilet", "tv", "laptop", "mouse",
+    "remote", "keyboard", "cell phone", "microwave", "oven", "toaster", "sink",
+    "refrigerator", "book", "clock", "vase", "scissors", "teddy bear", "hair drier",
+    "toothbrush",
+]
+
+
+class Actuator:
+    """Publishes Twist commands over ROS 2 when available, or logs the
+    decision when not. Both modes exercise the same control logic."""
+
+    def __init__(self):
+        self.node = None
+        self.publisher = None
+        self.twist_type = None
+        if not ROS2_REQUESTED:
+            log.info("actuation: ROS 2 disabled (set WENDY_MODEL_APP_ROS2=1 to publish %s)", ACTUATION_TOPIC)
+            return
+        try:
+            import rclpy
+            from geometry_msgs.msg import Twist
+        except ImportError as exc:
+            log.warning("actuation: ROS 2 requested but rclpy is unavailable (%s); logging decisions instead", exc)
+            return
+        rclpy.init()
+        self.node = rclpy.create_node("wendy_data_model_app")
+        self.publisher = self.node.create_publisher(Twist, ACTUATION_TOPIC, 10)
+        self.twist_type = Twist
+        log.info("actuation: publishing geometry_msgs/Twist on %s", ACTUATION_TOPIC)
+
+    def act(self, angular_z: float, linear_x: float) -> None:
+        if self.publisher is None:
+            log.info("actuation decision (not published): linear.x=%.3f angular.z=%.3f", linear_x, angular_z)
+            return
+        msg = self.twist_type()
+        msg.linear.x = float(linear_x)
+        msg.angular.z = float(angular_z)
+        self.publisher.publish(msg)
+
+    def close(self) -> None:
+        if self.node is not None:
+            import rclpy
+
+            self.node.destroy_node()
+            rclpy.shutdown()
+
+
+def steer_towards(detections, frame_width: int) -> tuple[float, float]:
+    """A demo proportional controller: turn towards the largest detected
+    person and creep forward when one is roughly centered. Returns
+    (angular_z, linear_x); zeros when no person is in view."""
+    people = [d for d in detections if d["class_id"] == PERSON_CLASS_ID]
+    if not people or frame_width <= 0:
+        return 0.0, 0.0
+    largest = max(people, key=lambda d: d["box"][2] * d["box"][3])
+    x, _, w, _ = largest["box"]
+    center_offset = ((x + w / 2.0) / frame_width) - 0.5  # -0.5 .. 0.5
+    angular_z = -1.2 * center_offset
+    linear_x = 0.1 if abs(center_offset) < 0.15 else 0.0
+    return angular_z, linear_x
+
+
+def letterbox(frame: np.ndarray) -> tuple[np.ndarray, float, int, int]:
+    """Resize with preserved aspect ratio onto a 640x640 canvas."""
+    h, w = frame.shape[:2]
+    scale = min(INPUT_SIZE / w, INPUT_SIZE / h)
+    nw, nh = int(round(w * scale)), int(round(h * scale))
+    resized = cv2.resize(frame, (nw, nh))
+    canvas = np.full((INPUT_SIZE, INPUT_SIZE, 3), 114, dtype=np.uint8)
+    dx, dy = (INPUT_SIZE - nw) // 2, (INPUT_SIZE - nh) // 2
+    canvas[dy : dy + nh, dx : dx + nw] = resized
+    return canvas, scale, dx, dy
+
+
+def detect(session: ort.InferenceSession, input_name: str, frame: np.ndarray) -> list[dict]:
+    """Run YOLOv8n and return [{class_id, class_name, confidence, box}]
+    with boxes as [x, y, w, h] in original frame pixels."""
+    canvas, scale, dx, dy = letterbox(frame)
+    blob = canvas[:, :, ::-1].astype(np.float32) / 255.0  # BGR -> RGB
+    blob = np.transpose(blob, (2, 0, 1))[np.newaxis, ...]
+    (output,) = session.run(None, {input_name: blob})
+    # Output shape (1, 84, 8400): 4 box coordinates + 80 class scores.
+    predictions = np.squeeze(output, axis=0).T  # (8400, 84)
+    scores = predictions[:, 4:]
+    class_ids = np.argmax(scores, axis=1)
+    confidences = scores[np.arange(len(class_ids)), class_ids]
+    keep = confidences >= CONFIDENCE_THRESHOLD
+    boxes_cxcywh = predictions[keep, :4]
+    class_ids = class_ids[keep]
+    confidences = confidences[keep]
+    boxes = []
+    for cx, cy, bw, bh in boxes_cxcywh:
+        x = (cx - bw / 2.0 - dx) / scale
+        y = (cy - bh / 2.0 - dy) / scale
+        boxes.append([x, y, bw / scale, bh / scale])
+    if not boxes:
+        return []
+    indices = cv2.dnn.NMSBoxes(boxes, confidences.tolist(), CONFIDENCE_THRESHOLD, IOU_THRESHOLD)
+    detections = []
+    for i in np.array(indices).flatten():
+        detections.append(
+            {
+                "class_id": int(class_ids[i]),
+                "class_name": COCO_CLASSES[int(class_ids[i])],
+                "confidence": round(float(confidences[i]), 4),
+                "box": [round(float(v), 1) for v in boxes[i]],
+            }
+        )
+    detections.sort(key=lambda d: d["confidence"], reverse=True)
+    return detections
+
+
+def open_camera() -> cv2.VideoCapture:
+    capture = cv2.VideoCapture(CAMERA_DEVICE, cv2.CAP_V4L2)
+    if not capture.isOpened():
+        # Fall back to the default backend for non-V4L2 dev machines.
+        capture = cv2.VideoCapture(CAMERA_DEVICE)
+    if not capture.isOpened():
+        log.error("cannot open camera %s; is the camera entitlement granted and a webcam attached?", CAMERA_DEVICE)
+        sys.exit(1)
+    return capture
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
+    log.info("model %s v%s from %s", MODEL_NAME, MODEL_VERSION, MODEL_PATH)
+    session = ort.InferenceSession(MODEL_PATH, providers=ort.get_available_providers())
+    input_name = session.get_inputs()[0].name
+    log.info("onnxruntime providers: %s", session.get_providers())
+
+    client = wendydata.DataSocketClient()
+    log.info("data socket: %s", client.path)
+    actuator = Actuator()
+    capture = open_camera()
+
+    interval = 1.0 / max(PREDICTIONS_PER_SECOND, 0.1)
+    person_present = False
+    try:
+        while True:
+            started = time.monotonic()
+            ok, frame = capture.read()
+            if not ok:
+                log.warning("camera read failed; retrying")
+                time.sleep(1.0)
+                continue
+
+            detections = detect(session, input_name, frame)
+            uncertainty = wendydata.uncertainty_score(
+                (d["confidence"] for d in detections), CONFIDENCE_THRESHOLD
+            )
+
+            record = wendydata.build_prediction(
+                MODEL_NAME,
+                MODEL_VERSION,
+                uncertainty,
+                detections[:TOP_DETECTIONS],
+                {"frame_width": frame.shape[1], "frame_height": frame.shape[0]},
+            )
+            client.send(record)
+
+            # Edge-trigger the demo event so a person standing in front of
+            # the camera fires the campaign once, not once per frame.
+            has_person = any(d["class_id"] == PERSON_CLASS_ID for d in detections)
+            if has_person and not person_present:
+                best = max(
+                    (d for d in detections if d["class_id"] == PERSON_CLASS_ID),
+                    key=lambda d: d["confidence"],
+                )
+                client.send(wendydata.build_event("person_detected", {"confidence": best["confidence"]}))
+                log.info("person detected (confidence %.2f)", best["confidence"])
+            person_present = has_person
+
+            angular_z, linear_x = steer_towards(detections, frame.shape[1])
+            actuator.act(angular_z, linear_x)
+
+            # Frame sampling keeps predictions at or under the configured rate.
+            time.sleep(max(0.0, interval - (time.monotonic() - started)))
+    except KeyboardInterrupt:
+        pass
+    finally:
+        capture.release()
+        client.close()
+        actuator.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/Examples/WendyDataModelApp/campaign.yaml
+++ b/Examples/WendyDataModelApp/campaign.yaml
@@ -1,0 +1,46 @@
+# Campaign for the WendyDataModelApp reference app. Deploy with:
+#
+#   wendy data campaign deploy campaign.yaml
+#
+# The app's prediction and event records arrive over the data socket and
+# arm these triggers; the "applications" source is always captured, so
+# every episode carries the records themselves in events.jsonl.
+version: 1
+
+name: model-harness-demo
+
+sources:
+  # "front" selects the only healthy camera on a single-camera device.
+  # Snapshot mode keeps a still every 30 seconds instead of continuous
+  # video, so an idle demo device stores almost nothing.
+  - camera: front
+    capture:
+      mode: snapshot
+      interval: 30s
+
+capture:
+  # Keep 10 seconds of pre-trigger application records and 20 seconds
+  # after the trigger.
+  buffer: 10s
+  after_trigger: 20s
+  triggers:
+    # Fired by the app's edge-triggered person event.
+    - event: person_detected
+    # Fired by any prediction whose attributes.uncertainty exceeds 0.65:
+    # frames where YOLOv8n saw nothing above its confidence threshold
+    # (uncertainty 1.0) or only low-confidence detections.
+    - model.uncertainty: "> 0.65"
+
+upload:
+  when: always
+
+retention:
+  local_quota: 5GiB
+
+export:
+  annotation: cvat
+
+# Pin the model this campaign collects for, matching the version every
+# prediction record reports in attributes.model_version.
+models:
+  yolov8n: "8.3.63"

--- a/Examples/WendyDataModelApp/test_wendydata.py
+++ b/Examples/WendyDataModelApp/test_wendydata.py
@@ -1,0 +1,79 @@
+"""Unit tests for the pure parts of the data socket client.
+
+Run with: python3 -m unittest discover Examples/WendyDataModelApp
+
+No camera, model, or agent is required: these cover the record framing
+and the uncertainty formula, the two pieces the agent-side smoke tests
+cannot see.
+"""
+
+import json
+import struct
+import unittest
+
+import wendydata
+
+
+class TestUncertaintyScore(unittest.TestCase):
+    def test_no_detections_is_fully_uncertain(self):
+        self.assertEqual(wendydata.uncertainty_score([], 0.25), 1.0)
+
+    def test_below_threshold_detections_are_ignored(self):
+        self.assertEqual(wendydata.uncertainty_score([0.1, 0.2], 0.25), 1.0)
+
+    def test_uses_max_confidence(self):
+        self.assertAlmostEqual(wendydata.uncertainty_score([0.3, 0.9, 0.5], 0.25), 0.1)
+
+    def test_certain_detection_scores_zero(self):
+        self.assertEqual(wendydata.uncertainty_score([1.0], 0.25), 0.0)
+
+    def test_clamped_to_unit_interval(self):
+        # A confidence above 1.0 (a broken model) must not go negative;
+        # campaign model.uncertainty thresholds are defined on 0..1.
+        self.assertEqual(wendydata.uncertainty_score([1.5], 0.25), 0.0)
+
+    def test_accepts_generators(self):
+        self.assertAlmostEqual(wendydata.uncertainty_score((c for c in [0.75]), 0.25), 0.25)
+
+
+class TestFraming(unittest.TestCase):
+    def test_length_prefix_is_big_endian(self):
+        frame = wendydata.frame_record({"version": 1})
+        (length,) = struct.unpack(">I", frame[:4])
+        self.assertEqual(length, len(frame) - 4)
+        self.assertEqual(json.loads(frame[4:]), {"version": 1})
+
+    def test_oversized_record_is_refused(self):
+        with self.assertRaises(ValueError):
+            wendydata.frame_record({"blob": "x" * wendydata.MAX_RECORD_BYTES})
+
+
+class TestRecords(unittest.TestCase):
+    def test_prediction_record_shape(self):
+        record = wendydata.build_prediction(
+            "yolov8n", "8.3.63", 0.35, [{"class_name": "person", "confidence": 0.65}]
+        )
+        self.assertEqual(record["version"], 1)
+        self.assertEqual(record["type"], "prediction")
+        self.assertEqual(record["model"], "yolov8n")
+        self.assertEqual(record["attributes"]["model_version"], "8.3.63")
+        # Campaign model.uncertainty triggers read attributes["uncertainty"].
+        self.assertAlmostEqual(record["attributes"]["uncertainty"], 0.35)
+        self.assertEqual(len(record["attributes"]["detections"]), 1)
+        self.assertIn("client_boottime_nanos", record)
+        self.assertIn("boot_id", record)
+
+    def test_event_record_shape(self):
+        record = wendydata.build_event("person_detected", {"confidence": 0.9})
+        self.assertEqual(record["version"], 1)
+        self.assertEqual(record["type"], "event")
+        self.assertEqual(record["name"], "person_detected")
+        self.assertEqual(record["attributes"]["confidence"], 0.9)
+
+    def test_records_fit_the_frame_limit(self):
+        record = wendydata.build_prediction("yolov8n", "8.3.63", 1.0, [])
+        self.assertLessEqual(len(wendydata.frame_record(record)), wendydata.MAX_RECORD_BYTES)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Examples/WendyDataModelApp/wendy.json
+++ b/Examples/WendyDataModelApp/wendy.json
@@ -1,0 +1,14 @@
+{
+    "appId": "sh.wendy.examples.wendydatamodelapp",
+    "platform": "linux",
+    "version": "1.0.0",
+    "language": "python",
+    "entitlements": [
+        {
+            "type": "camera"
+        },
+        {
+            "type": "data"
+        }
+    ]
+}

--- a/Examples/WendyDataModelApp/wendydata.py
+++ b/Examples/WendyDataModelApp/wendydata.py
@@ -1,0 +1,192 @@
+"""Minimal Wendy Data socket client and record helpers.
+
+This module is standard-library only so the record framing and the
+uncertainty formula are unit-testable without a camera, a model, or a
+running agent. The protocol matches the agent's application-record socket
+(go/internal/agent/services/app_data_socket.go):
+
+  - Unix stream socket, path in the WENDY_DATA_SOCKET environment variable
+    (the agent injects /run/wendy/data/data.sock for apps with the "data"
+    entitlement).
+  - Each record is a 4-byte big-endian length prefix followed by a JSON
+    document of at most 64 KiB.
+  - Records carry {"version": 1, "type": "event"|"prediction", ...} plus
+    CLOCK_BOOTTIME nanoseconds and the kernel boot id so the agent can
+    place them on the device timeline.
+  - Every record is acknowledged with {"version": 1, "state": ...} where
+    state is "buffered", "recorded", or "rejected".
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import struct
+import time
+
+log = logging.getLogger("wendydata")
+
+MAX_RECORD_BYTES = 64 * 1024
+DEFAULT_SOCKET_PATH = "/run/wendy/data/data.sock"
+
+ACK_OK_STATES = ("buffered", "recorded")
+
+
+def socket_path() -> str:
+    """The agent-injected data socket path, with the documented default."""
+    return os.environ.get("WENDY_DATA_SOCKET", DEFAULT_SOCKET_PATH)
+
+
+def boot_clock_nanos() -> int:
+    """Nanoseconds on the device boot clock (CLOCK_BOOTTIME).
+
+    CLOCK_BOOTTIME exists on Linux, which is where this app runs; on other
+    development platforms fall back to CLOCK_MONOTONIC so the pure helpers
+    stay testable.
+    """
+    clock = getattr(time, "CLOCK_BOOTTIME", time.CLOCK_MONOTONIC)
+    return time.clock_gettime_ns(clock)
+
+
+def read_boot_id() -> str:
+    """The kernel boot id, or an empty string off-Linux."""
+    try:
+        with open("/proc/sys/kernel/random/boot_id", "r", encoding="ascii") as f:
+            return f.read().strip()
+    except OSError:
+        return ""
+
+
+def uncertainty_score(confidences, threshold: float) -> float:
+    """Per-frame model uncertainty in 0..1.
+
+    Formula: 1 - max(confidence) over detections at or above the
+    confidence threshold; 1.0 when nothing was detected above the
+    threshold. A frame the model is sure about scores near 0, an empty or
+    ambiguous frame scores near 1, which is exactly what a campaign
+    trigger such as "model.uncertainty > 0.65" wants to collect.
+    """
+    best = 0.0
+    for c in confidences:
+        c = float(c)
+        if c >= threshold and c > best:
+            best = c
+    if best <= 0.0:
+        return 1.0
+    return max(0.0, min(1.0, 1.0 - best))
+
+
+def frame_record(payload: dict) -> bytes:
+    """Encode one record as a length-prefixed JSON frame."""
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    if len(body) > MAX_RECORD_BYTES:
+        raise ValueError(f"record is {len(body)} bytes; the protocol caps records at 64 KiB")
+    return struct.pack(">I", len(body)) + body
+
+
+def _base_record(record_type: str) -> dict:
+    return {
+        "version": 1,
+        "type": record_type,
+        "client_boottime_nanos": boot_clock_nanos(),
+        "boot_id": read_boot_id(),
+    }
+
+
+def build_prediction(model: str, model_version: str, uncertainty: float, detections, attributes: dict | None = None) -> dict:
+    """A "prediction" record. The agent requires the model name; the
+    uncertainty rides in attributes where campaign model.uncertainty
+    triggers read it."""
+    record = _base_record("prediction")
+    record["model"] = model
+    attrs = {
+        "model_version": model_version,
+        "uncertainty": float(uncertainty),
+        "detections": list(detections),
+    }
+    if attributes:
+        attrs.update(attributes)
+    record["attributes"] = attrs
+    return record
+
+
+def build_event(name: str, attributes: dict | None = None) -> dict:
+    """An "event" record. The agent requires the event name."""
+    record = _base_record("event")
+    record["name"] = name
+    if attributes:
+        record["attributes"] = dict(attributes)
+    return record
+
+
+class DataSocketClient:
+    """A small reconnect-and-retry client for the data socket.
+
+    send() delivers one record and returns the acknowledged state
+    ("buffered", "recorded", or "rejected"), or None when the socket is
+    unavailable and the record was dropped after one reconnect attempt.
+    The agent enforces its own per-connection rate limit (200 records per
+    second); callers should stay far below it.
+    """
+
+    def __init__(self, path: str | None = None, timeout: float = 2.0):
+        self.path = path or socket_path()
+        self.timeout = timeout
+        self._sock: socket.socket | None = None
+
+    def _connect(self) -> None:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.settimeout(self.timeout)
+        sock.connect(self.path)
+        self._sock = sock
+
+    def close(self) -> None:
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            finally:
+                self._sock = None
+
+    def _read_ack(self) -> dict:
+        header = self._recv_exact(4)
+        (length,) = struct.unpack(">I", header)
+        if length == 0 or length > MAX_RECORD_BYTES:
+            raise ConnectionError(f"ack length {length} out of range")
+        return json.loads(self._recv_exact(length))
+
+    def _recv_exact(self, n: int) -> bytes:
+        assert self._sock is not None
+        buf = b""
+        while len(buf) < n:
+            chunk = self._sock.recv(n - len(buf))
+            if not chunk:
+                raise ConnectionError("data socket closed by agent")
+            buf += chunk
+        return buf
+
+    def _send_once(self, frame: bytes) -> tuple[str, str]:
+        if self._sock is None:
+            self._connect()
+        assert self._sock is not None
+        self._sock.sendall(frame)
+        ack = self._read_ack()
+        return str(ack.get("state", "")), str(ack.get("error", ""))
+
+    def send(self, record: dict) -> str | None:
+        frame = frame_record(record)
+        for attempt in (1, 2):
+            try:
+                state, error = self._send_once(frame)
+            except (OSError, ConnectionError, json.JSONDecodeError) as exc:
+                self.close()
+                if attempt == 1:
+                    continue
+                log.warning("data socket unavailable, dropped %s record: %s", record.get("type"), exc)
+                return None
+            if state in ACK_OK_STATES:
+                return state
+            log.warning("agent rejected %s record: %s", record.get("type"), error or "unspecified")
+            return state
+        return None

--- a/go/internal/agent/data/example_campaign_test.go
+++ b/go/internal/agent/data/example_campaign_test.go
@@ -1,0 +1,67 @@
+package data
+
+import (
+	"os"
+	"testing"
+)
+
+// TestShippedModelAppCampaignParses guards the real
+// Examples/WendyDataModelApp/campaign.yaml against the campaign schema this
+// agent actually parses. It fails when the shipped example and the schema
+// drift apart, and asserts that the records the reference app emits fire the
+// campaign's triggers.
+func TestShippedModelAppCampaignParses(t *testing.T) {
+	raw, err := os.ReadFile("../../../../Examples/WendyDataModelApp/campaign.yaml")
+	if err != nil {
+		t.Fatalf("reading model app campaign example: %v", err)
+	}
+	campaign, err := ParseCampaign(raw)
+	if err != nil {
+		t.Fatalf("model app campaign.yaml does not parse: %v", err)
+	}
+
+	if len(campaign.Sources) != 1 || campaign.Sources[0].Camera == "" {
+		t.Fatalf("expected exactly one camera source, got %+v", campaign.Sources)
+	}
+	capture := campaign.Sources[0].Capture
+	if capture.EffectiveMode() != "snapshot" {
+		t.Errorf("camera capture mode = %q, want snapshot", capture.EffectiveMode())
+	}
+	if got := capture.IntervalDuration().String(); got != "30s" {
+		t.Errorf("snapshot interval = %s, want 30s", got)
+	}
+	if campaign.Upload.When != "always" {
+		t.Errorf("upload.when = %q, want always", campaign.Upload.When)
+	}
+	if campaign.LocalQuotaBytes() <= 0 {
+		t.Error("retention.local_quota did not parse to a positive quota")
+	}
+	if version, ok := campaign.Models["yolov8n"]; !ok || version == "" {
+		t.Errorf("campaign must pin the yolov8n model version, got %v", campaign.Models)
+	}
+
+	// The event record the app sends when a person appears.
+	if _, _, matched := campaign.Match(ApplicationRecord{Version: 1, Type: "event", Name: "person_detected"}); !matched {
+		t.Error("person_detected event did not fire the campaign")
+	}
+	// A prediction record above the uncertainty threshold, in the shape the
+	// app emits (uncertainty rides in attributes).
+	uncertain := ApplicationRecord{
+		Version:    1,
+		Type:       "prediction",
+		Model:      "yolov8n",
+		Attributes: map[string]any{"uncertainty": 0.9, "model_version": "8.3.63"},
+	}
+	if _, _, matched := campaign.Match(uncertain); !matched {
+		t.Error("high-uncertainty prediction did not fire the campaign")
+	}
+	confident := ApplicationRecord{
+		Version:    1,
+		Type:       "prediction",
+		Model:      "yolov8n",
+		Attributes: map[string]any{"uncertainty": 0.1},
+	}
+	if reason, _, matched := campaign.Match(confident); matched {
+		t.Errorf("confident prediction unexpectedly fired the campaign (%s)", reason)
+	}
+}

--- a/go/internal/shared/appconfig/wendy.schema.json
+++ b/go/internal/shared/appconfig/wendy.schema.json
@@ -326,6 +326,14 @@
         },
         {
           "properties": {
+            "type": { "const": "data" }
+          },
+          "required": ["type"],
+          "additionalProperties": false,
+          "description": "Submit structured event and prediction records to Wendy Data over the app-private data socket (WENDY_DATA_SOCKET). Never exposes the administrative agent socket."
+        },
+        {
+          "properties": {
             "type": { "const": "admin" }
           },
           "required": ["type"],

--- a/go/internal/shared/appconfig/wendy.schema.json
+++ b/go/internal/shared/appconfig/wendy.schema.json
@@ -296,6 +296,20 @@
         },
         {
           "properties": {
+            "type": { "const": "mcp" },
+            "port": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535,
+              "description": "Port the app's Model Context Protocol (MCP) server listens on."
+            }
+          },
+          "required": ["type", "port"],
+          "additionalProperties": false,
+          "description": "Declares the app's Model Context Protocol (MCP) server port so MCP clients can discover and reach it. At most one per app."
+        },
+        {
+          "properties": {
             "type": { "const": "http" },
             "port": {
               "type": "integer",

--- a/go/internal/shared/appconfig/wendy_data_model_app_test.go
+++ b/go/internal/shared/appconfig/wendy_data_model_app_test.go
@@ -1,0 +1,90 @@
+package appconfig
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+// TestWendyDataModelAppExampleValidates guards the real
+// Examples/WendyDataModelApp app config: the reference app for the model
+// harness must parse, validate, declare exactly the camera and data
+// entitlements it documents, and produce no ValidateJSON warnings. It fails
+// when the example and the config schema drift apart.
+func TestWendyDataModelAppExampleValidates(t *testing.T) {
+	const path = "../../../../Examples/WendyDataModelApp/wendy.json"
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading model app example: %v", err)
+	}
+	cfg, err := LoadFromBytes(raw)
+	if err != nil {
+		t.Fatalf("loading model app example: %v", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("model app wendy.json invalid: %v", err)
+	}
+	if warnings := ValidateJSON(raw); len(warnings) != 0 {
+		t.Fatalf("model app wendy.json produced warnings: %v", warnings)
+	}
+
+	var camera, data bool
+	for _, e := range cfg.Entitlements {
+		switch e.Type {
+		case EntitlementCamera:
+			camera = true
+		case EntitlementData:
+			data = true
+		}
+	}
+	if !camera {
+		t.Error("missing camera entitlement (sensors-in contract)")
+	}
+	if !data {
+		t.Error("missing data entitlement (predictions-out contract)")
+	}
+
+	// The published JSON schema must accept every entitlement type the
+	// example declares. The data entitlement was valid in Go-side validation
+	// before the schema listed it; this guard keeps the two surfaces from
+	// drifting again.
+	consts := schemaEntitlementConsts(t)
+	for _, e := range cfg.Entitlements {
+		if !consts[e.Type] {
+			t.Errorf("wendy.schema.json has no entitlement entry for type %q used by the example", e.Type)
+		}
+	}
+}
+
+// schemaEntitlementConsts walks $defs.entitlement.oneOf in the embedded
+// wendy.schema.json and returns the set of entitlement type consts it
+// declares.
+func schemaEntitlementConsts(t *testing.T) map[string]bool {
+	t.Helper()
+	var schema struct {
+		Defs struct {
+			Entitlement struct {
+				OneOf []struct {
+					Properties struct {
+						Type struct {
+							Const string `json:"const"`
+						} `json:"type"`
+					} `json:"properties"`
+				} `json:"oneOf"`
+			} `json:"entitlement"`
+		} `json:"$defs"`
+	}
+	if err := json.Unmarshal([]byte(SchemaJSON), &schema); err != nil {
+		t.Fatalf("wendy.schema.json is not valid JSON: %v", err)
+	}
+	consts := map[string]bool{}
+	for _, variant := range schema.Defs.Entitlement.OneOf {
+		if variant.Properties.Type.Const != "" {
+			consts[variant.Properties.Type.Const] = true
+		}
+	}
+	if len(consts) == 0 {
+		t.Fatal("wendy.schema.json declares no entitlement type consts")
+	}
+	return consts
+}

--- a/go/internal/shared/appconfig/wendy_data_model_app_test.go
+++ b/go/internal/shared/appconfig/wendy_data_model_app_test.go
@@ -54,6 +54,18 @@ func TestWendyDataModelAppExampleValidates(t *testing.T) {
 			t.Errorf("wendy.schema.json has no entitlement entry for type %q used by the example", e.Type)
 		}
 	}
+
+	// Beyond the example's own entitlements, the schema must enumerate every
+	// entitlement type the Go validator accepts. ValidEntitlementTypes is the
+	// source of truth; a type missing from the schema makes an editor
+	// validating against wendy.schema.json falsely reject a manifest the agent
+	// would happily run. Walking the full list here catches the whole class of
+	// Go/schema drift (this is how the data and mcp gaps went unnoticed).
+	for _, typ := range ValidEntitlementTypes {
+		if !consts[typ] {
+			t.Errorf("wendy.schema.json has no entitlement entry for supported type %q (Go/schema drift)", typ)
+		}
+	}
 }
 
 // schemaEntitlementConsts walks $defs.entitlement.oneOf in the embedded


### PR DESCRIPTION
## Problem

The Wendy Data platform defines three contracts an on-device model app must speak — sensors in through entitlements, predictions out through the data socket, actuation out through ROS 2 — but nothing in the repository demonstrates them together. Anyone building a model app (or preparing the Wendy Arm demo) has to reverse-engineer the record protocol from go/internal/agent/services/app_data_socket.go and the campaign schema from go/internal/agent/data/campaign.go, and nothing catches an example drifting when those schemas change.

Separately, wendy.schema.json never gained an entry for the data entitlement, so a wendy.json declaring `{"type": "data"}` failed editor-side JSON Schema validation even though Go-side validation and the entitlements guide accept it.

## Cause

Deliverable D5 (the reference model app) had not been built yet, and the JSON schema was not updated when the data entitlement landed.

## Solution

`Examples/WendyDataModelApp/` — one app plus campaign, so a Wendy Arm demo needs only `wendy run` and `wendy data campaign deploy campaign.yaml`:

- **app.py**: webcam frames via OpenCV/V4L2 (camera entitlement), YOLOv8n through onnxruntime on the CPU by default, one prediction record per processed frame (at most 5 per second by frame sampling), an edge-triggered `person_detected` event, and a demo proportional controller published as a ROS 2 Twist when `WENDY_MODEL_APP_ROS2=1` and rclpy exist, logged otherwise — a plain Jetson demo needs no ROS stack.
- **wendydata.py**: standard-library-only data socket client — 4-byte big-endian length prefix + JSON, CLOCK_BOOTTIME + boot id stamping, reconnect-and-retry, honoring the buffered/recorded/rejected acknowledgements. Uncertainty formula: `1 - max(detection confidence >= threshold)`, 1.0 when nothing clears the threshold, clamped to 0..1.
- **Dockerfile**: multi-stage; the export stage pins Ultralytics 8.3.63 and exports yolov8n.onnx at opset 12, the runtime stage carries only onnxruntime + OpenCV + NumPy. The Jetson GPU wheel path and the ROS 2 base-image variant are documented in the README. (A Dockerfile rather than a Stagefile because the DSL has no instruction for the export step; ClaudeOnDevice and HelloAudio set the precedent.)
- **campaign.yaml**: version 1, camera snapshot every 30s, triggers on `event: person_detected` and `model.uncertainty > 0.65`, upload always, 5GiB local quota, model version pinned in `models:`.
- **Smoke tests**: `appconfig.TestWendyDataModelAppExampleValidates` loads and validates the example wendy.json, requires zero ValidateJSON warnings, and walks the published schema's entitlement consts so example and schema cannot drift; `data.TestShippedModelAppCampaignParses` runs the example campaign through the real `ParseCampaign` and asserts both triggers fire on the exact record shapes the app emits. Python unit tests (11) cover framing and the uncertainty formula.
- **Schema fix** (own commit): add the missing data entitlement entry to wendy.schema.json.

## Testing

- `go test ./go/internal/agent/data/ ./go/internal/agent/services/ ./go/internal/shared/appconfig/` — pass
- `go build ./...` — green
- `python3 -m unittest discover Examples/WendyDataModelApp` — 11 tests pass
- Socket client exercised against a scripted fake agent (ack protocol, mid-stream disconnect + reconnect, rejection surfacing) — pass
- Not covered here (hardware-only): a live camera run, a real `wendy run` deploy, and episode capture on a device