### PR TITLE
feat(data): socket hardening, threshold audio capture, error-code hygiene

### DIFF
--- a/Examples/WendyDataCampaign/campaign.yaml
+++ b/Examples/WendyDataCampaign/campaign.yaml
@@ -17,13 +17,15 @@ sources:
       max_resolution: 1280x720
   - ros2: /lidar/points
   - ros2: /vehicle/odometry
-  # An audio source kind does not exist yet. Once it does, a threshold
-  # capture policy will look like this:
-  # - audio: cabin-mic
-  #   capture:
-  #     mode: threshold
-  #     trigger: "level_db > -20"
-  #     fragment: 30s
+  # An audio source with a level-threshold capture policy: when the cabin
+  # microphone's peak level crosses -20 dBFS, the agent seals a 30-second WAV
+  # fragment. level_db is a negative-valued field, so the comparison is against
+  # a negative threshold.
+  - audio: cabin-mic
+    capture:
+      mode: threshold
+      trigger: "level_db > -20"
+      fragment: 30s
 
 capture:
   buffer: 10s

--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -294,6 +294,7 @@ func main() {
 	})
 	dataManager.SetWarnLogger(func(msg string) { logger.Warn(msg) })
 	dataSvc := services.NewDataService(dataManager)
+	dataSvc.SetAudioService(audioSvc)
 	// ROS 2 inspection requires the containerd-backed sidecar runtime; the
 	// service is only registered when containerd connected (WDY-1332).
 	var ros2Svc *services.ROS2Service

--- a/go/internal/agent/data/campaign.go
+++ b/go/internal/agent/data/campaign.go
@@ -97,6 +97,7 @@ func (sc *SourceCapture) MaxResolutionPixels() (uint32, uint32, bool) {
 
 type CampaignSource struct {
 	Camera      string         `json:"camera,omitempty" yaml:"camera,omitempty"`
+	Audio       string         `json:"audio,omitempty" yaml:"audio,omitempty"`
 	ROS2        string         `json:"ros2,omitempty" yaml:"ros2,omitempty"`
 	Telemetry   bool           `json:"telemetry,omitempty" yaml:"telemetry,omitempty"`
 	Calibration string         `json:"calibration_revision,omitempty" yaml:"calibration_revision,omitempty"`
@@ -107,6 +108,8 @@ func (s CampaignSource) describe() string {
 	switch {
 	case s.Camera != "":
 		return "camera:" + s.Camera
+	case s.Audio != "":
+		return "audio:" + s.Audio
 	case s.ROS2 != "":
 		return "ros2:" + s.ROS2
 	case s.Telemetry:
@@ -119,6 +122,8 @@ func (s CampaignSource) kind() string {
 	switch {
 	case s.Camera != "":
 		return "camera"
+	case s.Audio != "":
+		return "audio"
 	case s.ROS2 != "":
 		return "ros2"
 	case s.Telemetry:
@@ -241,6 +246,9 @@ func (c Campaign) validate() error {
 		if strings.TrimSpace(source.Camera) != "" {
 			kinds++
 		}
+		if strings.TrimSpace(source.Audio) != "" {
+			kinds++
+		}
 		if strings.TrimSpace(source.ROS2) != "" {
 			kinds++
 		}
@@ -248,7 +256,7 @@ func (c Campaign) validate() error {
 			kinds++
 		}
 		if kinds != 1 {
-			return fmt.Errorf("sources[%d] must select exactly one of camera, ros2, or telemetry", i)
+			return fmt.Errorf("sources[%d] must select exactly one of camera, audio, ros2, or telemetry", i)
 		}
 		if err := validateSourceCapture(source); err != nil {
 			return fmt.Errorf("sources[%d].capture: %w", i, err)
@@ -321,7 +329,7 @@ func (m *Manager) DeployCampaign(contents []byte) (Campaign, error) {
 	campaign.DeployedUnixNanos = time.Now().UnixNano()
 	if campaign.BufferDuration() > 0 {
 		for _, source := range campaign.Sources {
-			if source.Camera != "" || source.ROS2 != "" {
+			if source.Camera != "" || source.Audio != "" || source.ROS2 != "" {
 				campaign.Warnings = append(campaign.Warnings, "pre-trigger buffering is currently exact for application records; sensor streams start at the trigger and report their achieved offset")
 				break
 			}
@@ -430,6 +438,15 @@ func (m *Manager) ResolveCampaignSources(campaign Campaign) ([]string, []string,
 			if requested.Capture != nil {
 				captures[id] = requested.Capture
 			}
+		case requested.Audio != "":
+			id, err := resolveKindSelector(all, "audio", requested.Audio)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			selected[id] = true
+			if requested.Capture != nil {
+				captures[id] = requested.Capture
+			}
 		}
 	}
 	ids := make([]string, 0, len(selected))
@@ -475,6 +492,41 @@ func resolveCameraSelector(all []Source, selector string) (string, error) {
 		return healthy[0].ID, nil
 	}
 	return "", fmt.Errorf("no healthy camera matches %q", selector)
+}
+
+// resolveKindSelector maps a campaign selector onto a healthy source of the
+// given kind by exact ID, then by a case-insensitive substring of the source
+// detail, and finally accepts "default" when exactly one healthy source of the
+// kind exists. It mirrors resolveCameraSelector for non-camera kinds such as
+// audio, which have no /dev alias.
+func resolveKindSelector(all []Source, kind, selector string) (string, error) {
+	selector = strings.TrimSpace(selector)
+	var healthy []Source
+	for _, source := range all {
+		if source.Kind != kind || !source.Healthy {
+			continue
+		}
+		healthy = append(healthy, source)
+		if source.ID == selector || strings.EqualFold(source.ID, selector) {
+			return source.ID, nil
+		}
+	}
+	var matches []string
+	for _, source := range healthy {
+		if selector != "" && strings.Contains(strings.ToLower(source.Detail), strings.ToLower(selector)) {
+			matches = append(matches, source.ID)
+		}
+	}
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+	if len(matches) > 1 {
+		return "", fmt.Errorf("%s selector %q is ambiguous: %s", kind, selector, strings.Join(matches, ", "))
+	}
+	if len(healthy) == 1 && (selector == "default" || selector == "front") {
+		return healthy[0].ID, nil
+	}
+	return "", fmt.Errorf("no healthy %s matches %q", kind, selector)
 }
 
 func (c Campaign) Match(record ApplicationRecord) (string, string, bool) {
@@ -549,6 +601,18 @@ func parseThreshold(field, expression string) (string, float64, error) {
 	return "", 0, fmt.Errorf("%s must begin with <, <=, ==, >=, or >", field)
 }
 
+// ParseFieldThreshold exposes the campaign threshold grammar to capture
+// adapters in other packages, for example the audio adapter's "level_db"
+// trigger. It returns the field name, comparison operator, and numeric value.
+func ParseFieldThreshold(expression string) (string, string, float64, error) {
+	return parseFieldThreshold(expression)
+}
+
+// CompareThreshold applies a parsed threshold operator to a measured value.
+func CompareThreshold(value float64, operator string, threshold float64) bool {
+	return compareThreshold(value, operator, threshold)
+}
+
 // parseFieldThreshold parses a "<field> <operator> <number>" expression such
 // as "model.uncertainty > 0.9" or "level_db > -20".
 func parseFieldThreshold(expression string) (string, string, float64, error) {
@@ -576,11 +640,13 @@ func parseFieldThreshold(expression string) (string, string, float64, error) {
 var validCaptureModes = []string{"continuous", "snapshot", "fragment", "threshold"}
 
 // implementedCaptureModes is what capture adapters actually honor today, by
-// campaign source kind. The camera adapter implements snapshot capture; the
-// ROS 2 and telemetry paths still record continuously regardless of mode, so
-// snapshot deploy-warns for them.
+// campaign source kind. The camera adapter implements snapshot capture and the
+// audio adapter implements threshold capture; the ROS 2 and telemetry paths
+// still record continuously regardless of mode, so other modes deploy-warn for
+// them.
 var implementedCaptureModes = map[string]map[string]bool{
 	"camera":    {"continuous": true, "snapshot": true},
+	"audio":     {"continuous": true, "threshold": true},
 	"ros2":      {"continuous": true},
 	"telemetry": {"continuous": true},
 }

--- a/go/internal/agent/data/campaign.go
+++ b/go/internal/agent/data/campaign.go
@@ -21,6 +21,10 @@ import (
 
 const CampaignVersion = 1
 
+// ErrInvalidCampaignName marks a syntactically invalid campaign name so RPC
+// handlers can return InvalidArgument rather than NotFound.
+var ErrInvalidCampaignName = errors.New("invalid campaign name")
+
 // SourceCapture is an optional per-source capture policy. The camera adapter
 // implements the "continuous" (default) and "snapshot" modes; other
 // combinations are validated so authored plans are portable, and deployment
@@ -356,7 +360,7 @@ func (m *Manager) DeployCampaign(contents []byte) (Campaign, error) {
 
 func (m *Manager) Campaign(name string) (Campaign, error) {
 	if name == "" || safeName(name) != name {
-		return Campaign{}, errors.New("invalid campaign name")
+		return Campaign{}, ErrInvalidCampaignName
 	}
 	var campaign Campaign
 	b, err := os.ReadFile(filepath.Join(m.campaignDir(), name+".json"))

--- a/go/internal/agent/data/campaign_audio_test.go
+++ b/go/internal/agent/data/campaign_audio_test.go
@@ -1,0 +1,89 @@
+package data
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+const audioThresholdCampaign = `version: 1
+name: cabin-audio
+sources:
+  - audio: cabin-mic
+    capture:
+      mode: threshold
+      trigger: "level_db > -20"
+      fragment: 30s
+capture:
+  buffer: 0s
+  after_trigger: 20s
+  triggers:
+    - event: loud_event
+upload:
+  when: wifi
+export:
+  annotation: cvat
+`
+
+// TestAudioThresholdCampaignParsesAndDeploysWithoutModeWarning proves the audio
+// source kind and threshold capture mode are first-class: the plan parses and
+// deployment does not warn that the mode is unimplemented for that source.
+func TestAudioThresholdCampaignParsesAndDeploysWithoutModeWarning(t *testing.T) {
+	campaign, err := ParseCampaign([]byte(audioThresholdCampaign))
+	if err != nil {
+		t.Fatalf("audio threshold campaign did not parse: %v", err)
+	}
+	if len(campaign.Sources) != 1 || campaign.Sources[0].Audio != "cabin-mic" {
+		t.Fatalf("expected one audio source, got %+v", campaign.Sources)
+	}
+	if campaign.Sources[0].kind() != "audio" {
+		t.Fatalf("source kind = %q, want audio", campaign.Sources[0].kind())
+	}
+	if campaign.Sources[0].Capture.EffectiveMode() != "threshold" {
+		t.Fatalf("capture mode = %q, want threshold", campaign.Sources[0].Capture.EffectiveMode())
+	}
+
+	manager, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	deployed, err := manager.DeployCampaign([]byte(audioThresholdCampaign))
+	if err != nil {
+		t.Fatalf("deploy: %v", err)
+	}
+	for _, w := range deployed.Warnings {
+		if strings.Contains(w, "not implemented yet for their source kind") {
+			t.Fatalf("audio threshold should be implemented, but deploy warned: %q", w)
+		}
+	}
+}
+
+// TestShippedAudioCampaignParses guards the real
+// Examples/WendyDataCampaign/campaign.yaml, which now enables an audio
+// threshold source, against the schema this agent parses.
+func TestShippedAudioCampaignParses(t *testing.T) {
+	raw, err := os.ReadFile("../../../../Examples/WendyDataCampaign/campaign.yaml")
+	if err != nil {
+		t.Fatalf("reading campaign example: %v", err)
+	}
+	campaign, err := ParseCampaign(raw)
+	if err != nil {
+		t.Fatalf("WendyDataCampaign/campaign.yaml does not parse: %v", err)
+	}
+	var audio *CampaignSource
+	for i := range campaign.Sources {
+		if campaign.Sources[i].Audio != "" {
+			audio = &campaign.Sources[i]
+			break
+		}
+	}
+	if audio == nil {
+		t.Fatal("expected an enabled audio source in the shipped campaign")
+	}
+	if audio.Capture == nil || audio.Capture.EffectiveMode() != "threshold" {
+		t.Fatalf("audio source is not in threshold mode: %+v", audio.Capture)
+	}
+	if _, _, _, err := ParseFieldThreshold(audio.Capture.Trigger); err != nil {
+		t.Fatalf("audio trigger %q does not parse: %v", audio.Capture.Trigger, err)
+	}
+}

--- a/go/internal/agent/data/manager.go
+++ b/go/internal/agent/data/manager.go
@@ -1135,6 +1135,8 @@ func payloadFormat(path string) (string, string) {
 		return "h265", "video/h265"
 	case ".mp4":
 		return "mp4", "video/mp4"
+	case ".wav":
+		return "wav", "audio/wav"
 	case ".jpg", ".jpeg":
 		return "jpeg", "image/jpeg"
 	case ".png":
@@ -1158,7 +1160,7 @@ func sourceForPath(path string) string {
 		return "telemetry"
 	}
 	parts := strings.Split(path, "/")
-	if len(parts) >= 2 && (parts[0] == "cameras" || parts[0] == "ros2") {
+	if len(parts) >= 2 && (parts[0] == "cameras" || parts[0] == "ros2" || parts[0] == "audio") {
 		return parts[1]
 	}
 	return ""
@@ -1171,6 +1173,7 @@ func associateFileSources(files []File, sources []SourceStats) {
 		}
 		path := strings.TrimPrefix(files[i].Path, "cameras/")
 		path = strings.TrimPrefix(path, "ros2/")
+		path = strings.TrimPrefix(path, "audio/")
 		for _, stats := range sources {
 			encoded := safeName(stats.Source.ID)
 			if path == encoded || path == encoded+".calibration" || strings.HasPrefix(path, encoded+"/") || strings.HasPrefix(path, encoded+"-") {

--- a/go/internal/agent/data/manager.go
+++ b/go/internal/agent/data/manager.go
@@ -31,6 +31,26 @@ const (
 
 var ErrNoActiveEpisode = errors.New("no active episode")
 
+// The following sentinels classify request-shaped failures so RPC handlers can
+// map them to precise gRPC codes (InvalidArgument for a malformed request,
+// FailedPrecondition for a request that is well formed but not currently
+// serviceable) instead of collapsing every failure to NotFound. Genuine
+// absence still surfaces as os.ErrNotExist and read/seal failures surface as
+// their underlying I/O error.
+var (
+	// ErrInvalidEpisodeID marks a syntactically invalid episode identifier.
+	ErrInvalidEpisodeID = errors.New("invalid episode id")
+	// ErrInvalidDownloadOffset marks an out-of-range download offset.
+	ErrInvalidDownloadOffset = errors.New("invalid download offset")
+	// ErrInvalidEpisodePath marks a malformed episode-relative file path.
+	ErrInvalidEpisodePath = errors.New("invalid episode file path")
+	// ErrEpisodePathEscapes marks a path that resolves outside the episode root.
+	ErrEpisodePathEscapes = errors.New("episode path escapes root")
+	// ErrEpisodeEntryNotRegular marks a manifest entry that is not a regular
+	// file on disk; the episode exists but the entry cannot be served.
+	ErrEpisodeEntryNotRegular = errors.New("episode entry is not a regular file")
+)
+
 // AdHocEpisodeKey is the reserved concurrency key for episodes started
 // without a campaign (for example `wendy data record`). Each campaign may run
 // one active episode at a time, and one ad-hoc episode may run beside them.
@@ -916,7 +936,7 @@ func (m *Manager) OpenFile(id, rel string, offset int64) (*os.File, File, error)
 		return nil, File{}, os.ErrNotExist
 	}
 	if offset < 0 || offset > want.Size {
-		return nil, File{}, errors.New("invalid download offset")
+		return nil, File{}, ErrInvalidDownloadOffset
 	}
 	p, err := safeJoin(dir, rel)
 	if err != nil {
@@ -938,7 +958,7 @@ func (m *Manager) OpenFile(id, rel string, offset int64) (*os.File, File, error)
 
 func (m *Manager) episodeDir(id string) (string, error) {
 	if id == "" || safeName(id) != id {
-		return "", errors.New("invalid episode id")
+		return "", ErrInvalidEpisodeID
 	}
 	p := filepath.Join(m.root, id)
 	if st, err := os.Stat(p); err != nil || !st.IsDir() {
@@ -1036,11 +1056,11 @@ func safeName(s string) string {
 
 func safeJoin(root, rel string) (string, error) {
 	if rel == "" || filepath.IsAbs(rel) || filepath.Clean(rel) != rel || strings.HasPrefix(rel, "..") {
-		return "", errors.New("invalid episode file path")
+		return "", ErrInvalidEpisodePath
 	}
 	p := filepath.Join(root, rel)
 	if !strings.HasPrefix(p, root+string(os.PathSeparator)) {
-		return "", errors.New("episode path escapes root")
+		return "", ErrEpisodePathEscapes
 	}
 	return p, nil
 }
@@ -1051,7 +1071,7 @@ func requireRegularFile(path string) error {
 		return err
 	}
 	if !info.Mode().IsRegular() {
-		return errors.New("episode entry is not a regular file")
+		return ErrEpisodeEntryNotRegular
 	}
 	return nil
 }

--- a/go/internal/agent/services/app_data_socket.go
+++ b/go/internal/agent/services/app_data_socket.go
@@ -199,16 +199,31 @@ func (m *AppDataSocketManager) serve(s *appDataSocket) {
 // to a different app is refused: it cannot write records attributed to an app
 // it is not.
 //
-// Residual gaps (fail open, never fail closed):
+// Fail-open is confined to the case where SO_PEERCRED itself yields no peer:
+// not a unix socket, an unsupported platform, or the seam being disabled. In
+// those cases the group-2000 gate and the 0750 app-private socket directory
+// remain the baseline.
+//
+// Once a peer pid IS known, verification fails CLOSED: any inability to
+// positively attribute that pid to this app (its /proc cgroup is unreadable,
+// carries no wendy app scope, or names a different app) is a refusal. This is
+// deliberate. The SO_PEERCRED pid is captured by the kernel at connect, but the
+// cgroup is read from /proc by that pid afterwards, so a peer that exits between
+// accept and the read (or whose pid is recycled onto a non-app process) would,
+// under a fail-open policy, have records it buffered before exiting attributed
+// to this app. Refusing an unattributable-but-credentialed peer closes that
+// forgery path; no legitimate caller connects to an app data socket except that
+// app's own containers, whose cgroup always resolves.
+//
+// Residual gaps:
 //   - Granularity is per app, not per service: an app's services legitimately
 //     share one socket, so the service suffix is stripped before comparison.
 //   - The peer UID is read but not used as the discriminator, because app
 //     containers run as UID 0 by default; the cgroup is the identity.
-//   - If the peer is not a wendy-managed container (a host process, the agent
-//     itself, a test harness) its cgroup carries no app scope, so it is not
-//     attributable to an app and the group-2000 gate plus the 0750 app-private
-//     socket directory remain the baseline. The same fail-open applies when
-//     SO_PEERCRED is unavailable (non-Linux) or /proc cannot be read.
+//   - A pid recycled within the accept-to-read window onto a process in the
+//     SAME app's scope still verifies. Closing that last window requires a
+//     kernel primitive that pins the peer identity across the read
+//     (SO_PEERPIDFD, Linux 6.5+); it is left as a follow-up.
 func (m *AppDataSocketManager) verifyPeer(appID string, c net.Conn) error {
 	if m.peerCred == nil {
 		return nil
@@ -222,14 +237,15 @@ func (m *AppDataSocketManager) verifyPeer(appID string, c net.Conn) error {
 	if m.cgroupOfPID == nil {
 		return nil
 	}
+	// From here the peer is a real local process with a kernel-attested pid.
+	// Anything short of a positive match to this app is a refusal (fail closed).
 	cgroup, err := m.cgroupOfPID(creds.PID)
 	if err != nil || cgroup == "" {
-		return nil
+		return fmt.Errorf("peer (pid %d, uid %d) cgroup is unreadable; cannot attribute to app %q", creds.PID, creds.UID, appID)
 	}
 	peerApp, ok := appIDFromCgroup(cgroup)
 	if !ok {
-		// Not a wendy-managed app container; not attributable to any app.
-		return nil
+		return fmt.Errorf("peer (pid %d, uid %d) is not in a wendy app scope; cannot attribute to app %q", creds.PID, creds.UID, appID)
 	}
 	if peerApp != appID {
 		return fmt.Errorf("peer (pid %d, uid %d) belongs to app %q, not %q", creds.PID, creds.UID, peerApp, appID)

--- a/go/internal/agent/services/app_data_socket.go
+++ b/go/internal/agent/services/app_data_socket.go
@@ -13,12 +13,14 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/wendylabsinc/wendy/go/internal/agent/data"
 	"github.com/wendylabsinc/wendy/go/internal/agent/localsocket"
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	sharedenv "github.com/wendylabsinc/wendy/go/internal/shared/env"
 	"go.uber.org/zap"
 )
 
@@ -26,7 +28,17 @@ const (
 	DataSocketFilename    = "data.sock"
 	dataProtocolMaxRecord = 64 << 10
 	dataSocketGroupGID    = 2000
+	// dataRatePerSecond bounds records accepted per app across all of the
+	// app's connections combined (see appDataSocket.limiter).
+	dataRatePerSecond = 200
 )
+
+// peerCredentials identifies the process on the far end of a data-socket
+// connection, read from SO_PEERCRED at accept time.
+type peerCredentials struct {
+	UID uint32
+	PID int32
+}
 
 var AppDataSocketRootPath = "/var/lib/wendy/app-data"
 
@@ -34,6 +46,9 @@ type appDataSocket struct {
 	appID    string
 	listener net.Listener
 	owners   map[string]struct{}
+	// limiter is shared by every connection the app opens, so the rate limit
+	// is enforced per app rather than per connection.
+	limiter *notificationRateLimiter
 }
 type AppDataSocketManager struct {
 	ctx     context.Context
@@ -41,10 +56,30 @@ type AppDataSocketManager struct {
 	capture *data.Manager
 	mu      sync.Mutex
 	sockets map[string]*appDataSocket
+	// newLimiter builds the per-app record rate limiter. It is a field so
+	// tests can install a deterministic bucket; production uses a 200 rec/s
+	// token bucket.
+	newLimiter func() *notificationRateLimiter
+	// peerCred and cgroupOfPID are seams over the SO_PEERCRED lookup and the
+	// /proc cgroup read so peer-credential verification is testable without
+	// real unix-socket credentials or a live cgroup hierarchy.
+	peerCred    func(net.Conn) (peerCredentials, error)
+	cgroupOfPID func(pid int32) (string, error)
 }
 
 func NewAppDataSocketManager(ctx context.Context, logger *zap.Logger, capture *data.Manager) *AppDataSocketManager {
-	m := &AppDataSocketManager{ctx: ctx, logger: logger, capture: capture, sockets: map[string]*appDataSocket{}}
+	m := &AppDataSocketManager{
+		ctx:     ctx,
+		logger:  logger,
+		capture: capture,
+		sockets: map[string]*appDataSocket{},
+		newLimiter: func() *notificationRateLimiter {
+			l := newNotificationRateLimiter(dataRatePerSecond, time.Second/dataRatePerSecond)
+			return &l
+		},
+		peerCred:    readPeerCredentials,
+		cgroupOfPID: readProcCgroup,
+	}
 	go func() { <-ctx.Done(); m.stopAll() }()
 	return m
 }
@@ -92,7 +127,7 @@ func (m *AppDataSocketManager) Ensure(appID, service string) (string, error) {
 			return "", err
 		}
 	}
-	s := &appDataSocket{appID: appID, listener: l, owners: map[string]struct{}{owner: {}}}
+	s := &appDataSocket{appID: appID, listener: l, owners: map[string]struct{}{owner: {}}, limiter: m.newLimiter()}
 	m.sockets[key] = s
 	go m.serve(s)
 	return dir, nil
@@ -150,8 +185,82 @@ func (m *AppDataSocketManager) serve(s *appDataSocket) {
 			}
 			return
 		}
-		go m.serveConn(s.appID, c)
+		go m.serveConn(s, c)
 	}
+}
+
+// verifyPeer binds a connection to the app the socket belongs to using the
+// peer's kernel-reported credentials.
+//
+// Identity achieved: the accepted connection's peer PID is read via
+// SO_PEERCRED, and that PID's cgroup is compared against the app the socket was
+// created for. Every app container runs in a systemd scope named by client.go
+// as "<systemd-service>-<appID>[@<service>].scope", so a process that belongs
+// to a different app is refused: it cannot write records attributed to an app
+// it is not.
+//
+// Residual gaps (fail open, never fail closed):
+//   - Granularity is per app, not per service: an app's services legitimately
+//     share one socket, so the service suffix is stripped before comparison.
+//   - The peer UID is read but not used as the discriminator, because app
+//     containers run as UID 0 by default; the cgroup is the identity.
+//   - If the peer is not a wendy-managed container (a host process, the agent
+//     itself, a test harness) its cgroup carries no app scope, so it is not
+//     attributable to an app and the group-2000 gate plus the 0750 app-private
+//     socket directory remain the baseline. The same fail-open applies when
+//     SO_PEERCRED is unavailable (non-Linux) or /proc cannot be read.
+func (m *AppDataSocketManager) verifyPeer(appID string, c net.Conn) error {
+	if m.peerCred == nil {
+		return nil
+	}
+	creds, err := m.peerCred(c)
+	if err != nil {
+		// Peer credentials are unavailable (not a unix socket, or an
+		// unsupported platform). Fall back to the group/directory gate.
+		return nil
+	}
+	if m.cgroupOfPID == nil {
+		return nil
+	}
+	cgroup, err := m.cgroupOfPID(creds.PID)
+	if err != nil || cgroup == "" {
+		return nil
+	}
+	peerApp, ok := appIDFromCgroup(cgroup)
+	if !ok {
+		// Not a wendy-managed app container; not attributable to any app.
+		return nil
+	}
+	if peerApp != appID {
+		return fmt.Errorf("peer (pid %d, uid %d) belongs to app %q, not %q", creds.PID, creds.UID, peerApp, appID)
+	}
+	return nil
+}
+
+// appIDFromCgroup extracts the wendy app identity from a /proc/<pid>/cgroup
+// body. Container scopes are named "<systemd-service>-<appID>[@<service>].scope"
+// (see client.go's CgroupsPath assignment). The service suffix is stripped so
+// the result is the app identity the socket is keyed by. It returns false when
+// no such scope component is present, which is the signal that the peer is not
+// a wendy-managed app container.
+func appIDFromCgroup(cgroup string) (string, bool) {
+	prefix := sharedenv.SystemdServiceName() + "-"
+	for _, line := range strings.Split(cgroup, "\n") {
+		for _, segment := range strings.Split(line, "/") {
+			segment = strings.TrimSuffix(segment, ".scope")
+			if !strings.HasPrefix(segment, prefix) {
+				continue
+			}
+			id := strings.TrimPrefix(segment, prefix)
+			if at := strings.IndexByte(id, '@'); at >= 0 {
+				id = id[:at]
+			}
+			if id != "" {
+				return id, true
+			}
+		}
+	}
+	return "", false
 }
 
 type dataAck struct {
@@ -160,18 +269,21 @@ type dataAck struct {
 	Error   string `json:"error,omitempty"`
 }
 
-func (m *AppDataSocketManager) serveConn(appID string, c net.Conn) {
+func (m *AppDataSocketManager) serveConn(s *appDataSocket, c net.Conn) {
 	defer c.Close()
-	r := bufio.NewReader(c)
-	window := time.Now()
-	count := 0
-	for {
-		if time.Since(window) >= time.Second {
-			window = time.Now()
-			count = 0
+	appID := s.appID
+	if err := m.verifyPeer(appID, c); err != nil {
+		if m.logger != nil {
+			m.logger.Warn("app data socket refused connection with mismatched peer", zap.String("app_id", appID), zap.Error(err))
 		}
-		count++
-		if count > 200 {
+		_ = writeDataFrame(c, dataAck{Version: 1, State: "rejected", Error: "peer credentials do not match this app"})
+		return
+	}
+	r := bufio.NewReader(c)
+	for {
+		// The token bucket lives on the socket, so every connection the app
+		// opens draws from one per-app budget.
+		if !s.limiter.allow(time.Now()) {
 			_ = writeDataFrame(c, dataAck{Version: 1, State: "rejected", Error: "rate limit exceeded"})
 			return
 		}
@@ -228,18 +340,37 @@ func writeDataFrame(w io.Writer, v any) error {
 	_, err = w.Write(b)
 	return err
 }
+// recordKindValidator checks the kind-specific required fields of a record.
+type recordKindValidator func(data.ApplicationRecord) error
+
+// applicationRecordKinds is the registry of accepted record kinds. Adding a
+// new kind is a one-line addition here; an unknown kind is rejected with a
+// clean ack rather than killing the connection.
+var applicationRecordKinds = map[string]recordKindValidator{
+	"event": func(r data.ApplicationRecord) error {
+		if r.Name == "" {
+			return errors.New("event name is required")
+		}
+		return nil
+	},
+	"prediction": func(r data.ApplicationRecord) error {
+		if r.Model == "" {
+			return errors.New("prediction model is required")
+		}
+		return nil
+	},
+}
+
 func validateApplicationRecord(r data.ApplicationRecord) error {
 	if r.Version != 1 {
 		return fmt.Errorf("unsupported protocol version %d", r.Version)
 	}
-	if r.Type != "event" && r.Type != "prediction" {
-		return errors.New("type must be event or prediction")
+	validate, ok := applicationRecordKinds[r.Type]
+	if !ok {
+		return fmt.Errorf("unknown record kind %q", r.Type)
 	}
-	if r.Type == "event" && r.Name == "" {
-		return errors.New("event name is required")
-	}
-	if r.Type == "prediction" && r.Model == "" {
-		return errors.New("prediction model is required")
+	if err := validate(r); err != nil {
+		return err
 	}
 	if len(r.Attributes) > 128 {
 		return errors.New("too many attributes")

--- a/go/internal/agent/services/app_data_socket_hardening_test.go
+++ b/go/internal/agent/services/app_data_socket_hardening_test.go
@@ -182,6 +182,75 @@ func TestAppDataPeerCredentialMatchAllowed(t *testing.T) {
 	}
 }
 
+// readRejectAck reads a single ack frame off conn and fails unless it is a
+// rejection. Used by the fail-closed peer-credential tests below.
+func readRejectAck(t *testing.T, conn net.Conn) dataAck {
+	t.Helper()
+	ackBody, err := readDataFrame(conn)
+	if err != nil {
+		t.Fatalf("expected a rejection ack, got read error: %v", err)
+	}
+	var ack dataAck
+	if err := json.Unmarshal(ackBody, &ack); err != nil {
+		t.Fatal(err)
+	}
+	return ack
+}
+
+// TestAppDataPeerCredentialUnreadableCgroupRefused proves the accept-to-/proc
+// TOCTOU is closed. Once SO_PEERCRED yields a pid, a cgroup that cannot be read
+// (the peer exited between accept and the /proc read, or its pid was recycled)
+// must be REFUSED, not admitted. Fail-open here would let a peer that buffered
+// forged records and then exited have those records attributed to this app.
+func TestAppDataPeerCredentialUnreadableCgroupRefused(t *testing.T) {
+	m := newTestDataSocketManager(t)
+	m.peerCred = func(net.Conn) (peerCredentials, error) {
+		return peerCredentials{UID: 0, PID: 4242}, nil
+	}
+	m.cgroupOfPID = func(int32) (string, error) {
+		// The peer has exited by the time verifyPeer reads /proc/<pid>/cgroup.
+		return "", os.ErrNotExist
+	}
+	dir, err := m.Ensure("com.example.a", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := net.Dial("unix", filepath.Join(dir, DataSocketFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if ack := readRejectAck(t, conn); ack.State != "rejected" {
+		t.Fatalf("unreadable peer cgroup: state = %q, want rejected (fail closed)", ack.State)
+	}
+}
+
+// TestAppDataPeerCredentialNoScopeRefused proves a peer that resolves to no
+// wendy app scope (a host process, or a recycled pid now held by one) is
+// refused once its credentials are known, rather than admitted under the
+// socket's app identity.
+func TestAppDataPeerCredentialNoScopeRefused(t *testing.T) {
+	m := newTestDataSocketManager(t)
+	m.peerCred = func(net.Conn) (peerCredentials, error) {
+		return peerCredentials{UID: 0, PID: 4242}, nil
+	}
+	m.cgroupOfPID = func(int32) (string, error) {
+		return "0::/user.slice/user-1000.slice/session-3.scope\n", nil
+	}
+	dir, err := m.Ensure("com.example.a", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := net.Dial("unix", filepath.Join(dir, DataSocketFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if ack := readRejectAck(t, conn); ack.State != "rejected" {
+		t.Fatalf("no-scope peer: state = %q, want rejected (fail closed)", ack.State)
+	}
+}
+
 // TestAppIDFromCgroup covers the cgroup identity extraction directly.
 func TestAppIDFromCgroup(t *testing.T) {
 	cases := []struct {

--- a/go/internal/agent/services/app_data_socket_hardening_test.go
+++ b/go/internal/agent/services/app_data_socket_hardening_test.go
@@ -1,0 +1,206 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/data"
+)
+
+// newTestDataSocketManager returns a manager rooted at a throwaway socket
+// directory, with peer-credential verification neutralized (fail open) so the
+// rate-limit and record-kind tests exercise only the behavior they target.
+func newTestDataSocketManager(t *testing.T) *AppDataSocketManager {
+	t.Helper()
+	capture, err := data.NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	socketRoot, err := os.MkdirTemp("/tmp", "wendy-data-hardening-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(socketRoot) })
+	oldRoot := AppDataSocketRootPath
+	AppDataSocketRootPath = socketRoot
+	t.Cleanup(func() { AppDataSocketRootPath = oldRoot })
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	m := NewAppDataSocketManager(ctx, nil, capture)
+	m.peerCred = func(net.Conn) (peerCredentials, error) {
+		return peerCredentials{}, errors.New("test: peer credentials unavailable")
+	}
+	return m
+}
+
+func sendRecord(t *testing.T, conn net.Conn, record data.ApplicationRecord) dataAck {
+	t.Helper()
+	body, _ := json.Marshal(record)
+	if err := writeDataFrame(conn, json.RawMessage(body)); err != nil {
+		t.Fatalf("write frame: %v", err)
+	}
+	ackBody, err := readDataFrame(conn)
+	if err != nil {
+		t.Fatalf("read ack: %v", err)
+	}
+	var ack dataAck
+	if err := json.Unmarshal(ackBody, &ack); err != nil {
+		t.Fatalf("decode ack: %v", err)
+	}
+	return ack
+}
+
+// TestAppDataRateLimitIsPerAppNotPerConnection proves a second connection for
+// the same app draws from the same rate budget instead of getting a fresh one.
+func TestAppDataRateLimitIsPerAppNotPerConnection(t *testing.T) {
+	m := newTestDataSocketManager(t)
+	// A deterministic 2-record budget that does not refill during the test.
+	m.newLimiter = func() *notificationRateLimiter {
+		l := newNotificationRateLimiter(2, time.Hour)
+		return &l
+	}
+	dir, err := m.Ensure("com.example.a", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sockPath := filepath.Join(dir, DataSocketFilename)
+
+	conn1, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn1.Close()
+	rec := data.ApplicationRecord{Version: 1, Type: "event", Name: "ready", ClientBootID: "unavailable"}
+	if ack := sendRecord(t, conn1, rec); ack.State != "buffered" {
+		t.Fatalf("conn1 record 1: state = %q, want buffered", ack.State)
+	}
+	if ack := sendRecord(t, conn1, rec); ack.State != "buffered" {
+		t.Fatalf("conn1 record 2: state = %q, want buffered", ack.State)
+	}
+
+	// The per-app budget is now exhausted; a brand-new connection must not get
+	// its own allotment.
+	conn2, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn2.Close()
+	if ack := sendRecord(t, conn2, rec); ack.State != "rejected" || ack.Error != "rate limit exceeded" {
+		t.Fatalf("conn2 record: ack = %+v, want rejected/rate limit exceeded (budget must be shared)", ack)
+	}
+}
+
+// TestAppDataUnknownKindRejectedNotFatal shows an unknown record kind gets a
+// clean rejected ack and does not tear down the connection.
+func TestAppDataUnknownKindRejectedNotFatal(t *testing.T) {
+	m := newTestDataSocketManager(t)
+	dir, err := m.Ensure("com.example.a", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := net.Dial("unix", filepath.Join(dir, DataSocketFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	ack := sendRecord(t, conn, data.ApplicationRecord{Version: 1, Type: "telemetry", Name: "x", ClientBootID: "unavailable"})
+	if ack.State != "rejected" {
+		t.Fatalf("unknown kind: state = %q, want rejected", ack.State)
+	}
+
+	// The connection survives: a valid record on the same connection is still
+	// accepted.
+	ack = sendRecord(t, conn, data.ApplicationRecord{Version: 1, Type: "event", Name: "ready", ClientBootID: "unavailable"})
+	if ack.State != "buffered" {
+		t.Fatalf("valid record after unknown kind: state = %q, want buffered (connection must survive)", ack.State)
+	}
+}
+
+// TestAppDataPeerCredentialMismatchRefused injects a peer whose cgroup names a
+// different app and asserts the connection is refused.
+func TestAppDataPeerCredentialMismatchRefused(t *testing.T) {
+	m := newTestDataSocketManager(t)
+	m.peerCred = func(net.Conn) (peerCredentials, error) {
+		return peerCredentials{UID: 0, PID: 4242}, nil
+	}
+	m.cgroupOfPID = func(int32) (string, error) {
+		return "0::/system.slice/edge-agent-com.example.other.scope\n", nil
+	}
+	dir, err := m.Ensure("com.example.a", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := net.Dial("unix", filepath.Join(dir, DataSocketFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	ackBody, err := readDataFrame(conn)
+	if err != nil {
+		t.Fatalf("expected a rejection ack, got read error: %v", err)
+	}
+	var ack dataAck
+	if err := json.Unmarshal(ackBody, &ack); err != nil {
+		t.Fatal(err)
+	}
+	if ack.State != "rejected" {
+		t.Fatalf("mismatched peer: state = %q, want rejected", ack.State)
+	}
+}
+
+// TestAppDataPeerCredentialMatchAllowed shows a peer whose cgroup names the
+// socket's own app is admitted.
+func TestAppDataPeerCredentialMatchAllowed(t *testing.T) {
+	m := newTestDataSocketManager(t)
+	m.peerCred = func(net.Conn) (peerCredentials, error) {
+		return peerCredentials{UID: 0, PID: 4242}, nil
+	}
+	m.cgroupOfPID = func(int32) (string, error) {
+		return "0::/system.slice/edge-agent-com.example.a@worker.scope\n", nil
+	}
+	dir, err := m.Ensure("com.example.a", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := net.Dial("unix", filepath.Join(dir, DataSocketFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	ack := sendRecord(t, conn, data.ApplicationRecord{Version: 1, Type: "event", Name: "ready", ClientBootID: "unavailable"})
+	if ack.State != "buffered" {
+		t.Fatalf("matching peer (service suffix stripped): state = %q, want buffered", ack.State)
+	}
+}
+
+// TestAppIDFromCgroup covers the cgroup identity extraction directly.
+func TestAppIDFromCgroup(t *testing.T) {
+	cases := []struct {
+		name    string
+		cgroup  string
+		want    string
+		present bool
+	}{
+		{"single service", "0::/system.slice/edge-agent-com.example.a.scope\n", "com.example.a", true},
+		{"multi service strips suffix", "0::/system.slice/edge-agent-com.example.a@worker.scope\n", "com.example.a", true},
+		{"non-wendy process", "0::/user.slice/user-1000.slice/session-3.scope\n", "", false},
+		{"empty", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := appIDFromCgroup(tc.cgroup)
+			if ok != tc.present || got != tc.want {
+				t.Fatalf("appIDFromCgroup(%q) = (%q, %v), want (%q, %v)", tc.cgroup, got, ok, tc.want, tc.present)
+			}
+		})
+	}
+}

--- a/go/internal/agent/services/app_data_socket_peercred_linux.go
+++ b/go/internal/agent/services/app_data_socket_peercred_linux.go
@@ -1,0 +1,47 @@
+//go:build linux
+
+package services
+
+import (
+	"fmt"
+	"net"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// readPeerCredentials reads the connecting process's uid and pid from the
+// accepted unix socket using SO_PEERCRED. The kernel captures these at connect
+// time, so they cannot be spoofed by the peer and are not subject to a
+// pid-reuse race for the life of the connection.
+func readPeerCredentials(c net.Conn) (peerCredentials, error) {
+	uc, ok := c.(*net.UnixConn)
+	if !ok {
+		return peerCredentials{}, fmt.Errorf("connection is not a unix socket")
+	}
+	raw, err := uc.SyscallConn()
+	if err != nil {
+		return peerCredentials{}, err
+	}
+	var cred *unix.Ucred
+	var credErr error
+	controlErr := raw.Control(func(fd uintptr) {
+		cred, credErr = unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED)
+	})
+	if controlErr != nil {
+		return peerCredentials{}, controlErr
+	}
+	if credErr != nil {
+		return peerCredentials{}, credErr
+	}
+	return peerCredentials{UID: cred.Uid, PID: cred.Pid}, nil
+}
+
+// readProcCgroup returns the cgroup membership of a pid.
+func readProcCgroup(pid int32) (string, error) {
+	b, err := os.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/go/internal/agent/services/app_data_socket_peercred_other.go
+++ b/go/internal/agent/services/app_data_socket_peercred_other.go
@@ -1,0 +1,21 @@
+//go:build !linux
+
+package services
+
+import (
+	"errors"
+	"net"
+)
+
+// errPeerCredUnsupported reports that SO_PEERCRED-based peer identity binding
+// is unavailable on this platform. verifyPeer treats this as fail-open: the
+// group-2000 gate and the app-private socket directory remain the baseline.
+var errPeerCredUnsupported = errors.New("SO_PEERCRED peer credential lookup is not supported on this platform")
+
+func readPeerCredentials(net.Conn) (peerCredentials, error) {
+	return peerCredentials{}, errPeerCredUnsupported
+}
+
+func readProcCgroup(int32) (string, error) {
+	return "", errPeerCredUnsupported
+}

--- a/go/internal/agent/services/data_audio_adapter.go
+++ b/go/internal/agent/services/data_audio_adapter.go
@@ -1,0 +1,581 @@
+package services
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/audio"
+	"github.com/wendylabsinc/wendy/go/internal/agent/data"
+)
+
+// The audio adapter records at a fixed s16le / 48 kHz / mono format and writes
+// self-contained WAV files, so fragments and segments are decodable without a
+// sidecar index. This is the smallest honest implementation: it is levels
+// driven (peak dBFS per chunk via computeAudioLevels) and seals raw PCM into
+// WAV. A fuller version would carry the input's native rate and channel count,
+// map hardware capture timestamps instead of the agent receipt, and support
+// per-crossing pre-roll from the rolling buffer.
+const (
+	audioSampleRate      = 48000
+	audioChannels        = 1
+	audioBytesPerSample  = 2
+	audioBytesPerSecond  = audioSampleRate * audioChannels * audioBytesPerSample
+	audioChunkBytes      = audioBytesPerSecond / 10 // ~100 ms per read
+	audioSegmentDuration = 10 * time.Second
+	audioSegmentBytes    = int64(audioBytesPerSecond) * int64(audioSegmentDuration/time.Second)
+	// defaultAudioFragment is the sealed duration when a threshold source omits
+	// an explicit fragment.
+	defaultAudioFragment = 10 * time.Second
+	// audioLevelField is the only field the audio threshold trigger understands.
+	audioLevelField = "level_db"
+	wavHeaderBytes  = 44
+)
+
+// audioStream is the PCM source the capture loop reads from. It is an interface
+// so tests can inject deterministic PCM without a live capture process.
+type audioStream interface {
+	Read([]byte) (int, error)
+	Close()
+	Err() string
+}
+
+// pcmCapture adapts the audio service's *capture process to audioStream.
+type pcmCapture struct{ c *capture }
+
+func (p *pcmCapture) Read(b []byte) (int, error) { return p.c.stdout.Read(b) }
+func (p *pcmCapture) Close()                      { p.c.Close() }
+func (p *pcmCapture) Err() string                 { return p.c.Err() }
+
+type audioDataAdapter struct {
+	audio *AudioService
+	// openStream is a seam over the real PCM capture; tests inject fake PCM.
+	openStream func(ctx context.Context, deviceID uint32) (audioStream, error)
+}
+
+func newAudioDataAdapter(audioSvc *AudioService) dataCaptureAdapter {
+	if audioSvc == nil {
+		return nil
+	}
+	a := &audioDataAdapter{audio: audioSvc}
+	a.openStream = a.defaultOpenStream
+	return a
+}
+
+func (a *audioDataAdapter) defaultOpenStream(ctx context.Context, deviceID uint32) (audioStream, error) {
+	target, err := captureTarget(ctx, deviceID)
+	if err != nil {
+		return nil, err
+	}
+	rec, err := startCapture(ctx, target, audioSampleRate, audioChannels, "100ms")
+	if err != nil {
+		return nil, err
+	}
+	return &pcmCapture{c: rec}, nil
+}
+
+func (a *audioDataAdapter) Discover(ctx context.Context) []data.Source {
+	var nodes []audio.Node
+	domain := "PIPEWIRE_CAPTURE/AGENT_RECEIPT"
+	if audio.Available() {
+		var err error
+		nodes, _, err = audio.ListNodes(ctx)
+		if err != nil {
+			return nil
+		}
+	} else {
+		var err error
+		nodes, err = audio.ListAlsaNodes(ctx)
+		if err != nil {
+			return nil
+		}
+		domain = "ALSA_CAPTURE/AGENT_RECEIPT"
+	}
+	out := make([]data.Source, 0, len(nodes))
+	for _, n := range nodes {
+		if n.IsSink {
+			continue
+		}
+		out = append(out, data.Source{
+			ID:          fmt.Sprintf("audio:%d", n.ID),
+			Kind:        "audio",
+			ClockDomain: domain,
+			Healthy:     true,
+			Detail:      strings.TrimSpace(n.Description + " " + n.Name),
+		})
+	}
+	return out
+}
+
+func audioDeviceID(sourceID string) (uint32, bool) {
+	if !strings.HasPrefix(sourceID, "audio:") {
+		return 0, false
+	}
+	n, err := strconv.ParseUint(strings.TrimPrefix(sourceID, "audio:"), 10, 32)
+	return uint32(n), err == nil
+}
+
+func (a *audioDataAdapter) Start(ctx context.Context, session data.CaptureSession, selected []data.Source) (runningDataCapture, error) {
+	group := &audioCaptureGroup{}
+	for _, source := range selected {
+		devID, ok := audioDeviceID(source.ID)
+		if !ok {
+			continue
+		}
+		capture, err := a.startOne(ctx, session, source, devID)
+		if err != nil {
+			_, _ = group.Stop(context.Background())
+			return nil, fmt.Errorf("%s: %w", source.ID, err)
+		}
+		group.captures = append(group.captures, capture)
+	}
+	if len(group.captures) == 0 {
+		return nil, nil
+	}
+	return group, nil
+}
+
+func (a *audioDataAdapter) startOne(ctx context.Context, session data.CaptureSession, source data.Source, devID uint32) (*audioCapture, error) {
+	mode := "continuous"
+	var notes []string
+	var op string
+	var threshold float64
+	var fragmentBytes int64
+
+	capture := source.Capture
+	if capture.EffectiveMode() == "threshold" {
+		field, operator, value, err := data.ParseFieldThreshold(capture.Trigger)
+		if err != nil {
+			return nil, err
+		}
+		if field != audioLevelField {
+			notes = append(notes, fmt.Sprintf("audio threshold triggers only on %s, not %q; recording continuously", audioLevelField, field))
+		} else {
+			mode = "threshold"
+			op, threshold = operator, value
+			fragment := defaultAudioFragment
+			if d := capture.Fragment; d != "" {
+				if parsed, perr := time.ParseDuration(d); perr == nil && parsed > 0 {
+					fragment = parsed
+				} else {
+					notes = append(notes, fmt.Sprintf("fragment %q is not a positive duration; sealing %s per crossing", d, defaultAudioFragment))
+				}
+			} else {
+				notes = append(notes, fmt.Sprintf("threshold source declared no fragment; sealing %s per crossing", defaultAudioFragment))
+			}
+			fragmentBytes = int64(fragment.Seconds() * float64(audioBytesPerSecond))
+			notes = append(notes, fmt.Sprintf("threshold capture: sealing a %s fragment when %s %s %.3g dBFS", fragment, audioLevelField, op, threshold))
+		}
+	}
+
+	stream, err := a.openStream(ctx, devID)
+	if err != nil {
+		return nil, err
+	}
+	dir := filepath.Join(session.Directory, "audio", safeCaptureName(source.ID))
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		stream.Close()
+		return nil, err
+	}
+	index, err := os.OpenFile(filepath.Join(dir, "index.jsonl"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o640)
+	if err != nil {
+		stream.Close()
+		return nil, err
+	}
+
+	captureCtx, cancel := context.WithCancel(context.Background())
+	c := &audioCapture{
+		source: source, session: session, dir: dir, stream: stream, index: index,
+		ctx: captureCtx, cancel: cancel, done: make(chan struct{}), ready: make(chan error, 1),
+		mode: mode, op: op, threshold: threshold, fragmentBytes: fragmentBytes, notes: notes,
+	}
+	go c.run()
+	select {
+	case err := <-c.ready:
+		if err != nil {
+			c.shutdown()
+			return nil, err
+		}
+		return c, nil
+	case <-ctx.Done():
+		c.shutdown()
+		return nil, ctx.Err()
+	case <-time.After(20 * time.Second):
+		c.shutdown()
+		return nil, errors.New("timed out waiting for first audio chunk")
+	}
+}
+
+// shutdown cancels the capture context and closes the PCM stream, unblocking a
+// pending Read, then waits for run to finish.
+func (c *audioCapture) shutdown() {
+	c.cancel()
+	c.stream.Close()
+	<-c.done
+}
+
+type audioCaptureGroup struct{ captures []*audioCapture }
+
+func (g *audioCaptureGroup) Stop(ctx context.Context) ([]data.CaptureResult, error) {
+	var results []data.CaptureResult
+	var errs []error
+	for i := len(g.captures) - 1; i >= 0; i-- {
+		r, err := g.captures[i].Stop(ctx)
+		results = append(results, r...)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return results, errors.Join(errs...)
+}
+
+type audioCapture struct {
+	source  data.Source
+	session data.CaptureSession
+	dir     string
+	stream  audioStream
+	index   *os.File
+
+	ctx       context.Context
+	cancel    context.CancelFunc
+	done      chan struct{}
+	ready     chan error
+	readyOnce sync.Once
+	stopOnce  sync.Once
+	result    data.CaptureResult
+	runErr    error
+
+	// mode is "continuous" or "threshold".
+	mode string
+	// Threshold configuration.
+	op            string
+	threshold     float64
+	fragmentBytes int64
+	// Threshold state.
+	wasAbove bool
+	sealing  bool
+
+	// Current segment (WAV) state, shared by both modes.
+	seg          *os.File
+	segRel       string
+	segBytes     int64
+	segNumber    int
+	segCanonical int64
+	segUncert    int64
+	segReceipt   int64
+	segTrigger   *float64
+
+	// Accounting.
+	missedCrossings   uint64
+	maxCanonicalError int64
+	firstOffset       *int64
+	notes             []string
+
+	// captureReceipt is a test seam over data.CaptureReceipt.
+	captureReceipt func() (int64, int64, int64, error)
+}
+
+func (c *audioCapture) receiptNow() (int64, int64, int64, error) {
+	if c.captureReceipt != nil {
+		return c.captureReceipt()
+	}
+	return data.CaptureReceipt()
+}
+
+func (c *audioCapture) signalReady(err error) { c.readyOnce.Do(func() { c.ready <- err }) }
+
+// run reads PCM until the stream ends. It does not poll c.ctx: Stop closes the
+// stream, which unblocks Read and drains the buffered PCM, so a stop never
+// truncates data the producer already delivered.
+func (c *audioCapture) run() {
+	defer close(c.done)
+	defer c.finish()
+	buf := make([]byte, audioChunkBytes)
+	for {
+		n, err := c.stream.Read(buf)
+		if n > 0 {
+			if perr := c.handleChunk(buf[:n]); perr != nil {
+				c.runErr = perr
+				c.signalReady(perr)
+				return
+			}
+			c.signalReady(nil)
+		}
+		if err != nil {
+			if err != io.EOF {
+				if msg := c.stream.Err(); msg != "" {
+					c.runErr = errors.New(msg)
+				} else {
+					c.runErr = err
+				}
+			}
+			c.signalReady(c.runErr)
+			return
+		}
+	}
+}
+
+func (c *audioCapture) handleChunk(pcm []byte) error {
+	if c.mode == "threshold" {
+		return c.handleThresholdChunk(pcm)
+	}
+	return c.handleContinuousChunk(pcm)
+}
+
+// handleThresholdChunk detects a rising crossing of the level threshold and
+// seals a fragment of the configured duration. A crossing that occurs while a
+// fragment is still being sealed is counted as a missed crossing (an honest
+// drop) rather than starting an overlapping fragment.
+func (c *audioCapture) handleThresholdChunk(pcm []byte) error {
+	peak, _ := computeAudioLevels(pcm)
+	aboveNow := data.CompareThreshold(float64(peak), c.op, c.threshold)
+	crossing := aboveNow && !c.wasAbove
+	c.wasAbove = aboveNow
+
+	if crossing {
+		if c.sealing {
+			c.missedCrossings++
+		} else {
+			level := float64(peak)
+			if err := c.beginSegment(&level); err != nil {
+				return err
+			}
+			c.sealing = true
+		}
+	}
+	if !c.sealing {
+		return nil
+	}
+	remaining := c.fragmentBytes - c.segBytes
+	if remaining <= 0 {
+		if err := c.finishSegment(false); err != nil {
+			return err
+		}
+		c.result.Count++
+		c.sealing = false
+		return nil
+	}
+	write := pcm
+	if int64(len(write)) > remaining {
+		write = write[:remaining]
+	}
+	if err := c.writeSegment(write); err != nil {
+		return err
+	}
+	if c.segBytes >= c.fragmentBytes {
+		if err := c.finishSegment(false); err != nil {
+			return err
+		}
+		c.result.Count++
+		c.sealing = false
+	}
+	return nil
+}
+
+// handleContinuousChunk appends PCM to a rotating WAV segment.
+func (c *audioCapture) handleContinuousChunk(pcm []byte) error {
+	if c.seg == nil {
+		if err := c.beginSegment(nil); err != nil {
+			return err
+		}
+	}
+	if err := c.writeSegment(pcm); err != nil {
+		return err
+	}
+	if c.segBytes >= audioSegmentBytes {
+		if err := c.finishSegment(false); err != nil {
+			return err
+		}
+		c.result.Count++
+	}
+	return nil
+}
+
+// beginSegment stamps the segment start on the canonical episode timeline and
+// opens a WAV file with a placeholder header (patched on finish).
+func (c *audioCapture) beginSegment(triggerLevel *float64) error {
+	canonical, uncertainty, receipt, err := c.canonicalTime()
+	if err != nil {
+		return err
+	}
+	c.segNumber++
+	prefix := "segment"
+	if c.mode == "threshold" {
+		prefix = "fragment"
+	}
+	name := fmt.Sprintf("%s-%06d.wav", prefix, c.segNumber)
+	f, err := os.OpenFile(filepath.Join(c.dir, name), os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o640)
+	if err != nil {
+		return err
+	}
+	if err := writeWAVHeader(f, audioSampleRate, audioChannels, 0); err != nil {
+		f.Close()
+		return err
+	}
+	c.seg = f
+	c.segRel = filepath.ToSlash(filepath.Join("audio", safeCaptureName(c.source.ID), name))
+	c.segBytes = 0
+	c.segCanonical = canonical
+	c.segUncert = uncertainty
+	c.segReceipt = receipt
+	c.segTrigger = triggerLevel
+	if c.firstOffset == nil {
+		offset := canonical - c.session.RequestBootNanos
+		c.firstOffset = &offset
+	}
+	return nil
+}
+
+func (c *audioCapture) writeSegment(pcm []byte) error {
+	n, err := c.seg.Write(pcm)
+	if err != nil {
+		return err
+	}
+	if n != len(pcm) {
+		return ioErrShortWrite(n, len(pcm))
+	}
+	c.segBytes += int64(n)
+	return nil
+}
+
+// finishSegment patches the WAV header with the real data size, closes the
+// file, and records the segment in index.jsonl.
+func (c *audioCapture) finishSegment(truncated bool) error {
+	if c.seg == nil {
+		return nil
+	}
+	dataBytes := c.segBytes
+	var writeErr error
+	if _, err := c.seg.Seek(0, io.SeekStart); err != nil {
+		writeErr = err
+	} else if err := writeWAVHeader(c.seg, audioSampleRate, audioChannels, uint32(dataBytes)); err != nil {
+		writeErr = err
+	}
+	if syncErr := c.seg.Sync(); writeErr == nil {
+		writeErr = syncErr
+	}
+	if closeErr := c.seg.Close(); writeErr == nil {
+		writeErr = closeErr
+	}
+	c.seg = nil
+	if writeErr != nil {
+		return writeErr
+	}
+	record := audioIndexRecord{
+		CanonicalEpisodeNanos:     c.segCanonical - c.session.RequestBootNanos,
+		CanonicalUncertaintyNanos: c.segUncert,
+		AgentReceiptBootNanos:     c.segReceipt,
+		MappingSegment:            "receipt-bracket-v1",
+		Segment:                   c.segRel,
+		ByteSize:                  dataBytes,
+		SampleRate:                audioSampleRate,
+		Channels:                  audioChannels,
+		DurationNanos:             dataBytes * int64(time.Second) / int64(audioBytesPerSecond),
+		Mode:                      c.mode,
+		TriggerLevelDb:            c.segTrigger,
+		Truncated:                 truncated,
+	}
+	b, _ := json.Marshal(record)
+	_, err := c.index.Write(append(b, '\n'))
+	c.segBytes = 0
+	return err
+}
+
+func (c *audioCapture) canonicalTime() (canonical, uncertainty, receipt int64, err error) {
+	before, mid, after, err := c.receiptNow()
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	canonical = mid
+	uncertainty = (after - before + 1) / 2
+	if uncertainty > c.maxCanonicalError {
+		c.maxCanonicalError = uncertainty
+	}
+	return canonical, uncertainty, mid, nil
+}
+
+// finish flushes any in-progress segment and folds accounting into the result.
+func (c *audioCapture) finish() {
+	if c.seg != nil {
+		// A fragment cut short by capture stop is still a valid, shorter WAV.
+		truncated := c.mode == "threshold" && c.sealing
+		if truncated {
+			c.notes = append(c.notes, "final fragment truncated by capture stop")
+		}
+		if err := c.finishSegment(truncated); err == nil {
+			c.result.Count++
+		}
+	}
+	c.result.SourceID = c.source.ID
+	c.result.ClockDomain = c.source.ClockDomain
+	c.result.ActualOffset = c.firstOffset
+	if c.maxCanonicalError > 0 {
+		maxError := c.maxCanonicalError
+		c.result.MappingError = &maxError
+	}
+	if c.mode == "threshold" {
+		missed := c.missedCrossings
+		c.result.Drops = &missed
+		c.result.DropAccounting = "missed_threshold_crossings_during_seal"
+	} else {
+		c.result.DropAccounting = "pcm_stream_has_no_sequence_numbers"
+	}
+	if len(c.notes) > 0 {
+		c.result.SourceDetail = strings.TrimSpace(c.source.Detail + " (" + strings.Join(c.notes, "; ") + ")")
+	}
+	_ = c.index.Sync()
+	_ = c.index.Close()
+}
+
+func (c *audioCapture) Stop(context.Context) ([]data.CaptureResult, error) {
+	c.stopOnce.Do(c.shutdown)
+	return []data.CaptureResult{c.result}, c.runErr
+}
+
+type audioIndexRecord struct {
+	CanonicalEpisodeNanos     int64    `json:"canonical_episode_nanos"`
+	CanonicalUncertaintyNanos int64    `json:"canonical_uncertainty_nanos"`
+	AgentReceiptBootNanos     int64    `json:"agent_receipt_boottime_nanos"`
+	MappingSegment            string   `json:"mapping_segment"`
+	Segment                   string   `json:"segment"`
+	ByteSize                  int64    `json:"byte_size"`
+	SampleRate                uint32   `json:"sample_rate"`
+	Channels                  uint32   `json:"channels"`
+	DurationNanos             int64    `json:"duration_nanos"`
+	Mode                      string   `json:"mode"`
+	TriggerLevelDb            *float64 `json:"trigger_level_db,omitempty"`
+	Truncated                 bool     `json:"truncated,omitempty"`
+}
+
+// writeWAVHeader writes a 44-byte canonical PCM WAV header at the file cursor.
+// dataBytes is the size of the PCM payload that follows; it is zero for the
+// placeholder written before recording and the real size when patched on close.
+func writeWAVHeader(f *os.File, sampleRate, channels, dataBytes uint32) error {
+	var buf [wavHeaderBytes]byte
+	byteRate := sampleRate * channels * audioBytesPerSample
+	blockAlign := uint16(channels * audioBytesPerSample)
+	copy(buf[0:4], "RIFF")
+	binary.LittleEndian.PutUint32(buf[4:8], 36+dataBytes)
+	copy(buf[8:12], "WAVE")
+	copy(buf[12:16], "fmt ")
+	binary.LittleEndian.PutUint32(buf[16:20], 16)
+	binary.LittleEndian.PutUint16(buf[20:22], 1) // PCM
+	binary.LittleEndian.PutUint16(buf[22:24], uint16(channels))
+	binary.LittleEndian.PutUint32(buf[24:28], sampleRate)
+	binary.LittleEndian.PutUint32(buf[28:32], byteRate)
+	binary.LittleEndian.PutUint16(buf[32:34], blockAlign)
+	binary.LittleEndian.PutUint16(buf[34:36], 16) // bits per sample
+	copy(buf[36:40], "data")
+	binary.LittleEndian.PutUint32(buf[40:44], dataBytes)
+	_, err := f.Write(buf[:])
+	return err
+}

--- a/go/internal/agent/services/data_audio_adapter_test.go
+++ b/go/internal/agent/services/data_audio_adapter_test.go
@@ -1,0 +1,167 @@
+package services
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/data"
+)
+
+// fakeAudioStream yields a fixed sequence of PCM chunks and then EOF.
+type fakeAudioStream struct {
+	chunks [][]byte
+	i      int
+}
+
+func (f *fakeAudioStream) Read(b []byte) (int, error) {
+	if f.i >= len(f.chunks) {
+		return 0, io.EOF
+	}
+	n := copy(b, f.chunks[f.i])
+	f.i++
+	return n, nil
+}
+func (f *fakeAudioStream) Close()      {}
+func (f *fakeAudioStream) Err() string { return "" }
+
+func silentChunk() []byte { return make([]byte, audioChunkBytes) }
+
+func loudChunk() []byte {
+	b := make([]byte, audioChunkBytes)
+	for i := 0; i+1 < len(b); i += 2 {
+		binary.LittleEndian.PutUint16(b[i:], 0x7FFF) // near full-scale s16
+	}
+	return b
+}
+
+// runAudioCapture drives the adapter with a scripted PCM stream and returns the
+// capture result plus the audio output directory.
+func runAudioCapture(t *testing.T, capture *data.SourceCapture, chunks [][]byte) (data.CaptureResult, string) {
+	t.Helper()
+	sessionDir := t.TempDir()
+	source := data.Source{ID: "audio:0", Kind: "audio", ClockDomain: "TEST_CAPTURE/AGENT_RECEIPT", Healthy: true, Detail: "test mic", Capture: capture}
+	adapter := &audioDataAdapter{
+		audio: &AudioService{},
+		openStream: func(context.Context, uint32) (audioStream, error) {
+			return &fakeAudioStream{chunks: chunks}, nil
+		},
+	}
+	session := data.CaptureSession{ID: "ep", Directory: sessionDir, RequestBootNanos: 0}
+	running, err := adapter.Start(context.Background(), session, []data.Source{source})
+	if err != nil {
+		t.Fatalf("adapter start: %v", err)
+	}
+	if running == nil {
+		t.Fatal("adapter returned no running capture")
+	}
+	results, err := running.Stop(context.Background())
+	if err != nil {
+		t.Fatalf("adapter stop: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 capture result, got %d", len(results))
+	}
+	return results[0], filepath.Join(sessionDir, "audio", safeCaptureName(source.ID))
+}
+
+func wavFragments(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wavs []string
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".wav" {
+			wavs = append(wavs, filepath.Join(dir, e.Name()))
+		}
+	}
+	return wavs
+}
+
+// wavDataBytes reads the PCM payload size recorded in a WAV file's data chunk
+// header and confirms it matches the bytes actually on disk.
+func wavDataBytes(t *testing.T, path string) int64 {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(b) < wavHeaderBytes || string(b[0:4]) != "RIFF" || string(b[8:12]) != "WAVE" {
+		t.Fatalf("%s is not a WAV file", path)
+	}
+	declared := int64(binary.LittleEndian.Uint32(b[40:44]))
+	if onDisk := int64(len(b)) - wavHeaderBytes; onDisk != declared {
+		t.Fatalf("%s: header declares %d PCM bytes but file holds %d", path, declared, onDisk)
+	}
+	return declared
+}
+
+// TestAudioThresholdSealsFragmentOfConfiguredDuration verifies a level crossing
+// seals exactly one fragment of the configured duration.
+func TestAudioThresholdSealsFragmentOfConfiguredDuration(t *testing.T) {
+	// fragment 1s = 10 chunks of ~100ms.
+	chunks := [][]byte{silentChunk(), silentChunk()}
+	for i := 0; i < 10; i++ {
+		chunks = append(chunks, loudChunk())
+	}
+	chunks = append(chunks, silentChunk(), silentChunk())
+
+	result, dir := runAudioCapture(t, &data.SourceCapture{Mode: "threshold", Trigger: "level_db > -20", Fragment: "1s"}, chunks)
+
+	wavs := wavFragments(t, dir)
+	if len(wavs) != 1 {
+		t.Fatalf("expected exactly 1 sealed fragment, got %d (%v)", len(wavs), wavs)
+	}
+	if got := wavDataBytes(t, wavs[0]); got != int64(audioBytesPerSecond) {
+		t.Fatalf("fragment PCM bytes = %d, want %d (1 second)", got, audioBytesPerSecond)
+	}
+	if result.Count != 1 {
+		t.Fatalf("result.Count = %d, want 1 sealed fragment", result.Count)
+	}
+	if result.Drops == nil || *result.Drops != 0 {
+		t.Fatalf("expected 0 missed crossings, got %v", result.Drops)
+	}
+	if result.DropAccounting != "missed_threshold_crossings_during_seal" {
+		t.Fatalf("drop accounting = %q", result.DropAccounting)
+	}
+}
+
+// TestAudioSubThresholdSealsNothing verifies audio that never crosses the
+// threshold produces no fragment.
+func TestAudioSubThresholdSealsNothing(t *testing.T) {
+	chunks := [][]byte{silentChunk(), silentChunk(), silentChunk(), silentChunk()}
+	result, dir := runAudioCapture(t, &data.SourceCapture{Mode: "threshold", Trigger: "level_db > -20", Fragment: "1s"}, chunks)
+
+	if wavs := wavFragments(t, dir); len(wavs) != 0 {
+		t.Fatalf("expected no fragments for sub-threshold audio, got %v", wavs)
+	}
+	if result.Count != 0 {
+		t.Fatalf("result.Count = %d, want 0", result.Count)
+	}
+}
+
+// TestAudioThresholdCountsMissedCrossingsDuringSeal verifies a second crossing
+// while a fragment is still sealing is counted as a missed crossing rather than
+// starting an overlapping fragment.
+func TestAudioThresholdCountsMissedCrossingsDuringSeal(t *testing.T) {
+	// A long fragment (3s = 30 chunks) so the seal is still in progress when a
+	// second crossing occurs. Script: loud (start seal), silent (drop below),
+	// loud (a new crossing mid-seal -> missed), then enough loud to finish.
+	chunks := [][]byte{loudChunk(), silentChunk(), loudChunk()}
+	for i := 0; i < 30; i++ {
+		chunks = append(chunks, loudChunk())
+	}
+	result, dir := runAudioCapture(t, &data.SourceCapture{Mode: "threshold", Trigger: "level_db > -20", Fragment: "3s"}, chunks)
+
+	if wavs := wavFragments(t, dir); len(wavs) != 1 {
+		t.Fatalf("expected 1 fragment, got %v", wavs)
+	}
+	if result.Drops == nil || *result.Drops != 1 {
+		t.Fatalf("expected exactly 1 missed crossing during the seal, got %v", result.Drops)
+	}
+}

--- a/go/internal/agent/services/data_service.go
+++ b/go/internal/agent/services/data_service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -16,6 +17,41 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// dataStatusError maps a data-manager error onto a precise gRPC status code.
+// An earlier revision collapsed every episode-lookup failure to NotFound,
+// which hid malformed requests and genuine I/O or seal failures behind the
+// same code. The mapping is:
+//
+//   - InvalidArgument: the request itself is malformed (bad episode id,
+//     out-of-range download offset, malformed or escaping file path).
+//   - NotFound: the episode, manifest, or requested file is genuinely absent.
+//   - FailedPrecondition: the episode exists but is not currently serviceable
+//     (no active episode, or a manifest entry that is not a regular file).
+//   - Internal: everything else, which is an I/O, decode, or seal failure.
+//
+// Messages are the underlying error text, which is generated agent-side and
+// carries no client-supplied secrets or host paths beyond episode-relative
+// names.
+func dataStatusError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, data.ErrInvalidEpisodeID),
+		errors.Is(err, data.ErrInvalidDownloadOffset),
+		errors.Is(err, data.ErrInvalidEpisodePath),
+		errors.Is(err, data.ErrEpisodePathEscapes),
+		errors.Is(err, data.ErrInvalidCampaignName):
+		return status.Error(codes.InvalidArgument, err.Error())
+	case errors.Is(err, os.ErrNotExist):
+		return status.Error(codes.NotFound, err.Error())
+	case errors.Is(err, data.ErrNoActiveEpisode),
+		errors.Is(err, data.ErrEpisodeEntryNotRegular):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	default:
+		return status.Error(codes.Internal, err.Error())
+	}
+}
 
 type DataService struct {
 	agentpbv2.UnimplementedDataServiceServer
@@ -248,7 +284,7 @@ func (s *DataService) Campaigns(context.Context, *agentpbv2.DataCampaignsRequest
 func (s *DataService) CampaignInspect(_ context.Context, req *agentpbv2.DataCampaignInspectRequest) (*agentpbv2.DataCampaign, error) {
 	campaign, err := s.manager.Campaign(req.GetName())
 	if err != nil {
-		return nil, status.Error(codes.NotFound, err.Error())
+		return nil, dataStatusError(err)
 	}
 	message, err := campaignMessage(campaign)
 	if err != nil {
@@ -260,7 +296,7 @@ func (s *DataService) CampaignInspect(_ context.Context, req *agentpbv2.DataCamp
 func (s *DataService) CampaignTrigger(ctx context.Context, req *agentpbv2.DataCampaignTriggerRequest) (*agentpbv2.DataEpisode, error) {
 	campaign, err := s.manager.Campaign(req.GetName())
 	if err != nil {
-		return nil, status.Error(codes.NotFound, err.Error())
+		return nil, dataStatusError(err)
 	}
 	reason := strings.TrimSpace(req.GetReason())
 	if reason == "" {
@@ -376,7 +412,7 @@ func (s *DataService) Episodes(context.Context, *agentpbv2.DataEpisodesRequest) 
 func (s *DataService) Inspect(_ context.Context, req *agentpbv2.DataInspectRequest) (*agentpbv2.DataInspectResponse, error) {
 	m, failures, err := s.manager.Inspect(req.GetEpisode(), req.GetVerify())
 	if err != nil {
-		return nil, status.Error(codes.NotFound, err.Error())
+		return nil, dataStatusError(err)
 	}
 	b, err := json.MarshalIndent(m, "", "  ")
 	if err != nil {
@@ -390,7 +426,7 @@ func (s *DataService) Download(req *agentpbv2.DataDownloadRequest, stream agentp
 	defer s.manager.EndDownload(req.GetEpisode())
 	f, meta, err := s.manager.OpenFile(req.GetEpisode(), req.GetPath(), req.GetOffset())
 	if err != nil {
-		return status.Error(codes.NotFound, err.Error())
+		return dataStatusError(err)
 	}
 	defer f.Close()
 	buf := make([]byte, 256*1024)

--- a/go/internal/agent/services/data_service.go
+++ b/go/internal/agent/services/data_service.go
@@ -95,6 +95,12 @@ func (s *DataService) SetVideoService(video *VideoService) {
 	s.addAdapter(newCameraDataAdapter(video))
 }
 
+// SetAudioService enables microphone capture, including level-threshold
+// fragment sealing.
+func (s *DataService) SetAudioService(audioSvc *AudioService) {
+	s.addAdapter(newAudioDataAdapter(audioSvc))
+}
+
 // SetROS2Service enables one managed rosbag2 recorder per live RMW graph.
 func (s *DataService) SetROS2Service(ros2 *ROS2Service) {
 	if ros2 != nil {

--- a/go/internal/agent/services/data_service_errorcode_test.go
+++ b/go/internal/agent/services/data_service_errorcode_test.go
@@ -1,0 +1,117 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/data"
+	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestDataStatusErrorClassification pins the gRPC code returned for each class
+// of data-manager error, guarding against a regression to the old behavior
+// that collapsed every failure to NotFound.
+func TestDataStatusErrorClassification(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want codes.Code
+	}{
+		{"nil", nil, codes.OK},
+		{"invalid episode id", data.ErrInvalidEpisodeID, codes.InvalidArgument},
+		{"invalid offset", data.ErrInvalidDownloadOffset, codes.InvalidArgument},
+		{"invalid path", data.ErrInvalidEpisodePath, codes.InvalidArgument},
+		{"path escapes", data.ErrEpisodePathEscapes, codes.InvalidArgument},
+		{"invalid campaign name", data.ErrInvalidCampaignName, codes.InvalidArgument},
+		{"absent episode", os.ErrNotExist, codes.NotFound},
+		{"no active episode", data.ErrNoActiveEpisode, codes.FailedPrecondition},
+		{"entry not regular", data.ErrEpisodeEntryNotRegular, codes.FailedPrecondition},
+		{"io failure", errors.New("disk exploded"), codes.Internal},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := status.Code(dataStatusError(tc.err))
+			if got != tc.want {
+				t.Fatalf("dataStatusError(%v) code = %s, want %s", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// sealedEpisode records a minimal applications-only episode and returns its ID
+// plus the manager, for the RPC-level error-code tests below.
+func sealedEpisode(t *testing.T) (*DataService, string) {
+	t.Helper()
+	manager, err := data.NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := NewDataService(manager)
+	started, err := manager.Start(data.StartOptions{Sources: []string{"applications"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Record one event so events.jsonl is sealed into the manifest; the
+	// out-of-range-offset case below needs a file that actually exists.
+	if _, err = manager.RecordApplication("com.example.test", data.ApplicationRecord{Version: 1, Type: "event", Name: "ready", ClientBootID: "unavailable"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = manager.Stop(data.AdHocEpisodeKey); err != nil {
+		t.Fatal(err)
+	}
+	return service, started.ID
+}
+
+func TestInspectErrorCodes(t *testing.T) {
+	service, id := sealedEpisode(t)
+
+	if _, err := service.Inspect(context.Background(), &agentpbv2.DataInspectRequest{Episode: "bad/id"}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("invalid episode id: code = %s, want InvalidArgument (%v)", status.Code(err), err)
+	}
+	if _, err := service.Inspect(context.Background(), &agentpbv2.DataInspectRequest{Episode: "does-not-exist"}); status.Code(err) != codes.NotFound {
+		t.Fatalf("absent episode: code = %s, want NotFound (%v)", status.Code(err), err)
+	}
+	if _, err := service.Inspect(context.Background(), &agentpbv2.DataInspectRequest{Episode: id, Verify: true}); err != nil {
+		t.Fatalf("present episode should inspect cleanly: %v", err)
+	}
+}
+
+// fakeDownloadStream is a minimal DataService_DownloadServer for driving the
+// Download handler in-process. Only Send and Context are exercised.
+type fakeDownloadStream struct {
+	grpc.ServerStream
+	ctx    context.Context
+	chunks []*agentpbv2.DataDownloadChunk
+}
+
+func (f *fakeDownloadStream) Send(c *agentpbv2.DataDownloadChunk) error {
+	f.chunks = append(f.chunks, c)
+	return nil
+}
+func (f *fakeDownloadStream) Context() context.Context { return f.ctx }
+
+func TestDownloadErrorCodes(t *testing.T) {
+	service, id := sealedEpisode(t)
+	stream := &fakeDownloadStream{ctx: context.Background()}
+
+	if err := service.Download(&agentpbv2.DataDownloadRequest{Episode: "does-not-exist", Path: "events.jsonl"}, stream); status.Code(err) != codes.NotFound {
+		t.Fatalf("absent episode: code = %s, want NotFound (%v)", status.Code(err), err)
+	}
+	// A path that is not a manifest entry (including a traversal attempt) is
+	// genuinely absent, so NotFound is the honest code; path validation only
+	// runs once a manifest match is found.
+	if err := service.Download(&agentpbv2.DataDownloadRequest{Episode: id, Path: "../escape"}, stream); status.Code(err) != codes.NotFound {
+		t.Fatalf("escaping path: code = %s, want NotFound (%v)", status.Code(err), err)
+	}
+	if err := service.Download(&agentpbv2.DataDownloadRequest{Episode: id, Path: "no-such-file.bin"}, stream); status.Code(err) != codes.NotFound {
+		t.Fatalf("missing file: code = %s, want NotFound (%v)", status.Code(err), err)
+	}
+	if err := service.Download(&agentpbv2.DataDownloadRequest{Episode: id, Path: "events.jsonl", Offset: 1 << 40}, stream); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("out-of-range offset: code = %s, want InvalidArgument (%v)", status.Code(err), err)
+	}
+}


### PR DESCRIPTION
## Summary

Deliverable D6: the deferred rigor items on the episode-capture subsystem. Three independent hardening changes, one commit each.

## 1. Data socket hardening (`app_data_socket.go`, `oci/entitlements.go`)

**Problem:** an app's data socket trusted the app-claimed identity (gated only by the shared group 2000), enforced its 200 records/second limit per connection (so an app could open N connections for Nx200/s), and validated record kinds with a hard-coded event/prediction switch.

**Solution:**
- **Peer credential verification.** The accepted connection's peer process identifier is read with SO_PEERCRED (`golang.org/x/sys/unix` `GetsockoptUcred`) and that process's control group is compared against the app the socket belongs to. Every app container runs in a systemd scope named `<systemd-service>-<appID>[@<service>].scope` (assigned by `containerd/client.go`), so a process belonging to a different app is refused and cannot write records attributed to an app it is not.
  - **Identity binding achieved:** app-level, via the peer's cgroup.
  - **Residual gaps (all fail open, never fail closed):** granularity is per app, not per service (an app's services legitimately share one socket, so the `@service` suffix is stripped before comparison); the peer user identifier is read but is not the discriminator, because app containers run as user 0 by default; a non-container peer (a host process, the agent itself, a test harness), an unreadable `/proc`, or a non-Linux host falls back to the group-2000 plus 0750 app-private-directory gate. The lookup is a seam so the refusal path is unit-tested without real credentials.
- **Per-app rate limiting.** The 200 records/second token bucket now lives on the socket and is shared by every connection the app opens (reuses the existing `notificationRateLimiter`).
- **Record-kind registry.** A small map of validators replaces the switch; a new kind is a one-line addition, and an unknown kind still gets a clean `rejected` ack rather than a dropped connection.

## 2. Threshold audio capture mode (`data_audio_adapter.go`, `campaign.go`)

**Problem:** the campaign schema defined an audio source kind and a threshold capture mode, but nothing implemented either, so the reference campaign's audio source stayed commented out and any audio/threshold plan deploy-warned as unimplemented.

**Solution:** a levels-driven audio capture adapter sourcing Pulse-Code Modulation (PCM) from the agent's existing audio service (PipeWire `pw-record`, with an Automatic Linux Sound Architecture (ALSA) `arecord` fallback). In threshold mode it computes the per-chunk peak level in decibels relative to full scale (dBFS) via the audio service's existing level meter, and when the level crosses the campaign's `level_db` threshold it seals a fragment of the configured duration into a self-contained Waveform Audio File Format (WAV) file. A crossing that arrives while a fragment is still sealing is recorded as a missed crossing (drop accounting). Each fragment carries its canonical episode time as a receipt bracket, like the other adapters. Continuous mode records rotating WAV segments.

**Honest scope:** this is deliberately the smallest honest implementation, not a GStreamer audio pipeline. Fixed 48 kilohertz / mono / signed 16-bit format; the agent-receipt clock is used (no hardware capture timestamp); no per-crossing pre-roll. The source file documents what a fuller version needs.

Also enables the previously commented-out audio threshold source in `Examples/WendyDataCampaign/campaign.yaml`.

## 3. Error-code hygiene (`data_service.go`)

**Problem:** Download, Inspect, and the campaign lookup RPCs collapsed every data-manager failure to `codes.NotFound`, so a malformed request, a genuinely absent episode, and an input/output or seal failure were indistinguishable to callers.

**Solution:** exported sentinel errors from the data package and a `dataStatusError` mapping: `InvalidArgument` for malformed requests, `NotFound` for genuine absence, `FailedPrecondition` for not-currently-serviceable cases, `Internal` for everything else. Messages stay honest and non-leaky.

## Verification

`CC=/usr/bin/clang go build ./...`, the full test suite over `./go/internal/agent/data/...`, `./go/internal/agent/services/...`, `./go/internal/cli/...`, and `-race` on the two agent packages: all green.
