### PR TITLE
fix(appconfig): declare camera user/password in wendy.schema.json + drift-parity test

### DIFF
--- a/go/internal/shared/appconfig/schema_parity_test.go
+++ b/go/internal/shared/appconfig/schema_parity_test.go
@@ -1,0 +1,55 @@
+package appconfig
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestSchemaEntitlementKeyParity asserts that every key allowedKeys permits for
+// an entitlement type is declared in that type's schema variant. The Go
+// validator is the source of truth; because each schema variant sets
+// "additionalProperties": false, a key missing from the schema makes editors
+// falsely reject manifests the agent accepts (this happened with the camera
+// entitlement's IP-camera "user"/"password" keys).
+func TestSchemaEntitlementKeyParity(t *testing.T) {
+	var schema struct {
+		Defs struct {
+			Entitlement struct {
+				OneOf []struct {
+					Properties map[string]json.RawMessage `json:"properties"`
+				} `json:"oneOf"`
+			} `json:"entitlement"`
+		} `json:"$defs"`
+	}
+	if err := json.Unmarshal([]byte(SchemaJSON), &schema); err != nil {
+		t.Fatalf("parse wendy.schema.json: %v", err)
+	}
+
+	variants := make(map[string]map[string]json.RawMessage)
+	for _, v := range schema.Defs.Entitlement.OneOf {
+		var typeConst struct {
+			Const string `json:"const"`
+		}
+		raw, ok := v.Properties["type"]
+		if !ok {
+			continue
+		}
+		if err := json.Unmarshal(raw, &typeConst); err != nil || typeConst.Const == "" {
+			continue
+		}
+		variants[typeConst.Const] = v.Properties
+	}
+
+	for entType, keys := range allowedKeys {
+		props, ok := variants[entType]
+		if !ok {
+			t.Errorf("entitlement type %q has no variant in wendy.schema.json", entType)
+			continue
+		}
+		for _, key := range keys {
+			if _, ok := props[key]; !ok {
+				t.Errorf("entitlement %q: allowedKeys permits %q but the schema variant does not declare it (editors will falsely reject valid manifests)", entType, key)
+			}
+		}
+	}
+}

--- a/go/internal/shared/appconfig/wendy.schema.json
+++ b/go/internal/shared/appconfig/wendy.schema.json
@@ -221,6 +221,14 @@
               "type": "array",
               "items": { "type": "string" },
               "description": "Allowed camera device paths. Accepted for compatibility with the deprecated video entitlement."
+            },
+            "user": {
+              "type": "string",
+              "description": "Username for authenticating to a network (IP) camera."
+            },
+            "password": {
+              "type": "string",
+              "description": "Password for authenticating to a network (IP) camera."
             }
           },
           "required": ["type"],


### PR DESCRIPTION
## Problem

An editor validating `wendy.json` against `wendy.schema.json` falsely rejects a valid network (Internet Protocol, IP) camera manifest that declares the camera entitlement's `user` and `password` keys, even though the agent accepts it.

## Cause

`allowedKeys[EntitlementCamera]` in `go/internal/shared/appconfig/appconfig.go` (the validator's source of truth) permits `type`, `mode`, `allowlist`, `user`, and `password`, but the camera variant in `wendy.schema.json` declared only `type`, `mode`, and `allowlist` with `additionalProperties: false`. The schema and the Go validator disagreed. This is the property-level analog of the `mcp`/`data` entitlement-type drift fixed on `feature/wendy-data-platform`.

## Solution

- Add `user` and `password` string properties to the camera variant in `wendy.schema.json`.
- Add `TestSchemaEntitlementKeyParity`, which walks `allowedKeys` and asserts every permitted key is declared in the matching schema variant, so this whole class of Go-versus-schema drift fails a test rather than surfacing as an editor false-rejection.

Mutation-verified: the test fails naming `user` and `password` when the schema additions are removed, and passes with them.

## Note on base branch

Opened against `feature/wendy-data-platform` rather than `main`: the parity test also requires the `mcp` and `data` variants, which exist on that integration branch but not yet on `main`. Basing it on `main` would mean duplicating that fix and conflicting at promotion.

## Verification

```
CC=/usr/bin/clang go test ./internal/shared/appconfig/...
```
