### PR TITLE
fix(appconfig): camera user/password and mcp schema drift + parity test

### DIFF
--- a/go/internal/shared/appconfig/schema_parity_test.go
+++ b/go/internal/shared/appconfig/schema_parity_test.go
@@ -1,0 +1,55 @@
+package appconfig
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestSchemaEntitlementKeyParity asserts that every key allowedKeys permits for
+// an entitlement type is declared in that type's schema variant. The Go
+// validator is the source of truth; because each schema variant sets
+// "additionalProperties": false, a key missing from the schema makes editors
+// falsely reject manifests the agent accepts (this happened with the camera
+// entitlement's IP-camera "user"/"password" keys).
+func TestSchemaEntitlementKeyParity(t *testing.T) {
+	var schema struct {
+		Defs struct {
+			Entitlement struct {
+				OneOf []struct {
+					Properties map[string]json.RawMessage `json:"properties"`
+				} `json:"oneOf"`
+			} `json:"entitlement"`
+		} `json:"$defs"`
+	}
+	if err := json.Unmarshal([]byte(SchemaJSON), &schema); err != nil {
+		t.Fatalf("parse wendy.schema.json: %v", err)
+	}
+
+	variants := make(map[string]map[string]json.RawMessage)
+	for _, v := range schema.Defs.Entitlement.OneOf {
+		var typeConst struct {
+			Const string `json:"const"`
+		}
+		raw, ok := v.Properties["type"]
+		if !ok {
+			continue
+		}
+		if err := json.Unmarshal(raw, &typeConst); err != nil || typeConst.Const == "" {
+			continue
+		}
+		variants[typeConst.Const] = v.Properties
+	}
+
+	for entType, keys := range allowedKeys {
+		props, ok := variants[entType]
+		if !ok {
+			t.Errorf("entitlement type %q has no variant in wendy.schema.json", entType)
+			continue
+		}
+		for _, key := range keys {
+			if _, ok := props[key]; !ok {
+				t.Errorf("entitlement %q: allowedKeys permits %q but the schema variant does not declare it (editors will falsely reject valid manifests)", entType, key)
+			}
+		}
+	}
+}

--- a/go/internal/shared/appconfig/wendy.schema.json
+++ b/go/internal/shared/appconfig/wendy.schema.json
@@ -221,6 +221,14 @@
               "type": "array",
               "items": { "type": "string" },
               "description": "Allowed camera device paths. Accepted for compatibility with the deprecated video entitlement."
+            },
+            "user": {
+              "type": "string",
+              "description": "Username for authenticating to a network (IP) camera."
+            },
+            "password": {
+              "type": "string",
+              "description": "Password for authenticating to a network (IP) camera."
             }
           },
           "required": ["type"],
@@ -293,6 +301,20 @@
           "required": ["type", "device"],
           "additionalProperties": false,
           "description": "Serial tty device access (USB-attached servo buses, sensors, microcontrollers)."
+        },
+        {
+          "properties": {
+            "type": { "const": "mcp" },
+            "port": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535,
+              "description": "Port the app's Model Context Protocol (MCP) server listens on."
+            }
+          },
+          "required": ["type", "port"],
+          "additionalProperties": false,
+          "description": "Declares the app's Model Context Protocol (MCP) server port so MCP clients can discover and reach it. At most one per app."
         },
         {
           "properties": {


### PR DESCRIPTION
## Problem

An editor validating `wendy.json` against `wendy.schema.json` falsely rejects two classes of valid manifest: a network (Internet Protocol, IP) camera manifest declaring the camera entitlement's `user` and `password` keys, and any manifest declaring the `mcp` entitlement at all.

## Cause

The schema drifted from the Go validator, which is the source of truth. `allowedKeys[EntitlementCamera]` in `go/internal/shared/appconfig/appconfig.go` permits `type`, `mode`, `allowlist`, `user`, and `password`, but the schema's camera variant listed only the first three with `additionalProperties: false`; and the `mcp` entitlement type had no schema variant despite being valid.

## Solution

- Add `user` and `password` string properties to the camera variant (IP-camera credentials).
- Add the `mcp` variant (byte-identical to the one on `feature/wendy-data-platform`, so the later promotion merge resolves cleanly).
- Add `TestSchemaEntitlementKeyParity`: walks `allowedKeys` and asserts every permitted key of every entitlement type is declared in the matching schema variant, turning this whole class of drift into a test failure instead of editor false-rejections. Mutation-verified in both directions.

## Verification

```
CC=/usr/bin/clang go test ./internal/shared/appconfig/...
```

Supersedes #1752 (which targeted the integration branch); this standalone version reaches main without waiting on the data-platform promotion.
