### PR TITLE
feat(data): WENDY_DATA_INGEST_URL override for the episode transfer worker

### DIFF
--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -977,6 +977,15 @@ func main() {
 	// on disk persistence (the manifest queue lives on disk) and, inside Run, on
 	// provisioning completion (it needs the cloud identity).
 	dataTransferWorker := services.NewDataTransferWorker(logger, dataManager, provisioningSvc)
+	// WENDY_DATA_INGEST_URL redirects episode uploads to a different
+	// DataIngestService endpoint (for example a dev cloud deployment) without
+	// touching the device's enrollment; identity still comes from the enrolled
+	// asset certificate.
+	if v := os.Getenv("WENDY_DATA_INGEST_URL"); v != "" {
+		dataTransferWorker.SetIngestHostOverride(v)
+		logger.Info("data transfer worker: ingest endpoint override set",
+			zap.String("url", v))
+	}
 	if telemetryBuf.DiskEnabled() {
 		wg.Add(1)
 		go func() {

--- a/go/internal/agent/services/cloud_flusher.go
+++ b/go/internal/agent/services/cloud_flusher.go
@@ -168,7 +168,7 @@ func zeroBytes(b []byte) {
 // identity over the same trust configuration. Callers own keyData and are
 // responsible for zeroing it; this function does not retain it beyond the
 // X509KeyPair parse.
-func dialCloudMTLS(host, certPEM, chainPEM string, keyData []byte) (*grpc.ClientConn, error) {
+func dialCloudMTLS(host, certPEM, chainPEM string, keyData []byte, extraOpts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	host = normalizeCloudHost(host)
 	// Build client cert PEM bundle: leaf cert + intermediate chain so that
 	// servers can verify the full chain without trusting the leaf directly.
@@ -196,7 +196,8 @@ func dialCloudMTLS(host, certPEM, chainPEM string, keyData []byte) (*grpc.Client
 		RootCAs:      caPool,
 	}
 
-	conn, err := grpc.NewClient(host, grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg)))
+	opts := append([]grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg))}, extraOpts...)
+	conn, err := grpc.NewClient(host, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/go/internal/agent/services/data_transfer_worker.go
+++ b/go/internal/agent/services/data_transfer_worker.go
@@ -11,6 +11,7 @@ import (
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/wendylabsinc/wendy/go/internal/agent/data"
 	cloudpb "github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
@@ -151,9 +152,30 @@ func (w *DataTransferWorker) dialFactory(ctx context.Context) (cloudpb.DataInges
 		return nil, 0, 0, nil, errors.New("data transfer worker: not provisioned")
 	}
 	certPEM, chainPEM, keyData := w.provisioningSvc.ProvisioningCerts()
+	// When an override endpoint is in use there is no Wendy Envoy ingress in
+	// front of the server to terminate mTLS and re-inject the certificate
+	// identity, so the worker sends the same URI form itself in
+	// x-wendy-client-cert (the header EnvoyCertMetadataExtractor reads; see
+	// the cross-repo end-to-end harness, which injects the identical header).
+	// The identity sent is the one the enrolled asset certificate asserts.
+	var extraOpts []grpc.DialOption
+	if w.ingestHostOverride != "" {
+		header := fmt.Sprintf("URI=urn:wendy:org:%d:asset:%d", orgID, assetID)
+		withIdentity := func(ctx context.Context) context.Context {
+			return metadata.AppendToOutgoingContext(ctx, "x-wendy-client-cert", header)
+		}
+		extraOpts = append(extraOpts,
+			grpc.WithChainUnaryInterceptor(func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+				return invoker(withIdentity(ctx), method, req, reply, cc, opts...)
+			}),
+			grpc.WithChainStreamInterceptor(func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+				return streamer(withIdentity(ctx), desc, cc, method, opts...)
+			}),
+		)
+	}
 	conn, err := func() (*grpc.ClientConn, error) {
 		defer zeroBytes(keyData)
-		return dialCloudMTLS(w.ingestDialHost(cloudHost), certPEM, chainPEM, keyData)
+		return dialCloudMTLS(w.ingestDialHost(cloudHost), certPEM, chainPEM, keyData, extraOpts...)
 	}()
 	if err != nil {
 		return nil, 0, 0, nil, err

--- a/go/internal/agent/services/data_transfer_worker.go
+++ b/go/internal/agent/services/data_transfer_worker.go
@@ -66,6 +66,11 @@ type DataTransferWorker struct {
 	factory         ingestClientFactory  // set in tests; production builds one from provisioningSvc
 
 	maxAttempts int
+	// ingestHostOverride, when non-empty, replaces the provisioning cloud host
+	// as the DataIngestService dial target. Enrollment is still required (the
+	// asset identity and client certificate come from provisioning); only the
+	// destination changes. Set from WENDY_DATA_INGEST_URL in main.
+	ingestHostOverride string
 	// onWiFi reports whether the device is currently on Wi-Fi, gating campaigns
 	// whose upload.when is "wifi". When nil, no network-type signal is wired and
 	// "wifi" is treated as "always" (see resolveShouldUpload).
@@ -90,6 +95,36 @@ func NewDataTransferWorker(logger *zap.Logger, manager *data.Manager, provisioni
 	}
 	w.factory = w.dialFactory
 	return w
+}
+
+// SetIngestHostOverride points the worker's uploads at host instead of the
+// provisioning cloud host. host may be a bare host, host:port, or an
+// http(s):// URL; the scheme and any path are stripped and the default port
+// (443) is applied by the dialer. An empty host clears the override.
+func (w *DataTransferWorker) SetIngestHostOverride(host string) {
+	w.ingestHostOverride = normalizeIngestOverride(host)
+}
+
+// normalizeIngestOverride reduces an override value to the host[:port] form
+// dialCloudMTLS expects, tolerating URL-shaped input such as the Cloud Run
+// service URL copied from gcloud.
+func normalizeIngestOverride(host string) string {
+	host = strings.TrimSpace(host)
+	host = strings.TrimPrefix(host, "https://")
+	host = strings.TrimPrefix(host, "http://")
+	if i := strings.IndexByte(host, '/'); i >= 0 {
+		host = host[:i]
+	}
+	return host
+}
+
+// ingestDialHost resolves the host the current pass should dial: the override
+// when set, the enrolled cloud host otherwise.
+func (w *DataTransferWorker) ingestDialHost(cloudHost string) string {
+	if w.ingestHostOverride != "" {
+		return w.ingestHostOverride
+	}
+	return cloudHost
 }
 
 // contextSleeper returns a sleep function that returns early when ctx is done,
@@ -118,7 +153,7 @@ func (w *DataTransferWorker) dialFactory(ctx context.Context) (cloudpb.DataInges
 	certPEM, chainPEM, keyData := w.provisioningSvc.ProvisioningCerts()
 	conn, err := func() (*grpc.ClientConn, error) {
 		defer zeroBytes(keyData)
-		return dialCloudMTLS(cloudHost, certPEM, chainPEM, keyData)
+		return dialCloudMTLS(w.ingestDialHost(cloudHost), certPEM, chainPEM, keyData)
 	}()
 	if err != nil {
 		return nil, 0, 0, nil, err

--- a/go/internal/agent/services/data_transfer_worker.go
+++ b/go/internal/agent/services/data_transfer_worker.go
@@ -128,6 +128,43 @@ func (w *DataTransferWorker) ingestDialHost(cloudHost string) string {
 	return cloudHost
 }
 
+// ingestCertIdentityHeader carries a certificate identity in the URI= form the
+// cloud's Envoy certificate metadata extractor reads. The extractor PREFERS
+// this header over the X-Forwarded-Client-Cert (XFCC) header that Envoy itself
+// injects, and production Envoy does not strip a client-supplied one, so a
+// device that sent this header on the normal enrolled path would be
+// self-asserting its identity. It must therefore only ever be attached on the
+// override path, which does not go through Envoy at all.
+const ingestCertIdentityHeader = "x-wendy-client-cert"
+
+// ingestDialOptions returns the extra dial options for this pass.
+//
+// On the normal enrolled path it returns nil, so no certificate identity
+// header is attached: Wendy's Envoy ingress terminates mutual Transport Layer
+// Security (mTLS) in front of the broker and injects the identity itself.
+//
+// With an ingest host override in effect there is no Envoy ingress in front of
+// the endpoint to do that, so the worker attaches the identity its enrolled
+// asset certificate asserts (the same URI form the cross-repo end-to-end
+// harness injects). orgID and assetID must come from ProvisioningInfo.
+func (w *DataTransferWorker) ingestDialOptions(orgID, assetID int32) []grpc.DialOption {
+	if w.ingestHostOverride == "" {
+		return nil
+	}
+	header := fmt.Sprintf("URI=urn:wendy:org:%d:asset:%d", orgID, assetID)
+	withIdentity := func(ctx context.Context) context.Context {
+		return metadata.AppendToOutgoingContext(ctx, ingestCertIdentityHeader, header)
+	}
+	return []grpc.DialOption{
+		grpc.WithChainUnaryInterceptor(func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+			return invoker(withIdentity(ctx), method, req, reply, cc, opts...)
+		}),
+		grpc.WithChainStreamInterceptor(func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+			return streamer(withIdentity(ctx), desc, cc, method, opts...)
+		}),
+	}
+}
+
 // contextSleeper returns a sleep function that returns early when ctx is done,
 // so backoff and bandwidth pacing stay responsive to shutdown.
 func contextSleeper(ctx context.Context) func(time.Duration) {
@@ -152,27 +189,10 @@ func (w *DataTransferWorker) dialFactory(ctx context.Context) (cloudpb.DataInges
 		return nil, 0, 0, nil, errors.New("data transfer worker: not provisioned")
 	}
 	certPEM, chainPEM, keyData := w.provisioningSvc.ProvisioningCerts()
-	// When an override endpoint is in use there is no Wendy Envoy ingress in
-	// front of the server to terminate mTLS and re-inject the certificate
-	// identity, so the worker sends the same URI form itself in
-	// x-wendy-client-cert (the header EnvoyCertMetadataExtractor reads; see
-	// the cross-repo end-to-end harness, which injects the identical header).
-	// The identity sent is the one the enrolled asset certificate asserts.
-	var extraOpts []grpc.DialOption
-	if w.ingestHostOverride != "" {
-		header := fmt.Sprintf("URI=urn:wendy:org:%d:asset:%d", orgID, assetID)
-		withIdentity := func(ctx context.Context) context.Context {
-			return metadata.AppendToOutgoingContext(ctx, "x-wendy-client-cert", header)
-		}
-		extraOpts = append(extraOpts,
-			grpc.WithChainUnaryInterceptor(func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-				return invoker(withIdentity(ctx), method, req, reply, cc, opts...)
-			}),
-			grpc.WithChainStreamInterceptor(func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
-				return streamer(withIdentity(ctx), desc, cc, method, opts...)
-			}),
-		)
-	}
+	// The identity sent, when one is sent at all, is the one the enrolled asset
+	// certificate asserts: it comes from ProvisioningInfo above, never from the
+	// environment or from anything an app on the device can influence.
+	extraOpts := w.ingestDialOptions(orgID, assetID)
 	conn, err := func() (*grpc.ClientConn, error) {
 		defer zeroBytes(keyData)
 		return dialCloudMTLS(w.ingestDialHost(cloudHost), certPEM, chainPEM, keyData, extraOpts...)

--- a/go/internal/agent/services/data_transfer_worker_test.go
+++ b/go/internal/agent/services/data_transfer_worker_test.go
@@ -442,3 +442,36 @@ func TestDataTransferWorker_AtLeastOnceDuplicateSafe(t *testing.T) {
 		t.Errorf("commit called %d times on already-complete replay, want 0", srv.commitCalls)
 	}
 }
+
+// TestIngestHostOverride verifies that SetIngestHostOverride redirects the
+// dial target (tolerating URL-shaped input) and that clearing it restores the
+// enrolled cloud host.
+func TestIngestHostOverride(t *testing.T) {
+	w := &DataTransferWorker{}
+
+	if got := w.ingestDialHost("cloud.wendy.sh"); got != "cloud.wendy.sh" {
+		t.Fatalf("no override: got %q, want cloud.wendy.sh", got)
+	}
+
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"https://wendy-data-dev-abc-uc.a.run.app", "wendy-data-dev-abc-uc.a.run.app"},
+		{"https://wendy-data-dev-abc-uc.a.run.app/", "wendy-data-dev-abc-uc.a.run.app"},
+		{"http://localhost:9800", "localhost:9800"},
+		{"ingest.example.com:50052", "ingest.example.com:50052"},
+		{"  ingest.example.com  ", "ingest.example.com"},
+	}
+	for _, c := range cases {
+		w.SetIngestHostOverride(c.in)
+		if got := w.ingestDialHost("cloud.wendy.sh"); got != c.want {
+			t.Errorf("override %q: got %q, want %q", c.in, got, c.want)
+		}
+	}
+
+	w.SetIngestHostOverride("")
+	if got := w.ingestDialHost("cloud.wendy.sh"); got != "cloud.wendy.sh" {
+		t.Fatalf("cleared override: got %q, want cloud.wendy.sh", got)
+	}
+}

--- a/go/internal/agent/services/data_transfer_worker_test.go
+++ b/go/internal/agent/services/data_transfer_worker_test.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/test/bufconn"
 
 	"github.com/wendylabsinc/wendy/go/internal/agent/data"
@@ -41,6 +42,30 @@ type fakeIngestServer struct {
 
 	beginCalls  int
 	commitCalls int
+
+	// Incoming request metadata recorded by startFakeIngest, per call kind, so
+	// tests can assert on what the client actually put on the wire.
+	unaryMD  metadata.MD
+	streamMD metadata.MD
+}
+
+// recordMD stores the metadata seen on an incoming call.
+func (s *fakeIngestServer) recordMD(stream bool, md metadata.MD) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if stream {
+		s.streamMD = md
+	} else {
+		s.unaryMD = md
+	}
+}
+
+// headerValues returns the values the client sent for key, on the unary and on
+// the streaming call respectively.
+func (s *fakeIngestServer) headerValues(key string) (unary, stream []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.unaryMD.Get(key), s.streamMD.Get(key)
 }
 
 func newFakeIngestServer() *fakeIngestServer {
@@ -134,17 +159,31 @@ func (s *fakeIngestServer) CommitEpisode(_ context.Context, _ *cloudpb.CommitEpi
 }
 
 // startFakeIngest registers the fake on a bufconn gRPC server and returns a
-// connected client plus a cleanup function.
-func startFakeIngest(t *testing.T, srv *fakeIngestServer) cloudpb.DataIngestServiceClient {
+// connected client plus a cleanup function. The server records the incoming
+// metadata of every call on srv. Any clientOpts are appended to the client's
+// dial options, which lets a test exercise real client interceptors.
+func startFakeIngest(t *testing.T, srv *fakeIngestServer, clientOpts ...grpc.DialOption) cloudpb.DataIngestServiceClient {
 	t.Helper()
 	lis := bufconn.Listen(1024 * 1024)
-	g := grpc.NewServer()
+	g := grpc.NewServer(
+		grpc.UnaryInterceptor(func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+			md, _ := metadata.FromIncomingContext(ctx)
+			srv.recordMD(false, md)
+			return handler(ctx, req)
+		}),
+		grpc.StreamInterceptor(func(v any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+			md, _ := metadata.FromIncomingContext(ss.Context())
+			srv.recordMD(true, md)
+			return handler(v, ss)
+		}),
+	)
 	cloudpb.RegisterDataIngestServiceServer(g, srv)
 	go func() { _ = g.Serve(lis) }()
-	conn, err := grpc.NewClient("passthrough:///bufnet",
+	opts := append([]grpc.DialOption{
 		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
+	}, clientOpts...)
+	conn, err := grpc.NewClient("passthrough:///bufnet", opts...)
 	if err != nil {
 		t.Fatalf("grpc.NewClient: %v", err)
 	}
@@ -473,5 +512,78 @@ func TestIngestHostOverride(t *testing.T) {
 	w.SetIngestHostOverride("")
 	if got := w.ingestDialHost("cloud.wendy.sh"); got != "cloud.wendy.sh" {
 		t.Fatalf("cleared override: got %q, want cloud.wendy.sh", got)
+	}
+}
+
+// runIdentityHeaderPass drives one real upload pass over bufconn with the dial
+// options an ingest host override of override produces, and returns the fake
+// server so the caller can inspect the metadata that reached it. orgID and
+// assetID stand in for what ProvisioningInfo reports on a real device.
+func runIdentityHeaderPass(t *testing.T, override string, orgID, assetID int32) *fakeIngestServer {
+	t.Helper()
+	mgr, root := newTestManager(t)
+	writeFixtureEpisode(t, root, "ep-identity", "", "pending", map[string][]byte{"blob.bin": []byte("payload")})
+
+	srv := newFakeIngestServer()
+	w := &DataTransferWorker{
+		logger:      zap.NewNop(),
+		manager:     mgr,
+		maxAttempts: transferMaxAttempts,
+		now:         time.Now,
+		newSleeper:  contextSleeper,
+	}
+	w.SetIngestHostOverride(override)
+	// The client is dialed with exactly the options dialFactory would pass, so
+	// the production interceptors (when there are any) run for real.
+	client := startFakeIngest(t, srv, w.ingestDialOptions(orgID, assetID)...)
+	w.factory = func(context.Context) (cloudpb.DataIngestServiceClient, uint64, uint64, func(), error) {
+		return client, uint64(orgID), uint64(assetID), func() {}, nil
+	}
+
+	if err := w.runPass(context.Background()); err != nil {
+		t.Fatalf("runPass: %v", err)
+	}
+	if got := uploadState(t, mgr, "ep-identity").State; got != uploadStateUploaded {
+		t.Fatalf("state = %q, want uploaded", got)
+	}
+	return srv
+}
+
+// TestIngestIdentityHeaderAbsentWithoutOverride is the security-relevant case.
+// On the normal enrolled path the broker sits behind Wendy's Envoy ingress,
+// which injects the certificate identity itself, and the cloud's extractor
+// prefers a client-supplied x-wendy-client-cert over Envoy's own
+// X-Forwarded-Client-Cert while production Envoy does not strip it. A device
+// that sent the header there would be self-asserting its identity, so it must
+// never appear on any call when no ingest host override is in effect.
+func TestIngestIdentityHeaderAbsentWithoutOverride(t *testing.T) {
+	if opts := (&DataTransferWorker{}).ingestDialOptions(91, 7532); opts != nil {
+		t.Errorf("no override: got %d dial options, want none", len(opts))
+	}
+
+	srv := runIdentityHeaderPass(t, "", 91, 7532)
+	unary, stream := srv.headerValues("x-wendy-client-cert")
+	if len(unary) != 0 {
+		t.Errorf("unary call carried x-wendy-client-cert %q without an override; the device must not self-assert identity on the enrolled path", unary)
+	}
+	if len(stream) != 0 {
+		t.Errorf("streaming call carried x-wendy-client-cert %q without an override; the device must not self-assert identity on the enrolled path", stream)
+	}
+}
+
+// TestIngestIdentityHeaderWithOverride pins the exact header value sent on the
+// override path: the URI form of the enrolled asset identity, built from the
+// org and asset that ProvisioningInfo reports, on both unary and streaming
+// calls.
+func TestIngestIdentityHeaderWithOverride(t *testing.T) {
+	srv := runIdentityHeaderPass(t, "https://ingest.example.com/", 91, 7532)
+	const want = "URI=urn:wendy:org:91:asset:7532"
+
+	unary, stream := srv.headerValues("x-wendy-client-cert")
+	if len(unary) != 1 || unary[0] != want {
+		t.Errorf("unary call: x-wendy-client-cert = %q, want exactly [%q]", unary, want)
+	}
+	if len(stream) != 1 || stream[0] != want {
+		t.Errorf("streaming call: x-wendy-client-cert = %q, want exactly [%q]", stream, want)
 	}
 }


### PR DESCRIPTION
## Problem

A device enrolled against production cannot upload episodes to a development or self-hosted DataIngestService: the episode transfer worker always dials the provisioning cloud host, so testing the ingest seam end-to-end requires re-enrolling the device against the target environment.

## Cause

DataTransferWorker.dialFactory reads its dial target exclusively from ProvisioningService.ProvisioningInfo(). There is no configuration point between worker construction in cmd/wendy-agent/main.go and the dial, unlike WENDY_BROKER_URL and WENDY_CLOUD_URL which already exist for their respective seams.

## Solution

Add SetIngestHostOverride on DataTransferWorker and apply it in main.go from the WENDY_DATA_INGEST_URL environment variable. Only the dial target changes: enrollment, the asset mutual Transport Layer Security (mTLS) identity presented to the server, and the telemetry flusher are untouched. URL-shaped values (scheme, trailing slash or path) are normalized to the host:port form dialCloudMTLS expects, so the Cloud Run URL from gcloud can be pasted verbatim.

Because an override endpoint has no Wendy Envoy ingress in front of it to terminate mTLS and inject the certificate identity, the worker attaches that identity itself when, and only when, the override is active: `x-wendy-client-cert: URI=urn:wendy:org:<org>:asset:<asset>`, built from ProvisioningInfo. The conditional matters for security. The cloud's EnvoyCertMetadataExtractor prefers this header over the X-Forwarded-Client-Cert (XFCC) header Envoy injects, and production Envoy does not strip a client-supplied one, so a device that sent it on the normal enrolled path would be self-asserting its identity.

## Test coverage

- `TestIngestHostOverride` covers host-string normalization only (scheme, trailing path, whitespace, clearing the override), not the header.
- `TestIngestIdentityHeaderAbsentWithoutOverride` asserts that with no override set, `ingestDialOptions` adds no interceptors and no `x-wendy-client-cert` reaches the server on either the unary or the streaming call. This is the regression guard against the interceptor ever becoming unconditional.
- `TestIngestIdentityHeaderWithOverride` asserts that with an override set, the header value is exactly `URI=urn:wendy:org:<org>:asset:<asset>` using the provisioning org and asset, on both the unary and the streaming call.

Both header tests drive a real gRPC connection over bufconn with exactly the dial options dialFactory passes, so the production interceptors run rather than a copy of them. Each was mutation-verified: making the interceptor unconditional fails the first, reordering the URI fields fails the second. `go test` and `go test -race` on `./internal/agent/services/...` are green.

Used on the Hubert demo device to point episode uploads at the wendy-data-dev Cloud Run service while its enrollment stays on production.
