### PR TITLE
fix(data): attribute app data socket peers under the cgroupfs driver

### DIFF
--- a/go/internal/agent/services/app_data_socket.go
+++ b/go/internal/agent/services/app_data_socket.go
@@ -260,14 +260,26 @@ func (m *AppDataSocketManager) verifyPeer(appID string, c net.Conn) error {
 // no such scope component is present, which is the signal that the peer is not
 // a wendy-managed app container.
 func appIDFromCgroup(cgroup string) (string, bool) {
-	prefix := sharedenv.SystemdServiceName() + "-"
+	svc := sharedenv.SystemdServiceName()
+	prefix := svc + "-"
 	for _, line := range strings.Split(cgroup, "\n") {
 		for _, segment := range strings.Split(line, "/") {
 			segment = strings.TrimSuffix(segment, ".scope")
-			if !strings.HasPrefix(segment, prefix) {
+			id := ""
+			switch {
+			case strings.HasPrefix(segment, prefix):
+				// systemd cgroup driver: runc translated the
+				// "system.slice:{svc}:{suffix}" CgroupsPath into a
+				// "{svc}-{suffix}.scope" unit.
+				id = strings.TrimPrefix(segment, prefix)
+			case strings.HasPrefix(segment, "system.slice:"+svc+":"):
+				// cgroupfs cgroup driver: the same CgroupsPath is taken as a
+				// literal directory name, colons and all, so the whole
+				// "system.slice:{svc}:{suffix}" string is one path segment.
+				id = strings.TrimPrefix(segment, "system.slice:"+svc+":")
+			default:
 				continue
 			}
-			id := strings.TrimPrefix(segment, prefix)
 			if at := strings.IndexByte(id, '@'); at >= 0 {
 				id = id[:at]
 			}

--- a/go/internal/agent/services/app_data_socket_hardening_test.go
+++ b/go/internal/agent/services/app_data_socket_hardening_test.go
@@ -263,6 +263,12 @@ func TestAppIDFromCgroup(t *testing.T) {
 		{"multi service strips suffix", "0::/system.slice/edge-agent-com.example.a@worker.scope\n", "com.example.a", true},
 		{"non-wendy process", "0::/user.slice/user-1000.slice/session-3.scope\n", "", false},
 		{"empty", "", "", false},
+		// cgroupfs driver: runc takes the "slice:prefix:name" CgroupsPath as a
+		// literal directory name instead of translating it to a systemd scope
+		// (observed on WendyOS 0.16.0 devices).
+		{"cgroupfs single service", "0::/system.slice/system.slice:edge-agent:com.example.a\n", "com.example.a", true},
+		{"cgroupfs multi service strips suffix", "0::/system.slice/system.slice:edge-agent:com.example.a@worker\n", "com.example.a", true},
+		{"cgroupfs other systemd service", "0::/system.slice/system.slice:other-agent:com.example.a\n", "", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/go/internal/agent/services/app_data_socket_hardening_test.go
+++ b/go/internal/agent/services/app_data_socket_hardening_test.go
@@ -251,6 +251,64 @@ func TestAppDataPeerCredentialNoScopeRefused(t *testing.T) {
 	}
 }
 
+// TestAppDataPeerCredentialCgroupfsMatchAllowed proves the socket admits a peer
+// whose cgroupfs-driver cgroup (literal "system.slice:{svc}:{appID}" path
+// segment) resolves to the socket's own app. This exercises the full
+// verifyPeer -> appIDFromCgroup path for the cgroupfs driver, not just the
+// systemd form the other socket-level tests use.
+func TestAppDataPeerCredentialCgroupfsMatchAllowed(t *testing.T) {
+	m := newTestDataSocketManager(t)
+	m.peerCred = func(net.Conn) (peerCredentials, error) {
+		return peerCredentials{UID: 0, PID: 4242}, nil
+	}
+	m.cgroupOfPID = func(int32) (string, error) {
+		return "0::/system.slice/system.slice:edge-agent:com.example.a@worker\n", nil
+	}
+	dir, err := m.Ensure("com.example.a", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := net.Dial("unix", filepath.Join(dir, DataSocketFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	ack := sendRecord(t, conn, data.ApplicationRecord{Version: 1, Type: "event", Name: "ready", ClientBootID: "unavailable"})
+	if ack.State != "buffered" {
+		t.Fatalf("matching cgroupfs peer: state = %q, want buffered", ack.State)
+	}
+}
+
+// TestAppDataPeerCredentialCgroupfsMismatchRefused proves the socket fails
+// closed under the cgroupfs driver: a peer that belongs to a DIFFERENT app is
+// refused, exactly as it is under systemd. This is the core D6 forgery guard,
+// verified on the cgroupfs code path that PR #1755 introduces.
+func TestAppDataPeerCredentialCgroupfsMismatchRefused(t *testing.T) {
+	m := newTestDataSocketManager(t)
+	m.peerCred = func(net.Conn) (peerCredentials, error) {
+		return peerCredentials{UID: 0, PID: 4242}, nil
+	}
+	m.cgroupOfPID = func(int32) (string, error) {
+		// Attacker owns com.attacker and tries to append a victim-named child
+		// cgroup. The real (parent) scope still wins, so the peer resolves to
+		// com.attacker and is refused on the com.victim socket.
+		return "0::/system.slice/system.slice:edge-agent:com.attacker/system.slice:edge-agent:com.victim\n", nil
+	}
+	dir, err := m.Ensure("com.victim", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := net.Dial("unix", filepath.Join(dir, DataSocketFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if ack := readRejectAck(t, conn); ack.State != "rejected" {
+		t.Fatalf("cgroupfs cross-app forgery: state = %q, want rejected (fail closed)", ack.State)
+	}
+}
+
 // TestAppIDFromCgroup covers the cgroup identity extraction directly.
 func TestAppIDFromCgroup(t *testing.T) {
 	cases := []struct {
@@ -269,6 +327,24 @@ func TestAppIDFromCgroup(t *testing.T) {
 		{"cgroupfs single service", "0::/system.slice/system.slice:edge-agent:com.example.a\n", "com.example.a", true},
 		{"cgroupfs multi service strips suffix", "0::/system.slice/system.slice:edge-agent:com.example.a@worker\n", "com.example.a", true},
 		{"cgroupfs other systemd service", "0::/system.slice/system.slice:other-agent:com.example.a\n", "", false},
+		// FORGERY ATTEMPT (cgroupfs): a peer that owns app com.attacker and has
+		// write access to its own delegated cgroup subtree creates a child
+		// cgroup literally named after the victim's scope and moves itself into
+		// it. The peer's true (parent) scope segment always precedes any child
+		// it can create, so first-match returns the attacker's real id, never
+		// the victim's. Fail closed against the mismatch downstream.
+		{"cgroupfs child cgroup forgery yields parent id", "0::/system.slice/system.slice:edge-agent:com.attacker/system.slice:edge-agent:com.victim\n", "com.attacker", true},
+		// FORGERY ATTEMPT (systemd): same delegation attack expressed as nested
+		// scope units. Parent scope still wins.
+		{"systemd child scope forgery yields parent id", "0::/system.slice/edge-agent-com.attacker.scope/edge-agent-com.victim.scope\n", "com.attacker", true},
+		// FAIL CLOSED (cgroupfs): an empty suffix is not a valid app identity;
+		// it must not resolve to any app.
+		{"cgroupfs empty suffix", "0::/system.slice/system.slice:edge-agent:\n", "", false},
+		// FAIL CLOSED (cgroupfs): empty appID with only a service suffix.
+		{"cgroupfs empty appID with service", "0::/system.slice/system.slice:edge-agent:@worker\n", "", false},
+		// FAIL CLOSED (cgroupfs): the exact-service prefix must match; a service
+		// whose name merely shares a prefix with edge-agent is not edge-agent.
+		{"cgroupfs service prefix is not a match", "0::/system.slice/system.slice:edge-agent-x:com.example.a\n", "", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Problem

On a real WendyOS device (Jetson Orin Nano, WendyOS 0.16.0, agent built from feature/wendy-data-platform) every connection from the reference app to its app data socket is refused with: peer (pid N, uid 0) is not in a wendy app scope; cannot attribute to app sh.wendy.examples.wendydatamodelapp. No prediction or event records reach the agent, so campaign triggers never arm. The end-to-end harness does not catch this because it exercises the systemd cgroup driver path.

## Cause

appIDFromCgroup only recognizes the systemd cgroup driver's translated scope form {svc}-{appID}[@service].scope. containerd on the device uses the cgroupfs driver, which takes the system.slice:{svc}:{appID} CgroupsPath assigned in client.go as a literal directory name, colons included. The peer's /proc/<pid>/cgroup therefore carries system.slice:edge-agent:sh.wendy.examples.wendydatamodelapp as a single path segment, extraction finds no app identity, and verification (correctly) fails closed, refusing the app's own records.

## Solution

Teach appIDFromCgroup the literal cgroupfs segment form: match system.slice:{svc}: with the same systemd service name and strip the same @service suffix as the scope form. Both cgroup drivers now attribute identically, and a peer under a different systemd service name still fails closed. Covered by new TestAppIDFromCgroup cases copied from the cgroup line observed on the device.

Found while preparing the Wendy Data Platform demo on the Hubert device; verified there by rebuilding the agent with this fix and watching the app's records be accepted.