### PR TITLE
docs(data): real-device demo runbook, example Dockerfile fixes, telemetry-only campaign variant

### DIFF
--- a/Examples/WendyDataModelApp/Dockerfile
+++ b/Examples/WendyDataModelApp/Dockerfile
@@ -11,9 +11,16 @@
 # (the same wheel HelloONNX's Stagefile resolves with `cuda: true`).
 
 FROM python:3.11-slim-bookworm AS export
+# Ultralytics depends on the GUI opencv-python wheel, whose import needs
+# X client libraries the slim image lacks (libxcb, libGL, glib). They are
+# build-stage only; the runtime stage keeps opencv-python-headless.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libxcb1 libgl1 libglib2.0-0 \
+    && rm -rf /var/lib/apt/lists/*
 # Pin the Ultralytics release; it is the model version reported in every
 # prediction record (WENDY_MODEL_VERSION) and pinned in campaign.yaml.
-RUN pip install --no-cache-dir "ultralytics==8.3.63" "onnx<2" onnxruntime
+# onnxscript backs torch.onnx.export from torch 2.13 onwards.
+RUN pip install --no-cache-dir "ultralytics==8.3.63" "onnx<2" onnxruntime onnxscript
 WORKDIR /export
 # Downloads the pinned yolov8n.pt weights and exports yolov8n.onnx.
 # opset 12 keeps the graph loadable by every onnxruntime this app targets.

--- a/Examples/WendyDataModelApp/campaign-hubert.yaml
+++ b/Examples/WendyDataModelApp/campaign-hubert.yaml
@@ -1,0 +1,43 @@
+# Campaign for the WendyDataModelApp reference app. Deploy with:
+#
+#   wendy data campaign deploy campaign.yaml
+#
+# The app's prediction and event records arrive over the data socket and
+# arm these triggers; the "applications" source is always captured, so
+# every episode carries the records themselves in events.jsonl.
+version: 1
+
+name: model-harness-demo
+
+sources:
+  # Hubert's only camera (/dev/video0) is held open by the app itself, so
+  # the campaign captures the telemetry stream instead; the "applications"
+  # source (predictions and events) is always captured regardless.
+  - telemetry: true
+
+capture:
+  # Keep 10 seconds of pre-trigger application records and 20 seconds
+  # after the trigger.
+  buffer: 10s
+  after_trigger: 20s
+  triggers:
+    # Fired by the app's edge-triggered person event.
+    - event: person_detected
+    # Fired by any prediction whose attributes.uncertainty exceeds 0.65:
+    # frames where YOLOv8n saw nothing above its confidence threshold
+    # (uncertainty 1.0) or only low-confidence detections.
+    - model.uncertainty: "> 0.65"
+
+upload:
+  when: always
+
+retention:
+  local_quota: 5GiB
+
+export:
+  annotation: cvat
+
+# Pin the model this campaign collects for, matching the version every
+# prediction record reports in attributes.model_version.
+models:
+  yolov8n: "8.3.63"

--- a/Examples/WendyDataModelApp/campaign-telemetry-only.yaml
+++ b/Examples/WendyDataModelApp/campaign-telemetry-only.yaml
@@ -1,6 +1,7 @@
-# Campaign for the WendyDataModelApp reference app. Deploy with:
+# Telemetry-only variant of the WendyDataModelApp reference campaign, for a
+# device with a single camera that the app itself holds open. Deploy with:
 #
-#   wendy data campaign deploy campaign.yaml
+#   wendy data campaign deploy campaign-telemetry-only.yaml
 #
 # The app's prediction and event records arrive over the data socket and
 # arm these triggers; the "applications" source is always captured, so
@@ -10,9 +11,9 @@ version: 1
 name: model-harness-demo
 
 sources:
-  # Hubert's only camera (/dev/video0) is held open by the app itself, so
-  # the campaign captures the telemetry stream instead; the "applications"
-  # source (predictions and events) is always captured regardless.
+  # The device's only camera is held open by the app itself, so the campaign
+  # captures the telemetry stream instead; the "applications" source
+  # (predictions and events) is always captured regardless.
   - telemetry: true
 
 capture:

--- a/go/internal/cli/assets/docs/wendy-data-platform-demo.md
+++ b/go/internal/cli/assets/docs/wendy-data-platform-demo.md
@@ -1,0 +1,218 @@
+# Wendy Data Platform demo runbook (Hubert)
+
+How to reproduce the end-to-end Wendy Data Platform demo on a real device from
+a clean start: a Jetson Orin Nano ("Hubert", `wendyos-hubert.local`) running
+the `feature/wendy-data-platform` agent, the D5 reference model app
+(`Examples/WendyDataModelApp`), a flight-recorder campaign, and episode
+uploads into the deployed dev cloud ingest service (`wendy-data-dev` on
+Cloud Run, project `cloud-c7e56`).
+
+Everything below was executed and verified on 2026-08-23. Episode
+`20260823T094944Z-8b61e446d12c495f` fired organically on
+`model.uncertainty > 0.65`, carried 97 yolov8n prediction records in
+`events.jsonl` (including the pre-trigger buffer), and reached the dev ingest
+catalog (upload state `uploaded`, which only flips after `CommitEpisode`
+verifies every file hash server-side).
+
+## Device facts (Hubert)
+
+| Fact | Value |
+|---|---|
+| Hostname / IP | `wendyos-hubert.local` / 10.60.10.90 (wlan0) |
+| Hardware | Jetson Orin Nano, 6 CPU, 8 GB RAM, GPU sm_87, CUDA 13.2, JetPack 7.2 |
+| OS | WendyOS 0.16.0 (blacksail), slot A, tegrauefi |
+| Enrollment | Production cloud, org 2, asset 172 (UNTOUCHED by this demo) |
+| Camera | Logitech C920 PRO HD on `/dev/video0` (`/dev/video1` is its metadata node) |
+| Agent before demo | 2026.08.07-174446 |
+| Agent during demo | `dev-data-platform-demo-ca322e8` (override + cgroupfs attribution fix) |
+| Disk | root 7.3 GiB (tight, see below); `/data` 440 GiB |
+| SSH | `root@10.60.10.90` (key auth; the `wendy` user refuses keys) |
+
+## 0. Prerequisites on the workstation
+
+- Go toolchain; cgo builds need `CC=/usr/bin/clang` on this Mac (the default
+  `clang` resolves to a swiftly shim that breaks cgo with a silent
+  "exit status 2").
+- Docker Desktop for the app image build. If a pull hangs, the desktop
+  credsStore is the cause: point `DOCKER_CONFIG` at a scratch directory
+  containing a `config.json` of `{}`.
+- `gcloud` for the ingest URL; on this Mac it needs
+  `CLOUDSDK_PYTHON=/opt/homebrew/bin/python3` (system Python 3.9 crashes it).
+
+## 1. Recon (read-only)
+
+```sh
+wendy device list --timeout 8s          # no --scan flag; --timeout scans once
+wendy device info --device wendyos-hubert.local
+ssh root@10.60.10.90 'df -h / /data; ls /dev/video*'
+```
+
+Check `df` before anything else. Hubert's root filesystem had been filled to
+100 percent by 64 daily agent-updater backups in `/opt/wendy/bin`
+(`wendy-agent.backup.*`, about 1.3 GiB); the nightly updater had been failing
+since Aug 12 (zero-byte backups) and the Aug 23 run left
+`/usr/local/bin/wendy-agent` truncated and the agent dead. Recovery, if this
+recurs:
+
+```sh
+ssh root@10.60.10.90 '
+  rm -f /opt/wendy/bin/wendy-agent.backup.*
+  cp /opt/wendy/bin/wendy-agent.latest /usr/local/bin/wendy-agent
+  systemctl restart wendyos-agent'
+```
+
+## 2. Build the integration agent and CLI
+
+```sh
+git -C ~/Documents/Projects/WendyOS fetch origin feature/wendy-data-platform
+git -C ~/Documents/Projects/WendyOS worktree add \
+    ~/Documents/Projects/WendyOS/.worktrees/demo-hubert origin/feature/wendy-data-platform
+cd ~/Documents/Projects/WendyOS/.worktrees/demo-hubert/go
+
+# Agent: pure Go, cross-compiles from macOS directly (CGO_ENABLED=0).
+make build-agent-linux-arm64 VERSION=dev-data-platform-demo
+
+# CLI: needs cgo (gousb, BLE); the darwin Makefile target's CGO_ENABLED=0
+# does not link, so build it directly:
+CC=/usr/bin/clang CGO_ENABLED=1 go build \
+    -ldflags "-s -w -X github.com/wendylabsinc/wendy/go/internal/shared/version.Version=dev-data-platform" \
+    -o bin/wendy-demo ./cmd/wendy
+./bin/wendy-demo data --help   # the data verbs exist only on this branch
+```
+
+## 3. Install the agent on Hubert
+
+Keep a rollback first (done; lives on the device):
+
+```sh
+ssh root@10.60.10.90 'ls /data/demo-hubert-rollback'
+# wendy-agent.2026.08.07.sha-5fd12f + ROLLBACK.txt with the restore command
+```
+
+Then push with the sanctioned update path and verify:
+
+```sh
+./bin/wendy-demo device update --binary bin/wendy-agent-linux-arm64 --device wendyos-hubert.local
+./bin/wendy-demo device info --device wendyos-hubert.local   # "version" shows the new build
+./bin/wendy-demo data sources --device wendyos-hubert.local  # v2 DataService answers; camera healthy
+```
+
+The nightly auto-updater would overwrite this agent at ~00:10; it is disabled
+for the demo window:
+
+```sh
+ssh root@10.60.10.90 'systemctl disable --now wendyos-agent-updater.timer'
+# undo after the demo:
+ssh root@10.60.10.90 'systemctl enable --now wendyos-agent-updater.timer'
+```
+
+## 4. Point the data plane at the dev cloud
+
+Enrollment stays on production; only the episode transfer worker is
+redirected. The agent's systemd unit reads `/etc/default/wendy-agent`
+(`EnvironmentFile=`), so:
+
+```sh
+URL=$(CLOUDSDK_PYTHON=/opt/homebrew/bin/python3 gcloud run services describe \
+      wendy-data-dev --region us-central1 --project cloud-c7e56 \
+      --format='value(status.url)')
+ssh root@10.60.10.90 "cat >> /etc/default/wendy-agent <<EOF
+WENDY_DATA_INGEST_URL=$URL
+WENDY_DATA_DIR=/data/wendy-agent/episodes
+EOF
+mkdir -p /data/wendy-agent/episodes && systemctl restart wendyos-agent"
+```
+
+- `WENDY_DATA_INGEST_URL` is new in PR #1754: it redirects the transfer
+  worker's dial target and, because Cloud Run has no Wendy Envoy ingress to
+  re-inject the mTLS identity, also attaches
+  `x-wendy-client-cert: URI=urn:wendy:org:<org>:asset:<asset>` (the header
+  `EnvoyCertMetadataExtractor` reads) carrying the enrolled asset identity.
+- `WENDY_DATA_DIR` moves the episode store off the 7.3 GiB root partition
+  (default `/var/lib/wendy-agent/data/episodes`) onto `/data`.
+
+Verify the override took: the agent logs
+`data transfer worker: ingest endpoint override set` at startup.
+
+## 5. Deploy the D5 app and campaign
+
+```sh
+cd ../Examples/WendyDataModelApp
+../../go/bin/wendy-demo run --device wendyos-hubert.local --detach --yes
+../../go/bin/wendy-demo data campaign deploy campaign-hubert.yaml --device wendyos-hubert.local
+../../go/bin/wendy-demo data campaign trigger model-harness-demo --device wendyos-hubert.local
+```
+
+Campaign adjustment made for Hubert: the checked-in `campaign.yaml` declares a
+`camera: front` snapshot source, but the app itself holds `/dev/video0` open
+(OpenCV), so the campaign's capture adapter gets `VIDIOC_S_FMT: device busy`
+and the trigger fails. The deployed variant replaces the camera source with
+`- telemetry: true` and keeps the triggers, upload policy, and model pin; the
+`applications` source (every prediction and event record) is always captured
+regardless, so episodes still carry the model's outputs. A second USB webcam
+would let the original camera source work unchanged.
+
+Verify, in order:
+
+```sh
+./bin/wendy-demo data episodes --device wendyos-hubert.local     # newest episode "complete"
+./bin/wendy-demo data inspect <episode-id> --device wendyos-hubert.local
+# trigger.reason, files [events.jsonl, telemetry.jsonl], upload.state "uploaded"
+```
+
+`upload.state: "uploaded"` is the cloud-side proof: the worker only records it
+after `CommitEpisode` succeeds, and the server verifies every stored object's
+SHA-256 against the manifest before flipping the catalog row to complete.
+Read-side inspection of the catalog (QueryEpisodes/GetEpisode) requires a user
+bearer token, not the asset identity; check rows in the dev ClickHouse
+(`episodes` / `episode_files` tables) or through the BI surface once wired.
+
+With nothing in front of the camera the app reports uncertainty 1.0, so the
+`model.uncertainty > 0.65` trigger fires organically; walking into the frame
+fires the edge-triggered `person_detected` instead. Each trigger seals one
+episode (10 s pre-buffer, 20 s post) which uploads within seconds.
+
+## Pitfalls discovered on the way (all hit for real)
+
+1. Full root disk from updater backups: see Recon above.
+2. `Dockerfile` export stage: ultralytics pulls the GUI `opencv-python`
+   wheel needing `libxcb1 libgl1 libglib2.0-0`, and torch >= 2.13 needs
+   `onnxscript` for ONNX export. Both fixed in this PR's Dockerfile.
+3. App data socket refused with "peer is not in a wendy app scope": Hubert's
+   containerd uses the cgroupfs driver, so the `system.slice:edge-agent:<app>`
+   cgroup path is literal and the attribution parser did not recognize it.
+   Fixed in PR #1755; without it no record ever reaches the agent.
+4. After ANY agent restart the app's data socket listener is gone and the app
+   gets ECONNREFUSED until the app is redeployed (`device apps remove --force`
+   then `wendy run`). Cause: the chunk-diff deploy path creates containers
+   without `sh.wendy/entitlement.*` labels, so `RestoreAppSystemAPISockets`
+   skips them. Open bug; fix the deploy order (agent first, app last) until
+   it lands.
+5. An episode that exhausts its 5 upload attempts is terminally `failed` and
+   is never retried; trigger a fresh episode after fixing connectivity.
+6. `wendy device apps start` streams logs and does not return with `--detach`
+   semantics; script around it or use `wendy run`.
+
+## Rollback
+
+```sh
+ssh root@10.60.10.90 '
+  cp /data/demo-hubert-rollback/wendy-agent.2026.08.07.sha-5fd12f /usr/local/bin/wendy-agent
+  chmod 755 /usr/local/bin/wendy-agent
+  sed -i "/WENDY_DATA_INGEST_URL/d;/WENDY_DATA_DIR/d" /etc/default/wendy-agent
+  systemctl restart wendyos-agent
+  systemctl enable --now wendyos-agent-updater.timer'
+```
+
+## Open gaps
+
+- Camera frames inside episodes need a second webcam (or an app change to
+  share frames) because the app monopolizes `/dev/video0`.
+- The cgroupfs attribution fix (PR #1755) and the ingest override (PR #1754)
+  must merge into `feature/wendy-data-platform`; Hubert currently runs a local
+  build combining both.
+- Chunk-diff deploys omit entitlement labels (pitfall 4) - open bug.
+- Catalog read verification from the CLI needs a dev bearer token; today the
+  proof is the commit-gated `uploaded` state plus the dev ClickHouse.
+- The GPU (onnxruntime-gpu) variant of the app was not exercised; the demo
+  runs the CPU path at 5 predictions per second.

--- a/go/internal/cli/assets/docs/wendy-data-platform-demo.md
+++ b/go/internal/cli/assets/docs/wendy-data-platform-demo.md
@@ -1,218 +1,245 @@
-# Wendy Data Platform demo runbook (Hubert)
+# Wendy Data Platform demo runbook
 
 How to reproduce the end-to-end Wendy Data Platform demo on a real device from
-a clean start: a Jetson Orin Nano ("Hubert", `wendyos-hubert.local`) running
-the `feature/wendy-data-platform` agent, the D5 reference model app
-(`Examples/WendyDataModelApp`), a flight-recorder campaign, and episode
-uploads into the deployed dev cloud ingest service (`wendy-data-dev` on
-Cloud Run, project `cloud-c7e56`).
+a clean start: an NVIDIA Jetson running a WendyOS agent built from the data
+platform branch, the reference model app (`Examples/WendyDataModelApp`), a
+flight-recorder campaign, and episode uploads into a deployed cloud ingest
+service.
 
-Everything below was executed and verified on 2026-08-23. Episode
-`20260823T094944Z-8b61e446d12c495f` fired organically on
-`model.uncertainty > 0.65`, carried 97 yolov8n prediction records in
-`events.jsonl` (including the pre-trigger buffer), and reached the dev ingest
-catalog (upload state `uploaded`, which only flips after `CommitEpisode`
-verifies every file hash server-side).
+The path this runbook walks has been executed on real hardware. An episode
+fires organically on the `model.uncertainty > 0.65` trigger, carries the app's
+YOLOv8n prediction records in `events.jsonl` (including the pre-trigger
+buffer), and reaches the ingest catalog with upload state `uploaded`, which
+only flips after `CommitEpisode` verifies every file hash server-side.
 
-## Device facts (Hubert)
+Placeholders used throughout, to be replaced with your own values:
 
-| Fact | Value |
+| Placeholder | What it is |
 |---|---|
-| Hostname / IP | `wendyos-hubert.local` / 10.60.10.90 (wlan0) |
-| Hardware | Jetson Orin Nano, 6 CPU, 8 GB RAM, GPU sm_87, CUDA 13.2, JetPack 7.2 |
-| OS | WendyOS 0.16.0 (blacksail), slot A, tegrauefi |
-| Enrollment | Production cloud, org 2, asset 172 (UNTOUCHED by this demo) |
-| Camera | Logitech C920 PRO HD on `/dev/video0` (`/dev/video1` is its metadata node) |
-| Agent before demo | 2026.08.07-174446 |
-| Agent during demo | `dev-data-platform-demo-ca322e8` (override + cgroupfs attribution fix) |
-| Disk | root 7.3 GiB (tight, see below); `/data` 440 GiB |
-| SSH | `root@10.60.10.90` (key auth; the `wendy` user refuses keys) |
+| `<device-hostname>` | The device's mDNS name, for example `wendyos-<name>.local` |
+| `<org-id>` | The organization the device is enrolled in |
+| `<asset-id>` | The device's asset identifier in that organization |
+| `<your-gcp-project>` | The Google Cloud project hosting the ingest service |
+| `<ingest-url>` | The ingest service URL the device should upload to |
+| `<episode-id>` | An episode identifier, as printed by `wendy data episodes` |
 
-## 0. Prerequisites on the workstation
+## 0. Record the device's starting state
 
-- Go toolchain; cgo builds need `CC=/usr/bin/clang` on this Mac (the default
-  `clang` resolves to a swiftly shim that breaks cgo with a silent
-  "exit status 2").
-- Docker Desktop for the app image build. If a pull hangs, the desktop
-  credsStore is the cause: point `DOCKER_CONFIG` at a scratch directory
-  containing a `config.json` of `{}`.
-- `gcloud` for the ingest URL; on this Mac it needs
-  `CLOUDSDK_PYTHON=/opt/homebrew/bin/python3` (system Python 3.9 crashes it).
+Before changing anything, write down what you are about to change, so you can
+put it back. The demo touches the agent binary, one environment file, and the
+auto-updater timer; it does not touch enrollment.
 
-## 1. Recon (read-only)
+| Fact | Why it matters |
+|---|---|
+| Hostname | Every `wendy` command below takes `--device <device-hostname>` |
+| Hardware and WendyOS version | Determines which agent build to install |
+| Enrollment (organization and asset) | Stays as-is; the demo redirects uploads only |
+| Camera device nodes | The app and the campaign compete for these, see step 5 |
+| Agent version before the demo | The rollback target |
+| Free space on `/` and on the data partition | Episodes are large; see step 4 |
+
+## 1. Prerequisites on the workstation
+
+- Go toolchain. On macOS, cgo builds need `CC=/usr/bin/clang`; if `clang`
+  resolves to a Swift toolchain shim, cgo fails with a silent
+  "exit status 2".
+- Docker for the app image build. If a pull hangs on macOS, the Docker Desktop
+  credential store is the usual cause: point `DOCKER_CONFIG` at a scratch
+  directory containing a `config.json` of `{}`.
+- The Google Cloud command-line interface (`gcloud`) if you need to look up the
+  ingest URL. If it crashes under an old system Python, set `CLOUDSDK_PYTHON`
+  to a newer interpreter.
+
+## 2. Recon (read-only)
 
 ```sh
 wendy device list --timeout 8s          # no --scan flag; --timeout scans once
-wendy device info --device wendyos-hubert.local
-ssh root@10.60.10.90 'df -h / /data; ls /dev/video*'
+wendy device info --device <device-hostname>
+ssh root@<device-hostname> 'df -h /; ls /dev/video*'
 ```
 
-Check `df` before anything else. Hubert's root filesystem had been filled to
-100 percent by 64 daily agent-updater backups in `/opt/wendy/bin`
-(`wendy-agent.backup.*`, about 1.3 GiB); the nightly updater had been failing
-since Aug 12 (zero-byte backups) and the Aug 23 run left
-`/usr/local/bin/wendy-agent` truncated and the agent dead. Recovery, if this
-recurs:
+Check `df` before anything else. A device whose root filesystem is full will
+fail the agent install in confusing ways. The failure mode seen in practice:
+the daily agent updater accumulates one backup of the agent binary per run in
+`/opt/wendy/bin` (`wendy-agent.backup.*`), fills the root partition, and then a
+failing update leaves `/usr/local/bin/wendy-agent` truncated and the agent
+dead. Recovery:
 
 ```sh
-ssh root@10.60.10.90 '
+ssh root@<device-hostname> '
   rm -f /opt/wendy/bin/wendy-agent.backup.*
   cp /opt/wendy/bin/wendy-agent.latest /usr/local/bin/wendy-agent
   systemctl restart wendyos-agent'
 ```
 
-## 2. Build the integration agent and CLI
+## 3. Build the agent and command-line interface (CLI)
 
 ```sh
-git -C ~/Documents/Projects/WendyOS fetch origin feature/wendy-data-platform
-git -C ~/Documents/Projects/WendyOS worktree add \
-    ~/Documents/Projects/WendyOS/.worktrees/demo-hubert origin/feature/wendy-data-platform
-cd ~/Documents/Projects/WendyOS/.worktrees/demo-hubert/go
+cd <wendyos-checkout>/go
 
 # Agent: pure Go, cross-compiles from macOS directly (CGO_ENABLED=0).
 make build-agent-linux-arm64 VERSION=dev-data-platform-demo
 
-# CLI: needs cgo (gousb, BLE); the darwin Makefile target's CGO_ENABLED=0
-# does not link, so build it directly:
+# CLI: needs cgo (gousb, Bluetooth Low Energy); the darwin Makefile target's
+# CGO_ENABLED=0 does not link, so build it directly:
 CC=/usr/bin/clang CGO_ENABLED=1 go build \
     -ldflags "-s -w -X github.com/wendylabsinc/wendy/go/internal/shared/version.Version=dev-data-platform" \
     -o bin/wendy-demo ./cmd/wendy
-./bin/wendy-demo data --help   # the data verbs exist only on this branch
+./bin/wendy-demo data --help   # confirm the data verbs exist in this build
 ```
 
-## 3. Install the agent on Hubert
+## 4. Install the agent on the device
 
-Keep a rollback first (done; lives on the device):
+Stage a rollback first, on the device, so recovery does not depend on the
+workstation:
 
 ```sh
-ssh root@10.60.10.90 'ls /data/demo-hubert-rollback'
-# wendy-agent.2026.08.07.sha-5fd12f + ROLLBACK.txt with the restore command
+ssh root@<device-hostname> '
+  mkdir -p /data/demo-rollback
+  cp /usr/local/bin/wendy-agent /data/demo-rollback/wendy-agent.pre-demo'
 ```
 
 Then push with the sanctioned update path and verify:
 
 ```sh
-./bin/wendy-demo device update --binary bin/wendy-agent-linux-arm64 --device wendyos-hubert.local
-./bin/wendy-demo device info --device wendyos-hubert.local   # "version" shows the new build
-./bin/wendy-demo data sources --device wendyos-hubert.local  # v2 DataService answers; camera healthy
+./bin/wendy-demo device update --binary bin/wendy-agent-linux-arm64 --device <device-hostname>
+./bin/wendy-demo device info --device <device-hostname>    # "version" shows the new build
+./bin/wendy-demo data sources --device <device-hostname>   # v2 DataService answers; camera healthy
 ```
 
-The nightly auto-updater would overwrite this agent at ~00:10; it is disabled
-for the demo window:
+The nightly auto-updater would overwrite this agent shortly after midnight, so
+disable it for the demo window and re-enable it afterwards:
 
 ```sh
-ssh root@10.60.10.90 'systemctl disable --now wendyos-agent-updater.timer'
+ssh root@<device-hostname> 'systemctl disable --now wendyos-agent-updater.timer'
 # undo after the demo:
-ssh root@10.60.10.90 'systemctl enable --now wendyos-agent-updater.timer'
+ssh root@<device-hostname> 'systemctl enable --now wendyos-agent-updater.timer'
 ```
 
-## 4. Point the data plane at the dev cloud
+## 5. Point the data plane at the ingest service
 
-Enrollment stays on production; only the episode transfer worker is
-redirected. The agent's systemd unit reads `/etc/default/wendy-agent`
-(`EnvironmentFile=`), so:
+Enrollment stays untouched; only the episode transfer worker is redirected. The
+agent's systemd unit reads `/etc/default/wendy-agent` (`EnvironmentFile=`), so:
 
 ```sh
-URL=$(CLOUDSDK_PYTHON=/opt/homebrew/bin/python3 gcloud run services describe \
-      wendy-data-dev --region us-central1 --project cloud-c7e56 \
+# If the service runs on Cloud Run, look the URL up rather than typing it:
+INGEST_URL=$(gcloud run services describe <ingest-service-name> \
+      --region <region> --project <your-gcp-project> \
       --format='value(status.url)')
-ssh root@10.60.10.90 "cat >> /etc/default/wendy-agent <<EOF
-WENDY_DATA_INGEST_URL=$URL
+
+ssh root@<device-hostname> "cat >> /etc/default/wendy-agent <<EOF
+WENDY_DATA_INGEST_URL=$INGEST_URL
 WENDY_DATA_DIR=/data/wendy-agent/episodes
 EOF
 mkdir -p /data/wendy-agent/episodes && systemctl restart wendyos-agent"
 ```
 
-- `WENDY_DATA_INGEST_URL` is new in PR #1754: it redirects the transfer
-  worker's dial target and, because Cloud Run has no Wendy Envoy ingress to
-  re-inject the mTLS identity, also attaches
-  `x-wendy-client-cert: URI=urn:wendy:org:<org>:asset:<asset>` (the header
-  `EnvoyCertMetadataExtractor` reads) carrying the enrolled asset identity.
-- `WENDY_DATA_DIR` moves the episode store off the 7.3 GiB root partition
-  (default `/var/lib/wendy-agent/data/episodes`) onto `/data`.
+- `WENDY_DATA_INGEST_URL` redirects the transfer worker's dial target. Where
+  the endpoint has no Wendy Envoy ingress in front of it to terminate mutual
+  Transport Layer Security (mTLS) and re-inject the certificate identity, the
+  worker also attaches
+  `x-wendy-client-cert: URI=urn:wendy:org:<org-id>:asset:<asset-id>` (the
+  header `EnvoyCertMetadataExtractor` reads) carrying the identity the enrolled
+  asset certificate asserts. That header is attached only when this override is
+  in effect.
+- `WENDY_DATA_DIR` moves the episode store off the root partition (default
+  `/var/lib/wendy-agent/data/episodes`) onto the larger data partition. Worth
+  doing on any device whose root partition is a few gigabytes.
 
 Verify the override took: the agent logs
 `data transfer worker: ingest endpoint override set` at startup.
 
-## 5. Deploy the D5 app and campaign
+## 6. Deploy the reference app and campaign
 
 ```sh
-cd ../Examples/WendyDataModelApp
-../../go/bin/wendy-demo run --device wendyos-hubert.local --detach --yes
-../../go/bin/wendy-demo data campaign deploy campaign-hubert.yaml --device wendyos-hubert.local
-../../go/bin/wendy-demo data campaign trigger model-harness-demo --device wendyos-hubert.local
+cd <wendyos-checkout>/Examples/WendyDataModelApp
+<wendyos-checkout>/go/bin/wendy-demo run --device <device-hostname> --detach --yes
+<wendyos-checkout>/go/bin/wendy-demo data campaign deploy campaign.yaml --device <device-hostname>
+<wendyos-checkout>/go/bin/wendy-demo data campaign trigger model-harness-demo --device <device-hostname>
 ```
 
-Campaign adjustment made for Hubert: the checked-in `campaign.yaml` declares a
-`camera: front` snapshot source, but the app itself holds `/dev/video0` open
-(OpenCV), so the campaign's capture adapter gets `VIDIOC_S_FMT: device busy`
-and the trigger fails. The deployed variant replaces the camera source with
-`- telemetry: true` and keeps the triggers, upload policy, and model pin; the
-`applications` source (every prediction and event record) is always captured
-regardless, so episodes still carry the model's outputs. A second USB webcam
-would let the original camera source work unchanged.
+### The camera conflict
 
-Verify, in order:
+The checked-in `campaign.yaml` declares a `camera: front` snapshot source, but
+on a single-camera device the app itself holds that camera open through OpenCV.
+The campaign's capture adapter then gets `VIDIOC_S_FMT: device busy` and the
+trigger fails. Two ways out:
+
+- Attach a second camera, and leave `campaign.yaml` as it is: the app keeps the
+  first camera and the campaign snapshots the second.
+- Deploy `campaign-telemetry-only.yaml` instead, which replaces the camera
+  source with `- telemetry: true` and keeps the triggers, upload policy, and
+  model pin unchanged. The `applications` source (every prediction and event
+  record) is always captured regardless, so episodes still carry the model's
+  outputs; they just carry no camera frames.
+
+### Verify, in order
 
 ```sh
-./bin/wendy-demo data episodes --device wendyos-hubert.local     # newest episode "complete"
-./bin/wendy-demo data inspect <episode-id> --device wendyos-hubert.local
+./bin/wendy-demo data episodes --device <device-hostname>            # newest episode "complete"
+./bin/wendy-demo data inspect <episode-id> --device <device-hostname>
 # trigger.reason, files [events.jsonl, telemetry.jsonl], upload.state "uploaded"
 ```
 
 `upload.state: "uploaded"` is the cloud-side proof: the worker only records it
 after `CommitEpisode` succeeds, and the server verifies every stored object's
 SHA-256 against the manifest before flipping the catalog row to complete.
-Read-side inspection of the catalog (QueryEpisodes/GetEpisode) requires a user
-bearer token, not the asset identity; check rows in the dev ClickHouse
-(`episodes` / `episode_files` tables) or through the BI surface once wired.
+Read-side inspection of the catalog (`QueryEpisodes` and `GetEpisode`) requires
+a user bearer token rather than the asset identity, so check the rows directly
+in the deployment's ClickHouse (`episodes` and `episode_files` tables) or
+through the business intelligence surface once it is wired.
+
+## What to expect in the episode
 
 With nothing in front of the camera the app reports uncertainty 1.0, so the
 `model.uncertainty > 0.65` trigger fires organically; walking into the frame
-fires the edge-triggered `person_detected` instead. Each trigger seals one
-episode (10 s pre-buffer, 20 s post) which uploads within seconds.
+fires the edge-triggered `person_detected` trigger instead. Each trigger seals
+one episode (10 seconds of pre-trigger buffer, 20 seconds after) which uploads
+within seconds. An episode of that length carries on the order of a hundred
+prediction records at the CPU path's 5 predictions per second.
 
 ## Pitfalls discovered on the way (all hit for real)
 
-1. Full root disk from updater backups: see Recon above.
-2. `Dockerfile` export stage: ultralytics pulls the GUI `opencv-python`
-   wheel needing `libxcb1 libgl1 libglib2.0-0`, and torch >= 2.13 needs
-   `onnxscript` for ONNX export. Both fixed in this PR's Dockerfile.
-3. App data socket refused with "peer is not in a wendy app scope": Hubert's
-   containerd uses the cgroupfs driver, so the `system.slice:edge-agent:<app>`
-   cgroup path is literal and the attribution parser did not recognize it.
-   Fixed in PR #1755; without it no record ever reaches the agent.
-4. After ANY agent restart the app's data socket listener is gone and the app
-   gets ECONNREFUSED until the app is redeployed (`device apps remove --force`
-   then `wendy run`). Cause: the chunk-diff deploy path creates containers
-   without `sh.wendy/entitlement.*` labels, so `RestoreAppSystemAPISockets`
-   skips them. Open bug; fix the deploy order (agent first, app last) until
-   it lands.
-5. An episode that exhausts its 5 upload attempts is terminally `failed` and
-   is never retried; trigger a fresh episode after fixing connectivity.
+1. Full root disk from accumulated updater backups: see the recon step.
+2. `Dockerfile` export stage: ultralytics pulls the graphical
+   `opencv-python` wheel, which needs `libxcb1 libgl1 libglib2.0-0`, and
+   torch 2.13 and newer needs `onnxscript` for Open Neural Network Exchange
+   (ONNX) export. Both are handled in the example's Dockerfile.
+3. App data socket refused with "peer is not in a wendy app scope": on a device
+   whose containerd uses the cgroupfs driver the `system.slice:edge-agent:<app>`
+   cgroup path is literal, which the attribution parser must recognize.
+   Without that, no record ever reaches the agent.
+4. After any agent restart the app's data socket listener is gone and the app
+   gets ECONNREFUSED until the app is redeployed
+   (`device apps remove --force`, then `wendy run`). Cause: the chunk-diff
+   deploy path creates containers without `sh.wendy/entitlement.*` labels, so
+   `RestoreAppSystemAPISockets` skips them. Open bug; until it is fixed, order
+   the deploy agent first, app last.
+5. An episode that exhausts its 5 upload attempts is terminally `failed` and is
+   never retried; trigger a fresh episode after fixing connectivity.
 6. `wendy device apps start` streams logs and does not return with `--detach`
    semantics; script around it or use `wendy run`.
 
 ## Rollback
 
 ```sh
-ssh root@10.60.10.90 '
-  cp /data/demo-hubert-rollback/wendy-agent.2026.08.07.sha-5fd12f /usr/local/bin/wendy-agent
+ssh root@<device-hostname> '
+  cp /data/demo-rollback/wendy-agent.pre-demo /usr/local/bin/wendy-agent
   chmod 755 /usr/local/bin/wendy-agent
   sed -i "/WENDY_DATA_INGEST_URL/d;/WENDY_DATA_DIR/d" /etc/default/wendy-agent
   systemctl restart wendyos-agent
   systemctl enable --now wendyos-agent-updater.timer'
 ```
 
+Enrollment is untouched by the demo, so there is nothing to restore there.
+
 ## Open gaps
 
-- Camera frames inside episodes need a second webcam (or an app change to
-  share frames) because the app monopolizes `/dev/video0`.
-- The cgroupfs attribution fix (PR #1755) and the ingest override (PR #1754)
-  must merge into `feature/wendy-data-platform`; Hubert currently runs a local
-  build combining both.
-- Chunk-diff deploys omit entitlement labels (pitfall 4) - open bug.
-- Catalog read verification from the CLI needs a dev bearer token; today the
-  proof is the commit-gated `uploaded` state plus the dev ClickHouse.
-- The GPU (onnxruntime-gpu) variant of the app was not exercised; the demo
-  runs the CPU path at 5 predictions per second.
+- Camera frames inside episodes need a second camera, or an app change to share
+  frames, because the reference app monopolizes the one it opens.
+- Chunk-diff deploys omit entitlement labels (pitfall 4), which is an open bug.
+- Catalog read verification from the CLI needs a user bearer token; today the
+  proof is the commit-gated `uploaded` state plus a direct ClickHouse read.
+- The graphics processing unit (GPU) variant of the app, using
+  `onnxruntime-gpu`, has not been exercised; the demo runs the CPU path at
+  5 predictions per second.


### PR DESCRIPTION
## Problem

The Wendy Data Platform demo had never been exercised on a real device. Doing so on a Jetson Orin Nano running WendyOS 0.16.0 surfaced that the reference app image no longer builds, that the checked-in campaign cannot start on a single-camera device, and that nothing documented the end-to-end path from device recon to an episode row in the development cloud catalog.

## Cause

Unpinned build dependencies drifted: ultralytics resolves the graphical opencv-python wheel whose import needs X client libraries absent from python:3.11-slim, and torch 2.13 moved torch.onnx.export onto onnxscript. Separately, the campaign's camera snapshot source needs exclusive Video4Linux2 (V4L2) access to /dev/video0, which the app itself already holds open through OpenCV, so CampaignTrigger fails with device busy.

## Solution

- Fix the Dockerfile export stage: install libxcb1, libgl1, libglib2.0-0 and add onnxscript. Build-stage only; the runtime image is unchanged.
- Add Examples/WendyDataModelApp/campaign-telemetry-only.yaml: the same campaign with the camera source swapped for the telemetry source, keeping the person_detected and model.uncertainty triggers, upload policy, retention, and the yolov8n model pin. The applications source is always captured, so episodes still carry every prediction record.
- Add docs/wendy-data-platform-demo.md: the runbook (recon, agent build and install with rollback, WENDY_DATA_INGEST_URL override, app and campaign deploy, trigger, and where the data lands), the camera-conflict explanation, the six pitfalls hit on the way, and the open gaps.

The runbook is written generically, with marked placeholders for the device hostname, organization and asset identifiers, cloud project, and ingest URL. It ships in the documentation asset tree of a public repository and is published by the docs workflow, so it carries no device-specific operational detail. The values from the verification run are recorded in the cloud repository's docs/wendy-data-platform-report.md, under "Hubert hardware demo".

Verified end to end on real hardware: an episode triggered organically on model.uncertainty > 0.65, carried 97 yolov8n prediction records, and reached the development catalog with upload state uploaded, which only flips after CommitEpisode passes server-side hash verification.

Depends on #1754 (ingest endpoint override) and #1755 (cgroupfs peer attribution); the runbook references both behaviors.
