### PR TITLE
test(data): allow TLS transport in the cross-repo end-to-end harness

### DIFF
--- a/go/internal/agent/services/data_transfer_worker_e2e_test.go
+++ b/go/internal/agent/services/data_transfer_worker_e2e_test.go
@@ -26,6 +26,7 @@ package services
 import (
 	"context"
 	"crypto/sha256"
+	"crypto/tls"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -37,6 +38,7 @@ import (
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 
@@ -51,6 +53,17 @@ const (
 	e2eOrgID   uint64 = 7
 	e2eAssetID uint64 = 42
 )
+
+// e2eTransportCreds selects the harness transport. The local stack listens
+// plaintext; a deployed Cloud Run service terminates TLS on 443, selected by
+// WENDY_DATA_E2E_TLS=1. The worker and service code are unchanged either way;
+// the transport is a harness seam exactly like the identity header.
+func e2eTransportCreds() grpc.DialOption {
+	if os.Getenv("WENDY_DATA_E2E_TLS") == "1" {
+		return grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12}))
+	}
+	return grpc.WithTransportCredentials(insecure.NewCredentials())
+}
 
 func e2eAddr(t *testing.T) string {
 	t.Helper()
@@ -79,7 +92,7 @@ func dialWorkerClient(t *testing.T, addr string) (*grpc.ClientConn, cloudpb.Data
 		return streamer(ctx, desc, cc, method, opts...)
 	}
 	conn, err := grpc.NewClient(addr,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		e2eTransportCreds(),
 		grpc.WithUnaryInterceptor(unary),
 		grpc.WithStreamInterceptor(stream),
 	)
@@ -97,7 +110,7 @@ func dialReadClient(t *testing.T, addr, token string) cloudpb.DataIngestServiceC
 		return invoker(ctx, method, req, reply, cc, opts...)
 	}
 	conn, err := grpc.NewClient(addr,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		e2eTransportCreds(),
 		grpc.WithUnaryInterceptor(unary),
 	)
 	if err != nil {


### PR DESCRIPTION
## Problem

The cross-repo end-to-end harness (`data_transfer_worker_e2e_test.go`) could only drive a plaintext local ingest service. The deployed dev ingest service runs behind Transport Layer Security (TLS) on port 443, so the harness could not verify the real transfer worker against the real deployed service, which is exactly the verification that matters before trusting the cloud path.

## Cause

The harness hard-coded insecure transport credentials for its dial, with no way to select TLS.

## Solution

Add a `WENDY_DATA_E2E_TLS=1` transport seam: when set, the harness dials with TLS credentials instead of insecure ones. Test-only change (15 lines in the harness); no production code is touched, and the test remains skipped unless `WENDY_DATA_E2E_ADDR` is set, so normal runs are unaffected.

This seam is what made the cloud end-to-end verification possible: the real transfer worker drove the deployed service, the episode reached catalog state complete, and real version 4 signed retrieval Uniform Resource Locators (URLs) were fetched and re-hashed clean, with the corruption negative check still failing the episode correctly. Results are recorded in the cloud repository's `docs/wendy-data-platform-load-results.md`.

Rebased onto the current integration branch so the diff is the seam alone.
