### PR TITLE
fix(cli): make wendy data sources readable

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
@@ -11,7 +11,7 @@ sizes, formats, and SHA-256 checksums.
 
 | Command | Description |
 |---|---|
-| `wendy data sources` | List camera, ROS 2, application, and telemetry sources. |
+| `wendy data sources` | List camera, audio, ROS 2, application, and telemetry sources. |
 | `wendy data record` | Start one detached Episode. With no source flags, every healthy discovered source is selected. |
 | `wendy data stop` | Stop and seal the active Episode. |
 | `wendy data episodes` | List finalized Episodes. |
@@ -32,6 +32,40 @@ wendy data stop
 wendy data episodes
 wendy data inspect <episode-id>
 wendy data download <episode-id> --output ./commissioning-episode
+```
+
+`sources` prints an aligned table whose `DETAIL` column carries the device's own
+description of each source, truncated to keep the table readable. A single kind
+can dominate a board: an NVIDIA Jetson exposes 20 internal audio-DMA routing
+channels alongside its real microphone, so when more than six sources share a
+kind the first six are listed and the remainder are counted in a note. Nothing
+is hidden from `--json`.
+
+```text
+SOURCE            KIND         CLOCK                       STATUS   DETAIL
+applications      application  CLOCK_BOOTTIME              healthy
+audio:16777217    audio        ALSA_CAPTURE/AGENT_RECEIPT  healthy  C920 [HD Pro Webcam C920], device 0: USB Audi...
+audio:16777729    audio        ALSA_CAPTURE/AGENT_RECEIPT  healthy  APE [NVIDIA Jetson Orin Nano APE], device 0: ...
+audio:16777730    audio        ALSA_CAPTURE/AGENT_RECEIPT  healthy  APE [NVIDIA Jetson Orin Nano APE], device 1: ...
+audio:16777731    audio        ALSA_CAPTURE/AGENT_RECEIPT  healthy  APE [NVIDIA Jetson Orin Nano APE], device 2: ...
+audio:16777732    audio        ALSA_CAPTURE/AGENT_RECEIPT  healthy  APE [NVIDIA Jetson Orin Nano APE], device 3: ...
+audio:16777733    audio        ALSA_CAPTURE/AGENT_RECEIPT  healthy  APE [NVIDIA Jetson Orin Nano APE], device 4: ...
+telemetry         telemetry    CLOCK_BOOTTIME              healthy
+v4l2:/dev/video0  camera       V4L2_BUFFER_TIMESTAMP       healthy  HD Pro Webcam C920: HD Pro Webc VIDEO_TRANSPO...
+
+... 15 more audio sources not listed (--kind audio to list all, --json for everything)
+```
+
+Narrow the table with `--kind`, which is repeatable or comma-separated and
+matches case-insensitively. A kind named there is never summarised, because
+asking for a kind is asking to see all of it. Without `--kind`, `--json` stays
+the full unfiltered response the device sent, so existing scripts keep working;
+with `--kind` it carries the filtered set.
+
+```sh
+wendy data sources --kind camera
+wendy data sources --kind camera,telemetry
+wendy data sources --kind audio            # every audio source, nothing summarised
 ```
 
 Episode IDs are stable opaque identifiers. Their readable UTC prefix is only a

--- a/go/internal/cli/commands/data.go
+++ b/go/internal/cli/commands/data.go
@@ -10,7 +10,9 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -117,26 +119,188 @@ func withDataClient(ctx context.Context, fn func(agentpbv2.DataServiceClient) er
 }
 
 func newDataSourcesCmd() *cobra.Command {
-	return &cobra.Command{Use: "sources", Short: "List recordable sources", Args: cobra.NoArgs, RunE: func(cmd *cobra.Command, _ []string) error {
-		return withDataClient(cmd.Context(), func(c agentpbv2.DataServiceClient) error {
-			r, e := c.Sources(cmd.Context(), &agentpbv2.DataSourcesRequest{})
+	var kinds []string
+	c := &cobra.Command{Use: "sources", Short: "List recordable sources", Args: cobra.NoArgs, RunE: func(cmd *cobra.Command, _ []string) error {
+		return withDataClient(cmd.Context(), func(client agentpbv2.DataServiceClient) error {
+			r, e := client.Sources(cmd.Context(), &agentpbv2.DataSourcesRequest{})
 			if e != nil {
 				return e
 			}
+			wanted := normalizeSourceKinds(kinds)
 			if jsonOutput {
-				return json.NewEncoder(cmd.OutOrStdout()).Encode(r)
+				return encodeDataSourcesJSON(cmd.OutOrStdout(), r, wanted)
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), "SOURCE\tKIND\tCLOCK\tSTATUS")
-			for _, s := range r.GetSources() {
-				health := "unhealthy"
-				if s.GetHealthy() {
-					health = "healthy"
-				}
-				fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\t%s\t%s\n", s.GetId(), s.GetKind(), s.GetClockDomain(), health)
-			}
-			return nil
+			return writeDataSources(cmd.OutOrStdout(), r.GetSources(), wanted)
 		})
 	}}
+	c.Flags().StringSliceVar(&kinds, "kind", nil, "Only list sources of this kind, for example camera or audio (repeatable or comma-separated)")
+	return c
+}
+
+// maxSourceDetailWidth bounds the DETAIL column so an ALSA card description
+// cannot push the table past a normal terminal width.
+const maxSourceDetailWidth = 48
+
+// sourceKindFloodLimit is how many sources of one kind are listed before the
+// rest are summarised. A Jetson reports 21 audio sources, 20 of which are
+// internal audio-DMA routing channels, and they bury everything else.
+const sourceKindFloodLimit = 6
+
+// encodeDataSourcesJSON keeps --json a machine contract: without --kind it is
+// byte-for-byte the response the device sent, never filtered and never
+// summarised, because scripts already consume it. With --kind it carries the
+// filtered set, which is what the caller asked for.
+func encodeDataSourcesJSON(out io.Writer, response *agentpbv2.DataSourcesResponse, wanted []string) error {
+	if len(wanted) == 0 {
+		return json.NewEncoder(out).Encode(response)
+	}
+	return json.NewEncoder(out).Encode(&agentpbv2.DataSourcesResponse{Sources: filterSourcesByKind(response.GetSources(), wanted)})
+}
+
+func normalizeSourceKinds(kinds []string) []string {
+	var out []string
+	for _, kind := range kinds {
+		if k := strings.ToLower(strings.TrimSpace(kind)); k != "" {
+			out = append(out, k)
+		}
+	}
+	return out
+}
+
+func filterSourcesByKind(sources []*agentpbv2.DataSource, wanted []string) []*agentpbv2.DataSource {
+	if len(wanted) == 0 {
+		return sources
+	}
+	var out []*agentpbv2.DataSource
+	for _, s := range sources {
+		for _, kind := range wanted {
+			if strings.EqualFold(s.GetKind(), kind) {
+				out = append(out, s)
+				break
+			}
+		}
+	}
+	return out
+}
+
+func truncateSourceDetail(detail string) string {
+	runes := []rune(detail)
+	if len(runes) <= maxSourceDetailWidth {
+		return detail
+	}
+	return string(runes[:maxSourceDetailWidth-3]) + "..."
+}
+
+// writeDataSources renders the source table. wanted holds the lower-cased kinds
+// the user asked for; kinds named there are never summarised, because asking for
+// a kind is asking to see all of it.
+func writeDataSources(out io.Writer, sources []*agentpbv2.DataSource, wanted []string) error {
+	shown := filterSourcesByKind(sources, wanted)
+	if len(shown) == 0 {
+		if len(sources) == 0 {
+			_, err := fmt.Fprintln(out, "No recordable sources reported by the device.")
+			return err
+		}
+		_, err := fmt.Fprintf(out, "No sources of kind %s. Kinds present on this device: %s.\n",
+			strings.Join(quoteAll(wanted), ", "), strings.Join(presentSourceKinds(sources), ", "))
+		return err
+	}
+
+	requested := make(map[string]bool, len(wanted))
+	for _, kind := range wanted {
+		requested[kind] = true
+	}
+	total := map[string]int{}
+	for _, s := range shown {
+		total[strings.ToLower(s.GetKind())]++
+	}
+
+	var rows []*agentpbv2.DataSource
+	omitted := map[string]int{}
+	var floodedOrder []string
+	seen := map[string]int{}
+	for _, s := range shown {
+		kind := strings.ToLower(s.GetKind())
+		if !requested[kind] && total[kind] > sourceKindFloodLimit && seen[kind] >= sourceKindFloodLimit {
+			if omitted[kind] == 0 {
+				floodedOrder = append(floodedOrder, kind)
+			}
+			omitted[kind]++
+			continue
+		}
+		seen[kind]++
+		rows = append(rows, s)
+	}
+
+	detailColumn := false
+	for _, s := range rows {
+		if s.GetDetail() != "" {
+			detailColumn = true
+			break
+		}
+	}
+
+	w := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
+	header := "SOURCE\tKIND\tCLOCK\tSTATUS"
+	if detailColumn {
+		header += "\tDETAIL"
+	}
+	fmt.Fprintln(w, header)
+	for _, s := range rows {
+		health := "unhealthy"
+		if s.GetHealthy() {
+			health = "healthy"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s", s.GetId(), s.GetKind(), s.GetClockDomain(), health)
+		if detailColumn {
+			fmt.Fprintf(w, "\t%s", truncateSourceDetail(s.GetDetail()))
+		}
+		fmt.Fprintln(w)
+	}
+	if err := w.Flush(); err != nil {
+		return err
+	}
+
+	// The notes sit outside the tabwriter block; a tab-free line inside it
+	// would split the table into two independently aligned halves.
+	for _, kind := range floodedOrder {
+		if _, err := fmt.Fprintf(out, "\n... %d more %s %s not listed (--kind %s to list all, --json for everything)\n",
+			omitted[kind], kind, pluralSource(omitted[kind]), kind); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func pluralSource(n int) string {
+	if n == 1 {
+		return "source"
+	}
+	return "sources"
+}
+
+func quoteAll(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		out = append(out, strconv.Quote(v))
+	}
+	return out
+}
+
+// presentSourceKinds lists the distinct kinds in first-seen order so the
+// message names what the device actually reported.
+func presentSourceKinds(sources []*agentpbv2.DataSource) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, s := range sources {
+		kind := s.GetKind()
+		if kind == "" || seen[kind] {
+			continue
+		}
+		seen[kind] = true
+		out = append(out, kind)
+	}
+	return out
 }
 
 func newDataRecordCmd() *cobra.Command {

--- a/go/internal/cli/commands/data_sources_test.go
+++ b/go/internal/cli/commands/data_sources_test.go
@@ -1,0 +1,303 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
+)
+
+func src(id, kind, clock string, healthy bool, detail string) *agentpbv2.DataSource {
+	return &agentpbv2.DataSource{Id: id, Kind: kind, ClockDomain: clock, Healthy: healthy, Detail: detail}
+}
+
+// orinNanoSources mirrors the real `wendy data sources` answer from a Jetson
+// Orin Nano: one USB webcam, one USB microphone, and 20 internal APE ADMAIF
+// audio-DMA routing channels that bury everything else.
+func orinNanoSources() []*agentpbv2.DataSource {
+	sources := []*agentpbv2.DataSource{
+		src("applications", "application", "CLOCK_BOOTTIME", true, ""),
+		src("audio:16777217", "audio", "ALSA_CAPTURE/AGENT_RECEIPT", true, "C920 [HD Pro Webcam C920], device 0: USB Audio [USB Audio] plughw:0,0"),
+	}
+	for i := 0; i < 20; i++ {
+		sources = append(sources, src(
+			fmt.Sprintf("audio:%d", 16777729+i), "audio", "ALSA_CAPTURE/AGENT_RECEIPT", true,
+			fmt.Sprintf("APE [NVIDIA Jetson Orin Nano APE], device %d: fe.admaif@290f000.ADMAIF%d (*) [] plughw:2,%d", i, i+1, i)))
+	}
+	return append(sources,
+		src("telemetry", "telemetry", "CLOCK_BOOTTIME", true, ""),
+		src("v4l2:/dev/video0", "camera", "V4L2_BUFFER_TIMESTAMP", true, "HD Pro Webcam C920: HD Pro Webc VIDEO_TRANSPORT_USB"))
+}
+
+func renderSources(t *testing.T, sources []*agentpbv2.DataSource, kinds ...string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := writeDataSources(&buf, sources, normalizeSourceKinds(kinds)); err != nil {
+		t.Fatalf("writeDataSources: %v", err)
+	}
+	return buf.String()
+}
+
+func manyOfKind(kind string, n int) []*agentpbv2.DataSource {
+	var out []*agentpbv2.DataSource
+	for i := 0; i < n; i++ {
+		out = append(out, src(fmt.Sprintf("%s:%d", kind, i), kind, "CLOCK_BOOTTIME", true, ""))
+	}
+	return out
+}
+
+func TestWriteDataSourcesTable(t *testing.T) {
+	cases := []struct {
+		name        string
+		sources     []*agentpbv2.DataSource
+		kinds       []string
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			name:        "aligned header without detail column",
+			sources:     []*agentpbv2.DataSource{src("applications", "application", "CLOCK_BOOTTIME", true, ""), src("telemetry", "telemetry", "CLOCK_BOOTTIME", false, "")},
+			wantContain: []string{"SOURCE        KIND         CLOCK           STATUS", "applications  application  CLOCK_BOOTTIME  healthy", "telemetry     telemetry    CLOCK_BOOTTIME  unhealthy"},
+			wantAbsent:  []string{"DETAIL", "\t"},
+		},
+		{
+			name:        "detail column present and aligned",
+			sources:     []*agentpbv2.DataSource{src("applications", "application", "CLOCK_BOOTTIME", true, ""), src("v4l2:/dev/video0", "camera", "V4L2_BUFFER_TIMESTAMP", true, "HD Pro Webcam C920")},
+			wantContain: []string{"STATUS   DETAIL", "v4l2:/dev/video0  camera       V4L2_BUFFER_TIMESTAMP  healthy  HD Pro Webcam C920"},
+			wantAbsent:  []string{"\t"},
+		},
+		{
+			name:        "kind filter keeps only the asked-for kind",
+			sources:     orinNanoSources(),
+			kinds:       []string{"camera"},
+			wantContain: []string{"v4l2:/dev/video0"},
+			wantAbsent:  []string{"applications", "telemetry", "audio:"},
+		},
+		{
+			name:        "kind filter is case insensitive",
+			sources:     orinNanoSources(),
+			kinds:       []string{"CaMeRa"},
+			wantContain: []string{"v4l2:/dev/video0"},
+			wantAbsent:  []string{"audio:"},
+		},
+		{
+			name:        "multiple kinds",
+			sources:     orinNanoSources(),
+			kinds:       []string{"camera", "telemetry"},
+			wantContain: []string{"v4l2:/dev/video0", "telemetry"},
+			wantAbsent:  []string{"audio:", "applications"},
+		},
+		{
+			name:        "unknown kind names the kinds present",
+			sources:     orinNanoSources(),
+			kinds:       []string{"lidar"},
+			wantContain: []string{`No sources of kind "lidar".`, "Kinds present on this device: application, audio, telemetry, camera."},
+			wantAbsent:  []string{"SOURCE", "audio:"},
+		},
+		{
+			name:        "empty device result",
+			sources:     nil,
+			wantContain: []string{"No recordable sources reported by the device."},
+			wantAbsent:  []string{"SOURCE"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := renderSources(t, c.sources, c.kinds...)
+			for _, want := range c.wantContain {
+				if !strings.Contains(got, want) {
+					t.Fatalf("output missing %q:\n%s", want, got)
+				}
+			}
+			for _, absent := range c.wantAbsent {
+				if strings.Contains(got, absent) {
+					t.Fatalf("output unexpectedly contains %q:\n%s", absent, got)
+				}
+			}
+		})
+	}
+}
+
+func TestWriteDataSourcesDetailTruncation(t *testing.T) {
+	long := "APE [NVIDIA Jetson Orin Nano APE], device 19: fe.admaif@290f000.ADMAIF20 (*) [] plughw:2,19"
+	got := renderSources(t, []*agentpbv2.DataSource{src("audio:1", "audio", "ALSA_CAPTURE", true, long)})
+	line := ""
+	for _, l := range strings.Split(got, "\n") {
+		if strings.HasPrefix(l, "audio:1") {
+			line = l
+		}
+	}
+	if line == "" {
+		t.Fatalf("no source row in output:\n%s", got)
+	}
+	detail := strings.TrimSpace(line[strings.Index(line, "healthy")+len("healthy"):])
+	if len([]rune(detail)) != maxSourceDetailWidth {
+		t.Fatalf("detail width = %d, want %d: %q", len([]rune(detail)), maxSourceDetailWidth, detail)
+	}
+	if !strings.HasSuffix(detail, "...") {
+		t.Fatalf("truncated detail should end in three dots: %q", detail)
+	}
+	if !strings.HasPrefix(long, strings.TrimSuffix(detail, "...")) {
+		t.Fatalf("truncated detail %q is not a prefix of %q", detail, long)
+	}
+
+	short := "HD Pro Webcam C920"
+	if got := truncateSourceDetail(short); got != short {
+		t.Fatalf("short detail was altered: %q", got)
+	}
+	exact := strings.Repeat("x", maxSourceDetailWidth)
+	if got := truncateSourceDetail(exact); got != exact {
+		t.Fatalf("detail of exactly the max width was truncated: %q", got)
+	}
+}
+
+func TestWriteDataSourcesDetailColumnOmittedWhenAllEmpty(t *testing.T) {
+	got := renderSources(t, []*agentpbv2.DataSource{
+		src("applications", "application", "CLOCK_BOOTTIME", true, ""),
+		src("telemetry", "telemetry", "CLOCK_BOOTTIME", true, ""),
+	})
+	if strings.Contains(got, "DETAIL") {
+		t.Fatalf("DETAIL column shown although no source carries a detail:\n%s", got)
+	}
+	if !strings.HasSuffix(strings.Split(got, "\n")[0], "STATUS") {
+		t.Fatalf("header should end at STATUS:\n%s", got)
+	}
+}
+
+func TestWriteDataSourcesFloodBoundary(t *testing.T) {
+	cases := []struct {
+		name        string
+		count       int
+		kinds       []string
+		wantRows    int
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{name: "exactly the limit lists every row", count: sourceKindFloodLimit, wantRows: sourceKindFloodLimit, wantAbsent: []string{"more audio"}},
+		{
+			name:        "one over the limit summarises the remainder",
+			count:       sourceKindFloodLimit + 1,
+			wantRows:    sourceKindFloodLimit,
+			wantContain: []string{"... 1 more audio source not listed (--kind audio to list all, --json for everything)"},
+		},
+		{
+			name:        "jetson audio flood",
+			count:       21,
+			wantRows:    sourceKindFloodLimit,
+			wantContain: []string{"... 15 more audio sources not listed (--kind audio to list all, --json for everything)"},
+		},
+		{
+			name:       "explicitly requested kind is never summarised",
+			count:      21,
+			kinds:      []string{"audio"},
+			wantRows:   21,
+			wantAbsent: []string{"more audio"},
+		},
+		{
+			name:       "explicit request is case insensitive too",
+			count:      21,
+			kinds:      []string{"AUDIO"},
+			wantRows:   21,
+			wantAbsent: []string{"more audio"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := renderSources(t, manyOfKind("audio", c.count), c.kinds...)
+			rows := 0
+			for _, line := range strings.Split(got, "\n") {
+				if strings.HasPrefix(line, "audio:") {
+					rows++
+				}
+			}
+			if rows != c.wantRows {
+				t.Fatalf("listed %d rows, want %d:\n%s", rows, c.wantRows, got)
+			}
+			for _, want := range c.wantContain {
+				if !strings.Contains(got, want) {
+					t.Fatalf("output missing %q:\n%s", want, got)
+				}
+			}
+			for _, absent := range c.wantAbsent {
+				if strings.Contains(got, absent) {
+					t.Fatalf("output unexpectedly contains %q:\n%s", absent, got)
+				}
+			}
+		})
+	}
+}
+
+// Summarisation must never hide a kind entirely, and it must not disturb the
+// kinds that are not flooding the table.
+func TestWriteDataSourcesFloodKeepsOtherKinds(t *testing.T) {
+	got := renderSources(t, orinNanoSources())
+	for _, want := range []string{"applications", "telemetry", "v4l2:/dev/video0", "audio:16777217", "... 15 more audio sources not listed"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "\t") {
+		t.Fatalf("output still contains raw tabs:\n%s", got)
+	}
+}
+
+// --json without --kind must stay byte-for-byte the full proto encoding,
+// because scripts consume it.
+func TestDataSourcesJSONUnchangedWithoutKind(t *testing.T) {
+	response := &agentpbv2.DataSourcesResponse{Sources: orinNanoSources()}
+
+	var want bytes.Buffer
+	if err := json.NewEncoder(&want).Encode(response); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	var got bytes.Buffer
+	if err := encodeDataSourcesJSON(&got, response, normalizeSourceKinds(nil)); err != nil {
+		t.Fatalf("encodeDataSourcesJSON: %v", err)
+	}
+	if got.String() != want.String() {
+		t.Fatalf("json output changed\n got: %s\nwant: %s", got.String(), want.String())
+	}
+	if !strings.Contains(got.String(), "audio:16777748") {
+		t.Fatalf("json output was summarised; it must carry every source:\n%s", got.String())
+	}
+
+	var filtered bytes.Buffer
+	if err := encodeDataSourcesJSON(&filtered, response, normalizeSourceKinds([]string{"camera"})); err != nil {
+		t.Fatalf("encodeDataSourcesJSON: %v", err)
+	}
+	if strings.Contains(filtered.String(), "audio:") {
+		t.Fatalf("--kind camera --json should drop audio sources:\n%s", filtered.String())
+	}
+	if !strings.Contains(filtered.String(), "v4l2:/dev/video0") {
+		t.Fatalf("--kind camera --json dropped the camera:\n%s", filtered.String())
+	}
+}
+
+func TestNormalizeSourceKinds(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{name: "nil", in: nil, want: nil},
+		{name: "lowercases and trims", in: []string{" Camera ", "AUDIO"}, want: []string{"camera", "audio"}},
+		{name: "drops empties from comma splits", in: []string{"camera", "", "  "}, want: []string{"camera"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := normalizeSourceKinds(c.in)
+			if len(got) != len(c.want) {
+				t.Fatalf("normalizeSourceKinds(%q) = %q, want %q", c.in, got, c.want)
+			}
+			for i := range got {
+				if got[i] != c.want[i] {
+					t.Fatalf("normalizeSourceKinds(%q) = %q, want %q", c.in, got, c.want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`wendy data sources` was unreadable on real hardware, reported while preparing a demo.

- Columns were raw tab separated with no tabwriter, so nothing aligned in a terminal.
- On a Jetson Orin Nano the command listed 21 audio sources, 20 of which are internal Audio Processing Engine (APE) ADMAIF audio-DMA routing channels, burying the four sources a human cares about: `applications`, `telemetry`, the `v4l2:/dev/video0` camera, and the one real microphone `audio:16777217` (the C920 webcam mic).
- The proto's `detail` field carries the readable Advanced Linux Sound Architecture (ALSA) card description and was never displayed, so every row was an opaque id.

## Cause

The handler printed `\t` separated rows straight to the command writer, with no alignment, no detail column, and no way to narrow the list.

## Solution

Display layer only; the agent and the proto are untouched.

1. Rows go through the repo's standard `tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)`, writing to `cmd.OutOrStdout()`.
2. A `DETAIL` column shows `GetDetail()`, truncated to 48 runes with three ASCII dots, placed last so truncation cannot misalign earlier columns. The column is omitted entirely when no listed source carries a detail.
3. A `--kind` flag filters client-side, case-insensitively, repeatable or comma-separated (`StringSliceVar`, matching `--entitlement` in `init_cmd.go`). An unknown kind names the kinds actually present rather than printing nothing.
4. When more than six sources share a kind, the first six are listed and the rest are counted in one note that names the flag showing them all. A kind named in `--kind` is never summarised.
5. `--json` without `--kind` is byte-for-byte the response the device sent, never filtered and never summarised, so scripts keep working. With `--kind` it carries the filtered set.

## Before

Real output from `wendyos-hubert.local` (a Jetson Orin Nano):

```text
SOURCE	KIND	CLOCK	STATUS
applications	application	CLOCK_BOOTTIME	healthy
audio:16777217	audio	ALSA_CAPTURE/AGENT_RECEIPT	healthy
audio:16777729	audio	ALSA_CAPTURE/AGENT_RECEIPT	healthy
audio:16777730	audio	ALSA_CAPTURE/AGENT_RECEIPT	healthy
audio:16777731	audio	ALSA_CAPTURE/AGENT_RECEIPT	healthy
audio:16777732	audio	ALSA_CAPTURE/AGENT_RECEIPT	healthy
audio:16777733	audio	ALSA_CAPTURE/AGENT_RECEIPT	healthy
audio:16777734	audio	ALSA_CAPTURE/AGENT_RECEIPT	healthy
audio:16777735	audio	ALSA_CAPTURE/AGENT_RECEIPT	healthy
audio:16777736	audio	ALSA_CAPTURE/AGENT_RECEIPT	healthy
audio:16777737	audio	ALSA_CAPTURE/AGENT_RECEIPT	healthy
audio:16777738	audio	ALSA_CAPTURE/AGENT_RECEIPT	healthy
audio:16777739	audio	ALSA_CAPTURE/AGENT_RECEIPT	healthy
audio:16777740	audio	ALSA_CAPTURE/AGENT_RECEIPT	healthy
audio:16777741	audio	ALSA_CAPTURE/AGENT_RECEIPT	healthy
audio:16777742	audio	ALSA_CAPTURE/AGENT_RECEIPT	healthy
audio:16777743	audio	ALSA_CAPTURE/AGENT_RECEIPT	healthy
audio:16777744	audio	ALSA_CAPTURE/AGENT_RECEIPT	healthy
audio:16777745	audio	ALSA_CAPTURE/AGENT_RECEIPT	healthy
audio:16777746	audio	ALSA_CAPTURE/AGENT_RECEIPT	healthy
audio:16777747	audio	ALSA_CAPTURE/AGENT_RECEIPT	healthy
audio:16777748	audio	ALSA_CAPTURE/AGENT_RECEIPT	healthy
telemetry	telemetry	CLOCK_BOOTTIME	healthy
v4l2:/dev/video0	camera	V4L2_BUFFER_TIMESTAMP	healthy
```

## After

`wendy data sources --device wendyos-hubert.local`

```text
SOURCE            KIND         CLOCK                       STATUS   DETAIL
applications      application  CLOCK_BOOTTIME              healthy
audio:16777217    audio        ALSA_CAPTURE/AGENT_RECEIPT  healthy  C920 [HD Pro Webcam C920], device 0: USB Audi...
audio:16777729    audio        ALSA_CAPTURE/AGENT_RECEIPT  healthy  APE [NVIDIA Jetson Orin Nano APE], device 0: ...
audio:16777730    audio        ALSA_CAPTURE/AGENT_RECEIPT  healthy  APE [NVIDIA Jetson Orin Nano APE], device 1: ...
audio:16777731    audio        ALSA_CAPTURE/AGENT_RECEIPT  healthy  APE [NVIDIA Jetson Orin Nano APE], device 2: ...
audio:16777732    audio        ALSA_CAPTURE/AGENT_RECEIPT  healthy  APE [NVIDIA Jetson Orin Nano APE], device 3: ...
audio:16777733    audio        ALSA_CAPTURE/AGENT_RECEIPT  healthy  APE [NVIDIA Jetson Orin Nano APE], device 4: ...
telemetry         telemetry    CLOCK_BOOTTIME              healthy
v4l2:/dev/video0  camera       V4L2_BUFFER_TIMESTAMP       healthy  HD Pro Webcam C920: HD Pro Webc VIDEO_TRANSPO...

... 15 more audio sources not listed (--kind audio to list all, --json for everything)
```

`wendy data sources --device wendyos-hubert.local --kind camera`

```text
SOURCE            KIND    CLOCK                  STATUS   DETAIL
v4l2:/dev/video0  camera  V4L2_BUFFER_TIMESTAMP  healthy  HD Pro Webcam C920: HD Pro Webc VIDEO_TRANSPO...
```

`wendy data sources --device wendyos-hubert.local --kind audio` lists all 21 audio sources with no summary line, because the kind was asked for explicitly.

`wendy data sources --device wendyos-hubert.local --kind lidar`

```text
No sources of kind "lidar". Kinds present on this device: application, audio, telemetry, camera.
```

`wendy data sources --device wendyos-hubert.local --json | head -c 300`

```text
{"sources":[{"id":"applications","kind":"application","clock_domain":"CLOCK_BOOTTIME","healthy":true},{"id":"audio:16777217","kind":"audio","clock_domain":"ALSA_CAPTURE/AGENT_RECEIPT","healthy":true,"detail":"C920 [HD Pro Webcam C920], device 0: USB Audio [USB Audio] plughw:0,0"},{"id":"audio:167777
```

The full `--json` output was diffed against the pre-change binary on the live device and is identical.

## Tests

The formatting is a pure `writeDataSources(io.Writer, []*agentpbv2.DataSource, []string)`, plus `encodeDataSourcesJSON`, so no gRPC scaffolding is needed. New table-driven tests in `go/internal/cli/commands/data_sources_test.go`:

- `TestWriteDataSourcesTable` (aligned header without detail column, detail column present and aligned, kind filter, case-insensitive kind filter, multiple kinds, unknown kind names the kinds present, empty device result)
- `TestWriteDataSourcesDetailTruncation`
- `TestWriteDataSourcesDetailColumnOmittedWhenAllEmpty`
- `TestWriteDataSourcesFloodBoundary` (exactly six vs seven, the 21-source Jetson case, explicitly requested kind never summarised, case-insensitive explicit request)
- `TestWriteDataSourcesFloodKeepsOtherKinds`
- `TestDataSourcesJSONUnchangedWithoutKind`
- `TestNormalizeSourceKinds`

`go build ./...`, `go vet ./internal/cli/...`, `go test ./internal/cli/...` and `gofmt -l` are all clean.

## Docs

`go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md` gains the real sample table, the summarisation rule, and the `--kind` examples. `wendy-data-platform-demo.md` only names the command and shows no listing, so it needed no change.
