### PR TITLE
fix: make the integration branch green (gofmt -s, Linux peer-cred test)

### DIFF
--- a/go/internal/agent/services/app_data_socket.go
+++ b/go/internal/agent/services/app_data_socket.go
@@ -368,6 +368,7 @@ func writeDataFrame(w io.Writer, v any) error {
 	_, err = w.Write(b)
 	return err
 }
+
 // recordKindValidator checks the kind-specific required fields of a record.
 type recordKindValidator func(data.ApplicationRecord) error
 

--- a/go/internal/agent/services/app_data_socket_hardening_test.go
+++ b/go/internal/agent/services/app_data_socket_hardening_test.go
@@ -309,6 +309,37 @@ func TestAppDataPeerCredentialCgroupfsMismatchRefused(t *testing.T) {
 	}
 }
 
+// TestAppDataRealCgroupOfTestProcessRefused pins the platform truth that every
+// other socket-level test here stubs away: with the PRODUCTION cgroup reader in
+// place, a peer that is a real local process outside any wendy app scope is
+// refused. The go-test process itself is such a peer, so this asserts the same
+// fail-closed outcome on both platforms without branching on either: on Linux
+// readProcCgroup reads /proc/<pid>/cgroup and finds no wendy app scope, and on
+// non-Linux it reports the lookup unsupported, which is equally unattributable.
+//
+// This is the case a socket-level happy-path test must inject around, and the
+// reason macOS-only verification cannot see the hardened behavior at all.
+func TestAppDataRealCgroupOfTestProcessRefused(t *testing.T) {
+	m := newTestDataSocketManager(t)
+	// Only the SO_PEERCRED lookup is stubbed, and it reports this very process.
+	// cgroupOfPID stays at the production readProcCgroup.
+	m.peerCred = func(net.Conn) (peerCredentials, error) {
+		return peerCredentials{UID: uint32(os.Getuid()), PID: int32(os.Getpid())}, nil
+	}
+	dir, err := m.Ensure("com.example.a", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := net.Dial("unix", filepath.Join(dir, DataSocketFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if ack := readRejectAck(t, conn); ack.State != "rejected" {
+		t.Fatalf("test process as peer: state = %q, want rejected (the go-test process is in no wendy app scope)", ack.State)
+	}
+}
+
 // TestAppIDFromCgroup covers the cgroup identity extraction directly.
 func TestAppIDFromCgroup(t *testing.T) {
 	cases := []struct {

--- a/go/internal/agent/services/app_data_socket_test.go
+++ b/go/internal/agent/services/app_data_socket_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/wendylabsinc/wendy/go/internal/agent/data"
+	sharedenv "github.com/wendylabsinc/wendy/go/internal/shared/env"
 )
 
 func TestDataProtocolLengthLimit(t *testing.T) {
@@ -38,6 +40,19 @@ func TestAppDataSocketIsPrivateAndRecordsIdentity(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	manager := NewAppDataSocketManager(ctx, nil, capture)
+	// The data socket is hardened: once SO_PEERCRED yields a peer pid,
+	// verifyPeer fails closed unless that pid's cgroup resolves to the socket's
+	// own app. The go-test process is not in a wendy app scope, so on Linux (the
+	// target platform, where SO_PEERCRED succeeds) an uninjected dial is
+	// correctly refused, while on macOS the no-peer fail-open branch hides that.
+	// Inject the same seams the D6 hardening tests use so the happy path is
+	// exercised deterministically on both platforms.
+	manager.peerCred = func(net.Conn) (peerCredentials, error) {
+		return peerCredentials{UID: 0, PID: 4242}, nil
+	}
+	manager.cgroupOfPID = func(int32) (string, error) {
+		return fmt.Sprintf("0::/system.slice/%s-com.example.a.scope\n", sharedenv.SystemdServiceName()), nil
+	}
 	dirA, err := manager.Ensure("com.example.a", "")
 	if err != nil {
 		t.Fatal(err)

--- a/go/internal/agent/services/data_audio_adapter.go
+++ b/go/internal/agent/services/data_audio_adapter.go
@@ -53,8 +53,8 @@ type audioStream interface {
 type pcmCapture struct{ c *capture }
 
 func (p *pcmCapture) Read(b []byte) (int, error) { return p.c.stdout.Read(b) }
-func (p *pcmCapture) Close()                      { p.c.Close() }
-func (p *pcmCapture) Err() string                 { return p.c.Err() }
+func (p *pcmCapture) Close()                     { p.c.Close() }
+func (p *pcmCapture) Err() string                { return p.c.Err() }
 
 type audioDataAdapter struct {
 	audio *AudioService

--- a/go/internal/agent/services/data_transfer_worker_e2e_test.go
+++ b/go/internal/agent/services/data_transfer_worker_e2e_test.go
@@ -200,10 +200,10 @@ func TestE2EDataPlatformHappyPath(t *testing.T) {
 	snapshot := deterministicBytes(3000, 0x22)
 	events := []byte("{\"t\":1,\"event\":\"start\"}\n{\"t\":2,\"event\":\"stop\"}\n")
 	mf := sealRealEpisode(t, mgr, map[string][]byte{
-		"camera.h264":     camera,
-		"snapshot.jpg":    snapshot,
+		"camera.h264":      camera,
+		"snapshot.jpg":     snapshot,
 		"app/events.jsonl": events,
-		"marker.empty":    {},
+		"marker.empty":     {},
 	})
 
 	t.Logf("sealed episode id=%s files=%d", mf.ID, len(mf.Files))


### PR DESCRIPTION
## Problem

`feature/wendy-data-platform` is red on two Continuous Integration (CI) checks, and must be green before promotion to `main`.

1. **Format Check.** `gofmt -l -s .` from `go/` reports three files: `internal/agent/services/app_data_socket.go`, `internal/agent/services/data_audio_adapter.go`, `internal/agent/services/data_transfer_worker_e2e_test.go`.
2. **`TestAppDataSocketIsPrivateAndRecordsIdentity` fails on Linux and passes on macOS.** The ack comes back `{Version:1 State:rejected Error:peer credentials do not match this app}`.

Both landed with 902586b8b.

## Cause

The root cause of both reaching the branch is that every verification pass on this code ran only on macOS, where the hardened code path cannot execute.

The test opens a real app data socket and dials it from the go-test process itself. After the D6 hardening, `verifyPeer` fails **closed** once it has a peer pid: any inability to positively attribute that pid to the owning app is a refusal. On Linux `SO_PEERCRED` succeeds, the go-test process is not in a wendy app cgroup scope, so `/proc/<pid>/cgroup` does not resolve to the app and the connection is correctly refused. On macOS `readPeerCredentials` returns `errPeerCredUnsupported`, the documented fail-open-when-no-peer branch applies, and the test passes without ever reaching the hardened path.

So the production behavior is correct. The test was simply never set up for a hardened socket, and a Mac cannot observe that.

## Solution

- `gofmt -w -s` on exactly those three files. The changes are one missing blank line before a declaration and two alignment blocks that `-s` rewrites. Nothing else was reformatted.
- `TestAppDataSocketIsPrivateAndRecordsIdentity` now injects the peer-credential and cgroup seams that the D6 hardening tests already use (`AppDataSocketManager.peerCred` / `.cgroupOfPID`), supplying a peer whose cgroup resolves to the app under test. The happy path is now exercised deterministically on both platforms. `verifyPeer` is unchanged, no build tag was added, and the test is not conditional on the platform.
- Added `TestAppDataRealCgroupOfTestProcessRefused`, which pins the platform truth the suite missed: with the **production** cgroup reader left in place, a real local peer outside any wendy app scope is refused. It asserts the same fail-closed outcome on both platforms without branching on either (Linux: no wendy scope in `/proc`; non-Linux: lookup unsupported, equally unattributable). This is exactly the case the happy-path test has to inject around.

The cross-app refusal test the reviewer asked about **already existed** and was not duplicated: `app_data_socket_hardening_test.go` already covers a different-app cgroup (`TestAppDataPeerCredentialMismatchRefused`), a non-app scope (`TestAppDataPeerCredentialNoScopeRefused`), an unreadable cgroup (`TestAppDataPeerCredentialUnreadableCgroupRefused`) and the cgroupfs cross-app forgery (`TestAppDataPeerCredentialCgroupfsMismatchRefused`).

## Verification

### Linux, before the fix (baseline, reproducing the CI failure)

Run on this Apple Silicon machine in a `linux/arm64` container matching the repo toolchain minor (`go.mod`: `go 1.26.6`):

```
docker run --rm --platform linux/arm64 -v <worktree>:/src -w /src golang:1.26 \
  go test ./go/internal/agent/services/ -run TestAppDataSocketIsPrivateAndRecordsIdentity -v
```

```
go version go1.26.7 linux/arm64
=== RUN   TestAppDataSocketIsPrivateAndRecordsIdentity
    app_data_socket_test.go:71: ack={Version:1 State:rejected Error:peer credentials do not match this app}
--- FAIL: TestAppDataSocketIsPrivateAndRecordsIdentity (0.05s)
FAIL
FAIL	github.com/wendylabsinc/wendy/go/internal/agent/services	0.059s
FAIL
```

### Linux, after the fix

```
go version go1.26.7 linux/arm64
=== RUN   TestAppDataRateLimitIsPerAppNotPerConnection
--- PASS: TestAppDataRateLimitIsPerAppNotPerConnection (0.18s)
=== RUN   TestAppDataUnknownKindRejectedNotFatal
--- PASS: TestAppDataUnknownKindRejectedNotFatal (0.00s)
=== RUN   TestAppDataPeerCredentialMismatchRefused
--- PASS: TestAppDataPeerCredentialMismatchRefused (0.00s)
=== RUN   TestAppDataPeerCredentialMatchAllowed
--- PASS: TestAppDataPeerCredentialMatchAllowed (0.00s)
=== RUN   TestAppDataPeerCredentialUnreadableCgroupRefused
--- PASS: TestAppDataPeerCredentialUnreadableCgroupRefused (0.00s)
=== RUN   TestAppDataPeerCredentialNoScopeRefused
--- PASS: TestAppDataPeerCredentialNoScopeRefused (0.00s)
=== RUN   TestAppDataPeerCredentialCgroupfsMatchAllowed
--- PASS: TestAppDataPeerCredentialCgroupfsMatchAllowed (0.00s)
=== RUN   TestAppDataPeerCredentialCgroupfsMismatchRefused
--- PASS: TestAppDataPeerCredentialCgroupfsMismatchRefused (0.00s)
=== RUN   TestAppDataRealCgroupOfTestProcessRefused
--- PASS: TestAppDataRealCgroupOfTestProcessRefused (0.00s)
=== RUN   TestAppIDFromCgroup
=== RUN   TestAppIDFromCgroup/single_service
=== RUN   TestAppIDFromCgroup/multi_service_strips_suffix
=== RUN   TestAppIDFromCgroup/non-wendy_process
=== RUN   TestAppIDFromCgroup/empty
=== RUN   TestAppIDFromCgroup/cgroupfs_single_service
=== RUN   TestAppIDFromCgroup/cgroupfs_multi_service_strips_suffix
=== RUN   TestAppIDFromCgroup/cgroupfs_other_systemd_service
=== RUN   TestAppIDFromCgroup/cgroupfs_child_cgroup_forgery_yields_parent_id
=== RUN   TestAppIDFromCgroup/systemd_child_scope_forgery_yields_parent_id
=== RUN   TestAppIDFromCgroup/cgroupfs_empty_suffix
=== RUN   TestAppIDFromCgroup/cgroupfs_empty_appID_with_service
=== RUN   TestAppIDFromCgroup/cgroupfs_service_prefix_is_not_a_match
--- PASS: TestAppIDFromCgroup (0.00s)
    --- PASS: TestAppIDFromCgroup/single_service (0.00s)
    --- PASS: TestAppIDFromCgroup/multi_service_strips_suffix (0.00s)
    --- PASS: TestAppIDFromCgroup/non-wendy_process (0.00s)
    --- PASS: TestAppIDFromCgroup/empty (0.00s)
    --- PASS: TestAppIDFromCgroup/cgroupfs_single_service (0.00s)
    --- PASS: TestAppIDFromCgroup/cgroupfs_multi_service_strips_suffix (0.00s)
    --- PASS: TestAppIDFromCgroup/cgroupfs_other_systemd_service (0.00s)
    --- PASS: TestAppIDFromCgroup/cgroupfs_child_cgroup_forgery_yields_parent_id (0.00s)
    --- PASS: TestAppIDFromCgroup/systemd_child_scope_forgery_yields_parent_id (0.00s)
    --- PASS: TestAppIDFromCgroup/cgroupfs_empty_suffix (0.00s)
    --- PASS: TestAppIDFromCgroup/cgroupfs_empty_appID_with_service (0.00s)
    --- PASS: TestAppIDFromCgroup/cgroupfs_service_prefix_is_not_a_match (0.00s)
=== RUN   TestDataProtocolLengthLimit
--- PASS: TestDataProtocolLengthLimit (0.00s)
=== RUN   TestAppDataSocketIsPrivateAndRecordsIdentity
--- PASS: TestAppDataSocketIsPrivateAndRecordsIdentity (0.01s)
=== RUN   TestValidateApplicationRecord
--- PASS: TestValidateApplicationRecord (0.00s)
PASS
ok	github.com/wendylabsinc/wendy/go/internal/agent/services	0.213s
```

Full package plus format and vet on the same container:

```
GOFMT-CLEAN
VET-OK
ok  	github.com/wendylabsinc/wendy/go/internal/agent/services	8.395s
```

`go build ./...` inside the plain `golang:1.26` image stops at `github.com/google/gousb` because `libusb-1.0` is not installed in that image. That is an image gap, not a code problem: `build.yml` provisions libusb from a pinned source tarball for the Linux CLI job, and `go build ./...` succeeds on macOS where Homebrew libusb is present.

### macOS

```
$ gofmt -l -s .        # from go/, no output
$ CC=/usr/bin/clang go build ./...
ld: warning: ignoring duplicate libraries: '-lobjc'
$ CC=/usr/bin/clang go vet ./go/internal/agent/...   # clean
$ CC=/usr/bin/clang go test ./go/internal/agent/services/...
ok  	github.com/wendylabsinc/wendy/go/internal/agent/services	25.706s
```

Do not merge without review.
