### PR TITLE
fix(data): report unrouted audio endpoints as unhealthy

### DIFF
--- a/go/internal/agent/data/campaign.go
+++ b/go/internal/agent/data/campaign.go
@@ -326,6 +326,9 @@ func (m *Manager) DeployCampaign(contents []byte) (Campaign, error) {
 	if err != nil {
 		return Campaign{}, err
 	}
+	if err := m.checkDeployableAudioSources(campaign); err != nil {
+		return Campaign{}, err
+	}
 	campaign.DeployedUnixNanos = time.Now().UnixNano()
 	if campaign.BufferDuration() > 0 {
 		for _, source := range campaign.Sources {
@@ -456,6 +459,62 @@ func (m *Manager) ResolveCampaignSources(campaign Campaign) ([]string, []string,
 	sort.Strings(ids)
 	sort.Strings(topics)
 	return ids, topics, captures, nil
+}
+
+// checkDeployableAudioSources refuses a campaign whose audio selector does not
+// name a healthy source, at deploy rather than at the first trigger.
+//
+// Resolution used to happen only in triggerCampaign, so a plan naming a source
+// that can never yield audio deployed cleanly and failed much later, or worse
+// resolved to an endpoint that streams digital silence forever: a sealed,
+// checksummed, uploaded episode full of nothing, with clean drop accounting and
+// no error at any layer. Deploy is the last moment an operator is present to
+// read the reason, so it is where the refusal belongs.
+//
+// It reuses resolveKindSelector so deploy and trigger cannot disagree about
+// what resolves, and is scoped to audio: camera and ROS 2 selectors keep their
+// existing deploy behavior.
+func (m *Manager) checkDeployableAudioSources(campaign Campaign) error {
+	var all []Source
+	loaded := false
+	for _, requested := range campaign.Sources {
+		if requested.Audio == "" {
+			continue
+		}
+		if !loaded {
+			all, loaded = m.Sources(context.Background()), true
+		}
+		if _, err := resolveKindSelector(all, "audio", requested.Audio); err == nil {
+			continue
+		}
+		// Name the reason, not just the miss: when the selector does match an
+		// enumerated source that is merely unhealthy, its detail already says
+		// why and what to check.
+		if unhealthy, ok := matchUnhealthySource(all, "audio", requested.Audio); ok {
+			return fmt.Errorf("audio source %q resolves to %s, which is unhealthy and would record silence: %s",
+				requested.Audio, unhealthy.ID, unhealthy.Detail)
+		}
+		return fmt.Errorf("audio source %q does not name a healthy capture source on this device", requested.Audio)
+	}
+	return nil
+}
+
+// matchUnhealthySource finds an unhealthy source of the given kind that the
+// selector names, so a refusal can quote the reason the source reported.
+func matchUnhealthySource(all []Source, kind, selector string) (Source, bool) {
+	selector = strings.TrimSpace(selector)
+	for _, source := range all {
+		if source.Kind != kind || source.Healthy {
+			continue
+		}
+		if source.ID == selector || strings.EqualFold(source.ID, selector) {
+			return source, true
+		}
+		if selector != "" && strings.Contains(strings.ToLower(source.Detail), strings.ToLower(selector)) {
+			return source, true
+		}
+	}
+	return Source{}, false
 }
 
 func resolveCameraSelector(all []Source, selector string) (string, error) {

--- a/go/internal/agent/data/campaign_audio_test.go
+++ b/go/internal/agent/data/campaign_audio_test.go
@@ -1,6 +1,8 @@
 package data
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -47,6 +49,11 @@ func TestAudioThresholdCampaignParsesAndDeploysWithoutModeWarning(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Deploy now resolves audio selectors, so the campaign needs a healthy
+	// source to name; see TestDeployRefusesUnhealthyAudioSource.
+	manager.SetSourceProvider(func(context.Context) []Source {
+		return []Source{{ID: "audio:1", Kind: "audio", ClockDomain: "ALSA_CAPTURE/AGENT_RECEIPT", Healthy: true, Detail: "cabin-mic USB Audio plughw:0,0"}}
+	})
 	deployed, err := manager.DeployCampaign([]byte(audioThresholdCampaign))
 	if err != nil {
 		t.Fatalf("deploy: %v", err)
@@ -85,5 +92,129 @@ func TestShippedAudioCampaignParses(t *testing.T) {
 	}
 	if _, _, _, err := ParseFieldThreshold(audio.Capture.Trigger); err != nil {
 		t.Fatalf("audio trigger %q does not parse: %v", audio.Capture.Trigger, err)
+	}
+}
+
+// admaifSource is one of the twenty Tegra audio-hub DMA endpoints a Jetson Orin
+// Nano advertises, with the detail the audio adapter now attaches. The
+// description is verbatim from wendyos-hubert.local.
+func admaifSource() Source {
+	return Source{
+		ID:          "audio:16777729",
+		Kind:        "audio",
+		ClockDomain: "ALSA_CAPTURE/AGENT_RECEIPT",
+		Healthy:     false,
+		Detail: "APE [NVIDIA Jetson Orin Nano APE], device 0: fe.admaif@290f000.ADMAIF1 (*) [] plughw:2,0; " +
+			"audio hub DMA endpoint, not a physical input: captures digital silence unless an external I2S codec is wired and the audio hub is routed to it",
+	}
+}
+
+const admaifCampaign = `version: 1
+name: cabin-audio
+sources:
+  - audio: ADMAIF1
+capture:
+  buffer: 0s
+  after_trigger: 20s
+  triggers:
+    - event: loud_event
+upload:
+  when: wifi
+export:
+  annotation: cvat
+`
+
+// TestDeployRefusesUnhealthyAudioSource proves a campaign pointed at an
+// endpoint that streams digital silence is refused while an operator is still
+// there to read why, rather than deploying cleanly and sealing empty episodes.
+func TestDeployRefusesUnhealthyAudioSource(t *testing.T) {
+	manager, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager.SetSourceProvider(func(context.Context) []Source {
+		return []Source{admaifSource()}
+	})
+
+	_, err = manager.DeployCampaign([]byte(admaifCampaign))
+	if err == nil {
+		t.Fatal("deploy accepted a campaign whose only audio source records silence")
+	}
+	// The refusal has to name the source and the reason, or the operator has
+	// nothing to act on.
+	for _, want := range []string{"ADMAIF1", "audio:16777729", "audio hub DMA endpoint"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("deploy error %q does not mention %q", err, want)
+		}
+	}
+	if _, err := manager.Campaign("cabin-audio"); err == nil {
+		t.Error("refused campaign was still persisted")
+	}
+}
+
+// TestResolveRefusesUnhealthyAudioSource covers the trigger-time half: even if
+// a campaign predates the deploy check, resolution must not select an unhealthy
+// audio source.
+func TestResolveRefusesUnhealthyAudioSource(t *testing.T) {
+	manager, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager.SetSourceProvider(func(context.Context) []Source {
+		return []Source{admaifSource()}
+	})
+	campaign, err := ParseCampaign([]byte(admaifCampaign))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := manager.ResolveCampaignSources(campaign); err == nil {
+		t.Fatal("resolution selected an audio source that records silence")
+	}
+}
+
+// TestDeployResolvesDefaultAudioPastTheHubEndpoints is the payoff on a real
+// Jetson: with the twenty audio-hub endpoints reporting unhealthy, exactly one
+// healthy audio source is left, so "default" is no longer ambiguous and lands
+// on the actual microphone.
+func TestDeployResolvesDefaultAudioPastTheHubEndpoints(t *testing.T) {
+	manager, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	c920 := Source{ID: "audio:16777217", Kind: "audio", ClockDomain: "ALSA_CAPTURE/AGENT_RECEIPT", Healthy: true,
+		Detail: "C920 [HD Pro Webcam C920], device 0: USB Audio [USB Audio] plughw:0,0"}
+	manager.SetSourceProvider(func(context.Context) []Source {
+		sources := []Source{c920}
+		for i := 0; i < 20; i++ {
+			admaif := admaifSource()
+			admaif.ID = fmt.Sprintf("audio:%d", 16777729+i)
+			sources = append(sources, admaif)
+		}
+		return sources
+	})
+
+	defaultCampaign := strings.Replace(admaifCampaign, "audio: ADMAIF1", "audio: default", 1)
+	if _, err := manager.DeployCampaign([]byte(defaultCampaign)); err != nil {
+		t.Fatalf("deploy of a default audio selector failed: %v", err)
+	}
+	campaign, err := ParseCampaign([]byte(defaultCampaign))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ids, _, _, err := manager.ResolveCampaignSources(campaign)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	found := false
+	for _, id := range ids {
+		if id == c920.ID {
+			found = true
+		}
+		if strings.HasPrefix(id, "audio:") && id != c920.ID {
+			t.Errorf("resolution selected an audio hub endpoint %s", id)
+		}
+	}
+	if !found {
+		t.Errorf("default audio did not resolve to the real microphone; got %v", ids)
 	}
 }

--- a/go/internal/agent/services/data_audio_adapter.go
+++ b/go/internal/agent/services/data_audio_adapter.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -83,6 +84,55 @@ func (a *audioDataAdapter) defaultOpenStream(ctx context.Context, deviceID uint3
 	return &pcmCapture{c: rec}, nil
 }
 
+// audioHubDMAEndpointReason is appended to the description of an audio-hub DMA
+// endpoint. It has to tell an operator both what is wrong and what would fix
+// it, because the endpoint opens and streams perfectly: the only symptom is
+// that every sample is zero.
+const audioHubDMAEndpointReason = "audio hub DMA endpoint, not a physical input: captures digital silence unless an external I2S codec is wired and the audio hub is routed to it"
+
+// admaifEndpointPattern matches the ALSA device identity that the Tegra Audio
+// Processing Engine's ASoC driver gives an Audio DMA Interface (ADMAIF)
+// front-end, as "arecord -l" renders it. On a Jetson Orin Nano that is
+// "fe.admaif@290f000.ADMAIF1 (*) []" through to ADMAIF20.
+//
+// Matching a driver-formatted string is fragile, which is why it is isolated
+// here behind isAudioHubDMAEndpoint: a future kernel may rename these, and this
+// is the single place to fix. It is nevertheless the right signal, and the two
+// seemingly more authoritative alternatives were measured on hardware and
+// rejected:
+//
+//   - The "(*)" and "[]" in the name do not mean "unrouted". /proc/asound/
+//     card2/pcm0c/info reports id "fe.admaif@290f000.ADMAIF1 (*)" with an empty
+//     name field, and arecord prints "<id> [<name>]" — so "[]" is just the
+//     empty PCM name and "(*)" is ASoC's marker for a dynamic PCM (a DPCM
+//     front-end). Both are structural to an ADMAIF, present routed or not. Only
+//     the "admaif" identity itself carries meaning.
+//
+//   - The audio hub crossbar mixer state is authoritative about routing, but
+//     routing is not the question. On wendyos-hubert the "ADMAIF1 Mux" control
+//     reads I2S2 and "ADMAIF2 Mux" reads I2S4 (NVIDIA's default board config),
+//     yet a one-second capture from the routed plughw:2,0 still returns 192044
+//     bytes containing zero non-zero samples, because /sys/kernel/debug/asoc/
+//     components lists no codec beyond two snd-soc-dummy entries: the I2S ports
+//     terminate in nothing. A mux-based health rule would therefore call
+//     ADMAIF1 and ADMAIF2 healthy while they deliver pure silence, which is the
+//     exact lie this check exists to remove — and it would cost twenty amixer
+//     subprocesses per enumeration to get there.
+//
+// So health is decided on the structural question the identity does answer:
+// this is a memory endpoint of the on-chip audio hub crossbar, not a physical
+// capture input. The endpoint is still enumerated, because someone who wires an
+// I2S codec and routes the hub has a legitimately usable ADMAIF and hiding it
+// would blind us to real hardware. It is reported unhealthy rather than absent,
+// and the reason names what to check.
+var admaifEndpointPattern = regexp.MustCompile(`(?i)admaif@[0-9a-f]+\.admaif[0-9]+`)
+
+// isAudioHubDMAEndpoint reports whether an audio source detail names an on-chip
+// audio-hub DMA endpoint rather than a physical capture device.
+func isAudioHubDMAEndpoint(detail string) bool {
+	return admaifEndpointPattern.MatchString(detail)
+}
+
 func (a *audioDataAdapter) Discover(ctx context.Context) []data.Source {
 	var nodes []audio.Node
 	domain := "PIPEWIRE_CAPTURE/AGENT_RECEIPT"
@@ -105,12 +155,18 @@ func (a *audioDataAdapter) Discover(ctx context.Context) []data.Source {
 		if n.IsSink {
 			continue
 		}
+		detail := strings.TrimSpace(n.Description + " " + n.Name)
+		healthy := true
+		if isAudioHubDMAEndpoint(detail) {
+			healthy = false
+			detail = strings.TrimSpace(detail + "; " + audioHubDMAEndpointReason)
+		}
 		out = append(out, data.Source{
 			ID:          fmt.Sprintf("audio:%d", n.ID),
 			Kind:        "audio",
 			ClockDomain: domain,
-			Healthy:     true,
-			Detail:      strings.TrimSpace(n.Description + " " + n.Name),
+			Healthy:     healthy,
+			Detail:      detail,
 		})
 	}
 	return out

--- a/go/internal/agent/services/data_audio_adapter_test.go
+++ b/go/internal/agent/services/data_audio_adapter_test.go
@@ -6,8 +6,10 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/wendylabsinc/wendy/go/internal/agent/audio"
 	"github.com/wendylabsinc/wendy/go/internal/agent/data"
 )
 
@@ -163,5 +165,211 @@ func TestAudioThresholdCountsMissedCrossingsDuringSeal(t *testing.T) {
 	}
 	if result.Drops == nil || *result.Drops != 1 {
 		t.Fatalf("expected exactly 1 missed crossing during the seal, got %v", result.Drops)
+	}
+}
+
+// jetsonArecordFixture is the verbatim "arecord -l" output from
+// wendyos-hubert.local, a Jetson Orin Nano: one real USB microphone on card 0
+// and the twenty Audio DMA Interface front-ends of the Tegra Audio Processing
+// Engine on card 2. Every one of the twenty opens, streams and returns pure
+// digital silence; a one-second capture from plughw:2,0 yields 192044 bytes
+// with zero non-zero samples, while the same capture from the C920 on
+// plughw:0,0 yields 159601 non-zero bytes.
+const jetsonArecordFixture = `**** List of CAPTURE Hardware Devices ****
+card 0: C920 [HD Pro Webcam C920], device 0: USB Audio [USB Audio]
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+card 2: APE [NVIDIA Jetson Orin Nano APE], device 0: fe.admaif@290f000.ADMAIF1 (*) []
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+card 2: APE [NVIDIA Jetson Orin Nano APE], device 1: fe.admaif@290f000.ADMAIF2 (*) []
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+card 2: APE [NVIDIA Jetson Orin Nano APE], device 2: fe.admaif@290f000.ADMAIF3 (*) []
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+card 2: APE [NVIDIA Jetson Orin Nano APE], device 3: fe.admaif@290f000.ADMAIF4 (*) []
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+card 2: APE [NVIDIA Jetson Orin Nano APE], device 4: fe.admaif@290f000.ADMAIF5 (*) []
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+card 2: APE [NVIDIA Jetson Orin Nano APE], device 5: fe.admaif@290f000.ADMAIF6 (*) []
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+card 2: APE [NVIDIA Jetson Orin Nano APE], device 6: fe.admaif@290f000.ADMAIF7 (*) []
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+card 2: APE [NVIDIA Jetson Orin Nano APE], device 7: fe.admaif@290f000.ADMAIF8 (*) []
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+card 2: APE [NVIDIA Jetson Orin Nano APE], device 8: fe.admaif@290f000.ADMAIF9 (*) []
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+card 2: APE [NVIDIA Jetson Orin Nano APE], device 9: fe.admaif@290f000.ADMAIF10 (*) []
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+card 2: APE [NVIDIA Jetson Orin Nano APE], device 10: fe.admaif@290f000.ADMAIF11 (*) []
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+card 2: APE [NVIDIA Jetson Orin Nano APE], device 11: fe.admaif@290f000.ADMAIF12 (*) []
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+card 2: APE [NVIDIA Jetson Orin Nano APE], device 12: fe.admaif@290f000.ADMAIF13 (*) []
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+card 2: APE [NVIDIA Jetson Orin Nano APE], device 13: fe.admaif@290f000.ADMAIF14 (*) []
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+card 2: APE [NVIDIA Jetson Orin Nano APE], device 14: fe.admaif@290f000.ADMAIF15 (*) []
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+card 2: APE [NVIDIA Jetson Orin Nano APE], device 15: fe.admaif@290f000.ADMAIF16 (*) []
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+card 2: APE [NVIDIA Jetson Orin Nano APE], device 16: fe.admaif@290f000.ADMAIF17 (*) []
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+card 2: APE [NVIDIA Jetson Orin Nano APE], device 17: fe.admaif@290f000.ADMAIF18 (*) []
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+card 2: APE [NVIDIA Jetson Orin Nano APE], device 18: fe.admaif@290f000.ADMAIF19 (*) []
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+card 2: APE [NVIDIA Jetson Orin Nano APE], device 19: fe.admaif@290f000.ADMAIF20 (*) []
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+`
+
+// jetsonAplayFixture is the playback half from the same device. Card 1 is the
+// HDMI codec; the APE card exposes the playback direction of the same twenty
+// ADMAIF front-ends. Sinks are skipped by Discover, so these only prove the
+// health check never reaches them.
+const jetsonAplayFixture = `**** List of PLAYBACK Hardware Devices ****
+card 1: HDA [NVIDIA Jetson Orin Nano HDA], device 3: HDMI 0 [HDMI 0]
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+card 2: APE [NVIDIA Jetson Orin Nano APE], device 0: fe.admaif@290f000.ADMAIF1 (*) []
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+`
+
+// discoverWithAlsaFixtures runs Discover over the ALSA fallback path with the
+// given aplay/arecord output, which is the path a WendyOS device actually takes
+// (the agent has no PipeWire session, so its sources report the
+// ALSA_CAPTURE/AGENT_RECEIPT clock domain).
+func discoverWithAlsaFixtures(t *testing.T, aplayOut, arecordOut string) []data.Source {
+	t.Helper()
+	origAvailable, origAplay, origArecord := audio.Available, audio.AplayListRun, audio.ArecordListRun
+	t.Cleanup(func() {
+		audio.Available, audio.AplayListRun, audio.ArecordListRun = origAvailable, origAplay, origArecord
+	})
+	audio.Available = func() bool { return false }
+	audio.AplayListRun = func(context.Context) ([]byte, error) { return []byte(aplayOut), nil }
+	audio.ArecordListRun = func(context.Context) ([]byte, error) { return []byte(arecordOut), nil }
+
+	adapter := &audioDataAdapter{audio: &AudioService{}}
+	return adapter.Discover(context.Background())
+}
+
+// TestIsAudioHubDMAEndpointOnRealDeviceStrings exercises the detection function
+// against the exact strings the kernel produced on hardware, since it parses a
+// driver-formatted name and nothing else pins that format.
+func TestIsAudioHubDMAEndpointOnRealDeviceStrings(t *testing.T) {
+	unrouted := []string{
+		"APE [NVIDIA Jetson Orin Nano APE], device 0: fe.admaif@290f000.ADMAIF1 (*) [] plughw:2,0",
+		"APE [NVIDIA Jetson Orin Nano APE], device 19: fe.admaif@290f000.ADMAIF20 (*) [] plughw:2,19",
+		// /proc/asound/card2/pcm0c/info reports the id without the empty name,
+		// so the check must not depend on the trailing "[]".
+		"fe.admaif@290f000.ADMAIF1 (*)",
+	}
+	for _, detail := range unrouted {
+		if !isAudioHubDMAEndpoint(detail) {
+			t.Errorf("isAudioHubDMAEndpoint(%q) = false, want true", detail)
+		}
+	}
+
+	physical := []string{
+		"C920 [HD Pro Webcam C920], device 0: USB Audio [USB Audio] plughw:0,0",
+		"HDA [NVIDIA Jetson Orin Nano HDA], device 3: HDMI 0 [HDMI 0] plughw:1,3",
+		"tegra-hsp [tegra-hsp], device 0: ADMA Interface [ADMA] plughw:3,0",
+	}
+	for _, detail := range physical {
+		if isAudioHubDMAEndpoint(detail) {
+			t.Errorf("isAudioHubDMAEndpoint(%q) = true, want false", detail)
+		}
+	}
+}
+
+// TestJetsonAudioHubEndpointsAreAllUnhealthy pins the shape of the device that
+// exposed this defect: of the twenty-one capture sources a Jetson Orin Nano
+// advertises, exactly one is a real microphone. Before this check all
+// twenty-one reported healthy, so a campaign could resolve to an endpoint that
+// records silence forever without erring at any layer.
+func TestJetsonAudioHubEndpointsAreAllUnhealthy(t *testing.T) {
+	sources := discoverWithAlsaFixtures(t, jetsonAplayFixture, jetsonArecordFixture)
+	if len(sources) != 21 {
+		t.Fatalf("got %d audio sources, want 21 (one C920 plus twenty ADMAIF); got %+v", len(sources), sources)
+	}
+
+	var healthy, unhealthy []data.Source
+	for _, source := range sources {
+		if source.Kind != "audio" {
+			t.Fatalf("unexpected source kind %q in audio discovery: %+v", source.Kind, source)
+		}
+		if source.Healthy {
+			healthy = append(healthy, source)
+		} else {
+			unhealthy = append(unhealthy, source)
+		}
+	}
+	if len(healthy) != 1 {
+		t.Fatalf("want exactly 1 healthy audio source, got %d: %+v", len(healthy), healthy)
+	}
+	if len(unhealthy) != 20 {
+		t.Fatalf("want all 20 ADMAIF endpoints unhealthy, got %d", len(unhealthy))
+	}
+
+	// The one healthy source is the real microphone, and its description
+	// survives intact so the source is still identifiable.
+	if !strings.Contains(healthy[0].Detail, "HD Pro Webcam C920") || !strings.Contains(healthy[0].Detail, "plughw:0,0") {
+		t.Errorf("healthy source is not the C920 with its description intact: %q", healthy[0].Detail)
+	}
+	if strings.Contains(healthy[0].Detail, audioHubDMAEndpointReason) {
+		t.Errorf("a real microphone was annotated with the audio hub reason: %q", healthy[0].Detail)
+	}
+
+	// Every unhealthy source keeps its description and gains the reason.
+	for _, source := range unhealthy {
+		if !strings.Contains(source.Detail, "fe.admaif@290f000.ADMAIF") {
+			t.Errorf("unhealthy source lost its description: %q", source.Detail)
+		}
+		if !strings.Contains(source.Detail, audioHubDMAEndpointReason) {
+			t.Errorf("unhealthy source does not say why: %q", source.Detail)
+		}
+		if !strings.Contains(source.Detail, "plughw:2,") {
+			t.Errorf("unhealthy source lost its device address: %q", source.Detail)
+		}
+	}
+}
+
+// TestUsbMicrophoneStaysHealthy proves the check does not cost a normal device
+// its health or its description when no audio hub endpoint is present at all.
+func TestUsbMicrophoneStaysHealthy(t *testing.T) {
+	const arecordOnlyUSB = `**** List of CAPTURE Hardware Devices ****
+card 0: C920 [HD Pro Webcam C920], device 0: USB Audio [USB Audio]
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0
+`
+	sources := discoverWithAlsaFixtures(t, "**** List of PLAYBACK Hardware Devices ****\n", arecordOnlyUSB)
+	if len(sources) != 1 {
+		t.Fatalf("got %d sources, want 1: %+v", len(sources), sources)
+	}
+	if !sources[0].Healthy {
+		t.Errorf("USB microphone reported unhealthy: %+v", sources[0])
+	}
+	want := "C920 [HD Pro Webcam C920], device 0: USB Audio [USB Audio] plughw:0,0"
+	if sources[0].Detail != want {
+		t.Errorf("detail = %q, want %q", sources[0].Detail, want)
 	}
 }


### PR DESCRIPTION
## Problem

The data harness advertised every internal Tegra audio-DMA endpoint as a healthy capture source.

A Jetson Orin Nano (`wendyos-hubert.local`) reports twenty of them on ALSA card 2, named `fe.admaif@290f000.ADMAIF1` through `ADMAIF20`. Before this change all twenty reported `healthy` alongside the one real microphone:

```
audio:16777217  audio  ALSA_CAPTURE/AGENT_RECEIPT  healthy  C920 [HD Pro Webcam C920], device 0: USB Audio [USB Audio] plughw:0,0
audio:16777729  audio  ALSA_CAPTURE/AGENT_RECEIPT  healthy  APE [NVIDIA Jetson Orin Nano APE], device 0: fe.admaif@290f000.ADMAIF1 (*) [] plughw:2,0
audio:16777730  audio  ALSA_CAPTURE/AGENT_RECEIPT  healthy  APE [NVIDIA Jetson Orin Nano APE], device 1: fe.admaif@290f000.ADMAIF2 (*) [] plughw:2,1
... through ADMAIF20, all healthy
```

They deliver pure digital silence. `arecord -D plughw:2,0` succeeds, produces a 192044-byte WAV, and contains **zero** non-zero bytes; the same capture from the C920 on `plughw:0,0` contains 159601 non-zero bytes. These sources open cleanly, stream cleanly, and yield silence forever, so a campaign pointed at one produced a valid, sealed, checksummed, uploaded episode full of nothing, with clean drop accounting and no error at any layer. That is a status that lies.

## Cause

`audioDataAdapter.Discover` hardcoded `Healthy: true` for every non-sink audio node, so the Audio DMA Interface (ADMAIF) front-ends of the Tegra Audio Processing Engine were indistinguishable from a physical microphone. They are the memory endpoints of the on-chip audio hub (AHUB) crossbar, and the ASoC driver registers all twenty whether or not anything is routed to them.

Separately, `DeployCampaign` never resolved its sources at all. Resolution happened only in `triggerCampaign`, so a campaign naming one of these deployed cleanly and failed much later, or worse resolved and recorded silence.

## Solution

Health is now decided from the ALSA device identity, isolated in a single function `isAudioHubDMAEndpoint`, and an audio-hub DMA endpoint reports `Healthy: false` with the reason appended to its description. The description is preserved so the source stays identifiable.

Enumeration is deliberately unchanged. Someone who has wired an I2S codec and configured AHUB routing has a legitimately usable ADMAIF, and hiding it would blind us to real hardware, so these are reported unhealthy rather than dropped, and `--kind audio` still lists all twenty.

### Why the device-identity signal, and not the two more authoritative ones

Both alternatives were measured on real hardware over SSH and rejected. The code comment records this so it is not relitigated:

1. **The name does not encode routing.** The premise that `(*)` marks "unrouted" and `[]` is an empty routed-source list is wrong. `/proc/asound/card2/pcm0c/info` reports `id: fe.admaif@290f000.ADMAIF1 (*)` with an **empty** `name:` field, and `arecord -l` prints `<id> [<name>]`. So `[]` is just the empty PCM name and `(*)` is ASoC's marker for a dynamic PCM (a DPCM front-end). Both are structural to an ADMAIF, present routed or not.

2. **The crossbar mixer is authoritative about routing, but routing is not the question.** On this device `ADMAIF1 Mux` reads `I2S2` and `ADMAIF2 Mux` reads `I2S4` (NVIDIA's default board config); the other eighteen read `None`. Yet a one-second capture from the *routed* `plughw:2,0` still returns 192044 bytes with zero non-zero samples, because `/sys/kernel/debug/asoc/components` lists no codec beyond two `snd-soc-dummy` entries: the I2S ports terminate in nothing. A mux-based health rule would therefore have called ADMAIF1 and ADMAIF2 healthy while they deliver pure silence, reproducing the exact lie this change removes, and would have cost twenty `amixer` subprocesses per enumeration to get there.

So health is decided on the structural question the identity does answer: is this a physical capture input, or a memory endpoint of the on-chip audio hub crossbar. Parsing a driver-formatted string is fragile, which is why it is one small named function with a comment stating that, testable and replaceable.

### Deploy-time refusal

`DeployCampaign` now resolves audio selectors through the same `resolveKindSelector` that trigger-time resolution uses, so deploy and trigger cannot disagree. An unhealthy audio source is refused while an operator is still present to read why, and the error names the source and quotes its reason:

```
audio source "ADMAIF1" resolves to audio:16777729, which is unhealthy and would record silence:
APE [NVIDIA Jetson Orin Nano APE], device 0: fe.admaif@290f000.ADMAIF1 (*) [] plughw:2,0;
audio hub DMA endpoint, not a physical input: captures digital silence unless an external
I2S codec is wired and the audio hub is routed to it
```

This is scoped to audio; camera and ROS 2 deploy behavior is unchanged.

A side benefit on a real Jetson: with the twenty endpoints reporting unhealthy, exactly one healthy audio source remains, so an `audio: default` selector is no longer ambiguous and lands on the actual microphone.

## Verification on real hardware

Agent cross-built for `linux/arm64`, installed on `wendyos-hubert.local`, service restarted. After:

```
SOURCE          KIND   CLOCK                       STATUS     DETAIL
audio:16777217  audio  ALSA_CAPTURE/AGENT_RECEIPT  healthy    C920 [HD Pro Webcam C920], device 0: USB Audi...
audio:16777729  audio  ALSA_CAPTURE/AGENT_RECEIPT  unhealthy  APE [NVIDIA Jetson Orin Nano APE], device 0: ...
audio:16777730  audio  ALSA_CAPTURE/AGENT_RECEIPT  unhealthy  APE [NVIDIA Jetson Orin Nano APE], device 1: ...
audio:16777731  audio  ALSA_CAPTURE/AGENT_RECEIPT  unhealthy  APE [NVIDIA Jetson Orin Nano APE], device 2: ...
audio:16777732  audio  ALSA_CAPTURE/AGENT_RECEIPT  unhealthy  APE [NVIDIA Jetson Orin Nano APE], device 3: ...
audio:16777733  audio  ALSA_CAPTURE/AGENT_RECEIPT  unhealthy  APE [NVIDIA Jetson Orin Nano APE], device 4: ...
telemetry       telemetry  CLOCK_BOOTTIME          healthy
v4l2:/dev/video0  camera  V4L2_BUFFER_TIMESTAMP    healthy    HD Pro Webcam C920: HD Pro Webc VIDEO_TRANSPO...

... 15 more audio sources not listed (--kind audio to list all, --json for everything)
```

The full detail on each, from `--json`:

```
APE [NVIDIA Jetson Orin Nano APE], device 0: fe.admaif@290f000.ADMAIF1 (*) [] plughw:2,0;
audio hub DMA endpoint, not a physical input: captures digital silence unless an external
I2S codec is wired and the audio hub is routed to it
```

`--kind audio` still lists all twenty-one, C920 healthy and twenty ADMAIF unhealthy. The CLI needed no change: the flood summariser from #1758 collapses them and the STATUS column now reads `unhealthy`.

## Tests

New, all with fixtures pasted verbatim from the device rather than invented:

- `TestIsAudioHubDMAEndpointOnRealDeviceStrings` — the detection function against the real `arecord -l` and `/proc/asound` strings, plus negatives for the C920, the HDMI codec, and a device merely containing "ADMA".
- `TestJetsonAudioHubEndpointsAreAllUnhealthy` — pins the Jetson shape: given the real card-2 device list, of twenty-one capture sources exactly one is healthy, it is the C920 with its description intact, and all twenty ADMAIF endpoints keep their description and address and gain the reason.
- `TestUsbMicrophoneStaysHealthy` — a normal USB microphone keeps its health and its exact description.
- `TestDeployRefusesUnhealthyAudioSource` — deploy fails, names the selector, the source ID and the reason, and does not persist the campaign.
- `TestResolveRefusesUnhealthyAudioSource` — trigger-time resolution also refuses, for campaigns predating the deploy check.
- `TestDeployResolvesDefaultAudioPastTheHubEndpoints` — `audio: default` resolves to the real microphone past the twenty endpoints.

`TestAudioThresholdCampaignParsesAndDeploysWithoutModeWarning` gained a source provider, because deploy now resolves audio selectors and that test deployed against an empty inventory. Its actual assertion, about mode warnings, is unchanged.

Verified on both platforms, since this is device code:

- macOS: `go vet` clean; `go test ./go/internal/agent/data/... ./go/internal/agent/services/... ./go/internal/agent/audio/... ./go/internal/cli/commands/` all `ok`.
- `linux/arm64` container (`golang:1.26`, matching go.mod's 1.26.6): `data`, `services` and `audio` all `ok`.
