### PR TITLE
fix(test): assert build does not offer --build-host, not that help never mentions it

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyBuildTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyBuildTests.swift
@@ -23,7 +23,7 @@ struct `'wendy build'` {
                 #expect(stdout.contains("--build-type"))
                 #expect(stdout.contains("--builder"))
                 #expect(stdout.contains("--dockerfile"))
-                #expect(!stdout.contains("--build-host"))
+                #expect(!Self.helpDeclaresFlag("--build-host", in: stdout))
                 #expect(stdout.contains("--json"))
                 #expect(result.stderr == "")
             }
@@ -167,5 +167,27 @@ struct `'wendy build'` {
     )
     func `rejects undocumented positional arguments`() async throws {
         // TODO: enable when build rejects positional arguments (WDY-1934).
+    }
+
+    /**
+     Reports whether a help listing declares `flag` as an option the command
+     accepts, meaning some line opens its flag column with it, optionally
+     behind a shorthand such as `-d, --device`.
+
+     A flag named inside another flag's description is prose, not an offered
+     option, so the global `--device` help mentioning `--build-host` must not
+     read as `wendy build` accepting `--build-host`.
+     */
+    private static func helpDeclaresFlag(_ flag: String, in help: String) -> Bool {
+        help.split(separator: "\n", omittingEmptySubsequences: false).contains { line in
+            var column = line.drop(while: { $0.isWhitespace })
+            if column.count > 4, column.first == "-", column.dropFirst(2).hasPrefix(", ") {
+                column = column.dropFirst(4)
+            }
+            guard column.hasPrefix(flag) else { return false }
+            // `--build-hostname` must not answer for `--build-host`.
+            guard let separator = column.dropFirst(flag.count).first else { return true }
+            return separator.isWhitespace || separator == "="
+        }
     }
 }


### PR DESCRIPTION
## Problem

The `wendy build` help test fails on every pull request, turning the `Local: macOS 26` and `Local: Ubuntu 24` Swift End-to-End (E2E) jobs red and blocking merge decisions on unrelated work.

The failure reproduces on the untouched base commit `34bf2ceea`, with the test file exactly as it is on `feature/wendy-data-platform`:

```
Test "prints command help" recorded an issue at WendyBuildTests.swift:26:17:
  Expectation failed: !((stdout -> "Detects the project type and builds a Docker image ...
Test run with 9 tests in 1 suite failed after 0.164 seconds with 1 issue.
```

So it is pre-existing, not caused by a recent change.

## Cause

The assertion was a substring search over the whole help blob:

```swift
#expect(!stdout.contains("--build-host"))
```

`wendy build --help` output at the base commit, unchanged by this pull request:

```
Detects the project type and builds a Docker image for the target device architecture.

Usage:
  wendy build [flags]

Flags:
      --build-type string   Build type to use when multiple project markers are present: docker, swift, or python
      --builder string      Image builder to force for Dockerfile/Containerfile builds: docker, apple-container, or buildkit
      --debug               Build compiled languages unoptimized (swift build -c debug, cargo without --release) instead of the release default
      --dockerfile string   Build file to build from: a Dockerfile, Containerfile, or Stagefile (e.g. Dockerfile.prod, Containerfile, prod.stagefile.yaml); shows a selection menu when multiple build files exist
      --gpu-arch string     GPU architecture a Stagefile cuda: stage targets (sm_87); taken from the device when one is selected
  -h, --help                help for build

Global Flags:
      --device wendy run   Target device hostname; wendy run accepts a comma-separated list to deploy one build to several devices (needs --build-host and --detach)
      --json               Output in JSON format
```

`--build-host` appears exactly once, inside the `--device` global flag's description, as prose. It is not offered as a flag: `wendy build` declares `--build-host` and then calls `MarkHidden` on it, precisely so the command does not advertise an option it cannot honour, and `wendy build --build-host x` still redirects the caller to `wendy run`.

The assertion was over-broad. The help prose is correct and useful, so it is unchanged here.

## Solution

Tighten the expectation to check for a flag declaration rather than any mention:

```swift
#expect(!Self.helpDeclaresFlag("--build-host", in: stdout))
```

`helpDeclaresFlag` scans the help output line by line and reports whether a line opens its flag column with the flag, optionally behind a shorthand such as `-d, --device`. It also refuses a longer name, so `--build-hostname` does not answer for `--build-host`. Prose that merely names a flag inside another flag's description no longer trips the check.

The help text itself is untouched, so the "after" output is byte-identical to the "before" output quoted above.

## Verification

Run the same way the `Local: macOS 26` job does, via `swift/Scripts/E2ETest.sh` with a filter for this suite (Swift 6.3.2, the pinned toolchain):

```
Test "prints command help" passed after 0.042 seconds.
Suite "'wendy build'" passed after 0.159 seconds.
Test run with 9 tests in 1 suite passed after 0.159 seconds.
```

### Mutation check

To prove the assertion still tests what it was meant to test, the `MarkHidden("build-host")` call in `go/internal/cli/commands/build.go` was temporarily removed so the flag becomes a real declared line in help. The tightened assertion fails, as it should:

```
Test "prints command help" recorded an issue at WendyBuildTests.swift:26:17:
  Expectation failed: !((Self -> `'wendy build'`).helpDeclaresFlag("--build-host", in: (stdout -> "Detects the project type ...
      --build-host string   WendyOS device to build the image on instead of this machine (e.g. a DGX Spark)
      --device wendy run   Target device hostname; wendy run accepts a comma-separated list to deploy one build to several devices (needs --build-host and --detach)
Test run with 9 tests in 1 suite failed after 0.163 seconds with 1 issue.
```

Note that in the failing output the declaration line and the prose line are both present, and the clean run above shows the prose line alone does not trip the check. The mutation was reverted; this pull request touches only the test file.

`swift format lint` reports no new findings, and `swift format` produces no diff on the changed file.

## Sibling assertions

Checked every negated `contains` assertion across `swift/WendyE2ETests/Tests`. This was the only "help output must not mention a flag" assertion in the tree, so no sibling had the same too-loose shape. The other negated assertions test different things (stderr silence, cache listing contents, device-picker prompts) and would not break on an unrelated prose change. `WendyDevicePsTests.swift:19` is the nearest relative, asserting a hidden subcommand is not listed, and it is already scoped by leading whitespace.

## Not verified locally

The `Local: Ubuntu 24` job was not run; there is no Linux runner here. The change is a pure Swift string assertion with no platform-specific behaviour, and the help output is generated by the same Cobra code on both platforms.

The full harness path with `--managed-agent` could not run on this machine: building `WendyAgentMac.app` needs full Xcode and only Command Line Tools are installed. The run used `--no-managed-agent`, which is sufficient because every test in this suite is a local CLI invocation that needs no agent. Separately, and out of scope here, `E2ETest.sh` exited 0 on that `xcodebuild` failure rather than failing the step.
