### PR TITLE
fix(example): three model-harness reference app follow-ups from review of #1761

### DIFF
--- a/Examples/WendyDataModelApp/Dockerfile
+++ b/Examples/WendyDataModelApp/Dockerfile
@@ -3,8 +3,8 @@
 # A Dockerfile rather than a Stagefile because the model is produced by a
 # build step (an Ultralytics ONNX export) that the Stagefile DSL has no
 # instruction for. The export stage is build-time only: ultralytics and
-# torch never enter the runtime image, which carries just onnxruntime,
-# OpenCV, and NumPy on the CPU.
+# torch never enter the runtime image, which carries onnxruntime, OpenCV,
+# NumPy, grpcio, and PyAV on the CPU (see the runtime stage below).
 #
 # Jetson GPU variant: see README.md. The runtime stage swaps
 # onnxruntime for the onnxruntime-gpu wheel from the Jetson wheel index

--- a/Examples/WendyDataModelApp/README.md
+++ b/Examples/WendyDataModelApp/README.md
@@ -123,10 +123,22 @@ carries onnxruntime, OpenCV, NumPy, grpcio, and PyAV.
 
 Sensor input is not optional the way the data socket is: without
 `WENDY_SENSOR_SOCKET` the app has no frames to score and exits with a
-clear message naming the missing entitlement. Without a data socket
-(running outside WendyOS, or without the `data` entitlement) it keeps
-running and logs each dropped record; without ROS 2 it logs each actuation
-decision.
+clear message naming the missing entitlement.
+
+A socket that was there and whose stream then ends is a different case, and
+is treated as transient: an agent restart or a dropped subscription ends
+`Subscribe` while the app itself is perfectly healthy. The app redials, up
+to `WENDY_SENSOR_RECONNECT_ATTEMPTS` consecutive times (default 5), one
+every `WENDY_SENSOR_RECONNECT_DELAY_SECONDS` (default 2), and the budget is
+refilled by every frame that arrives, so weeks of unrelated restarts do not
+add up to a shutdown. Only once the stream stays gone for the whole budget
+does the app exit, and it says so rather than stopping quietly with the
+campaign still armed. Set the attempts to 0 to exit on the first end of
+stream instead.
+
+Without a data socket (running outside WendyOS, or without the `data`
+entitlement) it keeps running and logs each dropped record; without ROS 2
+it logs each actuation decision.
 
 `proto/wendy/agent/services/v2/sensor_service.proto` is a copy of the
 canonical `Proto/wendy/agent/services/v2/sensor_service.proto`, because the

--- a/Examples/WendyDataModelApp/README.md
+++ b/Examples/WendyDataModelApp/README.md
@@ -101,6 +101,12 @@ far enough that the harness has to drop samples before it, the sample
 carries `dropped_before` and the app logs a warning — a gap in the sample
 identifiers is always explained, never silent.
 
+`encoding` is a per-sample field, not a per-stream one, so the decoder
+follows the samples: it is rebuilt whenever the encoding changes, and
+anything the retired decoder still holds is drained first and attributed to
+the samples that produced it. A decoder pinned to whichever encoding
+arrived first would decode nothing at all after a mid-stream switch.
+
 ## Run on a dev box (no GPU, no ROS 2)
 
 The default image is CPU-only and needs no ROS 2 stack:

--- a/Examples/WendyDataModelApp/app.py
+++ b/Examples/WendyDataModelApp/app.py
@@ -57,6 +57,13 @@ IOU_THRESHOLD = float(os.environ.get("WENDY_IOU_THRESHOLD", "0.45"))
 # harness delivered the frame, so the episode's model-input ledger records
 # every frame the app received, including the ones it chose not to score.
 PREDICTIONS_PER_SECOND = float(os.environ.get("WENDY_PREDICTIONS_PER_SECOND", "5"))
+# The sensor stream can end while the app is still healthy: the agent
+# restarts, or the subscription is dropped with the socket. The data socket
+# client already reconnects and retries, so the frame source does too, up to
+# this many consecutive attempts (0 disables it and exits on the first end of
+# stream). The budget is refilled by every frame that arrives.
+SENSOR_RECONNECT_ATTEMPTS = int(os.environ.get("WENDY_SENSOR_RECONNECT_ATTEMPTS", "5"))
+SENSOR_RECONNECT_DELAY_SECONDS = float(os.environ.get("WENDY_SENSOR_RECONNECT_DELAY_SECONDS", "2"))
 # Actuation is optional: a plain Jetson demo has no ROS 2 stack. Set
 # WENDY_MODEL_APP_ROS2=1 (and run an image with rclpy) to publish Twists.
 ROS2_REQUESTED = os.environ.get("WENDY_MODEL_APP_ROS2", "0") == "1"
@@ -227,8 +234,11 @@ def main() -> None:
     next_score_at = 0.0
     person_present = False
     skipped = 0
+    frame_stream = wendysensors.frames_with_reconnect(
+        sensors, SENSOR_RECONNECT_ATTEMPTS, SENSOR_RECONNECT_DELAY_SECONDS
+    )
     try:
-        for sensor_frame in sensors.frames():
+        for sensor_frame in frame_stream:
             if sensor_frame.dropped_before:
                 # The harness produced frames this app never received. Say so
                 # rather than leaving a silent gap in the sample identifiers.
@@ -283,6 +293,9 @@ def main() -> None:
 
             angular_z, linear_x = steer_towards(detections, frame.shape[1])
             actuator.act(angular_z, linear_x)
+        # Reached only once the stream stayed gone for the whole reconnect
+        # budget; frames_with_reconnect has already said why.
+        log.info("no more frames from %s; shutting down", source_id)
     except KeyboardInterrupt:
         pass
     finally:

--- a/Examples/WendyDataModelApp/test_wendydata.py
+++ b/Examples/WendyDataModelApp/test_wendydata.py
@@ -343,5 +343,92 @@ class TestDecoderFollowsTheEncoding(unittest.TestCase):
         self.assertEqual([f.sample_ids for f in frames], [[2]])
 
 
+class TestSensorStreamReconnect(unittest.TestCase):
+    """A stream that ends mid-life (an agent restart, a dropped socket) must be
+    redialled, or the app exits while the campaign is still armed. Bounded, so a
+    socket that is gone for good still exits with a diagnosis."""
+
+    _sensors = staticmethod(TestSampleAttribution._sensors)
+
+    class _Client:
+        """Replays a scripted series of subscriptions, one per frames() call."""
+
+        def __init__(self, streams):
+            self.streams = list(streams)
+            self.calls = 0
+            self.closes = 0
+
+        def frames(self):
+            self.calls += 1
+            if not self.streams:
+                return
+            stream = self.streams.pop(0)
+            if isinstance(stream, Exception):
+                raise stream
+            yield from stream
+
+        def close(self):
+            self.closes += 1
+
+    def test_frames_resume_after_the_stream_ends(self):
+        sensors = self._sensors()
+        client = self._Client([["a"], ["b", "c"]])
+        slept = []
+        with self.assertLogs("wendysensors", level="WARNING"):
+            got = list(
+                sensors.frames_with_reconnect(client, attempts=2, delay=0.5, sleep=slept.append)
+            )
+        # The frames from before and after the drop are one stream to the caller.
+        self.assertEqual(got, ["a", "b", "c"])
+        # Redialled after each of the two scripted streams ended, and once more
+        # after the empty third: an end of stream is never assumed to be final.
+        self.assertEqual(slept, [0.5, 0.5, 0.5])
+        self.assertEqual(client.closes, 3)
+        self.assertEqual(client.calls, 4)
+
+    def test_a_failing_stream_is_retried_then_given_up_on(self):
+        sensors = self._sensors()
+        client = self._Client([RuntimeError("socket gone")] * 10)
+        slept = []
+        with self.assertLogs("wendysensors", level="WARNING"):
+            got = list(
+                sensors.frames_with_reconnect(client, attempts=3, delay=0.1, sleep=slept.append)
+            )
+        self.assertEqual(got, [])
+        # Three reconnects, so four subscription attempts in total, and then it
+        # stops rather than spinning on a socket that is not coming back.
+        self.assertEqual(len(slept), 3)
+        self.assertEqual(client.calls, 4)
+
+    def test_the_budget_is_refilled_by_every_frame(self):
+        sensors = self._sensors()
+        # A budget of one, spent by every drop and refilled by every frame. Three
+        # short-lived streams therefore all get through; a lifetime budget of one
+        # would have stopped after the second.
+        client = self._Client([["a"], ["b"], ["c"]])
+        with self.assertLogs("wendysensors", level="WARNING"):
+            got = list(sensors.frames_with_reconnect(client, attempts=1, delay=0, sleep=lambda _: None))
+        self.assertEqual(got, ["a", "b", "c"])
+
+    def test_consecutive_drops_exhaust_the_budget(self):
+        sensors = self._sensors()
+        # The same budget of one, but nothing arrives to refill it: the stream
+        # that ends and the failure after it are two consecutive drops, so the
+        # third subscription is never attempted.
+        client = self._Client([["a"], RuntimeError("socket gone"), ["b"]])
+        with self.assertLogs("wendysensors", level="WARNING"):
+            got = list(sensors.frames_with_reconnect(client, attempts=1, delay=0, sleep=lambda _: None))
+        self.assertEqual(got, ["a"])
+        self.assertEqual(client.calls, 2)
+
+    def test_zero_attempts_exits_on_the_first_end_of_stream(self):
+        sensors = self._sensors()
+        client = self._Client([["a"], ["b"]])
+        with self.assertLogs("wendysensors", level="WARNING"):
+            got = list(sensors.frames_with_reconnect(client, attempts=0, delay=0, sleep=lambda _: None))
+        self.assertEqual(got, ["a"])
+        self.assertEqual(client.calls, 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Examples/WendyDataModelApp/test_wendydata.py
+++ b/Examples/WendyDataModelApp/test_wendydata.py
@@ -221,5 +221,127 @@ class TestSampleAttribution(unittest.TestCase):
         self.assertEqual([f.dropped_before for f in frames], [3, 0, 0])
 
 
+class TestDecoderFollowsTheEncoding(unittest.TestCase):
+    """The proto sets `encoding` per sample, not per stream. A decoder built
+    once from the first sample decodes nothing at all after a mid-stream switch,
+    which loses every frame from that point on without saying so."""
+
+    _sensors = staticmethod(TestSampleAttribution._sensors)
+    _Sample = TestSampleAttribution._Sample
+    _Decoder = TestSampleAttribution._Decoder
+    _Decoded = TestSampleAttribution._Decoded
+
+    class _Buffering:
+        """Turns no packet into a frame, but holds one back for the flush."""
+
+        def parse(self, payload):
+            return [payload]
+
+        def decode(self, packet):
+            if packet is None:
+                return [TestSampleAttribution._Decoded()]
+            return []
+
+    def test_a_mid_stream_encoding_change_rebuilds_the_decoder(self):
+        sensors = self._sensors()
+        asked_for = []
+
+        def make_decoder(encoding):
+            asked_for.append(encoding)
+            return self._Decoder(per_packet=1)
+
+        frames = list(
+            sensors.decode_samples(
+                [
+                    self._Sample(1, encoding="h264"),
+                    self._Sample(2, encoding="h264"),
+                    self._Sample(3, encoding="vp8"),
+                ],
+                make_decoder,
+            )
+        )
+        # One decoder per encoding, not one per sample and not one per stream.
+        self.assertEqual(asked_for, ["h264", "vp8"])
+        self.assertEqual([f.sample_ids for f in frames], [[1], [2], [3]])
+
+    def test_an_empty_first_encoding_does_not_pin_the_decoder(self):
+        sensors = self._sensors()
+        asked_for = []
+
+        def make_decoder(encoding):
+            asked_for.append(encoding)
+            return self._Decoder(per_packet=1)
+
+        frames = list(
+            sensors.decode_samples(
+                [
+                    self._Sample(1, encoding=""),
+                    self._Sample(2, encoding="h264"),
+                    self._Sample(3, encoding="vp8"),
+                ],
+                make_decoder,
+            )
+        )
+        # The empty encoding resolves to the documented default, so the explicit
+        # "h264" that follows is the same codec and must not rebuild anything.
+        self.assertEqual(asked_for, ["h264", "vp8"])
+        self.assertEqual([f.sample_ids for f in frames], [[1], [2], [3]])
+
+    def test_the_retired_decoder_is_flushed_with_its_own_attribution(self):
+        sensors = self._sensors()
+        built = []
+
+        def make_decoder(encoding):
+            decoder = self._Buffering() if encoding == "h264" else self._Decoder(per_packet=1)
+            built.append(encoding)
+            return decoder
+
+        frames = list(
+            sensors.decode_samples(
+                [
+                    self._Sample(1, encoding="h264", dropped_before=2),
+                    self._Sample(2, encoding="h264"),
+                    self._Sample(3, encoding="vp8"),
+                ],
+                make_decoder,
+            )
+        )
+        self.assertEqual(built, ["h264", "vp8"])
+        self.assertEqual(len(frames), 2)
+        # The flushed frame belongs to the samples that fed the old decoder, and
+        # carries their drop count and the timestamp of the last of them, not
+        # those of the first sample under the new encoding.
+        self.assertEqual(frames[0].sample_ids, [1, 2])
+        self.assertEqual(frames[0].dropped_before, 2)
+        self.assertEqual(frames[0].boottime_nanos, 2 * 1000)
+        # The bytes buffered under the old codec are not credited to the new one.
+        self.assertEqual(frames[1].sample_ids, [3])
+        self.assertEqual(frames[1].dropped_before, 0)
+
+    def test_a_decoder_that_cannot_be_flushed_does_not_end_the_stream(self):
+        sensors = self._sensors()
+
+        class Unflushable:
+            def parse(self, payload):
+                return [payload]
+
+            def decode(self, packet):
+                if packet is None:
+                    raise RuntimeError("this codec cannot be flushed")
+                return []
+
+        def make_decoder(encoding):
+            return Unflushable() if encoding == "h264" else self._Decoder(per_packet=1)
+
+        with self.assertLogs("wendysensors", level="WARNING"):
+            frames = list(
+                sensors.decode_samples(
+                    [self._Sample(1, encoding="h264"), self._Sample(2, encoding="vp8")],
+                    make_decoder,
+                )
+            )
+        self.assertEqual([f.sample_ids for f in frames], [[2]])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Examples/WendyDataModelApp/wendysensors.py
+++ b/Examples/WendyDataModelApp/wendysensors.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 from dataclasses import dataclass, field
 
 import grpc
@@ -53,6 +54,11 @@ DEFAULT_SOCKET_PATH = "/run/wendy/sensors/sensors.sock"
 # empty encoding followed by an explicit "h264" would rebuild the decoder for
 # no reason and throw away the bytes it had buffered.
 DEFAULT_ENCODING = "h264"
+
+# How many consecutive times a dropped subscription is redialled before the
+# stream is treated as gone for good, and how long to wait between attempts.
+DEFAULT_RECONNECT_ATTEMPTS = 5
+DEFAULT_RECONNECT_DELAY_SECONDS = 2.0
 
 
 def socket_path() -> str:
@@ -237,3 +243,56 @@ def _flush_decoder(decoder, sample_ids, dropped_before, tail):
             "%d buffered sample(s) produced no frame before the encoding change",
             len(sample_ids),
         )
+
+
+def frames_with_reconnect(
+    client,
+    attempts: int = DEFAULT_RECONNECT_ATTEMPTS,
+    delay: float = DEFAULT_RECONNECT_DELAY_SECONDS,
+    sleep=time.sleep,
+):
+    """Yield frames across a subscription that ends part way through its life.
+
+    `SensorClient.frames()` ends whenever the subscription does, and a
+    subscription ends for reasons that have nothing to do with the app: the
+    agent restarted, or the socket went away with it. The data side already
+    reconnects and retries (`wendydata.DataSocketClient.send`), so the input
+    side has to as well; without it a single agent restart ends the app quietly
+    while the campaign is still armed and there is still an episode to fill.
+
+    Bounded on purpose. A socket that is gone for good has to exit with a
+    diagnosis rather than spin forever, so the budget is finite. It counts
+    *consecutive* failures and is refilled by every frame that arrives, so a
+    long-lived app is not eventually killed by unrelated restarts spread over
+    days.
+
+    The source identifier is kept across reconnects. Harness identifiers are
+    stable, and re-resolving on every drop would let a transient failure move
+    the app onto a different camera without saying so.
+    """
+    remaining = attempts
+    while True:
+        try:
+            for frame in client.frames():
+                remaining = attempts
+                yield frame
+        except Exception as exc:  # noqa: BLE001 - grpc.RpcError and transport errors alike
+            log.warning("sensor stream failed: %s", exc)
+        else:
+            log.warning("sensor stream ended")
+        if remaining <= 0:
+            log.error(
+                "the sensor stream did not come back after %d reconnect attempt(s); giving up",
+                attempts,
+            )
+            return
+        remaining -= 1
+        # Drop the channel so the next Subscribe redials rather than reusing a
+        # connection the agent has already torn down.
+        client.close()
+        log.info(
+            "reconnecting to the sensor socket in %.1fs (%d attempt(s) left after this one)",
+            delay,
+            remaining,
+        )
+        sleep(delay)

--- a/Examples/WendyDataModelApp/wendysensors.py
+++ b/Examples/WendyDataModelApp/wendysensors.py
@@ -26,6 +26,10 @@ PyAV's parser, which handles both shapes, so a decoded frame may be the
 product of more than one sample; `SensorFrame.sample_ids` lists every
 sample that contributed to it, which is exactly what the prediction
 record's `inputs` list is for.
+
+`encoding` is per sample, not per stream, so the decoder is rebuilt
+whenever it changes rather than being pinned by whichever sample happened
+to arrive first.
 """
 
 from __future__ import annotations
@@ -42,6 +46,13 @@ from wendy.agent.services.v2 import sensor_service_pb2_grpc as sensorgrpc
 log = logging.getLogger("wendysensors")
 
 DEFAULT_SOCKET_PATH = "/run/wendy/sensors/sensors.sock"
+
+# The encoding assumed when a sample leaves the field empty. Normalizing here
+# rather than in the decoder factory keeps the value the decoder was built for
+# comparable to the value the next sample declares; if the two disagreed, an
+# empty encoding followed by an explicit "h264" would rebuild the decoder for
+# no reason and throw away the bytes it had buffered.
+DEFAULT_ENCODING = "h264"
 
 
 def socket_path() -> str:
@@ -113,7 +124,7 @@ class SensorClient:
         request = sensorpb.SensorSubscribeRequest(source_ids=[self.source_id], model=self.model)
         yield from decode_samples(
             stub.Subscribe(request),
-            lambda encoding: av.CodecContext.create(encoding or "h264", "r"),
+            lambda encoding: av.CodecContext.create(encoding, "r"),
         )
 
 
@@ -126,13 +137,40 @@ def decode_samples(samples, make_decoder):
     wrong loses the join key silently rather than loudly.
     """
     decoder = None
+    # The encoding the current decoder was built for. The proto allows this to
+    # change from sample to sample ("h264" or "vp8"), and a stream that switches
+    # decodes to nothing at all under the decoder the first sample happened to
+    # ask for, so the decoder follows the samples rather than the other way round.
+    decoder_encoding = None
     pending_ids: list[int] = []
     pending_drops = 0
+    # The most recent sample the pending bytes end at, so frames recovered by a
+    # flush are timestamped by the sample that actually produced them and not by
+    # the first sample of the next encoding.
+    pending_tail = None
     for sample in samples:
-        if decoder is None:
-            decoder = make_decoder(sample.encoding)
+        encoding = sample.encoding or DEFAULT_ENCODING
+        if decoder is None or encoding != decoder_encoding:
+            if decoder is not None:
+                log.info(
+                    "sample encoding changed from %s to %s; rebuilding the decoder",
+                    decoder_encoding,
+                    encoding,
+                )
+                yield from _flush_decoder(decoder, pending_ids, pending_drops, pending_tail)
+                # Whatever the retired decoder could not turn into a frame was
+                # encoded by the codec being replaced, so the new decoder can
+                # never produce a frame from it. Dropping the accumulation here
+                # is what keeps the next codec's frames from being credited with
+                # sample identifiers they were not computed from.
+                pending_ids = []
+                pending_drops = 0
+                pending_tail = None
+            decoder = make_decoder(encoding)
+            decoder_encoding = encoding
         pending_ids.append(sample.sample_id)
         pending_drops += sample.dropped_before
+        pending_tail = sample
         emitted = False
         for packet in decoder.parse(sample.payload):
             for decoded in decoder.decode(packet):
@@ -159,3 +197,43 @@ def decode_samples(samples, make_decoder):
             # whole path exists to carry.
             pending_ids = []
             pending_drops = 0
+            pending_tail = None
+
+
+def _flush_decoder(decoder, sample_ids, dropped_before, tail):
+    """Drain the frames a decoder still holds before it is replaced.
+
+    Called only at an encoding change. The buffered bytes belong to the codec
+    being retired, so this is the last moment anything can be decoded from them,
+    and the samples that fed them are still known: a frame recovered here keeps
+    the same attribution it would have had on the next sample. A decoder that
+    cannot be flushed loses the buffered samples, which is logged rather than
+    allowed to end the stream.
+    """
+    if not sample_ids or tail is None:
+        return
+    try:
+        drained = list(decoder.decode(None))
+    except Exception as exc:  # noqa: BLE001 - any codec failure here is survivable
+        log.warning(
+            "could not flush the decoder at an encoding change; %d buffered sample(s) produced no frame: %s",
+            len(sample_ids),
+            exc,
+        )
+        return
+    emitted = False
+    for decoded in drained:
+        yield SensorFrame(
+            source_id=tail.source_id,
+            sample_ids=list(sample_ids),
+            boottime_nanos=tail.boottime_nanos,
+            uncertainty_nanos=tail.timestamp_uncertainty_nanos,
+            dropped_before=0 if emitted else dropped_before,
+            image=decoded.to_ndarray(format="bgr24"),
+        )
+        emitted = True
+    if not emitted:
+        log.info(
+            "%d buffered sample(s) produced no frame before the encoding change",
+            len(sample_ids),
+        )


### PR DESCRIPTION
Three low-severity issues confirmed during adversarial review of the model
harness reference app. They were deliberately left out of the correctness
fix on #1761 to keep that commit scoped; this is the follow-up. One commit
each, since the concerns are independent.

Every file touched here exists only on `feature/wendy-data-platform` (the
example arrived in #1747 and grew in #1761), so this cannot target `main`.

## 1. The Dockerfile undercounted the runtime image

**Problem:** the header comment claimed the runtime image "carries just
onnxruntime, OpenCV, and NumPy on the CPU". It has also installed grpcio
and `av<15` since the app started taking frames from the sensor socket
instead of opening a camera.

**Cause:** the comment was written before the harness rewrite and was not
revisited when the pip line below it changed.

**Solution:** the comment now names all five packages, matching both the
pip line and README.md, which already had it right. A header comment whose
entire job is to say what does and does not enter the runtime image is
worse than no comment when it undercounts, because it reads as a checked
list.

## 2. The decoder was pinned to the first sample's encoding

**Problem:** `decode_samples` built one decoder from the first sample's
`encoding` and reused it for the life of the stream. `SensorSample.encoding`
is per sample, documented as naming the payload bytes "h264" or "vp8", so
two streams broke: a mid-stream encoding change fed one codec's bytes to
the other's decoder and every frame from the switch onward was lost, and an
empty `encoding` on the first sample alone pinned the h264 default even if
later samples said vp8.

**Cause:** the decoder was treated as a property of the subscription when
the proto makes it a property of the sample. Nothing detected the mismatch,
because a decoder producing no frames looks exactly like a camera with
nothing to say: the app kept running and sent no predictions.

**Solution:** track the encoding the decoder was built for and rebuild when
a sample declares a different one.

Two decisions worth review. First, the empty-encoding default moved out of
the caller's decoder factory and into `decode_samples` as
`DEFAULT_ENCODING`, so the value compared and the value built from are the
same one. The obvious fix, comparing raw `sample.encoding` while the factory
applied its own default, does work for the reported bug but rebuilds the
decoder for nothing when a stream sends an empty encoding followed by an
explicit "h264", discarding buffered bytes to no purpose.

Second, the pending sample-id accumulation is handled at the switch rather
than carried across it. The retired decoder is flushed first, so a frame it
still holds is emitted with the attribution it would have had on the next
sample, timestamped by the last sample that actually fed it. Whatever it
cannot produce is dropped with the decoder: those bytes belong to the codec
being replaced, and leaving them pending would credit the next codec's
frames with sample identifiers they were not computed from, which is the
same silent loss of the join key #1761 closed. A decoder that cannot be
flushed logs and keeps the stream alive rather than ending it.

## 3. A sensor stream that ended killed the app

**Problem:** `SensorClient.frames()` ends whenever the subscription does,
and `main()` consumed it with a bare for loop. The loop ran out, fell into
`finally`, closed both sockets and returned, so the container exited with
status 0 and nothing in the log saying why. An agent restart was enough to
end a model app while its campaign was still armed and there was still an
episode to fill.

**Cause:** the two halves of the app treated the same class of failure
differently. `wendydata.DataSocketClient.send` already reconnects and
retries on the output side, and the asymmetry made the input side look
deliberate when it was not. A clean generator exit is also
indistinguishable from a stream that genuinely finished, so there was
nothing to alert on.

**Solution:** `wendysensors.frames_with_reconnect` wraps the subscription
and resubscribes on both an end of stream and a transport error, bounded by
`WENDY_SENSOR_RECONNECT_ATTEMPTS` (default 5) at
`WENDY_SENSOR_RECONNECT_DELAY_SECONDS` (default 2). Bounded rather than
endless so a socket gone for good still exits with a diagnosis instead of
spinning. The budget counts consecutive failures and is refilled by every
frame that arrives, so an app running for weeks is not eventually killed by
unrelated restarts adding up. `KeyboardInterrupt` passes through untouched,
so Ctrl-C shuts down as before, and setting the attempts to 0 restores the
old exit-on-first-end behaviour.

The retry policy lives in app.py next to the other tunables; the loop
itself lives in wendysensors with an injectable sleep so it is unit
testable. That placement is the point: an untested reconnect loop is wrong
on the first real agent restart. The source identifier is deliberately kept
across reconnects rather than re-resolved, because re-resolving would let a
transient failure move the app onto a different camera without saying so.

## Behaviour changes to be aware of

The app no longer exits when the sensor stream ends; it retries for roughly
ten seconds first. Anything treating a clean exit as "the stream is
finished" sees a delay. Two new environment variables are read, both
optional with the defaults above.

## Verification

Ran:

- `python3 -m unittest test_wendydata -v` in `Examples/WendyDataModelApp`:
  27 tests pass. The 18 that existed are unchanged and still pass,
  including all of `TestSampleAttribution`. Nine are new: four in
  `TestDecoderFollowsTheEncoding` (the rebuild, an empty first encoding,
  the flush attribution, an unflushable decoder) and five in
  `TestSensorStreamReconnect` (resumption across a drop, the bounded
  give-up, the budget refill, consecutive drops exhausting it, and 0
  attempts).
- `python3 -m unittest discover Examples/WendyDataModelApp`, the form the
  README documents: same 27 pass.
- The Go guards for this example, `TestWendyDataModelAppExampleValidates`
  and the proto drift check `TestExampleSensorProtoMatchesCanonical`: both
  pass. Neither `campaign.yaml`, `wendy.json`, nor the proto changed here.
- `python3 -m py_compile` on all four modules.

Not run, and why:

- No hardware was attached, so neither a real mixed-encoding stream nor a
  real agent restart was exercised. No device here produces a stream that
  switches codec mid-flight. Both paths are covered only against scripted
  samples and subscriptions, which is the honest limit of this change: the
  attribution and control flow are tested, the PyAV and gRPC edges at the
  boundary are not.
- The image was not rebuilt. The Dockerfile change is a comment.