### PR TITLE
Fix USB chunk-diff deploy stalls and surface terminal errors

### DIFF
--- a/go/internal/agent/containerd/chunkstore.go
+++ b/go/internal/agent/containerd/chunkstore.go
@@ -22,7 +22,7 @@ import (
 )
 
 // maxStagedChunkBytes bounds a single staged chunk. The CDC chunker emits
-// chunks of at most chunk.MaxSize (256 KiB); this 4 MiB ceiling leaves ample
+// chunks of at most chunk.MaxSize (64 KiB); this 4 MiB ceiling leaves ample
 // headroom for legitimate clients while rejecting absurdly large payloads.
 const maxStagedChunkBytes = 4 << 20
 

--- a/go/internal/agent/containerd/prepare.go
+++ b/go/internal/agent/containerd/prepare.go
@@ -111,15 +111,36 @@ func prepareChunkHashes(raw [][]byte) ([][32]byte, error) {
 }
 
 func (c *Client) waitForChunks(ctx context.Context, hashes [][32]byte) error {
+	return waitForChunksWith(ctx, hashes, c.staging.changes, c.MissingChunks)
+}
+
+func waitForChunksWith(ctx context.Context, hashes [][32]byte, changes func() <-chan struct{}, missingChunks func(context.Context, [][32]byte) ([][32]byte, error)) error {
+	pending := hashes
+	validatingAll := true
 	for {
-		changed := c.staging.changes()
-		missing, err := c.MissingChunks(ctx, hashes)
+		changed := changes()
+		missing, err := missingChunks(ctx, pending)
 		if err != nil {
 			return err
 		}
 		if len(missing) == 0 {
-			return nil
+			if validatingAll {
+				return nil
+			}
+			// A different layer preparation can consume a shared staged chunk
+			// after an earlier check. Revalidate the full layer once at the end
+			// so narrowing the hot-path checks never weakens correctness.
+			pending = hashes
+			validatingAll = true
+			continue
 		}
+		// Only recheck hashes that were still absent. The old loop rescanned
+		// every hash after every staged chunk, making a layer with N hashes and
+		// M misses perform O(N*M) filesystem/index checks while WriteChunks was
+		// trying to feed it. Keeping the shrinking missing set makes progress
+		// proportional to the actual delta instead.
+		pending = missing
+		validatingAll = false
 		select {
 		case <-ctx.Done():
 			return ctx.Err()

--- a/go/internal/agent/containerd/prepare_test.go
+++ b/go/internal/agent/containerd/prepare_test.go
@@ -57,6 +57,42 @@ func TestWaitForChunksHonorsCancellation(t *testing.T) {
 	}
 }
 
+func TestWaitForChunksNarrowsRepeatedChecksToMissingHashes(t *testing.T) {
+	all := [][32]byte{{1}, {2}, {3}, {4}}
+	closed := make(chan struct{})
+	close(closed)
+	var checked [][][32]byte
+	responses := [][][32]byte{
+		{{2}, {3}, {4}}, // initial full check
+		{{3}, {4}},      // first arrival: only prior misses are checked
+		nil,             // the narrowed set is now complete
+		nil,             // final full-layer validation
+	}
+	missing := func(_ context.Context, hashes [][32]byte) ([][32]byte, error) {
+		checked = append(checked, append([][32]byte(nil), hashes...))
+		response := responses[len(checked)-1]
+		return response, nil
+	}
+
+	if err := waitForChunksWith(context.Background(), all, func() <-chan struct{} { return closed }, missing); err != nil {
+		t.Fatalf("waitForChunksWith: %v", err)
+	}
+	want := [][][32]byte{all, {{2}, {3}, {4}}, {{3}, {4}}, all}
+	if len(checked) != len(want) {
+		t.Fatalf("checked %d sets, want %d: %v", len(checked), len(want), checked)
+	}
+	for i := range want {
+		if len(checked[i]) != len(want[i]) {
+			t.Fatalf("check %d examined %d hashes, want %d", i, len(checked[i]), len(want[i]))
+		}
+		for j := range want[i] {
+			if checked[i][j] != want[i][j] {
+				t.Fatalf("check %d hash %d = %x, want %x", i, j, checked[i][j], want[i][j])
+			}
+		}
+	}
+}
+
 func TestPrepareChunkHashesRejectsMalformedHash(t *testing.T) {
 	if _, err := prepareChunkHashes([][]byte{{1, 2, 3}}); err == nil {
 		t.Fatal("expected malformed chunk hash error")

--- a/go/internal/agent/services/container_service.go
+++ b/go/internal/agent/services/container_service.go
@@ -20,6 +20,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	_ "google.golang.org/grpc/encoding/gzip" // accept compressed WriteChunks messages
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 

--- a/go/internal/agent/services/container_service_chunks_test.go
+++ b/go/internal/agent/services/container_service_chunks_test.go
@@ -3,11 +3,13 @@ package services
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"io"
 	"testing"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	grpcgzip "google.golang.org/grpc/encoding/gzip"
 
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
@@ -163,5 +165,30 @@ func TestWriteChunks(t *testing.T) {
 	}
 	if !bytes.Equal(fake.stagedChunks[0].data, data0) {
 		t.Fatalf("staged data mismatch: got %q, want %q", fake.stagedChunks[0].data, data0)
+	}
+}
+
+func TestWriteChunksAcceptsGzipOverGRPC(t *testing.T) {
+	fake := newFakeContainerd()
+	client, cleanup := startContainerServer(t, fake)
+	defer cleanup()
+
+	data := bytes.Repeat([]byte("compressed-chunk-payload"), 4096)
+	hash := sha256.Sum256(data)
+	stream, err := client.WriteChunks(context.Background(), grpc.UseCompressor(grpcgzip.Name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.Send(&agentpb.WriteChunksRequest{Hash: hash[:], Data: data}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := stream.CloseAndRecv(); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.stagedChunks) != 1 {
+		t.Fatalf("staged chunks = %d, want 1", len(fake.stagedChunks))
+	}
+	if fake.stagedChunks[0].hash != hash || !bytes.Equal(fake.stagedChunks[0].data, data) {
+		t.Fatal("gzip WriteChunks did not preserve the original hash and data")
 	}
 }

--- a/go/internal/cli/commands/chunkpush.go
+++ b/go/internal/cli/commands/chunkpush.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"runtime"
@@ -13,7 +14,9 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/go/internal/shared/chunk"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	grpcgzip "google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/status"
 )
 
@@ -25,6 +28,12 @@ import (
 // already parallelized across cores (chunk.ChunkReaderAt), so this need not
 // equal the core count.
 const maxConcurrentLayerPush = 4
+
+// maxChunksPerWriteStream bounds one client-streaming WriteChunks RPC. Closing
+// each small batch gets an application-level acknowledgement, limits how much
+// progress can be reported before the receiver confirms it, and starts a fresh
+// HTTP/2 stream at negligible overhead (at most 4 MiB per batch).
+const maxChunksPerWriteStream = 64
 
 // chunkTransferProgressWriter is implemented by interactive build output
 // adapters that can display chunk-upload bytes directly. Keeping this as an
@@ -619,7 +628,7 @@ func (r *resolvedChunkLayer) upload(ctx context.Context, cs agentpb.WendyContain
 	orderedHashes := r.header.GetChunkHashes()
 	qresp, err := cs.QueryChunks(ctx, &agentpb.QueryChunksRequest{ChunkHashes: orderedHashes})
 	if err != nil {
-		return err
+		return fmt.Errorf("querying missing chunks for layer %s: %w", r.header.GetDiffId(), err)
 	}
 	missing := make(map[[32]byte]bool, len(qresp.GetMissingHashes()))
 	for _, hb := range qresp.GetMissingHashes() {
@@ -645,30 +654,59 @@ func (r *resolvedChunkLayer) upload(ctx context.Context, cs agentpb.WendyContain
 		}
 		transferProgress.addTotal(missingBytes)
 		prog.LayerPlanned(len(orderedHashes), len(missing), missingBytes)
-		wc, err := cs.WriteChunks(ctx)
-		if err != nil {
-			return err
-		}
-		for _, ref := range r.refs {
+		var wc grpc.ClientStreamingClient[agentpb.WriteChunksRequest, agentpb.WriteChunksResponse]
+		chunksInStream := 0
+		for chunkIndex, ref := range r.refs {
 			if !missing[ref.Hash] {
 				continue
 			}
-			buf := make([]byte, ref.Len) // ref.Len <= chunk.MaxSize (256 KiB)
+			if wc == nil {
+				// Hardware reproduction showed that particular raw chunk payloads can
+				// stall a USB-NCM link while the compressed registry path succeeds.
+				// Give the fast path the same property; gRPC decompresses the message
+				// before the agent hashes and stages the original bytes.
+				wc, err = cs.WriteChunks(ctx, grpc.UseCompressor(grpcgzip.Name))
+				if err != nil {
+					return fmt.Errorf("opening chunk upload for layer %s: %w", r.header.GetDiffId(), err)
+				}
+			}
+			buf := make([]byte, ref.Len) // ref.Len <= chunk.MaxSize (64 KiB)
 			if _, err := r.dl.f.ReadAt(buf, int64(ref.Offset)); err != nil {
-				return err
+				return fmt.Errorf("reading chunk %d/%d for layer %s: %w", chunkIndex+1, len(r.refs), r.header.GetDiffId(), err)
 			}
 			hb := ref.Hash // copy
 			if err := wc.Send(&agentpb.WriteChunksRequest{
 				Hash: hb[:],
 				Data: buf,
 			}); err != nil {
-				return err
+				// grpc-go reports io.EOF from Send when the server has already
+				// closed a client-streaming RPC. CloseAndRecv carries the actual
+				// terminal status (for example ResourceExhausted or InvalidArgument);
+				// without this read the CLI hides the actionable agent error behind
+				// a bare EOF and incorrectly treats it as a transport drop.
+				if errors.Is(err, io.EOF) {
+					if _, terminalErr := wc.CloseAndRecv(); terminalErr != nil {
+						err = terminalErr
+					}
+				}
+				return fmt.Errorf("sending chunk %d/%d for layer %s: %w", chunkIndex+1, len(r.refs), r.header.GetDiffId(), err)
 			}
 			prog.ChunkSent(len(buf))
 			transferProgress.addSent(int64(len(buf)))
+			chunksInStream++
+			if chunksInStream == maxChunksPerWriteStream {
+				if _, err := wc.CloseAndRecv(); err != nil {
+					return fmt.Errorf("closing chunk upload batch after chunk %d/%d for layer %s: %w", chunkIndex+1, len(r.refs), r.header.GetDiffId(), err)
+				}
+				wc = nil
+				chunksInStream = 0
+			}
 		}
-		if _, err := wc.CloseAndRecv(); err != nil {
-			return err
+		if wc != nil {
+			_, err = wc.CloseAndRecv()
+		}
+		if err != nil {
+			return fmt.Errorf("closing chunk upload for layer %s: %w", r.header.GetDiffId(), err)
 		}
 	} else {
 		prog.LayerPlanned(len(orderedHashes), 0, 0)

--- a/go/internal/cli/commands/chunkpush_test.go
+++ b/go/internal/cli/commands/chunkpush_test.go
@@ -28,6 +28,18 @@ type imagePreparationRecorder struct {
 	called chan struct{}
 }
 
+func variedChunkTestData(n int) []byte {
+	data := make([]byte, n)
+	state := uint32(0x6d2b79f5)
+	for i := range data {
+		state ^= state << 13
+		state ^= state >> 17
+		state ^= state << 5
+		data[i] = byte(state)
+	}
+	return data
+}
+
 func (r *imagePreparationRecorder) ReportImagePreparation() {
 	r.once.Do(func() { close(r.called) })
 }
@@ -124,7 +136,9 @@ type fakeContainerClient struct {
 	queryFn                             func(*agentpb.QueryChunksRequest) *agentpb.QueryChunksResponse
 	queryLayersFn                       func(*agentpb.QueryLayersRequest) *agentpb.QueryLayersResponse
 	writeFn                             func(*agentpb.WriteChunksRequest) error
+	closeErr                            error
 	chunksWritten                       int
+	writeStreams                        int
 	writeStarted                        chan struct{}
 	blockWrites                         bool
 	writeOnce                           sync.Once
@@ -313,6 +327,7 @@ func (f *fakeContainerClient) QueryLayers(_ context.Context, in *agentpb.QueryLa
 }
 
 func (f *fakeContainerClient) WriteChunks(ctx context.Context, _ ...grpc.CallOption) (grpc.ClientStreamingClient[agentpb.WriteChunksRequest, agentpb.WriteChunksResponse], error) {
+	f.writeStreams++
 	return &fakeWriteChunksStream{parent: f, ctx: ctx}, nil
 }
 
@@ -339,7 +354,60 @@ func (s *fakeWriteChunksStream) Send(req *agentpb.WriteChunksRequest) error {
 }
 
 func (s *fakeWriteChunksStream) CloseAndRecv() (*agentpb.WriteChunksResponse, error) {
-	return &agentpb.WriteChunksResponse{}, nil
+	return &agentpb.WriteChunksResponse{}, s.parent.closeErr
+}
+
+func TestPushLayerByChunksSurfacesTerminalWriteStatusAfterSendEOF(t *testing.T) {
+	manifestCacheTestDir = t.TempDir()
+	t.Cleanup(func() { manifestCacheTestDir = "" })
+
+	layerTar := []byte("one missing chunk")
+	fake := &fakeContainerClient{
+		queryFn: func(req *agentpb.QueryChunksRequest) *agentpb.QueryChunksResponse {
+			return &agentpb.QueryChunksResponse{MissingHashes: req.GetChunkHashes()}
+		},
+		writeFn: func(*agentpb.WriteChunksRequest) error { return io.EOF },
+		closeErr: status.Error(codes.ResourceExhausted,
+			"chunk staging exceeds the device limit"),
+	}
+
+	_, err := pushLayerByChunks(context.Background(), fake, localLayer{
+		Digest:    "sha256:" + sha256Hex(layerTar),
+		MediaType: "application/vnd.oci.image.layer.v1.tar",
+		Blob:      layerTar,
+	})
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("error = %v, want ResourceExhausted terminal status", err)
+	}
+	if !strings.Contains(err.Error(), "chunk staging exceeds the device limit") {
+		t.Fatalf("error = %q, want terminal server detail", err)
+	}
+}
+
+func TestPushLayerByChunksBatchesLongUploads(t *testing.T) {
+	manifestCacheTestDir = t.TempDir()
+	t.Cleanup(func() { manifestCacheTestDir = "" })
+
+	layerTar := variedChunkTestData((maxChunksPerWriteStream + 8) * int(chunk.MaxSize))
+	fake := &fakeContainerClient{
+		queryFn: func(req *agentpb.QueryChunksRequest) *agentpb.QueryChunksResponse {
+			return &agentpb.QueryChunksResponse{MissingHashes: req.GetChunkHashes()}
+		},
+	}
+	if _, err := pushLayerByChunks(context.Background(), fake, localLayer{
+		Digest:    "sha256:" + sha256Hex(layerTar),
+		MediaType: "application/vnd.oci.image.layer.v1.tar",
+		Blob:      layerTar,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if fake.chunksWritten <= maxChunksPerWriteStream {
+		t.Fatalf("fixture wrote %d chunks, want more than one %d-chunk batch", fake.chunksWritten, maxChunksPerWriteStream)
+	}
+	wantStreams := (fake.chunksWritten + maxChunksPerWriteStream - 1) / maxChunksPerWriteStream
+	if fake.writeStreams != wantStreams {
+		t.Fatalf("WriteChunks streams = %d, want %d for %d chunks", fake.writeStreams, wantStreams, fake.chunksWritten)
+	}
 }
 
 func TestPushLayersByChunksWritesOnlyMissing(t *testing.T) {
@@ -348,7 +416,7 @@ func TestPushLayersByChunksWritesOnlyMissing(t *testing.T) {
 	manifestCacheTestDir = t.TempDir()
 	t.Cleanup(func() { manifestCacheTestDir = "" })
 
-	layerTar := bytes.Repeat([]byte("abc"), 300_000) // multi-chunk
+	layerTar := variedChunkTestData(900_000) // multi-chunk with distinct hashes
 	refs, err := chunk.Chunk(bytes.NewReader(layerTar))
 	if err != nil {
 		t.Fatalf("chunk.Chunk: %v", err)
@@ -497,7 +565,7 @@ func TestPushLayersByChunksReportsProgress(t *testing.T) {
 	manifestCacheTestDir = t.TempDir()
 	t.Cleanup(func() { manifestCacheTestDir = "" })
 
-	layerTar := bytes.Repeat([]byte("abc"), 300_000) // multi-chunk
+	layerTar := variedChunkTestData(900_000) // multi-chunk with distinct hashes
 	refs, err := chunk.Chunk(bytes.NewReader(layerTar))
 	if err != nil {
 		t.Fatalf("chunk.Chunk: %v", err)

--- a/go/internal/shared/chunk/chunk.go
+++ b/go/internal/shared/chunk/chunk.go
@@ -25,14 +25,18 @@ import (
 const (
 	MinSize uint64 = 16 << 10
 	AvgSize uint64 = 64 << 10
-	MaxSize uint64 = 256 << 10
+	// Keep each gRPC WriteChunks message at or below 64 KiB. Hardware testing
+	// showed that larger messages fail more readily on some USB-NCM links; the
+	// compressed WriteChunks transport handles content-sensitive stalls, while
+	// this bound limits worst-case per-message flow-control pressure.
+	MaxSize uint64 = 64 << 10
 )
 
 // AlgoVersion identifies the chunking algorithm. Bump it whenever a change here
 // would alter the chunk boundaries or hashes for the same input (gear table,
 // masks, size constants, or region size). Callers that persist chunk manifests
 // use it to reject stale caches produced by an older algorithm.
-const AlgoVersion = 2
+const AlgoVersion = 3
 
 // regionSize is the granularity of parallel chunking. The input is cut into
 // regions of this size and each is chunked independently, so a forced boundary

--- a/go/internal/shared/chunk/chunk_test.go
+++ b/go/internal/shared/chunk/chunk_test.go
@@ -6,6 +6,13 @@ import (
 	"testing"
 )
 
+func TestMaxSizeBoundsUSBTransportMessages(t *testing.T) {
+	const usbTransportCeiling = 64 << 10
+	if MaxSize > usbTransportCeiling {
+		t.Fatalf("MaxSize = %d, exceeds validated USB transport ceiling %d", MaxSize, usbTransportCeiling)
+	}
+}
+
 func TestChunkIsDeterministic(t *testing.T) {
 	data := make([]byte, 2<<20)
 	if _, err := rand.Read(data); err != nil {


### PR DESCRIPTION
## Summary

- gzip `WriteChunks` payloads and register gzip support in the agent
- cap CDC chunks at 64 KiB, roll the upload stream every 64 chunks, and bump the manifest algorithm to v3
- surface the terminal gRPC status after `Send` returns `io.EOF` instead of reporting a bare EOF
- narrow `PrepareImage` wait checks to the shrinking missing set, with a final full-layer revalidation

## Root cause and reproduction

On a freshly flashed Jetson Orin Nano running WendyOS 0.18.2 over the direct USB-NCM link, forced chunk-diff deployment consistently stalled on particular raw gRPC payloads. The client eventually received a TCP read timeout, but grpc-go first returned `io.EOF` from `Send`; because the CLI did not read the terminal stream status, users saw only `EOF` and automatic mode fell back to the slower registry path.

This was not a normal cache miss. Exact-payload probes showed failures at 256, 128, and 112 KiB. A 96 KiB probe succeeded, but the full 96 KiB-capped transfer later failed on a different payload. A 64 KiB-capped, periodically acknowledged transfer also failed on a particular chunk. Adding gRPC gzip was the decisive change: the exact remaining set completed without registry fallback.

The smaller messages and periodic `CloseAndRecv` acknowledgements bound transport pressure and unconfirmed progress. Gzip avoids the raw-payload-sensitive failure while preserving the original bytes delivered to the agent, which still verifies each chunk by SHA-256 before staging it.

## Hardware validation

Target: Jetson Orin Nano, WendyOS 0.18.2, direct USB-C/USB-NCM, C920 webcam template.

- forced fast path: 658 chunks / 41.9 MB logical data sent in 11.7 s; application started; registry fallback disabled
- warm rerun: no changes detected in 0.45 s
- application state: `RUNNING`
- `/debug`: C920 at `/dev/video0`, pipeline `playing`
- WebSocket stream: 3 consecutive valid JPEG frames with 3 distinct SHA-256 hashes
- device restored afterward to released agent `2026.08.22-032001`

## Tests

- `go test ./go/internal/shared/chunk ./go/internal/agent/containerd ./go/internal/agent/services ./go/internal/cli/commands -count=1`
- targeted changed-path tests under `-race`
- `go vet` for changed packages plus both binaries
- macOS CLI build and Linux arm64 agent cross-build
- Docker Layer Optimizer static check found no unrelated Dockerfile layer change to make

`go test ./... -count=1` passes every changed package but intermittently fails existing `TestSampleGPUFallsBackToTegrastatsForOrin` under full-suite load; that test passed 5/5 in isolation and is outside this diff.

## Compatibility

The chunk manifest version moves from 2 to 3 so stale 256 KiB manifests are rejected. A new agent accepts both uncompressed older clients and compressed new clients. A new CLI talking to an older agent can still use the existing automatic registry fallback until the agent is updated.