### PR TITLE
fix(cli): don't truncate the agent version or its ⚠ in wendy cloud discover

### DIFF
--- a/go/internal/cli/commands/cloud_discover_legend_test.go
+++ b/go/internal/cli/commands/cloud_discover_legend_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	bubbleTable "github.com/charmbracelet/bubbles/table"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/go/internal/shared/version"
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
@@ -63,5 +65,78 @@ func TestCloudDiscoverLegendEmptyWithoutVersions(t *testing.T) {
 	}
 	if legend := tui.DeviceWarningLegend(cloudLegendItems(assets, nil)); legend != "" {
 		t.Errorf("legend = %q, want none", legend)
+	}
+}
+
+// The legend is derived from the version data, but the glyph it documents has
+// to survive the table's column widths to be of any use. A release version is
+// 17 cells and the glyph pushes the cell to 19, so a tight Version cap used to
+// truncate both — printing "⚠ agent older than CLI" under a table where no row
+// showed a ⚠, and hiding the last digits of every version besides.
+func TestCloudDiscoverGlyphSurvivesRender(t *testing.T) {
+	orig := version.Version
+	t.Cleanup(func() { version.Version = orig })
+	version.Version = "2026.08.23-120000"
+
+	assets := []*cloudpb.Asset{
+		{Id: 1, Name: "Spark3"},
+		{Id: 2, Name: "wendy-arms"},
+	}
+	versions := map[int32]*agentpb.GetAgentVersionResponse{
+		1: {Version: "2026.08.22-032058"},
+		2: {Version: "dev"},
+	}
+
+	rows := cloudDiscoverTableRows(assets, versions)
+	cols := discoverTableColumns(rows)
+	table := newDiscoverTable(true)
+	table.SetColumns(cols)
+	table.SetRows(rows)
+	table.SetWidth(discoverTableWidth(cols))
+	table.SetHeight(discoverTableHeight(len(rows), 40, true))
+	view := table.View()
+
+	legend := tui.DeviceWarningLegend(cloudLegendItems(assets, versions))
+	if !strings.Contains(legend, tui.LegendOutdated) {
+		t.Fatalf("legend = %q, want it to document %q", legend, tui.LegendOutdated)
+	}
+	if !strings.Contains(view, tui.GlyphOutdated) {
+		t.Errorf("legend documents %q but the rendered table shows no glyph:\n%s", tui.LegendOutdated, view)
+	}
+	if !strings.Contains(view, "2026.08.22-032058") {
+		t.Errorf("release version rendered truncated:\n%s", view)
+	}
+}
+
+// The Version column holds a full release version even when nothing is flagged,
+// so two builds from the same day stay distinguishable.
+func TestCloudDiscoverVersionNotTruncated(t *testing.T) {
+	orig := version.Version
+	t.Cleanup(func() { version.Version = orig })
+	version.Version = "dev" // a dev CLI flags nothing, so no glyph is appended
+
+	assets := []*cloudpb.Asset{{Id: 1, Name: "Spark3"}}
+	versions := map[int32]*agentpb.GetAgentVersionResponse{1: {Version: "2026.08.22-032058"}}
+
+	rows := cloudDiscoverTableRows(assets, versions)
+	cols := discoverTableColumns(rows)
+	table := newDiscoverTable(false)
+	table.SetColumns(cols)
+	table.SetRows(rows)
+	table.SetWidth(discoverTableWidth(cols))
+	table.SetHeight(discoverTableHeight(len(rows), 40, false))
+
+	if view := table.View(); !strings.Contains(view, "2026.08.22-032058") {
+		t.Errorf("version truncated in the Version column:\n%s", view)
+	}
+}
+
+// A marked cell overrides the Version max width, so tightening that constant
+// can no longer silently eat the glyph.
+func TestDiscoverTableColumnsFitWarningGlyph(t *testing.T) {
+	rows := []bubbleTable.Row{{"", "Spark3", "Linux (arm64)", "2026.08.22-032058 " + tui.GlyphOutdated}}
+	cols := discoverTableColumns(rows)
+	if got, want := cols[3].Width, lipgloss.Width(rows[0][3]); got < want {
+		t.Errorf("Version column width = %d, want >= %d so the glyph is not truncated", got, want)
 	}
 }

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -870,10 +870,15 @@ func newDiscoverTable(interactive bool) tui.BubbleTable {
 // cloud devices are addressed by name/ID via the broker tunnel, so the IP adds
 // noise. (The interactive `wendy discover` table uses tui.PickerDeviceTableData,
 // not these.) The full address is still available in the clipboard JSON.
+//
+// The Version max must fit a release version in full plus the outdated glyph
+// cloudDiscoverTableRows appends: "2026.08.22-032058 ⚠" is 19 cells, and
+// discoverTableColumns adds 2 for the cell padding. A tighter cap truncated
+// every release version and silently ate the glyph the legend advertises.
 var (
 	discoverTableHeaders   = []string{"", "Name", "Type", "Version"}
 	discoverTableMinWidths = []int{3, 12, 10, 10}
-	discoverTableMaxWidths = []int{3, 33, 20, 16}
+	discoverTableMaxWidths = []int{3, 33, 20, 21}
 )
 
 var deviceTypeNames = map[string]string{
@@ -1012,18 +1017,35 @@ func discoverTableColumns(rows []bubbleTable.Row) []bubbleTable.Column {
 	cols := make([]bubbleTable.Column, len(discoverTableHeaders))
 	for i, title := range discoverTableHeaders {
 		width := lipgloss.Width(title)
+		marked := 0
 		for _, row := range rows {
 			if i >= len(row) {
 				continue
 			}
 			width = max(width, lipgloss.Width(row[i]))
+			if cellCarriesWarningGlyph(row[i]) {
+				marked = max(marked, lipgloss.Width(row[i]))
+			}
 		}
 		width += 2
 		width = max(width, discoverTableMinWidths[i])
 		width = min(width, discoverTableMaxWidths[i])
+		// A warning glyph sits at the end of the cell, so the max width is the
+		// first thing to eat it — and the legend explaining it is derived from
+		// the data, not from what rendered, leaving a documented marker no row
+		// shows. A marked cell therefore overrides the max width.
+		if marked > 0 {
+			width = max(width, marked)
+		}
 		cols[i] = bubbleTable.Column{Title: title, Width: width}
 	}
 	return cols
+}
+
+// cellCarriesWarningGlyph reports whether a rendered cell ends in one of the
+// warning glyphs the table legend documents.
+func cellCarriesWarningGlyph(cell string) bool {
+	return strings.HasSuffix(cell, tui.GlyphOutdated) || strings.HasSuffix(cell, tui.GlyphInsecure)
 }
 
 func discoverTableWidth(cols []bubbleTable.Column) int {


### PR DESCRIPTION
## What's wrong

Two bugs in the `wendy cloud discover` table, both from one column-width constant.

**1. Every release version rendered truncated.** The Version column was capped at 16 cells (`discoverTableMaxWidths`), but a release version is 17 — `2026.08.22-032058` came out as `2026.08.22-0320…`, hiding exactly the digits that tell two same-day builds apart.

**2. The legend advertised a glyph no row could show.** `cloudDiscoverTableRows` appends `" ⚠"` to a flagged version, making the cell 19 cells — 3 over the cap, so the marker was truncated away 100% of the time. The legend line, meanwhile, is derived from the version data and never looks at what rendered. So `⚠ agent older than CLI` printed under a table with zero marked rows — the exact invariant `picker.go` claims to uphold ("a warning is never advertised when none is shown"):

```
  Name          Type            Version
  Spark3        Linux (arm64)   2026.08.22-0320…
  wendy-arms    Jetson Orin     2026.08.22-0320…
⚠ agent older than CLI          ← explains a symbol that isn't there
```

## Fix

- Raise the Version cap 16 → 21 (17 + glyph + the 2 padding cells `discoverTableColumns` adds).
- Let a cell ending in a warning glyph **override** the max width, so tightening that constant later can't re-hide the marker. Small `cellCarriesWarningGlyph` helper covers `⚠` and `!`.

Semantics were never wrong — `agentBehindCLI` is correct and dev builds are excluded on both sides (WDY-1770). This is purely a rendering bug.

## Tests

Three new tests in `cloud_discover_legend_test.go`, each verified to fail on the pre-fix code:

- `TestCloudDiscoverGlyphSurvivesRender` — when the legend documents `⚠`, assert a `⚠` is in `table.View()`. **This is the gap that let the bug ship**: the existing test only checked the row string, never the render.
- `TestCloudDiscoverVersionNotTruncated` — full version visible with no glyph appended.
- `TestDiscoverTableColumnsFitWarningGlyph` — column width ≥ marked cell width.

Pre-fix output: `Version column width = 16, want >= 19`.

`go test ./internal/cli/commands -count=1`, `go vet`, `gofmt -s` all clean.

## Manual verification

Built with a stamped release version (a `dev` CLI flags nothing by design, so the path is dead there) and ran against the fleet — versions now show in full and the `⚠` lands on the `2026.08.22` rows while `dev` agents stay unmarked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
