### PR TITLE
fix(example): score the freshest frame so the model input join resolves

### DIFF
--- a/Examples/WendyDataModelApp/Dockerfile
+++ b/Examples/WendyDataModelApp/Dockerfile
@@ -46,7 +46,13 @@ RUN apt-get update \
 # av decodes the encoded samples the harness delivers (H.264 access units on
 # the native Video4Linux2 path, byte-stream chunks elsewhere); grpcio carries
 # the sensor subscription. Neither needs a camera device node.
-RUN pip install --no-cache-dir onnxruntime opencv-python-headless "numpy<3" grpcio "av<15"
+#
+# av is pinned exactly rather than bounded: PyAV 14.3.0 and 14.4.0 ship no
+# manylinux aarch64 wheel, so a bare "av<15" resolves to 14.4.0 on this
+# Jetson's arm64 runtime and falls back to a source build, which wants
+# ffmpeg 7, Cython and pkg-config that this slim image does not carry.
+# 14.2.0 is the newest release under 15 with a cp311 aarch64 wheel.
+RUN pip install --no-cache-dir onnxruntime opencv-python-headless "numpy<3" grpcio "av==14.2.0"
 WORKDIR /app
 COPY --from=export /export/yolov8n.onnx ./yolov8n.onnx
 COPY --from=protos /gen/wendy ./wendy

--- a/Examples/WendyDataModelApp/app.py
+++ b/Examples/WendyDataModelApp/app.py
@@ -52,10 +52,17 @@ CAMERA_SOURCE = os.environ.get("WENDY_CAMERA_SOURCE", "")
 CONFIDENCE_THRESHOLD = float(os.environ.get("WENDY_CONFIDENCE_THRESHOLD", "0.25"))
 IOU_THRESHOLD = float(os.environ.get("WENDY_IOU_THRESHOLD", "0.45"))
 # Rate-limit friendliness: the agent caps an app at 200 records per second
-# across its connections; this app skips frames so it sends at most this
-# many predictions per second (default 5). Skipping happens AFTER the
-# harness delivered the frame, so the episode's model-input ledger records
-# every frame the app received, including the ones it chose not to score.
+# across its connections; this is the ceiling this app holds itself to
+# (default 5 per second). It is a CEILING, not a target: on a CPU-only
+# Jetson Orin Nano one YOLOv8n inference takes roughly 450 ms, so the loop
+# runs at about 2 predictions per second and this gate never binds. What
+# actually keeps the app current is discarding the backlog rather than
+# draining it (see freshest_frames in wendysensors.py); lower this only to
+# spend less CPU on inference deliberately.
+#
+# Frames the app receives but does not score are still delivered, so the
+# episode's model-input ledger records every one of them, and each
+# prediction reports how many it passed over.
 PREDICTIONS_PER_SECOND = float(os.environ.get("WENDY_PREDICTIONS_PER_SECOND", "5"))
 # The sensor stream can end while the app is still healthy: the agent
 # restarts, or the subscription is dropped with the socket. The data socket
@@ -140,6 +147,30 @@ def steer_towards(detections, frame_width: int) -> tuple[float, float]:
     angular_z = -1.2 * center_offset
     linear_x = 0.1 if abs(center_offset) < 0.15 else 0.0
     return angular_z, linear_x
+
+
+def person_appearance(detections, person_present: bool) -> tuple[bool, float | None]:
+    """Decide whether this frame is the START of a person's appearance.
+
+    Returns (person_present_now, confidence_to_report). `confidence_to_report`
+    is None unless this frame is a rising edge, so the caller emits one
+    `person_detected` event per appearance rather than one per frame.
+
+    Edge-triggering is what makes the event usable as a campaign trigger. A
+    level-triggered event would fire on every frame a person stays in view,
+    and since the campaign starts an episode per trigger, someone walking past
+    would produce a stream of episodes instead of the one clip that actually
+    covers them. Kept as a pure function so that "one episode per appearance"
+    is a tested property rather than an inline claim, and it can be checked
+    without a camera, a model, or an agent.
+    """
+    people = [d for d in detections if d["class_id"] == PERSON_CLASS_ID]
+    if not people:
+        return False, None
+    if person_present:
+        # Still there. The episode already covering them is the right one.
+        return True, None
+    return True, max(d["confidence"] for d in people)
 
 
 def letterbox(frame: np.ndarray) -> tuple[np.ndarray, float, int, int]:
@@ -238,7 +269,18 @@ def main() -> None:
         sensors, SENSOR_RECONNECT_ATTEMPTS, SENSOR_RECONNECT_DELAY_SECONDS
     )
     try:
-        for sensor_frame in frame_stream:
+        # freshest_frames decodes on its own thread and hands over only the most
+        # recent frame, so inference always runs on current input rather than
+        # draining a backlog. Without it the loop falls behind the producer by
+        # however much slower inference is than capture, and the sample
+        # identifiers each prediction references drift out of the range the
+        # episode recorded, which is what makes the join unresolvable.
+        for sensor_frame, discarded in wendysensors.freshest_frames(frame_stream):
+            # Decoded while the previous inference was still running, then
+            # dropped on purpose. Added to the same counter the rate gate feeds
+            # so one field accounts for every frame that arrived and was not
+            # scored, whatever the reason.
+            skipped += discarded
             if sensor_frame.dropped_before:
                 # The harness produced frames this app never received. Say so
                 # rather than leaving a silent gap in the sample identifiers.
@@ -250,9 +292,10 @@ def main() -> None:
                 )
             now = time.monotonic()
             if now < next_score_at:
-                # Frame skipping keeps predictions at or under the configured
-                # rate. The skipped frames were still delivered, so the
-                # episode's ledger holds them.
+                # Holds predictions under PREDICTIONS_PER_SECOND. Rarely binds,
+                # because inference is slower than the ceiling; when it does,
+                # the frame is counted as skipped like any other. It was still
+                # delivered, so the episode's ledger holds it either way.
                 skipped += 1
                 continue
             next_score_at = now + interval
@@ -281,15 +324,10 @@ def main() -> None:
 
             # Edge-trigger the demo event so a person standing in front of
             # the camera fires the campaign once, not once per frame.
-            has_person = any(d["class_id"] == PERSON_CLASS_ID for d in detections)
-            if has_person and not person_present:
-                best = max(
-                    (d for d in detections if d["class_id"] == PERSON_CLASS_ID),
-                    key=lambda d: d["confidence"],
-                )
-                client.send(wendydata.build_event("person_detected", {"confidence": best["confidence"]}))
-                log.info("person detected (confidence %.2f)", best["confidence"])
-            person_present = has_person
+            person_present, confidence = person_appearance(detections, person_present)
+            if confidence is not None:
+                client.send(wendydata.build_event("person_detected", {"confidence": confidence}))
+                log.info("person detected (confidence %.2f)", confidence)
 
             angular_z, linear_x = steer_towards(detections, frame.shape[1])
             actuator.act(angular_z, linear_x)

--- a/Examples/WendyDataModelApp/test_wendydata.py
+++ b/Examples/WendyDataModelApp/test_wendydata.py
@@ -9,6 +9,7 @@ cannot see.
 
 import json
 import struct
+import threading
 import unittest
 
 import wendydata
@@ -428,6 +429,156 @@ class TestSensorStreamReconnect(unittest.TestCase):
             got = list(sensors.frames_with_reconnect(client, attempts=0, delay=0, sleep=lambda _: None))
         self.assertEqual(got, ["a"])
         self.assertEqual(client.calls, 1)
+
+
+class TestPersonAppearance(unittest.TestCase):
+    """`person_detected` is a campaign trigger, and the campaign starts one
+    episode per trigger. So the event must fire once when a person arrives and
+    stay quiet while they remain: level-triggering it would turn one person
+    walking past into a stream of episodes."""
+
+    @staticmethod
+    def _app():
+        """Import app.py with its model and imaging dependencies stubbed.
+
+        The appearance rule needs neither a model nor OpenCV, and a unit test
+        must not require onnxruntime to exercise it."""
+        import sys
+        import types
+
+        TestSampleAttribution._sensors()
+        for name in ("cv2", "numpy", "onnxruntime"):
+            sys.modules.setdefault(name, types.ModuleType(name))
+        import app
+
+        return app
+
+    @staticmethod
+    def _person(confidence):
+        return {"class_id": 0, "class_name": "person", "confidence": confidence}
+
+    @staticmethod
+    def _chair(confidence=0.7):
+        return {"class_id": 56, "class_name": "chair", "confidence": confidence}
+
+    def test_an_empty_frame_reports_nobody(self):
+        app = self._app()
+        self.assertEqual(app.person_appearance([], False), (False, None))
+
+    def test_other_classes_are_not_people(self):
+        app = self._app()
+        # The scene this demo runs in is full of furniture; none of it may fire
+        # the trigger.
+        self.assertEqual(app.person_appearance([self._chair()], False), (False, None))
+
+    def test_arrival_reports_the_best_confidence(self):
+        app = self._app()
+        present, confidence = app.person_appearance(
+            [self._person(0.61), self._chair(), self._person(0.88)], False
+        )
+        self.assertTrue(present)
+        self.assertAlmostEqual(confidence, 0.88)
+
+    def test_staying_in_frame_fires_only_once(self):
+        app = self._app()
+        present, confidence = app.person_appearance([self._person(0.9)], False)
+        self.assertEqual((present, confidence), (True, 0.9))
+        # Every later frame of the same appearance stays silent, so the campaign
+        # gets one episode covering the person rather than one per frame.
+        for _ in range(20):
+            present, confidence = app.person_appearance([self._person(0.9)], present)
+            self.assertTrue(present)
+            self.assertIsNone(confidence)
+
+    def test_leaving_and_returning_fires_again(self):
+        app = self._app()
+        present, first = app.person_appearance([self._person(0.8)], False)
+        self.assertEqual(first, 0.8)
+        present, gone = app.person_appearance([], present)
+        self.assertEqual((present, gone), (False, None))
+        # A second, separate appearance is a second episode, which is correct:
+        # it is a different moment worth recording.
+        present, again = app.person_appearance([self._person(0.7)], present)
+        self.assertEqual((present, again), (True, 0.7))
+
+
+class TestFreshestFrame(unittest.TestCase):
+    """Inference is far slower than capture, so a loop that scores every frame
+    it is handed falls steadily behind and its predictions reference samples the
+    episode has moved past. The backlog has to be discarded, and discarding it
+    has to be counted: an episode that silently drops frames is not honest."""
+
+    _sensors = staticmethod(TestSampleAttribution._sensors)
+
+    def test_every_frame_is_yielded_when_the_consumer_keeps_up(self):
+        sensors = self._sensors()
+        # Nothing is dropped just for passing through: a consumer fast enough to
+        # take each frame as it arrives must still see all of them. The producer
+        # is gated so exactly one frame exists at a time, which makes "kept up"
+        # a fact of the test rather than a race against the reader thread.
+        gate = threading.Semaphore(0)
+
+        def stream():
+            for frame in ("a", "b", "c"):
+                gate.acquire()
+                yield frame
+
+        frames = sensors.freshest_frames(stream())
+        got = []
+        for _ in range(3):
+            gate.release()
+            got.append(next(frames))
+        self.assertEqual([f for f, _ in got], ["a", "b", "c"])
+        self.assertEqual(sum(d for _, d in got), 0)
+
+    def test_a_slow_consumer_gets_the_newest_frame_and_the_discard_count(self):
+        sensors = self._sensors()
+        took_first = threading.Event()
+        produced_rest = threading.Event()
+
+        def stream():
+            yield "a"
+            # Hold until the consumer has taken "a", then produce a burst it
+            # never asked for: the reader running ahead while an inference is
+            # in flight, which is the situation this whole helper exists for.
+            took_first.wait(timeout=5)
+            yield "b"
+            yield "c"
+            yield "d"
+            produced_rest.set()
+
+        frames = sensors.freshest_frames(stream())
+        first = next(frames)
+        self.assertEqual(first, ("a", 0))
+        took_first.set()
+        self.assertTrue(produced_rest.wait(timeout=5))
+        # The consumer skips straight to the newest frame rather than working
+        # through b and c, and is told exactly how many it passed over.
+        self.assertEqual(next(frames), ("d", 2))
+        # Four produced, two yielded, two counted: nothing vanishes unrecorded.
+        self.assertEqual(list(frames), [])
+
+    def test_the_last_frames_survive_the_end_of_the_stream(self):
+        sensors = self._sensors()
+        # A stream that ends immediately still has its frames delivered; the
+        # end of stream must not race the final frame out of the slot.
+        got = list(sensors.freshest_frames(iter(["only"])))
+        self.assertEqual(got, [("only", 0)])
+
+    def test_a_reader_failure_reaches_the_consumer(self):
+        sensors = self._sensors()
+
+        def stream():
+            yield "a"
+            raise RuntimeError("decoder exploded")
+
+        frames = sensors.freshest_frames(stream())
+        # The frame decoded before the failure is still delivered, and the
+        # failure is then raised on the consumer's thread rather than vanishing
+        # into the reader and stalling the app forever.
+        self.assertEqual(next(frames), ("a", 0))
+        with self.assertRaises(RuntimeError):
+            next(frames)
 
 
 if __name__ == "__main__":

--- a/Examples/WendyDataModelApp/wendysensors.py
+++ b/Examples/WendyDataModelApp/wendysensors.py
@@ -30,12 +30,20 @@ record's `inputs` list is for.
 `encoding` is per sample, not per stream, so the decoder is rebuilt
 whenever it changes rather than being pinned by whichever sample happened
 to arrive first.
+
+Reading the stream and consuming it run at different speeds. Decoding is
+cheap and inference is not, so a consumer that scores every frame it is
+handed falls steadily behind the producer and ends up predicting on stale
+samples. `freshest_frames` is the fix: it reads and decodes on its own
+thread and keeps only the newest frame, so a prediction always references
+samples the episode still holds.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+import threading
 import time
 from dataclasses import dataclass, field
 
@@ -243,6 +251,82 @@ def _flush_decoder(decoder, sample_ids, dropped_before, tail):
             "%d buffered sample(s) produced no frame before the encoding change",
             len(sample_ids),
         )
+
+
+def freshest_frames(frames):
+    """Yield the newest decoded frame, discarding whatever queued up behind it.
+
+    A real-time inference loop has to judge the freshest frame available, not
+    drain a queue. The producer keeps running while the model is busy, so
+    anything that accumulated behind the frame being scored is already history
+    by the time the model reaches it. Worse, it is history that compounds: each
+    prediction falls a little further behind than the last, and the references
+    it carries name samples the episode has long since moved past. That is
+    precisely how a model input/outcome join ends up with nothing to pair, even
+    though both sides recorded honestly.
+
+    The backlog lives in the gRPC receive buffer, and the only way to learn
+    what is behind the current sample is to read it. So reading and decoding
+    run on their own thread and the newest decoded frame is kept in a
+    single-entry slot; a consumer that asks for a frame gets the most recent
+    one and the count of frames that were dropped to get there.
+
+    Decoding unconditionally is affordable, which is what makes this work: on a
+    Jetson Orin Nano one 1280x720 H.264 frame decodes in about 7 ms against
+    roughly 450 ms for one YOLOv8n inference on the CPU, so the decoder keeps
+    pace with the producer using a few percent of a core while the consumer
+    scores whatever is newest. Decode is not the expensive step; inference is.
+
+    Yields (frame, discarded) pairs. `discarded` is the number of decoded
+    frames thrown away since the previous yield, so the caller can report what
+    it skipped instead of leaving a silent gap. Frames are dropped here only
+    after being fully decoded, so a yielded frame's `sample_ids` still names
+    exactly the samples it was computed from.
+    """
+    state = threading.Condition()
+    slot: dict = {"frame": None, "discarded": 0, "done": False, "error": None}
+
+    def reader():
+        try:
+            for frame in frames:
+                with state:
+                    if slot["frame"] is not None:
+                        # A frame the consumer never asked for. Counted rather
+                        # than quietly overwritten: the prediction that finally
+                        # lands has to be able to say how much it passed over.
+                        slot["discarded"] += 1
+                    slot["frame"] = frame
+                    state.notify()
+        except BaseException as exc:  # noqa: BLE001 - re-raised on the consumer thread
+            with state:
+                slot["error"] = exc
+                state.notify()
+        finally:
+            with state:
+                slot["done"] = True
+                state.notify()
+
+    thread = threading.Thread(target=reader, name="sensor-decode", daemon=True)
+    thread.start()
+    while True:
+        with state:
+            while slot["frame"] is None and not slot["done"]:
+                state.wait()
+            frame = slot["frame"]
+            discarded = slot["discarded"]
+            slot["frame"] = None
+            slot["discarded"] = 0
+            error = slot["error"]
+            done = slot["done"]
+        if frame is not None:
+            # Drained before any end-of-stream or failure is reported, so the
+            # last frames the decoder managed to produce are still scored.
+            yield frame, discarded
+            continue
+        if error is not None:
+            raise error
+        if done:
+            return
 
 
 def frames_with_reconnect(


### PR DESCRIPTION
## Problem

On real hardware (`wendyos-fernando.local`, Jetson Orin Nano, WendyOS 0.18.2) the model harness demo produced episodes whose model input/outcome join had **zero resolvable pairs**.

Measured baseline, one 20 second episode:

| | |
|---|---|
| model-input ledger range | `28988-29154` (5 entries) |
| sample ids the predictions referenced | `24494-25162` |
| references resolving to frame bytes | **0 of 82** |
| `subscriber_drops` | 162 |

The app's predictions trailed the ledger by roughly 3800 sample ids, and the gap grew the longer the app ran.

## Cause

The app scored every frame the harness handed it, and inference is far slower than capture.

Measured inside the app's own container, on bytes the episode actually recorded:

| step | cost | throughput |
|---|---|---|
| H.264 decode, 1280x720 | **6.7 ms/frame** | 149 frames/sec |
| YOLOv8n inference, CPU | **873 ms/frame** | 1.15/sec |

Decode is about 1 percent of a decode-plus-infer frame. The backlog therefore accumulated in the gRPC receive buffer: each prediction was computed from a frame older than the last and named sample ids the episode had long since passed.

The existing rate gate could not help. It holds predictions under `PREDICTIONS_PER_SECOND` (default 5, a 200 ms interval), but a single inference already takes about 450 ms, so the gate never fired once. Every prediction in every episode reported `frames_skipped_since_last_prediction: 0`.

Worth stating plainly, because it was the working theory going in: decode being the bottleneck, and chunked payloads forcing decode work, are **not** the cause. The camera does deliver byte chunks rather than whole access units, but decoding them is nearly free.

## Solution

Read and decode on a separate thread and keep only the newest decoded frame (`freshest_frames` in `wendysensors.py`), so inference always runs on current input rather than draining a queue. Decoding unconditionally is what makes this affordable.

Honesty properties, which is the whole point of the ledger:

- Frames dropped to reach the newest one are **counted** and reported in the existing `frames_skipped_since_last_prediction` field, so the episode still accounts for every frame that arrived. Nothing is silently discarded.
- Frames are dropped only **after** being fully decoded, so a prediction's `inputs` list still names exactly the samples it was computed from.

### Result on the device

| | before | after |
|---|---|---|
| ledger range | `28988-29154` (5 entries) | `45143-45647` (369 entries) |
| referenced range | `24494-25162` | `44961-45637` |
| references resolving | **0 of 82** | **37 of 60** |

Splitting that 60 by whether frame bytes can exist at all:

- 23 references fall in the 10 second pre-trigger **application-record** window. Sensor capture starts at the trigger, so no camera bytes exist for them. 0 resolve, by design, and the deploy warning says so.
- 37 references fall inside the recorded camera window. **37 of 37 resolve — 100%.**

Every reference that can resolve does.

## Also in this change

**PyAV pinned exactly.** A bare `av<15` resolves to 14.4.0, and 14.3.0 and 14.4.0 are the two releases with no manylinux aarch64 wheel, so pip fell back to a source build wanting ffmpeg 7, Cython and pkg-config that the slim runtime image does not carry. The image failed to build for this device. 14.2.0 is the newest release under 15 with a cp311 aarch64 wheel.

**`person_detected` edge trigger extracted into a pure function** (`person_appearance`), so "one event per appearance, not one per frame" is a tested property rather than an inline claim. The campaign starts one episode per trigger, so level-triggering it would turn one person walking past into a stream of episodes.

## Tests

`python3 -m unittest test_wendydata` — 36 tests, all passing. New coverage:

- `TestFreshestFrame` — every frame is yielded to a consumer that keeps up; a slow consumer gets the newest frame plus an exact discard count; the last frames survive the end of stream; a reader-thread failure reaches the consumer instead of stalling the app.
- `TestPersonAppearance` — furniture is not a person; arrival reports the best confidence; staying in frame fires once; leaving and returning fires again.

## Not verified

- **The uncertainty trigger and `person_detected` were not exercised against a live person.** The camera on this device is currently aimed at a blank wall and a bright window, so YOLOv8n detects nothing at all and uncertainty sits at exactly 1.0. See the campaign notes in the demo repo; the camera needs re-aiming before the demo.
- No cloud-side verification. Episode upload and the ingest path were not checked in this change.
