### PR TITLE
Make episode camera capture playable with true variable-rate timing

### DIFF
--- a/go/cmd/episode-playable/main.go
+++ b/go/cmd/episode-playable/main.go
@@ -1,0 +1,82 @@
+// Command episode-playable turns a downloaded episode's camera capture into
+// playable MP4 files, one per camera source, with per-frame presentation
+// timestamps read from the episode's own cameras/<source>/index.jsonl.
+//
+// It exists because episode camera capture keeps a bare H.264 Annex-B
+// elementary stream, which carries no container and therefore no timing, so
+// players invent a frame rate and the clip runs at the wrong speed. Supplying
+// a fixed rate instead is wrong by construction: the capture rate varies with
+// device load. See the episodeexport package for the full reasoning.
+//
+// The episode directory is only read. Output goes to a separate directory,
+// because the elementary stream and its index are checksummed archival truth
+// and index.jsonl addresses frames by byte offset within the stream.
+//
+// This is the natural body of a future "wendy data export" verb; it is a
+// standalone command for now so it can ship without touching the CLI's command
+// surface.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/wendylabsinc/wendy/go/internal/episodeexport"
+)
+
+func main() {
+	out := flag.String("o", "", "directory to write playable files into (default \"<episode>-playable\" beside the episode)")
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), `usage: episode-playable [-o <output-dir>] <episode-dir>
+
+Writes one playable MP4 per camera source found under <episode-dir>/cameras,
+timed from each frame's canonical_episode_nanos in that source's index.jsonl.
+The episode directory is never modified.
+`)
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+	if flag.NArg() != 1 {
+		flag.Usage()
+		os.Exit(2)
+	}
+	episode := filepath.Clean(flag.Arg(0))
+	dest := *out
+	if dest == "" {
+		dest = episode + "-playable"
+	}
+
+	results, errs := episodeexport.Convert(episode, dest)
+	for _, r := range results {
+		if r.Output == "" {
+			continue
+		}
+		fmt.Printf("%s\n", r.Output)
+		fmt.Printf("  index lines      %d\n", r.IndexLines)
+		fmt.Printf("  frames written   %d\n", r.Frames)
+		fmt.Printf("  segments read    %d\n", r.Segments)
+		if r.Skipped > 0 {
+			fmt.Printf("  frames skipped   %d (bytes missing or truncated)\n", r.Skipped)
+		}
+		if r.Unparsed > 0 {
+			fmt.Printf("  index lines unusable %d (expected for an interrupted episode)\n", r.Unparsed)
+		}
+		fmt.Printf("  index span       %s\n", r.Span)
+		fmt.Printf("  interval min/mean/max  %s / %s / %s\n", r.MinInterval, r.MeanInterval, r.MaxInterval)
+		if r.BFrames {
+			fmt.Fprintf(os.Stderr, "episode-playable: warning: camera %s contains B slices, so its presentation order differs from the coded order index.jsonl records; the timing written for it is approximate\n", r.Source)
+		}
+	}
+	if len(errs) > 0 {
+		for _, err := range errs {
+			fmt.Fprintf(os.Stderr, "episode-playable: %v\n", err)
+		}
+		os.Exit(1)
+	}
+	if len(results) == 0 {
+		fmt.Fprintln(os.Stderr, "episode-playable: nothing to convert")
+		os.Exit(1)
+	}
+}

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
@@ -188,6 +188,76 @@ export:
   annotation: cvat
 ```
 
+## Playing back camera capture
+
+Camera capture is kept as a raw H.264 Annex-B elementary stream
+(`cameras/<source>/segment-NNNNNN.h264`). An elementary stream has no
+container, so it carries no timing at all, and a player handed one has nothing
+to build a presentation schedule from. Players invent a frame rate instead, so
+the clip runs at the wrong speed and reports the wrong duration. Passing a
+fixed rate with `ffmpeg -r` does not fix this: the capture rate is genuinely
+variable, falling as the device gets busy with inference, so no single number,
+including the measured average, describes more than a fraction of the clip.
+
+The timing is already recorded. `cameras/<source>/index.jsonl` carries one line
+per kept frame with `canonical_episode_nanos`, the frame's position on the
+Episode's canonical `CLOCK_BOOTTIME` timeline, alongside the segment file, byte
+offset and `byte_size` of its payload. The `episode-playable` command remuxes
+those payload bytes into an MP4 that gives every frame the presentation time
+the index recorded for it, so the variable frame rate is represented honestly
+rather than averaged away:
+
+```sh
+# From the repository root.
+CGO_ENABLED=0 go build -o bin/episode-playable ./go/cmd/episode-playable
+
+wendy data download <episode-id> -o /absolute/path/to/episode --device <device-hostname>
+./bin/episode-playable -o /absolute/path/to/playable /absolute/path/to/episode
+```
+
+Note that `wendy data download` needs an absolute `-o` path; a relative one
+fails with "server file path escapes destination".
+
+One `<source>.mp4` is written per camera source into the output directory,
+which must be somewhere other than the Episode. The command prints the index
+line count, the frames written, the segments read, the index's first-to-last
+span, and the minimum, mean and maximum inter-frame interval, which is enough
+to check the conversion numerically without watching it.
+
+Details worth knowing:
+
+- The Episode is only ever read. The elementary stream and its index are
+  checksummed archival truth, and `index.jsonl` addresses frames by byte offset
+  within the stream, so rewriting it in place would break the join between a
+  frame and the model input recorded against it.
+- It is a remux, not a transcode. The coded pictures are copied verbatim, so
+  the output is the same video, only re-framed.
+- MP4 was chosen over Matroska because the output has to play unmodified in
+  both VLC and QuickTime, and QuickTime cannot open Matroska. MP4 states an
+  explicit duration for every sample in its `stts` box, which represents a
+  variable frame rate exactly as precisely as Matroska timestamps do.
+- There is no external dependency. The muxer is pure Go, so no ffmpeg,
+  mkvmerge or PyAV is needed anywhere on the path from an Episode to a playable
+  file.
+- A frame the index names but whose bytes are missing or truncated is reported
+  and skipped rather than written short, because a truncated access unit makes
+  the file undecodable from that point on. A partial trailing index line, the
+  shape an interrupted Episode leaves behind, is counted as unusable and
+  ignored. Multiple segments per source and multiple sources per Episode are
+  both handled.
+- `byte_size` from the index is authoritative for how many bytes belong to a
+  frame. The model-input ledger's `payload_bytes` can exceed it for a frame
+  that opens a segment, because the segment begins at the parameter-set prefix
+  inside that payload rather than at its first byte.
+- The index records frames in capture order, which is coded order. That is
+  exact for the B-frame-free streams the device's encoder produces. A stream
+  containing B slices has a presentation order that differs from its coded
+  order, which the index does not carry, so such a stream is flagged with a
+  warning rather than silently mistimed.
+
+`wendy data export` is the natural future home for this, at which point the
+command becomes a verb on the CLI rather than a separate binary.
+
 ## Pre-trigger behavior
 
 Application pre-roll is exact, device-wide, and bounded by the campaign buffer

--- a/go/internal/cli/assets/docs/wendy-data-platform-demo.md
+++ b/go/internal/cli/assets/docs/wendy-data-platform-demo.md
@@ -217,6 +217,12 @@ counts the predictions that named their inputs, and — per source — whether t
 episode retains payloads for all of the consumed samples or only the subset the
 capture policy kept.
 
+To watch the camera capture rather than join against it, convert the episode
+with `episode-playable`; the camera capture is a raw elementary stream with no
+container, so players otherwise invent a frame rate and the clip runs at the
+wrong speed. See "Playing back camera capture" in the `wendy data` command
+documentation.
+
 ## Pitfalls discovered on the way (all hit for real)
 
 1. Full root disk from accumulated updater backups: see the recon step.

--- a/go/internal/episodeexport/playable.go
+++ b/go/internal/episodeexport/playable.go
@@ -1,0 +1,785 @@
+// Package episodeexport turns an episode's camera capture into files that
+// ordinary video players can play, without touching the episode itself.
+//
+// The problem it solves. Episode camera capture keeps an H.264 Annex-B
+// elementary stream (cameras/<source>/segment-NNNNNN.h264). An elementary
+// stream is a bare sequence of coded pictures: it has no container, and
+// therefore carries no timing whatsoever. A player handed one has nothing to
+// derive a presentation schedule from, so it invents a frame rate, and the clip
+// runs at the wrong speed and reports the wrong duration.
+//
+// Why a fixed frame rate is not the fix. Passing a constant rate, whether
+// guessed or measured as an average, replaces one wrong schedule with another.
+// The capture rate is genuinely variable: it falls as the device gets busy with
+// inference, so no single number describes more than a fraction of the clip.
+// One measured episode held 176 frames across 9.95 seconds, an average near
+// 17.7 Hz, but the instantaneous interval wandered well away from that and the
+// next episode has no reason to average the same.
+//
+// Where the real timing comes from. It was recorded all along.
+// cameras/<source>/index.jsonl holds one line per kept frame carrying
+// canonical_episode_nanos, the frame's position on the episode's canonical
+// CLOCK_BOOTTIME timeline, along with the segment file, byte offset and byte
+// size of its payload. This package remuxes those same payload bytes into an
+// MP4 whose sample table gives every frame the presentation time the index
+// recorded for it. Nothing here computes, averages, or assumes a rate.
+//
+// It is a remux, not a transcode: the coded pictures are copied verbatim and
+// only re-framed, so the output is bit-for-bit the same video.
+//
+// Container choice. MP4 with an explicit per-sample duration for every sample
+// in the stts box. Matroska is the more usual home for variable frame rate and
+// mkvmerge --timestamps the usual route to it, but mkvmerge is an extra
+// dependency and QuickTime Player cannot open Matroska at all, whereas MP4
+// represents variable frame rate exactly as precisely and plays unmodified in
+// both VLC and QuickTime. The muxer below is pure Go, so the tool has no
+// external dependency to be missing: there is no ffmpeg, mkvmerge or PyAV in
+// the path from an episode to a playable file.
+//
+// The episode is read-only here. Output is written to a separate destination
+// directory. The elementary stream and index are the checksummed archival
+// truth, and index.jsonl addresses frames by byte offset within the stream, so
+// rewriting it in place would break the join between a frame and the model
+// input recorded against it.
+package episodeexport
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// playableTimescale is the MP4 media timescale, in ticks per second. One tick
+// is a microsecond: fine enough that rounding a recorded nanosecond timestamp
+// is invisible beside any real frame interval, and coarse enough that a
+// per-sample duration stays inside the 32-bit stts field for any gap short of
+// 71 minutes.
+const playableTimescale = 1_000_000
+
+// ClipResult reports what one camera source produced, in the numbers needed to
+// check the conversion without watching it.
+type ClipResult struct {
+	// Source is the encoded camera source directory name.
+	Source string
+	// Output is the playable file written, empty when nothing was playable.
+	Output string
+	// IndexLines counts non-empty lines in index.jsonl, the number of frames
+	// the episode claims to have kept.
+	IndexLines int
+	// Frames counts samples actually written to the output.
+	Frames int
+	// Skipped counts frames the index named but which could not be muxed
+	// because their bytes were missing, truncated, or held no coded picture.
+	Skipped int
+	// Unparsed counts index lines that were not valid records, which is the
+	// expected shape of a partial tail left by an interrupted episode.
+	Unparsed int
+	// Segments counts distinct segment files the frames came from.
+	Segments int
+	// Span is the index's last-minus-first canonical timestamp.
+	Span time.Duration
+	// BFrames records that the stream contains B slices, so its presentation
+	// order is not the coded order the index records and the timing written
+	// here cannot be exact. See isBSlice.
+	BFrames bool
+	// MinInterval, MaxInterval and MeanInterval describe the spread of
+	// inter-frame intervals actually written. They differ from each other
+	// whenever the capture rate varied, which is the point.
+	MinInterval, MaxInterval, MeanInterval time.Duration
+}
+
+// Convert writes one playable MP4 per camera source found under
+// episodeDir/cameras into outDir, named <source>.mp4. The episode directory is
+// only ever read. A source whose clip cannot be built is reported in the
+// returned error list and skipped, so one damaged camera does not deny the
+// others.
+func Convert(episodeDir, outDir string) ([]ClipResult, []error) {
+	indexes, err := filepath.Glob(filepath.Join(episodeDir, "cameras", "*", "index.jsonl"))
+	if err != nil {
+		return nil, []error{fmt.Errorf("scanning camera sources: %w", err)}
+	}
+	if len(indexes) == 0 {
+		return nil, []error{fmt.Errorf("no cameras/<source>/index.jsonl under %s: not an episode directory, or it recorded no camera", episodeDir)}
+	}
+	sort.Strings(indexes)
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return nil, []error{err}
+	}
+
+	var (
+		results []ClipResult
+		errs    []error
+	)
+	for _, index := range indexes {
+		sourceDir := filepath.Dir(index)
+		source := filepath.Base(sourceDir)
+		out := filepath.Join(outDir, source+".mp4")
+		result, err := convertSource(episodeDir, sourceDir, index, out)
+		result.Source = source
+		if err != nil {
+			errs = append(errs, fmt.Errorf("camera %s: %w", source, err))
+			results = append(results, result)
+			continue
+		}
+		results = append(results, result)
+	}
+	return results, errs
+}
+
+func convertSource(episodeDir, sourceDir, indexPath, out string) (ClipResult, error) {
+	frames, result, err := readCameraIndex(indexPath)
+	if err != nil {
+		return result, err
+	}
+	if len(frames) == 0 {
+		return result, fmt.Errorf("index names no usable H.264 frames (%d unparsed lines)", result.Unparsed)
+	}
+	result.Span = time.Duration(frames[len(frames)-1].CanonicalEpisodeNanos - frames[0].CanonicalEpisodeNanos)
+
+	tmp := out + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
+	if err != nil {
+		return result, err
+	}
+	defer os.Remove(tmp)
+	stats, writeErr := muxAnnexBToMP4(f, episodeDir, frames)
+	closeErr := f.Close()
+	result.Frames, result.Skipped, result.Segments = stats.frames, stats.skipped, stats.segments
+	result.BFrames = stats.bFrames
+	result.MinInterval, result.MaxInterval, result.MeanInterval = stats.min, stats.max, stats.mean
+	if err := errors.Join(writeErr, closeErr); err != nil {
+		return result, err
+	}
+	if err := os.Rename(tmp, out); err != nil {
+		return result, err
+	}
+	result.Output = out
+	return result, nil
+}
+
+// cameraIndexLine is the read-side view of one cameras/<source>/index.jsonl
+// record, naming only the fields the remux needs. The writer's full record
+// lives with the camera adapter in the agent.
+type cameraIndexLine struct {
+	CanonicalEpisodeNanos int64  `json:"canonical_episode_nanos"`
+	Segment               string `json:"segment"`
+	ByteOffset            int64  `json:"byte_offset"`
+	ByteSize              int    `json:"byte_size"`
+	Codec                 string `json:"codec"`
+}
+
+// readCameraIndex reads the frame index and returns its H.264 frames sorted by
+// canonical episode time. Lines that are not valid records, which is what the
+// tail of an interrupted episode's index looks like, are counted and skipped
+// rather than guessed at.
+func readCameraIndex(path string) ([]cameraIndexLine, ClipResult, error) {
+	var result ClipResult
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, result, err
+	}
+	var frames []cameraIndexLine
+	for _, line := range strings.Split(string(b), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		result.IndexLines++
+		var rec cameraIndexLine
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			result.Unparsed++
+			continue
+		}
+		if rec.Segment == "" || rec.ByteSize <= 0 || !strings.HasSuffix(strings.ToLower(rec.Segment), ".h264") {
+			result.Unparsed++
+			continue
+		}
+		frames = append(frames, rec)
+	}
+	sort.SliceStable(frames, func(i, j int) bool {
+		return frames[i].CanonicalEpisodeNanos < frames[j].CanonicalEpisodeNanos
+	})
+	return frames, result, nil
+}
+
+// sample is one muxed access unit: its presentation time in media ticks, where
+// its bytes landed in mdat, and whether a decoder can start on it.
+type sample struct {
+	timestamp int64
+	offset    int64
+	size      int64
+	sync      bool
+}
+
+type muxStats struct {
+	frames, skipped, segments int
+	min, max, mean            time.Duration
+	bFrames                   bool
+}
+
+// isBSlice reports whether a VCL NAL unit carries a B slice. It matters
+// because the index records frames in capture order, which is coded order, and
+// this remux presents them in that same order. That is exact for the
+// B-frame-free streams the device's own encoder produces, but a stream with B
+// slices has a presentation order that differs from its coded order, and
+// recovering it needs picture order counts the index does not carry. Such a
+// stream is flagged rather than silently mistimed.
+func isBSlice(nal []byte) bool {
+	if len(nal) < 2 {
+		return false
+	}
+	r := &bitReader{b: unescapeRBSP(nal)}
+	r.skip(8) // nal_unit_header
+	r.ue()    // first_mb_in_slice
+	sliceType := r.ue()
+	if r.err != nil {
+		return false
+	}
+	return sliceType == 1 || sliceType == 6
+}
+
+// muxAnnexBToMP4 writes a complete MP4 to w. Sample payloads are streamed
+// straight from the segment files into mdat, so peak memory does not grow with
+// the length of the episode; the sample table is then written from the offsets
+// and sizes that streaming recorded.
+func muxAnnexBToMP4(w *os.File, episodeDir string, frames []cameraIndexLine) (muxStats, error) {
+	var stats muxStats
+	segments := &segmentReader{root: episodeDir, seen: map[string]bool{}}
+	defer segments.Close()
+
+	ftyp := box("ftyp", concat(
+		[]byte("isom"), u32(0x200),
+		[]byte("isom"), []byte("iso2"), []byte("avc1"), []byte("mp41"),
+	))
+	if _, err := w.Write(ftyp); err != nil {
+		return stats, err
+	}
+	// A 64-bit mdat header is written unconditionally so its payload size,
+	// known only once every sample has been copied, can be patched in place
+	// without moving any sample bytes.
+	const mdatHeader = int64(16)
+	mdatStart := int64(len(ftyp))
+	if _, err := w.Write(concat(u32(1), []byte("mdat"), u64(0))); err != nil {
+		return stats, err
+	}
+
+	var (
+		samples  []sample
+		sps, pps []byte
+		cursor   = mdatStart + mdatHeader
+	)
+	base := frames[0].CanonicalEpisodeNanos
+	for _, frame := range frames {
+		payload, err := segments.read(frame)
+		if err != nil {
+			// A frame the index names but whose bytes are missing or short is
+			// dropped and counted. Writing the bytes that do exist would put a
+			// truncated access unit in the file and make it undecodable from
+			// that point on.
+			stats.skipped++
+			continue
+		}
+		var (
+			body []byte
+			sync bool
+		)
+		for _, nal := range splitAnnexB(payload) {
+			if len(nal) == 0 {
+				continue
+			}
+			switch nal[0] & 0x1f {
+			case 7: // sequence parameter set, carried in avcC instead
+				if sps == nil {
+					sps = append([]byte(nil), nal...)
+				}
+				continue
+			case 8: // picture parameter set, carried in avcC instead
+				if pps == nil {
+					pps = append([]byte(nil), nal...)
+				}
+				continue
+			case 9, 12: // access unit delimiter, filler
+				continue
+			case 5: // coded slice of an IDR picture
+				sync = true
+				stats.bFrames = stats.bFrames || isBSlice(nal)
+			case 1: // coded slice of a non-IDR picture
+				stats.bFrames = stats.bFrames || isBSlice(nal)
+			}
+			body = append(body, u32(uint32(len(nal)))...)
+			body = append(body, nal...)
+		}
+		if len(body) == 0 {
+			stats.skipped++
+			continue
+		}
+		if _, err := w.Write(body); err != nil {
+			return stats, err
+		}
+		samples = append(samples, sample{
+			// Rounded from the recorded nanoseconds. Never derived from a rate.
+			timestamp: (frame.CanonicalEpisodeNanos - base + 500) / 1000,
+			offset:    cursor,
+			size:      int64(len(body)),
+			sync:      sync,
+		})
+		cursor += int64(len(body))
+	}
+	stats.frames, stats.segments = len(samples), len(segments.seen)
+	if len(samples) == 0 {
+		return stats, fmt.Errorf("no frame payload could be read (%d unreadable)", stats.skipped)
+	}
+	if sps == nil || pps == nil {
+		return stats, errors.New("stream carries no SPS/PPS, so no decoder configuration can be written")
+	}
+	width, height, err := spsDimensions(sps)
+	if err != nil {
+		return stats, fmt.Errorf("reading picture size from SPS: %w", err)
+	}
+
+	if _, err := w.WriteAt(u64(uint64(cursor-mdatStart)), mdatStart+8); err != nil {
+		return stats, err
+	}
+	if _, err := w.Seek(cursor, io.SeekStart); err != nil {
+		return stats, err
+	}
+	moov, durations, err := buildMoov(samples, sps, pps, width, height)
+	if err != nil {
+		return stats, err
+	}
+	if _, err := w.Write(moov); err != nil {
+		return stats, err
+	}
+	stats.min, stats.max, stats.mean = intervalSpread(durations)
+	return stats, nil
+}
+
+// intervalSpread summarises the inter-frame intervals written, over the
+// intervals between consecutive frames only: the final sample's hold time is
+// not a measured interval and is excluded.
+func intervalSpread(durations []uint32) (min, max, mean time.Duration) {
+	if len(durations) < 2 {
+		return 0, 0, 0
+	}
+	measured := durations[:len(durations)-1]
+	lo, hi, total := measured[0], measured[0], uint64(0)
+	for _, d := range measured {
+		if d < lo {
+			lo = d
+		}
+		if d > hi {
+			hi = d
+		}
+		total += uint64(d)
+	}
+	tick := time.Second / playableTimescale
+	return time.Duration(lo) * tick,
+		time.Duration(hi) * tick,
+		time.Duration(total/uint64(len(measured))) * tick
+}
+
+// segmentReader reads frame payloads out of the episode's segment files,
+// keeping the current segment open across the run of frames that share it. The
+// index's segment paths are episode-relative, so several segments per source
+// and several sources per episode both fall out naturally.
+type segmentReader struct {
+	root string
+	name string
+	file *os.File
+	size int64
+	seen map[string]bool
+}
+
+func (s *segmentReader) read(frame cameraIndexLine) ([]byte, error) {
+	if s.name != frame.Segment {
+		s.close()
+		f, err := os.Open(filepath.Join(s.root, filepath.FromSlash(frame.Segment)))
+		if err != nil {
+			return nil, err
+		}
+		info, err := f.Stat()
+		if err != nil {
+			f.Close()
+			return nil, err
+		}
+		s.name, s.file, s.size = frame.Segment, f, info.Size()
+		s.seen[frame.Segment] = true
+	}
+	// byte_size from the index is authoritative for how many bytes belong to
+	// this frame. The model-input ledger's payload_bytes can exceed it for a
+	// frame that opens a segment, because the segment begins at the
+	// parameter-set prefix inside that payload rather than at its first byte.
+	if frame.ByteOffset < 0 || frame.ByteOffset+int64(frame.ByteSize) > s.size {
+		return nil, fmt.Errorf("frame at offset %d size %d exceeds %s (%d bytes on disk)",
+			frame.ByteOffset, frame.ByteSize, frame.Segment, s.size)
+	}
+	buf := make([]byte, frame.ByteSize)
+	if _, err := io.ReadFull(io.NewSectionReader(s.file, frame.ByteOffset, int64(frame.ByteSize)), buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+func (s *segmentReader) close() {
+	if s.file != nil {
+		s.file.Close()
+	}
+	s.name, s.file, s.size = "", nil, 0
+}
+
+func (s *segmentReader) Close() { s.close() }
+
+// splitAnnexB returns the NAL unit payloads in an Annex-B byte stream, without
+// their start-code prefixes.
+func splitAnnexB(b []byte) [][]byte {
+	var out [][]byte
+	start := -1
+	for i := 0; i+2 < len(b); {
+		if b[i] == 0 && b[i+1] == 0 && b[i+2] == 1 {
+			if start >= 0 {
+				end := i
+				// A start code may be preceded by the fourth zero of a 4-byte
+				// prefix, which is not part of the preceding unit.
+				if end > start && b[end-1] == 0 {
+					end--
+				}
+				out = append(out, b[start:end])
+			}
+			i += 3
+			start = i
+			continue
+		}
+		i++
+	}
+	if start >= 0 && start < len(b) {
+		out = append(out, b[start:])
+	}
+	return out
+}
+
+// spsDimensions reads the coded picture size, in luma samples, out of an H.264
+// sequence parameter set. The size has to go into the track header and the
+// sample entry, and taking it from the bitstream avoids trusting a configured
+// resolution the camera may not have honoured.
+func spsDimensions(sps []byte) (int, int, error) {
+	r := &bitReader{b: unescapeRBSP(sps)}
+	if len(r.b) < 4 {
+		return 0, 0, errors.New("SPS too short")
+	}
+	r.skip(8) // nal_unit_header
+	profile := r.bits(8)
+	r.skip(8) // constraint flags and reserved bits
+	r.skip(8) // level_idc
+	r.ue()    // seq_parameter_set_id
+	chroma := uint64(1)
+	switch profile {
+	case 100, 110, 122, 244, 44, 83, 86, 118, 128, 138, 139, 134, 135:
+		chroma = r.ue()
+		if chroma == 3 {
+			r.skip(1) // separate_colour_plane_flag
+		}
+		r.ue()    // bit_depth_luma_minus8
+		r.ue()    // bit_depth_chroma_minus8
+		r.skip(1) // qpprime_y_zero_transform_bypass_flag
+		if r.bits(1) == 1 {
+			lists := 8
+			if chroma == 3 {
+				lists = 12
+			}
+			for i := 0; i < lists; i++ {
+				if r.bits(1) != 1 {
+					continue
+				}
+				size := 16
+				if i >= 6 {
+					size = 64
+				}
+				last, next := 8, 8
+				for j := 0; j < size && next != 0; j++ {
+					next = (last + int(r.se()) + 256) % 256
+					if next != 0 {
+						last = next
+					}
+				}
+			}
+		}
+	}
+	r.ue() // log2_max_frame_num_minus4
+	switch r.ue() {
+	case 0:
+		r.ue() // log2_max_pic_order_cnt_lsb_minus4
+	case 1:
+		r.skip(1)
+		r.se()
+		r.se()
+		for n := r.ue(); n > 0; n-- {
+			r.se()
+		}
+	}
+	r.ue()    // max_num_ref_frames
+	r.skip(1) // gaps_in_frame_num_value_allowed_flag
+	widthMBs := r.ue() + 1
+	heightMapUnits := r.ue() + 1
+	frameMBsOnly := r.bits(1)
+	if frameMBsOnly == 0 {
+		r.skip(1) // mb_adaptive_frame_field_flag
+	}
+	r.skip(1) // direct_8x8_inference_flag
+	var cropLeft, cropRight, cropTop, cropBottom uint64
+	if r.bits(1) == 1 { // frame_cropping_flag
+		cropLeft, cropRight, cropTop, cropBottom = r.ue(), r.ue(), r.ue(), r.ue()
+	}
+	if r.err != nil {
+		return 0, 0, r.err
+	}
+	// Crop offsets are counted in chroma sampling units: CropUnitX is SubWidthC
+	// and CropUnitY is SubHeightC times (2 - frame_mbs_only_flag).
+	subWidth, subHeight := uint64(2), uint64(2)
+	switch chroma {
+	case 0, 3:
+		subWidth, subHeight = 1, 1
+	case 2:
+		subWidth, subHeight = 2, 1
+	}
+	frameHeightMBs := (2 - frameMBsOnly) * heightMapUnits
+	width := int(widthMBs*16 - (cropLeft+cropRight)*subWidth)
+	height := int(frameHeightMBs*16 - (cropTop+cropBottom)*subHeight*(2-frameMBsOnly))
+	if width <= 0 || height <= 0 || width > 0xFFFF || height > 0xFFFF {
+		return 0, 0, fmt.Errorf("SPS yields an impossible picture size %dx%d", width, height)
+	}
+	return width, height, nil
+}
+
+// unescapeRBSP removes H.264 emulation prevention bytes.
+func unescapeRBSP(b []byte) []byte {
+	out := make([]byte, 0, len(b))
+	zeros := 0
+	for _, c := range b {
+		if zeros == 2 && c == 3 {
+			zeros = 0
+			continue
+		}
+		if c == 0 {
+			zeros++
+		} else {
+			zeros = 0
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+type bitReader struct {
+	b   []byte
+	pos int
+	err error
+}
+
+func (r *bitReader) bits(n int) uint64 {
+	var v uint64
+	for i := 0; i < n; i++ {
+		if r.pos >= len(r.b)*8 {
+			r.err = io.ErrUnexpectedEOF
+			return v
+		}
+		bit := (r.b[r.pos/8] >> (7 - uint(r.pos%8))) & 1
+		v = v<<1 | uint64(bit)
+		r.pos++
+	}
+	return v
+}
+
+func (r *bitReader) skip(n int) { r.bits(n) }
+
+func (r *bitReader) ue() uint64 {
+	zeros := 0
+	for {
+		if r.err != nil {
+			return 0
+		}
+		if r.bits(1) == 1 {
+			break
+		}
+		zeros++
+		if zeros > 32 {
+			r.err = errors.New("malformed exp-Golomb code")
+			return 0
+		}
+	}
+	if zeros == 0 {
+		return 0
+	}
+	return (1<<uint(zeros) - 1) + r.bits(zeros)
+}
+
+func (r *bitReader) se() int64 {
+	v := r.ue()
+	if v%2 == 0 {
+		return -int64(v / 2)
+	}
+	return int64((v + 1) / 2)
+}
+
+// buildMoov assembles the movie header and returns it with the per-sample
+// durations it wrote. All timing lives in stts, which carries an explicit
+// duration for every sample, so the variable capture rate survives into the
+// container instead of being flattened to an average.
+func buildMoov(samples []sample, sps, pps []byte, width, height int) ([]byte, []uint32, error) {
+	if len(sps) < 4 {
+		return nil, nil, errors.New("SPS too short for a decoder configuration record")
+	}
+	if len(sps) > 0xFFFF || len(pps) > 0xFFFF {
+		return nil, nil, errors.New("parameter set too large for a decoder configuration record")
+	}
+	durations := make([]uint32, len(samples))
+	for i := range samples {
+		if i+1 < len(samples) {
+			d := samples[i+1].timestamp - samples[i].timestamp
+			if d < 0 {
+				d = 0
+			}
+			durations[i] = uint32(d)
+			continue
+		}
+		// The final frame has no successor in the index, so nothing recorded
+		// how long it was shown. It is held for the length of the last measured
+		// interval: the single value here not read from the index, chosen
+		// because a zero-length final sample confuses players, and bounded so
+		// the clip's duration still matches the index span to within one frame.
+		if i > 0 {
+			durations[i] = durations[i-1]
+		}
+	}
+	var total uint64
+	for _, d := range durations {
+		total += uint64(d)
+	}
+
+	var sttsEntries []byte
+	runs := 0
+	for i := 0; i < len(durations); {
+		j := i
+		for j < len(durations) && durations[j] == durations[i] {
+			j++
+		}
+		sttsEntries = append(sttsEntries, u32(uint32(j-i))...)
+		sttsEntries = append(sttsEntries, u32(durations[i])...)
+		runs++
+		i = j
+	}
+	stts := box("stts", concat(u32(0), u32(uint32(runs)), sttsEntries))
+
+	var stssEntries []byte
+	syncs := 0
+	for i, s := range samples {
+		if s.sync {
+			stssEntries = append(stssEntries, u32(uint32(i+1))...)
+			syncs++
+		}
+	}
+	stss := box("stss", concat(u32(0), u32(uint32(syncs)), stssEntries))
+
+	var stszEntries []byte
+	for _, s := range samples {
+		if s.size > 0xFFFFFFFF {
+			return nil, nil, fmt.Errorf("sample of %d bytes is too large for MP4", s.size)
+		}
+		stszEntries = append(stszEntries, u32(uint32(s.size))...)
+	}
+	stsz := box("stsz", concat(u32(0), u32(0), u32(uint32(len(samples))), stszEntries))
+
+	// One sample per chunk keeps the sample-to-chunk map trivial and lets every
+	// sample's absolute file offset be stated directly.
+	stsc := box("stsc", concat(u32(0), u32(1), u32(1), u32(1), u32(1)))
+	var co64Entries []byte
+	for _, s := range samples {
+		co64Entries = append(co64Entries, u64(uint64(s.offset))...)
+	}
+	co64 := box("co64", concat(u32(0), u32(uint32(len(samples))), co64Entries))
+
+	avcC := concat(
+		[]byte{1, sps[1], sps[2], sps[3], 0xFF, 0xE1},
+		u16(uint16(len(sps))), sps,
+		[]byte{1},
+		u16(uint16(len(pps))), pps,
+	)
+	compressor := make([]byte, 32)
+	compressor[0] = byte(len("WendyOS episode remux"))
+	copy(compressor[1:], "WendyOS episode remux")
+	avc1 := box("avc1", concat(
+		make([]byte, 6), u16(1), // reserved, data_reference_index
+		make([]byte, 16), // pre_defined and reserved
+		u16(uint16(width)), u16(uint16(height)),
+		u32(0x00480000), u32(0x00480000), // 72 dpi horizontal and vertical
+		u32(0), u16(1), // reserved, frame_count
+		compressor,
+		u16(0x18), u16(0xFFFF), // depth, pre_defined
+		box("avcC", avcC),
+	))
+	stsd := box("stsd", concat(u32(0), u32(1), avc1))
+
+	stbl := box("stbl", concat(stsd, stts, stss, stsz, stsc, co64))
+	dinf := box("dinf", box("dref", concat(u32(0), u32(1), box("url ", u32(1)))))
+	vmhd := box("vmhd", concat(u32(1), u16(0), u16(0), u16(0), u16(0)))
+	minf := box("minf", concat(vmhd, dinf, stbl))
+	hdlr := box("hdlr", concat(u32(0), u32(0), []byte("vide"), make([]byte, 12), []byte("WendyOS episode camera\x00")))
+	mdhd := box("mdhd", concat(
+		[]byte{1, 0, 0, 0}, // version 1, so durations are 64-bit
+		u64(0), u64(0), u32(playableTimescale), u64(total),
+		u16(0x55C4), u16(0), // language "und"
+	))
+	mdia := box("mdia", concat(mdhd, hdlr, minf))
+	tkhd := box("tkhd", concat(
+		[]byte{1, 0, 0, 3}, // version 1, track enabled and in movie
+		u64(0), u64(0), u32(1), u32(0), u64(total),
+		make([]byte, 8), u16(0), u16(0), u16(0), u16(0),
+		unityMatrix(),
+		u32(uint32(width)<<16), u32(uint32(height)<<16),
+	))
+	trak := box("trak", concat(tkhd, mdia))
+	mvhd := box("mvhd", concat(
+		[]byte{1, 0, 0, 0},
+		u64(0), u64(0), u32(playableTimescale), u64(total),
+		u32(0x00010000), u16(0x0100), u16(0),
+		make([]byte, 8),
+		unityMatrix(),
+		make([]byte, 24),
+		u32(2),
+	))
+	return box("moov", concat(mvhd, trak)), durations, nil
+}
+
+func unityMatrix() []byte {
+	return concat(u32(0x00010000), u32(0), u32(0), u32(0), u32(0x00010000), u32(0), u32(0), u32(0), u32(0x40000000))
+}
+
+func box(kind string, payload ...[]byte) []byte {
+	body := concat(payload...)
+	out := make([]byte, 0, 8+len(body))
+	out = append(out, u32(uint32(8+len(body)))...)
+	out = append(out, kind...)
+	return append(out, body...)
+}
+
+func concat(parts ...[]byte) []byte {
+	n := 0
+	for _, p := range parts {
+		n += len(p)
+	}
+	out := make([]byte, 0, n)
+	for _, p := range parts {
+		out = append(out, p...)
+	}
+	return out
+}
+
+func u16(v uint16) []byte { b := make([]byte, 2); binary.BigEndian.PutUint16(b, v); return b }
+func u32(v uint32) []byte { b := make([]byte, 4); binary.BigEndian.PutUint32(b, v); return b }
+func u64(v uint64) []byte { b := make([]byte, 8); binary.BigEndian.PutUint64(b, v); return b }

--- a/go/internal/episodeexport/playable_test.go
+++ b/go/internal/episodeexport/playable_test.go
@@ -1,0 +1,304 @@
+package episodeexport
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// realSPS and realPPS are the parameter sets from an episode recorded on a
+// Jetson at 1280x720, so the SPS parser is exercised against the bitstream the
+// device actually produces rather than a hand-made one.
+const (
+	realSPS = "6764001facb200a00b7602dc08081a94000003000400000300f23c60c920"
+	realPPS = "68ebccb22c"
+)
+
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("decoding fixture: %v", err)
+	}
+	return b
+}
+
+func TestSPSDimensionsFromRealStream(t *testing.T) {
+	w, h, err := spsDimensions(mustHex(t, realSPS))
+	if err != nil {
+		t.Fatalf("spsDimensions: %v", err)
+	}
+	if w != 1280 || h != 720 {
+		t.Errorf("got %dx%d, want 1280x720", w, h)
+	}
+}
+
+func TestSplitAnnexBHandlesBothStartCodePrefixes(t *testing.T) {
+	// Three units: a 4-byte prefix, then a 3-byte prefix, then a 4-byte prefix.
+	stream := []byte{0, 0, 0, 1, 0x67, 0xAA, 0, 0, 1, 0x68, 0xBB, 0xCC, 0, 0, 0, 1, 0x65, 0xDD}
+	units := splitAnnexB(stream)
+	if len(units) != 3 {
+		t.Fatalf("got %d units, want 3: %v", len(units), units)
+	}
+	for i, want := range [][]byte{{0x67, 0xAA}, {0x68, 0xBB, 0xCC}, {0x65, 0xDD}} {
+		if string(units[i]) != string(want) {
+			t.Errorf("unit %d = % x, want % x", i, units[i], want)
+		}
+	}
+}
+
+// annexB frames the given NAL units as an Annex-B access unit.
+func annexB(nals ...[]byte) []byte {
+	var out []byte
+	for _, n := range nals {
+		out = append(out, 0, 0, 0, 1)
+		out = append(out, n...)
+	}
+	return out
+}
+
+// buildEpisode lays out a synthetic episode with two camera sources. cam-a
+// spans two segments with deliberately irregular frame intervals; cam-b holds
+// one frame whose index entry points past the end of its segment plus a partial
+// trailing line, which is the shape an interrupted episode leaves behind.
+func buildEpisode(t *testing.T) (dir string, wantIntervals []time.Duration) {
+	t.Helper()
+	dir = t.TempDir()
+	sps, pps := mustHex(t, realSPS), mustHex(t, realPPS)
+	idr := append([]byte{0x65}, make([]byte, 40)...)
+	slice := append([]byte{0x41}, make([]byte, 30)...)
+
+	// Intervals chosen so that no two are equal: a constant rate could not
+	// reproduce them, so the test fails if one is ever assumed.
+	gaps := []time.Duration{25 * time.Millisecond, 61 * time.Millisecond, 104 * time.Millisecond, 33 * time.Millisecond}
+	wantIntervals = gaps
+
+	type entry struct {
+		CanonicalEpisodeNanos int64  `json:"canonical_episode_nanos"`
+		Segment               string `json:"segment"`
+		ByteOffset            int64  `json:"byte_offset"`
+		ByteSize              int    `json:"byte_size"`
+		Codec                 string `json:"codec"`
+	}
+
+	camA := filepath.Join(dir, "cameras", "cam-a")
+	if err := os.MkdirAll(camA, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Each segment opens with SPS/PPS/IDR, as the capture pipeline arranges.
+	first := annexB(sps, pps, idr)
+	later := annexB(slice)
+	var (
+		seg1, seg2 []byte
+		lines      []entry
+		now        = int64(5_000_000_000) // an arbitrary non-zero episode origin
+	)
+	for i := 0; i < 3; i++ {
+		payload := later
+		if i == 0 {
+			payload = first
+		}
+		lines = append(lines, entry{now, "cameras/cam-a/segment-000001.h264", int64(len(seg1)), len(payload), "h264"})
+		seg1 = append(seg1, payload...)
+		now += int64(gaps[i])
+	}
+	// A second segment, opening with its own parameter sets and keyframe.
+	lines = append(lines, entry{now, "cameras/cam-a/segment-000002.h264", 0, len(first), "h264"})
+	seg2 = append(seg2, first...)
+	now += int64(gaps[3])
+	lines = append(lines, entry{now, "cameras/cam-a/segment-000002.h264", int64(len(seg2)), len(later), "h264"})
+	seg2 = append(seg2, later...)
+
+	write := func(path string, b []byte) {
+		if err := os.WriteFile(path, b, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(filepath.Join(camA, "segment-000001.h264"), seg1)
+	write(filepath.Join(camA, "segment-000002.h264"), seg2)
+	var index []byte
+	for _, l := range lines {
+		b, _ := json.Marshal(l)
+		index = append(index, b...)
+		index = append(index, '\n')
+	}
+	write(filepath.Join(camA, "index.jsonl"), index)
+
+	camB := filepath.Join(dir, "cameras", "cam-b")
+	if err := os.MkdirAll(camB, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write(filepath.Join(camB, "segment-000001.h264"), first)
+	bIndex, _ := json.Marshal(entry{1_000, "cameras/cam-b/segment-000001.h264", 0, len(first), "h264"})
+	missing, _ := json.Marshal(entry{50_000_000, "cameras/cam-b/segment-000001.h264", 1 << 20, 999, "h264"})
+	write(filepath.Join(camB, "index.jsonl"),
+		append(append(append(bIndex, '\n'), append(missing, '\n')...), []byte(`{"canonical_episode_na`)...))
+	return dir, wantIntervals
+}
+
+func TestConvertRealShapes(t *testing.T) {
+	dir, gaps := buildEpisode(t)
+	before := snapshot(t, dir)
+	out := filepath.Join(t.TempDir(), "playable")
+
+	results, errs := Convert(dir, out)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want one per camera source", len(results))
+	}
+
+	byName := map[string]ClipResult{}
+	for _, r := range results {
+		byName[r.Source] = r
+	}
+
+	a := byName["cam-a"]
+	if a.IndexLines != 5 || a.Frames != 5 {
+		t.Errorf("cam-a: index lines %d, frames %d; want 5 and 5", a.IndexLines, a.Frames)
+	}
+	if a.Segments != 2 {
+		t.Errorf("cam-a read %d segments, want 2", a.Segments)
+	}
+	if a.Skipped != 0 {
+		t.Errorf("cam-a skipped %d frames, want 0", a.Skipped)
+	}
+	var wantSpan time.Duration
+	for _, g := range gaps {
+		wantSpan += g
+	}
+	if a.Span != wantSpan {
+		t.Errorf("cam-a span %s, want %s", a.Span, wantSpan)
+	}
+	// The whole point: the spread of intervals survives. A muxer that assumed
+	// any single rate would report min == max == mean here.
+	if a.MinInterval != 25*time.Millisecond || a.MaxInterval != 104*time.Millisecond {
+		t.Errorf("cam-a intervals min %s max %s; want 25ms and 104ms", a.MinInterval, a.MaxInterval)
+	}
+	if a.MinInterval == a.MaxInterval {
+		t.Error("cam-a interval spread was flattened to a constant rate")
+	}
+
+	// A frame whose bytes are missing is reported and skipped, and a partial
+	// trailing line is counted as unusable, but the clip is still written.
+	b := byName["cam-b"]
+	if b.Frames != 1 || b.Skipped != 1 || b.Unparsed != 1 {
+		t.Errorf("cam-b: frames %d, skipped %d, unparsed %d; want 1, 1, 1", b.Frames, b.Skipped, b.Unparsed)
+	}
+	if b.Output == "" {
+		t.Error("cam-b produced no file despite having one good frame")
+	}
+
+	// The MP4's sample table must carry each recorded interval explicitly.
+	assertSampleDurations(t, a.Output, gaps)
+
+	// The episode itself is archival truth and must be untouched.
+	if after := snapshot(t, dir); after != before {
+		t.Errorf("episode directory was modified:\nbefore %s\nafter  %s", before, after)
+	}
+}
+
+// assertSampleDurations decodes the stts box and checks that the durations are
+// exactly the recorded intervals, with the final sample held for the last
+// measured interval.
+func assertSampleDurations(t *testing.T, path string, gaps []time.Duration) {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	i := indexOf(b, []byte("stts"))
+	if i < 0 {
+		t.Fatal("no stts box in output")
+	}
+	count := binary.BigEndian.Uint32(b[i+8:])
+	var got []time.Duration
+	for e := 0; e < int(count); e++ {
+		off := i + 12 + e*8
+		n := binary.BigEndian.Uint32(b[off:])
+		d := binary.BigEndian.Uint32(b[off+4:])
+		for k := uint32(0); k < n; k++ {
+			got = append(got, time.Duration(d)*time.Microsecond)
+		}
+	}
+	want := append(append([]time.Duration{}, gaps...), gaps[len(gaps)-1])
+	if len(got) != len(want) {
+		t.Fatalf("stts holds %d samples (%v), want %d (%v)", len(got), got, len(want), want)
+	}
+	for k := range want {
+		if got[k] != want[k] {
+			t.Errorf("sample %d duration %s, want %s", k, got[k], want[k])
+		}
+	}
+}
+
+func indexOf(haystack, needle []byte) int {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		match := true
+		for j := range needle {
+			if haystack[i+j] != needle[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return i
+		}
+	}
+	return -1
+}
+
+// snapshot fingerprints every file in dir by name, size and content, so any
+// modification to the episode is detectable.
+func snapshot(t *testing.T, dir string) string {
+	t.Helper()
+	out := ""
+	err := filepath.Walk(dir, func(p string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		b, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(dir, p)
+		out += fmt.Sprintf("%s:%d:%x\n", rel, len(b), sum(b))
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+func sum(b []byte) uint64 {
+	var h uint64 = 14695981039346656037
+	for _, c := range b {
+		h = (h ^ uint64(c)) * 1099511628211
+	}
+	return h
+}
+
+func TestConvertRejectsNonEpisodeDirectory(t *testing.T) {
+	_, errs := Convert(t.TempDir(), filepath.Join(t.TempDir(), "out"))
+	if len(errs) == 0 {
+		t.Fatal("expected an error for a directory holding no camera index")
+	}
+}
+
+func TestIsBSlice(t *testing.T) {
+	// first_mb_in_slice = 0 ("1"), slice_type = 1 ("010") -> B slice.
+	if !isBSlice([]byte{0x41, 0xA0}) {
+		t.Error("slice_type 1 should be reported as a B slice")
+	}
+	// first_mb_in_slice = 0 ("1"), slice_type = 0 ("1") -> P slice.
+	if isBSlice([]byte{0x41, 0xC0}) {
+		t.Error("slice_type 0 is a P slice, not a B slice")
+	}
+}


### PR DESCRIPTION
## Problem

Episode camera clips are unplayable in standard players. Opened in VLC or QuickTime, a clip runs at the wrong speed and reports the wrong duration.

## Cause

Capture keeps a raw H.264 Annex-B elementary stream (`cameras/<source>/segment-NNNNNN.h264`). An elementary stream has no container and therefore carries no timing at all, so a player has nothing to build a presentation schedule from and invents a frame rate instead.

Supplying a fixed rate is not the fix, and is wrong by construction: the capture rate is genuinely variable, falling as the device gets busy with inference. One measured episode held 176 frames across 9.95 s, an average near 17.7 Hz, while its actual inter-frame interval ranged from 25.8 ms to 103.0 ms, a factor of four. No single rate describes more than a fraction of such a clip.

## Solution

The timing was recorded all along. `cameras/<source>/index.jsonl` carries one line per kept frame with `canonical_episode_nanos`, the frame's position on the episode's canonical `CLOCK_BOOTTIME` timeline, alongside the segment file, byte offset and `byte_size` of its payload.

The new `episode-playable` command remuxes those same payload bytes into an MP4 whose sample table states an explicit duration for every sample, taken from those recorded timestamps. Nothing computes, averages, or assumes a rate.

```sh
CGO_ENABLED=0 go build -o bin/episode-playable ./go/cmd/episode-playable
wendy data download <id> -o /abs/path/episode --device <host>
./bin/episode-playable -o /abs/path/playable /abs/path/episode
```

### Design notes

- **MP4, not Matroska.** The output has to play unmodified in both VLC and QuickTime, and QuickTime cannot open Matroska at all. MP4's explicit per-sample `stts` durations represent a variable frame rate exactly as precisely as Matroska timestamps do.
- **No external dependency.** The muxer is pure Go, so there is no ffmpeg, mkvmerge or PyAV anywhere on the path from an episode to a playable file, and so nothing that can be absent and produce a broken file.
- **Read-side only.** The episode is never modified; output goes to a separate directory. The elementary stream and its index are checksummed archival truth, and `index.jsonl` addresses frames by byte offset within the stream, so rewriting it in place would break the join between a frame and the model input recorded against it. Nothing in the device write path or the sealing path is touched.
- **A remux, not a transcode.** Coded pictures are copied verbatim.

### Real shapes handled

Several segments per source; several sources per episode; a frame whose bytes are missing or truncated (reported and skipped, never written short, since a truncated access unit makes the file undecodable from that point on); and the partial trailing index line an interrupted episode leaves behind. `byte_size` from the index is authoritative for reading bytes, because the model-input ledger's `payload_bytes` can exceed it for a frame that opens a segment. A stream containing B slices, whose presentation order differs from the coded order the index records, is flagged with a warning rather than silently mistimed.

## Verification, on a real episode from `wendyos-fernando.local`

| Check | Result |
|---|---|
| Frame count vs index line count | 176 vs 176 |
| Presentation span vs index span | 9.953599 s vs 9.953599174 s |
| Container duration | 10.016263 s (span plus a one-frame hold for the final sample) |
| Decodes end to end | clean, no errors |
| Inter-frame min / mean / max | 25.757 ms / 56.878 ms / 103.037 ms, 175 distinct values, ratio 4.0 |
| Episode files afterwards | byte-identical, 0 of 6 changed |
| Picture size | 1280x720, read from the SPS |
| QuickTime engine (AVFoundation) | readable, duration 10.016263 s, 1280x720 |

The interval spread is the point: min, mean and max all differ by a wide margin, so the variable rate is preserved rather than flattened to an average.

One note on `ffmpeg -v error -i out.mp4 -f null -`: it emits a single non-monotonic-dts warning from the *null muxer*, whose output timebase is too coarse to separate genuinely variable intervals. Remuxing the same file with ffmpeg itself (`-c copy`) and re-running the test produces the identical warning at the identical frame, which confirms it is a property of the null muxer rather than of this file. Decoding is clean under `-f rawvideo` and under `ffprobe -count_frames`.

Unit tests cover the SPS parser against parameter sets from a real device stream, Annex-B splitting across both start-code prefix lengths, B-slice detection both ways, and an end-to-end conversion of a synthetic episode with two sources, two segments, a missing-bytes frame and a partial index tail, asserting the exact per-sample `stts` durations and that the episode directory is unchanged.

## Follow-up

`wendy data export` is the natural future home, at which point this becomes a CLI verb rather than a separate binary. It ships standalone so it needs no change to the CLI's command surface today.