### PR TITLE
fix(data): stop blocking episode start on the Roughtime consensus

### DIFF
--- a/go/internal/agent/data/manager.go
+++ b/go/internal/agent/data/manager.go
@@ -171,7 +171,14 @@ type activeEpisode struct {
 	// fsynced per sample: at sensor rates that would dominate the write path,
 	// and a torn tail is recovered exactly like every other episode JSONL.
 	modelInputs *os.File
+	// awaitConsensus reports that the episode's opening Roughtime consensus was
+	// moved off the start path and is still to be attached (see Start).
+	awaitConsensus bool
 }
+
+// consensusQueryTimeout bounds one Roughtime consensus query. It is the budget
+// for the slowest server in the pool, so an unreachable server costs this long.
+const consensusQueryTimeout = 5 * time.Second
 
 func NewManager(root string) (*Manager, error) {
 	implicitRoot := root == ""
@@ -277,9 +284,20 @@ func (m *Manager) Start(opts StartOptions) (Manifest, error) {
 	if err != nil {
 		return Manifest{}, err
 	}
+	// The Roughtime consensus is a network round trip to several public servers,
+	// and an unreachable server is only known once its 5s timeout expires. On
+	// the critical path it postpones every capture adapter by that timeout, and
+	// the camera cannot record what happened while it waited. It is therefore
+	// queried in the background and attached to the episode when it lands
+	// (deferConsensus), exactly as the in-episode clock sampler already does.
+	//
+	// The one case that still has to block is an episode whose caller demanded a
+	// UTC uncertainty bound: that gate can reject the episode, so its evidence
+	// must exist before recording begins.
+	deferConsensus := m.consensus != nil && opts.RequireUTCUncertainty <= 0
 	var consensus *timesync.Consensus
-	if m.consensus != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	if m.consensus != nil && !deferConsensus {
+		ctx, cancel := context.WithTimeout(context.Background(), consensusQueryTimeout)
 		c, queryErr := m.consensus(ctx)
 		cancel()
 		if queryErr == nil {
@@ -414,7 +432,7 @@ func (m *Manager) Start(opts StartOptions) (Manifest, error) {
 		_ = os.RemoveAll(dir)
 		return Manifest{}, err
 	}
-	a := &activeEpisode{key: key, dir: dir, manifest: manifest, capturesApplications: capturesApplications}
+	a := &activeEpisode{key: key, dir: dir, manifest: manifest, capturesApplications: capturesApplications, awaitConsensus: deferConsensus}
 	ctx, cancel := context.WithCancel(context.Background())
 	a.cancel = cancel
 	a.done = make(chan struct{})
@@ -543,6 +561,11 @@ func (m *Manager) sampleEpisode(ctx context.Context, a *activeEpisode) {
 	defer close(a.done)
 	clockTicker := time.NewTicker(5 * time.Minute)
 	defer clockTicker.Stop()
+	if a.awaitConsensus {
+		// Deliberately not waited on: the episode records while this runs, and
+		// the manifest is rewritten under the manager lock when it lands.
+		go m.queryAndAttachConsensus(ctx, a, true)
+	}
 	telemetryTicker := time.NewTicker(time.Second)
 	defer telemetryTicker.Stop()
 	for {
@@ -568,23 +591,38 @@ func (m *Manager) sampleEpisode(ctx context.Context, a *activeEpisode) {
 				m.mu.Unlock()
 			}
 		case <-clockTicker.C:
-			if m.consensus == nil {
-				continue
-			}
-			queryCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-			c, err := m.consensus(queryCtx)
-			cancel()
-			if err != nil {
-				continue
-			}
-			m.mu.Lock()
-			if m.active[a.key] == a {
-				a.manifest.Roughtime = append(a.manifest.Roughtime, c)
-				_ = writeManifest(a.dir, a.manifest)
-			}
-			m.mu.Unlock()
+			m.queryAndAttachConsensus(ctx, a, false)
 		}
 	}
+}
+
+// queryAndAttachConsensus runs one Roughtime consensus query and records it on
+// the episode, rewriting the manifest. opening marks the episode's first
+// consensus, which also settles system_clock_status the way a blocking
+// start-time query used to; later samples only append evidence.
+func (m *Manager) queryAndAttachConsensus(ctx context.Context, a *activeEpisode, opening bool) {
+	if m.consensus == nil {
+		return
+	}
+	queryCtx, cancel := context.WithTimeout(ctx, consensusQueryTimeout)
+	c, err := m.consensus(queryCtx)
+	cancel()
+	if err != nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.active[a.key] != a {
+		return
+	}
+	a.manifest.Roughtime = append(a.manifest.Roughtime, c)
+	if opening {
+		a.awaitConsensus = false
+		if len(a.manifest.UTCObservations) > 0 {
+			a.manifest.SystemClockStatus = clockAgreement(a.manifest.UTCObservations[0], c)
+		}
+	}
+	_ = writeManifest(a.dir, a.manifest)
 }
 
 func (m *Manager) enforceQuota() error {

--- a/go/internal/agent/data/manager_test.go
+++ b/go/internal/agent/data/manager_test.go
@@ -1,6 +1,9 @@
 package data
 
 import (
+	"context"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/timesync"
 	"bytes"
 	"encoding/json"
 	"os"
@@ -334,5 +337,60 @@ func TestSafeJoinRejectsTraversal(t *testing.T) {
 		if _, e := safeJoin("/safe", p); e == nil {
 			t.Errorf("accepted %q", p)
 		}
+	}
+}
+
+// TestStartDoesNotBlockOnRoughtimeConsensus pins the property that made the
+// trigger moment fall out of episode video: a Roughtime server that never
+// answers used to hold Start (and therefore every capture adapter) for the
+// whole query timeout, so the camera began recording seconds after the
+// trigger. The consensus is still recorded, just not on the start path.
+func TestStartDoesNotBlockOnRoughtimeConsensus(t *testing.T) {
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	released := make(chan struct{})
+	queried := make(chan struct{}, 4)
+	m.SetConsensusProvider(func(ctx context.Context) (timesync.Consensus, error) {
+		queried <- struct{}{}
+		select {
+		case <-released:
+		case <-ctx.Done():
+			return timesync.Consensus{}, ctx.Err()
+		}
+		return timesync.Consensus{Confidence: "degraded", Quorum: 2, LowerOffsetNanos: 1, UpperOffsetNanos: 2}, nil
+	})
+
+	start := time.Now()
+	started, err := m.Start(StartOptions{Sources: []string{"applications"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("Start blocked %s on an unresponsive consensus provider; it must not wait", elapsed)
+	}
+
+	// The query still happens, and its result still reaches the manifest.
+	select {
+	case <-queried:
+	case <-time.After(5 * time.Second):
+		t.Fatal("consensus was never queried in the background")
+	}
+	close(released)
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		var manifest Manifest
+		b, readErr := os.ReadFile(filepath.Join(m.root, started.ID+".partial", "manifest.json"))
+		if readErr == nil && json.Unmarshal(b, &manifest) == nil && len(manifest.Roughtime) > 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("background consensus never landed in the manifest")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if _, err := m.Stop(AdHocEpisodeKey); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/go/internal/agent/data/manager_test.go
+++ b/go/internal/agent/data/manager_test.go
@@ -3,9 +3,9 @@ package data
 import (
 	"context"
 
-	"github.com/wendylabsinc/wendy/go/internal/agent/timesync"
 	"bytes"
 	"encoding/json"
+	"github.com/wendylabsinc/wendy/go/internal/agent/timesync"
 	"os"
 	"path/filepath"
 	"strings"


### PR DESCRIPTION
## Problem

Episode video began several seconds after the trigger, so the moment that caused the recording was missing from the clip. Measured on `wendyos-fernando` with a Logitech C920, episode `20260824T151636Z-ae221af639f9f151`: 176 frames, first at `canonical_episode_nanos` 5,318,531,945 and last at 15,272,131,119. The camera covered 5.32 s to 15.27 s of a 15 s episode.

## Cause

Not the keyframe interval, which was the starting hypothesis. Both encoder paths already cap the group of pictures (GOP) at `keyframeIntervalFrames`: the native V4L2 path through `setV4L2KeyframeInterval`, and the GStreamer path through `keyframeArg`, which selects the property per element (`key-int-max` for x264enc, `iframeinterval` for nvv4l2h264enc, `gop-size` for avenc_h264/openh264enc, `extra-controls` for v4l2h264enc, `keyframe-max-dist` for vp8enc). The live pipeline on the device confirmed it, running `x264enc tune=zerolatency key-int-max=15`. So there is no native-versus-GStreamer asymmetry left to fix.

The delay was `Manager.Start` querying the Roughtime consensus synchronously before returning. Two of the four public servers in the pool were unreachable and each cost the full 5 s query timeout. Capture adapters are started by `DataService.startCapture` only after `Start` returns, so the camera could not begin recording until the consensus gave up. The manifest shows it precisely: `roughtime.int08h.com` and `roughtime.se` both time out at exactly 5.000 s after the episode origin, and the first camera frame follows 318 ms later. The `applications` source was unaffected because it is served from a pre-roll ring buffer rather than a live producer.

## Solution

Query the opening consensus in the background and attach it to the episode when it lands, reusing the same attach-and-rewrite path the in-episode clock sampler already used (now factored into `queryAndAttachConsensus`). An episode whose caller demanded a UTC uncertainty bound still queries synchronously, because that gate can reject the episode and its evidence must exist before recording begins.

Nothing is lost: the consensus evidence and the resulting `system_clock_status` still reach the manifest, just moments later.

## Verification on device

Agent built for linux/arm64 with the same flags CI uses (`CGO_ENABLED=0`), checked standing alone on `WENDY_AGENT_PORT=50151` where it reached "mTLS gRPC server listening" before exiting on the expected 4317 clash, then installed with `wendy device update --binary`.

| | before | after (2 episodes) |
|---|---|---|
| first camera frame | 5,318 ms | 881 ms, 628 ms |
| frames | 176 | 169, 173 |
| capture span | 9.95 s | 9.99 s, 9.98 s |

The residual is the GOP wait, bounded by 15 frames at the camera's actual 17.2 fps, which is 871 ms; both samples fall inside that bound.

## Still open, not addressed here

- The camera has no pre-roll. This campaign requests `requested_offset_nanos` of -10 s and only the `applications` source can honor it; camera capture necessarily starts at or after the trigger, so the trigger instant itself is still not in the video. Cutting the 5 s makes the clip start ~0.5 s after the trigger instead of 5.3 s, but pre-trigger video needs a camera-side ring buffer.
- With the framerate left unspecified, `keyframeIntervalFrames` assumes 30 fps, so 15 frames is 871 ms on a camera actually delivering 17.2 fps rather than the intended half second. Tightening that would change the native path too, so it is left alone.
- Agent restart still breaks a running app's sensor socket (documented in `wendy-data-platform-demo.md`). The model app crash-looped on `sensors.sock` ECONNREFUSED after the install and needed `apps remove --force` plus `wendy run`; it is RUNNING again with predictions flowing.