### PR TITLE
feat(cli): unify local and cloud device discovery

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/auth/use.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/auth/use.md
@@ -59,5 +59,8 @@ wendy auth use
 
 ## See also
 
+- In the Cloud tab of `wendy discover` or an interactive device picker, press
+  `o` to switch organizations, including organizations without local
+  credentials.
 - [`wendy auth default`](./default.md) — show or clear the persisted default
 - [`wendy auth login`](./login.md)

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/discover.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/discover.md
@@ -1,6 +1,6 @@
 # `wendy discover`
 
-Scans for Wendy devices on the local network and connected via USB Ethernet.
+Discovers local and Wendy Cloud devices in a tabbed terminal interface.
 
 ## Usage
 
@@ -10,7 +10,18 @@ wendy discover [flags]
 
 ## Description
 
-`wendy discover` combines two discovery mechanisms and merges the results:
+Without output or timeout flags, `wendy discover` opens a live TUI with two
+tabs:
+
+- **Local** discovers devices over LAN, USB, Bluetooth, and external providers.
+- **Cloud** lists online devices enrolled in the active Wendy Cloud
+  organization.
+
+Use `tab` or `shift+tab` to switch tabs. Cloud discovery starts lazily on the
+first visit to the Cloud tab, so the command makes no cloud connection if you
+only use Local discovery.
+
+Local discovery combines these mechanisms and merges their results:
 
 - **Ethernet (USB NCM) discovery** — enumerates host network adapters and
   returns those whose name or interface description contains "wendy"
@@ -59,7 +70,8 @@ WENDY_SHOW_LOCAL_DEVICES=1 wendy discover
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--timeout` | `5s` | How long to wait for mDNS responses |
+| `--type` | `all` | Local discovery type: `usb`, `lan`, `bluetooth`, `external`, or `all`. Does not affect the Cloud tab. |
+| `--timeout` | `5s` | Scan local devices once for this duration, print the results, and exit. When omitted, the live tabbed TUI runs until quit. |
 | `--json` | `false` | Output results as a JSON array instead of a table |
 
 ## Environment variables
@@ -68,12 +80,54 @@ WENDY_SHOW_LOCAL_DEVICES=1 wendy discover
 |----------|-------------|
 | `WENDY_SHOW_LOCAL_DEVICES` | When truthy (`1`/`true`/`yes`/`on`), include local run targets (this machine, Docker/OrbStack, Apple Container) in the table. JSON output always includes them regardless. |
 
-## Interactive table
+## Interactive TUI
 
-Without `--json`, discover renders a live table that refreshes as devices come
-and go (`↑`/`↓` navigate, `enter` copy, `a` copy all, `u` update agent, `d` set
-default, `x` unset default, `q` quit). A leading `✦` marks the current default
-device.
+Without `--json` or an explicitly set `--timeout`, discover renders Local and
+Cloud tables that refresh as devices come and go. A leading `✦` marks the
+current default device or organization.
+
+### Keyboard shortcuts
+
+| Key | Action |
+|-----|--------|
+| `tab` / `shift+tab` | Switch between Local and Cloud tabs |
+| `↑` / `↓` | Navigate the active device list |
+| `enter` | Copy the selected device as JSON; when logged out in Cloud, start login |
+| `a` | Copy all devices in the active tab as JSON |
+| `u` | Update the selected device's agent |
+| `d` / `x` | Set or clear the default device in Local |
+| `o` | Switch the active organization in Cloud |
+| `q` / `Ctrl+C` | Quit |
+
+### Local tab
+
+The Local tab shows devices found through the enabled local discovery
+transports. The `--type` flag filters this tab only.
+
+### Cloud tab
+
+The Cloud tab shows online, cloud-enrolled devices for the active organization.
+Its header includes the organization name and ID and marks the persisted
+default organization with `✦ default`.
+
+If no cloud credentials are stored, the Cloud tab displays `Wendy Cloud login —
+Not logged in`. Press `enter` to start browser-based login; after login succeeds,
+discovery restarts with the Cloud tab available. Press `tab` to return to Local
+or `q` to quit without logging in.
+
+### Switching organizations (`o`)
+
+Press `o` in the Cloud tab to choose from all organizations available through
+the stored sessions, including organizations for which this machine does not
+yet have credentials.
+
+- An organization with stored credentials becomes active immediately.
+- An organization without local credentials starts browser-based login against
+  its cloud environment. After login, the CLI verifies that credentials for the
+  selected organization were stored; if not, it reports an error and you can
+  repeat the flow.
+
+### Local table columns
 
 | Column | Description |
 |--------|-------------|

--- a/go/internal/cli/commands/cloud_org_switch.go
+++ b/go/internal/cli/commands/cloud_org_switch.go
@@ -1,0 +1,127 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	cloudpb "github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+)
+
+type accessibleCloudOrg struct {
+	org    *cloudpb.Organization
+	source *config.AuthConfig
+}
+
+// loadCloudOrgConfig is a seam for the post-login reload in tests.
+var loadCloudOrgConfig = config.Load
+
+// accessibleCloudOrganizations aggregates every organization visible through
+// the locally stored sessions. The source session is retained so an org that
+// has no local certificate yet can launch login against the same cloud
+// environment that reported the membership.
+func accessibleCloudOrganizations(ctx context.Context, cfg *config.Config) ([]accessibleCloudOrg, error) {
+	if cfg == nil || len(cfg.Auth) == 0 {
+		return nil, config.ErrNotLoggedIn
+	}
+
+	seen := make(map[int32]bool)
+	var (
+		result  []accessibleCloudOrg
+		lastErr error
+	)
+	for i := range cfg.Auth {
+		auth := &cfg.Auth[i]
+		if len(auth.Certificates) == 0 {
+			continue
+		}
+		orgs, err := listOrgsFromCloud(ctx, auth)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		for _, org := range orgs {
+			if org == nil || seen[org.GetId()] {
+				continue
+			}
+			seen[org.GetId()] = true
+			result = append(result, accessibleCloudOrg{org: org, source: auth})
+		}
+	}
+	if len(result) == 0 && lastErr != nil {
+		return nil, fmt.Errorf("listing organizations: %w", lastErr)
+	}
+	return result, nil
+}
+
+func cloudAuthForOrg(cfg *config.Config, orgID int32) *config.AuthConfig {
+	if cfg == nil {
+		return nil
+	}
+	for i := range cfg.Auth {
+		auth := &cfg.Auth[i]
+		if cloudAuthOrgID(auth) == orgID {
+			return auth
+		}
+	}
+	return nil
+}
+
+// switchCloudOrganization shows the full membership roster, including orgs
+// for which this machine does not hold credentials. Selecting an authenticated
+// org switches immediately. Selecting an unauthenticated org starts login and
+// requires that the chosen org's certificate be present afterwards.
+func switchCloudOrganization(ctx context.Context, cfg *config.Config) (*config.AuthConfig, *config.Config, error) {
+	accessible, err := accessibleCloudOrganizations(ctx, cfg)
+	if err != nil {
+		return nil, cfg, err
+	}
+	if len(accessible) == 0 {
+		return nil, cfg, fmt.Errorf("your account belongs to no organizations; contact your administrator")
+	}
+
+	orgs := make([]*cloudpb.Organization, 0, len(accessible))
+	byID := make(map[int32]accessibleCloudOrg, len(accessible))
+	for _, entry := range accessible {
+		orgs = append(orgs, entry.org)
+		byID[entry.org.GetId()] = entry
+	}
+
+	orgID, orgName, err := pickOrgInteractiveFn(orgs, cfg, false)
+	if err != nil {
+		return nil, cfg, err
+	}
+	if auth := cloudAuthForOrg(cfg, orgID); auth != nil {
+		fresh, loadErr := loadCloudOrgConfig()
+		if loadErr == nil {
+			cfg = fresh // captures a default changed with 'd' inside the picker
+			if freshAuth := cloudAuthForOrg(cfg, orgID); freshAuth != nil {
+				return freshAuth, cfg, nil
+			}
+		} else {
+			return auth, cfg, nil
+		}
+	}
+
+	entry, ok := byID[orgID]
+	if !ok || entry.source == nil {
+		return nil, cfg, fmt.Errorf("selected organization %d is no longer available", orgID)
+	}
+	fmt.Println(tui.InfoMessage(fmt.Sprintf("No credentials are stored for %s (org %d). Complete login and select that organization in the browser.", orgName, orgID)))
+	dashboard, grpcEndpoint := loginTargetsForAuth(entry.source)
+	if err := performLoginFn(ctx, dashboard, grpcEndpoint); err != nil {
+		return nil, cfg, err
+	}
+
+	fresh, err := loadCloudOrgConfig()
+	if err != nil {
+		return nil, cfg, fmt.Errorf("loading config after login: %w", err)
+	}
+	auth := cloudAuthForOrg(fresh, orgID)
+	if auth == nil {
+		return nil, fresh, errors.New("login completed, but credentials for the selected organization were not stored; press 'o' and select it again, then choose the same organization in the browser")
+	}
+	return auth, fresh, nil
+}

--- a/go/internal/cli/commands/cloud_org_switch_test.go
+++ b/go/internal/cli/commands/cloud_org_switch_test.go
@@ -1,0 +1,140 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	cloudpb "github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+)
+
+func stubCloudOrgSwitchPicker(t *testing.T, wantCount int, selectedID int32, selectedName string) {
+	t.Helper()
+	orig := pickOrgInteractiveFn
+	pickOrgInteractiveFn = func(orgs []*cloudpb.Organization, _ *config.Config, copyOnEnter bool) (int32, string, error) {
+		if copyOnEnter {
+			t.Error("cloud tab org switch must select, not copy")
+		}
+		if len(orgs) != wantCount {
+			t.Errorf("picker org count = %d, want %d", len(orgs), wantCount)
+		}
+		return selectedID, selectedName, nil
+	}
+	t.Cleanup(func() { pickOrgInteractiveFn = orig })
+}
+
+func stubCloudOrgReload(t *testing.T, cfg *config.Config, err error) {
+	t.Helper()
+	orig := loadCloudOrgConfig
+	loadCloudOrgConfig = func() (*config.Config, error) { return cfg, err }
+	t.Cleanup(func() { loadCloudOrgConfig = orig })
+}
+
+func stubCloudOrgLogin(t *testing.T, fn func(context.Context, string, string) error) {
+	t.Helper()
+	orig := performLoginFn
+	performLoginFn = fn
+	t.Cleanup(func() { performLoginFn = orig })
+}
+
+func TestAccessibleCloudOrganizationsIncludesUnconnectedMemberships(t *testing.T) {
+	cfg := &config.Config{Auth: []config.AuthConfig{*pickerAuth(7)}}
+	stubListOrgs(t, []*cloudpb.Organization{
+		makeOrg(7, "Connected"),
+		makeOrg(9, "Permitted only"),
+	}, nil)
+
+	orgs, err := accessibleCloudOrganizations(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("accessibleCloudOrganizations: %v", err)
+	}
+	if len(orgs) != 2 {
+		t.Fatalf("org count = %d, want 2", len(orgs))
+	}
+	if orgs[1].org.GetId() != 9 || orgs[1].source != &cfg.Auth[0] {
+		t.Fatalf("unconnected org lost membership/source: %+v", orgs[1])
+	}
+	if cloudAuthForOrg(cfg, 9) != nil {
+		t.Fatal("permitted-only org unexpectedly has local credentials")
+	}
+}
+
+func TestSwitchCloudOrganizationConnectedOrgSkipsLogin(t *testing.T) {
+	cfg := &config.Config{Auth: []config.AuthConfig{*pickerAuth(7), *pickerAuth(9)}}
+	stubListOrgs(t, []*cloudpb.Organization{makeOrg(7, "Seven"), makeOrg(9, "Nine")}, nil)
+	stubCloudOrgSwitchPicker(t, 2, 9, "Nine")
+	stubCloudOrgReload(t, cfg, nil)
+	stubCloudOrgLogin(t, func(context.Context, string, string) error {
+		t.Fatal("connected org should not start login")
+		return nil
+	})
+
+	auth, _, err := switchCloudOrganization(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("switchCloudOrganization: %v", err)
+	}
+	if got := cloudAuthOrgID(auth); got != 9 {
+		t.Fatalf("selected org = %d, want 9", got)
+	}
+}
+
+func TestSwitchCloudOrganizationUnconnectedOrgLogsIn(t *testing.T) {
+	source := pickerAuth(7)
+	source.CloudDashboard = "https://tenant.example"
+	source.CloudGRPC = "grpc.tenant.example:443"
+	cfg := &config.Config{Auth: []config.AuthConfig{*source}}
+	fresh := &config.Config{Auth: []config.AuthConfig{*source, {
+		CloudDashboard: source.CloudDashboard,
+		CloudGRPC:      source.CloudGRPC,
+		Certificates:   []config.CertificateInfo{{OrganizationID: 9}},
+	}}}
+	stubListOrgs(t, []*cloudpb.Organization{makeOrg(7, "Seven"), makeOrg(9, "Nine")}, nil)
+	stubCloudOrgSwitchPicker(t, 2, 9, "Nine")
+	stubCloudOrgReload(t, fresh, nil)
+	loginCalled := false
+	stubCloudOrgLogin(t, func(_ context.Context, dashboard, grpcEndpoint string) error {
+		loginCalled = true
+		if dashboard != source.CloudDashboard || grpcEndpoint != source.CloudGRPC {
+			t.Errorf("login targets = (%q, %q), want (%q, %q)", dashboard, grpcEndpoint, source.CloudDashboard, source.CloudGRPC)
+		}
+		return nil
+	})
+
+	auth, gotCfg, err := switchCloudOrganization(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("switchCloudOrganization: %v", err)
+	}
+	if !loginCalled {
+		t.Fatal("unconnected org did not start login")
+	}
+	if gotCfg != fresh || cloudAuthOrgID(auth) != 9 {
+		t.Fatalf("post-login selection = cfg:%p org:%d, want cfg:%p org:9", gotCfg, cloudAuthOrgID(auth), fresh)
+	}
+}
+
+func TestSwitchCloudOrganizationRequiresSelectedOrgCredentialsAfterLogin(t *testing.T) {
+	cfg := &config.Config{Auth: []config.AuthConfig{*pickerAuth(7)}}
+	stubListOrgs(t, []*cloudpb.Organization{makeOrg(7, "Seven"), makeOrg(9, "Nine")}, nil)
+	stubCloudOrgSwitchPicker(t, 2, 9, "Nine")
+	stubCloudOrgReload(t, cfg, nil)
+	stubCloudOrgLogin(t, func(context.Context, string, string) error { return nil })
+
+	_, _, err := switchCloudOrganization(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected missing selected-org credentials error")
+	}
+	if !strings.Contains(err.Error(), "credentials for the selected organization were not stored") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAccessibleCloudOrganizationsReportsListingFailure(t *testing.T) {
+	cfg := &config.Config{Auth: []config.AuthConfig{*pickerAuth(7)}}
+	stubListOrgs(t, nil, errors.New("offline"))
+	_, err := accessibleCloudOrganizations(context.Background(), cfg)
+	if err == nil || !strings.Contains(err.Error(), "offline") {
+		t.Fatalf("error = %v, want listing failure", err)
+	}
+}

--- a/go/internal/cli/commands/device_picker_tabs.go
+++ b/go/internal/cli/commands/device_picker_tabs.go
@@ -65,6 +65,13 @@ func tagDevicePickerCmd(cmd tea.Cmd, tab devicePickerTab) tea.Cmd {
 	}
 	return func() tea.Msg {
 		msg := cmd()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			tagged := make(tea.BatchMsg, 0, len(batch))
+			for _, child := range batch {
+				tagged = append(tagged, tagDevicePickerCmd(child, tab))
+			}
+			return tagged
+		}
 		if tab == devicePickerCloudTab {
 			return devicePickerCloudMsg{msg: msg}
 		}

--- a/go/internal/cli/commands/device_picker_tabs.go
+++ b/go/internal/cli/commands/device_picker_tabs.go
@@ -1,0 +1,293 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	cloudpb "github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+)
+
+type devicePickerTab int
+
+const (
+	devicePickerLocalTab devicePickerTab = iota
+	devicePickerCloudTab
+)
+
+type devicePickerAction int
+
+const (
+	devicePickerNoAction devicePickerAction = iota
+	devicePickerLogin
+	devicePickerSwitchOrg
+)
+
+// Child messages are tagged so background commands keep updating the correct
+// page after the user changes tabs.
+type devicePickerLocalMsg struct{ msg tea.Msg }
+type devicePickerCloudMsg struct{ msg tea.Msg }
+type devicePickerOrgMsg struct{ name string }
+
+type devicePickerModel struct {
+	local        tui.PickerModel
+	cloud        cloudDiscoverModel
+	cloudAuth    *config.AuthConfig
+	cloudOrg     string
+	cloudStarted bool
+	defaultOrg   int32
+	active       devicePickerTab
+	action       devicePickerAction
+	cancelled    bool
+	windowWidth  int
+}
+
+func newDevicePickerModel(ctx context.Context, local tui.PickerModel, auth *config.AuthConfig, defaultOrg int32) devicePickerModel {
+	m := devicePickerModel{
+		local:      local,
+		cloudAuth:  auth,
+		defaultOrg: defaultOrg,
+	}
+	if auth != nil {
+		m.cloud = newCloudDiscoverModel(ctx, auth, os.Getenv("WENDY_BROKER_URL"), false, true, nil)
+	}
+	return m
+}
+
+func tagDevicePickerCmd(cmd tea.Cmd, tab devicePickerTab) tea.Cmd {
+	if cmd == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		msg := cmd()
+		if tab == devicePickerCloudTab {
+			return devicePickerCloudMsg{msg: msg}
+		}
+		return devicePickerLocalMsg{msg: msg}
+	}
+}
+
+func (m devicePickerModel) Init() tea.Cmd {
+	return tagDevicePickerCmd(m.local.Init(), devicePickerLocalTab)
+}
+
+func (m devicePickerModel) startCloudCmd() tea.Cmd {
+	if m.cloudAuth == nil {
+		return nil
+	}
+	return tea.Batch(
+		tagDevicePickerCmd(m.cloud.Init(), devicePickerCloudTab),
+		m.loadOrgNameCmd(),
+	)
+}
+
+func (m devicePickerModel) loadOrgNameCmd() tea.Cmd {
+	ctx := m.cloud.ctx
+	auth := m.cloudAuth
+	orgID := cloudAuthOrgID(auth)
+	return func() tea.Msg {
+		orgs, err := listOrgsFromCloud(ctx, auth)
+		if err != nil {
+			return devicePickerOrgMsg{}
+		}
+		for _, org := range orgs {
+			if org.GetId() == orgID {
+				return devicePickerOrgMsg{name: org.GetName()}
+			}
+		}
+		return devicePickerOrgMsg{}
+	}
+}
+
+func (m devicePickerModel) updateLocal(msg tea.Msg) (devicePickerModel, tea.Cmd) {
+	updated, cmd := m.local.Update(msg)
+	m.local = updated.(tui.PickerModel)
+	if m.local.Selected() != nil {
+		return m, tea.Quit
+	}
+	if m.local.Cancelled() {
+		m.cancelled = true
+		return m, tea.Quit
+	}
+	return m, tagDevicePickerCmd(cmd, devicePickerLocalTab)
+}
+
+func (m devicePickerModel) updateCloud(msg tea.Msg) (devicePickerModel, tea.Cmd) {
+	updated, cmd := m.cloud.Update(msg)
+	m.cloud = updated.(cloudDiscoverModel)
+	if m.cloud.selected != nil {
+		return m, tea.Quit
+	}
+	if m.cloud.quitting {
+		m.cancelled = true
+		return m, tea.Quit
+	}
+	return m, tagDevicePickerCmd(cmd, devicePickerCloudTab)
+}
+
+func (m devicePickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case devicePickerLocalMsg:
+		return m.updateLocal(msg.msg)
+	case devicePickerCloudMsg:
+		if m.cloudAuth == nil {
+			return m, nil
+		}
+		return m.updateCloud(msg.msg)
+	case devicePickerOrgMsg:
+		m.cloudOrg = msg.name
+		return m, nil
+	case tea.WindowSizeMsg:
+		m.windowWidth = msg.Width
+		local, localCmd := m.updateLocal(msg)
+		m = local
+		if m.cloudAuth == nil {
+			return m, localCmd
+		}
+		cloud, cloudCmd := m.updateCloud(msg)
+		m = cloud
+		return m, tea.Batch(localCmd, cloudCmd)
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "tab", "shift+tab":
+			if m.active == devicePickerLocalTab {
+				m.active = devicePickerCloudTab
+				if m.cloudAuth != nil && !m.cloudStarted {
+					m.cloudStarted = true
+					return m, m.startCloudCmd()
+				}
+			} else {
+				m.active = devicePickerLocalTab
+			}
+			return m, nil
+		case "o":
+			if m.active == devicePickerCloudTab && m.cloudAuth != nil {
+				m.action = devicePickerSwitchOrg
+				return m, tea.Quit
+			}
+		case "enter":
+			if m.active == devicePickerCloudTab && m.cloudAuth == nil {
+				m.action = devicePickerLogin
+				return m, tea.Quit
+			}
+		case "q", "esc", "ctrl+c":
+			if m.active == devicePickerCloudTab && m.cloudAuth == nil {
+				m.cancelled = true
+				return m, tea.Quit
+			}
+		}
+
+		if m.active == devicePickerCloudTab {
+			if m.cloudAuth == nil {
+				return m, nil
+			}
+			return m.updateCloud(msg)
+		}
+		return m.updateLocal(msg)
+	}
+	return m, nil
+}
+
+var (
+	devicePickerTabActive   = lipgloss.NewStyle().Bold(true).Underline(true).Foreground(tui.ColorPrimary)
+	devicePickerTabInactive = lipgloss.NewStyle().Foreground(tui.ColorDim)
+	devicePickerOrgStyle    = lipgloss.NewStyle().Foreground(tui.ColorDim)
+)
+
+func (m devicePickerModel) View() string {
+	if m.cancelled || m.action != devicePickerNoAction || m.selectedLocal() != nil || m.selectedCloud() != nil {
+		return ""
+	}
+
+	header := deviceTabsHeader(m.active, m.windowWidth)
+
+	if m.active == devicePickerLocalTab {
+		return header + "\n\n" + m.local.View()
+	}
+
+	var body strings.Builder
+	body.WriteString(header)
+	body.WriteString("\n\n")
+	if m.cloudAuth == nil {
+		body.WriteString("Select a cloud device\n")
+		body.WriteString(devicePickerOrgStyle.Render("  ☐  Wendy Cloud login   Not logged in"))
+		body.WriteString("\n")
+		body.WriteString(devicePickerOrgStyle.Render("  enter log in, tab local, q quit"))
+		body.WriteString("\n")
+		return body.String()
+	}
+
+	body.WriteString(devicePickerOrgStyle.Render(deviceCloudOrgLabel(m.cloudAuth, m.cloudOrg, m.defaultOrg)))
+	body.WriteString("\n\n")
+	body.WriteString(m.cloud.View())
+	return body.String()
+}
+
+func deviceTabsHeader(active devicePickerTab, width int) string {
+	local := devicePickerTabInactive.Render("Local")
+	cloud := devicePickerTabInactive.Render("Cloud")
+	if active == devicePickerLocalTab {
+		local = devicePickerTabActive.Render("Local")
+	} else {
+		cloud = devicePickerTabActive.Render("Cloud")
+	}
+	header := local + devicePickerTabInactive.Render(" | ") + cloud + devicePickerTabInactive.Render("  (tab switch)")
+	if width > 0 {
+		header = tui.CropANSIView(header, 0, width)
+	}
+	return header
+}
+
+func deviceCloudOrgLabel(auth *config.AuthConfig, name string, defaultOrg int32) string {
+	orgID := cloudAuthOrgID(auth)
+	label := fmt.Sprintf("Organization: org %d", orgID)
+	if name != "" {
+		label = fmt.Sprintf("Organization: %s (org %d)", name, orgID)
+	}
+	if orgID != 0 && orgID == defaultOrg {
+		label += "  ✦ default"
+	}
+	return label + "  (o switch)"
+}
+
+func (m devicePickerModel) selectedLocal() *tui.PickerItem {
+	return m.local.Selected()
+}
+
+func (m devicePickerModel) selectedCloud() *cloudpb.Asset {
+	if m.cloudAuth == nil {
+		return nil
+	}
+	return m.cloud.selected
+}
+
+func cloudAuthOrgID(auth *config.AuthConfig) int32 {
+	if auth == nil || len(auth.Certificates) == 0 {
+		return 0
+	}
+	return int32(auth.Certificates[0].OrganizationID)
+}
+
+// devicePickerInitialAuth chooses the persisted default session when possible.
+// If the user has authenticated sessions but no default yet, the first valid
+// session is still useful as the initial cloud page; the 'o' hotkey lets them
+// switch and mark another session as default.
+func devicePickerInitialAuth(cfg *config.Config) *config.AuthConfig {
+	if cfg == nil || len(cfg.Auth) == 0 {
+		return nil
+	}
+	if auth, err := config.ResolveAuth(cfg, "", nil); err == nil {
+		return auth
+	}
+	for i := range cfg.Auth {
+		if len(cfg.Auth[i].Certificates) > 0 {
+			return &cfg.Auth[i]
+		}
+	}
+	return nil
+}

--- a/go/internal/cli/commands/device_picker_tabs_test.go
+++ b/go/internal/cli/commands/device_picker_tabs_test.go
@@ -1,0 +1,139 @@
+package commands
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	cloudpb "github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+)
+
+func pickerAuth(orgID int) *config.AuthConfig {
+	return &config.AuthConfig{
+		CloudGRPC:    "cloud.example:443",
+		Certificates: []config.CertificateInfo{{OrganizationID: orgID}},
+	}
+}
+
+func TestDevicePickerShowsLocalAndCloudTabs(t *testing.T) {
+	m := newDevicePickerModel(context.Background(), tui.NewPicker(), nil, 0)
+	updated, _ := m.Update(devicePickerLocalMsg{msg: tui.PickerAddMsg{Items: []tui.PickerItem{{Name: "local-pi"}}}})
+	m = updated.(devicePickerModel)
+
+	view := m.View()
+	for _, want := range []string{"Local", "Cloud", "tab switch", "local-pi"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("local picker view does not contain %q: %q", want, view)
+		}
+	}
+}
+
+func TestDevicePickerLoggedOutCloudTabOffersLoginRow(t *testing.T) {
+	m := newDevicePickerModel(context.Background(), tui.NewPicker(), nil, 0)
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(devicePickerModel)
+
+	view := m.View()
+	for _, want := range []string{"Wendy Cloud login", "Not logged in", "enter log in"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("logged-out cloud view does not contain %q: %q", want, view)
+		}
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(devicePickerModel)
+	if cmd == nil {
+		t.Fatal("login row did not quit the picker")
+	}
+	if m.action != devicePickerLogin {
+		t.Fatalf("action = %v, want login", m.action)
+	}
+}
+
+func TestDevicePickerStartsCloudDiscoveryOnFirstCloudTabVisit(t *testing.T) {
+	m := newDevicePickerModel(context.Background(), tui.NewPicker(), pickerAuth(7), 7)
+	if m.cloudStarted {
+		t.Fatal("cloud discovery started before the Cloud tab was visited")
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(devicePickerModel)
+	if !m.cloudStarted {
+		t.Fatal("cloud discovery did not start on the first Cloud tab visit")
+	}
+	if cmd == nil {
+		t.Fatal("first Cloud tab visit did not schedule discovery")
+	}
+
+	updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(devicePickerModel)
+	if cmd != nil {
+		t.Fatal("returning to Local unexpectedly restarted cloud discovery")
+	}
+	updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if cmd != nil {
+		t.Fatal("second Cloud tab visit restarted cloud discovery")
+	}
+}
+
+func TestDevicePickerCloudTabShowsDefaultOrgAndSwitchHotkey(t *testing.T) {
+	auth := pickerAuth(7)
+	m := newDevicePickerModel(context.Background(), tui.NewPicker(), auth, 7)
+	m.active = devicePickerCloudTab
+	updated, _ := m.Update(devicePickerOrgMsg{name: "Robotics"})
+	m = updated.(devicePickerModel)
+
+	view := m.View()
+	for _, want := range []string{"Organization: Robotics (org 7)", "default", "o switch"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("authenticated cloud view does not contain %q: %q", want, view)
+		}
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'o'}})
+	m = updated.(devicePickerModel)
+	if cmd == nil {
+		t.Fatal("org switch hotkey did not quit the picker")
+	}
+	if m.action != devicePickerSwitchOrg {
+		t.Fatalf("action = %v, want switch org", m.action)
+	}
+}
+
+func TestDevicePickerSelectsCloudAsset(t *testing.T) {
+	auth := pickerAuth(7)
+	m := newDevicePickerModel(context.Background(), tui.NewPicker(), auth, 7)
+	m.active = devicePickerCloudTab
+	asset := &cloudpb.Asset{Id: 42, Name: "cloud-pi"}
+
+	updated, _ := m.Update(devicePickerCloudMsg{msg: cloudScanMsg{assets: []*cloudpb.Asset{asset}}})
+	m = updated.(devicePickerModel)
+	if !strings.Contains(m.View(), "cloud-pi") {
+		t.Fatalf("cloud asset missing from view: %q", m.View())
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(devicePickerModel)
+	if cmd == nil {
+		t.Fatal("selecting a cloud asset did not quit the picker")
+	}
+	if got := m.selectedCloud(); got == nil || got.GetId() != 42 {
+		t.Fatalf("selected cloud asset = %v, want id 42", got)
+	}
+}
+
+func TestDevicePickerInitialAuthUsesDefaultOrg(t *testing.T) {
+	cfg := &config.Config{
+		DefaultOrgID: 9,
+		Auth: []config.AuthConfig{
+			*pickerAuth(7),
+			*pickerAuth(9),
+		},
+	}
+	if got := devicePickerInitialAuth(cfg); cloudAuthOrgID(got) != 9 {
+		t.Fatalf("initial org = %d, want default org 9", cloudAuthOrgID(got))
+	}
+}

--- a/go/internal/cli/commands/device_picker_tabs_test.go
+++ b/go/internal/cli/commands/device_picker_tabs_test.go
@@ -125,6 +125,29 @@ func TestDevicePickerSelectsCloudAsset(t *testing.T) {
 	}
 }
 
+func TestTagDevicePickerCmdPreservesBatchChildren(t *testing.T) {
+	cmd := tagDevicePickerCmd(tea.Batch(
+		func() tea.Msg { return "first" },
+		func() tea.Msg { return "second" },
+	), devicePickerCloudTab)
+	batch, ok := cmd().(tea.BatchMsg)
+	if !ok {
+		t.Fatal("tagged batch returned unexpected message type")
+	}
+	if len(batch) != 2 {
+		t.Fatalf("tagged batch children = %d, want 2", len(batch))
+	}
+	for i, child := range batch {
+		msg, ok := child().(devicePickerCloudMsg)
+		if !ok {
+			t.Fatalf("child %d returned unexpected message type", i)
+		}
+		if msg.msg == nil {
+			t.Fatalf("child %d lost its payload", i)
+		}
+	}
+}
+
 func TestDevicePickerInitialAuthUsesDefaultOrg(t *testing.T) {
 	cfg := &config.Config{
 		DefaultOrgID: 9,

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -219,10 +219,9 @@ func noDevicesHint() string {
 func discoverContinuous(ctx context.Context, opts discovery.DiscoveryOptions, includeLocal bool) error {
 	cfg, err := config.Load()
 	if err != nil {
-		return fmt.Errorf("loading config: %w", err)
+		cfg = nil
 	}
 	cloudAuth := devicePickerInitialAuth(cfg)
-
 	for {
 		err := discoverContinuousWithCloudAuth(ctx, opts, includeLocal, cloudAuth, defaultOrgForCloudAuth(cfg, cloudAuth))
 		switch {

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"runtime"
@@ -35,8 +36,8 @@ func newDiscoverCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "discover",
-		Short: "Discover WendyOS devices on the network",
-		Long:  "Continuously scan for WendyOS devices until Ctrl+C. Use --timeout to scan once for a fixed duration.",
+		Short: "Discover local and cloud WendyOS devices",
+		Long:  "Continuously discover WendyOS devices in Local and Cloud tabs until Ctrl+C. Use --timeout to scan local devices once for a fixed duration.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts := discovery.DiscoveryOptions{
 				// The continuous TUI path streams LAN devices directly via
@@ -87,7 +88,7 @@ func newDiscoverCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&discoverType, "type", "all", "Discovery type: usb, lan, bluetooth, external, all")
+	cmd.Flags().StringVar(&discoverType, "type", "all", "Local discovery type: usb, lan, bluetooth, external, all")
 	cmd.Flags().DurationVar(&timeout, "timeout", 5*time.Second, "Scan once for this duration then exit")
 
 	return cmd
@@ -216,13 +217,80 @@ func noDevicesHint() string {
 // discoverContinuous runs scans in a loop, refreshing the table until Ctrl+C.
 // includeLocal surfaces local run targets that are hidden by default.
 func discoverContinuous(ctx context.Context, opts discovery.DiscoveryOptions, includeLocal bool) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+	cloudAuth := devicePickerInitialAuth(cfg)
+
+	for {
+		err := discoverContinuousWithCloudAuth(ctx, opts, includeLocal, cloudAuth, defaultOrgForCloudAuth(cfg, cloudAuth))
+		switch {
+		case errors.Is(err, errDevicePickerLogin):
+			if err := performLogin(ctx, defaultCloudDashboard, defaultCloudGRPC); err != nil {
+				return err
+			}
+			cfg, err = config.Load()
+			if err != nil {
+				return fmt.Errorf("loading config after login: %w", err)
+			}
+			cloudAuth = devicePickerInitialAuth(cfg)
+		case errors.Is(err, errDevicePickerSwitchOrg):
+			cfg, err = config.Load()
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+			picked, freshCfg, pickErr := switchCloudOrganization(ctx, cfg)
+			if errors.Is(pickErr, ErrUserCancelled) {
+				continue
+			}
+			if pickErr != nil {
+				return pickErr
+			}
+			cloudAuth = picked
+			cfg = freshCfg
+		default:
+			return err
+		}
+	}
+}
+
+func defaultOrgForCloudAuth(cfg *config.Config, auth *config.AuthConfig) int32 {
+	if cfg == nil {
+		return 0
+	}
+	if cfg.DefaultOrgID != 0 {
+		return cfg.DefaultOrgID
+	}
+	if auth != nil && cfg.DefaultCloudGRPC == auth.CloudGRPC {
+		return cloudAuthOrgID(auth)
+	}
+	return 0
+}
+
+func discoverContinuousWithCloudAuth(ctx context.Context, opts discovery.DiscoveryOptions, includeLocal bool, cloudAuth *config.AuthConfig, defaultOrg int32) error {
 	opts.Timeout = 3 * time.Second // per-scan timeout
-	m := newDiscoverModel(ctx, opts, includeLocal)
+	discoverCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	local := newDiscoverModel(discoverCtx, opts, includeLocal)
+	m := newDiscoverTabsModel(discoverCtx, local, cloudAuth, defaultOrg)
 	// Alt screen: the table grows to fill the window, and the alternate
 	// buffer restores the user's terminal content when the TUI exits.
 	p := tea.NewProgram(m, tea.WithAltScreen())
-	if _, err := p.Run(); err != nil {
+	finalModel, err := p.Run()
+	if err != nil {
 		return fmt.Errorf("TUI error: %w", err)
+	}
+	dm, ok := finalModel.(discoverTabsModel)
+	if !ok {
+		return fmt.Errorf("discover TUI returned unexpected model %T", finalModel)
+	}
+	switch dm.action {
+	case devicePickerLogin:
+		return errDevicePickerLogin
+	case devicePickerSwitchOrg:
+		return errDevicePickerSwitchOrg
 	}
 	return nil
 }

--- a/go/internal/cli/commands/discover_tabs.go
+++ b/go/internal/cli/commands/discover_tabs.go
@@ -1,0 +1,204 @@
+package commands
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+)
+
+type discoverTabsLocalMsg struct{ msg tea.Msg }
+type discoverTabsCloudMsg struct{ msg tea.Msg }
+type discoverTabsOrgMsg struct{ name string }
+
+type discoverTabsModel struct {
+	local        discoverModel
+	cloud        cloudDiscoverModel
+	cloudAuth    *config.AuthConfig
+	cloudOrg     string
+	cloudStarted bool
+	defaultOrg   int32
+	active       devicePickerTab
+	action       devicePickerAction
+	cancelled    bool
+	windowWidth  int
+}
+
+func newDiscoverTabsModel(ctx context.Context, local discoverModel, auth *config.AuthConfig, defaultOrg int32) discoverTabsModel {
+	m := discoverTabsModel{
+		local:      local,
+		cloudAuth:  auth,
+		defaultOrg: defaultOrg,
+	}
+	if auth != nil {
+		m.cloud = newCloudDiscoverModel(ctx, auth, os.Getenv("WENDY_BROKER_URL"), false, false, nil)
+	}
+	return m
+}
+
+// tagDiscoverTabsCmd preserves which dashboard owns an asynchronous result.
+// discoverModel.Init returns tea.Batch, so BatchMsg children must be tagged
+// individually rather than hiding the batch inside one wrapper message.
+func tagDiscoverTabsCmd(cmd tea.Cmd, tab devicePickerTab) tea.Cmd {
+	if cmd == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		msg := cmd()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			tagged := make(tea.BatchMsg, 0, len(batch))
+			for _, child := range batch {
+				tagged = append(tagged, tagDiscoverTabsCmd(child, tab))
+			}
+			return tagged
+		}
+		if tab == devicePickerCloudTab {
+			return discoverTabsCloudMsg{msg: msg}
+		}
+		return discoverTabsLocalMsg{msg: msg}
+	}
+}
+
+func (m discoverTabsModel) Init() tea.Cmd {
+	return tagDiscoverTabsCmd(m.local.Init(), devicePickerLocalTab)
+}
+
+func (m discoverTabsModel) startCloudCmd() tea.Cmd {
+	if m.cloudAuth == nil {
+		return nil
+	}
+	return tea.Batch(
+		tagDiscoverTabsCmd(m.cloud.Init(), devicePickerCloudTab),
+		m.loadOrgNameCmd(),
+	)
+}
+
+func (m discoverTabsModel) loadOrgNameCmd() tea.Cmd {
+	ctx := m.cloud.ctx
+	auth := m.cloudAuth
+	orgID := cloudAuthOrgID(auth)
+	return func() tea.Msg {
+		orgs, err := listOrgsFromCloud(ctx, auth)
+		if err != nil {
+			return discoverTabsOrgMsg{}
+		}
+		for _, org := range orgs {
+			if org.GetId() == orgID {
+				return discoverTabsOrgMsg{name: org.GetName()}
+			}
+		}
+		return discoverTabsOrgMsg{}
+	}
+}
+
+func (m discoverTabsModel) updateLocal(msg tea.Msg) (discoverTabsModel, tea.Cmd) {
+	updated, cmd := m.local.Update(msg)
+	m.local = updated.(discoverModel)
+	if m.local.quitting {
+		m.cancelled = true
+		return m, tea.Quit
+	}
+	return m, tagDiscoverTabsCmd(cmd, devicePickerLocalTab)
+}
+
+func (m discoverTabsModel) updateCloud(msg tea.Msg) (discoverTabsModel, tea.Cmd) {
+	updated, cmd := m.cloud.Update(msg)
+	m.cloud = updated.(cloudDiscoverModel)
+	if m.cloud.quitting {
+		m.cancelled = true
+		return m, tea.Quit
+	}
+	return m, tagDiscoverTabsCmd(cmd, devicePickerCloudTab)
+}
+
+func (m discoverTabsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case discoverTabsLocalMsg:
+		return m.updateLocal(msg.msg)
+	case discoverTabsCloudMsg:
+		if m.cloudAuth == nil {
+			return m, nil
+		}
+		return m.updateCloud(msg.msg)
+	case discoverTabsOrgMsg:
+		m.cloudOrg = msg.name
+		return m, nil
+	case tea.WindowSizeMsg:
+		m.windowWidth = msg.Width
+		local, localCmd := m.updateLocal(msg)
+		m = local
+		if m.cloudAuth == nil {
+			return m, localCmd
+		}
+		cloud, cloudCmd := m.updateCloud(msg)
+		m = cloud
+		return m, tea.Batch(localCmd, cloudCmd)
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "tab", "shift+tab":
+			if m.active == devicePickerLocalTab {
+				m.active = devicePickerCloudTab
+				if m.cloudAuth != nil && !m.cloudStarted {
+					m.cloudStarted = true
+					return m, m.startCloudCmd()
+				}
+			} else {
+				m.active = devicePickerLocalTab
+			}
+			return m, nil
+		case "o":
+			if m.active == devicePickerCloudTab && m.cloudAuth != nil {
+				m.action = devicePickerSwitchOrg
+				return m, tea.Quit
+			}
+		case "enter":
+			if m.active == devicePickerCloudTab && m.cloudAuth == nil {
+				m.action = devicePickerLogin
+				return m, tea.Quit
+			}
+		case "q", "esc", "ctrl+c":
+			if m.active == devicePickerCloudTab && m.cloudAuth == nil {
+				m.cancelled = true
+				return m, tea.Quit
+			}
+		}
+
+		if m.active == devicePickerCloudTab {
+			if m.cloudAuth == nil {
+				return m, nil
+			}
+			return m.updateCloud(msg)
+		}
+		return m.updateLocal(msg)
+	}
+	return m, nil
+}
+
+func (m discoverTabsModel) View() string {
+	if m.cancelled || m.action != devicePickerNoAction {
+		return ""
+	}
+	header := deviceTabsHeader(m.active, m.windowWidth)
+	if m.active == devicePickerLocalTab {
+		return header + "\n\n" + m.local.View()
+	}
+
+	var body strings.Builder
+	body.WriteString(header)
+	body.WriteString("\n\n")
+	if m.cloudAuth == nil {
+		body.WriteString("Discover cloud devices\n")
+		body.WriteString(devicePickerOrgStyle.Render("  ☐  Wendy Cloud login   Not logged in"))
+		body.WriteString("\n")
+		body.WriteString(devicePickerOrgStyle.Render("  enter log in, tab local, q quit"))
+		body.WriteString("\n")
+		return body.String()
+	}
+
+	body.WriteString(devicePickerOrgStyle.Render(deviceCloudOrgLabel(m.cloudAuth, m.cloudOrg, m.defaultOrg)))
+	body.WriteString("\n\n")
+	body.WriteString(m.cloud.View())
+	return body.String()
+}

--- a/go/internal/cli/commands/discover_tabs_test.go
+++ b/go/internal/cli/commands/discover_tabs_test.go
@@ -1,0 +1,117 @@
+package commands
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+)
+
+func newTestDiscoverTabsModel(authOrg int, defaultOrg int32) discoverTabsModel {
+	ctx := context.Background()
+	local := newDiscoverModel(ctx, defaultOpts(), true)
+	if authOrg == 0 {
+		return newDiscoverTabsModel(ctx, local, nil, defaultOrg)
+	}
+	return newDiscoverTabsModel(ctx, local, pickerAuth(authOrg), defaultOrg)
+}
+
+func TestDiscoverTabsShowsLocalAndCloud(t *testing.T) {
+	m := newTestDiscoverTabsModel(0, 0)
+	view := m.View()
+	for _, want := range []string{"Local", "Cloud", "tab switch", "Scanning for WendyOS devices"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("local discover view does not contain %q: %q", want, view)
+		}
+	}
+}
+
+func TestDiscoverTabsLoggedOutCloudOffersLogin(t *testing.T) {
+	m := newTestDiscoverTabsModel(0, 0)
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(discoverTabsModel)
+
+	view := m.View()
+	for _, want := range []string{"Discover cloud devices", "Wendy Cloud login", "Not logged in"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("logged-out cloud discover view does not contain %q: %q", want, view)
+		}
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(discoverTabsModel)
+	if cmd == nil || m.action != devicePickerLogin {
+		t.Fatalf("login row result: cmd=%v action=%v", cmd != nil, m.action)
+	}
+}
+
+func TestDiscoverTabsStartsCloudLazilyAndShowsDefaultOrg(t *testing.T) {
+	m := newTestDiscoverTabsModel(7, 7)
+	if m.cloudStarted {
+		t.Fatal("cloud discovery started before visiting the Cloud tab")
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(discoverTabsModel)
+	if cmd == nil || !m.cloudStarted {
+		t.Fatalf("first Cloud visit: cmd=%v started=%v", cmd != nil, m.cloudStarted)
+	}
+	updated, _ = m.Update(discoverTabsOrgMsg{name: "Robotics"})
+	m = updated.(discoverTabsModel)
+	for _, want := range []string{"Organization: Robotics (org 7)", "default", "o switch"} {
+		if !strings.Contains(m.View(), want) {
+			t.Fatalf("cloud discover view does not contain %q: %q", want, m.View())
+		}
+	}
+}
+
+func TestDiscoverTabsOrgSwitchHotkey(t *testing.T) {
+	m := newTestDiscoverTabsModel(7, 7)
+	m.active = devicePickerCloudTab
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'o'}})
+	m = updated.(discoverTabsModel)
+	if cmd == nil || m.action != devicePickerSwitchOrg {
+		t.Fatalf("org switch result: cmd=%v action=%v", cmd != nil, m.action)
+	}
+}
+
+func TestDiscoverTabsCloudRosterUsesCloudDiscoverDashboard(t *testing.T) {
+	m := newTestDiscoverTabsModel(7, 7)
+	m.active = devicePickerCloudTab
+	asset := &cloudpb.Asset{Id: 42, Name: "cloud-pi"}
+
+	updated, _ := m.Update(discoverTabsCloudMsg{msg: cloudScanMsg{assets: []*cloudpb.Asset{asset}}})
+	m = updated.(discoverTabsModel)
+	view := m.View()
+	for _, want := range []string{"cloud-pi", "enter copy", "a copy all", "u update"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("cloud roster does not contain %q: %q", want, view)
+		}
+	}
+}
+
+func TestTagDiscoverTabsCmdPreservesBatchChildren(t *testing.T) {
+	cmd := tagDiscoverTabsCmd(tea.Batch(
+		func() tea.Msg { return "first" },
+		func() tea.Msg { return "second" },
+	), devicePickerLocalTab)
+	batch, ok := cmd().(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("tagged batch returned unexpected message type")
+	}
+	if len(batch) != 2 {
+		t.Fatalf("tagged batch children = %d, want 2", len(batch))
+	}
+	for i, child := range batch {
+		msg, ok := child().(discoverTabsLocalMsg)
+		if !ok {
+			t.Fatalf("child %d returned unexpected message type", i)
+		}
+		if msg.msg == nil {
+			t.Fatalf("child %d lost its payload", i)
+		}
+	}
+}

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -3534,7 +3534,7 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, includeBl
 			if err != nil {
 				return nil, fmt.Errorf("loading config: %w", err)
 			}
-			picked, freshCfg, pickErr := switchCloudOrganization(ctx, cfg)
+			picked, _, pickErr := switchCloudOrganization(ctx, cfg)
 			if errors.Is(pickErr, ErrUserCancelled) {
 				continue
 			}
@@ -3542,7 +3542,6 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, includeBl
 				return nil, pickErr
 			}
 			cloudAuth = picked
-			cfg = freshCfg
 		default:
 			return selected, err
 		}
@@ -3589,10 +3588,9 @@ func pickDeviceWithCloudAuth(ctx context.Context, excludeProviders map[string]bo
 		return "Default device cleared."
 	}
 
-	p := tea.NewProgram(newDevicePickerModel(ctx, picker, cloudAuth, defaultOrgID))
-
 	// Cancel continuous discovery when the picker exits.
 	discoverCtx, discoverCancel := context.WithCancel(ctx)
+	p := tea.NewProgram(newDevicePickerModel(discoverCtx, picker, cloudAuth, defaultOrgID))
 
 	sendLANItem := func(dev models.LANDevice, insecure bool, probe tui.ProbeState) {
 		devCopy := dev

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -3500,8 +3500,9 @@ func discoverProviderForPicker(ctx context.Context, prov providers.DeviceProvide
 	}
 }
 
-// pickDevice runs an interactive TUI that discovers devices across all
-// transports and providers, then lets the user select one.
+// pickDevice runs the interactive Local | Cloud TUI. The local page discovers
+// devices across all transports and providers; the cloud page lists the
+// selected organization's online Wendy Cloud devices.
 // LAN discovery runs continuously so devices that come online after the
 // initial scan still appear in the picker.
 // excludeProviders hides the named provider keys from the picker. Local run
@@ -3510,14 +3511,62 @@ func discoverProviderForPicker(ctx context.Context, prov providers.DeviceProvide
 // cannot talk over BLE never show a device they can't use (see
 // IncludeBluetooth).
 func pickDevice(ctx context.Context, excludeProviders map[string]bool, includeBluetooth bool, suppressUpdateCheck bool) (*SelectedDevice, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, fmt.Errorf("loading config: %w", err)
+	}
+	cloudAuth := devicePickerInitialAuth(cfg)
+
+	for {
+		selected, err := pickDeviceWithCloudAuth(ctx, excludeProviders, includeBluetooth, suppressUpdateCheck, cloudAuth)
+		switch {
+		case errors.Is(err, errDevicePickerLogin):
+			if err := performLogin(ctx, defaultCloudDashboard, defaultCloudGRPC); err != nil {
+				return nil, err
+			}
+			cfg, err = config.Load()
+			if err != nil {
+				return nil, fmt.Errorf("loading config after login: %w", err)
+			}
+			cloudAuth = devicePickerInitialAuth(cfg)
+		case errors.Is(err, errDevicePickerSwitchOrg):
+			cfg, err = config.Load()
+			if err != nil {
+				return nil, fmt.Errorf("loading config: %w", err)
+			}
+			picked, freshCfg, pickErr := switchCloudOrganization(ctx, cfg)
+			if errors.Is(pickErr, ErrUserCancelled) {
+				continue
+			}
+			if pickErr != nil {
+				return nil, pickErr
+			}
+			cloudAuth = picked
+			cfg = freshCfg
+		default:
+			return selected, err
+		}
+	}
+}
+
+var (
+	errDevicePickerLogin     = errors.New("device picker requested cloud login")
+	errDevicePickerSwitchOrg = errors.New("device picker requested organization switch")
+)
+
+func pickDeviceWithCloudAuth(ctx context.Context, excludeProviders map[string]bool, includeBluetooth bool, suppressUpdateCheck bool, cloudAuth *config.AuthConfig) (*SelectedDevice, error) {
 	excludeProviders = hideLocalProviders(excludeProviders)
 
 	picker := tui.NewPicker()
 	picker.MergeItem = mergePickerItem
 
 	// Load current default device to show ✦ indicator.
-	if loadedCfg, err := config.Load(); err == nil && loadedCfg.DefaultDevice != "" {
-		picker.DefaultKey = strings.ToLower(loadedCfg.DefaultDevice)
+	defaultOrgID := int32(0)
+	if loadedCfg, err := config.Load(); err == nil {
+		defaultOrgID = defaultOrgForCloudAuth(loadedCfg, cloudAuth)
+		if loadedCfg.DefaultDevice != "" {
+			picker.DefaultKey = strings.ToLower(loadedCfg.DefaultDevice)
+		}
 	}
 
 	// Allow 'd' to set default and 'x' to unset default from the picker.
@@ -3540,7 +3589,7 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, includeBl
 		return "Default device cleared."
 	}
 
-	p := tea.NewProgram(picker)
+	p := tea.NewProgram(newDevicePickerModel(ctx, picker, cloudAuth, defaultOrgID))
 
 	// Cancel continuous discovery when the picker exits.
 	discoverCtx, discoverCancel := context.WithCancel(ctx)
@@ -3554,7 +3603,7 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, includeBl
 		if probe != tui.ProbePending {
 			hint = lanNoAccessHint(&devCopy, dev.AgentVersion)
 		}
-		p.Send(tui.PickerAddMsg{Items: []tui.PickerItem{{
+		p.Send(devicePickerLocalMsg{msg: tui.PickerAddMsg{Items: []tui.PickerItem{{
 			Name:          dev.DisplayName,
 			Type:          "LAN",
 			USB:           dev.USB,
@@ -3577,7 +3626,7 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, includeBl
 				CPUArchitecture: dev.CPUArchitecture,
 				LAN:             &devCopy,
 			}},
-		}}})
+		}}}})
 	}
 	// Streaming LAN discovery — cached rows appear instantly, live sightings
 	// and probe outcomes follow, and the engine itself handles offline
@@ -3618,7 +3667,7 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, includeBl
 			continue
 		}
 		go discoverProviderForPicker(discoverCtx, prov, func(items []tui.PickerItem) {
-			p.Send(tui.PickerAddMsg{Items: items})
+			p.Send(devicePickerLocalMsg{msg: tui.PickerAddMsg{Items: items}})
 		})
 	}
 
@@ -3655,7 +3704,7 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, includeBl
 							}},
 						})
 					}
-					p.Send(tui.PickerAddMsg{Items: items})
+					p.Send(devicePickerLocalMsg{msg: tui.PickerAddMsg{Items: items}})
 				}
 
 				select {
@@ -3673,14 +3722,29 @@ func pickDevice(ctx context.Context, excludeProviders map[string]bool, includeBl
 		return nil, fmt.Errorf("device picker: %w", err)
 	}
 
-	pm, ok := finalModel.(tui.PickerModel)
+	dm, ok := finalModel.(devicePickerModel)
 	if !ok {
 		return nil, fmt.Errorf("device picker returned unexpected model %T", finalModel)
 	}
-	if pm.Cancelled() {
+	switch dm.action {
+	case devicePickerLogin:
+		return nil, errDevicePickerLogin
+	case devicePickerSwitchOrg:
+		return nil, errDevicePickerSwitchOrg
+	}
+	if dm.cancelled {
 		return nil, ErrUserCancelled
 	}
-	sel := pm.Selected()
+	if asset := dm.selectedCloud(); asset != nil {
+		cliLogln("Connecting to %s via cloud tunnel...", asset.GetName())
+		conn, err := connectCloudAsset(ctx, cloudAuth, asset, dm.cloud.brokerURL)
+		if err != nil {
+			return nil, err
+		}
+		return &SelectedDevice{Agent: conn}, nil
+	}
+
+	sel := dm.selectedLocal()
 	if sel == nil {
 		return nil, fmt.Errorf("no device selected")
 	}

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -3513,7 +3513,7 @@ func discoverProviderForPicker(ctx context.Context, prov providers.DeviceProvide
 func pickDevice(ctx context.Context, excludeProviders map[string]bool, includeBluetooth bool, suppressUpdateCheck bool) (*SelectedDevice, error) {
 	cfg, err := config.Load()
 	if err != nil {
-		return nil, fmt.Errorf("loading config: %w", err)
+		cfg = nil
 	}
 	cloudAuth := devicePickerInitialAuth(cfg)
 


### PR DESCRIPTION
## Summary

- add Local and Cloud tabs to the shared device picker
- add the same tabbed experience to interactive wendy discover and wendy device list
- show login state and the selected/default organization in Cloud views
- let organization switching show both authenticated orgs and permitted orgs without local credentials
- start login when an unconnected organization is selected and verify its credentials afterward
- keep Cloud discovery lazy until the Cloud tab is opened

## Validation

- go test ./internal/cli/...
- go vet ./internal/cli/commands ./internal/cli/tui
- git diff --check