### PR TITLE
fix(cli): let wendy data download accept a relative output directory

### DIFF
--- a/go/internal/cli/commands/data.go
+++ b/go/internal/cli/commands/data.go
@@ -548,13 +548,30 @@ func newDataDownloadCmd() *cobra.Command {
 	return c
 }
 
-func downloadOne(ctx context.Context, c agentpbv2.DataServiceClient, id, root, rel string, size int64, wantHash string) error {
+// stagedFilePath resolves a manifest-relative path inside the staging
+// directory and rejects anything that would land outside it. Both sides are
+// made absolute first: filepath.Join cleans its result, so a relative root such
+// as "./ep2.partial" would otherwise never match a "./ep2.partial/" prefix and
+// every file in the manifest would be refused.
+func stagedFilePath(root, rel string) (string, error) {
 	if rel == "" || filepath.IsAbs(rel) || filepath.Clean(rel) != rel || strings.HasPrefix(rel, "..") {
-		return errors.New("server returned unsafe file path")
+		return "", errors.New("server returned unsafe file path")
 	}
-	p := filepath.Join(root, rel)
-	if !strings.HasPrefix(p, root+string(os.PathSeparator)) {
-		return errors.New("server file path escapes destination")
+	base, e := filepath.Abs(root)
+	if e != nil {
+		return "", e
+	}
+	p := filepath.Join(base, rel)
+	if !strings.HasPrefix(p, base+string(os.PathSeparator)) {
+		return "", errors.New("server file path escapes destination")
+	}
+	return p, nil
+}
+
+func downloadOne(ctx context.Context, c agentpbv2.DataServiceClient, id, root, rel string, size int64, wantHash string) error {
+	p, e := stagedFilePath(root, rel)
+	if e != nil {
+		return e
 	}
 	if e := os.MkdirAll(filepath.Dir(p), 0o750); e != nil {
 		return e

--- a/go/internal/cli/commands/data_download_test.go
+++ b/go/internal/cli/commands/data_download_test.go
@@ -1,0 +1,80 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestStagedFilePathAcceptsRelativeRoot guards the regression where
+// `wendy data download <episode> -o ./somedir` rejected every manifest file:
+// filepath.Join cleans its result, so joining "./ep2.partial" with
+// "events.jsonl" yields "ep2.partial/events.jsonl", which never carries the
+// "./ep2.partial/" prefix the containment check compared against.
+func TestStagedFilePathAcceptsRelativeRoot(t *testing.T) {
+	abs := t.TempDir()
+	cases := []struct {
+		name string
+		root string
+		rel  string
+	}{
+		{"relative dot-slash root", "./ep2.partial", "events.jsonl"},
+		{"relative dot-slash root nested file", "./ep2.partial", filepath.Join("camera", "0000.mp4")},
+		{"bare relative root", "ep2.partial", "events.jsonl"},
+		{"absolute root", abs, "events.jsonl"},
+		{"absolute root nested file", abs, filepath.Join("camera", "0000.mp4")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := stagedFilePath(tc.root, tc.rel)
+			if err != nil {
+				t.Fatalf("stagedFilePath(%q, %q) = error %v, want the file to resolve", tc.root, tc.rel, err)
+			}
+			wantRoot, err := filepath.Abs(tc.root)
+			if err != nil {
+				t.Fatalf("filepath.Abs(%q): %v", tc.root, err)
+			}
+			want := filepath.Join(wantRoot, tc.rel)
+			if got != want {
+				t.Fatalf("stagedFilePath(%q, %q) = %q, want %q", tc.root, tc.rel, got, want)
+			}
+		})
+	}
+}
+
+// TestStagedFilePathRejectsUnsafePaths confirms the traversal protection still
+// holds once the containment check is done on cleaned, absolute paths.
+func TestStagedFilePathRejectsUnsafePaths(t *testing.T) {
+	abs := t.TempDir()
+	roots := []string{"./ep2.partial", "ep2.partial", abs}
+	rels := []struct {
+		name string
+		rel  string
+	}{
+		{"empty", ""},
+		{"parent", ".."},
+		{"parent traversal", filepath.Join("..", "escape.jsonl")},
+		{"nested traversal", filepath.Join("camera", "..", "..", "escape.jsonl")},
+		{"unclean", "./events.jsonl"},
+		{"trailing traversal", filepath.Join("camera", "..")},
+		{"absolute", string(os.PathSeparator) + filepath.Join("etc", "passwd")},
+	}
+	for _, root := range roots {
+		for _, tc := range rels {
+			t.Run(root+"/"+tc.name, func(t *testing.T) {
+				got, err := stagedFilePath(root, tc.rel)
+				if err == nil {
+					t.Fatalf("stagedFilePath(%q, %q) = %q, want an error", root, tc.rel, got)
+				}
+				base, absErr := filepath.Abs(root)
+				if absErr != nil {
+					t.Fatalf("filepath.Abs(%q): %v", root, absErr)
+				}
+				if got != "" && strings.HasPrefix(got, base+string(os.PathSeparator)) {
+					t.Fatalf("stagedFilePath(%q, %q) returned %q inside the destination", root, tc.rel, got)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`wendy data download <episode-id> -o ./somedir` always failed, on the very first
file in the manifest:

```
server file path escapes destination
```

The episode and every path in its manifest were safe. The only workaround was to
pass an absolute `-o` path.

## Cause

`downloadOne` in `go/internal/cli/commands/data.go` checked containment by
comparing the joined path against the raw, uncleaned root:

```go
p := filepath.Join(root, rel)
if !strings.HasPrefix(p, root+string(os.PathSeparator)) {
    return errors.New("server file path escapes destination")
}
```

`filepath.Join` cleans its result. With `-o ./somedir` the staging root is
`./somedir.partial`, so the join produced `somedir.partial/events.jsonl`, which
never carries the `./somedir.partial/` prefix the check demanded. The comparison
was between a cleaned path and an unclean one, so it rejected every file
regardless of content. An absolute `-o` worked only because an absolute path is
already clean and the two sides happened to agree.

Worth recording for the next person: cleaning only `rel` does not fix this, and
neither does `filepath.Clean(root)` on its own. `Clean(".")` is `"."`, and
`Join(".", "x")` is `"x"`, so a root of `.` would still fail the prefix test.
The root has to be made absolute for the comparison to be sound in every case.

## Solution

Resolve the root with `filepath.Abs` before comparing, so the cleaning that
`Join` performs cannot change the answer. The path resolution moves into a new
`stagedFilePath(root, rel)` helper so it can be tested without a gRPC client;
`downloadOne` now calls it and is otherwise untouched.

The traversal protection is intact. The validation of the server-supplied
relative path is unchanged and still runs first, rejecting empty, absolute,
unclean, and `..`-prefixed paths before any join happens, and the prefix check
now runs on two absolute, cleaned paths.

No behaviour changes for callers that already worked: an absolute `-o` resolves
to exactly the same path as before. Relative roots that previously errored now
succeed, which is the point of the change.

## Verification

Run in `go/`:

- `go test ./internal/cli/commands/ -run TestStagedFilePath -v` — 26 subtests pass.
- `go test ./internal/cli/commands/` — package green.
- `go build ./...`, `go vet ./internal/cli/commands/`, `gofmt -l` — all clean.
- Confirmed the test is a real regression test: with the old body restored in the
  helper, the relative-root cases fail with exactly the reported
  `server file path escapes destination`.

New tests in `go/internal/cli/commands/data_download_test.go`:

- `TestStagedFilePathAcceptsRelativeRoot` covers `./ep2.partial`, a bare
  `ep2.partial`, and an absolute `t.TempDir()` root, each with a top-level and a
  nested manifest file, asserting the resolved path.
- `TestStagedFilePathRejectsUnsafePaths` runs every one of those roots against
  empty, `..`, `../escape.jsonl`, `camera/../../escape.jsonl`, `./events.jsonl`,
  `camera/..`, and an absolute `/etc/passwd`. Each must error, and the test also
  asserts nothing inside the destination is returned.

Not run: an end-to-end `wendy data download` against a real device. The change is
below the gRPC layer and the helper is exercised directly, but the manual check
worth doing is `wendy data download <episode-id> -o ./somedir` against a device
with a recorded episode, confirming the files land under `./somedir`.

Base is `feature/wendy-data-platform`, not `main`: the `wendy data download`
command only exists on the feature branch.
