### PR TITLE
fix(cli): substitute template tokens in .mojo files

### DIFF
--- a/go/internal/cli/commands/template.go
+++ b/go/internal/cli/commands/template.go
@@ -759,7 +759,7 @@ func isTextFile(path string) bool {
 	ext := strings.ToLower(filepath.Ext(path))
 	switch ext {
 	case ".json", ".toml", ".yaml", ".yml", ".md", ".txt", ".html", ".css",
-		".js", ".ts", ".py", ".rs", ".swift", ".go",
+		".js", ".ts", ".py", ".rs", ".swift", ".go", ".mojo",
 		".cpp", ".c", ".h", ".hpp", ".cmake", ".sh", ".bash", ".zsh",
 		".dockerfile", ".gitignore", ".env", ".cfg", ".ini", ".xml",
 		".svg", ".lock":

--- a/go/internal/cli/commands/template_test.go
+++ b/go/internal/cli/commands/template_test.go
@@ -856,3 +856,19 @@ func TestCollectSchemaAnswers_RequiredNoDefaultErrors(t *testing.T) {
 		t.Errorf("error = %q, want it to mention --var for supplying the value", err.Error())
 	}
 }
+
+func TestIsTextFile_CoversTemplateSourceExtensions(t *testing.T) {
+	// Every language the templates repo ships must have its source files
+	// substituted; a miss leaves {{.PORT}}-style tokens in scaffolded code.
+	for _, path := range []string{
+		"main.py", "src/main.rs", "Sources/App/main.swift",
+		"app/index.js", "main.mojo", "pkg/wendynet/net.mojo",
+	} {
+		if !isTextFile(path) {
+			t.Errorf("isTextFile(%q) = false; template tokens would not be substituted", path)
+		}
+	}
+	if isTextFile("assets/logo.jpeg") {
+		t.Error("isTextFile should reject binary assets")
+	}
+}


### PR DESCRIPTION
`wendy init` walks template files and substitutes `{{.VAR}}` tokens only in files `isTextFile()` classifies as text. The allowlist covers `.py/.rs/.swift/...` but not `.mojo`, so the Mojo templates being added in WendyTemplates PR #88 scaffold with raw `{{.PORT}}` tokens in their sources and fail to build with a Mojo parse error.

One-line fix plus a regression test that pins every template-repo source extension.

Until this ships, the mojo templates read `PORT` from the environment (set via Dockerfile `ENV`, which is substituted) — that workaround can be reverted once this release is the floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)