### PR TITLE
ci: run macOS binary builds on self-hosted wendy-developer runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -263,7 +263,9 @@ jobs:
 
   build-go-macos:
     name: ${{ matrix.artifact-name }}
-    runs-on: macos-15
+    runs-on:
+      group: wendy-developer
+      labels: [self-hosted, macOS, ARM64]
     needs: [determine-version]
     # Attest SLSA build provenance in the job that produces the archive, so the
     # provenance reflects the actual build environment (not a downstream job).
@@ -332,7 +334,9 @@ jobs:
 
   build-agent-macos-app:
     name: wendy-agent-macos-app
-    runs-on: macos-26
+    runs-on:
+      group: wendy-developer
+      labels: [self-hosted, macOS, ARM64]
     timeout-minutes: 45
     needs: [determine-version]
     steps:


### PR DESCRIPTION
## What

Move the two macOS binary-build jobs in `build.yml` off GitHub-hosted runners and onto the self-hosted `wendy-developer` macOS/ARM64 pool:

- `build-go-macos`: `macos-15` → `group: wendy-developer`, `labels: [self-hosted, macOS, ARM64]`
- `build-agent-macos-app`: `macos-26` → same

## Why

Route mac binary builds to our own hardware (`wendy-developer-macos-26-01`). Uses the same `runs-on` group/labels convention already in `integration-tests.yml` and `nightly-os-update.yml`.

## Notes

- Targets the pool by label, not a single named runner (GitHub matches labels/group, not runner names). If more than one macOS runner joins the group, jobs load-balance across them; add a unique label to pin to one box.
- `build-go-macos` `brew install`s libusb and uses `setup-go` — the self-hosted box needs Homebrew available. Worth watching the first run.