### PR TITLE
fix(agent): reliably restart macOS agent after update

### DIFF
--- a/Proto/wendy/agent/services/v1/wendy_agent_v1_service.proto
+++ b/Proto/wendy/agent/services/v1/wendy_agent_v1_service.proto
@@ -225,11 +225,9 @@ message GetAgentVersionResponse {
     // even when version strings cannot distinguish builds (dev builds).
     // Empty when the agent cannot hash its own executable.
     //
-    // Only comparable to the update payload on platforms where that payload
-    // IS the executable (linux). The darwin payload is an app-bundle zip, so
-    // its hash can never match this field — the CLI must skip the comparison
-    // there, and a future darwin implementation should instead persist and
-    // report the hash of the update payload it committed.
+    // Linux uploads the executable directly. The Darwin payload is an
+    // app-bundle ZIP, so its updater extracts and hashes Contents/MacOS before
+    // comparing it with this field.
     string binary_sha256 = 20;
     // Device hostname (gethostname(2)). The CLI uses it to identify a device
     // reached over the USB well-known link-local address, where no mDNS TXT

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -1,7 +1,9 @@
 package commands
 
 import (
+	"archive/zip"
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -13,6 +15,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path"
 	"strings"
 	"sync"
 	"syscall"
@@ -2387,9 +2390,17 @@ func newDeviceUpdateCmd() *cobra.Command {
 			// Hash the binary we're about to upload. Skipped when already
 			// current: no binary was downloaded and no upload happens.
 			var sha256Hash string
+			var verificationSHA string
 			if !agentAlreadyCurrent {
 				h := sha256.Sum256(binaryData)
 				sha256Hash = hex.EncodeToString(h[:])
+				verificationSHA = sha256Hash
+				if strings.EqualFold(preUpdateVersion.GetOs(), "darwin") {
+					verificationSHA, err = darwinAgentExecutableSHA256(binaryData)
+					if err != nil {
+						return fmt.Errorf("inspecting macOS agent bundle: %w", err)
+					}
+				}
 			}
 
 			if agentAlreadyCurrent {
@@ -2439,17 +2450,18 @@ func newDeviceUpdateCmd() *cobra.Command {
 				// swap landed — always check what the device actually runs
 				// before claiming success (a silent no-op or rollback still
 				// reports the old binary here). The darwin artifact is an
-				// app-bundle ZIP, so its hash can never equal a hash of the
-				// running executable: skip the hash comparison there and let
-				// the version check carry the verdict. The verify window
+				// app-bundle ZIP, so compare the executable inside that ZIP with
+				// the executable hash snapshotted by the Mac agent at launch. This
+				// proves both the swap and the restart; older agents leave it empty.
+				// The verify window
 				// matches the restart budget so a mismatch re-poll can
 				// outlast a lingering old agent.
-				verifySHA := sha256Hash
-				if strings.EqualFold(preUpdateVersion.GetOs(), "darwin") {
-					verifySHA = ""
-				}
-				verified, verifyErr := verifyAgentAfterUpdate(ctx, conn.AgentService, verifySHA, expectedAgentVersion,
-					agentVerifyWaitOptions{Timeout: agentRestartTimeoutFor(preUpdateVersion.GetOs())})
+				requireHash := strings.EqualFold(preUpdateVersion.GetOs(), "darwin")
+				verified, verifyErr := verifyAgentAfterUpdate(ctx, conn.AgentService, verificationSHA, expectedAgentVersion,
+					agentVerifyWaitOptions{
+						Timeout:     agentRestartTimeoutFor(preUpdateVersion.GetOs()),
+						RequireHash: requireHash,
+					})
 				if verifyErr != nil {
 					return verifyErr
 				}
@@ -2584,6 +2596,46 @@ func checkELFArchitecture(data []byte, deviceArch string) error {
 // magic "PK\x03\x04" (what ditto -c -k produces).
 func isZipArchive(data []byte) bool {
 	return len(data) >= 4 && data[0] == 'P' && data[1] == 'K' && data[2] == 0x03 && data[3] == 0x04
+}
+
+// darwinAgentExecutableSHA256 extracts and hashes the executable the Mac agent
+// will launch from the uploaded app-bundle ZIP. The relaunched agent reports
+// the hash of its mapped executable, making even same-version dev updates
+// distinguishable from the process that performed the on-disk replacement.
+func darwinAgentExecutableSHA256(data []byte) (string, error) {
+	archive, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return "", fmt.Errorf("opening ZIP: %w", err)
+	}
+
+	var executable *zip.File
+	for _, file := range archive.File {
+		name := path.Clean(strings.TrimPrefix(file.Name, "./"))
+		parts := strings.Split(name, "/")
+		if len(parts) != 4 || !strings.HasSuffix(parts[0], ".app") ||
+			parts[1] != "Contents" || parts[2] != "MacOS" || parts[3] != "WendyAgentMac" {
+			continue
+		}
+		if executable != nil {
+			return "", errors.New("ZIP contains more than one WendyAgentMac executable")
+		}
+		executable = file
+	}
+	if executable == nil {
+		return "", errors.New("ZIP does not contain a top-level WendyAgentMac.app executable")
+	}
+
+	reader, err := executable.Open()
+	if err != nil {
+		return "", fmt.Errorf("opening WendyAgentMac executable: %w", err)
+	}
+	defer reader.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, reader); err != nil {
+		return "", fmt.Errorf("hashing WendyAgentMac executable: %w", err)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // isELFBinary reports whether data begins with the ELF magic (0x7f 'E' 'L'
@@ -2883,6 +2935,10 @@ func agentUpdateVerified(reported, expected string) bool {
 type agentVerifyWaitOptions struct {
 	Timeout      time.Duration
 	PollInterval time.Duration
+	// RequireHash refuses the version-only fallback. macOS uses this because
+	// its executable digest is what proves a new process started, even
+	// when two dev bundles carry the same version string.
+	RequireHash bool
 }
 
 const (
@@ -2894,10 +2950,10 @@ const (
 // against what the update uploaded. A reported binary hash compared to the
 // uploaded one is definitive in both directions — it is what makes dev pushes
 // provable, since dev builds share identical version strings. Version
-// comparison is only the fallback for agents that cannot report a hash (the
-// mac agent, pre-hash releases), and with nothing to compare a reachable
-// agent is accepted.
-func evaluateAgentUpdateOutcome(resp *agentpb.GetAgentVersionResponse, uploadedSHA256, expectedVersion string) error {
+// comparison is only the fallback for agents that cannot report a hash. When
+// requireHash is true (macOS), an empty hash means the old process or a broken
+// replacement answered and is not accepted.
+func evaluateAgentUpdateOutcome(resp *agentpb.GetAgentVersionResponse, uploadedSHA256, expectedVersion string, requireHash bool) error {
 	reportedHash := resp.GetBinarySha256()
 	if reportedHash != "" && uploadedSHA256 != "" {
 		if strings.EqualFold(reportedHash, uploadedSHA256) {
@@ -2906,6 +2962,9 @@ func evaluateAgentUpdateOutcome(resp *agentpb.GetAgentVersionResponse, uploadedS
 		return fmt.Errorf("the device is not running the binary that was uploaded "+
 			"(running sha256 %s, uploaded %s); the update did not apply — re-run 'wendy device update'",
 			reportedHash, uploadedSHA256)
+	}
+	if requireHash {
+		return fmt.Errorf("the updated agent did not report its executable hash; restart was not verified — re-run 'wendy device update'")
 	}
 	if agentUpdateVerified(resp.GetVersion(), expectedVersion) {
 		return nil
@@ -2918,8 +2977,7 @@ func evaluateAgentUpdateOutcome(resp *agentpb.GetAgentVersionResponse, uploadedS
 // agentVerifyResult is what verifyAgentAfterUpdate learned about the agent
 // that answered. HashVerified reports whether the running binary's hash was
 // actually compared and matched — callers must not claim cryptographic proof
-// without it, since a hash-less agent (mac, pre-hash releases) passes the
-// version fallback vacuously.
+// without it, since a hash-less pre-hash agent can pass the version fallback.
 type agentVerifyResult struct {
 	Version      string
 	HashVerified bool
@@ -2948,7 +3006,7 @@ func verifyAgentAfterUpdate(ctx context.Context, agentService agentpb.WendyAgent
 	for {
 		resp, err := agentService.GetAgentVersion(waitCtx, &agentpb.GetAgentVersionRequest{})
 		if err == nil {
-			if verdict := evaluateAgentUpdateOutcome(resp, uploadedSHA256, expectedVersion); verdict != nil {
+			if verdict := evaluateAgentUpdateOutcome(resp, uploadedSHA256, expectedVersion, opts.RequireHash); verdict != nil {
 				lastVerdictErr = verdict
 			} else {
 				return agentVerifyResult{

--- a/go/internal/cli/commands/device_update_test.go
+++ b/go/internal/cli/commands/device_update_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"archive/zip"
 	"bytes"
 	"context"
 	"errors"
@@ -16,6 +17,25 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
+
+func makeMacAgentZIP(t *testing.T, entries map[string][]byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, contents := range entries {
+		entry, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("zip.Create(%q): %v", name, err)
+		}
+		if _, err := entry.Write(contents); err != nil {
+			t.Fatalf("writing %q: %v", name, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("closing zip: %v", err)
+	}
+	return buf.Bytes()
+}
 
 // fakeUpdateAgentStream satisfies agentpb.WendyAgentService_UpdateAgentClient
 // (a grpc.BidiStreamingClient[UpdateAgentRequest, UpdateAgentResponse]) via
@@ -99,6 +119,42 @@ func TestIsZipArchive(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDarwinAgentExecutableSHA256(t *testing.T) {
+	t.Run("hashes the executable inside the app bundle", func(t *testing.T) {
+		archive := makeMacAgentZIP(t, map[string][]byte{
+			"WendyAgentMac.app/Contents/Info.plist":          []byte("plist"),
+			"WendyAgentMac.app/Contents/MacOS/WendyAgentMac": []byte("hello"),
+		})
+		got, err := darwinAgentExecutableSHA256(archive)
+		if err != nil {
+			t.Fatalf("darwinAgentExecutableSHA256() error = %v", err)
+		}
+		const want = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+		if got != want {
+			t.Fatalf("darwinAgentExecutableSHA256() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("rejects an archive without the agent executable", func(t *testing.T) {
+		archive := makeMacAgentZIP(t, map[string][]byte{
+			"WendyAgentMac.app/Contents/Info.plist": []byte("plist"),
+		})
+		if _, err := darwinAgentExecutableSHA256(archive); err == nil {
+			t.Fatal("darwinAgentExecutableSHA256() error = nil, want missing executable error")
+		}
+	})
+
+	t.Run("rejects ambiguous app bundles", func(t *testing.T) {
+		archive := makeMacAgentZIP(t, map[string][]byte{
+			"WendyAgentMac.app/Contents/MacOS/WendyAgentMac": []byte("one"),
+			"Other.app/Contents/MacOS/WendyAgentMac":         []byte("two"),
+		})
+		if _, err := darwinAgentExecutableSHA256(archive); err == nil {
+			t.Fatal("darwinAgentExecutableSHA256() error = nil, want ambiguity error")
+		}
+	})
 }
 
 func TestCheckLocalAgentArtifact(t *testing.T) {
@@ -422,34 +478,36 @@ func TestAgentUpdateVerified(t *testing.T) {
 // evaluateAgentUpdateOutcome precedence: a reported binary hash compared to
 // the uploaded one is definitive in both directions (it is what makes dev
 // pushes provable, since dev builds share identical version strings); version
-// comparison is only the fallback for agents that cannot report a hash; with
-// nothing to compare, a reachable agent is accepted.
+// comparison is only the fallback for agents that cannot report a hash unless
+// the caller requires hash proof (the macOS restart-verification path).
 func TestEvaluateAgentUpdateOutcome(t *testing.T) {
 	resp := func(ver, hash string) *agentpb.GetAgentVersionResponse {
 		return &agentpb.GetAgentVersionResponse{Version: ver, BinarySha256: hash}
 	}
 	tests := []struct {
-		name       string
-		resp       *agentpb.GetAgentVersionResponse
-		uploaded   string
-		expected   string
-		wantErr    bool
-		wantSubstr string
+		name        string
+		resp        *agentpb.GetAgentVersionResponse
+		uploaded    string
+		expected    string
+		requireHash bool
+		wantErr     bool
+		wantSubstr  string
 	}{
-		{"hash match verifies", resp("2026.07.01-223311", "aabb01"), "aabb01", "2026.07.01-223311", false, ""},
-		{"hash match proves a dev-over-dev push", resp("dev", "cafe02"), "cafe02", "", false, ""},
-		{"hash match is definitive even against an older-looking version", resp("2026.06.30-120000", "cafe03"), "cafe03", "2026.07.01-223311", false, ""},
-		{"hash comparison ignores case", resp("dev", "CAFE04"), "cafe04", "", false, ""},
-		{"hash mismatch fails even when versions agree", resp("2026.07.01-223311", "aaaa05"), "bbbb06", "2026.07.01-223311", true, "not running the binary"},
-		{"no reported hash falls back to version pass", resp("2026.07.01-223311", ""), "aabb07", "2026.07.01-223311", false, ""},
-		{"no reported hash falls back to version fail", resp("2026.06.30-120000", ""), "aabb08", "2026.07.01-223311", true, "2026.06.30-120000"},
-		{"no uploaded hash falls back to version", resp("2026.07.01-223311", "aabb09"), "", "2026.07.01-223311", false, ""},
-		{"dev reported against a release expectation fails", resp("dev", ""), "", "2026.07.01-223311", true, "dev"},
-		{"nothing to compare accepts a reachable agent", resp("dev", ""), "", "", false, ""},
+		{"hash match verifies", resp("2026.07.01-223311", "aabb01"), "aabb01", "2026.07.01-223311", false, false, ""},
+		{"hash match proves a dev-over-dev push", resp("dev", "cafe02"), "cafe02", "", true, false, ""},
+		{"hash match is definitive even against an older-looking version", resp("2026.06.30-120000", "cafe03"), "cafe03", "2026.07.01-223311", true, false, ""},
+		{"hash comparison ignores case", resp("dev", "CAFE04"), "cafe04", "", true, false, ""},
+		{"hash mismatch fails even when versions agree", resp("2026.07.01-223311", "aaaa05"), "bbbb06", "2026.07.01-223311", true, true, "not running the binary"},
+		{"no reported hash falls back to version pass", resp("2026.07.01-223311", ""), "aabb07", "2026.07.01-223311", false, false, ""},
+		{"required hash rejects the still-running old mac agent", resp("dev", ""), "aabb07", "", true, true, "restart was not verified"},
+		{"no reported hash falls back to version fail", resp("2026.06.30-120000", ""), "aabb08", "2026.07.01-223311", false, true, "2026.06.30-120000"},
+		{"no uploaded hash falls back to version", resp("2026.07.01-223311", "aabb09"), "", "2026.07.01-223311", false, false, ""},
+		{"dev reported against a release expectation fails", resp("dev", ""), "", "2026.07.01-223311", false, true, "dev"},
+		{"nothing to compare accepts a reachable agent", resp("dev", ""), "", "", false, false, ""},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := evaluateAgentUpdateOutcome(tc.resp, tc.uploaded, tc.expected)
+			err := evaluateAgentUpdateOutcome(tc.resp, tc.uploaded, tc.expected, tc.requireHash)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("evaluateAgentUpdateOutcome() error = %v, wantErr %v", err, tc.wantErr)
 			}

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentService.swift
@@ -8,6 +8,8 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     var hostname: any HostnameSetting = ScutilHostname()
     var wifi: any WiFiManaging = WiFiController()
     var bluetooth: any BluetoothManaging = BluetoothScanner()
+    /// Digest of the executable mapped by this process, captured at startup.
+    var binarySHA256: String = ""
     /// Serializes agent self-updates. Held by `WendyAgent` (not created here)
     /// so the same lock survives the service rebuilds that provisioning
     /// transitions perform.
@@ -93,6 +95,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
         #endif
         response.memTotalBytes = Int64(clamping: ProcessInfo.processInfo.physicalMemory)
         response.cpuCount = UInt32(clamping: ProcessInfo.processInfo.activeProcessorCount)
+        response.binarySha256 = self.binarySHA256
         return ServerResponse(message: response)
     }
 

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/Platform/AgentExecutableDigest.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/Platform/AgentExecutableDigest.swift
@@ -1,0 +1,14 @@
+import CryptoKit
+import Foundation
+
+/// Hashes the executable mapped by this agent process. The CLI extracts and
+/// hashes the same file from a macOS update ZIP, so a match proves that the
+/// replacement bundle launched even when its version string did not change.
+enum AgentExecutableDigest {
+    static func sha256(at url: URL?) -> String {
+        guard let url, let data = try? Data(contentsOf: url, options: .mappedIfSafe) else {
+            return ""
+        }
+        return SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/Platform/AgentRelauncher.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/Platform/AgentRelauncher.swift
@@ -15,18 +15,10 @@ struct AgentRelauncher: AgentRelaunchScheduling {
     /// Injected by the app target (clean quit path); nil ⇒ exit(0).
     let terminate: (@Sendable () async -> Void)?
 
-    /// How long the graceful quit gets before the process is forced down.
-    /// Two bounds pin this value:
-    ///  - It must outlast a real teardown: `WendyAgent.stop()` stops running
-    ///    apps *sequentially*, and a containerized app can cost ~10 s (the
-    ///    `docker stop` timeout) plus a ~5 s attached wait, so two running
-    ///    apps already need ~30-35 s. The old 15 s hard-killed every update on
-    ///    a device that was actually running something.
-    ///  - It must stay comfortably inside the CLI's darwin agent-restart wait
-    ///    (`darwinAgentRestartTimeout`, 60 s, polled from the update ack):
-    ///    exiting at 45 s still leaves the relaunched app time to come back up
-    ///    before the CLI gives up on it.
-    static let hardExitDelay: Duration = .seconds(45)
+    /// The app target's update-specific termination path does not stop deployed
+    /// apps; they survive the agent process and are adopted after relaunch. This
+    /// is only a watchdog for AppKit failing to terminate promptly.
+    static let hardExitDelay: Duration = .seconds(10)
 
     /// How long the gRPC ack gets to flush to the client before the graceful
     /// quit tears the connection down.
@@ -60,7 +52,7 @@ struct AgentRelauncher: AgentRelaunchScheduling {
               /bin/sleep 0.5
               i=$((i+1)); [ "$i" -ge 600 ] && exit 1
             done
-            exec /usr/bin/open "$2"
+            exec /usr/bin/open -n "$2"
             """
         return ["-c", script, "wendy-agent-relaunch", String(pid), bundlePath]
     }

--- a/swift/WendyAgentCore/Sources/WendyAgent/WendyAgent.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/WendyAgent.swift
@@ -28,8 +28,13 @@ public actor WendyAgent {
     public private(set) var status: WendyAgentStatus = .idle
     public private(set) var apps: [WendyAppInfo] = []
 
+    /// Snapshotted before any RPC service starts so post-update verification
+    /// describes the executable this process actually mapped.
+    private let runningExecutableSHA256: String
+
     public init(configuration: WendyAgentConfiguration = .init()) {
         self.configuration = configuration
+        self.runningExecutableSHA256 = AgentExecutableDigest.sha256(at: Bundle.main.executableURL)
     }
 
     public func start() async throws {
@@ -336,6 +341,7 @@ public actor WendyAgent {
 
         let services: [any RegistrableRPCService] = [
             AgentService(
+                binarySHA256: self.runningExecutableSHA256,
                 updateLock: self.agentUpdateLock,
                 updateDependencies: .init(
                     relauncher: AgentRelauncher(terminate: self.agentTerminationHandler)

--- a/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/shared.pb.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/shared.pb.swift
@@ -114,6 +114,58 @@ public nonisolated enum AppRunningState: SwiftProtobuf.Enum, Swift.CaseIterable 
 
 }
 
+/// Charge state of a system battery, as reported by the kernel.
+public nonisolated enum BatteryState: SwiftProtobuf.Enum, Swift.CaseIterable {
+  public typealias RawValue = Int
+
+  /// kernel reports "Unknown", or no status file
+  case unknown // = 0
+  case charging // = 1
+  case discharging // = 2
+  case full // = 3
+
+  /// Present on a charger but deliberately not charging (e.g. a charge
+  /// threshold is holding the pack below 100%). Distinct from FULL.
+  case notCharging // = 4
+  case UNRECOGNIZED(Int)
+
+  public init() {
+    self = .unknown
+  }
+
+  public init?(rawValue: Int) {
+    switch rawValue {
+    case 0: self = .unknown
+    case 1: self = .charging
+    case 2: self = .discharging
+    case 3: self = .full
+    case 4: self = .notCharging
+    default: self = .UNRECOGNIZED(rawValue)
+    }
+  }
+
+  public var rawValue: Int {
+    switch self {
+    case .unknown: return 0
+    case .charging: return 1
+    case .discharging: return 2
+    case .full: return 3
+    case .notCharging: return 4
+    case .UNRECOGNIZED(let i): return i
+    }
+  }
+
+  // The compiler won't synthesize support with the UNRECOGNIZED case.
+  public static let allCases: [BatteryState] = [
+    .unknown,
+    .charging,
+    .discharging,
+    .full,
+    .notCharging,
+  ]
+
+}
+
 public nonisolated struct RestartPolicy: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -186,6 +238,38 @@ public nonisolated struct AppContainer: Sendable {
   public init() {}
 }
 
+/// BatteryStats is the device's aggregate system-battery state. It is only ever
+/// set for devices that actually have a battery: consumers must treat its
+/// absence as "mains-powered" and show nothing, never as 0%.
+public nonisolated struct BatteryStats: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Charge level, 0-100, across every system battery on the device.
+  public var percent: Double = 0
+
+  public var state: BatteryState = .unknown
+
+  /// Estimated seconds until empty (discharging) or until full (charging).
+  /// Absent whenever the kernel reports no usable charge/discharge rate — a
+  /// missing estimate is reported as missing rather than extrapolated.
+  public var secondsRemaining: Int64 {
+    get {_secondsRemaining ?? 0}
+    set {_secondsRemaining = newValue}
+  }
+  /// Returns true if `secondsRemaining` has been explicitly set.
+  public var hasSecondsRemaining: Bool {self._secondsRemaining != nil}
+  /// Clears the value of `secondsRemaining`. Subsequent reads from it will return its default value.
+  public mutating func clearSecondsRemaining() {self._secondsRemaining = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _secondsRemaining: Int64? = nil
+}
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 nonisolated extension RestartPolicyMode: SwiftProtobuf._ProtoNameProviding {
@@ -194,6 +278,10 @@ nonisolated extension RestartPolicyMode: SwiftProtobuf._ProtoNameProviding {
 
 nonisolated extension AppRunningState: SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0STOPPED\0\u{1}RUNNING\0\u{1}CRASH_LOOPING\0")
+}
+
+nonisolated extension BatteryState: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0BATTERY_STATE_UNKNOWN\0\u{1}BATTERY_STATE_CHARGING\0\u{1}BATTERY_STATE_DISCHARGING\0\u{1}BATTERY_STATE_FULL\0\u{1}BATTERY_STATE_NOT_CHARGING\0")
 }
 
 nonisolated extension RestartPolicy: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
@@ -331,6 +419,50 @@ nonisolated extension AppContainer: SwiftProtobuf.Message, SwiftProtobuf._Messag
     if lhs.exitCode != rhs.exitCode {return false}
     if lhs.terminationReason != rhs.terminationReason {return false}
     if lhs.httpPort != rhs.httpPort {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension BatteryStats: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = "BatteryStats"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}percent\0\u{1}state\0\u{3}seconds_remaining\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularDoubleField(value: &self.percent) }()
+      case 2: try { try decoder.decodeSingularEnumField(value: &self.state) }()
+      case 3: try { try decoder.decodeSingularInt64Field(value: &self._secondsRemaining) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    if self.percent.bitPattern != 0 {
+      try visitor.visitSingularDoubleField(value: self.percent, fieldNumber: 1)
+    }
+    if self.state != .unknown {
+      try visitor.visitSingularEnumField(value: self.state, fieldNumber: 2)
+    }
+    try { if let v = self._secondsRemaining {
+      try visitor.visitSingularInt64Field(value: v, fieldNumber: 3)
+    } }()
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: BatteryStats, rhs: BatteryStats) -> Bool {
+    if lhs.percent != rhs.percent {return false}
+    if lhs.state != rhs.state {return false}
+    if lhs._secondsRemaining != rhs._secondsRemaining {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/wendy_agent_v1_service.pb.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgentGRPC/Proto/wendy/agent/services/v1/wendy_agent_v1_service.pb.swift
@@ -620,6 +620,44 @@ public nonisolated struct Wendy_Agent_Services_V1_GetAgentVersionResponse: @unch
     set {_uniqueStorage()._cpuCount = newValue}
   }
 
+  /// Hex SHA-256 of the executable this agent process was started from.
+  /// Lets an updater confirm an uploaded binary is what actually runs,
+  /// even when version strings cannot distinguish builds (dev builds).
+  /// Empty when the agent cannot hash its own executable.
+  ///
+  /// Linux uploads the executable directly. The Darwin payload is an
+  /// app-bundle ZIP, so its updater extracts and hashes Contents/MacOS before
+  /// comparing it with this field.
+  public var binarySha256: String {
+    get {_storage._binarySha256}
+    set {_uniqueStorage()._binarySha256 = newValue}
+  }
+
+  /// Device hostname (gethostname(2)). The CLI uses it to identify a device
+  /// reached over the USB well-known link-local address, where no mDNS TXT
+  /// records are available. Empty on agents predating this field.
+  ///
+  /// Numbered 21, not 20: this field was authored on PR #1621 against 20,
+  /// which binary_sha256 above had already taken on main. The battery field
+  /// below was deliberately started at 22 to leave 21 free for exactly this
+  /// renumber, so no wire number is reused across the two merges.
+  public var hostname: String {
+    get {_storage._hostname}
+    set {_uniqueStorage()._hostname = newValue}
+  }
+
+  /// Aggregate system-battery state, from /sys/class/power_supply. Absent on
+  /// mains-powered devices and on agents predating this field, so `wendy
+  /// device info` shows no battery line for either.
+  public var battery: BatteryStats {
+    get {_storage._battery ?? BatteryStats()}
+    set {_uniqueStorage()._battery = newValue}
+  }
+  /// Returns true if `battery` has been explicitly set.
+  public var hasBattery: Bool {_storage._battery != nil}
+  /// Clears the value of `battery`. Subsequent reads from it will return its default value.
+  public mutating func clearBattery() {_uniqueStorage()._battery = nil}
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -2507,7 +2545,7 @@ nonisolated extension Wendy_Agent_Services_V1_GetAgentVersionRequest: SwiftProto
 
 nonisolated extension Wendy_Agent_Services_V1_GetAgentVersionResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetAgentVersionResponse"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}version\0\u{3}os_version\0\u{1}os\0\u{3}cpu_architecture\0\u{3}public_key\0\u{1}featureset\0\u{3}device_type\0\u{3}has_gpu\0\u{3}gpu_vendor\0\u{3}jetpack_version\0\u{3}cuda_version\0\u{3}storage_medium\0\u{3}disk_used_bytes\0\u{3}disk_total_bytes\0\u{1}partitions\0\u{3}gpu_arch\0\u{3}network_interfaces\0\u{3}mem_total_bytes\0\u{3}cpu_count\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}version\0\u{3}os_version\0\u{1}os\0\u{3}cpu_architecture\0\u{3}public_key\0\u{1}featureset\0\u{3}device_type\0\u{3}has_gpu\0\u{3}gpu_vendor\0\u{3}jetpack_version\0\u{3}cuda_version\0\u{3}storage_medium\0\u{3}disk_used_bytes\0\u{3}disk_total_bytes\0\u{1}partitions\0\u{3}gpu_arch\0\u{3}network_interfaces\0\u{3}mem_total_bytes\0\u{3}cpu_count\0\u{3}binary_sha256\0\u{1}hostname\0\u{1}battery\0")
 
   fileprivate class _StorageClass {
     var _version: String = String()
@@ -2529,6 +2567,9 @@ nonisolated extension Wendy_Agent_Services_V1_GetAgentVersionResponse: SwiftProt
     var _networkInterfaces: [Wendy_Agent_Services_V1_NetworkInterface] = []
     var _memTotalBytes: Int64 = 0
     var _cpuCount: UInt32 = 0
+    var _binarySha256: String = String()
+    var _hostname: String = String()
+    var _battery: BatteryStats? = nil
 
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
@@ -2558,6 +2599,9 @@ nonisolated extension Wendy_Agent_Services_V1_GetAgentVersionResponse: SwiftProt
       _networkInterfaces = source._networkInterfaces
       _memTotalBytes = source._memTotalBytes
       _cpuCount = source._cpuCount
+      _binarySha256 = source._binarySha256
+      _hostname = source._hostname
+      _battery = source._battery
     }
   }
 
@@ -2595,6 +2639,9 @@ nonisolated extension Wendy_Agent_Services_V1_GetAgentVersionResponse: SwiftProt
         case 17: try { try decoder.decodeRepeatedMessageField(value: &_storage._networkInterfaces) }()
         case 18: try { try decoder.decodeSingularInt64Field(value: &_storage._memTotalBytes) }()
         case 19: try { try decoder.decodeSingularUInt32Field(value: &_storage._cpuCount) }()
+        case 20: try { try decoder.decodeSingularStringField(value: &_storage._binarySha256) }()
+        case 21: try { try decoder.decodeSingularStringField(value: &_storage._hostname) }()
+        case 22: try { try decoder.decodeSingularMessageField(value: &_storage._battery) }()
         default: break
         }
       }
@@ -2664,6 +2711,15 @@ nonisolated extension Wendy_Agent_Services_V1_GetAgentVersionResponse: SwiftProt
       if _storage._cpuCount != 0 {
         try visitor.visitSingularUInt32Field(value: _storage._cpuCount, fieldNumber: 19)
       }
+      if !_storage._binarySha256.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._binarySha256, fieldNumber: 20)
+      }
+      if !_storage._hostname.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._hostname, fieldNumber: 21)
+      }
+      try { if let v = _storage._battery {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 22)
+      } }()
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -2692,6 +2748,9 @@ nonisolated extension Wendy_Agent_Services_V1_GetAgentVersionResponse: SwiftProt
         if _storage._networkInterfaces != rhs_storage._networkInterfaces {return false}
         if _storage._memTotalBytes != rhs_storage._memTotalBytes {return false}
         if _storage._cpuCount != rhs_storage._cpuCount {return false}
+        if _storage._binarySha256 != rhs_storage._binarySha256 {return false}
+        if _storage._hostname != rhs_storage._hostname {return false}
+        if _storage._battery != rhs_storage._battery {return false}
         return true
       }
       if !storagesAreEqual {return false}

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/AgentUpdatePlatformTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/AgentUpdatePlatformTests.swift
@@ -161,13 +161,36 @@ struct AgentUpdateLockTests {
     }
 }
 
+@Suite("AgentExecutableDigest")
+struct AgentExecutableDigestTests {
+    @Test("hashes the executable bytes the CLI extracts from the update ZIP")
+    func hashesFile() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "AgentExecutableDigestTests-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(
+            at: root,
+            withIntermediateDirectories: true
+        )
+        let executable = root.appendingPathComponent("WendyAgentMac")
+        try Data("hello".utf8).write(to: executable)
+
+        #expect(
+            AgentExecutableDigest.sha256(at: executable)
+                == "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        )
+        #expect(AgentExecutableDigest.sha256(at: nil).isEmpty)
+        #expect(AgentExecutableDigest.sha256(at: root.appendingPathComponent("missing")).isEmpty)
+    }
+}
+
 @Suite("AgentRelauncher.scheduleTermination timings")
 struct AgentRelauncherTerminationTimingTests {
-    @Test("the hard-exit watchdog outlasts a multi-app teardown but stays inside the CLI's wait")
+    @Test("the hard-exit watchdog quickly backs up the update-specific AppKit quit")
     func hardExitDelayBounds() {
-        #expect(AgentRelauncher.hardExitDelay == .seconds(45))
-        // Two containerized apps stop sequentially at ~10 s + ~5 s each.
-        #expect(AgentRelauncher.hardExitDelay > .seconds(35))
+        #expect(AgentRelauncher.hardExitDelay == .seconds(10))
         // The CLI polls a darwin agent for 60 s after the update ack.
         #expect(AgentRelauncher.hardExitDelay < .seconds(60))
     }
@@ -193,7 +216,7 @@ struct AgentRelauncherMakeArgumentsTests {
         #expect(script.contains(#"while /bin/kill -0 "$1" 2>/dev/null; do"#))
         #expect(script.contains("/bin/sleep 0.5"))
         #expect(script.contains(#"[ "$i" -ge 600 ] && exit 1"#))
-        #expect(script.contains(#"exec /usr/bin/open "$2""#))
+        #expect(script.contains(#"exec /usr/bin/open -n "$2""#))
 
         // $0 is a placeholder positional arg (script name); $1/$2 are pid/path.
         #expect(arguments[2] == "wendy-agent-relaunch")

--- a/swift/WendyAgentMac/Sources/AppDelegate.swift
+++ b/swift/WendyAgentMac/Sources/AppDelegate.swift
@@ -33,11 +33,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate,
             )
 
             // Registered before start() so the services the agent builds at
-            // startup capture it. Invoked from a detached task after the
-            // update RPC has returned, so stop()'s drain cannot deadlock on
-            // the still-open update stream.
+            // startup capture it. A self-update must end this process without
+            // running the ordinary Quit teardown: deployed apps should survive
+            // and be adopted by the replacement agent, and draining the gRPC
+            // server here can wait on the update RPC that triggered the quit.
             await self.wendyAgent.setAgentTerminationHandler { [weak self] in
-                await self?.performQuit()
+                await self?.performUpdateQuit()
             }
 
             do {
@@ -69,9 +70,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate,
         self.performQuit()
     }
 
-    /// Shuts the agent down and terminates the app. Shared by the Quit menu
-    /// item and the agent's post-update termination handler; re-entrant calls
-    /// are ignored.
+    /// Shuts the agent down and terminates the app after an explicit user Quit.
     private func performQuit() {
         guard !self.isQuitting else { return }
         self.isQuitting = true
@@ -81,6 +80,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate,
             await self.wendyAgent.stop()
             NSApplication.shared.terminate(nil)
         }
+    }
+
+    /// Ends only the agent app after a committed self-update. The detached
+    /// relaunch watcher opens the freshly-installed bundle once this PID exits.
+    private func performUpdateQuit() {
+        NSApplication.shared.terminate(nil)
     }
 
     func windowWillClose(_ notification: Notification) {


### PR DESCRIPTION
## Summary
- terminate the macOS agent through an update-specific path so the replaced app can relaunch without draining the triggering RPC or stopping deployed apps
- relaunch with a new app instance and retain a hard-exit watchdog
- verify the restarted process by hashing the executable inside the uploaded app bundle and comparing it with the hash reported by the new agent
- regenerate the Swift protobuf bindings needed to report the executable digest

## Testing
- go test ./internal/cli/commands
- swift test (351 tests)
- swift format lint --strict on changed Swift sources
- xcodebuild WendyAgentMac Debug for generic macOS with code signing disabled