### PR TITLE
fix(tests): match the end-to-end assertion to wendy discover's help text

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDiscoverTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDiscoverTests.swift
@@ -16,7 +16,7 @@ struct `'wendy discover'` {
             try await cli.sh("wendy discover --help") { result in
                 let stdout = result.stdout
                 #expect(result.status.isSuccess)
-                #expect(stdout.contains("Continuously scan for WendyOS devices"))
+                #expect(stdout.contains("Continuously discover WendyOS devices"))
                 #expect(stdout.contains("Usage:"))
                 #expect(stdout.contains("wendy discover [flags]"))
                 #expect(stdout.contains("--timeout"))


### PR DESCRIPTION
## Problem

The `Local: Ubuntu 24` and `Local: macOS 26` suites fail on a single test out of 929:

```
✘ Test "prints command help" recorded an issue at WendyDiscoverTests.swift:19:17
```

## Cause

The test expects the help output to contain "Continuously scan for WendyOS devices". The command's actual `Long` description in `go/internal/cli/commands/discover.go:40` is:

> Continuously discover WendyOS devices in Local and Cloud tabs until Ctrl+C. Use --timeout to scan local devices once for a fixed duration.

Both the current wording and the stale expectation are present on `main` together, so this is a pre-existing failure rather than a regression from any open branch. It surfaced while bringing a long-running integration branch up to date with main, where the same one test failed on both platforms.

## Solution

Update the assertion to the wording the command actually prints. The help text is the intended one, so only the test changes.

Found while unblocking #1751, but fixed separately because it is main's bug and unrelated to that branch.