### PR TITLE
docs: document JetPack 7.2 targeting for Jetson (WDY-2561)

### DIFF
--- a/go/internal/cli/assets/docs/wendyos/jetson/README.md
+++ b/go/internal/cli/assets/docs/wendyos/jetson/README.md
@@ -2,26 +2,23 @@
 
 WendyOS supports the following NVIDIA Jetson targets:
 
-| Board | Machine config | SoC | JetPack / L4T | Mender OTA | Yocto series |
+| Board | Machine config | SoC | JetPack / L4T | OTA | Yocto series |
 |---|---|---|---|---|---|
-| Jetson AGX Orin DevKit (NVMe) | `jetson-agx-orin-devkit-nvme-wendyos` | tegra234 | JetPack 6.2.1 / L4T 36.4.4 | Yes | scarthgap |
-| Jetson AGX Orin DevKit (eMMC) | `jetson-agx-orin-devkit-emmc-wendyos` | tegra234 | JetPack 6.2.1 / L4T 36.4.4 | Yes | scarthgap |
-| Jetson Orin Nano DevKit (NVMe) | `jetson-orin-nano-devkit-nvme-wendyos` | tegra234 | JetPack 6.2.1 / L4T 36.4.4 | Yes | scarthgap |
-| Jetson Orin Nano DevKit (SD) | `jetson-orin-nano-devkit-wendyos` | tegra234 | JetPack 6.2.1 / L4T 36.4.4 | Yes | scarthgap |
-| Jetson AGX Thor DevKit (NVMe) | `jetson-agx-thor-devkit-nvme-wendyos` | tegra264 | JetPack 7.1 / L4T 38.4.0 | No (Phase 1) | wrynose |
+| Jetson AGX Orin DevKit (NVMe) | `jetson-agx-orin-devkit-nvme-wendyos` | tegra234 | JetPack 7.2 / L4T 39.2.0 | wendyos-update | blacksail |
+| Jetson AGX Orin DevKit (eMMC) | `jetson-agx-orin-devkit-emmc-wendyos` | tegra234 | JetPack 7.2 / L4T 39.2.0 | wendyos-update | blacksail |
+| Jetson Orin Nano DevKit (NVMe) | `jetson-orin-nano-devkit-nvme-wendyos` | tegra234 | JetPack 7.2 / L4T 39.2.0 | wendyos-update | blacksail |
+| Jetson Orin Nano DevKit (SD) | `jetson-orin-nano-devkit-wendyos` | tegra234 | JetPack 7.2 / L4T 39.2.0 | wendyos-update | blacksail |
+| Jetson AGX Thor DevKit (NVMe) | `jetson-agx-thor-devkit-nvme-wendyos` | tegra264 | JetPack 7.2 / L4T 39.2.0 | wendyos-update | blacksail |
 
 ---
 
 ## AGX Thor (tegra264)
 
-The AGX Thor target uses the **wrynose** Yocto series. It is built from a separate layer tree cloned into `repos/wrynose/` alongside the scarthgap tree used by Orin boards.
+All Jetson boards — Orin (tegra234) and Thor (tegra264) — now build from the **blacksail** Yocto series in a split-poky composition, unified on JetPack 7.2 / L4T R39.2.0. Mender has been removed; all boards use the WendyOS `wendyos-update` OTA stack (`WENDYOS_OTA = "wendy"`). The notes below cover the tegra264-specific (Thor) differences that remain:
 
-Key differences from Orin builds:
-
-- **No Mender OTA** — Mender on Thor is deferred. `WENDYOS_MENDER = "0"` is set automatically for tegra264. There is no A/B partition layout and no `/data` partition in Phase 1.
-- **Flash format** — produces `tegraflash-tar` (a compressed tar of the tegraflash package) rather than separate `tegraflash` + `mender` artefacts.
+- **Flash format** — produces `tegraflash-tar` (a compressed tar of the tegraflash package) rather than a separate `tegraflash` artefact.
 - **Bootloader** — uses NVIDIA prebuilt UEFI firmware (`tegra-uefi-prebuilt`).
-- **Image name suffix** — wrynose oe-core defaults `IMAGE_NAME_SUFFIX` to `.rootfs`, which would produce deployed symlinks such as `wendyos-image-${MACHINE}.rootfs.tegraflash-tar`. The Thor machine config explicitly sets `IMAGE_NAME_SUFFIX = ""` so the deployed symlink matches the expected name `wendyos-image-${MACHINE}.tegraflash-tar`, consistent with all other boards.
+- **Image name suffix** — oe-core master defaults `IMAGE_NAME_SUFFIX` to `.rootfs`, which would produce deployed symlinks such as `wendyos-image-${MACHINE}.rootfs.tegraflash-tar`. The Thor machine config explicitly sets `IMAGE_NAME_SUFFIX = ""` so the deployed symlink matches the expected name `wendyos-image-${MACHINE}.tegraflash-tar`, consistent with all other boards.
 
 To bootstrap a Thor build:
 

--- a/go/internal/cli/assets/skills/wendy/SKILL.md
+++ b/go/internal/cli/assets/skills/wendy/SKILL.md
@@ -8,7 +8,7 @@ references:
 # WendyOS
 
 WendyOS is an Embedded Linux operating system for edge computing. It supports:
-- NVIDIA Jetson devices (production with OTA updates)
+- NVIDIA Jetson devices (production with OTA updates); target JetPack 7.2 or later
 - Raspberry Pi 4/5 (edge devices)
 - ARM64/AMD64 VMs (development)
 


### PR DESCRIPTION
Closes WDY-2561.

## What

1. **`skills/wendy/SKILL.md`** — the wendy CLI skill now tells app authors that apps targeting NVIDIA Jetsons can **target JetPack 7.2 or later**.
2. **`docs/wendyos/jetson/README.md`** — reconciled the Jetson board table with the current `wendyos-builder` `main`:
   - All Jetson boards (Orin `tegra234` + Thor `tegra264`) unified on **JetPack 7.2 / L4T R39.2.0**.
   - Yocto series → **blacksail** (was scarthgap for Orin / wrynose for Thor).
   - OTA column → **wendyos-update** (`WENDYOS_OTA = "wendy"`); **Mender removed**.
   - Updated the AGX Thor section prose (dropped stale Mender/wrynose/scarthgap notes; kept the tegra264-specific flash-format / bootloader / image-suffix notes).

## Source of truth

Versions/series/OTA confirmed against `wendyos-builder` `main` board confs (`jetson-agx-thor/local.conf`, `jetson-agx-orin/repos.overrides`): `WENDYOS_LAYER_TREE="blacksail"`, meta-tegra `wip-l4t-r39.2.0`, JP7 extension layer, `WENDYOS_OTA = "wendy"`.

The sibling website ticket (WDY-2562) is **not** covered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)