### PR TITLE
fix: prepare self-hosted macOS release builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -288,10 +288,15 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
-          cache-dependency-path: go.sum
+          cache: false
 
       - name: Install libusb
-        run: brew list libusb >/dev/null 2>&1 || brew install libusb
+        run: |
+          set -euo pipefail
+          echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+          echo "/usr/local/bin" >> "$GITHUB_PATH"
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+          brew list libusb >/dev/null 2>&1 || brew install libusb
 
       # build-wendy.sh links libusb statically and fails the build if a dynamic
       # libusb dependency sneaks in — a plain `go build` would produce a binary

--- a/swift/Scripts/SetupSigningCI.sh
+++ b/swift/Scripts/SetupSigningCI.sh
@@ -21,10 +21,13 @@ KEYCHAIN_PATH="${TEMP_DIR}/wendy-signing.keychain-db"
 KEYCHAIN_PASSWORD="$(openssl rand -hex 24)"
 CERT_PATH="${TEMP_DIR}/developer-id-application.cer"
 KEY_PATH="${TEMP_DIR}/developer-id-application.key"
+DEVELOPER_ID_CA_PATH="${TEMP_DIR}/developer-id-g2-ca.cer"
+DEVELOPER_ID_CA_URL="https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer"
+DEVELOPER_ID_CA_SHA256="f16cd3c54c7f83cea4bf1a3e6a0819c8aaa8e4a1528fd144715f350643d2df3a"
 NOTARY_PROFILE="${NOTARY_PROFILE:-wendy-notary-profile}"
 
 cleanup() {
-  rm -f "$CERT_PATH" "$KEY_PATH"
+  rm -f "$CERT_PATH" "$KEY_PATH" "$DEVELOPER_ID_CA_PATH"
 }
 trap cleanup EXIT
 
@@ -34,6 +37,15 @@ printf '%s' "$DEVELOPER_ID_KEY" | base64 --decode > "$KEY_PATH"
 security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
 security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+curl -fsSL "$DEVELOPER_ID_CA_URL" -o "$DEVELOPER_ID_CA_PATH"
+ACTUAL_DEVELOPER_ID_CA_SHA256=$(shasum -a 256 "$DEVELOPER_ID_CA_PATH" | awk '{ print $1 }')
+if [ "$ACTUAL_DEVELOPER_ID_CA_SHA256" != "$DEVELOPER_ID_CA_SHA256" ]; then
+  echo "::error::Apple Developer ID intermediate certificate checksum mismatch"
+  exit 1
+fi
+security import "$DEVELOPER_ID_CA_PATH" -k "$KEYCHAIN_PATH"
+
 security import "$CERT_PATH" \
   -k "$KEYCHAIN_PATH" \
   -T /usr/bin/codesign \


### PR DESCRIPTION
> **In plain terms:** Mac releases stopped after their builds moved from GitHub's Macs to Wendy's own runner. Signing lacked part of Apple's public trust chain, while the command-line build could not find Homebrew and collided with a persistent cache. This makes both jobs set up what they need instead of relying on GitHub's preconfigured machines.

## Summary
- Download Apple's Developer ID G2 intermediate into the ephemeral signing setup and verify it against a pinned SHA-256 before import.
- Add the installed Homebrew locations to the macOS CLI job's PATH.
- Disable `setup-go` cache restoration for that persistent runner, matching the successful self-hosted integration jobs.

## Tests
- `bash -n swift/Scripts/SetupSigningCI.sh`
- `shellcheck swift/Scripts/SetupSigningCI.sh`
- `actionlint -ignore 'shellcheck reported issue' .github/workflows/build.yml`
- `git diff --check`
- Downloaded the Apple certificate, verified the pinned SHA-256, and checked that it is currently valid with OpenSSL.
- Existing workflow run 32807803946 attempt 3 passed signing, build, notarization, stapling, and artifact upload after the same intermediate was added to the runner's System keychain.

## Validation remaining
- One controlled, non-publishing run of this branch to prove the workflow-contained certificate import and CLI setup on the self-hosted runner.
