### PR TITLE
docs: state JetPack 7.2 support on the WendyOS website (WDY-2562)

### DIFF
--- a/go/internal/cli/assets/docs/hardware/gpu.mdx
+++ b/go/internal/cli/assets/docs/hardware/gpu.mdx
@@ -9,6 +9,8 @@ The `gpu` entitlement exposes the host GPU to your app for CUDA, ML inference, i
 
 Today this covers **NVIDIA GPUs (CUDA)** — both NVIDIA Jetson devices and x86 Intel/AMD machines with an NVIDIA card. **AMD GPU acceleration via ROCm is in progress.**
 
+On NVIDIA Jetson, the latest WendyOS is built on **JetPack 7.2** (L4T R39.2.0, CUDA 13). Target JetPack 7.2 or later when selecting CUDA wheels or base images for your app.
+
 Add the entitlement from your project directory:
 
 ```bash

--- a/go/internal/cli/assets/docs/installation/wendyos-nvidia-jetson-agx-thor.mdx
+++ b/go/internal/cli/assets/docs/installation/wendyos-nvidia-jetson-agx-thor.mdx
@@ -5,6 +5,8 @@ description: Install WendyOS on an NVIDIA Jetson AGX Thor over USB recovery
 
 Jetson AGX Thor uses a dedicated USB recovery flash path. WendyOS flashes the Thor's QSPI and internal NVMe directly; no external drive is required.
 
+WendyOS on Jetson is built on **JetPack 7.2** (L4T R39.2.0). Apps can target JetPack 7.2 or later.
+
 ## What You Need
 
 - NVIDIA Jetson AGX Thor Developer Kit

--- a/go/internal/cli/assets/docs/installation/wendyos-nvidia-jetson-orin-nano.mdx
+++ b/go/internal/cli/assets/docs/installation/wendyos-nvidia-jetson-orin-nano.mdx
@@ -5,6 +5,8 @@ description: Install WendyOS on an NVIDIA Jetson Orin Nano
 
 The Jetson Orin Nano installation flow writes WendyOS to an NVMe SSD, then boots the device from that drive.
 
+WendyOS on Jetson is built on **JetPack 7.2** (L4T R39.2.0). Apps can target JetPack 7.2 or later.
+
 ## What You Need
 
 - NVIDIA Jetson Orin Nano Developer Kit


### PR DESCRIPTION
Closes WDY-2562.

## What

The docs website had **no** JetPack version statement anywhere user-facing. Added one where readers look:

- **`hardware/gpu.mdx`** — the latest WendyOS on NVIDIA Jetson is built on **JetPack 7.2** (L4T R39.2.0, CUDA 13); target 7.2+ when selecting CUDA wheels or base images.
- **`installation/wendyos-nvidia-jetson-orin-nano.mdx`** and **`installation/wendyos-nvidia-jetson-agx-thor.mdx`** — one-line note that WendyOS on Jetson is built on JetPack 7.2 and apps can target 7.2 or later.

## Related

- Sibling ticket WDY-2561 (the wendy CLI skill + Jetson board reference) is #1788.
- Versions confirmed against `wendyos-builder` `main` (JetPack 7.2 / L4T R39.2.0 / CUDA 13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)