### PR TITLE
fix: isolate CI notarization credentials

### DIFF
--- a/swift/Scripts/Build.sh
+++ b/swift/Scripts/Build.sh
@@ -167,6 +167,7 @@ if [[ "$DEV_BUILD" -ne 1 ]]; then
 
   xcrun notarytool submit "$NOTARY_ZIP" \
     --keychain-profile "$NOTARY_PROFILE" \
+    --keychain "$KEYCHAIN_PATH" \
     --wait
 
   xcrun stapler staple -v "$APP_PATH"

--- a/swift/Scripts/SetupSigningCI.sh
+++ b/swift/Scripts/SetupSigningCI.sh
@@ -61,8 +61,6 @@ security set-key-partition-list \
   -s \
   -k "$KEYCHAIN_PASSWORD" \
   "$KEYCHAIN_PATH"
-security list-keychains -d user -s "$KEYCHAIN_PATH"
-
 SIGNING_IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | awk -F '"' '/Developer ID Application/ { print $2; exit }')
 if [ -z "$SIGNING_IDENTITY" ]; then
   echo "::error::Could not find a Developer ID Application identity in the imported certificate"
@@ -72,7 +70,8 @@ fi
 xcrun notarytool store-credentials "$NOTARY_PROFILE" \
   --apple-id "$NOTARY_APPLE_ID" \
   --team-id "$NOTARY_TEAM_ID" \
-  --password "$NOTARY_PASSWORD"
+  --password "$NOTARY_PASSWORD" \
+  --keychain "$KEYCHAIN_PATH"
 
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
   {


### PR DESCRIPTION
> **In plain terms:** The Mac release can now find its signing certificate, but notarization still tries to use the runner's locked personal keychain and stops the release. This keeps notarization entirely inside CI's temporary unlocked keychain, so it does not need a person or permanent account access.

## Summary
- Store validated notary credentials in the ephemeral signing keychain explicitly.
- Read that same keychain explicitly when submitting the app to Apple.
- Stop replacing the runner user's keychain search list.

## Tests
- `bash -n swift/Scripts/SetupSigningCI.sh swift/Scripts/Build.sh`
- `shellcheck swift/Scripts/SetupSigningCI.sh swift/Scripts/Build.sh`
- `git diff --check`
- Verified the installed `notarytool` supports `--keychain` for both `store-credentials` and `submit`.

## Context
- Follow-up to #1789.
- Merge-triggered run 32836161509 proved the CLI fix, certificate import, identity discovery, and notary credential validation; it failed only when `notarytool` attempted interactive Login-keychain access.
