### PR TITLE
Run macOS E2E jobs in disposable Tart VMs

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,6 +6,7 @@ self-hosted-runner:
     - X64
     - macOS
     - macos-26
+    - wendy-e2e-macos-tart
 
 config-variables: null
 

--- a/.github/runners/macos-e2e-tart/README.md
+++ b/.github/runners/macos-e2e-tart/README.md
@@ -97,8 +97,8 @@ As that operator account, install the verified versions:
 ```bash
 brew install openai/tools/tart openai/tools/softnet jq
 
-tart --version       # Tart 2.36.0
-softnet --version     # softnet 0.23.0
+tart --version        # 2.36.0
+softnet --version     # softnet 0.23.0-<build>
 ```
 
 Then run the installer from a trusted, reviewed checkout. Pass the **path** to

--- a/.github/runners/macos-e2e-tart/README.md
+++ b/.github/runners/macos-e2e-tart/README.md
@@ -15,18 +15,25 @@ checkout or mounts a host directory into a guest.
 
 | Component | Pin |
 | --- | --- |
-| Guest | macOS 26, Xcode 26.6 |
-| Upstream image | `ghcr.io/cirruslabs/macos-tahoe-xcode@sha256:61f6e857a3d65dd2f8daf9c51c7b837fa458bcc9181ae8556e645b534dab6bf6` |
-| Golden image | `wendy-macos-26-xcode-26.6-e2e-v1` |
+| Guest | macOS 26, Xcode 26.5 (the repository's pinned build version) |
+| Upstream image | Cirrus `macos-tahoe-xcode:26.5` content digest `sha256:61f6e857a3d65dd2f8daf9c51c7b837fa458bcc9181ae8556e645b534dab6bf6` |
+| Golden image | `wendy-macos-26-xcode-26.5-e2e-v1` |
 | Actions runner | `2.336.0`, archive SHA-256 `8e8839c49b7060b6b2154f4931f815df330c27f167d53ef2239ee3dfce28b079` |
 | Tart | `2.36.0` |
 | Softnet | `0.23.0` |
 | Guest resources | 8 CPUs, 12 GB RAM, one concurrent guest |
 | Runner group/label | existing `wendy-developer` / unique `wendy-e2e-macos-tart` |
 
-The upstream digest was resolved from the Cirrus Labs Xcode 26.6 release on
-2026-08-25. The runner archive digest is published on the GitHub Actions runner
-`v2.336.0` release. Do not replace either with `latest` in installed config.
+The upstream digest was resolved from Cirrus Labs' versioned `26.5` tag on
+2026-08-25 and corresponds to its [Xcode 26.5 release][cirrus-26.5]. Xcode 26.5
+matches `XCODE_VERSION` in `.github/workflows/build.yml`; the hosted rollback
+may carry a newer patch image. The runner archive digest is published on the
+GitHub Actions runner `v2.336.0` release. Do not replace either with `latest` in
+installed config. Cirrus does not currently publish a signature/attestation for
+this Tart artifact, so promotion verifies the content address and guest contents
+but cannot claim vendor-attested provenance.
+
+[cirrus-26.5]: https://github.com/cirruslabs/macos-image-templates/releases/tag/26.5
 
 ## Security and lifecycle
 

--- a/.github/runners/macos-e2e-tart/README.md
+++ b/.github/runners/macos-e2e-tart/README.md
@@ -20,7 +20,7 @@ checkout or mounts a host directory into a guest.
 | Golden image | `wendy-macos-26-xcode-26.5-e2e-v1` |
 | Actions runner | `2.336.0`, archive SHA-256 `8e8839c49b7060b6b2154f4931f815df330c27f167d53ef2239ee3dfce28b079` |
 | Tart | `2.36.0` |
-| Softnet | `0.23.0` |
+| Guest networking | Tart standard NAT |
 | Guest resources | 8 CPUs, 12 GB RAM, one concurrent guest |
 | Runner group/label | existing `wendy-developer` / unique `wendy-e2e-macos-tart` |
 
@@ -37,10 +37,9 @@ but cannot claim vendor-attested provenance.
 
 ## Security and lifecycle
 
-- The controller creates a local APFS copy-on-write clone, starts it with no
-  directory mounts, no clipboard, no audio, and Softnet's default policy.
-  Softnet permits public IPv4 egress but blocks private IPv4 destinations and
-  guest-initiated host access.
+- The controller creates a local APFS copy-on-write clone and starts it with no
+  directory mounts, clipboard, or audio. This PoC uses Tart's standard NAT
+  networking; it does not claim private-LAN or host-network isolation.
 - A temporary fine-grained PAT creates each repository-level JIT configuration.
   It is restricted to `wendylabsinc/WendyOS` with only Administration write,
   remains on the host, and is revoked after the PoC. The one-job JIT
@@ -95,10 +94,9 @@ headless macOS 15+ requires an available unlocked login keychain.
 As that operator account, install the verified versions:
 
 ```bash
-brew install openai/tools/tart openai/tools/softnet jq
+brew install openai/tools/tart jq
 
 tart --version        # 2.36.0
-softnet --version     # softnet 0.23.0-<build>
 ```
 
 Then run the installer from a trusted, reviewed checkout. Pass the **path** to
@@ -112,11 +110,10 @@ sudo .github/runners/macos-e2e-tart/install-host.sh \
 ```
 
 The installer copies immutable scripts/config, copies the PAT as operator-owned
-mode 0400, configures the pinned Softnet binary's required setuid bit, and prints
-exact image-promotion and LaunchAgent commands. It deliberately does not start
-the service before the image exists.
+mode 0400, and prints exact image-promotion and LaunchAgent commands. It
+deliberately does not start the service before the image exists.
 
-Image preparation clones the pinned OCI digest, boots with Softnet and no
+Image preparation clones the pinned OCI digest, boots with standard NAT and no
 mounts, installs only the Wendy E2E dependencies and exact runner archive,
 checks passwordless guest sudo, removes runner/test residue, stops the VM, and
 renames the candidate to the immutable golden name. Promotion fails closed; a
@@ -162,7 +159,7 @@ cannot publish a release. Before merge, apply one of the same-repository PR labe
 it again. After merge, use the equivalent workflow-dispatch choice.
 
 1. **Normal completion:** run `smoke`; confirm public egress, no VirtioFS host
-   mount, no private-LAN reachability, and successful completion. Then confirm
+   mount, passwordless guest sudo, and successful completion. Then confirm
    that guest name disappears and a different waiting JIT runner appears.
 2. **Cancellation:** run `wait-for-cancellation`, wait until the job starts,
    cancel it, and confirm the clone is destroyed without an in-guest cleanup

--- a/.github/runners/macos-e2e-tart/README.md
+++ b/.github/runners/macos-e2e-tart/README.md
@@ -1,0 +1,181 @@
+# Disposable Tart runner for macOS Swift E2E
+
+This directory is the reproducible template for the single Wendy-owned macOS
+Swift E2E runner. The workflow still uses the existing composite action, setup,
+tests, artifacts, and hosted analysis job. Only the macOS execution boundary
+changes: every job gets a fresh Tart clone and a repository-scoped JIT Actions
+runner.
+
+The checked-in scripts are **deployment inputs**, not runtime code. The host
+installer copies them to root-owned `/Library/Application Support/Wendy/TartE2E`.
+The LaunchAgent only executes that immutable copy; it never sources a workflow
+checkout or mounts a host directory into a guest.
+
+## Pinned route
+
+| Component | Pin |
+| --- | --- |
+| Guest | macOS 26, Xcode 26.6 |
+| Upstream image | `ghcr.io/cirruslabs/macos-tahoe-xcode@sha256:61f6e857a3d65dd2f8daf9c51c7b837fa458bcc9181ae8556e645b534dab6bf6` |
+| Golden image | `wendy-macos-26-xcode-26.6-e2e-v1` |
+| Actions runner | `2.336.0`, archive SHA-256 `8e8839c49b7060b6b2154f4931f815df330c27f167d53ef2239ee3dfce28b079` |
+| Tart | `2.36.0` |
+| Softnet | `0.23.0` |
+| Guest resources | 8 CPUs, 12 GB RAM, one concurrent guest |
+| Runner group/label | `wendy-e2e-macos-tart` / `wendy-e2e-macos-tart` |
+
+The upstream digest was resolved from the Cirrus Labs Xcode 26.6 release on
+2026-08-25. The runner archive digest is published on the GitHub Actions runner
+`v2.336.0` release. Do not replace either with `latest` in installed config.
+
+## Security and lifecycle
+
+- The controller creates a local APFS copy-on-write clone, starts it with no
+  directory mounts, no clipboard, no audio, and Softnet's default policy.
+  Softnet permits public IPv4 egress but blocks private IPv4 destinations and
+  guest-initiated host access.
+- A host-only GitHub App creates a repository-level JIT configuration. The app
+  installation is restricted to `wendylabsinc/WendyOS`; its private key never
+  enters the guest. The one-job JIT configuration crosses Tart's control socket
+  on stdin and is not written to host disk or a host process argument.
+- The runner group is restricted to WendyOS and the workflow selects both the
+  unique group and unique label. It does not select `macos-*` or the shared
+  `wendy-developer` pool.
+- Passwordless sudo exists only for `admin` inside the disposable guest. SSH
+  password authentication is disabled. The existing E2E setup may enable sshd
+  and create a guest-local loopback key because the harness runs local sessions
+  over SSH.
+- The controller and a separate host watchdog both enforce a 9,300-second guest
+  lifetime. The watchdog survives a controller failure. Either path force-stops
+  and deletes the clone; startup also deletes stale `wendy-e2e-job-*` clones.
+- New guests are refused below 60 GB host free space and forcibly destroyed
+  below 20 GB. Runner output stays on the guest so a hostile log stream cannot
+  fill host logs.
+
+A guest job can gain root, kill its runner and guest agent, fill its own disk,
+or install persistence in that VM. It cannot alter the root-owned host
+controller/watchdog, and those processes do not depend on guest cooperation to
+destroy the VM.
+
+## One-time GitHub setup
+
+Use an organization owner or a role with runner-group administration. Do not
+supply credentials to a workflow or paste them into chat.
+
+1. Create an organization runner group named `wendy-e2e-macos-tart`.
+2. Set repository access to **Selected repositories** and select only
+   `wendylabsinc/WendyOS`. Record the numeric group ID from the API/UI URL.
+3. Create or reuse a GitHub App installed only on WendyOS. Give it repository
+   **Administration: write** (required by the repository JIT-config endpoint)
+   and **Metadata: read**. Do not grant contents, secrets, packages, or org-wide
+   repository access.
+4. Generate one App private key and transfer the file directly to the target
+   host's protected local filesystem. Do not commit it or put it in shell
+   history. Record the App and installation IDs; those IDs are not secrets.
+
+The current interactive `gh` token intentionally cannot administer runners, so
+these steps require the bounded owner action above rather than broadening a
+developer token.
+
+## Install on the M4 Pro host
+
+The supported host is the Wendy-controlled M4 Pro Mac mini (24 GB RAM, 512 GB
+SSD). Keep one logged-in operator GUI session: Virtualization.framework on
+headless macOS 15+ requires an available unlocked login keychain.
+
+As that operator account, install the verified versions:
+
+```bash
+brew install openai/tools/tart openai/tools/softnet jq
+
+tart --version       # Tart 2.36.0
+softnet --version     # softnet 0.23.0
+```
+
+Then run the installer from a trusted, reviewed checkout. Pass the **path** to
+the already-transferred App key; never paste key content:
+
+```bash
+sudo .github/runners/macos-e2e-tart/install-host.sh \
+  --operator-user <logged-in-operator> \
+  --github-app-id <app-id> \
+  --github-app-installation-id <installation-id> \
+  --runner-group-id <runner-group-id> \
+  --github-app-key /path/to/transferred-github-app.pem
+```
+
+The installer copies immutable scripts/config, copies the App key as operator-owned
+mode 0400, configures the pinned Softnet binary's required setuid bit, and prints the exact
+image-promotion and LaunchAgent commands. It deliberately does not start the
+service before the image exists.
+
+Image preparation clones the pinned OCI digest, boots with Softnet and no
+mounts, installs only the Wendy E2E dependencies and exact runner archive,
+checks passwordless guest sudo, removes runner/test residue, stops the VM, and
+renames the candidate to the immutable golden name. Promotion fails closed; a
+failed candidate is deleted. Build a new versioned golden name for updates—do
+not mutate the active golden image.
+
+## Operations
+
+Inspect the controller without exposing credentials:
+
+```bash
+launchctl print gui/$(id -u)/org.wendy.macos-e2e-tart
+log show --last 30m --predicate 'process == "logger" AND eventMessage CONTAINS "wendy-e2e"'
+tart list --source local
+```
+
+Stop capacity before maintenance:
+
+```bash
+launchctl bootout gui/$(id -u)/org.wendy.macos-e2e-tart
+```
+
+After an image/config update, bootstrap and start the installed LaunchAgent:
+
+```bash
+launchctl bootstrap gui/$(id -u) /Library/LaunchAgents/org.wendy.macos-e2e-tart.plist
+launchctl kickstart -k gui/$(id -u)/org.wendy.macos-e2e-tart
+```
+
+Never diagnose by copying `/Library/Application Support/Wendy/TartE2E/secrets`,
+JIT configuration, guest disks, or runner diagnostic logs into an issue or CI
+artifact. Lifecycle logs contain only guest/runner names, status, and capacity
+messages.
+
+## Controlled validation
+
+Use `.github/workflows/macos-e2e-tart-validation.yml` only from a trusted branch
+and select one scenario at a time. It has read-only repository permissions and
+cannot publish a release.
+
+1. **Normal completion:** run `smoke`; confirm public egress, no VirtioFS host
+   mount, no private-LAN reachability, and successful completion. Then confirm
+   that guest name disappears and a different waiting JIT runner appears.
+2. **Cancellation:** run `wait-for-cancellation`, wait until the job starts,
+   cancel it, and confirm the clone is destroyed without an in-guest cleanup
+   step. Run `smoke` immediately afterward to prove replacement capacity.
+3. **Persistence:** run `persistence`. The first job installs a root LaunchDaemon
+   and marker; the dependent job must see neither in its new guest.
+4. **Disk pressure:** run `disk-pressure`. It allocates all but 2 GB of guest
+   free space. The dependent fresh-guest check must have more than 10 GB free;
+   host free space must return after clone destruction.
+5. **Watchdog:** run `watchdog` only in a maintenance window. The job deliberately
+   outlives 9,300 seconds and is expected to fail when the host watchdog destroys
+   its VM. A subsequent `smoke` must start in a new guest.
+6. **Hosted rollback:** dispatch `swift-e2e-tests.yml` with **macOS runner =
+   github-hosted** and a focused test filter. Confirm `Local: macOS 26
+   (GitHub-hosted rollback)` runs on GitHub's `macos-26-arm64` image while the
+   Tart job is skipped.
+
+Record run URLs, clone names, timestamps, host free-space before/after, and the
+expected outcome. Do not record credentials or attach guest disks. Unrelated
+Swift E2E assertion failures are not evidence that lifecycle cleanup failed.
+
+## Capacity and licensing
+
+Concurrency is intentionally one. Before running multiple simultaneous macOS
+VMs, Wendy must record legal review of Apple's virtualization/license terms and
+re-check host memory/disk headroom. Do not let that expansion question block or
+silently change this one-guest route.

--- a/.github/runners/macos-e2e-tart/README.md
+++ b/.github/runners/macos-e2e-tart/README.md
@@ -41,10 +41,11 @@ but cannot claim vendor-attested provenance.
   directory mounts, no clipboard, no audio, and Softnet's default policy.
   Softnet permits public IPv4 egress but blocks private IPv4 destinations and
   guest-initiated host access.
-- A host-only GitHub App creates a repository-level JIT configuration. The app
-  installation is restricted to `wendylabsinc/WendyOS`; its private key never
-  enters the guest. The one-job JIT configuration crosses Tart's control socket
-  on stdin and is not written to host disk or a host process argument.
+- A temporary fine-grained PAT creates each repository-level JIT configuration.
+  It is restricted to `wendylabsinc/WendyOS` with only Administration write,
+  remains on the host, and is revoked after the PoC. The one-job JIT
+  configuration crosses Tart's control socket on stdin and is not written to
+  host disk or a host process argument.
 - The JIT runner joins the existing `wendy-developer` group, but jobs also
   require the unique `wendy-e2e-macos-tart` label. The persistent Mac has only
   the shared `macOS`/`ARM64` labels, so it cannot satisfy this route. Repository
@@ -73,16 +74,16 @@ Do not supply credentials to a workflow or paste them into chat.
 1. Record the numeric ID of the existing `wendy-developer` runner group from its
    GitHub organization settings URL. This is a non-secret value; no new group or
    group-policy change is required.
-2. Create or reuse a GitHub App installed only on WendyOS. Give it repository
-   **Administration: write** (required by the repository JIT-config endpoint)
-   and **Metadata: read**. Do not grant contents, secrets, packages, or org-wide
-   repository access.
-3. Generate one App private key and transfer the file directly to the target
-   host's protected local filesystem. Do not commit it or put it in shell
-   history. Record the App and installation IDs; those IDs are not secrets.
+2. Create a fine-grained personal access token owned by `wendylabsinc`, expiring
+   after the PoC, with access only to `WendyOS` and repository
+   **Administration: write**. Do not grant contents, secrets, packages, or
+   organization permissions.
+3. Transfer the token directly to a mode-0600 file on the target host. Do not
+   commit it, pass it as a command argument, put it in shell history, or paste it
+   into chat. Revoke the token as soon as validation is complete.
 
-The current interactive `gh` token intentionally cannot read runner-group IDs,
-so retrieving that non-secret ID remains a bounded owner action rather than a
+The current interactive `gh` token intentionally cannot administer runners or
+read runner-group IDs, so these remain bounded owner actions rather than a
 reason to broaden a developer token.
 
 ## Install on the M4 Pro host
@@ -101,21 +102,19 @@ softnet --version     # softnet 0.23.0
 ```
 
 Then run the installer from a trusted, reviewed checkout. Pass the **path** to
-the already-transferred App key; never paste key content:
+the already-transferred PAT file; never paste token content:
 
 ```bash
 sudo .github/runners/macos-e2e-tart/install-host.sh \
   --operator-user <logged-in-operator> \
-  --github-app-id <app-id> \
-  --github-app-installation-id <installation-id> \
   --runner-group-id <runner-group-id> \
-  --github-app-key /path/to/transferred-github-app.pem
+  --github-pat-file ~/.config/wendy/macos-e2e-tart.token
 ```
 
-The installer copies immutable scripts/config, copies the App key as operator-owned
-mode 0400, configures the pinned Softnet binary's required setuid bit, and prints the exact
-image-promotion and LaunchAgent commands. It deliberately does not start the
-service before the image exists.
+The installer copies immutable scripts/config, copies the PAT as operator-owned
+mode 0400, configures the pinned Softnet binary's required setuid bit, and prints
+exact image-promotion and LaunchAgent commands. It deliberately does not start
+the service before the image exists.
 
 Image preparation clones the pinned OCI digest, boots with Softnet and no
 mounts, installs only the Wendy E2E dependencies and exact runner archive,

--- a/.github/runners/macos-e2e-tart/README.md
+++ b/.github/runners/macos-e2e-tart/README.md
@@ -148,7 +148,11 @@ messages.
 
 Use `.github/workflows/macos-e2e-tart-validation.yml` only from a trusted branch
 and select one scenario at a time. It has read-only repository permissions and
-cannot publish a release.
+cannot publish a release. Before merge, apply one of the same-repository PR labels
+`macos-e2e-tart:smoke`, `macos-e2e-tart:wait-for-cancellation`,
+`macos-e2e-tart:persistence`, `macos-e2e-tart:disk-pressure`, or
+`macos-e2e-tart:watchdog`; fork PRs are rejected. Remove a label before applying
+it again. After merge, use the equivalent workflow-dispatch choice.
 
 1. **Normal completion:** run `smoke`; confirm public egress, no VirtioFS host
    mount, no private-LAN reachability, and successful completion. Then confirm

--- a/.github/runners/macos-e2e-tart/README.md
+++ b/.github/runners/macos-e2e-tart/README.md
@@ -22,7 +22,7 @@ checkout or mounts a host directory into a guest.
 | Tart | `2.36.0` |
 | Softnet | `0.23.0` |
 | Guest resources | 8 CPUs, 12 GB RAM, one concurrent guest |
-| Runner group/label | `wendy-e2e-macos-tart` / `wendy-e2e-macos-tart` |
+| Runner group/label | existing `wendy-developer` / unique `wendy-e2e-macos-tart` |
 
 The upstream digest was resolved from the Cirrus Labs Xcode 26.6 release on
 2026-08-25. The runner archive digest is published on the GitHub Actions runner
@@ -38,9 +38,11 @@ The upstream digest was resolved from the Cirrus Labs Xcode 26.6 release on
   installation is restricted to `wendylabsinc/WendyOS`; its private key never
   enters the guest. The one-job JIT configuration crosses Tart's control socket
   on stdin and is not written to host disk or a host process argument.
-- The runner group is restricted to WendyOS and the workflow selects both the
-  unique group and unique label. It does not select `macos-*` or the shared
-  `wendy-developer` pool.
+- The JIT runner joins the existing `wendy-developer` group, but jobs also
+  require the unique `wendy-e2e-macos-tart` label. The persistent Mac has only
+  the shared `macOS`/`ARM64` labels, so it cannot satisfy this route. Repository
+  scope, the unique label, and host-owned lifecycle form the isolation boundary;
+  the shared group is not treated as one.
 - Passwordless sudo exists only for `admin` inside the disposable guest. SSH
   password authentication is disabled. The existing E2E setup may enable sshd
   and create a guest-local loopback key because the harness runs local sessions
@@ -59,23 +61,22 @@ destroy the VM.
 
 ## One-time GitHub setup
 
-Use an organization owner or a role with runner-group administration. Do not
-supply credentials to a workflow or paste them into chat.
+Do not supply credentials to a workflow or paste them into chat.
 
-1. Create an organization runner group named `wendy-e2e-macos-tart`.
-2. Set repository access to **Selected repositories** and select only
-   `wendylabsinc/WendyOS`. Record the numeric group ID from the API/UI URL.
-3. Create or reuse a GitHub App installed only on WendyOS. Give it repository
+1. Record the numeric ID of the existing `wendy-developer` runner group from its
+   GitHub organization settings URL. This is a non-secret value; no new group or
+   group-policy change is required.
+2. Create or reuse a GitHub App installed only on WendyOS. Give it repository
    **Administration: write** (required by the repository JIT-config endpoint)
    and **Metadata: read**. Do not grant contents, secrets, packages, or org-wide
    repository access.
-4. Generate one App private key and transfer the file directly to the target
+3. Generate one App private key and transfer the file directly to the target
    host's protected local filesystem. Do not commit it or put it in shell
    history. Record the App and installation IDs; those IDs are not secrets.
 
-The current interactive `gh` token intentionally cannot administer runners, so
-these steps require the bounded owner action above rather than broadening a
-developer token.
+The current interactive `gh` token intentionally cannot read runner-group IDs,
+so retrieving that non-secret ID remains a bounded owner action rather than a
+reason to broaden a developer token.
 
 ## Install on the M4 Pro host
 

--- a/.github/runners/macos-e2e-tart/config.env.example
+++ b/.github/runners/macos-e2e-tart/config.env.example
@@ -10,10 +10,10 @@ GITHUB_APP_INSTALLATION_ID=REQUIRED
 RUNNER_GROUP_ID=REQUIRED
 RUNNER_LABEL=wendy-e2e-macos-tart
 
-# This digest resolved from ghcr.io/cirruslabs/macos-tahoe-xcode:latest on
-# 2026-08-25. The corresponding image release contains macOS 26 and Xcode 26.6.
+# This digest is the OCI content address referenced by the vendor's versioned
+# ghcr.io/cirruslabs/macos-tahoe-xcode:26.5 tag on 2026-08-25.
 UPSTREAM_IMAGE=ghcr.io/cirruslabs/macos-tahoe-xcode@sha256:61f6e857a3d65dd2f8daf9c51c7b837fa458bcc9181ae8556e645b534dab6bf6
-GOLDEN_IMAGE=wendy-macos-26-xcode-26.6-e2e-v1
+GOLDEN_IMAGE=wendy-macos-26-xcode-26.5-e2e-v1
 
 TART_BIN=/opt/homebrew/bin/tart
 TART_VERSION=2.36.0

--- a/.github/runners/macos-e2e-tart/config.env.example
+++ b/.github/runners/macos-e2e-tart/config.env.example
@@ -4,8 +4,6 @@
 
 GITHUB_OWNER=wendylabsinc
 GITHUB_REPOSITORY=WendyOS
-GITHUB_APP_ID=REQUIRED
-GITHUB_APP_INSTALLATION_ID=REQUIRED
 # Numeric ID of the existing wendy-developer runner group.
 RUNNER_GROUP_ID=REQUIRED
 RUNNER_LABEL=wendy-e2e-macos-tart
@@ -20,7 +18,6 @@ TART_VERSION=2.36.0
 SOFTNET_BIN=/opt/homebrew/bin/softnet
 SOFTNET_VERSION=0.23.0
 JQ_BIN=/opt/homebrew/bin/jq
-OPENSSL_BIN=/usr/bin/openssl
 
 RUNNER_VERSION=2.336.0
 RUNNER_ARCHIVE_SHA256=8e8839c49b7060b6b2154f4931f815df330c27f167d53ef2239ee3dfce28b079
@@ -32,6 +29,6 @@ HOST_CRITICAL_FREE_GB=20
 POLL_SECONDS=15
 
 INSTALL_ROOT='/Library/Application Support/Wendy/TartE2E'
-GITHUB_APP_PRIVATE_KEY='/Library/Application Support/Wendy/TartE2E/secrets/github-app.pem'
+GITHUB_PAT_FILE='/Library/Application Support/Wendy/TartE2E/secrets/github-pat'
 STATE_DIR='REQUIRED'
 TART_HOME='REQUIRED'

--- a/.github/runners/macos-e2e-tart/config.env.example
+++ b/.github/runners/macos-e2e-tart/config.env.example
@@ -15,8 +15,6 @@ GOLDEN_IMAGE=wendy-macos-26-xcode-26.5-e2e-v1
 
 TART_BIN=/opt/homebrew/bin/tart
 TART_VERSION=2.36.0
-SOFTNET_BIN=/opt/homebrew/bin/softnet
-SOFTNET_VERSION=0.23.0
 JQ_BIN=/opt/homebrew/bin/jq
 
 RUNNER_VERSION=2.336.0

--- a/.github/runners/macos-e2e-tart/config.env.example
+++ b/.github/runners/macos-e2e-tart/config.env.example
@@ -6,6 +6,7 @@ GITHUB_OWNER=wendylabsinc
 GITHUB_REPOSITORY=WendyOS
 GITHUB_APP_ID=REQUIRED
 GITHUB_APP_INSTALLATION_ID=REQUIRED
+# Numeric ID of the existing wendy-developer runner group.
 RUNNER_GROUP_ID=REQUIRED
 RUNNER_LABEL=wendy-e2e-macos-tart
 

--- a/.github/runners/macos-e2e-tart/config.env.example
+++ b/.github/runners/macos-e2e-tart/config.env.example
@@ -1,0 +1,36 @@
+# Non-secret configuration installed at
+# /Library/Application Support/Wendy/TartE2E/config.env.
+# The install script replaces the values marked REQUIRED.
+
+GITHUB_OWNER=wendylabsinc
+GITHUB_REPOSITORY=WendyOS
+GITHUB_APP_ID=REQUIRED
+GITHUB_APP_INSTALLATION_ID=REQUIRED
+RUNNER_GROUP_ID=REQUIRED
+RUNNER_LABEL=wendy-e2e-macos-tart
+
+# This digest resolved from ghcr.io/cirruslabs/macos-tahoe-xcode:latest on
+# 2026-08-25. The corresponding image release contains macOS 26 and Xcode 26.6.
+UPSTREAM_IMAGE=ghcr.io/cirruslabs/macos-tahoe-xcode@sha256:61f6e857a3d65dd2f8daf9c51c7b837fa458bcc9181ae8556e645b534dab6bf6
+GOLDEN_IMAGE=wendy-macos-26-xcode-26.6-e2e-v1
+
+TART_BIN=/opt/homebrew/bin/tart
+TART_VERSION=2.36.0
+SOFTNET_BIN=/opt/homebrew/bin/softnet
+SOFTNET_VERSION=0.23.0
+JQ_BIN=/opt/homebrew/bin/jq
+OPENSSL_BIN=/usr/bin/openssl
+
+RUNNER_VERSION=2.336.0
+RUNNER_ARCHIVE_SHA256=8e8839c49b7060b6b2154f4931f815df330c27f167d53ef2239ee3dfce28b079
+RUNNER_CPU_COUNT=8
+RUNNER_MEMORY_MB=12288
+RUNNER_MAX_SECONDS=9300
+HOST_MIN_FREE_GB=60
+HOST_CRITICAL_FREE_GB=20
+POLL_SECONDS=15
+
+INSTALL_ROOT='/Library/Application Support/Wendy/TartE2E'
+GITHUB_APP_PRIVATE_KEY='/Library/Application Support/Wendy/TartE2E/secrets/github-app.pem'
+STATE_DIR='REQUIRED'
+TART_HOME='REQUIRED'

--- a/.github/runners/macos-e2e-tart/controller.sh
+++ b/.github/runners/macos-e2e-tart/controller.sh
@@ -1,0 +1,290 @@
+#!/bin/bash
+# shellcheck disable=SC2016 # jq and guest scripts intentionally expand elsewhere.
+set -euo pipefail
+umask 077
+
+CONFIG_PATH="${WENDY_TART_E2E_CONFIG:-/Library/Application Support/Wendy/TartE2E/config.env}"
+# shellcheck disable=SC1090
+source "$CONFIG_PATH"
+export TART_HOME
+runtime_path="$(dirname "$TART_BIN"):$(dirname "$SOFTNET_BIN"):$(dirname "$JQ_BIN"):/usr/bin:/bin:/usr/sbin:/sbin"
+export PATH="$runtime_path"
+
+current_vm=""
+tart_run_pid=""
+runner_bridge_pid=""
+watchdog_pid=""
+lock_owned=false
+
+log() {
+  /usr/bin/logger -t wendy-tart-e2e -- "$*"
+  printf '%s\n' "$*"
+}
+
+fail() {
+  log "ERROR: $*"
+  return 1
+}
+
+assert_immutable_file() {
+  local path="$1" owner mode
+  owner="$(stat -f '%Su' "$path")"
+  mode="$(stat -f '%OLp' "$path")"
+  [[ "$owner" == root ]] || fail "$path must be owned by root"
+  (( (8#$mode & 8#22) == 0 )) || fail "$path must not be group/world writable"
+}
+
+assert_protected_key() {
+  local path="$1" owner mode
+  owner="$(stat -f '%Su' "$path")"
+  mode="$(stat -f '%OLp' "$path")"
+  [[ "$owner" == "$(id -un)" ]] || fail "$path must be owned by the controller account"
+  (( (8#$mode & 8#77) == 0 )) || fail "$path must not grant group/world permissions"
+}
+
+verify_installation() {
+  assert_immutable_file "$0"
+  assert_immutable_file "$CONFIG_PATH"
+  assert_immutable_file "$INSTALL_ROOT/bin/watchdog.sh"
+  assert_protected_key "$GITHUB_APP_PRIVATE_KEY"
+  [[ "$GITHUB_APP_ID" =~ ^[0-9]+$ ]] || fail "GITHUB_APP_ID must be numeric"
+  [[ "$GITHUB_APP_INSTALLATION_ID" =~ ^[0-9]+$ ]] || fail "GITHUB_APP_INSTALLATION_ID must be numeric"
+  [[ "$RUNNER_GROUP_ID" =~ ^[0-9]+$ ]] || fail "RUNNER_GROUP_ID must be numeric"
+  [[ "$RUNNER_LABEL" =~ ^[A-Za-z0-9._-]+$ ]] || fail "RUNNER_LABEL is invalid"
+  [[ "$GOLDEN_IMAGE" =~ ^[A-Za-z0-9._:-]+$ ]] || fail "GOLDEN_IMAGE is invalid"
+  [[ "$RUNNER_MAX_SECONDS" =~ ^[0-9]+$ ]] || fail "RUNNER_MAX_SECONDS must be numeric"
+
+  [[ "$($TART_BIN --version)" == "Tart $TART_VERSION" ]] \
+    || fail "expected Tart $TART_VERSION"
+  [[ "$($SOFTNET_BIN --version)" == "softnet $SOFTNET_VERSION" ]] \
+    || fail "expected Softnet $SOFTNET_VERSION"
+  "$JQ_BIN" --version >/dev/null
+  "$OPENSSL_BIN" version >/dev/null
+  "$TART_BIN" list --source local --quiet | grep -Fxq "$GOLDEN_IMAGE" \
+    || fail "golden image is missing: $GOLDEN_IMAGE"
+}
+
+acquire_lock() {
+  mkdir -p "$STATE_DIR"
+  local lock_dir="$STATE_DIR/controller.lock"
+  if ! mkdir "$lock_dir" 2>/dev/null; then
+    local previous_pid=""
+    previous_pid="$(cat "$lock_dir/pid" 2>/dev/null || true)"
+    if [[ "$previous_pid" =~ ^[0-9]+$ ]] && kill -0 "$previous_pid" 2>/dev/null; then
+      fail "another controller is running as PID $previous_pid"
+      exit 1
+    fi
+    rm -rf "$lock_dir"
+    mkdir "$lock_dir"
+  fi
+  printf '%s\n' "$$" > "$lock_dir/pid"
+  lock_owned=true
+}
+
+release_lock() {
+  if [[ "$lock_owned" == true ]]; then
+    rm -rf "$STATE_DIR/controller.lock"
+    lock_owned=false
+  fi
+}
+
+free_gb() {
+  df -Pk "$TART_HOME" | awk 'NR == 2 { print int($4 / 1024 / 1024) }'
+}
+
+cleanup_current() {
+  set +e
+  if [[ -n "$watchdog_pid" ]]; then
+    kill "$watchdog_pid" >/dev/null 2>&1
+    wait "$watchdog_pid" >/dev/null 2>&1
+    watchdog_pid=""
+  fi
+  if [[ -n "$current_vm" ]]; then
+    "$TART_BIN" stop --timeout 5 "$current_vm" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$runner_bridge_pid" ]]; then
+    kill "$runner_bridge_pid" >/dev/null 2>&1
+    wait "$runner_bridge_pid" >/dev/null 2>&1
+    runner_bridge_pid=""
+  fi
+  if [[ -n "$tart_run_pid" ]]; then
+    kill "$tart_run_pid" >/dev/null 2>&1
+    wait "$tart_run_pid" >/dev/null 2>&1
+    tart_run_pid=""
+  fi
+  if [[ -n "$current_vm" ]]; then
+    "$TART_BIN" delete "$current_vm" >/dev/null 2>&1 || true
+    log "destroyed disposable guest $current_vm"
+    current_vm=""
+  fi
+  set -e
+}
+
+shutdown() {
+  local status=$?
+  trap - EXIT INT TERM HUP
+  cleanup_current
+  release_lock
+  exit "$status"
+}
+trap shutdown EXIT INT TERM HUP
+
+base64url() {
+  /usr/bin/base64 | tr -d '=\n' | tr '+/' '-_'
+}
+
+github_app_token() {
+  local now issued expires header payload unsigned signature jwt
+  now="$(date +%s)"
+  issued="$((now - 60))"
+  expires="$((now + 540))"
+  header="$(printf '%s' '{"alg":"RS256","typ":"JWT"}' | base64url)"
+  payload="$(printf '{"iat":%s,"exp":%s,"iss":"%s"}' "$issued" "$expires" "$GITHUB_APP_ID" | base64url)"
+  unsigned="${header}.${payload}"
+  signature="$(printf '%s' "$unsigned" \
+    | "$OPENSSL_BIN" dgst -sha256 -sign "$GITHUB_APP_PRIVATE_KEY" \
+    | base64url)"
+  jwt="${unsigned}.${signature}"
+
+  curl --fail --silent --show-error \
+    --request POST \
+    --header "Accept: application/vnd.github+json" \
+    --header "Authorization: Bearer $jwt" \
+    --header "X-GitHub-Api-Version: 2022-11-28" \
+    "https://api.github.com/app/installations/${GITHUB_APP_INSTALLATION_ID}/access_tokens" \
+    | "$JQ_BIN" -er '.token'
+}
+
+generate_jit_config() {
+  local token="$1" runner_name="$2" labels payload
+  labels="$($JQ_BIN -cn \
+    --arg custom "$RUNNER_LABEL" \
+    '["self-hosted", "macOS", "ARM64", $custom]')"
+  payload="$($JQ_BIN -cn \
+    --arg name "$runner_name" \
+    --argjson group "$RUNNER_GROUP_ID" \
+    --argjson labels "$labels" \
+    '{name: $name, runner_group_id: $group, work_folder: "_work", labels: $labels}')"
+
+  curl --fail --silent --show-error \
+    --request POST \
+    --header "Accept: application/vnd.github+json" \
+    --header "Authorization: Bearer $token" \
+    --header "X-GitHub-Api-Version: 2022-11-28" \
+    --header "Content-Type: application/json" \
+    --data "$payload" \
+    "https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPOSITORY}/actions/runners/generate-jitconfig" \
+    | "$JQ_BIN" -er '.encoded_jit_config'
+}
+
+remove_stale_guests() {
+  local vm
+  while IFS= read -r vm; do
+    [[ "$vm" == wendy-e2e-job-* ]] || continue
+    "$TART_BIN" stop --timeout 5 "$vm" >/dev/null 2>&1 || true
+    "$TART_BIN" delete "$vm" >/dev/null 2>&1 || true
+    log "removed stale disposable guest $vm"
+  done < <("$TART_BIN" list --source local --quiet)
+}
+
+run_one_guest() {
+  local available runner_name token jit_config started_at now bridge_status=0 ready=false
+  available="$(free_gb)"
+  if (( available < HOST_MIN_FREE_GB )); then
+    log "waiting: ${available}GB free is below the ${HOST_MIN_FREE_GB}GB start threshold"
+    sleep 60
+    return 0
+  fi
+
+  runner_name="wendy-e2e-$(date -u +%s)-$RANDOM"
+  current_vm="wendy-e2e-job-${runner_name#wendy-e2e-}"
+  "$TART_BIN" clone "$GOLDEN_IMAGE" "$current_vm"
+  "$TART_BIN" set "$current_vm" --cpu "$RUNNER_CPU_COUNT" --memory "$RUNNER_MEMORY_MB"
+
+  WENDY_TART_E2E_CONFIG="$CONFIG_PATH" \
+    "$INSTALL_ROOT/bin/watchdog.sh" "$current_vm" "$$" "$RUNNER_MAX_SECONDS" &
+  watchdog_pid=$!
+
+  "$TART_BIN" run \
+    --no-graphics \
+    --no-audio \
+    --no-clipboard \
+    --net-softnet \
+    "$current_vm" >/dev/null 2>&1 &
+  tart_run_pid=$!
+
+  for _ in $(seq 1 60); do
+    if ! kill -0 "$tart_run_pid" >/dev/null 2>&1; then
+      fail "guest exited before its agent became ready: $current_vm"
+      return 1
+    fi
+    if "$TART_BIN" exec "$current_vm" /usr/bin/true >/dev/null 2>&1; then
+      ready=true
+      break
+    fi
+    sleep 5
+  done
+  if [[ "$ready" != true ]]; then
+    fail "guest agent did not become ready within 5 minutes: $current_vm"
+    return 1
+  fi
+
+  token="$(github_app_token)"
+  jit_config="$(generate_jit_config "$token" "$runner_name")"
+  unset token
+
+  # The one-time JIT credential crosses into the guest over Tart's host-owned
+  # control socket on stdin. It is never written to host disk or placed in a
+  # host process argument. Runner output remains inside the disposable guest.
+  {
+    printf '%s\n' "$jit_config"
+  } | "$TART_BIN" exec -i "$current_vm" /bin/bash -c '
+    set -euo pipefail
+    IFS= read -r jit_config
+    cd /Users/admin/actions-runner
+    exec ./run.sh --jitconfig "$jit_config" > /Users/admin/actions-runner.log 2>&1
+  ' &
+  runner_bridge_pid=$!
+  unset jit_config
+
+  log "registered JIT runner $runner_name in disposable guest $current_vm"
+  started_at="$(date +%s)"
+  while kill -0 "$runner_bridge_pid" >/dev/null 2>&1; do
+    if ! kill -0 "$tart_run_pid" >/dev/null 2>&1; then
+      log "guest process exited unexpectedly: $current_vm"
+      break
+    fi
+    available="$(free_gb)"
+    if (( available < HOST_CRITICAL_FREE_GB )); then
+      log "critical host disk threshold reached (${available}GB); forcing guest cleanup"
+      break
+    fi
+    now="$(date +%s)"
+    if (( now - started_at >= RUNNER_MAX_SECONDS )); then
+      log "controller lifetime limit reached for $current_vm"
+      break
+    fi
+    sleep "$POLL_SECONDS"
+  done
+
+  if [[ -n "$runner_bridge_pid" ]]; then
+    if kill -0 "$runner_bridge_pid" >/dev/null 2>&1; then
+      "$TART_BIN" stop --timeout 5 "$current_vm" >/dev/null 2>&1 || true
+    fi
+    wait "$runner_bridge_pid" || bridge_status=$?
+    runner_bridge_pid=""
+  fi
+  log "runner bridge exited with status $bridge_status for $current_vm"
+  cleanup_current
+}
+
+acquire_lock
+verify_installation
+remove_stale_guests
+log "controller started for ${GITHUB_OWNER}/${GITHUB_REPOSITORY} label $RUNNER_LABEL"
+
+while true; do
+  # Keep errexit active inside the lifecycle function. launchd applies the
+  # restart throttle if an unhandled host/API/Tart operation fails.
+  run_one_guest
+done

--- a/.github/runners/macos-e2e-tart/controller.sh
+++ b/.github/runners/macos-e2e-tart/controller.sh
@@ -45,6 +45,7 @@ assert_protected_secret() {
 }
 
 verify_installation() {
+  local installed_tart_version installed_softnet_version installed_softnet_build
   assert_immutable_file "$0"
   assert_immutable_file "$CONFIG_PATH"
   assert_immutable_file "$INSTALL_ROOT/bin/watchdog.sh"
@@ -55,10 +56,15 @@ verify_installation() {
   [[ "$GOLDEN_IMAGE" =~ ^[A-Za-z0-9._:-]+$ ]] || fail "GOLDEN_IMAGE is invalid"
   [[ "$RUNNER_MAX_SECONDS" =~ ^[0-9]+$ ]] || fail "RUNNER_MAX_SECONDS must be numeric"
 
-  [[ "$($TART_BIN --version)" == "Tart $TART_VERSION" ]] \
-    || fail "expected Tart $TART_VERSION"
-  [[ "$($SOFTNET_BIN --version)" == "softnet $SOFTNET_VERSION" ]] \
-    || fail "expected Softnet $SOFTNET_VERSION"
+  installed_tart_version="$($TART_BIN --version)"
+  installed_softnet_version="$($SOFTNET_BIN --version)"
+  installed_softnet_build="${installed_softnet_version#softnet }"
+  [[ "$installed_tart_version" == "$TART_VERSION" ]] \
+    || fail "expected Tart $TART_VERSION, got $installed_tart_version"
+  [[ "$installed_softnet_version" == softnet\ * && \
+     ("$installed_softnet_build" == "$SOFTNET_VERSION" || \
+      "$installed_softnet_build" == "$SOFTNET_VERSION"-*) ]] \
+    || fail "expected Softnet $SOFTNET_VERSION, got $installed_softnet_version"
   "$JQ_BIN" --version >/dev/null
   "$TART_BIN" list --source local --quiet | grep -Fxq "$GOLDEN_IMAGE" \
     || fail "golden image is missing: $GOLDEN_IMAGE"

--- a/.github/runners/macos-e2e-tart/controller.sh
+++ b/.github/runners/macos-e2e-tart/controller.sh
@@ -9,7 +9,7 @@ CONFIG_PATH="${WENDY_TART_E2E_CONFIG:-/Library/Application Support/Wendy/TartE2E
 # shellcheck disable=SC1090
 source "$CONFIG_PATH"
 export TART_HOME
-runtime_path="$(dirname "$TART_BIN"):$(dirname "$SOFTNET_BIN"):$(dirname "$JQ_BIN"):/usr/bin:/bin:/usr/sbin:/sbin"
+runtime_path="$(dirname "$TART_BIN"):$(dirname "$JQ_BIN"):/usr/bin:/bin:/usr/sbin:/sbin"
 export PATH="$runtime_path"
 
 current_vm=""
@@ -45,7 +45,7 @@ assert_protected_secret() {
 }
 
 verify_installation() {
-  local installed_tart_version installed_softnet_version installed_softnet_build
+  local installed_tart_version
   assert_immutable_file "$0"
   assert_immutable_file "$CONFIG_PATH"
   assert_immutable_file "$INSTALL_ROOT/bin/watchdog.sh"
@@ -57,14 +57,8 @@ verify_installation() {
   [[ "$RUNNER_MAX_SECONDS" =~ ^[0-9]+$ ]] || fail "RUNNER_MAX_SECONDS must be numeric"
 
   installed_tart_version="$($TART_BIN --version)"
-  installed_softnet_version="$($SOFTNET_BIN --version)"
-  installed_softnet_build="${installed_softnet_version#softnet }"
   [[ "$installed_tart_version" == "$TART_VERSION" ]] \
     || fail "expected Tart $TART_VERSION, got $installed_tart_version"
-  [[ "$installed_softnet_version" == softnet\ * && \
-     ("$installed_softnet_build" == "$SOFTNET_VERSION" || \
-      "$installed_softnet_build" == "$SOFTNET_VERSION"-*) ]] \
-    || fail "expected Softnet $SOFTNET_VERSION, got $installed_softnet_version"
   "$JQ_BIN" --version >/dev/null
   "$TART_BIN" list --source local --quiet | grep -Fxq "$GOLDEN_IMAGE" \
     || fail "golden image is missing: $GOLDEN_IMAGE"
@@ -202,7 +196,6 @@ run_one_guest() {
     --no-graphics \
     --no-audio \
     --no-clipboard \
-    --net-softnet \
     "$current_vm" >/dev/null 2>&1 &
   tart_run_pid=$!
 

--- a/.github/runners/macos-e2e-tart/controller.sh
+++ b/.github/runners/macos-e2e-tart/controller.sh
@@ -36,7 +36,7 @@ assert_immutable_file() {
   (( (8#$mode & 8#22) == 0 )) || fail "$path must not be group/world writable"
 }
 
-assert_protected_key() {
+assert_protected_secret() {
   local path="$1" owner mode
   owner="$(stat -f '%Su' "$path")"
   mode="$(stat -f '%OLp' "$path")"
@@ -48,9 +48,8 @@ verify_installation() {
   assert_immutable_file "$0"
   assert_immutable_file "$CONFIG_PATH"
   assert_immutable_file "$INSTALL_ROOT/bin/watchdog.sh"
-  assert_protected_key "$GITHUB_APP_PRIVATE_KEY"
-  [[ "$GITHUB_APP_ID" =~ ^[0-9]+$ ]] || fail "GITHUB_APP_ID must be numeric"
-  [[ "$GITHUB_APP_INSTALLATION_ID" =~ ^[0-9]+$ ]] || fail "GITHUB_APP_INSTALLATION_ID must be numeric"
+  assert_protected_secret "$GITHUB_PAT_FILE"
+  [[ -s "$GITHUB_PAT_FILE" ]] || fail "GitHub PAT file must not be empty"
   [[ "$RUNNER_GROUP_ID" =~ ^[0-9]+$ ]] || fail "RUNNER_GROUP_ID must be numeric"
   [[ "$RUNNER_LABEL" =~ ^[A-Za-z0-9._-]+$ ]] || fail "RUNNER_LABEL is invalid"
   [[ "$GOLDEN_IMAGE" =~ ^[A-Za-z0-9._:-]+$ ]] || fail "GOLDEN_IMAGE is invalid"
@@ -61,7 +60,6 @@ verify_installation() {
   [[ "$($SOFTNET_BIN --version)" == "softnet $SOFTNET_VERSION" ]] \
     || fail "expected Softnet $SOFTNET_VERSION"
   "$JQ_BIN" --version >/dev/null
-  "$OPENSSL_BIN" version >/dev/null
   "$TART_BIN" list --source local --quiet | grep -Fxq "$GOLDEN_IMAGE" \
     || fail "golden image is missing: $GOLDEN_IMAGE"
 }
@@ -131,40 +129,13 @@ shutdown() {
 }
 trap shutdown EXIT INT TERM HUP
 
-base64url() {
-  /usr/bin/base64 | tr -d '=\n' | tr '+/' '-_'
-}
-
-github_app_token() {
+github_pat() {
   set +x
-  local now issued expires header payload unsigned signature jwt token_request
-  now="$(date +%s)"
-  issued="$((now - 60))"
-  expires="$((now + 540))"
-  header="$(printf '%s' '{"alg":"RS256","typ":"JWT"}' | base64url)"
-  payload="$(printf '{"iat":%s,"exp":%s,"iss":"%s"}' "$issued" "$expires" "$GITHUB_APP_ID" | base64url)"
-  unsigned="${header}.${payload}"
-  signature="$(printf '%s' "$unsigned" \
-    | "$OPENSSL_BIN" dgst -sha256 -sign "$GITHUB_APP_PRIVATE_KEY" \
-    | base64url)"
-  jwt="${unsigned}.${signature}"
-  token_request="$($JQ_BIN -cn \
-    --arg repository "$GITHUB_REPOSITORY" \
-    '{repositories: [$repository], permissions: {administration: "write"}}')"
-
-  # Feed the short-lived JWT through curl's stdin config, never argv or disk.
-  {
-    printf '%s\n' 'request = "POST"'
-    printf '%s\n' 'header = "Accept: application/vnd.github+json"'
-    printf 'header = "Authorization: Bearer %s"\n' "$jwt"
-    printf '%s\n' 'header = "X-GitHub-Api-Version: 2022-11-28"'
-    printf '%s\n' 'header = "Content-Type: application/json"'
-    printf 'url = "https://api.github.com/app/installations/%s/access_tokens"\n' \
-      "$GITHUB_APP_INSTALLATION_ID"
-  } | curl --fail --silent --show-error \
-    --config - \
-    --data "$token_request" \
-    | "$JQ_BIN" -er '.token'
+  local token
+  token="$(< "$GITHUB_PAT_FILE")"
+  [[ "$token" =~ ^github_pat_[A-Za-z0-9_]+$ ]] \
+    || fail "GitHub PAT file has an invalid fine-grained token format"
+  printf '%s' "$token"
 }
 
 generate_jit_config() {
@@ -178,7 +149,7 @@ generate_jit_config() {
     --argjson labels "$labels" \
     '{name: $name, runner_group_id: $group, work_folder: "_work", labels: $labels}')"
 
-  # Feed the installation token through curl's stdin config, never argv or disk.
+  # Feed the PAT through curl's stdin config, never argv or disk.
   {
     printf '%s\n' 'request = "POST"'
     printf '%s\n' 'header = "Accept: application/vnd.github+json"'
@@ -245,7 +216,7 @@ run_one_guest() {
     return 1
   fi
 
-  token="$(github_app_token)"
+  token="$(github_pat)"
   jit_config="$(generate_jit_config "$token" "$runner_name")"
   unset token
 

--- a/.github/runners/macos-e2e-tart/controller.sh
+++ b/.github/runners/macos-e2e-tart/controller.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # shellcheck disable=SC2016 # jq and guest scripts intentionally expand elsewhere.
 set -euo pipefail
+# Never permit inherited xtrace to expose short-lived GitHub credentials.
+set +x
 umask 077
 
 CONFIG_PATH="${WENDY_TART_E2E_CONFIG:-/Library/Application Support/Wendy/TartE2E/config.env}"
@@ -134,7 +136,8 @@ base64url() {
 }
 
 github_app_token() {
-  local now issued expires header payload unsigned signature jwt
+  set +x
+  local now issued expires header payload unsigned signature jwt token_request
   now="$(date +%s)"
   issued="$((now - 60))"
   expires="$((now + 540))"
@@ -145,13 +148,22 @@ github_app_token() {
     | "$OPENSSL_BIN" dgst -sha256 -sign "$GITHUB_APP_PRIVATE_KEY" \
     | base64url)"
   jwt="${unsigned}.${signature}"
+  token_request="$($JQ_BIN -cn \
+    --arg repository "$GITHUB_REPOSITORY" \
+    '{repositories: [$repository], permissions: {administration: "write"}}')"
 
-  curl --fail --silent --show-error \
-    --request POST \
-    --header "Accept: application/vnd.github+json" \
-    --header "Authorization: Bearer $jwt" \
-    --header "X-GitHub-Api-Version: 2022-11-28" \
-    "https://api.github.com/app/installations/${GITHUB_APP_INSTALLATION_ID}/access_tokens" \
+  # Feed the short-lived JWT through curl's stdin config, never argv or disk.
+  {
+    printf '%s\n' 'request = "POST"'
+    printf '%s\n' 'header = "Accept: application/vnd.github+json"'
+    printf 'header = "Authorization: Bearer %s"\n' "$jwt"
+    printf '%s\n' 'header = "X-GitHub-Api-Version: 2022-11-28"'
+    printf '%s\n' 'header = "Content-Type: application/json"'
+    printf 'url = "https://api.github.com/app/installations/%s/access_tokens"\n' \
+      "$GITHUB_APP_INSTALLATION_ID"
+  } | curl --fail --silent --show-error \
+    --config - \
+    --data "$token_request" \
     | "$JQ_BIN" -er '.token'
 }
 
@@ -166,14 +178,18 @@ generate_jit_config() {
     --argjson labels "$labels" \
     '{name: $name, runner_group_id: $group, work_folder: "_work", labels: $labels}')"
 
-  curl --fail --silent --show-error \
-    --request POST \
-    --header "Accept: application/vnd.github+json" \
-    --header "Authorization: Bearer $token" \
-    --header "X-GitHub-Api-Version: 2022-11-28" \
-    --header "Content-Type: application/json" \
+  # Feed the installation token through curl's stdin config, never argv or disk.
+  {
+    printf '%s\n' 'request = "POST"'
+    printf '%s\n' 'header = "Accept: application/vnd.github+json"'
+    printf 'header = "Authorization: Bearer %s"\n' "$token"
+    printf '%s\n' 'header = "X-GitHub-Api-Version: 2022-11-28"'
+    printf '%s\n' 'header = "Content-Type: application/json"'
+    printf 'url = "https://api.github.com/repos/%s/%s/actions/runners/generate-jitconfig"\n' \
+      "$GITHUB_OWNER" "$GITHUB_REPOSITORY"
+  } | curl --fail --silent --show-error \
+    --config - \
     --data "$payload" \
-    "https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPOSITORY}/actions/runners/generate-jitconfig" \
     | "$JQ_BIN" -er '.encoded_jit_config'
 }
 

--- a/.github/runners/macos-e2e-tart/image-prepare.sh
+++ b/.github/runners/macos-e2e-tart/image-prepare.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -euo pipefail
+
+# Runs inside the candidate guest through `tart exec -i`. It must never receive
+# host credentials, signing material, or a repository checkout.
+
+runner_version="${1:?runner version is required}"
+runner_sha256="${2:?runner archive SHA-256 is required}"
+
+if [[ "$(sw_vers -productVersion)" != 26.* ]]; then
+  echo "ERROR: expected macOS 26" >&2
+  exit 1
+fi
+if [[ "$(xcodebuild -version | awk '/^Xcode / { print $2 }')" != "26.6" ]]; then
+  echo "ERROR: expected Xcode 26.6" >&2
+  exit 1
+fi
+
+# Match the useful parts of the GitHub-hosted setup while keeping the image
+# deliberately narrow for the existing Swift E2E route.
+eval "$(/opt/homebrew/bin/brew shellenv)"
+export HOMEBREW_NO_AUTO_UPDATE=1
+export HOMEBREW_NO_INSTALL_CLEANUP=1
+brew install bash curl git go make zip
+
+runner_root="/Users/admin/actions-runner"
+archive="$(mktemp -t actions-runner).tar.gz"
+trap 'rm -f "$archive"' EXIT
+curl --fail --silent --show-error --location \
+  "https://github.com/actions/runner/releases/download/v${runner_version}/actions-runner-osx-arm64-${runner_version}.tar.gz" \
+  --output "$archive"
+echo "${runner_sha256}  ${archive}" | shasum -a 256 --check
+rm -rf "$runner_root"
+mkdir -p "$runner_root"
+tar -xzf "$archive" -C "$runner_root"
+
+# The public base image uses admin/admin. Jobs need passwordless sudo inside the
+# disposable guest, but inbound password authentication is unnecessary.
+printf 'admin ALL=(ALL) NOPASSWD: ALL\n' \
+  | sudo tee /etc/sudoers.d/wendy-e2e >/dev/null
+sudo chmod 0440 /etc/sudoers.d/wendy-e2e
+sudo visudo -cf /etc/sudoers.d/wendy-e2e
+sudo mkdir -p /etc/ssh/sshd_config.d
+printf '%s\n' \
+  'PasswordAuthentication no' \
+  'KbdInteractiveAuthentication no' \
+  | sudo tee /etc/ssh/sshd_config.d/90-wendy-e2e.conf >/dev/null
+sudo chmod 0644 /etc/ssh/sshd_config.d/90-wendy-e2e.conf
+
+# Never promote runner registration residue or machine-specific test state.
+rm -f \
+  "$runner_root/.credentials" \
+  "$runner_root/.credentials_rsaparams" \
+  "$runner_root/.runner"
+rm -rf \
+  "$runner_root/_diag" \
+  "$runner_root/_work" \
+  /Users/admin/Library/Caches/org.swift.swiftpm \
+  /Users/admin/.cache/org.swift.swiftpm \
+  /Users/admin/.wendy
+
+# Fail image preparation unless the exact route prerequisites are present.
+for command in bash curl git go make swift xcodebuild zip ssh ssh-keygen; do
+  command -v "$command" >/dev/null
+done
+"$runner_root/bin/Runner.Listener" --version | grep -Fx "$runner_version"
+sudo -n true
+
+echo "Prepared macOS $(sw_vers -productVersion), $(xcodebuild -version | tr '\n' ' '), Actions runner ${runner_version}."

--- a/.github/runners/macos-e2e-tart/image-prepare.sh
+++ b/.github/runners/macos-e2e-tart/image-prepare.sh
@@ -11,8 +11,8 @@ if [[ "$(sw_vers -productVersion)" != 26.* ]]; then
   echo "ERROR: expected macOS 26" >&2
   exit 1
 fi
-if [[ "$(xcodebuild -version | awk '/^Xcode / { print $2 }')" != "26.6" ]]; then
-  echo "ERROR: expected Xcode 26.6" >&2
+if [[ "$(xcodebuild -version | awk '/^Xcode / { print $2 }')" != "26.5" ]]; then
+  echo "ERROR: expected Xcode 26.5" >&2
   exit 1
 fi
 

--- a/.github/runners/macos-e2e-tart/install-host.sh
+++ b/.github/runners/macos-e2e-tart/install-host.sh
@@ -7,30 +7,24 @@ usage() {
 Usage: sudo ./install-host.sh OPTIONS
 
 Required options:
-  --operator-user USER             Logged-in macOS account that will run Tart
-  --github-app-id ID               GitHub App ID (not a secret)
-  --github-app-installation-id ID  Installation ID for WendyOS (not a secret)
-  --runner-group-id ID             ID of the existing wendy-developer group
-  --github-app-key PATH            Existing GitHub App private-key file
+  --operator-user USER    Logged-in macOS account that will run Tart
+  --runner-group-id ID    ID of the existing wendy-developer group
+  --github-pat-file PATH  Existing temporary fine-grained PAT file
 
-The key is copied into the host-owned secret directory. Never paste key content
-into a shell command, workflow, issue, PR, or chat.
+The PAT is copied into the host-owned secret directory. Never paste token content
+into a shell command, workflow, issue, PR, or chat. Revoke it after the PoC.
 EOF
 }
 
 operator_user=""
-app_id=""
-installation_id=""
 runner_group_id=""
-app_key=""
+github_pat_file=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --operator-user) operator_user="${2:-}"; shift 2 ;;
-    --github-app-id) app_id="${2:-}"; shift 2 ;;
-    --github-app-installation-id) installation_id="${2:-}"; shift 2 ;;
     --runner-group-id) runner_group_id="${2:-}"; shift 2 ;;
-    --github-app-key) app_key="${2:-}"; shift 2 ;;
+    --github-pat-file) github_pat_file="${2:-}"; shift 2 ;;
     --help|-h) usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage >&2; exit 64 ;;
   esac
@@ -38,10 +32,9 @@ done
 
 [[ "$(id -u)" == 0 ]] || { echo "ERROR: run with sudo" >&2; exit 1; }
 [[ -n "$operator_user" ]] || { usage >&2; exit 64; }
-[[ "$app_id" =~ ^[0-9]+$ ]] || { echo "ERROR: invalid GitHub App ID" >&2; exit 64; }
-[[ "$installation_id" =~ ^[0-9]+$ ]] || { echo "ERROR: invalid installation ID" >&2; exit 64; }
 [[ "$runner_group_id" =~ ^[0-9]+$ ]] || { echo "ERROR: invalid runner group ID" >&2; exit 64; }
-[[ -f "$app_key" ]] || { echo "ERROR: GitHub App key does not exist" >&2; exit 1; }
+[[ -f "$github_pat_file" ]] || { echo "ERROR: GitHub PAT file does not exist" >&2; exit 1; }
+[[ -s "$github_pat_file" ]] || { echo "ERROR: GitHub PAT file is empty" >&2; exit 1; }
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 install_root="/Library/Application Support/Wendy/TartE2E"
@@ -53,9 +46,11 @@ tart_home="$operator_home/.tart"
 launch_agent="/Library/LaunchAgents/org.wendy.macos-e2e-tart.plist"
 
 [[ -d "$operator_home" ]] || { echo "ERROR: operator home is missing" >&2; exit 1; }
-mkdir -p "$install_root/bin" "$install_root/secrets" "$state_dir" "$tart_home"
+install -d -o root -g wheel -m 0755 "$install_root" "$install_root/bin"
+install -d -o "$operator_user" -g "$operator_gid" -m 0700 \
+  "$install_root/secrets" "$state_dir" "$tart_home"
 
-for tool in /opt/homebrew/bin/tart /opt/homebrew/bin/softnet /opt/homebrew/bin/jq /usr/bin/openssl; do
+for tool in /opt/homebrew/bin/tart /opt/homebrew/bin/softnet /opt/homebrew/bin/jq; do
   [[ -x "$tool" ]] || {
     echo "ERROR: missing $tool" >&2
     echo "Install the pinned host tools as $operator_user before running this script." >&2
@@ -71,26 +66,22 @@ install -o root -g wheel -m 0755 "$script_dir/controller.sh" "$install_root/bin/
 install -o root -g wheel -m 0755 "$script_dir/watchdog.sh" "$install_root/bin/watchdog.sh"
 install -o root -g wheel -m 0755 "$script_dir/prepare-image.sh" "$install_root/bin/prepare-image.sh"
 install -o root -g wheel -m 0755 "$script_dir/image-prepare.sh" "$install_root/bin/image-prepare.sh"
-install -o "$operator_user" -g "$operator_gid" -m 0400 "$app_key" "$install_root/secrets/github-app.pem"
+install -o "$operator_user" -g "$operator_gid" -m 0400 "$github_pat_file" "$install_root/secrets/github-pat"
 
 config_tmp="$(mktemp)"
 trap 'rm -f "$config_tmp"' EXIT
 awk \
-  -v app_id="$app_id" \
-  -v installation_id="$installation_id" \
   -v runner_group_id="$runner_group_id" \
   -v state_dir="$state_dir" \
   -v tart_home="$tart_home" '
-    $0 == "GITHUB_APP_ID=REQUIRED" { print "GITHUB_APP_ID=" app_id; next }
-    $0 == "GITHUB_APP_INSTALLATION_ID=REQUIRED" { print "GITHUB_APP_INSTALLATION_ID=" installation_id; next }
     $0 == "RUNNER_GROUP_ID=REQUIRED" { print "RUNNER_GROUP_ID=" runner_group_id; next }
     $0 == "STATE_DIR='\''REQUIRED'\''" { print "STATE_DIR='\''" state_dir "'\''"; next }
     $0 == "TART_HOME='\''REQUIRED'\''" { print "TART_HOME='\''" tart_home "'\''"; next }
     { print }
   ' "$script_dir/config.env.example" > "$config_tmp"
-# SECURITY: The operator LaunchAgent must read this non-secret config. Its App,
-# installation and group IDs are public identifiers; the referenced key remains
-# separately protected at 0400 and the root-owned config is not writable.
+# SECURITY: The operator LaunchAgent must read this non-secret config. The group
+# ID and token path are not credentials; the referenced PAT remains separately
+# protected at 0400 and the root-owned config is not writable.
 install -o root -g wheel -m 0644 "$config_tmp" "$install_root/config.env"
 install -o root -g wheel -m 0644 "$script_dir/org.wendy.macos-e2e-tart.plist" "$launch_agent"
 
@@ -101,7 +92,7 @@ chown root:wheel "$softnet_real"
 chmod 4755 "$softnet_real"
 
 chown -R "$operator_user:$operator_gid" "$state_dir" "$tart_home"
-chmod 0700 "$state_dir"
+chmod 0700 "$state_dir" "$tart_home"
 plutil -lint "$launch_agent" >/dev/null
 
 # Image creation is a separate, auditable promotion step. Do not start the

--- a/.github/runners/macos-e2e-tart/install-host.sh
+++ b/.github/runners/macos-e2e-tart/install-host.sh
@@ -88,6 +88,9 @@ awk \
     $0 == "TART_HOME='\''REQUIRED'\''" { print "TART_HOME='\''" tart_home "'\''"; next }
     { print }
   ' "$script_dir/config.env.example" > "$config_tmp"
+# SECURITY: The operator LaunchAgent must read this non-secret config. Its App,
+# installation and group IDs are public identifiers; the referenced key remains
+# separately protected at 0400 and the root-owned config is not writable.
 install -o root -g wheel -m 0644 "$config_tmp" "$install_root/config.env"
 install -o root -g wheel -m 0644 "$script_dir/org.wendy.macos-e2e-tart.plist" "$launch_agent"
 

--- a/.github/runners/macos-e2e-tart/install-host.sh
+++ b/.github/runners/macos-e2e-tart/install-host.sh
@@ -89,6 +89,14 @@ awk \
 install -o root -g wheel -m 0644 "$config_tmp" "$install_root/config.env"
 install -o root -g wheel -m 0644 "$script_dir/org.wendy.macos-e2e-tart.plist" "$launch_agent"
 
+# Undo the privileged Softnet binary mode used by the earlier PoC revision.
+# Tart may retain Softnet as a Homebrew dependency, but this route never invokes it.
+if [[ -e /opt/homebrew/bin/softnet ]]; then
+  legacy_softnet_real="$(/usr/bin/python3 -c 'import os; print(os.path.realpath("/opt/homebrew/bin/softnet"))')"
+  chown "$operator_user:$operator_gid" "$legacy_softnet_real"
+  chmod 0755 "$legacy_softnet_real"
+fi
+
 chown -R "$operator_user:$operator_gid" "$state_dir" "$tart_home"
 chmod 0700 "$state_dir" "$tart_home"
 plutil -lint "$launch_agent" >/dev/null

--- a/.github/runners/macos-e2e-tart/install-host.sh
+++ b/.github/runners/macos-e2e-tart/install-host.sh
@@ -10,7 +10,7 @@ Required options:
   --operator-user USER             Logged-in macOS account that will run Tart
   --github-app-id ID               GitHub App ID (not a secret)
   --github-app-installation-id ID  Installation ID for WendyOS (not a secret)
-  --runner-group-id ID             ID of the dedicated runner group
+  --runner-group-id ID             ID of the existing wendy-developer group
   --github-app-key PATH            Existing GitHub App private-key file
 
 The key is copied into the host-owned secret directory. Never paste key content

--- a/.github/runners/macos-e2e-tart/install-host.sh
+++ b/.github/runners/macos-e2e-tart/install-host.sh
@@ -57,10 +57,14 @@ for tool in /opt/homebrew/bin/tart /opt/homebrew/bin/softnet /opt/homebrew/bin/j
     exit 1
   }
 done
-[[ "$(sudo -u "$operator_user" /opt/homebrew/bin/tart --version)" == 'Tart 2.36.0' ]] \
-  || { echo "ERROR: expected Tart 2.36.0" >&2; exit 1; }
-[[ "$(sudo -u "$operator_user" /opt/homebrew/bin/softnet --version)" == 'softnet 0.23.0' ]] \
-  || { echo "ERROR: expected Softnet 0.23.0" >&2; exit 1; }
+installed_tart_version="$(sudo -u "$operator_user" /opt/homebrew/bin/tart --version)"
+installed_softnet_version="$(sudo -u "$operator_user" /opt/homebrew/bin/softnet --version)"
+installed_softnet_build="${installed_softnet_version#softnet }"
+[[ "$installed_tart_version" == '2.36.0' ]] \
+  || { echo "ERROR: expected Tart 2.36.0, got $installed_tart_version" >&2; exit 1; }
+[[ "$installed_softnet_version" == softnet\ * && \
+   ("$installed_softnet_build" == '0.23.0' || "$installed_softnet_build" == 0.23.0-*) ]] \
+  || { echo "ERROR: expected Softnet 0.23.0, got $installed_softnet_version" >&2; exit 1; }
 
 install -o root -g wheel -m 0755 "$script_dir/controller.sh" "$install_root/bin/controller.sh"
 install -o root -g wheel -m 0755 "$script_dir/watchdog.sh" "$install_root/bin/watchdog.sh"

--- a/.github/runners/macos-e2e-tart/install-host.sh
+++ b/.github/runners/macos-e2e-tart/install-host.sh
@@ -55,7 +55,7 @@ install -d -o root -g wheel -m 0755 "$install_root" "$install_root/bin"
 install -d -o "$operator_user" -g "$operator_gid" -m 0700 \
   "$install_root/secrets" "$state_parent" "$state_dir" "$tart_home"
 
-for tool in /opt/homebrew/bin/tart /opt/homebrew/bin/softnet /opt/homebrew/bin/jq; do
+for tool in /opt/homebrew/bin/tart /opt/homebrew/bin/jq; do
   [[ -x "$tool" ]] || {
     echo "ERROR: missing $tool" >&2
     echo "Install the pinned host tools as $operator_user before running this script." >&2
@@ -63,13 +63,8 @@ for tool in /opt/homebrew/bin/tart /opt/homebrew/bin/softnet /opt/homebrew/bin/j
   }
 done
 installed_tart_version="$(sudo -u "$operator_user" /opt/homebrew/bin/tart --version)"
-installed_softnet_version="$(sudo -u "$operator_user" /opt/homebrew/bin/softnet --version)"
-installed_softnet_build="${installed_softnet_version#softnet }"
 [[ "$installed_tart_version" == '2.36.0' ]] \
   || { echo "ERROR: expected Tart 2.36.0, got $installed_tart_version" >&2; exit 1; }
-[[ "$installed_softnet_version" == softnet\ * && \
-   ("$installed_softnet_build" == '0.23.0' || "$installed_softnet_build" == 0.23.0-*) ]] \
-  || { echo "ERROR: expected Softnet 0.23.0, got $installed_softnet_version" >&2; exit 1; }
 
 install -o root -g wheel -m 0755 "$script_dir/controller.sh" "$install_root/bin/controller.sh"
 install -o root -g wheel -m 0755 "$script_dir/watchdog.sh" "$install_root/bin/watchdog.sh"
@@ -93,12 +88,6 @@ awk \
 # protected at 0400 and the root-owned config is not writable.
 install -o root -g wheel -m 0644 "$config_tmp" "$install_root/config.env"
 install -o root -g wheel -m 0644 "$script_dir/org.wendy.macos-e2e-tart.plist" "$launch_agent"
-
-# Softnet needs elevated vmnet initialization, then drops privileges. Configure
-# only the pinned binary selected by Homebrew, not an arbitrary PATH lookup.
-softnet_real="$(/usr/bin/python3 -c 'import os; print(os.path.realpath("/opt/homebrew/bin/softnet"))')"
-chown root:wheel "$softnet_real"
-chmod 4755 "$softnet_real"
 
 chown -R "$operator_user:$operator_gid" "$state_dir" "$tart_home"
 chmod 0700 "$state_dir" "$tart_home"

--- a/.github/runners/macos-e2e-tart/install-host.sh
+++ b/.github/runners/macos-e2e-tart/install-host.sh
@@ -37,7 +37,8 @@ done
 [[ -s "$github_pat_file" ]] || { echo "ERROR: GitHub PAT file is empty" >&2; exit 1; }
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
-install_root="/Library/Application Support/Wendy/TartE2E"
+install_parent="/Library/Application Support/Wendy"
+install_root="$install_parent/TartE2E"
 operator_uid="$(id -u "$operator_user")"
 operator_gid="$(id -g "$operator_user")"
 operator_home="$(dscl . -read "/Users/$operator_user" NFSHomeDirectory | awk '{print $2}')"
@@ -46,6 +47,9 @@ tart_home="$operator_home/.tart"
 launch_agent="/Library/LaunchAgents/org.wendy.macos-e2e-tart.plist"
 
 [[ -d "$operator_home" ]] || { echo "ERROR: operator home is missing" >&2; exit 1; }
+# install(1) applies the requested mode only to named destinations. Name the
+# intermediate Wendy directory explicitly so umask 077 cannot make it root-only.
+install -d -o root -g wheel -m 0711 "$install_parent"
 install -d -o root -g wheel -m 0755 "$install_root" "$install_root/bin"
 install -d -o "$operator_user" -g "$operator_gid" -m 0700 \
   "$install_root/secrets" "$state_dir" "$tart_home"

--- a/.github/runners/macos-e2e-tart/install-host.sh
+++ b/.github/runners/macos-e2e-tart/install-host.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+set -euo pipefail
+umask 077
+
+usage() {
+  cat <<'EOF'
+Usage: sudo ./install-host.sh OPTIONS
+
+Required options:
+  --operator-user USER             Logged-in macOS account that will run Tart
+  --github-app-id ID               GitHub App ID (not a secret)
+  --github-app-installation-id ID  Installation ID for WendyOS (not a secret)
+  --runner-group-id ID             ID of the dedicated runner group
+  --github-app-key PATH            Existing GitHub App private-key file
+
+The key is copied into the host-owned secret directory. Never paste key content
+into a shell command, workflow, issue, PR, or chat.
+EOF
+}
+
+operator_user=""
+app_id=""
+installation_id=""
+runner_group_id=""
+app_key=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --operator-user) operator_user="${2:-}"; shift 2 ;;
+    --github-app-id) app_id="${2:-}"; shift 2 ;;
+    --github-app-installation-id) installation_id="${2:-}"; shift 2 ;;
+    --runner-group-id) runner_group_id="${2:-}"; shift 2 ;;
+    --github-app-key) app_key="${2:-}"; shift 2 ;;
+    --help|-h) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 64 ;;
+  esac
+done
+
+[[ "$(id -u)" == 0 ]] || { echo "ERROR: run with sudo" >&2; exit 1; }
+[[ -n "$operator_user" ]] || { usage >&2; exit 64; }
+[[ "$app_id" =~ ^[0-9]+$ ]] || { echo "ERROR: invalid GitHub App ID" >&2; exit 64; }
+[[ "$installation_id" =~ ^[0-9]+$ ]] || { echo "ERROR: invalid installation ID" >&2; exit 64; }
+[[ "$runner_group_id" =~ ^[0-9]+$ ]] || { echo "ERROR: invalid runner group ID" >&2; exit 64; }
+[[ -f "$app_key" ]] || { echo "ERROR: GitHub App key does not exist" >&2; exit 1; }
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+install_root="/Library/Application Support/Wendy/TartE2E"
+operator_uid="$(id -u "$operator_user")"
+operator_gid="$(id -g "$operator_user")"
+operator_home="$(dscl . -read "/Users/$operator_user" NFSHomeDirectory | awk '{print $2}')"
+state_dir="$operator_home/Library/Application Support/Wendy/TartE2E"
+tart_home="$operator_home/.tart"
+launch_agent="/Library/LaunchAgents/org.wendy.macos-e2e-tart.plist"
+
+[[ -d "$operator_home" ]] || { echo "ERROR: operator home is missing" >&2; exit 1; }
+mkdir -p "$install_root/bin" "$install_root/secrets" "$state_dir" "$tart_home"
+
+for tool in /opt/homebrew/bin/tart /opt/homebrew/bin/softnet /opt/homebrew/bin/jq /usr/bin/openssl; do
+  [[ -x "$tool" ]] || {
+    echo "ERROR: missing $tool" >&2
+    echo "Install the pinned host tools as $operator_user before running this script." >&2
+    exit 1
+  }
+done
+[[ "$(sudo -u "$operator_user" /opt/homebrew/bin/tart --version)" == 'Tart 2.36.0' ]] \
+  || { echo "ERROR: expected Tart 2.36.0" >&2; exit 1; }
+[[ "$(sudo -u "$operator_user" /opt/homebrew/bin/softnet --version)" == 'softnet 0.23.0' ]] \
+  || { echo "ERROR: expected Softnet 0.23.0" >&2; exit 1; }
+
+install -o root -g wheel -m 0755 "$script_dir/controller.sh" "$install_root/bin/controller.sh"
+install -o root -g wheel -m 0755 "$script_dir/watchdog.sh" "$install_root/bin/watchdog.sh"
+install -o root -g wheel -m 0755 "$script_dir/prepare-image.sh" "$install_root/bin/prepare-image.sh"
+install -o root -g wheel -m 0755 "$script_dir/image-prepare.sh" "$install_root/bin/image-prepare.sh"
+install -o "$operator_user" -g "$operator_gid" -m 0400 "$app_key" "$install_root/secrets/github-app.pem"
+
+config_tmp="$(mktemp)"
+trap 'rm -f "$config_tmp"' EXIT
+awk \
+  -v app_id="$app_id" \
+  -v installation_id="$installation_id" \
+  -v runner_group_id="$runner_group_id" \
+  -v state_dir="$state_dir" \
+  -v tart_home="$tart_home" '
+    $0 == "GITHUB_APP_ID=REQUIRED" { print "GITHUB_APP_ID=" app_id; next }
+    $0 == "GITHUB_APP_INSTALLATION_ID=REQUIRED" { print "GITHUB_APP_INSTALLATION_ID=" installation_id; next }
+    $0 == "RUNNER_GROUP_ID=REQUIRED" { print "RUNNER_GROUP_ID=" runner_group_id; next }
+    $0 == "STATE_DIR='\''REQUIRED'\''" { print "STATE_DIR='\''" state_dir "'\''"; next }
+    $0 == "TART_HOME='\''REQUIRED'\''" { print "TART_HOME='\''" tart_home "'\''"; next }
+    { print }
+  ' "$script_dir/config.env.example" > "$config_tmp"
+install -o root -g wheel -m 0644 "$config_tmp" "$install_root/config.env"
+install -o root -g wheel -m 0644 "$script_dir/org.wendy.macos-e2e-tart.plist" "$launch_agent"
+
+# Softnet needs elevated vmnet initialization, then drops privileges. Configure
+# only the pinned binary selected by Homebrew, not an arbitrary PATH lookup.
+softnet_real="$(/usr/bin/python3 -c 'import os; print(os.path.realpath("/opt/homebrew/bin/softnet"))')"
+chown root:wheel "$softnet_real"
+chmod 4755 "$softnet_real"
+
+chown -R "$operator_user:$operator_gid" "$state_dir" "$tart_home"
+chmod 0700 "$state_dir"
+plutil -lint "$launch_agent" >/dev/null
+
+# Image creation is a separate, auditable promotion step. Do not start the
+# controller until the immutable golden image exists.
+echo "Host lifecycle files installed outside workflow-writable paths."
+echo "Next, while logged in as $operator_user:"
+echo "  launchctl bootout gui/$operator_uid/org.wendy.macos-e2e-tart 2>/dev/null || true"
+echo "  WENDY_TART_E2E_CONFIG='$install_root/config.env' '$install_root/bin/prepare-image.sh'"
+echo "  launchctl bootstrap gui/$operator_uid '$launch_agent'"
+echo "  launchctl kickstart -k gui/$operator_uid/org.wendy.macos-e2e-tart"

--- a/.github/runners/macos-e2e-tart/install-host.sh
+++ b/.github/runners/macos-e2e-tart/install-host.sh
@@ -42,7 +42,8 @@ install_root="$install_parent/TartE2E"
 operator_uid="$(id -u "$operator_user")"
 operator_gid="$(id -g "$operator_user")"
 operator_home="$(dscl . -read "/Users/$operator_user" NFSHomeDirectory | awk '{print $2}')"
-state_dir="$operator_home/Library/Application Support/Wendy/TartE2E"
+state_parent="$operator_home/Library/Application Support/Wendy"
+state_dir="$state_parent/TartE2E"
 tart_home="$operator_home/.tart"
 launch_agent="/Library/LaunchAgents/org.wendy.macos-e2e-tart.plist"
 
@@ -52,7 +53,7 @@ launch_agent="/Library/LaunchAgents/org.wendy.macos-e2e-tart.plist"
 install -d -o root -g wheel -m 0711 "$install_parent"
 install -d -o root -g wheel -m 0755 "$install_root" "$install_root/bin"
 install -d -o "$operator_user" -g "$operator_gid" -m 0700 \
-  "$install_root/secrets" "$state_dir" "$tart_home"
+  "$install_root/secrets" "$state_parent" "$state_dir" "$tart_home"
 
 for tool in /opt/homebrew/bin/tart /opt/homebrew/bin/softnet /opt/homebrew/bin/jq; do
   [[ -x "$tool" ]] || {

--- a/.github/runners/macos-e2e-tart/org.wendy.macos-e2e-tart.plist
+++ b/.github/runners/macos-e2e-tart/org.wendy.macos-e2e-tart.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>org.wendy.macos-e2e-tart</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Library/Application Support/Wendy/TartE2E/bin/controller.sh</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>WENDY_TART_E2E_CONFIG</key>
+    <string>/Library/Application Support/Wendy/TartE2E/config.env</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>ThrottleInterval</key>
+  <integer>30</integer>
+  <key>StandardOutPath</key>
+  <string>/dev/null</string>
+  <key>StandardErrorPath</key>
+  <string>/dev/null</string>
+</dict>
+</plist>

--- a/.github/runners/macos-e2e-tart/prepare-image.sh
+++ b/.github/runners/macos-e2e-tart/prepare-image.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# shellcheck disable=SC2016 # Guest verification expands only inside the VM.
+set -euo pipefail
+umask 077
+
+CONFIG_PATH="${WENDY_TART_E2E_CONFIG:-/Library/Application Support/Wendy/TartE2E/config.env}"
+# shellcheck disable=SC1090
+source "$CONFIG_PATH"
+export TART_HOME
+runtime_path="$(dirname "$TART_BIN"):$(dirname "$SOFTNET_BIN"):$(dirname "$JQ_BIN"):/usr/bin:/bin:/usr/sbin:/sbin"
+export PATH="$runtime_path"
+
+candidate="${GOLDEN_IMAGE}.candidate.$(date -u +%Y%m%d%H%M%S)"
+run_pid=""
+
+cleanup() {
+  local status=$?
+  trap - EXIT INT TERM
+  if [[ -n "$run_pid" ]]; then
+    "$TART_BIN" stop --timeout 5 "$candidate" >/dev/null 2>&1 || true
+    kill "$run_pid" >/dev/null 2>&1 || true
+    wait "$run_pid" >/dev/null 2>&1 || true
+  fi
+  if [[ $status -ne 0 ]]; then
+    "$TART_BIN" delete "$candidate" >/dev/null 2>&1 || true
+  fi
+  exit "$status"
+}
+trap cleanup EXIT INT TERM
+
+if "$TART_BIN" list --source local --quiet | grep -Fxq "$GOLDEN_IMAGE"; then
+  echo "ERROR: golden image already exists: $GOLDEN_IMAGE" >&2
+  echo "Promote a new versioned GOLDEN_IMAGE instead of mutating it in place." >&2
+  exit 1
+fi
+
+"$TART_BIN" clone "$UPSTREAM_IMAGE" "$candidate"
+"$TART_BIN" set "$candidate" --cpu "$RUNNER_CPU_COUNT" --memory "$RUNNER_MEMORY_MB"
+"$TART_BIN" run \
+  --no-graphics \
+  --no-audio \
+  --no-clipboard \
+  --net-softnet \
+  "$candidate" >/dev/null 2>&1 &
+run_pid=$!
+
+ready=false
+for _ in $(seq 1 60); do
+  if ! kill -0 "$run_pid" >/dev/null 2>&1; then
+    echo "ERROR: candidate VM exited before its guest agent became ready" >&2
+    exit 1
+  fi
+  if "$TART_BIN" exec "$candidate" /usr/bin/true >/dev/null 2>&1; then
+    ready=true
+    break
+  fi
+  sleep 5
+done
+if [[ "$ready" != true ]]; then
+  echo "ERROR: candidate guest agent did not become ready within 5 minutes" >&2
+  exit 1
+fi
+
+"$TART_BIN" exec -i "$candidate" /bin/bash -s -- \
+  "$RUNNER_VERSION" "$RUNNER_ARCHIVE_SHA256" \
+  < "$INSTALL_ROOT/bin/image-prepare.sh"
+
+# Verify the promoted image through the same no-mount, Softnet-isolated route.
+"$TART_BIN" exec "$candidate" /bin/bash -c '
+  set -euo pipefail
+  sudo -n true
+  test ! -e /Users/admin/actions-runner/.runner
+  test ! -e /Users/admin/actions-runner/.credentials
+  test "$(xcodebuild -version | awk '\''/^Xcode / { print $2 }'\'')" = 26.6
+  /Users/admin/actions-runner/bin/Runner.Listener --version
+'
+
+"$TART_BIN" stop --timeout 30 "$candidate"
+wait "$run_pid" || true
+run_pid=""
+"$TART_BIN" rename "$candidate" "$GOLDEN_IMAGE"
+# The local golden image is now independent. Remove only its exact OCI cache
+# entry so the 512 GB host retains enough room for guest copy-on-write growth.
+"$TART_BIN" delete "$UPSTREAM_IMAGE" >/dev/null 2>&1 || true
+
+echo "Promoted immutable Tart image: $GOLDEN_IMAGE"
+echo "Source: $UPSTREAM_IMAGE"

--- a/.github/runners/macos-e2e-tart/prepare-image.sh
+++ b/.github/runners/macos-e2e-tart/prepare-image.sh
@@ -71,7 +71,7 @@ fi
   sudo -n true
   test ! -e /Users/admin/actions-runner/.runner
   test ! -e /Users/admin/actions-runner/.credentials
-  test "$(xcodebuild -version | awk '\''/^Xcode / { print $2 }'\'')" = 26.6
+  test "$(xcodebuild -version | awk '\''/^Xcode / { print $2 }'\'')" = 26.5
   /Users/admin/actions-runner/bin/Runner.Listener --version
 '
 
@@ -79,8 +79,9 @@ fi
 wait "$run_pid" || true
 run_pid=""
 "$TART_BIN" rename "$candidate" "$GOLDEN_IMAGE"
-# The local golden image is now independent. Remove only its exact OCI cache
-# entry so the 512 GB host retains enough room for guest copy-on-write growth.
+# SECURITY: The exact source digest remains in immutable config and is printed
+# below for audit/re-pull. Its ~69 GB compressed cache is pruned deliberately so
+# the 512 GB host retains enough headroom for hostile guest disk growth.
 "$TART_BIN" delete "$UPSTREAM_IMAGE" >/dev/null 2>&1 || true
 
 echo "Promoted immutable Tart image: $GOLDEN_IMAGE"

--- a/.github/runners/macos-e2e-tart/prepare-image.sh
+++ b/.github/runners/macos-e2e-tart/prepare-image.sh
@@ -7,7 +7,7 @@ CONFIG_PATH="${WENDY_TART_E2E_CONFIG:-/Library/Application Support/Wendy/TartE2E
 # shellcheck disable=SC1090
 source "$CONFIG_PATH"
 export TART_HOME
-runtime_path="$(dirname "$TART_BIN"):$(dirname "$SOFTNET_BIN"):$(dirname "$JQ_BIN"):/usr/bin:/bin:/usr/sbin:/sbin"
+runtime_path="$(dirname "$TART_BIN"):$(dirname "$JQ_BIN"):/usr/bin:/bin:/usr/sbin:/sbin"
 export PATH="$runtime_path"
 
 candidate="${GOLDEN_IMAGE}.candidate.$(date -u +%Y%m%d%H%M%S)"
@@ -40,7 +40,6 @@ fi
   --no-graphics \
   --no-audio \
   --no-clipboard \
-  --net-softnet \
   "$candidate" >/dev/null 2>&1 &
 run_pid=$!
 
@@ -65,7 +64,7 @@ fi
   "$RUNNER_VERSION" "$RUNNER_ARCHIVE_SHA256" \
   < "$INSTALL_ROOT/bin/image-prepare.sh"
 
-# Verify the promoted image through the same no-mount, Softnet-isolated route.
+# Verify the promoted image through the same no-mount, standard NAT route.
 "$TART_BIN" exec "$candidate" /bin/bash -c '
   set -euo pipefail
   sudo -n true

--- a/.github/runners/macos-e2e-tart/watchdog.sh
+++ b/.github/runners/macos-e2e-tart/watchdog.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -u
+
+vm_name="${1:?VM name is required}"
+controller_pid="${2:?controller PID is required}"
+max_seconds="${3:?maximum lifetime is required}"
+config_path="${WENDY_TART_E2E_CONFIG:-/Library/Application Support/Wendy/TartE2E/config.env}"
+# shellcheck disable=SC1090
+source "$config_path"
+export TART_HOME
+
+started_at="$(date +%s)"
+while kill -0 "$controller_pid" >/dev/null 2>&1; do
+  now="$(date +%s)"
+  if (( now - started_at >= max_seconds )); then
+    /usr/bin/logger -t wendy-tart-e2e "watchdog expired for $vm_name after ${max_seconds}s"
+    break
+  fi
+  sleep 10
+done
+
+# This process is host-owned and independent of the guest job. Even a job that
+# kills the runner, guest agent, or sshd cannot stop forced VM destruction.
+"$TART_BIN" stop --timeout 5 "$vm_name" >/dev/null 2>&1 || true
+"$TART_BIN" delete "$vm_name" >/dev/null 2>&1 || true

--- a/.github/workflows/macos-e2e-tart-validation.yml
+++ b/.github/workflows/macos-e2e-tart-validation.yml
@@ -1,0 +1,146 @@
+name: Validate disposable macOS E2E runner
+
+on:
+  workflow_dispatch:
+    inputs:
+      scenario:
+        description: Disposable-boundary scenario
+        required: true
+        type: choice
+        options:
+          - smoke
+          - wait-for-cancellation
+          - persistence
+          - disk-pressure
+          - watchdog
+
+concurrency:
+  group: macos-e2e-tart-validation
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  exercise:
+    name: Exercise ${{ inputs.scenario }}
+    permissions:
+      contents: read
+    runs-on:
+      group: wendy-e2e-macos-tart
+      labels: [self-hosted, wendy-e2e-macos-tart]
+    timeout-minutes: 170
+    steps:
+      - name: Record disposable guest identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          printf 'host=%s\n' "$(scutil --get ComputerName)"
+          sw_vers
+          xcodebuild -version
+
+      - name: Verify isolated route
+        if: inputs.scenario == 'smoke'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if mount | grep -Fq 'com.apple.virtio-fs'; then
+            echo 'ERROR: a host VirtioFS mount is present' >&2
+            exit 1
+          fi
+          curl --fail --silent --show-error --max-time 15 https://api.github.com/zen >/dev/null
+          for address in 10.255.255.254 172.31.255.254 192.168.255.254; do
+            if nc -G 2 -z "$address" 443 >/dev/null 2>&1; then
+              echo "ERROR: reached private-LAN probe $address" >&2
+              exit 1
+            fi
+          done
+          sudo -n true
+
+      - name: Wait for operator cancellation
+        if: inputs.scenario == 'wait-for-cancellation'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo 'Cancel this workflow now. No in-guest cleanup step will run.'
+          sleep 9600
+
+      - name: Attempt guest persistence
+        if: inputs.scenario == 'persistence'
+        shell: bash
+        run: |
+          set -euo pipefail
+          marker='/Library/Application Support/Wendy/tart-persistence-marker'
+          plist='/Library/LaunchDaemons/org.wendy.tart-persistence-validation.plist'
+          sudo mkdir -p "$(dirname "$marker")"
+          sudo touch "$marker"
+          cat <<'PLIST' | sudo tee "$plist" >/dev/null
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0"><dict>
+            <key>Label</key><string>org.wendy.tart-persistence-validation</string>
+            <key>ProgramArguments</key><array>
+              <string>/usr/bin/touch</string>
+              <string>/Library/Application Support/Wendy/tart-persistence-launched</string>
+            </array>
+            <key>RunAtLoad</key><true/>
+          </dict></plist>
+          PLIST
+          sudo chown root:wheel "$plist"
+          sudo chmod 0644 "$plist"
+          sudo launchctl bootstrap system "$plist"
+          test -e "$marker"
+          test -e '/Library/Application Support/Wendy/tart-persistence-launched'
+
+      - name: Exhaust disposable guest disk
+        if: inputs.scenario == 'disk-pressure'
+        shell: bash
+        run: |
+          set -euo pipefail
+          free_kb="$(df -Pk "$RUNNER_TEMP" | awk 'NR == 2 { print $4 }')"
+          reserve_kb=$((2 * 1024 * 1024))
+          if (( free_kb <= reserve_kb )); then
+            echo "ERROR: guest started with only ${free_kb}KB free" >&2
+            exit 1
+          fi
+          allocate_kb=$((free_kb - reserve_kb))
+          echo "Allocating ${allocate_kb}KB inside the disposable guest"
+          mkfile "${allocate_kb}k" "$RUNNER_TEMP/wendy-disk-pressure"
+          sync
+          df -h "$RUNNER_TEMP"
+
+      - name: Outlive host watchdog
+        if: inputs.scenario == 'watchdog'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo 'The host watchdog should destroy this guest after 9,300 seconds.'
+          sleep 9600
+
+  verify-fresh:
+    name: Verify a fresh guest
+    needs: exercise
+    if: >-
+      ${{ always() && needs.exercise.result == 'success' &&
+          (inputs.scenario == 'persistence' || inputs.scenario == 'disk-pressure') }}
+    permissions:
+      contents: read
+    runs-on:
+      group: wendy-e2e-macos-tart
+      labels: [self-hosted, wendy-e2e-macos-tart]
+    timeout-minutes: 15
+    steps:
+      - name: Verify prior guest state is absent
+        shell: bash
+        run: |
+          set -euo pipefail
+          test ! -e '/Library/LaunchDaemons/org.wendy.tart-persistence-validation.plist'
+          test ! -e '/Library/Application Support/Wendy/tart-persistence-marker'
+          test ! -e '/Library/Application Support/Wendy/tart-persistence-launched'
+          free_kb="$(df -Pk "$RUNNER_TEMP" | awk 'NR == 2 { print $4 }')"
+          minimum_kb=$((10 * 1024 * 1024))
+          if (( free_kb < minimum_kb )); then
+            echo "ERROR: fresh guest has less than 10GB free (${free_kb}KB)" >&2
+            exit 1
+          fi
+          printf 'fresh-host=%s free-kb=%s\n' "$(scutil --get ComputerName)" "$free_kb"

--- a/.github/workflows/macos-e2e-tart-validation.yml
+++ b/.github/workflows/macos-e2e-tart-validation.yml
@@ -58,7 +58,7 @@ jobs:
     permissions:
       contents: read
     runs-on:
-      group: wendy-e2e-macos-tart
+      group: wendy-developer
       labels: [self-hosted, wendy-e2e-macos-tart]
     timeout-minutes: 170
     steps:
@@ -158,7 +158,7 @@ jobs:
     permissions:
       contents: read
     runs-on:
-      group: wendy-e2e-macos-tart
+      group: wendy-developer
       labels: [self-hosted, wendy-e2e-macos-tart]
     timeout-minutes: 15
     steps:

--- a/.github/workflows/macos-e2e-tart-validation.yml
+++ b/.github/workflows/macos-e2e-tart-validation.yml
@@ -70,7 +70,7 @@ jobs:
           sw_vers
           xcodebuild -version
 
-      - name: Verify isolated route
+      - name: Verify PoC route
         if: needs.select-scenario.outputs.scenario == 'smoke'
         shell: bash
         run: |
@@ -80,12 +80,6 @@ jobs:
             exit 1
           fi
           curl --fail --silent --show-error --max-time 15 https://api.github.com/zen >/dev/null
-          for address in 10.255.255.254 172.31.255.254 192.168.255.254; do
-            if nc -G 2 -z "$address" 443 >/dev/null 2>&1; then
-              echo "ERROR: reached private-LAN probe $address" >&2
-              exit 1
-            fi
-          done
           sudo -n true
 
       - name: Wait for operator cancellation

--- a/.github/workflows/macos-e2e-tart-validation.yml
+++ b/.github/workflows/macos-e2e-tart-validation.yml
@@ -1,6 +1,8 @@
 name: Validate disposable macOS E2E runner
 
 on:
+  pull_request:
+    types: [labeled]
   workflow_dispatch:
     inputs:
       scenario:
@@ -22,8 +24,37 @@ permissions:
   contents: read
 
 jobs:
+  select-scenario:
+    name: Select trusted validation scenario
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch' ||
+          (github.event.pull_request.head.repo.full_name == github.repository &&
+           startsWith(github.event.label.name, 'macos-e2e-tart:')) }}
+    permissions:
+      contents: read
+    runs-on: ubuntu-24.04
+    outputs:
+      scenario: ${{ steps.scenario.outputs.value }}
+    steps:
+      - name: Validate selection
+        id: scenario
+        shell: bash
+        env:
+          DISPATCH_SCENARIO: ${{ inputs.scenario || '' }}
+          PR_LABEL: ${{ github.event.label.name || '' }}
+        run: |
+          set -euo pipefail
+          scenario="${DISPATCH_SCENARIO:-${PR_LABEL#macos-e2e-tart:}}"
+          case "$scenario" in
+            smoke|wait-for-cancellation|persistence|disk-pressure|watchdog) ;;
+            *) echo "ERROR: invalid validation scenario" >&2; exit 64 ;;
+          esac
+          echo "value=$scenario" >> "$GITHUB_OUTPUT"
+
   exercise:
-    name: Exercise ${{ inputs.scenario }}
+    name: Exercise ${{ needs.select-scenario.outputs.scenario }}
+    needs: select-scenario
+    if: needs.select-scenario.result == 'success'
     permissions:
       contents: read
     runs-on:
@@ -40,7 +71,7 @@ jobs:
           xcodebuild -version
 
       - name: Verify isolated route
-        if: inputs.scenario == 'smoke'
+        if: needs.select-scenario.outputs.scenario == 'smoke'
         shell: bash
         run: |
           set -euo pipefail
@@ -58,7 +89,7 @@ jobs:
           sudo -n true
 
       - name: Wait for operator cancellation
-        if: inputs.scenario == 'wait-for-cancellation'
+        if: needs.select-scenario.outputs.scenario == 'wait-for-cancellation'
         shell: bash
         run: |
           set -euo pipefail
@@ -66,7 +97,7 @@ jobs:
           sleep 9600
 
       - name: Attempt guest persistence
-        if: inputs.scenario == 'persistence'
+        if: needs.select-scenario.outputs.scenario == 'persistence'
         shell: bash
         run: |
           set -euo pipefail
@@ -93,7 +124,7 @@ jobs:
           test -e '/Library/Application Support/Wendy/tart-persistence-launched'
 
       - name: Exhaust disposable guest disk
-        if: inputs.scenario == 'disk-pressure'
+        if: needs.select-scenario.outputs.scenario == 'disk-pressure'
         shell: bash
         run: |
           set -euo pipefail
@@ -110,7 +141,7 @@ jobs:
           df -h "$RUNNER_TEMP"
 
       - name: Outlive host watchdog
-        if: inputs.scenario == 'watchdog'
+        if: needs.select-scenario.outputs.scenario == 'watchdog'
         shell: bash
         run: |
           set -euo pipefail
@@ -119,10 +150,11 @@ jobs:
 
   verify-fresh:
     name: Verify a fresh guest
-    needs: exercise
+    needs: [select-scenario, exercise]
     if: >-
       ${{ always() && needs.exercise.result == 'success' &&
-          (inputs.scenario == 'persistence' || inputs.scenario == 'disk-pressure') }}
+          (needs.select-scenario.outputs.scenario == 'persistence' ||
+           needs.select-scenario.outputs.scenario == 'disk-pressure') }}
     permissions:
       contents: read
     runs-on:

--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -87,6 +87,8 @@ jobs:
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/swift-e2e-run
         with:
           tests: ${{ inputs.tests || '' }}

--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -78,7 +78,7 @@ jobs:
     permissions:
       contents: read
     runs-on:
-      group: wendy-e2e-macos-tart
+      group: wendy-developer
       labels: [self-hosted, wendy-e2e-macos-tart]
     concurrency:
       group: device-local-macos-tart

--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -28,6 +28,14 @@ on:
         description: 'Optional ref to diff against (empty = full review)'
         required: false
         default: ''
+      macos_runner:
+        description: 'macOS execution route'
+        required: false
+        default: tart
+        type: choice
+        options:
+          - tart
+          - github-hosted
   workflow_call:
     inputs:
       tests:
@@ -42,6 +50,10 @@ on:
         type: string
         required: false
         default: ''
+      macos_runner:
+        type: string
+        required: false
+        default: tart
     secrets:
       WENDY_E2E_SLACK_WEBHOOK_URL:
         required: false
@@ -56,14 +68,44 @@ concurrency:
 
 permissions:
   contents: read
-  actions: read
-  issues: write
-  pull-requests: write
 
 jobs:
   swift-e2e-local-macos:
-    name: 'Local: macOS 26'
-    if: ${{ inputs.target_group == '' || inputs.target_group == 'all' || inputs.target_group == 'local' }}
+    name: 'Local: macOS 26 (Tart)'
+    if: >-
+      ${{ (inputs.target_group == '' || inputs.target_group == 'all' || inputs.target_group == 'local') &&
+          (inputs.macos_runner == '' || inputs.macos_runner == 'tart') }}
+    permissions:
+      contents: read
+    runs-on:
+      group: wendy-e2e-macos-tart
+      labels: [self-hosted, wendy-e2e-macos-tart]
+    concurrency:
+      group: device-local-macos-tart
+      cancel-in-progress: false
+      queue: max
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/swift-e2e-run
+        with:
+          tests: ${{ inputs.tests || '' }}
+          target_id: local-macos
+          runner_id: macos-26
+          cli_os: macOS
+          device_address: 127.0.0.1:50051
+          agent_os: macOS
+          transport: local
+          setup: true
+          managed_agent: true
+
+  swift-e2e-local-macos-hosted-rollback:
+    name: 'Local: macOS 26 (GitHub-hosted rollback)'
+    if: >-
+      ${{ (inputs.target_group == '' || inputs.target_group == 'all' || inputs.target_group == 'local') &&
+          inputs.macos_runner == 'github-hosted' }}
+    permissions:
+      contents: read
     runs-on: macos-26
     concurrency:
       group: device-local-macos-hosted
@@ -71,7 +113,7 @@ jobs:
       queue: max
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/swift-e2e-run
         with:
           tests: ${{ inputs.tests || '' }}
@@ -87,6 +129,8 @@ jobs:
   swift-e2e-local-ubuntu:
     name: 'Local: Ubuntu 24'
     if: ${{ inputs.target_group == '' || inputs.target_group == 'all' || inputs.target_group == 'local' }}
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     concurrency:
       group: device-local-ubuntu-hosted
@@ -426,7 +470,13 @@ jobs:
     if: ${{ always() && !cancelled() }}
     needs:
       - swift-e2e-local-macos
+      - swift-e2e-local-macos-hosted-rollback
       - swift-e2e-local-ubuntu
+    permissions:
+      contents: read
+      actions: read
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     env:


### PR DESCRIPTION
- **Advances:** [WDY-2575 — Run macOS E2E jobs in disposable Tart VMs](https://linear.app/wendylabsinc/issue/WDY-2575/run-macos-e2e-jobs-in-disposable-tart-vms)

> **In plain terms:** macOS E2E jobs can now target a fresh Tart VM instead of running directly on the persistent Mac. The existing bare-metal and GitHub-hosted routes remain available while the PoC is validated.

## Summary
- Route macOS E2E through a repository-scoped, one-job JIT runner selected by the existing `wendy-developer` group and unique `wendy-e2e-macos-tart` label.
- Clone and destroy one macOS 26/Xcode 26.5 guest per job, with host-owned timeout, cleanup, disk limits, image preparation, and temporary PAT storage.
- Use Tart standard NAT with no host mounts. This PoC does not claim host or private-LAN network isolation.
- Preserve an explicit GitHub-hosted rollback and add controlled lifecycle validation scenarios.

## Tests
- `bash -n .github/runners/macos-e2e-tart/*.sh`
- `shellcheck .github/runners/macos-e2e-tart/*.sh`
- `actionlint .github/workflows/swift-e2e-tests.yml .github/workflows/macos-e2e-tart-validation.yml`
- `plutil -lint .github/runners/macos-e2e-tart/org.wendy.macos-e2e-tart.plist`
- Golden image promotion completed on the M4 and locally: macOS 26.4, Xcode 26.5, Actions runner 2.336.0.
- Local standard-NAT guest preparation completed without changing the host route or interrupting SSH.

## Remaining validation
- JIT registration and a real GitHub job require the temporary WendyOS runner-administration PAT on the test host.
- Then run normal completion, cancellation, persistence, disk-pressure, watchdog, no-mount, and GitHub-hosted rollback scenarios.
- The current Ubuntu E2E failure is an unrelated `wendy discover` help-text expectation.
