### PR TITLE
feat: build Wendy-native multi-service manifests with wendy build

### DIFF
--- a/Examples/IsolatedServices/README.md
+++ b/Examples/IsolatedServices/README.md
@@ -73,6 +73,16 @@ Expected output:
 [worker] ✓ service name resolution via /etc/hosts works
 ```
 
+## Build only
+
+```sh
+wendy build
+```
+
+Builds the two local images `sh.wendy.examples.isolatedservices-api:latest` and
+`sh.wendy.examples.isolatedservices-worker:latest` without needing a connected
+device.
+
 ## Dependency ordering (WDY-879)
 
 `dependsOn: ["api"]` tells Wendy to start `api` before `worker`.  On stop,

--- a/go/internal/cli/assets/docs/apps/wendy-services.md
+++ b/go/internal/cli/assets/docs/apps/wendy-services.md
@@ -1,6 +1,6 @@
 # Multi-Service Apps with `wendy.json`
 
-When your project needs more than one container managed through a `wendy.json` file (rather than a `docker-compose.yml`), declare a `services` map in `wendy.json`. `wendy run` detects the map and automatically orchestrates a parallel multi-service build and deployment.
+When your project needs more than one container managed through a `wendy.json` file (rather than a `docker-compose.yml`), declare a `services` map in `wendy.json`. `wendy run` detects the map and automatically orchestrates a parallel multi-service build and deployment. `wendy build` detects the same map and builds the images locally without deploying — see [Building without deploying](#building-without-deploying).
 
 ## `wendy.json` structure
 
@@ -137,6 +137,17 @@ eliminating any collision risk from the hyphen separator).
 
 > **Note:** Single-container apps (no `serviceName` in the top-level
 > `wendy.json`) are unaffected — their container ID remains the bare `appId`.
+
+## Building without deploying
+
+`wendy build` detects the same `services` map and builds every service (or a `--service` closure) into the local image store, tagged `<appid>-<service>:latest`, without deploying: nothing is pushed to a registry and nothing is created or started on a device. Useful for CI and pre-flight checks — confirm every service builds before running `wendy run`:
+
+```sh
+wendy build
+wendy build --service api
+```
+
+See [`wendy build`](../clients/wendy-cli/commands/build.md#multi-service-manifests) for the full flag reference (`--service`, `--max-concurrency`, `--builder`, `--gpu-arch`, `--debug`).
 
 ## Filtering with `--service`
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/build.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/build.md
@@ -30,7 +30,7 @@ The same flag on [`wendy run`](run.md) and `wendy fleet run` additionally enable
 
 `wendy build` scans the project directory for a build manifest in the following priority order:
 
-1. `wendy.json` with a non-empty `services` map — multi-service build. Takes precedence unconditionally, even over a root-level Compose file, Dockerfile, or other marker below; each service resolves its own build file independently inside its `context` directory, using the same per-directory Stagefile-before-Dockerfile rule as entry 2. See [Multi-service manifests](#multi-service-manifests).
+1. `wendy.json` with a non-empty `services` map — multi-service build. Takes precedence unconditionally, even over a root-level Compose file, Dockerfile, or other marker below; each service resolves its own build file independently inside its `context` directory, using the same per-directory Stagefile-before-Dockerfile rule as the Stagefile entry below. See [Multi-service manifests](#multi-service-manifests).
 2. `docker-compose.yml` / `compose.yml` — multi-service Compose project
 3. `build.stagefile.yaml` / `<name>.stagefile.yaml` — Stagefile, compiled to a digest-pinned Dockerfile at build time. Checked ahead of plain Dockerfiles: a Stagefile is the more explicit build signal, and a project that has one usually keeps a generated Dockerfile beside it.
 4. `Dockerfile` / `Containerfile` (or dot/hyphen variants) — container image build

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/build.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/build.md
@@ -11,6 +11,8 @@ The build command is mainly used to verify your app can build/compile.
 | `--builder` | auto | Image builder to force for Dockerfile/Containerfile builds: `docker`, `apple-container`, or `buildkit`. |
 | `--gpu-arch` | from the device | GPU architecture a Stagefile `cuda:` stage targets; taken from the device when one is selected. |
 | `--debug` | `false` | Build compiled languages unoptimized instead of the release default — see below. |
+| `--service <name>` | all services | Build only the named service and its dependencies (multi-service projects) — see [Multi-service manifests](#multi-service-manifests). |
+| `--max-concurrency <n>` | `0` | Multi-service: max service images to build at once (0 = default limit of 4). |
 
 ### `--debug`
 
@@ -28,16 +30,46 @@ The same flag on [`wendy run`](run.md) and `wendy fleet run` additionally enable
 
 `wendy build` scans the project directory for a build manifest in the following priority order:
 
-1. `docker-compose.yml` / `compose.yml` — multi-service Compose project
-2. `build.stagefile.yaml` / `<name>.stagefile.yaml` — Stagefile, compiled to a digest-pinned Dockerfile at build time. Checked ahead of plain Dockerfiles: a Stagefile is the more explicit build signal, and a project that has one usually keeps a generated Dockerfile beside it.
-3. `Dockerfile` / `Containerfile` (or dot/hyphen variants) — container image build
-4. `Package.swift` — Swift Package Manager project
-5. `*.xcodeproj` — Xcode project (macOS targets only)
-6. `requirements.txt` / `setup.py` / `pyproject.toml` — Python project (Dockerfile auto-generated)
+1. `wendy.json` with a non-empty `services` map — multi-service build. Takes precedence unconditionally, even over a root-level Compose file, Dockerfile, or other marker below; each service resolves its own build file independently inside its `context` directory, using the same per-directory Stagefile-before-Dockerfile rule as entry 2. See [Multi-service manifests](#multi-service-manifests).
+2. `docker-compose.yml` / `compose.yml` — multi-service Compose project
+3. `build.stagefile.yaml` / `<name>.stagefile.yaml` — Stagefile, compiled to a digest-pinned Dockerfile at build time. Checked ahead of plain Dockerfiles: a Stagefile is the more explicit build signal, and a project that has one usually keeps a generated Dockerfile beside it.
+4. `Dockerfile` / `Containerfile` (or dot/hyphen variants) — container image build
+5. `Package.swift` — Swift Package Manager project
+6. `*.xcodeproj` — Xcode project (macOS targets only)
+7. `requirements.txt` / `setup.py` / `pyproject.toml` — Python project (Dockerfile auto-generated)
 
-If multiple manifests are present you can override detection with `--build-type`.
+If multiple manifests are present you can override detection with `--build-type`; a `services` map is the exception — it always wins, and `--build-type`/`--dockerfile` are rejected outright rather than used to pick something else (see [Multi-service manifests](#multi-service-manifests)).
 
 A Stagefile is a YAML build descriptor that compiles to a real Dockerfile with guarantees a hand-written one does not get by default: base images are digest-pinned through a committed lockfile, each install step is emitted with the correct flags and a scoped cache mount, the `.dockerignore` is derived from the declared copy paths, and there is no raw-shell escape hatch. The compiled Dockerfile and its paired `.dockerignore` are written next to the source as build output — see [Stagefile naming](#stagefile-naming) for the artifact names. Most projects under [`Examples/`](https://github.com/wendylabsinc/wendyos/tree/main/Examples) use this format and are worth reading as reference.
+
+## Multi-service manifests
+
+A `wendy.json` with a non-empty `services` map builds one **local** image per service instead of a single image — the same manifest [`wendy run`](run.md) detects and orchestrates, but building only. Nothing is pushed to a registry and nothing is created or started; no device is required.
+
+Each image is tagged `<lowercase-appId>-<lowercase-service>:latest`. For example, an app with `appId: "sh.wendy.examples.isolatedservices"` and services `api` and `worker` produces:
+
+```
+sh.wendy.examples.isolatedservices-api:latest
+sh.wendy.examples.isolatedservices-worker:latest
+```
+
+Each service resolves its own build file independently inside its own `context` directory — Stagefile preferred over Dockerfile/Containerfile, the same rule [Manifest detection](#manifest-detection) uses per directory. Because there is no single build file or type to pick across services, `--dockerfile` and `--build-type` are not supported here and return an error.
+
+Build only one service and its dependencies with `--service`:
+
+```sh
+wendy build --service api
+```
+
+`--service <name>` resolves `<name>` plus every service reachable through its `dependsOn` graph; services outside that subset are not built. An unknown service name returns an error immediately.
+
+Up to 4 service images build in parallel by default. Override with `--max-concurrency <n>`; `0` restores the default limit of 4.
+
+`--builder`, `--gpu-arch`, and `--debug` behave exactly as in a single-image build, applied per service — with one exception: `--builder buildkit` is not supported for multi-service builds, only `docker` and `apple-container`. As with single-image builds, `wendy build` passes no build-args, so a hand-written Dockerfile's `ARG WENDY_PLATFORM` / `ARG WENDY_DEBUG` take their declared defaults here.
+
+With no device selected, the target platform defaults to `linux/arm64`; selecting a device uses that device's own platform instead, same as single-image builds.
+
+A `services` map takes precedence over any root-level build marker present in the same project — see [Manifest detection](#manifest-detection).
 
 ## Selecting a build file
 
@@ -70,6 +102,7 @@ Everything in the `Dockerfile.generated*` namespace is a build artifact: it is e
 
 | Manifest | Required host | Notes |
 |---|---|---|
+| `wendy.json` `services` map | Docker Desktop or Apple `container` on Apple silicon macOS | Local build only — no push, no device required; each service resolves and builds independently with `--builder docker` or `--builder apple-container` (`buildkit` is not supported here). See [Multi-service manifests](#multi-service-manifests) |
 | `<name>.stagefile.yaml` | Same as `Dockerfile` | Compiled to `Dockerfile.generated[.<variant>]` and then built through the Dockerfile path, so every builder below applies unchanged |
 | `Dockerfile` / `Containerfile` | Docker Desktop, Apple `container` on Apple silicon macOS, or WendyOS | Local Docker builds use `docker buildx`; `--device apple-container` uses `container build`; WendyOS device builds can select `--builder docker` or `--builder apple-container` |
 | `Package.swift` | macOS or Linux | Requires a host Swift toolchain |

--- a/go/internal/cli/commands/build.go
+++ b/go/internal/cli/commands/build.go
@@ -3,10 +3,12 @@ package commands
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -41,6 +43,13 @@ type buildOptions struct {
 	// buildHost names a WendyOS device that builds the image instead of this
 	// machine. Empty means build locally.
 	buildHost string
+	// service selects one service (and its dependencies) to build, for a
+	// multi-service (wendy.json services map) project. Empty builds every
+	// service.
+	service string
+	// maxConcurrency caps how many service images build at once in a
+	// multi-service project (0 = default limit of 4).
+	maxConcurrency int
 }
 
 var appleContainerLocalProviderHintSupported = func() bool {
@@ -60,6 +69,9 @@ func newBuildCmd() *cobra.Command {
 			}
 			if _, err := normalizeImageBuilder(opts.builder); err != nil {
 				return err
+			}
+			if opts.maxConcurrency < 0 {
+				return fmt.Errorf("--max-concurrency must be >= 0 (0 = default limit of 4)")
 			}
 			if err := validateBuildHostFlags(opts.buildHost, opts.builder); err != nil {
 				return err
@@ -189,6 +201,26 @@ func newBuildCmd() *cobra.Command {
 				defer target.Agent.Close()
 			}
 
+			// A validated wendy.json with a non-empty services map routes to the
+			// multi-service build: one LOCAL image per selected service, never
+			// pushing to a registry or touching create/start container RPCs.
+			if cfgErr == nil && len(appCfg.Services) > 0 {
+				// cmd.Flags().Changed, not opts.buildType/opts.dockerfile: the
+				// --dockerfile defaulting above (opts.buildType = "docker") mutates
+				// the struct, not the flag-set state, so Changed still reflects what
+				// the user actually typed.
+				if cmd.Flags().Changed("dockerfile") || cmd.Flags().Changed("build-type") {
+					return fmt.Errorf("--dockerfile and --build-type are not supported for multi-service projects; each service resolves its own build file from its context")
+				}
+				if normalized, _ := normalizeImageBuilder(opts.builder); normalized == imageBuilderBuildkit {
+					return fmt.Errorf("--builder buildkit is not supported for multi-service builds; use docker or apple-container")
+				}
+				return runMultiServiceBuild(cmd.Context(), cwd, appCfg, target, opts)
+			}
+			if opts.service != "" {
+				return fmt.Errorf("--service requires a wendy.json services map")
+			}
+
 			// Detect all build options and filter by target capabilities.
 			options := detectBuildOptions(cwd)
 			if target != nil && target.Provider != nil {
@@ -209,21 +241,7 @@ func newBuildCmd() *cobra.Command {
 			if cfgErr == nil {
 				cfgPlatform = appCfg.Platform
 			}
-			platform := "linux/arm64"
-			if target != nil && target.Agent != nil {
-				versionResp, err := target.Agent.AgentService.GetAgentVersion(cmd.Context(), &agentpb.GetAgentVersionRequest{})
-				if err == nil {
-					agentOS := versionResp.GetOs()
-					if agentOS == "" {
-						agentOS = "linux"
-					}
-					arch := versionResp.GetCpuArchitecture()
-					if arch == "" {
-						arch = "arm64"
-					}
-					platform = resolveAgentPlatform(cfgPlatform, agentOS, arch)
-				}
-			}
+			platform := resolveBuildPlatform(cmd.Context(), target, cfgPlatform)
 
 			appID := filepath.Base(cwd)
 			if cfgErr == nil {
@@ -247,11 +265,86 @@ func newBuildCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.gpuArch, "gpu-arch", "", fmt.Sprintf("GPU architecture a Stagefile cuda: stage targets (%s); taken from the device when one is selected", strings.Join(gpu.KnownArches(), ", ")))
 	cmd.Flags().BoolVar(&opts.debug, "debug", false, "Build compiled languages unoptimized (swift build -c debug, cargo without --release) instead of the release default")
 	cmd.Flags().StringVar(&opts.buildHost, "build-host", "", "WendyOS device to build the image on instead of this machine (e.g. a DGX Spark)")
+	cmd.Flags().StringVar(&opts.service, "service", "", "Build only the named service and its dependencies (multi-service projects)")
+	cmd.Flags().IntVar(&opts.maxConcurrency, "max-concurrency", 0, "Multi-service: max service images to build at once (0 = default limit of 4)")
 	if err := cmd.Flags().MarkHidden("build-host"); err != nil {
 		panic(err)
 	}
 
 	return cmd
+}
+
+// resolveBuildPlatform is the target platform for a `wendy build`: the
+// selected device's own OS/arch when an agent is connected (cfgPlatform
+// overrides its GPU-arch guess the same way `wendy run` honors it), or
+// linux/arm64 with no device to ask.
+func resolveBuildPlatform(ctx context.Context, target *SelectedDevice, cfgPlatform string) string {
+	platform := "linux/arm64"
+	if target != nil && target.Agent != nil {
+		versionResp, err := target.Agent.AgentService.GetAgentVersion(ctx, &agentpb.GetAgentVersionRequest{})
+		if err == nil {
+			agentOS := versionResp.GetOs()
+			if agentOS == "" {
+				agentOS = "linux"
+			}
+			arch := versionResp.GetCpuArchitecture()
+			if arch == "" {
+				arch = "arm64"
+			}
+			platform = resolveAgentPlatform(cfgPlatform, agentOS, arch)
+		}
+	}
+	return platform
+}
+
+// runMultiServiceBuild is the `wendy build` flavor of a services-map project:
+// one LOCAL image per selected service, built in parallel. It never pushes to
+// a registry and never calls create/start container RPCs — those belong to
+// `wendy run`'s multi-service path (runMultiServiceWithAgent).
+func runMultiServiceBuild(ctx context.Context, cwd string, appCfg *appconfig.AppConfig, target *SelectedDevice, opts buildOptions) error {
+	services, err := resolveServiceSubset(appCfg.Services, opts.service)
+	if err != nil {
+		return err
+	}
+
+	platform := resolveBuildPlatform(ctx, target, appCfg.Platform)
+
+	// Ensure the Apple Container system is up once, before the parallel
+	// builds, so an explicit --builder apple-container prompts/starts a single
+	// time rather than racing across service goroutines.
+	if err := ensureAppleContainerSystemForBuilder(ctx, opts.builder, false); err != nil {
+		return err
+	}
+
+	dirs := make([]string, 0, len(services))
+	for _, svc := range services {
+		dirs = append(dirs, filepath.Join(cwd, svc.Context))
+	}
+	gpuArch := resolveGPUArchForDirs(ctx, dirs, opts.gpuArch, agentConn(target))
+
+	// Debug only: this deliberately matches `wendy run`'s multi-service path
+	// (no frameworkStagefileOptions) so both commands build identical images.
+	sfOpts := debugStagefileOptions(opts.debug)
+
+	failed, err := buildServicesLocal(ctx, cwd, appCfg.AppID, services, platform, opts.builder, gpuArch, opts.maxConcurrency, false, sfOpts...)
+	if err != nil {
+		return err
+	}
+	if len(failed) > 0 {
+		return joinServiceErrors(failed)
+	}
+
+	names := make([]string, 0, len(services))
+	for name := range services {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	tags := make([]string, 0, len(names))
+	for _, name := range names {
+		tags = append(tags, strings.ToLower(appCfg.AppID)+"-"+strings.ToLower(name)+":latest")
+	}
+	cliSuccess("Built %d service image(s): %s", len(tags), strings.Join(tags, ", "))
+	return nil
 }
 
 func resolveDetectedBuildOption(options []BuildOption, requestedType, requestedDockerfile string) (*BuildOption, error) {
@@ -640,6 +733,63 @@ func buildDockerProjectWithBuilder(ctx context.Context, builder, dir, imageName,
 		return err
 	}
 	return runAppleContainerBuildWithProgress(ctx, dir, imageName, platform, dockerfile)
+}
+
+// buildLocalServiceImage is the per-service local build step for multi-service
+// `wendy build`. Package var so tests can substitute a fake builder.
+var buildLocalServiceImage = buildServiceImageLocally
+
+// buildServiceImageLocally builds one service's image into the local image
+// store (docker --load, or the Apple Container CLI's implicit local store) —
+// never a registry. It mirrors buildDockerProjectWithBuilder's builder
+// selection but is writer-driven and context-aware, as buildServicesParallelCore
+// requires: no os.Stdout, no owned spinner, no --builder buildkit (rejected at
+// the command level before this is ever called).
+func buildServiceImageLocally(ctx context.Context, builder, contextDir, imageName, platform, dockerfile string, buildOut, logOut io.Writer) error {
+	if dockerfile == "" {
+		return fmt.Errorf("no container build file found in %s; add a Dockerfile, Containerfile, or Stagefile (e.g. build.stagefile.yaml)", contextDir)
+	}
+	normalized, err := normalizeImageBuilder(builder)
+	if err != nil {
+		return err
+	}
+
+	if !imageBuilderWasExplicit(builder) && shouldAutoAttemptAppleContainerBuilder() {
+		// Same auto-attempt semantics as the single-image path: never prompt or
+		// start services as a side effect, just try and fall back to Docker.
+		if err := checkAppleContainerBuilder(ctx); err == nil {
+			if err := buildImageWithAppleContainer(ctx, contextDir, imageName, platform, dockerfile, nil, buildOut, logOut); err == nil {
+				return nil
+			} else {
+				logAppleContainerFallback(logOut, err)
+			}
+		} else {
+			logAppleContainerFallback(logOut, err)
+		}
+	}
+
+	if normalized == imageBuilderAppleContainer {
+		// The Apple Container system itself is ensured once by the caller before
+		// the parallel builds start, not per service.
+		return buildImageWithAppleContainer(ctx, contextDir, imageName, platform, dockerfile, nil, buildOut, logOut)
+	}
+
+	// No OCI-layout export and no per-service cache-dir isolation: a plain
+	// --load build uses the daemon-side BuildKit cache, which is
+	// concurrency-safe on its own.
+	args := []string{"buildx", "build", "--platform", platform, "--progress", "plain", "-f", dockerfile, "-t", imageName, "--load", "."}
+	fmt.Fprintf(logOut, "[buildx] starting build: docker %s\n", strings.Join(args, " "))
+	cmd := imageBuilderCommandContext(ctx, "docker", args...)
+	cmd.Dir = contextDir
+	// --progress plain emits BuildKit's step output on stderr; both streams go
+	// to buildOut so tui.BuildParser (wired in by the core's per-service
+	// writers) sees it.
+	cmd.Stdout = buildOut
+	cmd.Stderr = buildOut
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("building image %s: %w", imageName, err)
+	}
+	return nil
 }
 
 func buildPythonProject(ctx context.Context, builder, dir, imageName, platform string) error {

--- a/go/internal/cli/commands/build.go
+++ b/go/internal/cli/commands/build.go
@@ -276,7 +276,7 @@ func newBuildCmd() *cobra.Command {
 
 // resolveBuildPlatform is the target platform for a `wendy build`: the
 // selected device's own OS/arch when an agent is connected (cfgPlatform
-// overrides its GPU-arch guess the same way `wendy run` honors it), or
+// overrides the device-reported OS (and arch, when it names one)), or
 // linux/arm64 with no device to ask.
 func resolveBuildPlatform(ctx context.Context, target *SelectedDevice, cfgPlatform string) string {
 	platform := "linux/arm64"

--- a/go/internal/cli/commands/build.go
+++ b/go/internal/cli/commands/build.go
@@ -62,7 +62,7 @@ func newBuildCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "build",
 		Short: "Build the application in the current directory",
-		Long:  "Detects the project type and builds a Docker image for the target device architecture.",
+		Long:  "Detects the project type and builds a Docker image for the target device architecture. For a wendy.json with a services map, builds one local image per service tagged <appid>-<service>:latest; nothing is pushed or deployed.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.dockerfile != "" && opts.buildType != "" && normalizeBuildType(opts.buildType) != "docker" {
 				return fmt.Errorf("--dockerfile cannot be used with --build-type=%s", opts.buildType)

--- a/go/internal/cli/commands/build_multiservice_test.go
+++ b/go/internal/cli/commands/build_multiservice_test.go
@@ -1,0 +1,575 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	"github.com/wendylabsinc/wendy/go/internal/stagefile"
+)
+
+// Coverage for WDY-2563: multi-service `wendy build` detection (a validated
+// wendy.json services map routes to runMultiServiceBuild instead of the
+// single-image detectBuildOptions path), --service/--max-concurrency
+// selection, the --dockerfile/--build-type/--builder buildkit refusals, and
+// the no-push/no-deploy guarantee (buildServiceImage, the device-registry
+// seam, must never be invoked from this path).
+
+// writeMultiServiceBuildProject writes a temp project with a validated
+// wendy.json services map — appID, one entry per services key with the given
+// dependsOn list and context "./<name>" — and one subdirectory per service
+// holding a minimal Dockerfile. Modeled on newServiceTree (multibuild_test.go)
+// but with a real manifest, mirroring Examples/IsolatedServices/wendy.json's
+// shape (appId/platform/version/services) so appconfig.Validate accepts it.
+// Returns the project root.
+func writeMultiServiceBuildProject(t *testing.T, appID string, services map[string][]string) string {
+	t.Helper()
+	root := t.TempDir()
+
+	svcCfg := make(map[string]*appconfig.ServiceConfig, len(services))
+	for name, deps := range services {
+		dir := filepath.Join(root, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		svcCfg[name] = &appconfig.ServiceConfig{Context: "./" + name, DependsOn: deps}
+	}
+
+	cfg := &appconfig.AppConfig{
+		AppID:    appID,
+		Platform: "linux/arm64",
+		Version:  "1.0.0",
+		Services: svcCfg,
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "wendy.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// setupMultiServiceBuildCmdTest arranges the seams every command-level
+// `wendy build` multi-service test needs:
+//
+//   - WENDY_AGENT_SOCKET points at a socket that does not exist, so
+//     resolveTarget's dialAgentSocketIfSet short-circuits immediately instead
+//     of falling through to config load / mDNS discovery / an interactive
+//     picker (see helpers_socket_test.go, buildkit_test.go:69's
+//     TestShouldUseBuildkitOnDevice). The lazy gRPC client this produces makes
+//     any subsequent RPC (e.g. resolveBuildPlatform's GetAgentVersion) fail
+//     fast with Unavailable, which the production code already tolerates by
+//     falling back to its linux/arm64 default — RPC failures are tolerated by
+//     design here.
+//   - isInteractiveTerminalFn is forced non-interactive so no TUI spinner
+//     opens.
+//   - buildServiceImage (the push-to-device-registry seam) fails the test if
+//     it is ever invoked — the no-push/no-deploy guarantee for `wendy build`
+//     against a services-map project.
+//
+// All three are restored via t.Cleanup.
+func setupMultiServiceBuildCmdTest(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("WENDY_AGENT_SOCKET", filepath.Join(t.TempDir(), "agent.sock"))
+
+	origInteractive := isInteractiveTerminalFn
+	t.Cleanup(func() { isInteractiveTerminalFn = origInteractive })
+	isInteractiveTerminalFn = func() bool { return false }
+
+	origPush := buildServiceImage
+	t.Cleanup(func() { buildServiceImage = origPush })
+	buildServiceImage = func(context.Context, *grpcclient.AgentConnection, int, string, string, string, string, string, string, map[string]string, string, io.Writer, io.Writer) error {
+		t.Errorf("push path invoked")
+		return nil
+	}
+}
+
+// localBuildCall is one recorded invocation of the buildLocalServiceImage seam.
+type localBuildCall struct {
+	contextDir string
+	imageName  string
+	dockerfile string
+}
+
+// localBuildRecorder collects buildLocalServiceImage calls behind a mutex, for
+// command-level `wendy build` tests that assert on which services were built
+// and with what arguments, without touching Docker.
+type localBuildRecorder struct {
+	mu    sync.Mutex
+	calls []localBuildCall
+}
+
+func (r *localBuildRecorder) record(contextDir, imageName, dockerfile string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, localBuildCall{contextDir: contextDir, imageName: imageName, dockerfile: dockerfile})
+}
+
+func (r *localBuildRecorder) snapshot() []localBuildCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]localBuildCall, len(r.calls))
+	copy(out, r.calls)
+	return out
+}
+
+// stubLocalBuild installs a buildLocalServiceImage stub backed by fn,
+// restoring the original via t.Cleanup.
+func stubLocalBuild(t *testing.T, fn func(ctx context.Context, builder, contextDir, imageName, platform, dockerfile string, buildOut, logOut io.Writer) error) {
+	t.Helper()
+	orig := buildLocalServiceImage
+	t.Cleanup(func() { buildLocalServiceImage = orig })
+	buildLocalServiceImage = fn
+}
+
+func TestBuildCmd_MultiService_BuildsFromManifestOnly(t *testing.T) {
+	root := writeMultiServiceBuildProject(t, "myapp", map[string][]string{
+		"api":    nil,
+		"worker": nil,
+	})
+	chdirTo(t, root)
+	setupMultiServiceBuildCmdTest(t)
+
+	rec := &localBuildRecorder{}
+	stubLocalBuild(t, func(_ context.Context, _, contextDir, imageName, _, dockerfile string, _, _ io.Writer) error {
+		rec.record(contextDir, imageName, dockerfile)
+		return nil
+	})
+
+	cmd := newBuildCmd()
+	cmd.SetArgs([]string{})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() = %v, want nil", err)
+	}
+
+	calls := rec.snapshot()
+	if len(calls) != 2 {
+		t.Fatalf("recorded %d local build calls, want exactly 2 (one per service): %+v", len(calls), calls)
+	}
+	seen := map[string]bool{}
+	for _, c := range calls {
+		name := filepath.Base(c.contextDir)
+		if seen[name] {
+			t.Fatalf("service %q built more than once", name)
+		}
+		seen[name] = true
+
+		wantImage := strings.ToLower("myapp") + "-" + strings.ToLower(name) + ":latest"
+		if c.imageName != wantImage {
+			t.Errorf("service %s: imageName = %q, want %q", name, c.imageName, wantImage)
+		}
+		wantContext := filepath.Clean(filepath.Join(root, "./"+name))
+		if filepath.Clean(c.contextDir) != wantContext {
+			t.Errorf("service %s: contextDir = %q, want %q", name, c.contextDir, wantContext)
+		}
+	}
+	if !seen["api"] || !seen["worker"] {
+		t.Fatalf("expected both api and worker built, got %+v", seen)
+	}
+}
+
+func TestBuildCmd_MultiService_ServiceFlagSelectsDependencyClosure(t *testing.T) {
+	root := writeMultiServiceBuildProject(t, "myapp", map[string][]string{
+		"api":    nil,
+		"worker": {"api"},
+		"extra":  nil,
+	})
+	chdirTo(t, root)
+	setupMultiServiceBuildCmdTest(t)
+
+	rec := &localBuildRecorder{}
+	stubLocalBuild(t, func(_ context.Context, _, contextDir, imageName, _, dockerfile string, _, _ io.Writer) error {
+		rec.record(contextDir, imageName, dockerfile)
+		return nil
+	})
+
+	cmd := newBuildCmd()
+	cmd.SetArgs([]string{"--service", "worker"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() = %v, want nil", err)
+	}
+
+	var got []string
+	for _, c := range rec.snapshot() {
+		got = append(got, filepath.Base(c.contextDir))
+	}
+	slices.Sort(got)
+	want := []string{"api", "worker"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("built services = %v, want %v (worker's dependency closure, not extra)", got, want)
+	}
+
+	// Separately: an unknown --service value is refused, naming the bad value.
+	cmd2 := newBuildCmd()
+	cmd2.SetArgs([]string{"--service", "nope"})
+	cmd2.SetOut(io.Discard)
+	cmd2.SetErr(io.Discard)
+	err := cmd2.Execute()
+	if err == nil {
+		t.Fatal("Execute() with --service nope = nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "nope") {
+		t.Fatalf("error = %q, want it to name the unknown service %q", err.Error(), "nope")
+	}
+}
+
+func TestBuildCmd_MultiService_ReportsEveryFailedService(t *testing.T) {
+	root := writeMultiServiceBuildProject(t, "myapp", map[string][]string{
+		"a": nil,
+		"b": nil,
+		"c": nil,
+	})
+	chdirTo(t, root)
+	setupMultiServiceBuildCmdTest(t)
+
+	stubLocalBuild(t, func(_ context.Context, _, contextDir, _, _, _ string, _, _ io.Writer) error {
+		switch filepath.Base(contextDir) {
+		case "a":
+			return errors.New("boom in a")
+		case "c":
+			return errors.New("boom in c")
+		default:
+			return nil
+		}
+	})
+
+	cmd := newBuildCmd()
+	cmd.SetArgs([]string{})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() = nil, want an error reporting the failed services")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "service a:") {
+		t.Errorf("error %q missing \"service a:\"", msg)
+	}
+	if !strings.Contains(msg, "service c:") {
+		t.Errorf("error %q missing \"service c:\"", msg)
+	}
+	if strings.Contains(msg, "service b:") {
+		t.Errorf("error %q must not report service b (it did not fail)", msg)
+	}
+}
+
+func TestBuildCmd_MultiService_RejectsSingleImageFlags(t *testing.T) {
+	root := writeMultiServiceBuildProject(t, "myapp", map[string][]string{
+		"api":    nil,
+		"worker": nil,
+	})
+	// A root-level Dockerfile so --dockerfile's earlier confinedDockerfilePath
+	// existence check passes and the multi-service rejection (not "does not
+	// exist") is what's actually exercised.
+	if err := os.WriteFile(filepath.Join(root, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	chdirTo(t, root)
+	setupMultiServiceBuildCmdTest(t)
+
+	stubLocalBuild(t, func(context.Context, string, string, string, string, string, io.Writer, io.Writer) error {
+		t.Errorf("local build path invoked; every case in this table must be rejected before any build starts")
+		return nil
+	})
+
+	cases := []struct {
+		name       string
+		args       []string
+		wantSubstr string
+	}{
+		{
+			name:       "dockerfile",
+			args:       []string{"--dockerfile", "Dockerfile"},
+			wantSubstr: "not supported for multi-service projects",
+		},
+		{
+			name:       "build-type",
+			args:       []string{"--build-type", "docker"},
+			wantSubstr: "not supported for multi-service projects",
+		},
+		{
+			name:       "builder buildkit",
+			args:       []string{"--builder", "buildkit"},
+			wantSubstr: "--builder buildkit is not supported for multi-service builds",
+		},
+		{
+			name:       "max-concurrency negative",
+			args:       []string{"--max-concurrency", "-1"},
+			wantSubstr: "--max-concurrency must be >= 0",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newBuildCmd()
+			cmd.SetArgs(tc.args)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("Execute(%v) = nil, want an error containing %q", tc.args, tc.wantSubstr)
+			}
+			if !strings.Contains(err.Error(), tc.wantSubstr) {
+				t.Fatalf("Execute(%v) error = %q, want it to contain %q", tc.args, err.Error(), tc.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestBuildCmd_MultiService_StagefileContextsResolveThroughPlanner(t *testing.T) {
+	root := writeMultiServiceBuildProject(t, "myapp", map[string][]string{
+		"api": nil,
+	})
+	chdirTo(t, root)
+	setupMultiServiceBuildCmdTest(t)
+
+	origPlan := planResolveDockerfile
+	t.Cleanup(func() { planResolveDockerfile = origPlan })
+	planResolveDockerfile = func(string, string, bool, string, ...stagefile.Option) (string, error) {
+		return "Dockerfile.generated", nil
+	}
+
+	rec := &localBuildRecorder{}
+	stubLocalBuild(t, func(_ context.Context, _, contextDir, imageName, _, dockerfile string, _, _ io.Writer) error {
+		rec.record(contextDir, imageName, dockerfile)
+		return nil
+	})
+
+	cmd := newBuildCmd()
+	cmd.SetArgs([]string{})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() = %v, want nil", err)
+	}
+
+	calls := rec.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("recorded %d local build calls, want 1: %+v", len(calls), calls)
+	}
+	if calls[0].dockerfile != "Dockerfile.generated" {
+		t.Fatalf("dockerfile = %q, want the planner-resolved %q (service contexts must flow through the same seam as `wendy run`)", calls[0].dockerfile, "Dockerfile.generated")
+	}
+}
+
+func TestBuildCmd_ServiceFlagWithoutServicesMapErrors(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A wendy.json with no services map: single-app config, not multi-service.
+	const wendyJSON = `{"appId":"myapp","platform":"linux/arm64","version":"1.0.0"}`
+	if err := os.WriteFile(filepath.Join(root, "wendy.json"), []byte(wendyJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	chdirTo(t, root)
+	setupMultiServiceBuildCmdTest(t)
+
+	stubLocalBuild(t, func(context.Context, string, string, string, string, string, io.Writer, io.Writer) error {
+		t.Errorf("local build path invoked; --service without a services map must be refused first")
+		return nil
+	})
+
+	cmd := newBuildCmd()
+	cmd.SetArgs([]string{"--service", "api"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() = nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "--service requires a wendy.json services map") {
+		t.Fatalf("error = %q, want it to contain %q", err.Error(), "--service requires a wendy.json services map")
+	}
+}
+
+// TestBuildServicesLocal_BoundedConcurrencyAndSingleBuildPerService covers
+// WDY-2563's --max-concurrency for the local (no-push) build flavor: with 6
+// services and maxConcurrency=2, buildServicesLocal must never run more than 2
+// builds at once, and each service must be built exactly once.
+func TestBuildServicesLocal_BoundedConcurrencyAndSingleBuildPerService(t *testing.T) {
+	root, services := newServiceTree(t, 6)
+
+	var mu sync.Mutex
+	current, peak := 0, 0
+	built := map[string]int{}
+	stubLocalBuild(t, func(_ context.Context, _, _, imageName, _, _ string, _, _ io.Writer) error {
+		mu.Lock()
+		current++
+		if current > peak {
+			peak = current
+		}
+		built[imageName]++
+		mu.Unlock()
+
+		// Hold the slot briefly so overlapping calls are actually observable;
+		// the semaphore in buildServicesParallelCore is what bounds peak, not
+		// this sleep.
+		time.Sleep(20 * time.Millisecond)
+
+		mu.Lock()
+		current--
+		mu.Unlock()
+		return nil
+	})
+
+	failed, err := buildServicesLocal(context.Background(), root, "app", services, "linux/arm64", "docker", "", 2, true)
+	if err != nil {
+		t.Fatalf("buildServicesLocal: %v", err)
+	}
+	if len(failed) != 0 {
+		t.Fatalf("unexpected build failures: %v", sortedServiceErrorKeys(failed))
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if peak > 2 {
+		t.Fatalf("peak concurrent builds = %d, want <= 2 (maxConcurrency)", peak)
+	}
+	if len(built) != len(services) {
+		t.Fatalf("built %d distinct images, want %d: %v", len(built), len(services), built)
+	}
+	for name, count := range built {
+		if count != 1 {
+			t.Errorf("image %s built %d times, want exactly 1", name, count)
+		}
+	}
+}
+
+// TestBuildServicesLocal_CancellationReturnsNilMapAndStopsQueued mirrors
+// TestBuildServicesParallelCancellationStopsActiveAndQueuedBuilds
+// (multibuild_test.go) through buildServicesLocal: one Ctrl-C must stop the
+// active build and never start any queued one.
+func TestBuildServicesLocal_CancellationReturnsNilMapAndStopsQueued(t *testing.T) {
+	root, services := newServiceTree(t, 4)
+
+	started := make(chan struct{}, len(services))
+	var mu sync.Mutex
+	startCount := 0
+	stubLocalBuild(t, func(ctx context.Context, _, _, _, _, _ string, _, _ io.Writer) error {
+		mu.Lock()
+		startCount++
+		mu.Unlock()
+		started <- struct{}{}
+		<-ctx.Done()
+		return ctx.Err()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	type outcome struct {
+		failed map[string]error
+		err    error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		failed, err := buildServicesLocal(ctx, root, "app", services, "linux/arm64", "docker", "", 1, true)
+		done <- outcome{failed: failed, err: err}
+	}()
+
+	select {
+	case <-started:
+		cancel()
+	case <-time.After(5 * time.Second):
+		t.Fatal("first service build did not start")
+	}
+
+	select {
+	case got := <-done:
+		if !errors.Is(got.err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled", got.err)
+		}
+		if got.failed != nil {
+			t.Fatalf("failed = %v, want nil for operation cancellation", got.failed)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("buildServicesLocal did not return after cancellation")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if startCount != 1 {
+		t.Fatalf("started %d service builders after cancellation, want exactly the active one", startCount)
+	}
+}
+
+func TestBuildServiceImageLocally_MissingBuildFileNamesContext(t *testing.T) {
+	contextDir := t.TempDir()
+	err := buildServiceImageLocally(context.Background(), "", contextDir, "app-api:latest", "linux/arm64", "", io.Discard, io.Discard)
+	if err == nil {
+		t.Fatal("buildServiceImageLocally with dockerfile=\"\" = nil, want an error")
+	}
+	if !strings.Contains(err.Error(), contextDir) {
+		t.Errorf("error %q does not name the context dir %q", err.Error(), contextDir)
+	}
+	if !strings.Contains(err.Error(), "no container build file found") {
+		t.Errorf("error %q missing \"no container build file found\"", err.Error())
+	}
+}
+
+func TestBuildServiceImageLocally_DockerBuildxLoadArgs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("stub builder uses the POSIX `true` command")
+	}
+
+	origCmd := imageBuilderCommandContext
+	origGOOS := imageBuilderHostGOOS
+	t.Cleanup(func() {
+		imageBuilderCommandContext = origCmd
+		imageBuilderHostGOOS = origGOOS
+	})
+	// linux (not darwin/arm64) disables the Apple Container auto-attempt so
+	// the plain docker buildx path below is what actually runs.
+	imageBuilderHostGOOS = func() string { return "linux" }
+
+	var gotProgram string
+	var gotArgs []string
+	var gotCmd *exec.Cmd
+	imageBuilderCommandContext = func(ctx context.Context, name string, arg ...string) *exec.Cmd {
+		gotProgram = name
+		gotArgs = append([]string(nil), arg...)
+		gotCmd = exec.Command("true")
+		return gotCmd
+	}
+
+	contextDir := t.TempDir()
+	err := buildServiceImageLocally(context.Background(), "", contextDir, "foo-api:latest", "linux/arm64", "Dockerfile", io.Discard, io.Discard)
+	if err != nil {
+		t.Fatalf("buildServiceImageLocally: %v", err)
+	}
+
+	if gotProgram != "docker" {
+		t.Fatalf("program = %q, want %q", gotProgram, "docker")
+	}
+	want := []string{"buildx", "build", "--platform", "linux/arm64", "--progress", "plain", "-f", "Dockerfile", "-t", "foo-api:latest", "--load", "."}
+	if !slices.Equal(gotArgs, want) {
+		t.Fatalf("args = %v, want %v", gotArgs, want)
+	}
+	if gotCmd == nil {
+		t.Fatal("imageBuilderCommandContext was never called")
+	}
+	if gotCmd.Dir != contextDir {
+		t.Fatalf("cmd.Dir = %q, want %q", gotCmd.Dir, contextDir)
+	}
+}

--- a/go/internal/cli/commands/commands_test.go
+++ b/go/internal/cli/commands/commands_test.go
@@ -288,6 +288,12 @@ func TestNewBuildCmd(t *testing.T) {
 	if cmd.Flags().Lookup("builder") == nil {
 		t.Error("missing flag \"builder\"")
 	}
+	if cmd.Flags().Lookup("service") == nil {
+		t.Error("missing flag \"service\"")
+	}
+	if cmd.Flags().Lookup("max-concurrency") == nil {
+		t.Error("missing flag \"max-concurrency\"")
+	}
 }
 
 func TestNewDeviceCmd(t *testing.T) {

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -26,6 +26,10 @@ import (
 
 const maxConcurrentBuilds = 4
 
+// serviceBuildFn builds the image for one service. repo is the lowercased
+// "<appID>-<service>" name that is both the image repo and the cache key.
+type serviceBuildFn func(ctx context.Context, contextDir, repo, dockerfile string, buildOut, logOut io.Writer) error
+
 // multiBuildConcurrency returns the default number of service images to
 // build+push at once for a group of numServices.
 func multiBuildConcurrency(numServices int) int {
@@ -591,11 +595,11 @@ func droppedSummary(dropped map[string]string) string {
 	return fmt.Sprintf(", %d skipped (failed dependency: %s)", len(names), strings.Join(names, ", "))
 }
 
-// buildServicesParallel builds all service images concurrently (up to
-// maxConcurrentBuilds at a time). Services in skip are already on the device with
-// unchanged inputs, so their build+push is skipped (WDY-1692). Progress is shown
-// via a Bubbletea multi-spinner in interactive terminals and via plain log lines
-// otherwise.
+// buildServicesParallelCore builds all service images concurrently (up to
+// maxConcurrentBuilds at a time), invoking build for each one. Services in skip
+// are already on the device with unchanged inputs, so their build+push is
+// skipped (WDY-1692). Progress is shown via a Bubbletea multi-spinner in
+// interactive terminals and via plain log lines otherwise.
 //
 // dockerfiles carries the build file planning already resolved per service, so a
 // Stagefile project is not compiled twice in the same run. It is best-effort:
@@ -603,16 +607,12 @@ func droppedSummary(dropped map[string]string) string {
 // could not plan, so a service missing from the map resolves its own build file
 // here — which is also where that resolution's error belongs, since this is the
 // path that reports per-service failures.
-func buildServicesParallel(
+func buildServicesParallelCore(
 	ctx context.Context,
-	conn *grpcclient.AgentConnection,
-	regPort int,
-	agentOS string,
+	build serviceBuildFn,
 	cwd, appID string,
 	services map[string]*appconfig.ServiceConfig,
-	platform string,
-	buildArgs map[string]string,
-	builder string,
+	gpuArch string,
 	skip map[string]bool,
 	dockerfiles map[string]string,
 	maxConcurrency int,
@@ -627,10 +627,6 @@ func buildServicesParallel(
 		names = append(names, n)
 	}
 	sort.Strings(names)
-
-	// Resolved once for the group: every service deploys to this one device,
-	// so they share its GPU architecture.
-	gpuArch := serviceGPUArch(buildCtx, cwd, services, conn)
 
 	type result struct {
 		name string
@@ -732,7 +728,7 @@ func buildServicesParallel(
 				// Pass the per-service repo as the build's cache key so each concurrent
 				// build gets its own isolated local buildx cache dir (WDY-1689); sharing
 				// one dir corrupts BuildKit's cache-export ingest store under concurrency.
-				err = buildServiceImage(buildCtx, conn, regPort, agentOS, builder, contextDir, repo, platform, dockerfile, buildArgs, repo, buildOut, logOutW)
+				err = build(buildCtx, contextDir, repo, dockerfile, buildOut, logOutW)
 			}
 			dur := time.Since(start)
 
@@ -804,6 +800,36 @@ func buildServicesParallel(
 		return nil, ctx.Err()
 	}
 	return failed, nil
+}
+
+// buildServicesParallel is the push-destination flavor of
+// buildServicesParallelCore: it builds and pushes each service's image to the
+// device registry, via the buildServiceImage seam.
+func buildServicesParallel(
+	ctx context.Context,
+	conn *grpcclient.AgentConnection,
+	regPort int,
+	agentOS string,
+	cwd, appID string,
+	services map[string]*appconfig.ServiceConfig,
+	platform string,
+	buildArgs map[string]string,
+	builder string,
+	skip map[string]bool,
+	dockerfiles map[string]string,
+	maxConcurrency int,
+	quietBuild bool,
+	sfOpts ...stagefile.Option,
+) (map[string]error, error) {
+	// Resolved once for the group: every service deploys to this one device,
+	// so they share its GPU architecture.
+	gpuArch := serviceGPUArch(ctx, cwd, services, conn)
+
+	build := func(ctx context.Context, contextDir, repo, dockerfile string, buildOut, logOut io.Writer) error {
+		return buildServiceImage(ctx, conn, regPort, agentOS, builder, contextDir, repo, platform, dockerfile, buildArgs, repo, buildOut, logOut)
+	}
+
+	return buildServicesParallelCore(ctx, build, cwd, appID, services, gpuArch, skip, dockerfiles, maxConcurrency, quietBuild, sfOpts...)
 }
 
 // sortedServiceErrorKeys returns the service names in failed, sorted, for stable

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -832,6 +832,23 @@ func buildServicesParallel(
 	return buildServicesParallelCore(ctx, build, cwd, appID, services, gpuArch, skip, dockerfiles, maxConcurrency, quietBuild, sfOpts...)
 }
 
+// buildServicesLocal builds every service image into the local image store
+// (no device, no registry push) — the `wendy build` flavor over
+// buildServicesParallelCore.
+func buildServicesLocal(ctx context.Context, cwd, appID string, services map[string]*appconfig.ServiceConfig,
+	platform, builder, gpuArch string, maxConcurrency int, quietBuild bool,
+	sfOpts ...stagefile.Option) (map[string]error, error) {
+	build := func(ctx context.Context, contextDir, repo, dockerfile string, buildOut, logOut io.Writer) error {
+		return buildLocalServiceImage(ctx, builder, contextDir, repo+":latest", platform, dockerfile, buildOut, logOut)
+	}
+	// skip=nil: `wendy build` builds every selected service every invocation —
+	// push-skip fingerprinting is a device-deploy optimization and does not
+	// apply here. dockerfiles=nil: the core's per-service planResolveDockerfile
+	// fallback resolves each context, the same non-interactive
+	// Stagefile>Dockerfile rules `wendy run` uses.
+	return buildServicesParallelCore(ctx, build, cwd, appID, services, gpuArch, nil, nil, maxConcurrency, quietBuild, sfOpts...)
+}
+
 // sortedServiceErrorKeys returns the service names in failed, sorted, for stable
 // error/report output.
 func sortedServiceErrorKeys(failed map[string]error) []string {


### PR DESCRIPTION
Fixes WDY-2563

## Summary

`wendy build` now recognizes Wendy-native multi-service manifests — a `wendy.json` with a non-empty `services` map — and builds one **local** image per selected service, tagged `<lowercase-appId>-<lowercase-service>:latest`. Previously the command only scanned the project root for build markers, so a valid multi-service project (e.g. `Examples/IsolatedServices`) failed with a misleading "no supported build type found" error even though `wendy run` handled it fine.

## How

- **Refactor (no behavior change):** `buildServicesParallel`'s orchestration (bounded concurrency, multi-spinner progress, cancellation, per-service cache isolation, aggregated errors) is extracted into a destination-agnostic `buildServicesParallelCore` that takes a per-service build callback. `wendy run` keeps its exact signature and behavior as a thin push wrapper; `wendy build` supplies a new local build-and-load callback.
- **Local primitive:** `buildServiceImageLocally` runs `docker buildx build --platform … --progress plain -f … -t … --load .` per service context (with the same Apple Container auto-attempt semantics as single-image builds), never touching a registry or any create/start container RPCs.
- **Command wiring:** the multi-service branch runs before root-marker detection; platform resolution is the extracted single-image rules (`resolveBuildPlatform`, default `linux/arm64`); `--gpu-arch` flows through the existing multi-directory resolver; new `--service` (dependency closure) and `--max-concurrency` flags mirror `wendy run`; `--dockerfile`/`--build-type`/`--builder buildkit` are rejected for multi-service projects with clear errors.
- **Docs:** `build.md` manifest detection + new multi-service section, `wendy-services.md`, `Examples/IsolatedServices/README.md`, and the command's long help.

## Tests

10 new tests in `build_multiservice_test.go` cover: detection with only `wendy.json` at the root, exact image tags and context dirs, `--service` closure selection and unknown-service errors (first coverage of `resolveServiceSubset`), multi-failure aggregation naming each failing service, flag rejections, Stagefile resolution through the shared planner seam, bounded concurrency, cancellation's nil-map contract, missing-build-file errors, and the exact buildx argv. Every command-level test also stubs the push seam to fail if it is ever invoked — the no-push guarantee is asserted, not assumed. `multibuild_test.go` and `stress_test.go` are deliberately untouched and pass unmodified as the refactor's regression gate.

`go build ./...`, `go vet`, and `go test ./go/internal/cli/commands/ -race` are green. The full-repo suite passes except `go/internal/agent/oci`'s host-hardware-dependent GPU tests, which fail identically on `main` on the same machine (pre-existing, unrelated).

## Notes

- Per-service `frameworks` Stagefile options are applied by **neither** command's multi-service path today; this PR deliberately keeps `wendy build` symmetric with `wendy run` (debug-only Stagefile options) so both build identical images. Closing that gap for both commands is a separate follow-up.
- The provider-device paths (`--device docker` / `--device apple-container`) keep their existing single-image behavior for multi-service projects, matching `wendy run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
