### PR TITLE
test: match the discover help text the CLI now prints

### DIFF
--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDiscoverTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDiscoverTests.swift
@@ -16,7 +16,7 @@ struct `'wendy discover'` {
             try await cli.sh("wendy discover --help") { result in
                 let stdout = result.stdout
                 #expect(result.status.isSuccess)
-                #expect(stdout.contains("Continuously scan for WendyOS devices"))
+                #expect(stdout.contains("Continuously discover WendyOS devices"))
                 #expect(stdout.contains("Usage:"))
                 #expect(stdout.contains("wendy discover [flags]"))
                 #expect(stdout.contains("--timeout"))


### PR DESCRIPTION
Unifying local and cloud discovery reworded the Long description; the E2E expectation kept the old wording and has failed on main since. (4109e8cc6 feat(cli): unify local and cloud device discovery)