### PR TITLE
wendy device update --pr N (OTA the OS to a wendyos-builder PR build)

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/update.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/update.md
@@ -2,7 +2,7 @@ Updates the wendy-agent installation on the remote device, then checks for a new
 
 If the device responds with "an update is already in progress" (a `FailedPrecondition` error), a previous upload likely committed without the agent restarting — a bug fixed in this release. Reboot the device to clear the stale lock, then retry.
 
-On the auto-download path, if the device already runs the resolved release version, the upload and agent restart are skipped and the command reports that it is already up to date. The OS update step below still runs afterward — except in `--json` mode, where the command returns immediately and the OS update step is not run.
+On the auto-download path, if the device already runs the resolved release version, the upload and agent restart are skipped and the command reports that it is already up to date. The OS update step below still runs afterward — except in `--json` mode, where the command returns immediately and the OS update step is not run. Because `--json` skips the OS step, combining it with `--pr` is refused outright rather than silently ignoring the requested PR image.
 
 GitHub release lookups use the `GITHUB_TOKEN` environment variable for authentication when it is present, and fall back to unauthenticated requests otherwise.
 
@@ -57,6 +57,38 @@ After the agent is updated, the command checks for an OS update on WendyOS devic
 If the available artifact uses the wendyos-update stack (`.wendy` format) but the device image predates that stack, the auto-detected OS update is not offered — the command prints an explanation instead of prompting, and the agent-only update still counts as a success. This check runs only when an update is actually available; an already-current device is not warned.
 
 An explicit `--artifact-url` pointing to a `.wendy` artifact on an incompatible device is **not** silently skipped: `device update` exits non-zero with the same reflash explanation.
+
+## Update the OS to a pull-request build
+
+```sh
+wendy device update --pr 123 --yes
+```
+
+`--pr N` makes the OS update step install the WendyOS image built by
+wendyos-builder PR #N instead of the manifest's latest. The agent-binary step is
+unaffected: `--nightly` still selects the agent channel, and `--binary` still
+uploads your build and re-applies it after the OS reboot.
+
+PR images are **debug builds**: SSH is enabled, root login is passwordless, and
+the serial console is active. They are for testing the PR on hardware — **never
+install a PR image on a production device.** Artifacts are deleted when the PR
+is closed.
+
+`--pr` is supported for Linux disk-image devices (Raspberry Pi, Jetson Orin
+Nano, Jetson AGX Orin) with OTA support; it is not supported for Jetson AGX
+Thor or ESP32 targets. It is mutually exclusive with `--artifact-url` and
+`--json`.
+
+A `--pr` run never skips as "already current": a PR's version tag (`pr-N`) is
+constant across rebuilds, so re-running after pushing a new commit to the same
+PR always re-flashes. And unlike the default OS step — which degrades to an
+agent-only success when the OS check fails — a `--pr` run must install that
+PR's build or exit non-zero.
+
+`--pr` works over the cloud tunnel (`wendy cloud device update --pr N`): the
+resolved artifact is a public URL the device downloads directly, with only the
+control stream tunneled. As with any cloud-tunneled OS update, the command does
+not wait for the reboot (see [Post-update outcome](#post-update-outcome)).
 
 ## Pre-0.17.0 devices require a reflash
 

--- a/go/internal/cli/commands/cloud_tunnel.go
+++ b/go/internal/cli/commands/cloud_tunnel.go
@@ -96,6 +96,29 @@ func connectToCloudAgent(ctx context.Context, cloudGRPC, deviceName, brokerURL s
 	return connectCloudAsset(ctx, auth, asset, brokerURL)
 }
 
+// detachedTunnelContext returns the context to open a connection-scoped broker
+// tunnel stream on, given the context that bounds only the dial.
+//
+// A dial context routinely outlives its usefulness the moment the connection is
+// handed to the caller: the reconnect helpers (waitForCloudAgentRestart,
+// waitForUpdatedAgentReady, runAgentConnectionSpinner) each wrap the dial in a
+// timeout they cancel as soon as the connection is returned. A tunnel stream
+// opened directly on the dial context dies with that cancel, so every
+// reconnected cloud connection arrived dead — its liveness probe passed only
+// because it ran before the cancel, and the next RPC failed with
+// "error reading from server: EOF".
+//
+// The returned context therefore does not inherit dialCtx's cancellation (its
+// values are kept). Until handoff is called, cancelling dialCtx still ends it,
+// so an abandoned dial attempt cannot leak a live stream; handoff severs that
+// link at the successful hand-over, after which only cancel — which the caller
+// must wire into the connection's Close path — ends the context.
+func detachedTunnelContext(dialCtx context.Context) (tunnelCtx context.Context, handoff func(), cancel context.CancelFunc) {
+	tunnelCtx, tunnelCancel := context.WithCancel(context.WithoutCancel(dialCtx))
+	stop := context.AfterFunc(dialCtx, tunnelCancel)
+	return tunnelCtx, func() { stop() }, tunnelCancel
+}
+
 func connectCloudAsset(ctx context.Context, auth *config.AuthConfig, asset *cloudpb.Asset, brokerURL string) (*grpcclient.AgentConnection, error) {
 	brokerConn, err := clouddefaults.DialBroker(auth, brokerURL)
 	if err != nil {
@@ -109,10 +132,23 @@ func connectCloudAsset(ctx context.Context, auth *config.AuthConfig, asset *clou
 		}
 	}()
 
+	// The tunnel stream lives exactly as long as the context it is opened on,
+	// and ctx here may be a short per-attempt dial timeout the caller cancels
+	// right after we return (see detachedTunnelContext). Open the stream on a
+	// context detached at handoff and ended by Close instead.
+	tunnelCtx, tunnelHandoff, tunnelCancel := detachedTunnelContext(ctx)
+	handedOff := false
+	defer func() {
+		if !handedOff {
+			tunnelHandoff()
+			tunnelCancel()
+		}
+	}()
+
 	// Provisioned agents serve mTLS on agentPort+1 (50052) for remote clients; the
 	// plaintext port (50051) is shut down after provisioning. (On-device containers
 	// with the admin entitlement can reach the agent via the local unix socket.)
-	tunnelConn, err := openBrokerTunnel(ctx, brokerConn, auth, asset.GetId(), defaultAgentPort+1)
+	tunnelConn, err := openBrokerTunnel(tunnelCtx, brokerConn, auth, asset.GetId(), defaultAgentPort+1)
 	if err != nil {
 		return nil, fmt.Errorf("opening cloud tunnel to %s: %w", asset.GetName(), err)
 	}
@@ -178,8 +214,10 @@ func connectCloudAsset(ctx context.Context, auth *config.AuthConfig, asset *clou
 	agentConn.Reconnect = func(rctx context.Context) (*grpcclient.AgentConnection, error) {
 		return waitForCloudAgentRestart(rctx, auth, asset, brokerURL)
 	}
-	agentConn.ExtraClosers = append(agentConn.ExtraClosers, closeFunc(closeTunnel), brokerConn)
+	agentConn.ExtraClosers = append(agentConn.ExtraClosers, closeFunc(closeTunnel), brokerConn, closeFunc(tunnelCancel))
 	cleanupBroker = false
+	tunnelHandoff()
+	handedOff = true
 	return agentConn, nil
 }
 

--- a/go/internal/cli/commands/cloud_tunnel_detach_test.go
+++ b/go/internal/cli/commands/cloud_tunnel_detach_test.go
@@ -1,0 +1,67 @@
+package commands
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// waitDone reports whether ctx becomes done within a short grace period —
+// AfterFunc-driven cancellation propagates asynchronously.
+func waitDone(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return true
+	case <-time.After(2 * time.Second):
+		return false
+	}
+}
+
+// The bug this contract exists for: reconnect helpers cancel their per-attempt
+// dial context as soon as the connection is returned, and the broker tunnel
+// stream opened on that context died with it — every reconnected cloud
+// connection was dead on arrival ("error reading from server: EOF" right after
+// a successful liveness probe). After handoff, the tunnel context must survive
+// the dial context's cancellation.
+func TestDetachedTunnelContextSurvivesDialCancelAfterHandoff(t *testing.T) {
+	dialCtx, dialCancel := context.WithCancel(context.Background())
+	tunnelCtx, handoff, cancel := detachedTunnelContext(dialCtx)
+	defer cancel()
+
+	handoff()
+	dialCancel()
+
+	// Deterministic given handoff() returned before dialCancel(): the
+	// dial-cancel link is severed synchronously, so give propagation no grace.
+	select {
+	case <-tunnelCtx.Done():
+		t.Fatal("tunnel context died with the dial context despite handoff")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+// Before handoff the dial is still in flight, so cancelling the dial context
+// must take the tunnel context down with it — an abandoned dial attempt must
+// not leak a live broker stream.
+func TestDetachedTunnelContextDiesWithDialCtxBeforeHandoff(t *testing.T) {
+	dialCtx, dialCancel := context.WithCancel(context.Background())
+	tunnelCtx, _, cancel := detachedTunnelContext(dialCtx)
+	defer cancel()
+
+	dialCancel()
+	if !waitDone(tunnelCtx) {
+		t.Fatal("tunnel context survived dial-context cancellation before handoff")
+	}
+}
+
+// cancel is the connection's Close path: it must end the tunnel context even
+// after handoff severed the dial-context link.
+func TestDetachedTunnelContextCancelEndsItAfterHandoff(t *testing.T) {
+	tunnelCtx, handoff, cancel := detachedTunnelContext(context.Background())
+
+	handoff()
+	cancel()
+	if !waitDone(tunnelCtx) {
+		t.Fatal("tunnel context survived its own cancel")
+	}
+}

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -3024,6 +3024,16 @@ func verifyAgentAfterUpdate(ctx context.Context, agentService agentpb.WendyAgent
 }
 
 func updatedAgentReconnectFunc(ctx context.Context, previous *grpcclient.AgentConnection) func(context.Context) (*grpcclient.AgentConnection, error) {
+	// A connection with a pinned Reconnect (cloud tunnel — bound to the exact
+	// asset id) reconnects through it. Re-running discovery instead would
+	// relaunch the interactive device picker in the middle of the restart wait
+	// when the device was picked interactively (cloudDeviceConfig.DeviceName is
+	// only the --device flag), and even a named lookup can misresolve while the
+	// restarting device's heartbeat lapses.
+	if previous != nil && previous.Reconnect != nil {
+		return previous.Reconnect
+	}
+
 	if cloudCfg, ok := cloudDeviceConfigFromContext(ctx); ok {
 		return func(waitCtx context.Context) (*grpcclient.AgentConnection, error) {
 			return connectToCloudAgent(waitCtx, cloudCfg.CloudGRPC, cloudCfg.DeviceName, cloudCfg.BrokerURL)

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -2058,9 +2058,14 @@ type osUpdateOutcome struct {
 // device_type, so the pre-update snapshot may be stale. Non-WendyOS targets and
 // devices without an OTA backend are skipped silently, and any failure to
 // re-read or look up the OS is reported but non-fatal — `device update` still
-// succeeds as an agent-only update. The returned outcome reports whether an OTA
-// was actually applied and whether the device came back online in this run.
-func maybeCheckOSUpdate(ctx context.Context, preUpdateVersion *agentpb.GetAgentVersionResponse, priorConn *grpcclient.AgentConnection, nightly, assumeYes bool, artifactURLOverride string) (osUpdateOutcome, error) {
+// succeeds as an agent-only update. Exception: when prNumber > 0 the OS
+// artifact resolves from that wendyos-builder PR's manifest, the already-current
+// skip is suppressed (a PR tag is constant across rebuilds), and failures on
+// the way to the install are hard errors instead — the PR OS install is the
+// explicitly requested outcome, so it must not degrade to an agent-only
+// success. The returned outcome reports whether an OTA was actually applied and
+// whether the device came back online in this run.
+func maybeCheckOSUpdate(ctx context.Context, preUpdateVersion *agentpb.GetAgentVersionResponse, priorConn *grpcclient.AgentConnection, nightly, assumeYes bool, artifactURLOverride string, prNumber int) (osUpdateOutcome, error) {
 	if preUpdateVersion == nil {
 		return osUpdateOutcome{}, nil
 	}
@@ -2082,6 +2087,9 @@ func maybeCheckOSUpdate(ctx context.Context, preUpdateVersion *agentpb.GetAgentV
 	fmt.Println("Checking for OS updates...")
 	conn, err := reconnectAgentAfterRestart(ctx, priorConn)
 	if err != nil {
+		if prNumber > 0 {
+			return osUpdateOutcome{}, fmt.Errorf("reconnecting for the PR %d OS update: %w", prNumber, err)
+		}
 		fmt.Printf("Could not check for OS updates: %v\n", err)
 		return osUpdateOutcome{}, nil
 	}
@@ -2119,18 +2127,33 @@ func maybeCheckOSUpdate(ctx context.Context, preUpdateVersion *agentpb.GetAgentV
 		// newer agent may report it correctly where an older one did not.
 		versionResp, err := conn.AgentService.GetAgentVersion(ctx, &agentpb.GetAgentVersionRequest{})
 		if err != nil {
+			if prNumber > 0 {
+				return osUpdateOutcome{}, fmt.Errorf("reading the device version for the PR %d OS update: %w", prNumber, err)
+			}
 			fmt.Printf("Could not check for OS updates: %v\n", err)
 			return osUpdateOutcome{}, nil
 		}
 
 		deviceType := versionResp.GetDeviceType()
 		if deviceType == "" {
+			if prNumber > 0 {
+				return osUpdateOutcome{}, fmt.Errorf("device did not report a device type; cannot resolve the PR %d OS image", prNumber)
+			}
 			// No device type → cannot auto-select the GCS artifact; skip quietly.
 			return osUpdateOutcome{}, nil
 		}
 
-		u, latestVer, err := getLatestOTAInfoForDeviceType(deviceType, versionResp.GetStorageMedium(), nightly)
+		u, latestVer, err := func() (string, string, error) {
+			if prNumber > 0 {
+				return getPROTAInfoForDeviceType(prNumber, deviceType, versionResp.GetStorageMedium())
+			}
+			return getLatestOTAInfoForDeviceType(deviceType, versionResp.GetStorageMedium(), nightly)
+		}()
 		if err != nil {
+			// A --pr update must resolve to that PR's build or fail outright.
+			if prNumber > 0 {
+				return osUpdateOutcome{}, err
+			}
 			fmt.Printf("Could not check for OS updates: %v\n", err)
 			return osUpdateOutcome{}, nil
 		}
@@ -2142,7 +2165,7 @@ func maybeCheckOSUpdate(ctx context.Context, preUpdateVersion *agentpb.GetAgentV
 			fromVer = "unknown"
 		}
 
-		decision := decideOSUpdate(currentOS, latestVer, nightly, assumeYes, isInteractiveTerminal())
+		decision := decideOSUpdate(prNumber, currentOS, latestVer, nightly, assumeYes, isInteractiveTerminal())
 
 		// Don't offer an update the device is guaranteed to reject (e.g. a
 		// wendyos-update release for a device whose image predates the
@@ -2159,16 +2182,28 @@ func maybeCheckOSUpdate(ctx context.Context, preUpdateVersion *agentpb.GetAgentV
 
 		switch decision {
 		case osActionAlreadyCurrent:
+			// Unreachable under --pr: decideOSUpdate never returns AlreadyCurrent
+			// for prNumber > 0, so the plain-channel message is always accurate.
 			fmt.Printf("OS is already at the latest version (%s).\n", currentOS)
 			return osUpdateOutcome{}, nil
 		case osActionReportOnly:
+			if prNumber > 0 {
+				// The default text suggests plain `wendy os update`, which would
+				// not install the PR build — steer to a --yes re-run instead.
+				fmt.Printf("PR %d OS image available (%s). Re-run with --yes to apply.\n", prNumber, latestVer)
+				return osUpdateOutcome{}, nil
+			}
 			fmt.Printf("OS update available (%s). Re-run with --yes or run 'wendy os update' to apply.\n", latestVer)
 			return osUpdateOutcome{}, nil
 		case osActionApply:
 			// fall through to apply
 		case osActionPrompt:
 			ensureDeviceWiFiForOSUpdate(ctx, conn)
-			if !confirmDefaultNoFn(fmt.Sprintf("OS update available (%s → %s). Apply now?", fromVer, latestVer)) {
+			prompt := fmt.Sprintf("OS update available (%s → %s). Apply now?", fromVer, latestVer)
+			if prNumber > 0 {
+				prompt = fmt.Sprintf("Install PR %d OS image (%s → %s)? It is an unhardened debug build.", prNumber, fromVer, latestVer)
+			}
+			if !confirmDefaultNoFn(prompt) {
 				fmt.Println("Skipping OS update. Run 'wendy os update' to apply later.")
 				return osUpdateOutcome{}, nil
 			}
@@ -2272,17 +2307,32 @@ func newDeviceUpdateCmd() *cobra.Command {
 	var nightly bool
 	var assumeYes bool
 	var artifactURL string
+	var prNumber int
 
 	cmd := &cobra.Command{
 		Use:   "update",
-		Short: "Update the agent binary on the target device",
+		Short: "Update the agent binary and WendyOS on the target device",
 		Long: "Updates the agent binary on the device (downloaded from GitHub, or --binary for a local file), then checks for a newer WendyOS image. " +
 			"When an OS update is available it prompts before applying (default no); use --yes to apply without prompting. Non-interactive runs report the available update without applying it. " +
 			"--nightly selects the nightly channel for both the agent and the OS. " +
 			"--artifact-url applies a specific OS update artifact instead of the manifest's latest; this works over the cloud tunnel (the device downloads the artifact directly from the URL). " +
+			"--pr N applies the OS image built by wendyos-builder PR #N instead of the manifest's latest — an unhardened debug build for testing PRs on hardware; it also works over the cloud tunnel. --pr cannot be combined with --artifact-url or --json. " +
 			"macOS agents receive the signed app-bundle zip (wendy-agent-macos-<arch>.zip) instead of a Linux binary; --binary accepts one of those zips for dev pushes to a Mac agent.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+
+			if prNumber > 0 {
+				if artifactURL != "" {
+					return fmt.Errorf("--pr cannot be combined with --artifact-url")
+				}
+				// The OS step is the whole point of --pr, and JSON mode skips it
+				// (see the jsonOutput returns below) — refuse rather than let the
+				// user believe they tested the PR's image.
+				if jsonOutput {
+					return fmt.Errorf("--pr cannot be combined with --json: the OS-update step is skipped in JSON mode")
+				}
+				fmt.Fprintln(cmd.ErrOrStderr(), tui.WarningMessage("PR images are unhardened debug builds (passwordless root, SSH on). Do not use in production."))
+			}
 
 			conn, err := connectToAgent(ctx, ExcludeProviders("local", "docker", "wendy-lite"), SuppressUpdateCheck())
 			if err != nil {
@@ -2482,7 +2532,7 @@ func newDeviceUpdateCmd() *cobra.Command {
 				// !isWendyOSUpdateTarget gate rejects a non-"WendyOS-" os_version
 				// and empty device_type before any reconnect/network call, so
 				// `device update` on a Mac only ever updates the agent binary.
-				outcome, err = maybeCheckOSUpdate(ctx, preUpdateVersion, conn, nightly, assumeYes, artifactURL)
+				outcome, err = maybeCheckOSUpdate(ctx, preUpdateVersion, conn, nightly, assumeYes, artifactURL, prNumber)
 				if err != nil {
 					return err
 				}
@@ -2524,6 +2574,7 @@ func newDeviceUpdateCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&nightly, "nightly", false, "Use the latest nightly (prerelease) build for both the agent and the OS")
 	cmd.Flags().BoolVarP(&assumeYes, "yes", "y", false, "Apply an available OS update without prompting")
 	cmd.Flags().StringVar(&artifactURL, "artifact-url", "", "Apply this OS update artifact URL instead of the manifest's latest")
+	cmd.Flags().IntVar(&prNumber, "pr", 0, "OTA-update the OS to the image built by wendyos-builder PR #N (debug build; mutually exclusive with --artifact-url and --json)")
 
 	return cmd
 }

--- a/go/internal/cli/commands/device_test.go
+++ b/go/internal/cli/commands/device_test.go
@@ -137,7 +137,7 @@ func TestMaybeCheckOSUpdateSkips(t *testing.T) {
 			// backend do reconnect to re-read the version, so they're not covered
 			// here.) A nil connection is safe because the gate returns before it
 			// is used.
-			outcome, err := maybeCheckOSUpdate(context.Background(), tc.version, nil, false, false, "")
+			outcome, err := maybeCheckOSUpdate(context.Background(), tc.version, nil, false, false, "", 0)
 			if err != nil {
 				t.Fatalf("maybeCheckOSUpdate() error = %v, want nil", err)
 			}

--- a/go/internal/cli/commands/device_update_pr_test.go
+++ b/go/internal/cli/commands/device_update_pr_test.go
@@ -1,0 +1,38 @@
+package commands
+
+import "testing"
+
+func TestDeviceUpdatePRFlag(t *testing.T) {
+	cmd := newDeviceUpdateCmd()
+	if cmd.Flags().Lookup("pr") == nil {
+		t.Fatal("expected --pr flag on device update")
+	}
+}
+
+func TestDeviceUpdatePRMutualExclusion(t *testing.T) {
+	const mutexErr = "--pr cannot be combined with --artifact-url"
+	cmd := newDeviceUpdateCmd()
+	cmd.SetArgs([]string{"--pr", "123", "--artifact-url", "https://example.com/image.wendy"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for --pr with --artifact-url")
+	}
+	if got := err.Error(); got != mutexErr {
+		t.Errorf("unexpected error: %q; want %q", got, mutexErr)
+	}
+}
+
+func TestDeviceUpdatePRJSONExclusion(t *testing.T) {
+	const jsonErr = "--pr cannot be combined with --json: the OS-update step is skipped in JSON mode"
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = false })
+	cmd := newDeviceUpdateCmd()
+	cmd.SetArgs([]string{"--pr", "123"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for --pr with --json")
+	}
+	if got := err.Error(); got != jsonErr {
+		t.Errorf("unexpected error: %q; want %q", got, jsonErr)
+	}
+}

--- a/go/internal/cli/commands/device_update_reconnect_test.go
+++ b/go/internal/cli/commands/device_update_reconnect_test.go
@@ -1,0 +1,39 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+)
+
+// A cloud-tunnel connection carries a Reconnect closure pinned to the exact
+// asset id (cloud_tunnel.go). updatedAgentReconnectFunc must reuse it rather
+// than re-running device discovery: discovery relaunches the interactive cloud
+// picker mid-"Waiting for agent to restart..." when the device was picked
+// interactively (no --device, so cloudDeviceConfig.DeviceName is empty), and
+// even with a name it can misresolve while the restarting device's heartbeat
+// lapses.
+func TestUpdatedAgentReconnectFuncPrefersPinnedReconnect(t *testing.T) {
+	sentinel := errors.New("pinned reconnect used")
+	previous := &grpcclient.AgentConnection{
+		Reconnect: func(context.Context) (*grpcclient.AgentConnection, error) {
+			return nil, sentinel
+		},
+	}
+	// Simulate `wendy cloud device update` with an interactively picked device:
+	// cloud config present, DeviceName empty.
+	ctx := context.WithValue(context.Background(), cloudDeviceContextKey{}, cloudDeviceConfig{})
+
+	reconnect := updatedAgentReconnectFunc(ctx, previous)
+
+	// Already-cancelled so that, should the closure wrongly re-run discovery,
+	// it fails fast instead of touching auth config or the network.
+	rctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := reconnect(rctx)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("reconnect did not use the connection's pinned Reconnect; got err=%v", err)
+	}
+}

--- a/go/internal/cli/commands/os_cmd.go
+++ b/go/internal/cli/commands/os_cmd.go
@@ -211,9 +211,14 @@ const (
 
 // decideOSUpdate chooses how the OS-update step behaves when a newer OS may be
 // available. It is pure so it can be unit-tested; the caller is responsible for
-// running the interactive prompt when the result is osActionPrompt.
-func decideOSUpdate(currentOSVersion, latestVersion string, nightly, assumeYes, interactive bool) osUpdateAction {
-	if osAlreadyCurrent(currentOSVersion, latestVersion, nightly) {
+// running the interactive prompt when the result is osActionPrompt. A --pr
+// request (prNumber > 0) never resolves to osActionAlreadyCurrent: a PR's
+// version tag ("pr-N") is constant across rebuilds, so treating a matching tag
+// as current would silently no-op a re-test after a new push to the same PR
+// (same rationale as osUpdateShouldSkipAlreadyCurrent, which implements the
+// suppression).
+func decideOSUpdate(prNumber int, currentOSVersion, latestVersion string, nightly, assumeYes, interactive bool) osUpdateAction {
+	if osUpdateShouldSkipAlreadyCurrent(prNumber, currentOSVersion, latestVersion, nightly) {
 		return osActionAlreadyCurrent
 	}
 	switch {

--- a/go/internal/cli/commands/os_cmd_test.go
+++ b/go/internal/cli/commands/os_cmd_test.go
@@ -105,6 +105,7 @@ func TestOSUpdateShouldSkipAlreadyCurrent(t *testing.T) {
 func TestDecideOSUpdate(t *testing.T) {
 	tests := []struct {
 		name        string
+		prNumber    int
 		current     string
 		latest      string
 		nightly     bool
@@ -112,18 +113,21 @@ func TestDecideOSUpdate(t *testing.T) {
 		interactive bool
 		want        osUpdateAction
 	}{
-		{"already current", "WendyOS-0.10.4", "0.10.4", false, false, false, osActionAlreadyCurrent},
-		{"newer with yes", "WendyOS-0.10.4", "0.12.0", false, true, false, osActionApply},
-		{"newer with yes overrides tty", "WendyOS-0.10.4", "0.12.0", false, true, true, osActionApply},
-		{"newer interactive prompts", "WendyOS-0.10.4", "0.12.0", false, false, true, osActionPrompt},
-		{"newer noninteractive reports", "WendyOS-0.10.4", "0.12.0", false, false, false, osActionReportOnly},
+		{"already current", 0, "WendyOS-0.10.4", "0.10.4", false, false, false, osActionAlreadyCurrent},
+		{"newer with yes", 0, "WendyOS-0.10.4", "0.12.0", false, true, false, osActionApply},
+		{"newer with yes overrides tty", 0, "WendyOS-0.10.4", "0.12.0", false, true, true, osActionApply},
+		{"newer interactive prompts", 0, "WendyOS-0.10.4", "0.12.0", false, false, true, osActionPrompt},
+		{"newer noninteractive reports", 0, "WendyOS-0.10.4", "0.12.0", false, false, false, osActionReportOnly},
+		{"pr identical tag interactive prompts", 123, "WendyOS-pr-123", "pr-123", false, false, true, osActionPrompt},
+		{"pr identical tag with yes applies", 123, "WendyOS-pr-123", "pr-123", false, true, false, osActionApply},
+		{"pr noninteractive reports", 123, "WendyOS-0.17.0", "pr-123", false, false, false, osActionReportOnly},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := decideOSUpdate(tc.current, tc.latest, tc.nightly, tc.assumeYes, tc.interactive)
+			got := decideOSUpdate(tc.prNumber, tc.current, tc.latest, tc.nightly, tc.assumeYes, tc.interactive)
 			if got != tc.want {
-				t.Fatalf("decideOSUpdate(%q,%q,nightly=%v,yes=%v,tty=%v) = %v, want %v",
-					tc.current, tc.latest, tc.nightly, tc.assumeYes, tc.interactive, got, tc.want)
+				t.Fatalf("decideOSUpdate(pr=%d,%q,%q,nightly=%v,yes=%v,tty=%v) = %v, want %v",
+					tc.prNumber, tc.current, tc.latest, tc.nightly, tc.assumeYes, tc.interactive, got, tc.want)
 			}
 		})
 	}

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceUpdateTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyCloudDeviceUpdateTests.swift
@@ -22,6 +22,7 @@ struct `'wendy cloud device update'` {
                 #expect(result.stdout.contains("--binary"))
                 #expect(result.stdout.contains("--nightly"))
                 #expect(result.stdout.contains("--artifact-url"))
+                #expect(result.stdout.contains("--pr"))
                 #expect(result.stdout.contains("--yes"))
                 #expect(result.stdout.contains("--device"))
                 #expect(result.stderr == "")

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceUpdateTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyDeviceUpdateTests.swift
@@ -22,6 +22,7 @@ struct `'wendy device update'` {
                 #expect(result.stdout.contains("--binary"))
                 #expect(result.stdout.contains("--nightly"))
                 #expect(result.stdout.contains("--artifact-url"))
+                #expect(result.stdout.contains("--pr"))
                 #expect(result.stdout.contains("--yes"))
                 #expect(result.stdout.contains("--device"))
                 #expect(result.stderr == "")
@@ -123,6 +124,31 @@ struct `'wendy device update'` {
                 #expect(result.status.isFailure)
                 #expect(result.stdout == "")
                 #expect(result.stderr.contains("unknown flag"))
+            }
+        }
+    }
+
+    /**
+     Rejects requests that combine `--pr` with another OS artifact source or
+     with `--json` (which skips the OS-update step entirely).
+
+     Source validation fails before device discovery, downloading, or
+     contacting update services, so no device or authentication is needed.
+     */
+    @Test
+    func `rejects conflicting artifact sources locally`() async throws {
+        try await self.scenario.run(authenticated: false) { cli, _ in
+            try await cli.sh(
+                "wendy device update --pr 123 --artifact-url https://example.invalid/update.wendy"
+            ) { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("--pr cannot be combined"))
+            }
+            try await cli.sh("wendy device update --pr 123 --json") { result in
+                #expect(result.status.isFailure)
+                #expect(result.stdout == "")
+                #expect(result.stderr.contains("--pr cannot be combined with --json"))
             }
         }
     }


### PR DESCRIPTION
## Summary

`wendy cloud device update` is the only way to OTA a WendyOS device over the cloud tunnel, but unlike the other WendyOS-updating commands (`wendy os update --pr` / `wendy os install --pr`, #1360) it could not install a wendyos-builder PR image. Since `wendy cloud device update` reuses the `wendy device update` cobra command, adding `--pr` to `newDeviceUpdateCmd()` gives it to both commands at once.

The OS-update step resolves the artifact through the shared `getPROTAInfoForDeviceType` resolver, which returns a public GCS URL the device fetches directly — so it works over the cloud tunnel unchanged, exactly like `--artifact-url` already does.

Also fixes the command's `Short:` description, which claimed the command only updates the agent binary ("Update the agent binary on the target device") when it also checks for and applies WendyOS updates.

## Behavior

- `--pr` is mutually exclusive with `--artifact-url`, and with `--json`: JSON mode skips the OS-update step entirely, so combining it with `--pr` would silently ignore the requested PR install. Both guards fail locally before any device connection.
- `--pr` + `--nightly` and `--pr` + `--binary` remain allowed — those control the agent-binary side, which `--pr` does not touch (`--nightly` still selects the agent channel, `--binary` is still re-applied after the OS reboot).
- A `--pr` run never skips as "already current": a PR's version tag (`pr-N`) is constant across rebuilds, so re-running after a new push to the same PR always re-flashes (`decideOSUpdate` now routes through the existing `osUpdateShouldSkipAlreadyCurrent`).
- Under `--pr`, failures that previously degraded to a non-fatal agent-only success (reconnect, version re-read, manifest resolution) are hard errors — the PR OS install is the explicitly requested outcome.
- Prompt-unless-`--yes` semantics and the unhardened-debug-build warning match `os update --pr`.

## Testing

- New `device_update_pr_test.go` (flag presence, both mutual-exclusion errors, exact messages), pr cases in `TestDecideOSUpdate`, updated `TestMaybeCheckOSUpdateSkips` signature.
- Swift e2e: `--pr` added to the help assertions of the `wendy device update` and `wendy cloud device update` suites, plus a local `rejects conflicting artifact sources locally` test mirroring the `wendy os update` suite. Not compile-verified locally (no Swift toolchain on this machine) — relying on CI.
- `gofmt`/`go vet`/`go build ./...` clean; `go test ./go/internal/cli/commands/` passes. Full `go test ./go/...`: 77 packages pass; `go/internal/agent/oci` GPU-entitlement tests fail identically on a clean `main` checkout (pre-existing, host-environment dependent).
- Manual smoke: both commands' `--help` show `--pr` and the new Short; both guard errors exit non-zero without touching a device.

## Docs

`docs/clients/wendy-cli/commands/device/update.md` gains an "Update the OS to a pull-request build" section (mirroring `os/update.md`) and the `--json` note now mentions the `--pr` refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)