### PR TITLE
fix(cli): fingerprint container runtime state

### DIFF
--- a/go/internal/cli/commands/deployfastpath.go
+++ b/go/internal/cli/commands/deployfastpath.go
@@ -90,7 +90,14 @@ func computeDeployDesiredHash(buildInputHash string, appCfg *appconfig.AppConfig
 	runtimeCfg.Xcode = nil
 	runtimeCfg.Run = nil // effective arguments are carried separately below
 	runtimeCfg.Readiness = nil
-	runtimeCfg.Hooks = nil
+	hook := postStartAgentHook(appCfg)
+	if hook != "" {
+		runtimeCfg.Hooks = &appconfig.HooksConfig{
+			PostStart: &appconfig.HookCommand{Agent: hook},
+		}
+	} else {
+		runtimeCfg.Hooks = nil
+	}
 	runtimeCfg.Python = nil
 	runtimeCfg.Files = nil
 	runtimeCfg.Brewfile = ""

--- a/go/internal/cli/commands/deployfastpath.go
+++ b/go/internal/cli/commands/deployfastpath.go
@@ -54,6 +54,67 @@ type deployFingerprint struct {
 	LayerDiffIDs []string `json:"layerDiffIds,omitempty"`
 }
 
+// deployRuntimeIdentity is the subset of a single-container deployment that
+// affects the container the agent creates. Build-only and CLI-only settings
+// are deliberately absent: changing a readiness probe or a host-side hook must
+// not invalidate an otherwise reusable container, while changing resources,
+// entitlements, isolation, framework wiring, arguments, environment, or the
+// restart policy must.
+//
+// Keep AppConfig as a value so newly-added device runtime fields fail safe: they
+// are included unless runtimeAppConfig explicitly clears them below.
+type deployRuntimeIdentity struct {
+	AppConfig     appconfig.AppConfig    `json:"appConfig"`
+	UserArgs      []string               `json:"userArgs,omitempty"`
+	Env           []string               `json:"env,omitempty"`
+	RestartPolicy *agentpb.RestartPolicy `json:"restartPolicy,omitempty"`
+}
+
+// computeDeployDesiredHash combines the already-computed build-input hash
+// (Dockerfile/context, target platform, build args, and deploy environment)
+// with the effective create/start configuration. The old fast path used the
+// build hash directly, which meant a resource, entitlement, isolation,
+// user-arg, or restart-policy-only change could incorrectly leave the old
+// container running.
+func computeDeployDesiredHash(buildInputHash string, appCfg *appconfig.AppConfig, userArgs, env []string, restartPolicy *agentpb.RestartPolicy) (string, error) {
+	if buildInputHash == "" || appCfg == nil {
+		return "", fmt.Errorf("build input hash and app config are required")
+	}
+
+	runtimeCfg := *appCfg
+	// These fields influence local build selection, native file deployment, or
+	// CLI lifecycle behavior, but are not consumed when the Linux container is
+	// created. Excluding them lets readiness/hook-only edits retain the running
+	// container without weakening device-runtime correctness.
+	runtimeCfg.Platform = ""
+	runtimeCfg.Xcode = nil
+	runtimeCfg.Run = nil // effective arguments are carried separately below
+	runtimeCfg.Readiness = nil
+	runtimeCfg.Hooks = nil
+	runtimeCfg.Python = nil
+	runtimeCfg.Files = nil
+	runtimeCfg.Brewfile = ""
+	runtimeCfg.Env = nil // resolved values are carried separately below
+	runtimeCfg.Services = nil
+
+	payload, err := json.Marshal(deployRuntimeIdentity{
+		AppConfig:     runtimeCfg,
+		UserArgs:      userArgs,
+		Env:           env,
+		RestartPolicy: restartPolicy,
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshaling deploy runtime identity: %w", err)
+	}
+
+	h := sha256.New()
+	io.WriteString(h, "wendy-deploy-desired-state-v1\n")
+	io.WriteString(h, buildInputHash)
+	h.Write([]byte{'\n'})
+	h.Write(payload)
+	return "sha256:" + hex.EncodeToString(h.Sum(nil)), nil
+}
+
 // deployFingerprintPath returns the on-disk location for an app+device
 // fingerprint. deviceKey identifies the target device (see deviceFingerprintKey).
 func deployFingerprintPath(appID, deviceKey string) (string, error) {
@@ -235,10 +296,15 @@ func computeBuildInputHash(cwd, dockerfile, platform string, buildArgs map[strin
 	return "sha256:" + hex.EncodeToString(h.Sum(nil)), nil
 }
 
-// dockerfileBasesContentPinned is the fail-closed eligibility gate for a
-// persistent no-build skip. Old device content proves what was deployed, but
-// only digest-pinned external bases prove a rebuild would still resolve the
-// same inputs. scratch and references to prior named stages are also stable.
+// dockerfileBasesContentPinned reports whether rebuilding this Dockerfile is
+// independent of mutable registry tags. Persistent no-build skipping is only
+// safe when every external base is scratch or digest-pinned; merely proving
+// that the previously-built layers still exist on the device does not prove a
+// mutable FROM tag still resolves to those layers.
+//
+// This intentionally accepts only a small, unambiguous subset of Dockerfile
+// syntax. ARG-expanded bases and malformed/uncertain instructions fail closed
+// to a normal build. Multi-stage references to an earlier named stage are safe.
 func dockerfileBasesContentPinned(cwd, dockerfile string) (bool, error) {
 	if dockerfile == "" {
 		dockerfile = "Dockerfile"
@@ -249,7 +315,7 @@ func dockerfileBasesContentPinned(cwd, dockerfile string) (bool, error) {
 	}
 	f, err := os.Open(dfPath)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("reading Dockerfile base images: %w", err)
 	}
 	defer f.Close()
 
@@ -280,6 +346,8 @@ func dockerfileBasesContentPinned(cwd, dockerfile string) (bool, error) {
 		foundFrom = true
 		i := 1
 		for i < len(fields) && strings.HasPrefix(fields[i], "--") {
+			// FROM flags use --key=value. Reject split/unknown forms instead of
+			// guessing which following token is the image reference.
 			if !strings.Contains(fields[i], "=") {
 				return false, nil
 			}
@@ -299,6 +367,7 @@ func dockerfileBasesContentPinned(cwd, dockerfile string) (bool, error) {
 				return false, nil
 			}
 		}
+
 		if i+2 < len(fields) && strings.EqualFold(fields[i+1], "AS") {
 			alias := strings.ToLower(fields[i+2])
 			if alias == "" || strings.HasPrefix(alias, "$") {
@@ -310,7 +379,7 @@ func dockerfileBasesContentPinned(cwd, dockerfile string) (bool, error) {
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return false, err
+		return false, fmt.Errorf("scanning Dockerfile base images: %w", err)
 	}
 	if logical.Len() != 0 {
 		return false, nil

--- a/go/internal/cli/commands/deployfastpath_test.go
+++ b/go/internal/cli/commands/deployfastpath_test.go
@@ -5,6 +5,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
 
 func writeFile(t *testing.T, dir, rel, content string) {
@@ -68,15 +71,21 @@ func TestComputeBuildInputHash_BuildArgsAndDockerfile(t *testing.T) {
 
 func TestDockerfileBasesContentPinned(t *testing.T) {
 	digest := "sha256:" + strings.Repeat("a", 64)
-	for _, tt := range []struct {
-		name, dockerfile string
-		want             bool
+	tests := []struct {
+		name       string
+		dockerfile string
+		want       bool
 	}{
 		{name: "scratch", dockerfile: "FROM scratch\n", want: true},
-		{name: "pinned multistage", dockerfile: "FROM alpine@" + digest + " AS build\nFROM build\n", want: true},
-		{name: "mutable tag", dockerfile: "FROM alpine:3.20\n"},
-		{name: "arg base", dockerfile: "ARG BASE=alpine@" + digest + "\nFROM ${BASE}\n"},
-	} {
+		{name: "digest pinned", dockerfile: "FROM --platform=linux/arm64 python:3.12@" + digest + " AS base\nFROM base AS app\n", want: true},
+		{name: "mutable tag", dockerfile: "FROM python:3.12\n"},
+		{name: "arg expanded", dockerfile: "ARG BASE=python:3.12\nFROM ${BASE}\n"},
+		{name: "mixed multistage", dockerfile: "FROM alpine@" + digest + " AS build\nFROM ubuntu:24.04\n"},
+		{name: "continued pinned", dockerfile: "FROM --platform=linux/arm64 \\\n alpine@" + digest + " AS base\nFROM base\n", want: true},
+		{name: "no from", dockerfile: "RUN true\n"},
+		{name: "split flag rejected", dockerfile: "FROM --platform linux/arm64 alpine@" + digest + "\n"},
+	}
+	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
 			writeFile(t, dir, "Dockerfile", tt.dockerfile)
@@ -284,5 +293,60 @@ func TestBuildInputHashSaltIsV2(t *testing.T) {
 	}
 	if strings.Contains(string(data), `"wendy-deploy-fingerprint-v1\n"`) {
 		t.Fatal("v1 salt string still present in deployfastpath.go")
+	}
+}
+
+func TestComputeDeployDesiredHash_RuntimeChangesInvalidate(t *testing.T) {
+	baseCfg := &appconfig.AppConfig{AppID: "demo", Version: "1.0.0"}
+	base, err := computeDeployDesiredHash("sha256:image", baseCfg, []string{"serve"}, []string{"LOG_LEVEL=info"}, &agentpb.RestartPolicy{Mode: agentpb.RestartPolicyMode_UNLESS_STOPPED})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		cfg  *appconfig.AppConfig
+		args []string
+		env  []string
+		mode agentpb.RestartPolicyMode
+	}{
+		{name: "version", cfg: &appconfig.AppConfig{AppID: "demo", Version: "2.0.0"}, args: []string{"serve"}, env: []string{"LOG_LEVEL=info"}, mode: agentpb.RestartPolicyMode_UNLESS_STOPPED},
+		{name: "entitlement", cfg: &appconfig.AppConfig{AppID: "demo", Version: "1.0.0", Entitlements: []appconfig.Entitlement{{Type: "network/host"}}}, args: []string{"serve"}, env: []string{"LOG_LEVEL=info"}, mode: agentpb.RestartPolicyMode_UNLESS_STOPPED},
+		{name: "arguments", cfg: baseCfg, args: []string{"worker"}, env: []string{"LOG_LEVEL=info"}, mode: agentpb.RestartPolicyMode_UNLESS_STOPPED},
+		{name: "environment", cfg: baseCfg, args: []string{"serve"}, env: []string{"LOG_LEVEL=debug"}, mode: agentpb.RestartPolicyMode_UNLESS_STOPPED},
+		{name: "restart policy", cfg: baseCfg, args: []string{"serve"}, env: []string{"LOG_LEVEL=info"}, mode: agentpb.RestartPolicyMode_NO},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := computeDeployDesiredHash("sha256:image", tt.cfg, tt.args, tt.env, &agentpb.RestartPolicy{Mode: tt.mode})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got == base {
+				t.Fatalf("runtime change did not invalidate desired-state hash: %s", got)
+			}
+		})
+	}
+}
+
+func TestComputeDeployDesiredHash_CLIOnlyChangesDoNotInvalidate(t *testing.T) {
+	baseCfg := &appconfig.AppConfig{AppID: "demo", Version: "1.0.0"}
+	changedCfg := &appconfig.AppConfig{
+		AppID:     "demo",
+		Version:   "1.0.0",
+		Readiness: &appconfig.ReadinessConfig{TCPSocket: &appconfig.TCPSocketProbe{Port: 8080}},
+		Hooks:     &appconfig.HooksConfig{PostStart: &appconfig.HookCommand{CLI: "open http://device"}},
+	}
+	policy := &agentpb.RestartPolicy{Mode: agentpb.RestartPolicyMode_UNLESS_STOPPED}
+	base, err := computeDeployDesiredHash("sha256:image", baseCfg, nil, nil, policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := computeDeployDesiredHash("sha256:image", changedCfg, nil, nil, policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != base {
+		t.Fatalf("CLI-only readiness/hook change invalidated container identity: %s != %s", got, base)
 	}
 }

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -1999,8 +1999,19 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 	// the normal deploy below, so it can never deploy stale code.
 	deviceKey := deviceFingerprintKey(versionResp)
 	inputHash, hashErr := computeBuildInputHash(cwd, opts.dockerfile, platform, buildArgs, deployEnv)
+	if hashErr == nil {
+		var basesPinned bool
+		basesPinned, hashErr = dockerfileBasesContentPinned(cwd, opts.dockerfile)
+		if hashErr == nil && !basesPinned {
+			hashErr = fmt.Errorf("persistent build skip requires digest-pinned base images")
+		}
+	}
+	desiredHash := ""
+	if hashErr == nil {
+		desiredHash, hashErr = computeDeployDesiredHash(inputHash, appCfg, opts.userArgs, deployEnv, resolveRestartPolicy(opts))
+	}
 	if !isDarwinAgent && opts.detach && !opts.deploy && hashErr == nil {
-		if done, _ := tryDeployFastPath(ctx, conn, appCfg, deviceKey, inputHash, opts); done {
+		if done, _ := tryDeployFastPath(ctx, conn, appCfg, deviceKey, desiredHash, opts); done {
 			mark("fast-path (skipped build)")
 			return nil
 		}
@@ -2047,7 +2058,7 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 				// Record the layer diff IDs we deployed so the next run's fast path
 				// can verify the device still holds this content before skipping the
 				// build (WDY-1824).
-				saveDeployFingerprint(appCfg.AppID, deviceKey, deployFingerprint{InputHash: inputHash, AppVersion: appCfg.Version, LayerDiffIDs: diffIDs})
+				saveDeployFingerprint(appCfg.AppID, deviceKey, deployFingerprint{InputHash: desiredHash, AppVersion: appCfg.Version, LayerDiffIDs: diffIDs})
 			}
 			return nil
 		} else if isChunkDeployCancellation(ctx, err) {


### PR DESCRIPTION
## Summary

Make the detached deployment fast path fingerprint the effective container
runtime configuration in addition to image build inputs.

The previous fingerprint could leave a stale running container in place after
changes to resources, entitlements, isolation, framework wiring, user arguments,
version, or restart policy. The new desired-state hash includes every
device-relevant create/start input while intentionally excluding CLI-only
readiness and host-hook configuration.

Existing fingerprints fail closed and receive one normal redeploy before the
new identity can authorize a skip.

Persistent no-build skipping also fails closed for mutable `FROM` references.
Every external Dockerfile base must be `scratch` or digest-pinned; otherwise a
normal build resolves the tag again instead of treating old cached layers as
proof that the upstream base is still current.

## Tests

- Runtime state sensitivity and CLI-only exclusions
- Digest-pinned, scratch, multi-stage, mutable-tag, and ARG-expanded base cases
- Detached fast-path regression tests under the race detector
- `go vet ./go/internal/cli/commands`
