### PR TITLE
perf(agent): stage writable snapshots before replace

### DIFF
--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -37,6 +37,7 @@ import (
 	"github.com/containerd/errdefs"
 	"github.com/containerd/typeurl/v2"
 	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"go.uber.org/zap"
 
@@ -116,6 +117,13 @@ type Client struct {
 	// serviceIPs maps appID → serviceName → IP for isolated-mode apps.
 	// Updated after each successful CNI ADD. Protected by mu.
 	serviceIPs map[string]map[string]string
+
+	// preparedSnapshots holds a fresh, never-executed writable rootfs prepared
+	// by PrepareImage while chunks are still arriving. CreateContainer consumes
+	// it exactly once. It is guarded separately from mu because image preparation
+	// intentionally overlaps deployment work.
+	preparedSnapshotsMu sync.Mutex
+	preparedSnapshots   map[string]*preparedSnapshot
 
 	// appStopping tracks appIDs that are currently being stopped.
 	// Set before releasing c.mu in StopContainer; cleared in the cleanup phase.
@@ -274,20 +282,21 @@ func NewClient(logger *zap.Logger, address string, proxyMgr *dbusproxy.Manager) 
 	snapshotter := probeSnapshotter(logger)
 
 	return &Client{
-		client:          c,
-		logger:          logger,
-		namespace:       "default",
-		proxyManager:    proxyMgr,
-		appServices:     make(map[string]map[string]*appconfig.ServiceConfig),
-		primaryPIDs:     make(map[string]uint32),
-		appIsolation:    make(map[string]string),
-		warnedExposures: make(map[string]struct{}),
-		serviceIPs:      make(map[string]map[string]string),
-		appStopping:     make(map[string]bool),
-		ros2ExecRefs:    make(map[string]int),
-		chunkIndex:      idx,
-		staging:         newStaging(defaultChunkStagingDir),
-		snapshotter:     snapshotter,
+		client:            c,
+		logger:            logger,
+		namespace:         "default",
+		proxyManager:      proxyMgr,
+		appServices:       make(map[string]map[string]*appconfig.ServiceConfig),
+		primaryPIDs:       make(map[string]uint32),
+		appIsolation:      make(map[string]string),
+		warnedExposures:   make(map[string]struct{}),
+		serviceIPs:        make(map[string]map[string]string),
+		preparedSnapshots: make(map[string]*preparedSnapshot),
+		appStopping:       make(map[string]bool),
+		ros2ExecRefs:      make(map[string]int),
+		chunkIndex:        idx,
+		staging:           newStaging(defaultChunkStagingDir),
+		snapshotter:       snapshotter,
 	}, nil
 }
 
@@ -298,6 +307,7 @@ func NewClient(logger *zap.Logger, address string, proxyMgr *dbusproxy.Manager) 
 // Close releases the underlying containerd client connection and stops all
 // D-Bus proxy processes.
 func (c *Client) Close() error {
+	c.discardAllPreparedSnapshots()
 	if c.proxyManager != nil {
 		c.proxyManager.StopAll()
 	}
@@ -1468,17 +1478,46 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 		return fmt.Errorf("marshaling OCI spec: %w", err)
 	}
 
-	// Create the container with a new snapshot from the image.
+	// Prefer the fresh writable rootfs PrepareImage created concurrently with
+	// upload. Immutable layer snapshots are reused either way; consuming this
+	// active snapshot moves the final snapshotter Prepare call off the replace
+	// critical path. A prepared snapshot is single-use and has never backed a
+	// task, so runtime filesystem mutations can never leak across deployments.
 	snapshotKey := SnapshotKey(appID, serviceName)
+	snapshotOpt := containerd.WithNewSnapshot(snapshotKey, image)
+	var prepared *preparedSnapshot
+	if diffIDs, rootErr := image.RootFS(ctx); rootErr == nil {
+		prepared = c.takePreparedSnapshot(imageName, identity.ChainID(diffIDs).String())
+		if prepared != nil {
+			// The lease has a bounded expiration so an abandoned preparation
+			// cannot pin storage forever. If GC already collected that snapshot,
+			// discard the stale bookkeeping and retain the normal synchronous
+			// WithNewSnapshot fallback selected above.
+			if _, statErr := c.client.SnapshotService(c.snapshotter).Stat(ctx, prepared.key); statErr != nil {
+				prepared.discard()
+				prepared = nil
+			} else {
+				snapshotKey = prepared.key
+				snapshotOpt = containerd.WithSnapshot(snapshotKey)
+			}
+		}
+	}
 	_, err = c.client.NewContainer(ctx, containerName,
 		containerd.WithImage(image),
 		containerd.WithSnapshotter(c.snapshotter),
-		containerd.WithNewSnapshot(snapshotKey, image),
+		snapshotOpt,
 		containerd.WithContainerLabels(labels),
 		containerd.WithNewSpec(
 			oci.WithSpecFromBytes(specJSON),
 		),
 	)
+	if prepared != nil {
+		if err != nil {
+			prepared.discard()
+		} else {
+			prepared.releaseLease()
+		}
+	}
 	if err != nil {
 		return fmt.Errorf("creating container %q: %w", containerName, err)
 	}

--- a/go/internal/agent/containerd/prepare.go
+++ b/go/internal/agent/containerd/prepare.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/containerd/containerd/v2/core/leases"
 	"github.com/containerd/errdefs"
+	"github.com/google/uuid"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"go.uber.org/zap"
@@ -26,12 +27,15 @@ func (c *Client) PrepareImage(ctx context.Context, imageName string, layers []*a
 	if err != nil {
 		return fmt.Errorf("creating image preparation lease: %w", err)
 	}
+	releaseLease := true
 	defer func() {
-		if err := doneLease(cleanupCtx); err != nil {
-			c.logger.Warn("Failed to release image preparation lease; relying on expiration backstop",
-				zap.Duration("expiration", unpackLeaseExpiration),
-				zap.Error(err),
-			)
+		if releaseLease {
+			if err := doneLease(cleanupCtx); err != nil {
+				c.logger.Warn("Failed to release image preparation lease; relying on expiration backstop",
+					zap.Duration("expiration", unpackLeaseExpiration),
+					zap.Error(err),
+				)
+			}
 		}
 	}()
 
@@ -89,6 +93,29 @@ func (c *Client) PrepareImage(ctx context.Context, imageName string, layers []*a
 
 	if err := c.AssembleImage(ctx, imageName, layers, imageConfig); err != nil {
 		return fmt.Errorf("assembling prepared image: %w", err)
+	}
+
+	// Prepare a pristine writable rootfs while the caller is still outside the
+	// container replacement window. Failure is deliberately best-effort: all
+	// immutable layers and the image record are already prepared, so create can
+	// safely fall back to containerd.WithNewSnapshot.
+	preparedKey := "wendy-prepared-" + uuid.NewString()
+	if _, err := sn.Prepare(ctx, preparedKey, parentChainID); err != nil {
+		c.logger.Debug("Could not stage writable rootfs; create will prepare it synchronously",
+			zap.String("image", normalizeImageName(imageName)),
+			zap.Error(err),
+		)
+	} else {
+		c.storePreparedSnapshot(normalizeImageName(imageName), &preparedSnapshot{
+			key:     preparedKey,
+			parent:  parentChainID,
+			release: func() { _ = doneLease(cleanupCtx) },
+			remove:  func() { _ = sn.Remove(cleanupCtx, preparedKey) },
+		})
+		// The stored snapshot owns this lease until CreateContainer consumes or
+		// replaces it. The 30-minute expiration remains a crash/disconnect
+		// backstop.
+		releaseLease = false
 	}
 	c.logger.Info("Prepared image before container start",
 		zap.String("image", normalizeImageName(imageName)),

--- a/go/internal/agent/containerd/prepared_snapshot.go
+++ b/go/internal/agent/containerd/prepared_snapshot.go
@@ -1,0 +1,68 @@
+package containerd
+
+// preparedSnapshot is a fresh active snapshot that has never backed a task.
+// remove and release are idempotent at the containerd layer; the small once
+// guards keep our bookkeeping deterministic under replacement/close races.
+type preparedSnapshot struct {
+	key    string
+	parent string
+
+	release func()
+	remove  func()
+}
+
+func (p *preparedSnapshot) releaseLease() {
+	if p != nil && p.release != nil {
+		p.release()
+		p.release = nil
+	}
+}
+
+func (p *preparedSnapshot) discard() {
+	if p == nil {
+		return
+	}
+	if p.remove != nil {
+		p.remove()
+		p.remove = nil
+	}
+	p.releaseLease()
+}
+
+// storePreparedSnapshot keeps at most one staged rootfs per normalized image.
+// A newer preparation supersedes an abandoned one and cleans it immediately.
+func (c *Client) storePreparedSnapshot(imageName string, prepared *preparedSnapshot) {
+	c.preparedSnapshotsMu.Lock()
+	if c.preparedSnapshots == nil {
+		c.preparedSnapshots = make(map[string]*preparedSnapshot)
+	}
+	old := c.preparedSnapshots[imageName]
+	c.preparedSnapshots[imageName] = prepared
+	c.preparedSnapshotsMu.Unlock()
+	old.discard()
+}
+
+// takePreparedSnapshot transfers single-use ownership to the create path. A
+// parent mismatch means the image name was repointed after preparation; discard
+// the stale rootfs and let create use the normal path.
+func (c *Client) takePreparedSnapshot(imageName, parent string) *preparedSnapshot {
+	c.preparedSnapshotsMu.Lock()
+	prepared := c.preparedSnapshots[imageName]
+	delete(c.preparedSnapshots, imageName)
+	c.preparedSnapshotsMu.Unlock()
+	if prepared != nil && prepared.parent != parent {
+		prepared.discard()
+		return nil
+	}
+	return prepared
+}
+
+func (c *Client) discardAllPreparedSnapshots() {
+	c.preparedSnapshotsMu.Lock()
+	all := c.preparedSnapshots
+	c.preparedSnapshots = make(map[string]*preparedSnapshot)
+	c.preparedSnapshotsMu.Unlock()
+	for _, prepared := range all {
+		prepared.discard()
+	}
+}

--- a/go/internal/agent/containerd/prepared_snapshot_test.go
+++ b/go/internal/agent/containerd/prepared_snapshot_test.go
@@ -1,0 +1,56 @@
+package containerd
+
+import "testing"
+
+func trackedPrepared(key, parent string, removed, released *int) *preparedSnapshot {
+	return &preparedSnapshot{
+		key: key, parent: parent,
+		remove:  func() { *removed++ },
+		release: func() { *released++ },
+	}
+}
+
+func TestPreparedSnapshotConsumedExactlyOnce(t *testing.T) {
+	c := &Client{}
+	removed, released := 0, 0
+	p := trackedPrepared("fresh", "chain", &removed, &released)
+	c.storePreparedSnapshot("demo:latest", p)
+
+	if got := c.takePreparedSnapshot("demo:latest", "chain"); got != p {
+		t.Fatalf("take = %p, want %p", got, p)
+	}
+	if got := c.takePreparedSnapshot("demo:latest", "chain"); got != nil {
+		t.Fatalf("second take = %#v, want nil", got)
+	}
+	p.releaseLease()
+	if removed != 0 || released != 1 {
+		t.Fatalf("removed=%d released=%d, want 0/1", removed, released)
+	}
+}
+
+func TestPreparedSnapshotReplacementAndMismatchDiscard(t *testing.T) {
+	c := &Client{}
+	removed, released := 0, 0
+	c.storePreparedSnapshot("demo:latest", trackedPrepared("old", "old-chain", &removed, &released))
+	c.storePreparedSnapshot("demo:latest", trackedPrepared("new", "new-chain", &removed, &released))
+	if removed != 1 || released != 1 {
+		t.Fatalf("replacement cleanup removed=%d released=%d, want 1/1", removed, released)
+	}
+	if got := c.takePreparedSnapshot("demo:latest", "different-chain"); got != nil {
+		t.Fatalf("mismatched take = %#v, want nil", got)
+	}
+	if removed != 2 || released != 2 {
+		t.Fatalf("mismatch cleanup removed=%d released=%d, want 2/2", removed, released)
+	}
+}
+
+func TestPreparedSnapshotCloseDiscardsAll(t *testing.T) {
+	c := &Client{}
+	removed, released := 0, 0
+	c.storePreparedSnapshot("one:latest", trackedPrepared("one", "chain", &removed, &released))
+	c.storePreparedSnapshot("two:latest", trackedPrepared("two", "chain", &removed, &released))
+	c.discardAllPreparedSnapshots()
+	if removed != 2 || released != 2 {
+		t.Fatalf("close cleanup removed=%d released=%d, want 2/2", removed, released)
+	}
+}

--- a/go/internal/agent/containerd/prepared_snapshot_test.go
+++ b/go/internal/agent/containerd/prepared_snapshot_test.go
@@ -5,8 +5,8 @@ import "testing"
 func trackedPrepared(key, parent string, removed, released *int) *preparedSnapshot {
 	return &preparedSnapshot{
 		key: key, parent: parent,
-		remove:  func() { *removed++ },
-		release: func() { *released++ },
+		remove:  func() { (*removed)++ },
+		release: func() { (*released)++ },
 	}
 }
 


### PR DESCRIPTION
## Summary

Stage a pristine writable rootfs snapshot during `PrepareImage`, then consume it
exactly once when the container is created.

This moves the final snapshotter `Prepare` call out of the replace/start critical
path. Immutable image-layer snapshots continue to use the existing cache. The
staged writable snapshot is fresh and has never backed a task, so application
filesystem mutations cannot leak between deployments.

Preparation is best-effort: a missing, mismatched, expired, or failed staged
snapshot falls back to `WithNewSnapshot`. Superseded and abandoned snapshots are
leased, bounded, and cleaned on replacement or client close.

## Stack

Depends on #1806 (runtime fingerprint correctness prerequisite).

## Tests

- Single-use consumption
- Replacement/mismatch cleanup
- Client-close cleanup
- Containerd preparation tests under the race detector
- `go vet ./go/internal/agent/containerd`
