### PR TITLE
feat(cli): support interleaved native copy layers

### DIFF
--- a/go/internal/cli/commands/nativelayers.go
+++ b/go/internal/cli/commands/nativelayers.go
@@ -172,12 +172,15 @@ const nativeStateName = "state.json"
 
 // nativeState records the native path's ground truth: the deps-input hash the
 // current layout was built against, the manifest we last wrote (or adopted),
-// and OUR app-layer digests in copy-entry order. A later run may go native
-// only when all three still match reality.
+// and our app-layer digests plus exact manifest positions in copy-entry order.
+// Positions make the instruction mapping explicit: digest-only replacement is ambiguous when an
+// identical layer blob appears more than once in an image. A later run may go
+// native only when all of this state still matches reality.
 type nativeState struct {
-	DepsHash        string   `json:"deps_hash"`
-	ManifestDigest  string   `json:"manifest_digest"`
-	AppLayerDigests []string `json:"app_layer_digests"`
+	DepsHash          string   `json:"deps_hash"`
+	ManifestDigest    string   `json:"manifest_digest"`
+	AppLayerDigests   []string `json:"app_layer_digests"`
+	AppLayerPositions []int    `json:"app_layer_positions"`
 }
 
 // loadNativeState returns the recorded state, or (nil, false) on any miss or
@@ -191,8 +194,14 @@ func loadNativeState(dir string) (*nativeState, bool) {
 	if err := json.Unmarshal(data, &s); err != nil {
 		return nil, false
 	}
-	if s.DepsHash == "" || s.ManifestDigest == "" || len(s.AppLayerDigests) == 0 {
+	if s.DepsHash == "" || s.ManifestDigest == "" || len(s.AppLayerDigests) == 0 ||
+		len(s.AppLayerPositions) != len(s.AppLayerDigests) {
 		return nil, false
+	}
+	for i, pos := range s.AppLayerPositions {
+		if pos < 0 || (i > 0 && pos <= s.AppLayerPositions[i-1]) {
+			return nil, false
+		}
 	}
 	return &s, true
 }
@@ -231,9 +240,10 @@ const nativeLayersEnv = "WENDY_NATIVE_LAYERS"
 // nativeBuildEligibility decides whether this build may use the native
 // app-layer path. All must hold: the resolved dockerfile is the compiled
 // Stagefile output, the Stagefile parses, the final stage does not compile
-// (`build:`), it has at least one `from: local` copy, and every local copy
-// comes after all cross-stage copies — the local copies must be the image's
-// LAST layers for the adoption mapping to hold.
+// (`build:`), and it has at least one `from: local` copy. Local and cross-stage
+// copies may be interleaved: the compiler emits every final-stage copy as the
+// final ordered filesystem-layer sequence, so adoption can map local entries
+// to their exact positions within that sequence.
 func nativeBuildEligibility(cwd, dockerfile string) (*spec.File, bool) {
 	if os.Getenv(nativeLayersEnv) == "off" {
 		return nil, false
@@ -258,12 +268,6 @@ func nativeBuildEligibility(cwd, dockerfile string) (*spec.File, bool) {
 	for _, c := range final.Copy {
 		if c.From == "local" {
 			locals++
-			continue
-		}
-		if locals > 0 {
-			// A cross-stage copy after a local one breaks the "local copies are
-			// the last layers" invariant.
-			return nil, false
 		}
 	}
 	if locals == 0 {
@@ -398,14 +402,14 @@ func writeLayoutBlob(dir string, data []byte) (string, error) {
 }
 
 // spliceNativeLayers rewrites the layout dir's image for the target platform:
-// the layers whose digests are `replace` (matched BY DIGEST, in order) become
-// `with`, the config's rootfs.diff_ids follow 1:1, and index.json atomically
-// points at the rewritten manifest (any attestation entries are dropped —
+// the layers at `positions` become `with` after their current digests are
+// verified against `replace`; the config's rootfs.diff_ids follow 1:1, and
+// index.json atomically points at the rewritten manifest (any attestation entries are dropped —
 // provenance no longer describes the spliced image). Superseded blobs stay on
 // disk for the deploy-time GC. Returns the new manifest digest.
-func spliceNativeLayers(dir, platform string, replace []string, with []*nativeLayer) (string, error) {
-	if len(replace) != len(with) {
-		return "", fmt.Errorf("splice: %d digests to replace but %d layers given", len(replace), len(with))
+func spliceNativeLayers(dir, platform string, positions []int, replace []string, with []*nativeLayer) (string, error) {
+	if len(positions) != len(replace) || len(replace) != len(with) {
+		return "", fmt.Errorf("splice: %d positions, %d digests, and %d layers given", len(positions), len(replace), len(with))
 	}
 	manifestData, _, err := ociLayoutDirManifest(dir, platform)
 	if err != nil {
@@ -434,17 +438,16 @@ func spliceNativeLayers(dir, platform string, replace []string, with []*nativeLa
 		return "", fmt.Errorf("splice: config diff_ids (%d) do not align with manifest layers (%d)", len(diffIDs), len(m.Layers))
 	}
 
-	// Locate every replace digest, in order.
-	positions := make([]int, 0, len(replace))
-	next := 0
-	for i := range m.Layers {
-		if next < len(replace) && m.Layers[i].Digest == replace[next] {
-			positions = append(positions, i)
-			next++
+	for i, pos := range positions {
+		if pos < 0 || pos >= len(m.Layers) {
+			return "", fmt.Errorf("splice: layer position %d is outside manifest with %d layers", pos, len(m.Layers))
 		}
-	}
-	if next != len(replace) {
-		return "", fmt.Errorf("splice: layer %q not found in manifest", replace[next])
+		if i > 0 && pos <= positions[i-1] {
+			return "", fmt.Errorf("splice: layer positions must be strictly increasing")
+		}
+		if m.Layers[pos].Digest != replace[i] {
+			return "", fmt.Errorf("splice: layer at position %d is %q, want %q", pos, m.Layers[pos].Digest, replace[i])
+		}
 	}
 
 	for j, pos := range positions {
@@ -513,6 +516,33 @@ func spliceNativeLayers(dir, platform string, replace []string, with []*nativeLa
 		return "", err
 	}
 	return manifestDigest, nil
+}
+
+// nativeAppLayerPositions maps final-stage local copy entries to manifest
+// positions. With no final-stage build step, codegen emits the complete copy:
+// list as the image's final ordered filesystem-layer sequence. Counting the
+// whole list, rather than only local entries, permits local and cross-stage
+// copies to be interleaved without guessing which descriptors belong to us.
+func nativeAppLayerPositions(manifestLayers int, sf *spec.File) ([]int, bool) {
+	if len(sf.Stages) == 0 {
+		return nil, false
+	}
+	final := sf.Stages[len(sf.Stages)-1]
+	if final.Build != nil {
+		return nil, false
+	}
+	copies := final.Copy
+	if len(copies) == 0 || manifestLayers < len(copies) {
+		return nil, false
+	}
+	base := manifestLayers - len(copies)
+	positions := make([]int, 0, len(copies))
+	for i, entry := range copies {
+		if entry.From == "local" {
+			positions = append(positions, base+i)
+		}
+	}
+	return positions, len(positions) > 0
 }
 
 // nativeAppCopyEntries returns the final stage's `from: local` copy entries —
@@ -603,9 +633,9 @@ func nativeNonDirNames(l *nativeLayer) map[string]bool {
 
 // adoptNativeLayers runs after a successful buildx build of an eligible
 // project: it rebuilds each final-stage local copy entry natively, sanity
-// checks the manifest's LAST M layers against them (the file-name sets must
-// match — this is the one place the position→instruction assumption is
-// trusted, and only under verification), splices, and records state. Returns
+// maps them into the final stage's complete copy-layer tail, checks the mapped
+// layers against them (the file-name sets must match), splices, and records
+// the verified positions. Returns
 // false with no error when the check rejects; the buildx layers then ship
 // as-is and the native path stays disabled until the next buildx build.
 func adoptNativeLayers(dir, platform, cwd string, sf *spec.File, depsHash string) (bool, error) {
@@ -621,7 +651,8 @@ func adoptNativeLayers(dir, platform, cwd string, sf *spec.File, depsHash string
 	if err := json.Unmarshal(manifestData, &m); err != nil {
 		return false, nil
 	}
-	if len(m.Layers) < len(entries) {
+	positions, ok := nativeAppLayerPositions(len(m.Layers), sf)
+	if !ok || len(positions) != len(entries) {
 		return false, nil
 	}
 	cfgHex, err := digestToHex(m.Config.Digest)
@@ -638,28 +669,28 @@ func adoptNativeLayers(dir, platform, cwd string, sf *spec.File, depsHash string
 		return false, nil
 	}
 
-	base := len(m.Layers) - len(entries)
 	replace := make([]string, len(entries))
 	for i, nl := range native {
-		got, err := layoutLayerFileNames(dir, m.Layers[base+i])
+		pos := positions[i]
+		got, err := layoutLayerFileNames(dir, m.Layers[pos])
 		if err != nil {
 			return false, nil
 		}
 		want := nativeNonDirNames(nl)
 		if len(got) != len(want) {
-			cliLogln("native layers: buildx layer %d file set differs from copy entry %d; keeping buildx layers", base+i, i)
+			cliLogln("native layers: buildx layer %d file set differs from copy entry %d; keeping buildx layers", pos, i)
 			return false, nil
 		}
 		for n := range want {
 			if !got[n] {
-				cliLogln("native layers: buildx layer %d is missing %q; keeping buildx layers", base+i, n)
+				cliLogln("native layers: buildx layer %d is missing %q; keeping buildx layers", pos, n)
 				return false, nil
 			}
 		}
-		replace[i] = m.Layers[base+i].Digest
+		replace[i] = m.Layers[pos].Digest
 	}
 
-	manifestDigest, err := spliceNativeLayers(dir, platform, replace, native)
+	manifestDigest, err := spliceNativeLayers(dir, platform, positions, replace, native)
 	if err != nil {
 		return false, err
 	}
@@ -668,9 +699,10 @@ func adoptNativeLayers(dir, platform, cwd string, sf *spec.File, depsHash string
 		digests[i] = nl.Digest
 	}
 	if err := saveNativeState(dir, nativeState{
-		DepsHash:        depsHash,
-		ManifestDigest:  manifestDigest,
-		AppLayerDigests: digests,
+		DepsHash:          depsHash,
+		ManifestDigest:    manifestDigest,
+		AppLayerDigests:   digests,
+		AppLayerPositions: positions,
 	}); err != nil {
 		return false, err
 	}
@@ -686,7 +718,8 @@ func tryNativeRebuild(dir, platform, cwd string, sf *spec.File, st *nativeState)
 		return false, nil
 	}
 	entries := nativeAppCopyEntries(sf)
-	if len(entries) == 0 || len(entries) != len(st.AppLayerDigests) {
+	if len(entries) == 0 || len(entries) != len(st.AppLayerDigests) ||
+		len(st.AppLayerPositions) != len(st.AppLayerDigests) {
 		return false, nil
 	}
 	cfgData, _, err := ociLayoutDirConfig(dir, platform)
@@ -710,7 +743,7 @@ func tryNativeRebuild(dir, platform, cwd string, sf *spec.File, st *nativeState)
 		// while invalidating mtimes and making an unchanged run look like work.
 		return true, nil
 	}
-	newDigest, err := spliceNativeLayers(dir, platform, st.AppLayerDigests, native)
+	newDigest, err := spliceNativeLayers(dir, platform, st.AppLayerPositions, st.AppLayerDigests, native)
 	if err != nil {
 		return false, nil
 	}
@@ -719,9 +752,10 @@ func tryNativeRebuild(dir, platform, cwd string, sf *spec.File, st *nativeState)
 		digests[i] = nl.Digest
 	}
 	if err := saveNativeState(dir, nativeState{
-		DepsHash:        st.DepsHash,
-		ManifestDigest:  newDigest,
-		AppLayerDigests: digests,
+		DepsHash:          st.DepsHash,
+		ManifestDigest:    newDigest,
+		AppLayerDigests:   digests,
+		AppLayerPositions: append([]int(nil), st.AppLayerPositions...),
 	}); err != nil {
 		return false, err
 	}

--- a/go/internal/cli/commands/nativelayers_test.go
+++ b/go/internal/cli/commands/nativelayers_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -327,16 +328,35 @@ func TestNativeStateRoundTrip(t *testing.T) {
 		t.Fatal("missing state must load as not-ok")
 	}
 	want := nativeState{
-		DepsHash:        "sha256:aaa",
-		ManifestDigest:  "sha256:bbb",
-		AppLayerDigests: []string{"sha256:ccc"},
+		DepsHash:          "sha256:aaa",
+		ManifestDigest:    "sha256:bbb",
+		AppLayerDigests:   []string{"sha256:ccc"},
+		AppLayerPositions: []int{2},
 	}
 	if err := saveNativeState(dir, want); err != nil {
 		t.Fatal(err)
 	}
 	got, ok := loadNativeState(dir)
-	if !ok || got.DepsHash != want.DepsHash || got.ManifestDigest != want.ManifestDigest || len(got.AppLayerDigests) != 1 || got.AppLayerDigests[0] != "sha256:ccc" {
+	if !ok || got.DepsHash != want.DepsHash || got.ManifestDigest != want.ManifestDigest || len(got.AppLayerDigests) != 1 || got.AppLayerDigests[0] != "sha256:ccc" || len(got.AppLayerPositions) != 1 || got.AppLayerPositions[0] != 2 {
 		t.Fatalf("round-trip mismatch: %+v ok=%v", got, ok)
+	}
+
+	for name, state := range map[string]nativeState{
+		"missing positions": {
+			DepsHash: "sha256:aaa", ManifestDigest: "sha256:bbb", AppLayerDigests: []string{"sha256:ccc"},
+		},
+		"duplicate positions": {
+			DepsHash: "sha256:aaa", ManifestDigest: "sha256:bbb", AppLayerDigests: []string{"sha256:ccc", "sha256:ddd"}, AppLayerPositions: []int{2, 2},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := saveNativeState(dir, state); err != nil {
+				t.Fatal(err)
+			}
+			if _, ok := loadNativeState(dir); ok {
+				t.Fatal("invalid position mapping must load as not-ok")
+			}
+		})
 	}
 
 	if err := os.WriteFile(filepath.Join(dir, "state.json"), []byte("{corrupt"), 0o600); err != nil {
@@ -405,6 +425,159 @@ func writeTwoLayerLayoutDir(t *testing.T, dir string, depsTar, appTar []byte, wo
 		"blobs/sha256/" + sha256Hex(appTar):  appTar,
 	})
 	return appDigest
+}
+
+// writeLayerLayoutDir builds a layout with an arbitrary ordered layer list and
+// aligned diff IDs. Layers are uncompressed tar blobs, which exercises the
+// same reader path as buildx's OCI exporter without making tests depend on
+// Docker.
+func writeLayerLayoutDir(t *testing.T, dir string, layerTars [][]byte, workingDir string) []string {
+	t.Helper()
+	digests := make([]string, len(layerTars))
+	diffIDs := make([]string, len(layerTars))
+	descs := make([]ociManifestDesc, len(layerTars))
+	entries := map[string][]byte{
+		"oci-layout": []byte(`{"imageLayoutVersion":"1.0.0"}`),
+	}
+	for i, layer := range layerTars {
+		digests[i] = "sha256:" + sha256Hex(layer)
+		diffIDs[i] = digests[i]
+		descs[i] = ociManifestDesc{
+			MediaType: "application/vnd.oci.image.layer.v1.tar",
+			Digest:    digests[i],
+			Size:      int64(len(layer)),
+		}
+		entries["blobs/sha256/"+sha256Hex(layer)] = layer
+	}
+	config, err := json.Marshal(map[string]any{
+		"architecture": "arm64",
+		"os":           "linux",
+		"config":       map[string]any{"WorkingDir": workingDir},
+		"rootfs":       map[string]any{"type": "layers", "diff_ids": diffIDs},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	configDigest := "sha256:" + sha256Hex(config)
+	manifest, err := json.Marshal(ociManifest{
+		SchemaVersion: 2,
+		MediaType:     "application/vnd.oci.image.manifest.v1+json",
+		Config: ociManifestDesc{
+			MediaType: "application/vnd.oci.image.config.v1+json",
+			Digest:    configDigest,
+			Size:      int64(len(config)),
+		},
+		Layers: descs,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestDigest := "sha256:" + sha256Hex(manifest)
+	index, err := json.Marshal(map[string]any{
+		"schemaVersion": 2,
+		"manifests": []map[string]any{{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest":    manifestDigest,
+			"size":      len(manifest),
+			"platform":  map[string]any{"os": "linux", "architecture": "arm64"},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries["index.json"] = index
+	entries["blobs/sha256/"+sha256Hex(config)] = config
+	entries["blobs/sha256/"+sha256Hex(manifest)] = manifest
+	writeOCILayoutDir(t, dir, entries)
+	return digests
+}
+
+func TestNativeAppLayerPositions(t *testing.T) {
+	sf := &spec.File{Stages: []spec.Stage{{Copy: []spec.CopyEntry{
+		{From: "local", Paths: []string{"a"}},
+		{From: "builder", Paths: []string{"/out"}},
+		{From: "local", Paths: []string{"b"}},
+	}}}}
+	got, ok := nativeAppLayerPositions(7, sf)
+	if !ok || len(got) != 2 || got[0] != 4 || got[1] != 6 {
+		t.Fatalf("nativeAppLayerPositions = %v, %v; want [4 6], true", got, ok)
+	}
+	if _, ok := nativeAppLayerPositions(2, sf); ok {
+		t.Fatal("a manifest shorter than the complete final copy list must be rejected")
+	}
+	sf.Stages[0].Build = &spec.Build{Lang: "go"}
+	if _, ok := nativeAppLayerPositions(7, sf); ok {
+		t.Fatal("a final-stage build after copy layers must be rejected")
+	}
+}
+
+func TestAdoptNativeLayersInterleavedWithStageCopies(t *testing.T) {
+	proj := t.TempDir()
+	writeFile(t, proj, "a.txt", "a-v1\n")
+	writeFile(t, proj, "b.txt", "b-v1\n")
+	sf := &spec.File{Version: 1, Stages: []spec.Stage{
+		{Name: "builder", From: "debian:12"},
+		{Name: "app", From: "debian:12", Copy: []spec.CopyEntry{
+			{From: "local", Paths: []string{"a.txt"}, Dest: "app/"},
+			{From: "builder", Paths: []string{"/out"}, Dest: "/runtime/out"},
+			{From: "local", Paths: []string{"b.txt"}, Dest: "app/"},
+		}},
+	}}
+
+	baseTar := tarBytes(t, map[string]string{"usr/lib/base": "base"})
+	aTar := tarBytes(t, map[string]string{"app/": "", "app/a.txt": "a-v1\n"})
+	bTar := tarBytes(t, map[string]string{"app/": "", "app/b.txt": "b-v1\n"})
+	// Deliberately duplicate the following local layer blob. Digest-only
+	// splicing would find this cross-stage layer first and replace the wrong
+	// descriptor; explicit instruction positions must leave it untouched.
+	crossStageTar := bTar
+	dir := t.TempDir()
+	original := writeLayerLayoutDir(t, dir, [][]byte{baseTar, aTar, crossStageTar, bTar}, "/")
+
+	ok, err := adoptNativeLayers(dir, "linux/arm64", proj, sf, "sha256:deps1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("adoption should accept verified local copies interleaved with stage copies")
+	}
+	st, stateOK := loadNativeState(dir)
+	if !stateOK || len(st.AppLayerPositions) != 2 || st.AppLayerPositions[0] != 1 || st.AppLayerPositions[1] != 3 {
+		t.Fatalf("state positions = %+v, ok=%v; want [1 3]", st, stateOK)
+	}
+	layers, _, err := readOCILayoutDirLayers(dir, "linux/arm64")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if layers[0].Digest != original[0] || layers[2].Digest != original[2] {
+		t.Fatal("adoption changed a base or interleaved cross-stage layer")
+	}
+	if layers[1].Digest == original[1] || layers[3].Digest == original[3] {
+		t.Fatal("adoption did not replace both mapped local-copy layers")
+	}
+
+	firstNative := layers[1].Digest
+	writeFile(t, proj, "b.txt", "b-v2\n")
+	rebuilt, err := tryNativeRebuild(dir, "linux/arm64", proj, sf, st)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rebuilt {
+		t.Fatal("interleaved local copies should rebuild without buildx")
+	}
+	layers, _, err = readOCILayoutDirLayers(dir, "linux/arm64")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if layers[0].Digest != original[0] || layers[2].Digest != original[2] {
+		t.Fatal("native rebuild changed a base or interleaved cross-stage layer")
+	}
+	if layers[1].Digest != firstNative {
+		t.Fatal("unchanged first local-copy layer changed")
+	}
+	if layers[3].Digest == st.AppLayerDigests[1] {
+		t.Fatal("edited second local-copy layer did not change")
+	}
 }
 
 func TestAdoptAndSpliceNativeLayers(t *testing.T) {
@@ -656,11 +829,11 @@ func TestNativeBuildEligibility(t *testing.T) {
 		}
 	})
 
-	t.Run("local copy before a stage copy is ineligible", func(t *testing.T) {
+	t.Run("local copy before a stage copy is eligible", func(t *testing.T) {
 		dir := t.TempDir()
 		writeFile(t, dir, "build.stagefile.yaml", "version: 1\nstages:\n  - name: builder\n    from: golang:1\n    copy:\n      - from: local\n        paths: [main.go]\n  - name: app\n    from: debian:12\n    copy:\n      - from: local\n        paths: [main.go]\n      - from: builder\n        paths: [/out]\n        dest: /out\n")
-		if _, ok := nativeBuildEligibility(dir, "Dockerfile.generated"); ok {
-			t.Fatal("local copies must be the final layers to be eligible")
+		if _, ok := nativeBuildEligibility(dir, "Dockerfile.generated"); !ok {
+			t.Fatal("interleaved local and stage copies should be eligible")
 		}
 	})
 


### PR DESCRIPTION
## Summary

Extend Stagefile native app-layer rebuilding to support local COPY entries
interleaved with cross-stage COPY entries.

The implementation maps local copies to exact manifest positions, persists the
position with each digest, and revalidates position, digest, and exact non-directory
file set before every splice. This avoids digest-only ambiguity when identical
layer blobs occur more than once.

Invalid, ambiguous, stale, and older native state falls back to BuildKit. Final
stages containing `build:`/RUN remain ineligible; arbitrary command semantics are
not synthesized as tar layers.

## Tests

- Interleaved adoption and incremental rebuild
- Base/cross-stage layer preservation
- Duplicate-digest position safety
- State validation and fail-closed behavior
- Native tests under the race detector
- `go vet ./go/internal/cli/commands`
