### PR TITLE
perf(cli): add content-verified skipping to multi-service builds

### DIFF
--- a/go/internal/cli/commands/chunkpush_test.go
+++ b/go/internal/cli/commands/chunkpush_test.go
@@ -79,7 +79,7 @@ func TestChunkIndexProgressDoesNotReportPartialTotal(t *testing.T) {
 
 func TestComposeChunkProgressKeepsUploadVisible(t *testing.T) {
 	var events []tui.BuildStepEvent
-	w := &composeBuildProgressWriter{
+	w := &imageBuildProgressWriter{
 		Writer: io.Discard,
 		emit:   func(e tui.BuildStepEvent) { events = append(events, e) },
 	}

--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -44,6 +44,15 @@ func normalizeImageRef(ref string) string {
 	return reference.TagNameOnly(named).String()
 }
 
+func imageRefContentPinned(ref string) bool {
+	parsed, err := reference.ParseAnyReference(strings.TrimSpace(ref))
+	if err != nil {
+		return false
+	}
+	_, ok := parsed.(reference.Digested)
+	return ok
+}
+
 func composeServiceWatchHash(imageIdentity string, cfg *appconfig.AppConfig, cmd string, userArgs []string, restartPolicy *agentpb.RestartPolicy, env []string) (string, error) {
 	return watchDesiredHash(struct {
 		ImageIdentity string
@@ -126,7 +135,10 @@ type composeBuildJob struct {
 	buildArgs  map[string]string
 }
 
-type composeBuildProgressWriter struct {
+// imageBuildProgressWriter adapts the common chunk/preparation progress
+// callbacks and captures the prepared image identity for both Compose and
+// wendy.json multi-service schedulers.
+type imageBuildProgressWriter struct {
 	io.Writer
 	emit          func(tui.BuildStepEvent)
 	reportContent func([]string)
@@ -134,7 +146,7 @@ type composeBuildProgressWriter struct {
 	uploadStarted bool
 }
 
-func (w *composeBuildProgressWriter) emitEvent(e tui.BuildStepEvent) {
+func (w *imageBuildProgressWriter) emitEvent(e tui.BuildStepEvent) {
 	if w.emit != nil {
 		w.emit(e)
 	}
@@ -142,15 +154,15 @@ func (w *composeBuildProgressWriter) emitEvent(e tui.BuildStepEvent) {
 
 // ReportImageContent records the uncompressed identities of the image that was
 // prepared on the device. Keeping this on the same writer used for chunk
-// progress lets the Compose scheduler persist a fail-closed deploy fingerprint
-// without coupling its generic build function signature to OCI internals.
-func (w *composeBuildProgressWriter) ReportImageContent(diffIDs []string) {
+// progress lets both service schedulers persist a fail-closed deploy fingerprint
+// without coupling their generic build function signatures to OCI internals.
+func (w *imageBuildProgressWriter) ReportImageContent(diffIDs []string) {
 	if w.reportContent != nil {
 		w.reportContent(append([]string(nil), diffIDs...))
 	}
 }
 
-func (w *composeBuildProgressWriter) ReportChunkTransfer(current, total int64, rate float64) {
+func (w *imageBuildProgressWriter) ReportChunkTransfer(current, total int64, rate float64) {
 	w.progressMu.Lock()
 	defer w.progressMu.Unlock()
 	w.uploadStarted = true
@@ -163,7 +175,7 @@ func (w *composeBuildProgressWriter) ReportChunkTransfer(current, total int64, r
 	})
 }
 
-func (w *composeBuildProgressWriter) ReportChunkIndex(current, total int64, rate float64, done bool) {
+func (w *imageBuildProgressWriter) ReportChunkIndex(current, total int64, rate float64, done bool) {
 	status := tui.BuildStepRunning
 	if done {
 		status = tui.BuildStepDone
@@ -186,7 +198,7 @@ func (w *composeBuildProgressWriter) ReportChunkIndex(current, total int64, rate
 	})
 }
 
-func (w *composeBuildProgressWriter) ReportRegistryFallback(reason error) {
+func (w *imageBuildProgressWriter) ReportRegistryFallback(reason error) {
 	detail := "chunk preparation unavailable"
 	if reason != nil {
 		detail = fmt.Sprintf("chunk preparation unavailable: %v", reason)
@@ -200,7 +212,7 @@ func (w *composeBuildProgressWriter) ReportRegistryFallback(reason error) {
 	})
 }
 
-func (w *composeBuildProgressWriter) ReportImagePreparation() {
+func (w *imageBuildProgressWriter) ReportImagePreparation() {
 	w.emitEvent(tui.BuildStepEvent{
 		ID:      "image-prepare",
 		Kind:    tui.BuildVertexExport,
@@ -209,7 +221,7 @@ func (w *composeBuildProgressWriter) ReportImagePreparation() {
 	})
 }
 
-func (w *composeBuildProgressWriter) ReportImagePreparationQueued() {
+func (w *imageBuildProgressWriter) ReportImagePreparationQueued() {
 	w.emitEvent(tui.BuildStepEvent{
 		ID:      "image-prepare-queue",
 		Kind:    tui.BuildVertexExport,
@@ -321,7 +333,7 @@ func buildComposeServicesParallel(ctx context.Context, conn *grpcclient.AgentCon
 				buildOut = &logBuf
 				logOut = &logBuf
 			}
-			buildOut = &composeBuildProgressWriter{
+			buildOut = &imageBuildProgressWriter{
 				Writer: buildOut,
 				emit:   emit,
 				reportContent: func(ids []string) {
@@ -1275,6 +1287,7 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 
 		appCfg := svcCfgs[name]
 		imageIdentity := normalizeImageRef(svc.Image)
+		contentPinned := imageRefContentPinned(svc.Image)
 		if ctxDir != "" {
 			// Compile a Stagefile (or apply safe in-memory Dockerfile fixes) the
 			// same way the single-service path does — docker build itself knows
@@ -1291,6 +1304,10 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 			// directory rename changes the Compose repository even when its source
 			// bytes do not, so reusing the old preparation would be unsafe.
 			imageIdentity = fmt.Sprintf("localhost:%d/%s-%s:latest@%s", regPort, projectName, name, imageIdentity)
+			contentPinned, err = dockerfileBasesContentPinned(ctxDir, dockerfile)
+			if err != nil {
+				return fmt.Errorf("checking service %s base images: %w", name, err)
+			}
 		}
 
 		restartPolicy := resolveRestartPolicy(opts)
@@ -1299,7 +1316,7 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 		}
 		cmd, extraArgs := composeArgv(svc)
 		desiredHash, hashErr := composeServiceWatchHash(imageIdentity, appCfg, cmd, extraArgs, restartPolicy, composeEnv(svc))
-		if hashErr == nil {
+		if hashErr == nil && contentPinned {
 			desiredHashes[name] = desiredHash
 			candidates[name] = watchServiceCandidate{appID: appCfg.AppID, containerName: appCfg.ContainerName(), desiredHash: desiredHash}
 		}

--- a/go/internal/cli/commands/compose_test.go
+++ b/go/internal/cli/commands/compose_test.go
@@ -254,6 +254,18 @@ func TestComposeServiceWatchHashTracksCreateRequest(t *testing.T) {
 	}
 }
 
+func TestImageRefContentPinned(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("b", 64)
+	if !imageRefContentPinned("docker.io/library/alpine@" + digest) {
+		t.Fatal("digest-pinned image was not eligible")
+	}
+	for _, ref := range []string{"alpine", "alpine:3.20", "${IMAGE}", ""} {
+		if imageRefContentPinned(ref) {
+			t.Fatalf("mutable or invalid image %q was eligible", ref)
+		}
+	}
+}
+
 func TestPlanComposeBuildSkipsVerifiedUnchangedService(t *testing.T) {
 	isolateFingerprintCache(t)
 	const (

--- a/go/internal/cli/commands/deployfastpath.go
+++ b/go/internal/cli/commands/deployfastpath.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/distribution/reference"
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
@@ -234,6 +235,90 @@ func computeBuildInputHash(cwd, dockerfile, platform string, buildArgs map[strin
 	return "sha256:" + hex.EncodeToString(h.Sum(nil)), nil
 }
 
+// dockerfileBasesContentPinned is the fail-closed eligibility gate for a
+// persistent no-build skip. Old device content proves what was deployed, but
+// only digest-pinned external bases prove a rebuild would still resolve the
+// same inputs. scratch and references to prior named stages are also stable.
+func dockerfileBasesContentPinned(cwd, dockerfile string) (bool, error) {
+	dfPath := filepath.Join(cwd, "Dockerfile")
+	if dockerfile != "" {
+		resolved, err := confinedDockerfilePath(cwd, dockerfile)
+		if err != nil {
+			return false, err
+		}
+		dfPath = resolved
+	}
+	f, err := os.Open(dfPath)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	var logical strings.Builder
+	stages := make(map[string]struct{})
+	foundFrom := false
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		continued := strings.HasSuffix(line, "\\")
+		line = strings.TrimSpace(strings.TrimSuffix(line, "\\"))
+		if logical.Len() > 0 {
+			logical.WriteByte(' ')
+		}
+		logical.WriteString(line)
+		if continued {
+			continue
+		}
+
+		fields := strings.Fields(logical.String())
+		logical.Reset()
+		if len(fields) == 0 || !strings.EqualFold(fields[0], "FROM") {
+			continue
+		}
+		foundFrom = true
+		i := 1
+		for i < len(fields) && strings.HasPrefix(fields[i], "--") {
+			if !strings.Contains(fields[i], "=") {
+				return false, nil
+			}
+			i++
+		}
+		if i >= len(fields) {
+			return false, nil
+		}
+		base := fields[i]
+		_, priorStage := stages[strings.ToLower(base)]
+		if !strings.EqualFold(base, "scratch") && !priorStage {
+			parsed, parseErr := reference.ParseAnyReference(base)
+			if parseErr != nil {
+				return false, nil
+			}
+			if _, pinned := parsed.(reference.Digested); !pinned {
+				return false, nil
+			}
+		}
+		if i+2 < len(fields) && strings.EqualFold(fields[i+1], "AS") {
+			alias := strings.ToLower(fields[i+2])
+			if alias == "" || strings.HasPrefix(alias, "$") {
+				return false, nil
+			}
+			stages[alias] = struct{}{}
+		} else if i+1 != len(fields) {
+			return false, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return false, err
+	}
+	if logical.Len() != 0 {
+		return false, nil
+	}
+	return foundFrom, nil
+}
+
 // dockerIgnore is a conservative .dockerignore matcher. It only excludes a path
 // when a pattern confidently matches; negation (!) and patterns it cannot parse
 // are ignored, which keeps the matcher safe (it can only under-exclude, leading
@@ -449,13 +534,9 @@ func deviceHasAllLayers(ctx context.Context, conn *grpcclient.AgentConnection, d
 	if len(diffIDs) == 0 {
 		return false
 	}
-	resp, err := conn.ContainerService.QueryLayers(ctx, &agentpb.QueryLayersRequest{DiffIds: diffIDs})
-	if err != nil {
+	present, ok := devicePresentLayers(ctx, conn, diffIDs)
+	if !ok {
 		return false
-	}
-	present := make(map[string]bool, len(resp.GetPresent()))
-	for _, p := range resp.GetPresent() {
-		present[p.GetDiffId()] = true
 	}
 	for _, id := range diffIDs {
 		if !present[id] {
@@ -463,6 +544,25 @@ func deviceHasAllLayers(ctx context.Context, conn *grpcclient.AgentConnection, d
 		}
 	}
 	return true
+}
+
+// devicePresentLayers performs one fail-closed layer-presence query and returns
+// the confirmed set. Keeping the raw set available lets multi-service planners
+// batch every candidate service into one RPC instead of paying one round trip
+// per service. The bool is false for old agents and all other RPC failures.
+func devicePresentLayers(ctx context.Context, conn *grpcclient.AgentConnection, diffIDs []string) (map[string]bool, bool) {
+	if len(diffIDs) == 0 {
+		return nil, false
+	}
+	resp, err := conn.ContainerService.QueryLayers(ctx, &agentpb.QueryLayersRequest{DiffIds: diffIDs})
+	if err != nil {
+		return nil, false
+	}
+	present := make(map[string]bool, len(resp.GetPresent()))
+	for _, p := range resp.GetPresent() {
+		present[p.GetDiffId()] = true
+	}
+	return present, true
 }
 
 // lookupAppState queries the device for the running state of a single app.

--- a/go/internal/cli/commands/deployfastpath.go
+++ b/go/internal/cli/commands/deployfastpath.go
@@ -240,13 +240,12 @@ func computeBuildInputHash(cwd, dockerfile, platform string, buildArgs map[strin
 // only digest-pinned external bases prove a rebuild would still resolve the
 // same inputs. scratch and references to prior named stages are also stable.
 func dockerfileBasesContentPinned(cwd, dockerfile string) (bool, error) {
-	dfPath := filepath.Join(cwd, "Dockerfile")
-	if dockerfile != "" {
-		resolved, err := confinedDockerfilePath(cwd, dockerfile)
-		if err != nil {
-			return false, err
-		}
-		dfPath = resolved
+	if dockerfile == "" {
+		dockerfile = "Dockerfile"
+	}
+	dfPath, err := confinedDockerfilePath(cwd, dockerfile)
+	if err != nil {
+		return false, err
 	}
 	f, err := os.Open(dfPath)
 	if err != nil {

--- a/go/internal/cli/commands/deployfastpath_test.go
+++ b/go/internal/cli/commands/deployfastpath_test.go
@@ -66,6 +66,31 @@ func TestComputeBuildInputHash_BuildArgsAndDockerfile(t *testing.T) {
 	}
 }
 
+func TestDockerfileBasesContentPinned(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("a", 64)
+	for _, tt := range []struct {
+		name, dockerfile string
+		want             bool
+	}{
+		{name: "scratch", dockerfile: "FROM scratch\n", want: true},
+		{name: "pinned multistage", dockerfile: "FROM alpine@" + digest + " AS build\nFROM build\n", want: true},
+		{name: "mutable tag", dockerfile: "FROM alpine:3.20\n"},
+		{name: "arg base", dockerfile: "ARG BASE=alpine@" + digest + "\nFROM ${BASE}\n"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, dir, "Dockerfile", tt.dockerfile)
+			got, err := dockerfileBasesContentPinned(dir, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("dockerfileBasesContentPinned() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestComputeBuildInputHash_HonorsDockerignore(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "Dockerfile", "FROM python:3.11-slim\nCOPY app.py .\n")

--- a/go/internal/cli/commands/deployfastpath_test.go
+++ b/go/internal/cli/commands/deployfastpath_test.go
@@ -91,6 +91,20 @@ func TestDockerfileBasesContentPinned(t *testing.T) {
 	}
 }
 
+func TestDockerfileBasesContentPinned_ConfinesDefaultDockerfile(t *testing.T) {
+	outside := t.TempDir()
+	writeFile(t, outside, "Dockerfile", "FROM scratch\n")
+
+	dir := t.TempDir()
+	if err := os.Symlink(filepath.Join(outside, "Dockerfile"), filepath.Join(dir, "Dockerfile")); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := dockerfileBasesContentPinned(dir, ""); err == nil {
+		t.Fatal("expected default Dockerfile symlink outside project to be rejected")
+	}
+}
+
 func TestComputeBuildInputHash_HonorsDockerignore(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "Dockerfile", "FROM python:3.11-slim\nCOPY app.py .\n")

--- a/go/internal/cli/commands/deployskip_test.go
+++ b/go/internal/cli/commands/deployskip_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
@@ -54,6 +55,7 @@ type multiSvcContainerClient struct {
 	appName       string
 	services      []string
 	presentLayers map[string]bool
+	queryCalls    [][]string
 }
 
 func (f *multiSvcContainerClient) ListContainers(_ context.Context, _ *agentpb.ListContainersRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[agentpb.ListContainersResponse], error) {
@@ -67,6 +69,7 @@ func (f *multiSvcContainerClient) ListContainers(_ context.Context, _ *agentpb.L
 }
 
 func (f *multiSvcContainerClient) QueryLayers(_ context.Context, in *agentpb.QueryLayersRequest, _ ...grpc.CallOption) (*agentpb.QueryLayersResponse, error) {
+	f.queryCalls = append(f.queryCalls, append([]string(nil), in.GetDiffIds()...))
 	resp := &agentpb.QueryLayersResponse{}
 	for _, id := range in.GetDiffIds() {
 		if f.presentLayers[id] {
@@ -92,9 +95,8 @@ func writeServiceContext(t *testing.T, cwd, rel, platform string) string {
 // TestPlanServicePushSkips_MissingLayersForcesRebuild is the multi-service side
 // of WDY-1824: a service whose inputs are unchanged AND whose container is
 // present must still NOT be skipped when its recorded image content is not
-// confirmed on the device. Here the fingerprint carries diff IDs (the state a
-// future content-verifiable multi-service push would produce) but the device no
-// longer holds them.
+// confirmed on the device. Here the fingerprint carries the diff IDs recorded
+// by the chunk-preparation path, but the device no longer holds them.
 func TestPlanServicePushSkips_MissingLayersForcesRebuild(t *testing.T) {
 	isolateFingerprintCache(t)
 
@@ -124,17 +126,14 @@ func TestPlanServicePushSkips_MissingLayersForcesRebuild(t *testing.T) {
 	}
 }
 
-// TestPlanServicePushSkips_RegistryPushNeverSkips pins the current, deliberate
-// behavior of the multi-service (registry-push) path: even when inputs are
+// TestPlanServicePushSkips_RegistryPushNeverSkips pins the deliberate behavior
+// of --chunking=off's registry-push path: even when inputs are
 // unchanged and the container is present, the planner declines the skip because
 // it cannot confirm the device still holds the pushed content (WDY-1824).
 //
-// This is the reachable production state: runMultiServiceWithAgent saves
-// fingerprints via saveDeployFingerprint(...deployFingerprint{InputHash, AppVersion})
-// with NO layer diff IDs (the registry-push builder never surfaces device-verifiable
-// content identity), so contentPresentForService fails closed. Restoring the
-// WDY-1692 skip here needs the deferred registry-digest pre-check; when that
-// lands this test should flip to assert a skip.
+// The registry-push builder does not surface a device-verifiable content
+// identity, so contentPresentForService fails closed. Default chunk preparation
+// records layer diff IDs and can skip through the test below.
 func TestPlanServicePushSkips_RegistryPushNeverSkips(t *testing.T) {
 	isolateFingerprintCache(t)
 
@@ -164,11 +163,90 @@ func TestPlanServicePushSkips_RegistryPushNeverSkips(t *testing.T) {
 	}
 }
 
+func TestPlanServicePushSkipsBatchesLayerChecksAcrossServices(t *testing.T) {
+	isolateFingerprintCache(t)
+
+	const (
+		appID     = "grp"
+		deviceKey = "devkey"
+		platform  = "linux/arm64"
+		shared    = "sha256:shared"
+		apiLayer  = "sha256:api"
+		jobLayer  = "sha256:job"
+	)
+	cwd := t.TempDir()
+	apiHash := writeServiceContext(t, cwd, "api", platform)
+	jobHash := writeServiceContext(t, cwd, "job", platform)
+	saveDeployFingerprint(serviceFingerprintKey(appID, "api"), deviceKey, deployFingerprint{InputHash: apiHash, LayerDiffIDs: []string{shared, apiLayer}})
+	saveDeployFingerprint(serviceFingerprintKey(appID, "job"), deviceKey, deployFingerprint{InputHash: jobHash, LayerDiffIDs: []string{shared, jobLayer}})
+
+	services := map[string]*appconfig.ServiceConfig{
+		"api": {Context: "./api"},
+		"job": {Context: "./job"},
+	}
+	fake := &multiSvcContainerClient{
+		appName:       appID,
+		services:      []string{"api", "job"},
+		presentLayers: map[string]bool{shared: true, apiLayer: true, jobLayer: true},
+	}
+	conn := &grpcclient.AgentConnection{ContainerService: fake}
+
+	skip, _, _ := planServicePushSkips(context.Background(), conn, cwd, appID, deviceKey, platform, nil, services, nil)
+	if !skip["api"] || !skip["job"] {
+		t.Fatalf("skip = %v, want both services content-verified", skip)
+	}
+	if len(fake.queryCalls) != 1 {
+		t.Fatalf("QueryLayers called %d times, want one batched call", len(fake.queryCalls))
+	}
+	want := []string{apiLayer, jobLayer, shared}
+	slices.Sort(want)
+	if !slices.Equal(fake.queryCalls[0], want) {
+		t.Fatalf("QueryLayers diff IDs = %v, want de-duplicated %v", fake.queryCalls[0], want)
+	}
+}
+
+func TestRecordServiceDeployFingerprintsPersistsPreparedContentOnlyOnSuccess(t *testing.T) {
+	isolateFingerprintCache(t)
+
+	services := map[string]*appconfig.ServiceConfig{
+		"api":      {},
+		"failed":   {},
+		"registry": {},
+		"skipped":  {},
+	}
+	saveDeployFingerprint(serviceFingerprintKey("grp", "registry"), "device", deployFingerprint{
+		InputHash: "old-verifiable", LayerDiffIDs: []string{"sha256:old"},
+	})
+	recordServiceDeployFingerprints(
+		"grp", "1.2.3", "device", services,
+		map[string]bool{"skipped": true},
+		map[string]error{"failed": context.Canceled},
+		map[string]string{"api": "api-hash", "failed": "failed-hash", "registry": "registry-hash", "skipped": "skipped-hash"},
+		map[string][]string{"api": {"sha256:base", "sha256:api"}, "failed": {"sha256:partial"}},
+	)
+
+	fp, ok := loadDeployFingerprint(serviceFingerprintKey("grp", "api"), "device")
+	if !ok {
+		t.Fatal("successful service fingerprint was not persisted")
+	}
+	if fp.InputHash != "api-hash" || fp.AppVersion != "1.2.3" || !slices.Equal(fp.LayerDiffIDs, []string{"sha256:base", "sha256:api"}) {
+		t.Fatalf("successful fingerprint = %+v, want input/version/prepared diff IDs", fp)
+	}
+	for _, name := range []string{"failed", "skipped"} {
+		if _, ok := loadDeployFingerprint(serviceFingerprintKey("grp", name), "device"); ok {
+			t.Fatalf("%s service unexpectedly persisted a fingerprint", name)
+		}
+	}
+	registry, ok := loadDeployFingerprint(serviceFingerprintKey("grp", "registry"), "device")
+	if !ok || registry.InputHash != "old-verifiable" || !slices.Equal(registry.LayerDiffIDs, []string{"sha256:old"}) {
+		t.Fatalf("registry fallback overwrote verifiable fingerprint: %+v", registry)
+	}
+}
+
 // TestContentPresentForService_VerifiesRecordedLayers documents the content-
-// verification primitive itself: should a multi-service push ever record
-// device-verifiable layer diff IDs (e.g. a future chunk-diff-based push), a skip
-// is authorized only when the device confirms every one of them, and declined
-// when any is missing.
+// verification primitive itself: when chunk preparation records device-
+// verifiable layer diff IDs, a skip is authorized only when the device confirms
+// every one of them, and declined when any is missing.
 func TestContentPresentForService_VerifiesRecordedLayers(t *testing.T) {
 	const (
 		a = "sha256:aaaa"

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -106,10 +106,11 @@ func serviceTopoOrder(services map[string]*appconfig.ServiceConfig) ([]string, e
 	return appconfig.ServiceTopoOrder(services)
 }
 
-// buildServiceImage is the per-service build+push step. It is a package var so
-// stress/concurrency tests can substitute a fake builder and exercise the
-// parallel scheduling, skip handling, and failure-map collection without Docker.
-var buildServiceImage = buildAndPushImageForAgent
+// buildServiceImage is the default per-service build+prepare step. It shares
+// Compose's persistent OCI-layout/chunk path, including its registry fallback,
+// so successful builds can report device-verifiable layer diff IDs. It is a
+// package var so stress/concurrency tests can substitute a fake builder.
+var buildServiceImage = buildAndPrepareComposeImageForAgent
 
 // serviceGPUArch is the GPU architecture every service in a multi-service
 // project builds against: one device, so one answer, resolved once for the
@@ -138,8 +139,9 @@ const maxConcurrentPlans = 8
 // whether a service's build+push can be skipped: which build file it builds
 // from, and the hash of everything that could change its image.
 type servicePlan struct {
-	dockerfile string
-	inputHash  string
+	dockerfile    string
+	inputHash     string
+	contentPinned bool
 }
 
 // computeServicePlans resolves each service's build file and build-input hash.
@@ -176,9 +178,13 @@ func computeServicePlans(cwd, platform, gpuArch string, appCfg *appconfig.AppCon
 			if err != nil {
 				return
 			}
+			contentPinned, err := dockerfileBasesContentPinned(contextDir, dockerfile)
+			if err != nil {
+				return
+			}
 
 			mu.Lock()
-			plans[name] = servicePlan{dockerfile: dockerfile, inputHash: hash}
+			plans[name] = servicePlan{dockerfile: dockerfile, inputHash: hash, contentPinned: contentPinned}
 			mu.Unlock()
 		})
 	}
@@ -260,19 +266,6 @@ func deviceContainerNames(ctx context.Context, conn *grpcclient.AgentConnection)
 // never changes the input hash), so skipping on those alone could leave the
 // device running a stale/partial image while the CLI reports success.
 //
-// Content verification for the multi-service builder path is a known gap: these
-// services are built and pushed to the *device registry* (buildAndPushImageForAgent),
-// whose compressed layer blobs are keyed by compressed digest, so the diff-ID
-// QueryLayers check that guards the single-service chunk-diff fast path
-// (deviceHasAllLayers) can never confirm them. The WDY-1692 commit already
-// called this out ("a device-registry digest pre-check is a planned follow-up
-// for full robustness against a wiped registry") and it is tracked as the
-// WDY-1824 follow-up. Until that registry-digest RPC lands, contentPresent
-// fails closed for every registry-push service, so this path never skips — the
-// safe behavior, at the cost of re-pushing unchanged images (the WDY-1692
-// optimization stays dormant for multi-service, deliberately and visibly, not
-// via a silently-unsatisfiable diff-ID check).
-//
 // Best-effort throughout: any error for a service (or WENDY_PUSH_SKIP=0) just
 // means "don't skip it".
 //
@@ -291,6 +284,12 @@ func planServicePushSkips(ctx context.Context, conn *grpcclient.AgentConnection,
 
 	plans := computeServicePlans(cwd, platform, serviceGPUArch(ctx, cwd, services, conn), appCfg, services, buildArgs, sfOpts...)
 	present := deviceContainerNames(ctx, conn)
+	type candidate struct {
+		name string
+		fp   *deployFingerprint
+	}
+	var candidates []candidate
+	allDiffIDs := map[string]struct{}{}
 	for name := range services {
 		plan, planned := plans[name]
 		if !planned {
@@ -298,6 +297,12 @@ func planServicePushSkips(ctx context.Context, conn *grpcclient.AgentConnection,
 		}
 		hashes[name] = plan.inputHash
 		dockerfiles[name] = plan.dockerfile
+		if !plan.contentPinned {
+			// A mutable FROM tag must be resolved by a normal build. Presence of
+			// the last deployment's layers is not proof that tag is unchanged.
+			delete(hashes, name)
+			continue
+		}
 
 		fp, ok := loadDeployFingerprint(serviceFingerprintKey(appID, name), deviceKey)
 		if !ok || fp.InputHash != plan.inputHash {
@@ -306,29 +311,50 @@ func planServicePushSkips(ctx context.Context, conn *grpcclient.AgentConnection,
 		if !present[strings.ToLower(multiServiceContainerName(appID, name))] {
 			continue
 		}
-		// Container presence is not enough: confirm the device still holds the
-		// image content we pushed. Without this a skip can leave a stale/partial
-		// image running while we report success (WDY-1824).
-		if !contentPresentForService(ctx, conn, fp) {
+		if len(fp.LayerDiffIDs) == 0 {
 			continue
 		}
-		skip[name] = true
+		candidates = append(candidates, candidate{name: name, fp: fp})
+		for _, id := range fp.LayerDiffIDs {
+			allDiffIDs[id] = struct{}{}
+		}
+	}
+
+	// Container presence is not enough: confirm the device still holds the
+	// exact content we prepared. Query every candidate service in one RPC to
+	// avoid making push-skip latency scale with the service count.
+	ids := make([]string, 0, len(allDiffIDs))
+	for id := range allDiffIDs {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	confirmed, ok := devicePresentLayers(ctx, conn, ids)
+	if !ok {
+		return skip, hashes, dockerfiles
+	}
+	for _, candidate := range candidates {
+		allPresent := true
+		for _, id := range candidate.fp.LayerDiffIDs {
+			if !confirmed[id] {
+				allPresent = false
+				break
+			}
+		}
+		if allPresent {
+			skip[candidate.name] = true
+		}
 	}
 	return skip, hashes, dockerfiles
 }
 
 // contentPresentForService reports whether the device is confirmed to still hold
-// the image content recorded for a registry-push service, gating a push-skip
+// the image content recorded for a service, gating a push-skip
 // (WDY-1824).
 //
-// It is fail-closed. The multi-service builder pushes to the device registry,
-// whose layers the diff-ID QueryLayers check cannot see (compressed blobs are
-// keyed by compressed digest, not by uncompressed diff ID). So recorded layer
-// diff IDs are still verified via QueryLayers when present — a future
-// chunk-diff-based multi-service push would record verifiable IDs — but a
-// fingerprint without them (every registry push today) can never be confirmed
-// and returns false. Confirming registry-pushed content needs the device
-// registry-digest pre-check deferred from WDY-1692; see WDY-1824 follow-up.
+// It is fail-closed. The default chunk-preparation path records diff IDs that
+// QueryLayers can verify. Registry-only builds do not expose an equivalent
+// device-verifiable identity yet, so their fingerprints omit diff IDs and this
+// returns false.
 func contentPresentForService(ctx context.Context, conn *grpcclient.AgentConnection, fp *deployFingerprint) bool {
 	if fp == nil {
 		return false
@@ -390,9 +416,9 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	// to still hold. This is the WDY-1692 optimization (avoid re-pushing unchanged
 	// images — notably the multi-GB GPU base — and the HEAD-check storm re-push
 	// triggers), tightened for WDY-1824 so it never skips onto stale/partial
-	// content. NOTE: the registry-push builder path can't yet prove content
-	// presence, so this currently skips nothing for multi-service; see
-	// planServicePushSkips / contentPresentForService.
+	// content. The default builder now uses the same chunk-preparation path as
+	// Compose and records its layer diff IDs; registry-only builds continue to
+	// fail closed because they do not provide a verifiable content identity.
 	deviceKey := deviceFingerprintKey(versionResp)
 	sfOpts := debugStagefileOptions(opts.debug)
 	skip, hashes, dockerfiles := planServicePushSkips(ctx, conn, cwd, appCfg.AppID, deviceKey, platform, appCfg, services, buildArgs, sfOpts...)
@@ -443,22 +469,12 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	}
 
 	// Build all service images in parallel, then create and start containers.
-	failed, buildErr := buildServicesParallel(ctx, conn, regPort, agentOS, cwd, appCfg.AppID, services, platform, buildArgs, opts.builder, skip, dockerfiles, opts.maxConcurrency, opts.quietBuild, sfOpts...)
+	failed, preparedContent, buildErr := buildServicesParallelWithContent(ctx, conn, regPort, agentOS, cwd, appCfg.AppID, services, platform, buildArgs, opts.builder, opts.chunking, skip, dockerfiles, opts.maxConcurrency, opts.quietBuild, sfOpts...)
 	if buildErr != nil {
 		return buildErr
 	}
 
-	// Record fingerprints for the services we actually built+pushed, so the next
-	// run can skip them. Skipped services already have a matching fingerprint;
-	// failed services must not be recorded (their image isn't on the device).
-	for name := range services {
-		if skip[name] || failed[name] != nil {
-			continue
-		}
-		if h, ok := hashes[name]; ok {
-			saveDeployFingerprint(serviceFingerprintKey(appCfg.AppID, name), deviceKey, deployFingerprint{InputHash: h, AppVersion: appCfg.Version})
-		}
-	}
+	recordServiceDeployFingerprints(appCfg.AppID, appCfg.Version, deviceKey, services, skip, failed, hashes, preparedContent)
 
 	// Default (all-or-nothing): any build/push failure aborts the whole group so
 	// no half-deployed group is left behind. --keep-going deploys what built and
@@ -579,6 +595,27 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	// In --keep-going mode, exit non-zero after deploying the healthy subset so
 	// callers/CI still see that some services failed.
 	return partialErr
+}
+
+// recordServiceDeployFingerprints persists only successful build/preparations.
+// Skipped services retain their already-matching fingerprint; failed services
+// must never record content that may only have been partially transferred.
+func recordServiceDeployFingerprints(appID, appVersion, deviceKey string, services map[string]*appconfig.ServiceConfig, skip map[string]bool, failed map[string]error, hashes map[string]string, preparedContent map[string][]string) {
+	for name := range services {
+		if skip[name] || failed[name] != nil {
+			continue
+		}
+		// Registry-only/fallback builds do not surface device-verifiable diff
+		// IDs. Leave any existing verifiable fingerprint intact instead of
+		// replacing it with one that can never authorize a content check.
+		if h, ok := hashes[name]; ok && len(preparedContent[name]) > 0 {
+			saveDeployFingerprint(serviceFingerprintKey(appID, name), deviceKey, deployFingerprint{
+				InputHash:    h,
+				AppVersion:   appVersion,
+				LayerDiffIDs: preparedContent[name],
+			})
+		}
+	}
 }
 
 // droppedSummary formats the services skipped because a dependency failed, for
@@ -802,9 +839,9 @@ func buildServicesParallelCore(
 	return failed, nil
 }
 
-// buildServicesParallel is the push-destination flavor of
-// buildServicesParallelCore: it builds and pushes each service's image to the
-// device registry, via the buildServiceImage seam.
+// buildServicesParallel is retained as the test/build scheduling seam. Normal
+// multi-service runs use buildServicesParallelWithContent so successful chunk
+// preparations can persist their exact image identities.
 func buildServicesParallel(
 	ctx context.Context,
 	conn *grpcclient.AgentConnection,
@@ -821,15 +858,71 @@ func buildServicesParallel(
 	quietBuild bool,
 	sfOpts ...stagefile.Option,
 ) (map[string]error, error) {
+	failed, _, err := buildServicesParallelWithContent(ctx, conn, regPort, agentOS, cwd, appID, services, platform, buildArgs, builder, chunkingAuto, skip, dockerfiles, maxConcurrency, quietBuild, sfOpts...)
+	return failed, err
+}
+
+// buildServicesParallelWithContent builds each service using the same
+// OCI-layout/chunk preparation path as Compose and returns the uncompressed
+// layer identities reported by successful preparations. --chunking=off keeps
+// the registry-only path; because it cannot currently report a device-
+// verifiable identity, its content result is deliberately empty and subsequent
+// skip checks fail closed.
+func buildServicesParallelWithContent(
+	ctx context.Context,
+	conn *grpcclient.AgentConnection,
+	regPort int,
+	agentOS string,
+	cwd, appID string,
+	services map[string]*appconfig.ServiceConfig,
+	platform string,
+	buildArgs map[string]string,
+	builder, chunking string,
+	skip map[string]bool,
+	dockerfiles map[string]string,
+	maxConcurrency int,
+	quietBuild bool,
+	sfOpts ...stagefile.Option,
+) (map[string]error, map[string][]string, error) {
 	// Resolved once for the group: every service deploys to this one device,
 	// so they share its GPU architecture.
 	gpuArch := serviceGPUArch(ctx, cwd, services, conn)
 
+	content := map[string][]string{}
+	var contentMu sync.Mutex
 	build := func(ctx context.Context, contextDir, repo, dockerfile string, buildOut, logOut io.Writer) error {
-		return buildServiceImage(ctx, conn, regPort, agentOS, builder, contextDir, repo, platform, dockerfile, buildArgs, repo, buildOut, logOut)
+		buildImage := buildServiceImage
+		if chunking == chunkingOff {
+			buildImage = buildAndPushImageForAgent
+		} else if chunking == chunkingForce {
+			buildImage = buildAndPrepareComposeImageForAgentForce
+		}
+		reportingOut := &imageBuildProgressWriter{
+			Writer: buildOut,
+			reportContent: func(ids []string) {
+				contentMu.Lock()
+				content[repo] = ids
+				contentMu.Unlock()
+			},
+		}
+		return buildImage(ctx, conn, regPort, agentOS, builder, contextDir, repo, platform, dockerfile, buildArgs, repo, reportingOut, logOut)
 	}
 
-	return buildServicesParallelCore(ctx, build, cwd, appID, services, gpuArch, skip, dockerfiles, maxConcurrency, quietBuild, sfOpts...)
+	failed, err := buildServicesParallelCore(withComposePrepareLimiter(ctx), build, cwd, appID, services, gpuArch, skip, dockerfiles, maxConcurrency, quietBuild, sfOpts...)
+	if err != nil {
+		return failed, nil, err
+	}
+	byService := make(map[string][]string, len(content))
+	for name := range services {
+		if failed[name] != nil || skip[name] {
+			continue
+		}
+		repo := fmt.Sprintf("%s-%s", strings.ToLower(appID), strings.ToLower(name))
+		if ids := content[repo]; len(ids) > 0 {
+			byService[name] = append([]string(nil), ids...)
+		}
+	}
+	return failed, byService, nil
 }
 
 // buildServicesLocal builds every service image into the local image store

--- a/go/internal/cli/commands/multibuild_test.go
+++ b/go/internal/cli/commands/multibuild_test.go
@@ -187,6 +187,62 @@ func TestBuildServicesParallelReusesPlannedDockerfile(t *testing.T) {
 	}
 }
 
+func TestBuildServicesParallelWithContentReportsPreparedLayers(t *testing.T) {
+	root, services := newServiceTree(t, 2)
+	planned := map[string]string{"svc00": "Dockerfile", "svc01": "Dockerfile"}
+
+	originalBuild := buildServiceImage
+	t.Cleanup(func() { buildServiceImage = originalBuild })
+	buildServiceImage = func(_ context.Context, _ *grpcclient.AgentConnection, _ int, _, _, _, repo, _, _ string, _ map[string]string, _ string, stream, _ io.Writer) error {
+		reporter, ok := stream.(interface{ ReportImageContent([]string) })
+		if !ok {
+			return fmt.Errorf("build output for %s cannot report image content", repo)
+		}
+		reporter.ReportImageContent([]string{"sha256:" + repo})
+		return nil
+	}
+
+	failed, content, err := buildServicesParallelWithContent(
+		context.Background(), nil, 5000, "linux", root, "app", services,
+		"linux/arm64", nil, "docker", chunkingAuto, nil, planned, 2, true)
+	if err != nil {
+		t.Fatalf("buildServicesParallelWithContent: %v", err)
+	}
+	if len(failed) != 0 {
+		t.Fatalf("failed = %v, want none", failed)
+	}
+	for name := range services {
+		want := "sha256:app-" + name
+		if got := content[name]; len(got) != 1 || got[0] != want {
+			t.Errorf("content[%s] = %v, want [%s]", name, got, want)
+		}
+	}
+}
+
+func TestBuildServicesParallelWithContentDropsFailedBuildIdentity(t *testing.T) {
+	root, services := newServiceTree(t, 1)
+	originalBuild := buildServiceImage
+	t.Cleanup(func() { buildServiceImage = originalBuild })
+	buildServiceImage = func(_ context.Context, _ *grpcclient.AgentConnection, _ int, _, _, _, _ string, _ string, _ string, _ map[string]string, _ string, stream, _ io.Writer) error {
+		stream.(interface{ ReportImageContent([]string) }).ReportImageContent([]string{"sha256:partial"})
+		return errors.New("prepare failed")
+	}
+
+	failed, content, err := buildServicesParallelWithContent(
+		context.Background(), nil, 5000, "linux", root, "app", services,
+		"linux/arm64", nil, "docker", chunkingAuto, nil,
+		map[string]string{"svc00": "Dockerfile"}, 1, true)
+	if err != nil {
+		t.Fatalf("buildServicesParallelWithContent infrastructure error: %v", err)
+	}
+	if failed["svc00"] == nil {
+		t.Fatal("failed build missing from failure map")
+	}
+	if len(content) != 0 {
+		t.Fatalf("content = %v, want none for failed build", content)
+	}
+}
+
 func TestBuildServicesParallelCancellationStopsActiveAndQueuedBuilds(t *testing.T) {
 	root, services := newServiceTree(t, 4)
 	planned := make(map[string]string, len(services))


### PR DESCRIPTION
## Summary

Give regular `wendy.json` multi-service deployments the same content-verified
push skipping as Compose.

The default Docker path now uses the shared persistent OCI-layout/chunk-preparation
implementation and records ordered layer diff IDs after successful preparation.
On later runs, every candidate service is verified in one deduplicated
`QueryLayers` request before build/push is skipped.

Compatibility remains fail closed: old agents, RPC errors, missing layers,
registry-only mode, non-Docker builders, and failed/partial preparations all use
the normal build/push path and never persist an unverifiable identity.
Mutable Dockerfile bases and Compose image tags also rebuild normally; persistent
skipping requires digest-pinned external content (or `scratch`).

## Stack

Depends on #1810, which pipelines the shared deploy preflight operations.

## Tests

- Batched layer verification across services
- Successful-only fingerprint persistence
- Mutable-tag and digest-pinned eligibility
- Prepared-content propagation and failed-build suppression
- Focused tests under the race detector
- `go vet ./go/internal/cli/commands`

The full commands package still has the existing macOS `/private/var` versus
`/var` temporary-path assertion failure; the focused suite passes.
