### PR TITLE
perf(cli): pipeline deploy preflight probes

### DIFF
--- a/go/internal/cli/commands/chunkpush.go
+++ b/go/internal/cli/commands/chunkpush.go
@@ -294,21 +294,66 @@ func pushLayersByChunksWithStrictPrepareOutput(ctx context.Context, cs agentpb.W
 // pass nil prog and get their progress through output's optional
 // chunk*ProgressWriter interfaces instead; both sinks are nil-safe.
 func pushLayersByChunksWithPrepareMode(ctx context.Context, cs agentpb.WendyContainerServiceClient, layers []localLayer, prepare imagePrepareFunc, output io.Writer, strictPrepare bool, prog *chunkPushProgress) ([]*agentpb.RunContainerLayerHeader, error) {
+	return pushLayersByChunksWithPrepareModeAndCache(ctx, cs, layers, prepare, output, strictPrepare, prog, loadManifestCache)
+}
+
+type cachedManifestResult struct {
+	manifest *cachedManifest
+	found    bool
+}
+
+// pushLayersByChunksWithPrepareModeAndCache is split from the public call path
+// so tests can control cache-read timing without touching the process-global
+// cache directory. Cache reads are metadata-only: a miss never decompresses or
+// chunks a layer until QueryLayers has confirmed that the full layer is absent.
+func pushLayersByChunksWithPrepareModeAndCache(ctx context.Context, cs agentpb.WendyContainerServiceClient, layers []localLayer, prepare imagePrepareFunc, output io.Writer, strictPrepare bool, prog *chunkPushProgress, loadCache func(string) (*cachedManifest, bool)) ([]*agentpb.RunContainerLayerHeader, error) {
 	headers := make([]*agentpb.RunContainerLayerHeader, len(layers))
 
-	// Capability probe: a single empty QueryChunks tells us whether the agent
-	// supports chunk-diff at all BEFORE we decompress and chunk the first layer.
-	// An old agent returns Unimplemented, which bubbles up so deployByChunkDiff
-	// falls back to a registry push instead of wasting a layer's worth of work.
-	if _, err := cs.QueryChunks(ctx, &agentpb.QueryChunksRequest{}); err != nil {
+	// Start both remote preflight queries and local manifest-cache reads together.
+	// QueryChunks is the authoritative capability check: an old agent's
+	// Unimplemented error still bubbles up and triggers the registry fallback.
+	// QueryLayers remains optional and fails closed to chunking every layer.
+	// Only cache metadata is touched here; expensive decompression stays behind
+	// the layer-presence result below.
+	var (
+		present   map[string]int64
+		preloaded = make([]cachedManifestResult, len(layers))
+	)
+	preflightCtx, cancelPreflight := context.WithCancel(ctx)
+	defer cancelPreflight()
+	capabilityDone := make(chan error, 1)
+	go func() {
+		_, err := cs.QueryChunks(preflightCtx, &agentpb.QueryChunksRequest{})
+		capabilityDone <- err
+	}()
+	layersDone := make(chan map[string]int64, 1)
+	go func() {
+		layersDone <- queryPresentLayers(preflightCtx, cs, layers, output)
+	}()
+	cacheDone := make(chan struct{})
+	go func() {
+		defer close(cacheDone)
+		var cacheGroup errgroup.Group
+		cacheGroup.SetLimit(maxConcurrentLayerPush)
+		for i, l := range layers {
+			i, digest := i, l.Digest
+			cacheGroup.Go(func() error {
+				if preflightCtx.Err() != nil {
+					return nil
+				}
+				preloaded[i].manifest, preloaded[i].found = loadCache(digest)
+				return nil
+			})
+		}
+		_ = cacheGroup.Wait()
+	}()
+	if err := <-capabilityDone; err != nil {
+		cancelPreflight()
+		<-cacheDone
 		return nil, err
 	}
-
-	// Layer pre-check: ask which layers the device already has by diff ID so we
-	// can skip them entirely. A layer the device already holds yields no dedup, so
-	// decompressing and content-chunking it would be pure waste. Degrades to
-	// chunking every layer when the agent is too old or the query fails.
-	present := queryPresentLayers(ctx, cs, layers, output)
+	<-cacheDone
+	present = <-layersDone
 
 	// Build the present-layer headers up front and collect the indices that still
 	// need a chunk-diff push. A present-layer header carries no chunk hashes, so
@@ -376,7 +421,7 @@ func pushLayersByChunksWithPrepareMode(ctx context.Context, cs agentpb.WendyCont
 	for _, idx := range toPush {
 		idx, l := idx, layers[idx]
 		resolveGroup.Go(func() error {
-			r, err := resolveChunkLayer(l, indexProgress)
+			r, err := resolveChunkLayerWithCache(l, indexProgress, preloaded[idx])
 			if err != nil {
 				return err
 			}
@@ -482,7 +527,7 @@ func queryPresentLayers(ctx context.Context, cs agentpb.WendyContainerServiceCli
 	}
 	resp, err := cs.QueryLayers(ctx, &agentpb.QueryLayersRequest{DiffIds: diffIDs})
 	if err != nil {
-		if !isUnimplementedRPCError(err) {
+		if ctx.Err() == nil && !isUnimplementedRPCError(err) {
 			// The agent supports chunk-diff (the probe succeeded) but the layer
 			// pre-check failed for another reason; chunk everything rather than
 			// abort the deploy over a missed optimization.
@@ -562,6 +607,11 @@ func (r *resolvedChunkLayer) ensureDecompressed(progress *chunkIndexProgress) er
 }
 
 func resolveChunkLayer(l localLayer, progress *chunkIndexProgress) (*resolvedChunkLayer, error) {
+	m, ok := loadManifestCache(l.Digest)
+	return resolveChunkLayerWithCache(l, progress, cachedManifestResult{manifest: m, found: ok})
+}
+
+func resolveChunkLayerWithCache(l localLayer, progress *chunkIndexProgress, cached cachedManifestResult) (*resolvedChunkLayer, error) {
 	var (
 		diffID        string
 		size          int64
@@ -596,8 +646,8 @@ func resolveChunkLayer(l localLayer, progress *chunkIndexProgress) (*resolvedChu
 		return nil
 	}
 
-	if cm, ok := loadManifestCache(l.Digest); ok {
-		diffID, size, orderedHashes = cm.DiffID, cm.Size, cm.Hashes
+	if cached.found {
+		diffID, size, orderedHashes = cached.manifest.DiffID, cached.manifest.Size, cached.manifest.Hashes
 	} else {
 		if err := decompressAndChunk(); err != nil {
 			return nil, err

--- a/go/internal/cli/commands/chunkpush_test.go
+++ b/go/internal/cli/commands/chunkpush_test.go
@@ -527,9 +527,78 @@ func TestPushLayersByChunksSkipsPresentLayer(t *testing.T) {
 	}
 }
 
+func TestPushLayersByChunksOverlapsRemotePreflightAndLocalCacheReads(t *testing.T) {
+	diffID := "sha256:" + strings.Repeat("ef", 32)
+	capabilityStarted := make(chan struct{})
+	layersStarted := make(chan struct{})
+	cacheStarted := make(chan struct{})
+	capabilityRelease := make(chan struct{})
+	layersRelease := make(chan struct{})
+	cacheRelease := make(chan struct{})
+	var capabilityOnce, layersOnce, cacheOnce sync.Once
+	releaseCapability := func() { capabilityOnce.Do(func() { close(capabilityRelease) }) }
+	releaseLayers := func() { layersOnce.Do(func() { close(layersRelease) }) }
+	releaseCache := func() { cacheOnce.Do(func() { close(cacheRelease) }) }
+	defer releaseCapability()
+	defer releaseLayers()
+	defer releaseCache()
+
+	fake := &fakeContainerClient{
+		queryFn: func(req *agentpb.QueryChunksRequest) *agentpb.QueryChunksResponse {
+			if len(req.GetChunkHashes()) != 0 {
+				t.Fatalf("unexpected non-capability QueryChunks call")
+			}
+			close(capabilityStarted)
+			<-capabilityRelease
+			return &agentpb.QueryChunksResponse{}
+		},
+		queryLayersFn: func(*agentpb.QueryLayersRequest) *agentpb.QueryLayersResponse {
+			close(layersStarted)
+			<-layersRelease
+			return &agentpb.QueryLayersResponse{Present: []*agentpb.PresentLayer{{DiffId: diffID, Size: 123}}}
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := pushLayersByChunksWithPrepareModeAndCache(
+			context.Background(), fake, []localLayer{{Digest: "sha256:cached", DiffID: diffID}},
+			nil, nil, false, nil,
+			func(string) (*cachedManifest, bool) {
+				close(cacheStarted)
+				<-cacheRelease
+				return nil, false
+			},
+		)
+		done <- err
+	}()
+
+	for name, started := range map[string]<-chan struct{}{
+		"capability probe": capabilityStarted,
+		"layer query":      layersStarted,
+		"manifest cache":   cacheStarted,
+	} {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			releaseCapability()
+			releaseLayers()
+			releaseCache()
+			t.Fatalf("%s did not start while the other preflight operations were blocked", name)
+		}
+	}
+	releaseCapability()
+	releaseLayers()
+	releaseCache()
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
 // TestPushLayersByChunksProbeUnimplemented verifies that an agent which does not
 // support chunk-diff at all (QueryChunks returns Unimplemented) surfaces the
-// error before any layer work, so the caller can fall back to a registry push.
+// error before any layer materialization, so the caller can fall back to a
+// registry push. The optional QueryLayers request may run concurrently.
 func TestPushLayersByChunksProbeUnimplemented(t *testing.T) {
 	manifestCacheTestDir = t.TempDir()
 	t.Cleanup(func() { manifestCacheTestDir = "" })
@@ -553,6 +622,10 @@ type probeUnsupportedClient struct {
 
 func (probeUnsupportedClient) QueryChunks(_ context.Context, _ *agentpb.QueryChunksRequest, _ ...grpc.CallOption) (*agentpb.QueryChunksResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "QueryChunks not implemented")
+}
+
+func (probeUnsupportedClient) QueryLayers(_ context.Context, _ *agentpb.QueryLayersRequest, _ ...grpc.CallOption) (*agentpb.QueryLayersResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "QueryLayers not implemented")
 }
 
 // TestPushLayersByChunksReportsProgress verifies that pushLayersByChunks wires

--- a/go/internal/cli/commands/chunkresume_test.go
+++ b/go/internal/cli/commands/chunkresume_test.go
@@ -18,8 +18,9 @@ import (
 // unavailableContainerClient always fails QueryChunks with a gRPC Unavailable
 // status, modelling a tunnel that's already down by the time the chunk
 // push's capability probe goes out. calls counts invocations so tests can
-// assert a dead connection is probed exactly once per attempt (no layer work
-// is ever reached after the probe fails).
+// assert the authoritative capability probe runs exactly once per attempt.
+// The optional whole-layer query may start alongside it, but no layer is ever
+// materialized or uploaded after the capability probe fails.
 type unavailableContainerClient struct {
 	agentpb.WendyContainerServiceClient // embedded nil
 	calls                               int
@@ -27,6 +28,10 @@ type unavailableContainerClient struct {
 
 func (c *unavailableContainerClient) QueryChunks(_ context.Context, _ *agentpb.QueryChunksRequest, _ ...grpc.CallOption) (*agentpb.QueryChunksResponse, error) {
 	c.calls++
+	return nil, status.Error(codes.Unavailable, "tunnel dropped")
+}
+
+func (c *unavailableContainerClient) QueryLayers(_ context.Context, _ *agentpb.QueryLayersRequest, _ ...grpc.CallOption) (*agentpb.QueryLayersResponse, error) {
 	return nil, status.Error(codes.Unavailable, "tunnel dropped")
 }
 

--- a/go/internal/cli/commands/cloud_tunnel.go
+++ b/go/internal/cli/commands/cloud_tunnel.go
@@ -213,10 +213,11 @@ func waitForCloudAgentRestart(ctx context.Context, auth *config.AuthConfig, asse
 			continue
 		}
 		probeCtx, probeCancel := context.WithTimeout(ctx, 3*time.Second)
-		_, probeErr := conn.AgentService.GetAgentVersion(probeCtx, &agentpb.GetAgentVersionRequest{})
+		resp, probeErr := conn.AgentService.GetAgentVersion(probeCtx, &agentpb.GetAgentVersionRequest{})
 		probeCancel()
 		attemptCancel()
 		if probeErr == nil {
+			conn.CacheAgentVersion(resp)
 			return conn, nil
 		}
 		conn.Close()

--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -1177,7 +1177,7 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 		cliLogln("warning: %s", w)
 	}
 
-	versionResp, err := conn.AgentService.GetAgentVersion(ctx, &agentpb.GetAgentVersionRequest{})
+	versionResp, err := agentVersionForRun(ctx, conn)
 	if err != nil {
 		return fmt.Errorf("querying device version: %w", err)
 	}

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -671,7 +671,7 @@ func resolveGPUArchForDirs(ctx context.Context, dirs []string, flagArch string, 
 	if !needed {
 		return ""
 	}
-	resp, err := conn.AgentService.GetAgentVersion(ctx, &agentpb.GetAgentVersionRequest{})
+	resp, err := agentVersionForRun(ctx, conn)
 	if err != nil {
 		// Deliberately not fatal. The compiler is where "a GPU stage needs a
 		// target" is enforced, and its error names the fix; failing here would

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1029,7 +1029,7 @@ func connectAgentAtAddressWithProvisionedHint(ctx context.Context, addr string, 
 		// command UIs don't surface delayed transport errors, and so provisioned
 		// agents that only expose the mTLS port can report an auth error.
 		probeCtx, cancel := context.WithTimeout(ctx, agentPlaintextProbeTimeout)
-		_, probeErr := conn.AgentService.GetAgentVersion(probeCtx, &agentpb.GetAgentVersionRequest{})
+		resp, probeErr := conn.AgentService.GetAgentVersion(probeCtx, &agentpb.GetAgentVersionRequest{})
 		cancel()
 		tm("  ↳ plaintext probe (GetAgentVersion)")
 		if probeErr != nil {
@@ -1043,6 +1043,7 @@ func connectAgentAtAddressWithProvisionedHint(ctx context.Context, addr string, 
 			}
 			return nil, probeErr
 		}
+		conn.CacheAgentVersion(resp)
 	}
 	// This is the choke point's only real proof-of-life exit: conn.IsMTLS
 	// means dialAgentLadder already verified it with a live probe, and the
@@ -2031,7 +2032,10 @@ func cacheFastPathReachable(ctx context.Context, conn *grpcclient.AgentConnectio
 	}
 	probeCtx, cancel := context.WithTimeout(ctx, probeTimeout)
 	defer cancel()
-	_, probeErr := conn.AgentService.GetAgentVersion(probeCtx, &agentpb.GetAgentVersionRequest{})
+	resp, probeErr := conn.AgentService.GetAgentVersion(probeCtx, &agentpb.GetAgentVersionRequest{})
+	if probeErr == nil {
+		conn.CacheAgentVersion(resp)
+	}
 	return probeErr == nil
 }
 
@@ -2267,9 +2271,10 @@ func (w *mtlsWalk) dialAddr(ctx context.Context, cand string, isPrimary bool) (*
 			// the old 8s budget (which also covered .local mDNS resolution) made
 			// an unreachable mTLS port cost 8s before the plaintext fallback.
 			probeCtx, cancel := context.WithTimeout(ctx, mtlsProbeTimeout)
-			_, probeErr := conn.AgentService.GetAgentVersion(probeCtx, &agentpb.GetAgentVersionRequest{})
+			resp, probeErr := conn.AgentService.GetAgentVersion(probeCtx, &agentpb.GetAgentVersionRequest{})
 			cancel()
 			if probeErr == nil {
+				conn.CacheAgentVersion(resp)
 				rememberCertOrg(host, w.allCerts[i].OrganizationID)
 				return conn, nil
 			}
@@ -2631,11 +2636,16 @@ func checkAndOfferUpdate(ctx context.Context, conn *grpcclient.AgentConnection) 
 	if updateCheckRecentlyPassed(conn.Host) {
 		return conn, nil
 	}
-	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
-	resp, err := conn.AgentService.GetAgentVersion(probeCtx, &agentpb.GetAgentVersionRequest{})
-	cancel()
-	if err != nil {
-		return conn, nil
+	resp, ok := conn.CachedAgentVersion()
+	if !ok {
+		probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		var err error
+		resp, err = conn.AgentService.GetAgentVersion(probeCtx, &agentpb.GetAgentVersionRequest{})
+		cancel()
+		if err != nil {
+			return conn, nil
+		}
+		conn.CacheAgentVersion(resp)
 	}
 
 	agentVer := resp.GetVersion()
@@ -2740,9 +2750,10 @@ func waitForAgentRestart(ctx context.Context, addr string) (*grpcclient.AgentCon
 			continue
 		}
 		probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
-		_, probeErr := conn.AgentService.GetAgentVersion(probeCtx, &agentpb.GetAgentVersionRequest{})
+		resp, probeErr := conn.AgentService.GetAgentVersion(probeCtx, &agentpb.GetAgentVersionRequest{})
 		cancel()
 		if probeErr == nil {
+			conn.CacheAgentVersion(resp)
 			return conn, nil
 		}
 		conn.Close()

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -1409,6 +1409,9 @@ func TestConnectAgentAtAddressWithProvisionedHint_SelfHealsExistingDiscoveryEntr
 		t.Fatalf("connectAgentAtAddressWithProvisionedHint: %v", err)
 	}
 	defer conn.Close()
+	if _, ok := conn.CachedAgentVersion(); !ok {
+		t.Fatal("successful plaintext liveness probe was not retained on the connection")
+	}
 
 	reloaded, err := discoverycache.LoadFrom(cachePath)
 	if err != nil {

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -344,7 +344,7 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 		return err
 	}
 
-	versionResp, err := conn.AgentService.GetAgentVersion(ctx, &agentpb.GetAgentVersionRequest{})
+	versionResp, err := agentVersionForRun(ctx, conn)
 	if err != nil {
 		return fmt.Errorf("querying device version: %w", err)
 	}

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -1051,11 +1051,30 @@ func appConfigFileMissing(cfgPath string) (bool, error) {
 	return false, nil
 }
 
+// agentVersionForRun reuses the liveness/version probe already performed while
+// establishing a direct-agent connection. Cloud and test connections that do
+// not probe during dial still perform the RPC here, then make the result
+// available to later run phases on this connection.
+func agentVersionForRun(ctx context.Context, conn *grpcclient.AgentConnection) (*agentpb.GetAgentVersionResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if resp, ok := conn.CachedAgentVersion(); ok {
+		return resp, nil
+	}
+	resp, err := conn.AgentService.GetAgentVersion(ctx, &agentpb.GetAgentVersionRequest{})
+	if err != nil {
+		return nil, err
+	}
+	conn.CacheAgentVersion(resp)
+	return resp, nil
+}
+
 func preflightMissingAppConfigForMacTarget(ctx context.Context, target *SelectedDevice, projectType string) error {
 	if target == nil || target.Agent == nil {
 		return nil
 	}
-	versionResp, err := target.Agent.AgentService.GetAgentVersion(ctx, &agentpb.GetAgentVersionRequest{})
+	versionResp, err := agentVersionForRun(ctx, target.Agent)
 	if err != nil {
 		return fmt.Errorf("querying device version for Mac target preflight: %w", err)
 	}
@@ -1267,7 +1286,7 @@ func runSwiftWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cw
 	}
 
 	// Query the device OS and architecture.
-	versionResp, err := conn.AgentService.GetAgentVersion(ctx, &agentpb.GetAgentVersionRequest{})
+	versionResp, err := agentVersionForRun(ctx, conn)
 	if err != nil {
 		return fmt.Errorf("querying device version: %w", err)
 	}
@@ -1365,7 +1384,7 @@ func runSwiftWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cw
 // via SyncFiles gRPC, and creates/starts the container.
 func runMacOSSwiftPMWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd string, appCfg *appconfig.AppConfig, opts runOptions) error {
 	// Verify CPU architecture matches.
-	versionResp, err := conn.AgentService.GetAgentVersion(ctx, &agentpb.GetAgentVersionRequest{})
+	versionResp, err := agentVersionForRun(ctx, conn)
 	if err != nil {
 		return fmt.Errorf("querying device version: %w", err)
 	}
@@ -1849,12 +1868,12 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 
 	// Resolve the target platform. Query the agent for its OS and architecture,
 	// then determine the effective platform from wendy.json or defaults.
-	versionResp, err := conn.AgentService.GetAgentVersion(ctx, &agentpb.GetAgentVersionRequest{})
+	versionResp, err := agentVersionForRun(ctx, conn)
 	if err != nil {
 		return fmt.Errorf("querying device version: %w", err)
 	}
 	printRunDiskUsageWarning(versionResp)
-	mark("agent GetAgentVersion (in runWithAgent)")
+	mark("agent version metadata (in runWithAgent)")
 	agentOS := versionResp.GetOs()
 	architecture := versionResp.GetCpuArchitecture()
 	if architecture == "" {
@@ -2529,7 +2548,7 @@ func announceReachableURL(ctx context.Context, conn *grpcclient.AgentConnection,
 		return ""
 	}
 
-	resp, err := conn.AgentService.GetAgentVersion(ctx, &agentpb.GetAgentVersionRequest{})
+	resp, err := agentVersionForRun(ctx, conn)
 	if err != nil {
 		return ""
 	}

--- a/go/internal/cli/commands/run_hooks_test.go
+++ b/go/internal/cli/commands/run_hooks_test.go
@@ -37,6 +37,58 @@ func (f *fakeAgentVersionClient) GetAgentVersion(_ context.Context, _ *agentpb.G
 	return f.resp, f.err
 }
 
+func TestAgentVersionForRunReusesConnectionProbe(t *testing.T) {
+	client := &fakeAgentVersionClient{resp: &agentpb.GetAgentVersionResponse{Version: "unexpected-rpc"}}
+	conn := &grpcclient.AgentConnection{AgentService: client}
+	want := &agentpb.GetAgentVersionResponse{Version: "connect-probe", Os: "linux"}
+	conn.CacheAgentVersion(want)
+
+	got, err := agentVersionForRun(context.Background(), conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("agentVersionForRun returned %p, want cached response %p", got, want)
+	}
+	if client.calls != 0 {
+		t.Fatalf("GetAgentVersion calls = %d, want 0", client.calls)
+	}
+}
+
+func TestAgentVersionForRunCachesFirstRPC(t *testing.T) {
+	want := &agentpb.GetAgentVersionResponse{Version: "queried", Os: "linux"}
+	client := &fakeAgentVersionClient{resp: want}
+	conn := &grpcclient.AgentConnection{AgentService: client}
+
+	for range 2 {
+		got, err := agentVersionForRun(context.Background(), conn)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != want {
+			t.Fatalf("agentVersionForRun returned %p, want %p", got, want)
+		}
+	}
+	if client.calls != 1 {
+		t.Fatalf("GetAgentVersion calls = %d, want 1", client.calls)
+	}
+}
+
+func TestAgentVersionForRunHonorsCanceledContextBeforeCache(t *testing.T) {
+	client := &fakeAgentVersionClient{resp: &agentpb.GetAgentVersionResponse{Version: "unexpected-rpc"}}
+	conn := &grpcclient.AgentConnection{AgentService: client}
+	conn.CacheAgentVersion(&agentpb.GetAgentVersionResponse{Version: "cached"})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := agentVersionForRun(ctx, conn); !errors.Is(err, context.Canceled) {
+		t.Fatalf("agentVersionForRun error = %v, want context.Canceled", err)
+	}
+	if client.calls != 0 {
+		t.Fatalf("GetAgentVersion calls = %d, want 0", client.calls)
+	}
+}
+
 // neverReconnect is a non-nil Reconnect stub used to mark an AgentConnection
 // as a cloud connection (conn.Reconnect != nil is the cloud detection
 // signal — see resolveHookHost). It is never actually invoked by these

--- a/go/internal/cli/commands/usb_direct.go
+++ b/go/internal/cli/commands/usb_direct.go
@@ -276,6 +276,7 @@ func usbDirectFallback(ctx context.Context, wantHost string) (*grpcclient.AgentC
 			conn.Close()
 			continue
 		}
+		conn.CacheAgentVersion(resp)
 		return conn, true
 	}
 	return nil, false

--- a/go/internal/cli/commands/usb_direct_test.go
+++ b/go/internal/cli/commands/usb_direct_test.go
@@ -301,6 +301,9 @@ func TestUSBDirectFallbackMatchesHostname(t *testing.T) {
 	if rec.closed {
 		t.Fatal("a matched connection must be returned live, not closed")
 	}
+	if cached, ok := conn.CachedAgentVersion(); !ok || cached.GetHostname() != "wendy-orin" {
+		t.Fatalf("matched connection did not retain its successful version probe: (%v, %v)", cached, ok)
+	}
 }
 
 func TestUSBDirectFallbackRejectsWrongOrUnknownHostname(t *testing.T) {

--- a/go/internal/cli/grpcclient/client.go
+++ b/go/internal/cli/grpcclient/client.go
@@ -46,6 +46,11 @@ const (
 	// we see availability regressions.
 	grpcKeepaliveTime    = 15 * time.Minute
 	grpcKeepaliveTimeout = 10 * time.Second
+
+	// A connection probe and the command phase that consumes its metadata are
+	// normally adjacent. Bound reuse so long-running watch/build sessions still
+	// refresh mutable fields such as interfaces and disk usage.
+	agentVersionCacheTTL = 10 * time.Second
 )
 
 // tlsDebugWriter is where WENDY_TLS_DEBUG resumption logging is written.
@@ -80,6 +85,13 @@ type AgentConnection struct {
 	FileSyncService     agentpb.WendyFileSyncServiceClient
 	TimeSyncService     agentpbv2.WendyTimeSyncServiceClient
 	BuildService        agentpbv2.WendyBuildServiceClient
+	// cachedAgentVersion retains a successful liveness probe performed while
+	// establishing this connection. Direct-agent connects already call
+	// GetAgentVersion to force gRPC's lazy dial and authenticate the peer; run
+	// commands can reuse that exact response instead of immediately issuing the
+	// same RPC again. The cache is deliberately connection-local: it is never
+	// persisted across processes or carried across reconnects.
+	cachedAgentVersion atomic.Pointer[agentVersionCacheEntry]
 	// observedServerOrg holds the org ID read from the device's server
 	// certificate during the TLS handshake (set by the OnServerIdentity sink
 	// wired in ConnectWithTLSAndPins). Written on the handshake goroutine, read
@@ -105,6 +117,34 @@ type AgentConnection struct {
 	// out of gRPC's handshake-failure string. nil for connections that never
 	// install the sink.
 	pinMismatch *atomic.Pointer[devicepin.PinMismatchError]
+}
+
+type agentVersionCacheEntry struct {
+	response *agentpb.GetAgentVersionResponse
+	cachedAt time.Time
+}
+
+// CacheAgentVersion records a successful GetAgentVersion response for reuse by
+// a later caller on this same live connection. Responses returned by grpc-go
+// are immutable in Wendy's callers after receipt, so retaining the pointer is
+// safe; atomic storage also covers probes completed on gRPC/spinner goroutines.
+func (c *AgentConnection) CacheAgentVersion(resp *agentpb.GetAgentVersionResponse) {
+	if c != nil && resp != nil {
+		c.cachedAgentVersion.Store(&agentVersionCacheEntry{response: resp, cachedAt: time.Now()})
+	}
+}
+
+// CachedAgentVersion returns the version response already obtained while
+// proving this connection live, when one is available.
+func (c *AgentConnection) CachedAgentVersion() (*agentpb.GetAgentVersionResponse, bool) {
+	if c == nil {
+		return nil, false
+	}
+	entry := c.cachedAgentVersion.Load()
+	if entry == nil || time.Since(entry.cachedAt) > agentVersionCacheTTL {
+		return nil, false
+	}
+	return entry.response, true
 }
 
 // verifiedIdentitySink returns the OnVerifiedServerIdentity callback that

--- a/go/internal/cli/grpcclient/client_test.go
+++ b/go/internal/cli/grpcclient/client_test.go
@@ -4,7 +4,34 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
+
+func TestAgentConnectionCachesSuccessfulVersionProbe(t *testing.T) {
+	conn := &AgentConnection{}
+	if _, ok := conn.CachedAgentVersion(); ok {
+		t.Fatal("new connection unexpectedly has a cached version")
+	}
+	want := &agentpb.GetAgentVersionResponse{Version: "test-version", Os: "linux"}
+	conn.CacheAgentVersion(want)
+	got, ok := conn.CachedAgentVersion()
+	if !ok || got != want {
+		t.Fatalf("CachedAgentVersion() = (%p, %v), want (%p, true)", got, ok, want)
+	}
+}
+
+func TestAgentConnectionDoesNotReuseStaleVersionProbe(t *testing.T) {
+	conn := &AgentConnection{}
+	conn.cachedAgentVersion.Store(&agentVersionCacheEntry{
+		response: &agentpb.GetAgentVersionResponse{Version: "stale"},
+		cachedAt: time.Now().Add(-agentVersionCacheTTL - time.Second),
+	})
+	if _, ok := conn.CachedAgentVersion(); ok {
+		t.Fatal("stale probe unexpectedly remained reusable")
+	}
+}
 
 // ── grpcTarget ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- overlap chunk capability probing, whole-layer presence checks, and local manifest-cache reads
- keep expensive layer decompression behind the device-presence result and preserve old-agent registry fallback
- reuse successful connection-local agent version probes for a short bounded window across run, Compose, multi-service, GPU, update, and URL paths

## Testing

- `TMPDIR=/private/tmp GOCACHE=/private/tmp/wendy-gocache go test -race ./go/internal/cli/commands ./go/internal/cli/grpcclient -count=1`
- `go vet ./go/internal/cli/commands ./go/internal/cli/grpcclient`
- `git diff --check HEAD^ HEAD`

## Follow-up

Cross-process connection persistence is intentionally separated into a stacked broker PR.
