### PR TITLE
perf(agent): reuse verified bridge network sandboxes

### DIFF
--- a/go/internal/agent/cni/bridge/bridge.go
+++ b/go/internal/agent/cni/bridge/bridge.go
@@ -1015,6 +1015,14 @@ func CmdCheck(args *skel.CmdArgs) error {
 		return err
 	}
 
+	// SECURITY: prevResult is untrusted expected-state input, never proof that
+	// the network is healthy. Success below requires fresh observations from
+	// both namespaces: validateCniBrInterface/validateCniVethInterface query
+	// host netlink state, validateCniContainerInterface queries the opened
+	// container netns, and ValidateExpectedInterfaceIPs/ValidateExpectedRoute
+	// compare its live addresses and routes. Keep those live checks mandatory
+	// when syncing this vendored plugin with upstream.
+	//
 	// Parse previous result.
 	if n.NetConf.RawPrevResult == nil {
 		return fmt.Errorf("Required prevResult missing")

--- a/go/internal/agent/cni/hostlocal/hostlocal.go
+++ b/go/internal/agent/cni/hostlocal/hostlocal.go
@@ -50,8 +50,13 @@ func CmdCheck(args *skel.CmdArgs) error {
 		return err
 	}
 
+	// SECURITY: do not treat prevResult as evidence of an allocation. CHECK
+	// reopens the live host-local allocation store and verifies that this exact
+	// container/interface still owns a lease. Keep this lookup mandatory when
+	// syncing the vendored plugin with upstream.
+	//
 	// Look to see if there is at least one IP address allocated to the container
-	// in the data dir, irrespective of what that address actually is
+	// in the data dir, irrespective of what that address actually is.
 	store, err := disk.New(ipamConf.Name, ipamConf.DataDir)
 	if err != nil {
 		return err

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -3645,6 +3645,10 @@ func (c *Client) StopContainer(ctx context.Context, name string) error {
 		c.mu.Unlock()
 		return err
 	}
+	if c.appStopping[appID] {
+		c.mu.Unlock()
+		return fmt.Errorf("%w: %q", errAppStopping, appID)
+	}
 	stopOrder := c.resolveStopOrder(ctx, appID, ctrs)
 	// Mark app as stopping before releasing the mutex so any concurrent
 	// CreateContainerWithProgress call will see it and abort (SOC2-CC6, NIST-AC-3).
@@ -3653,6 +3657,12 @@ func (c *Client) StopContainer(ctx context.Context, name string) error {
 	}
 	c.appStopping[appID] = true
 	c.mu.Unlock()
+
+	// A whole-app operation is keyed by bare appID, while service starts and
+	// creates are keyed by concrete container ID. Hold every member key for the
+	// remainder of teardown so CNI ADD/CHECK/DEL cannot overlap this group stop.
+	unlockTargets := c.lockAdditionalNetworkOperations(name, stopOrder)
+	defer unlockTargets()
 
 	// Pause the restart monitor for every container about to be stopped, for
 	// the whole rest of this function: without it, a crash-looping member's
@@ -3925,14 +3935,39 @@ func (c *Client) DeleteContainer(ctx context.Context, name string, deleteImage b
 	unlockNetwork := c.lockNetworkOperation(name)
 	defer unlockNetwork()
 	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	ctx = c.withNamespace(ctx)
 	// A bare appID deletes every service; "{appID}_{serviceName}" deletes one.
 	ctrs, appID, wholeApp, err := c.resolveTargets(ctx, name)
 	if err != nil {
+		c.mu.Unlock()
 		return err
 	}
+	if c.appStopping[appID] {
+		c.mu.Unlock()
+		return fmt.Errorf("%w: %q", errAppStopping, appID)
+	}
+	if c.appStopping == nil {
+		c.appStopping = make(map[string]bool)
+	}
+	c.appStopping[appID] = true
+	c.mu.Unlock()
+
+	containerIDs := make([]string, 0, len(ctrs))
+	for _, ctr := range ctrs {
+		containerIDs = append(containerIDs, ctr.ID())
+	}
+	// See StopContainer: the bare group key alone does not serialize against
+	// per-service create/start operations. Acquire all concrete member keys
+	// before re-taking c.mu, preserving network-lock -> c.mu ordering.
+	unlockTargets := c.lockAdditionalNetworkOperations(name, containerIDs)
+	defer unlockTargets()
+
+	c.mu.Lock()
+	defer func() {
+		delete(c.appStopping, appID)
+		c.mu.Unlock()
+	}()
 
 	seen := make(map[string]bool)
 	var errs []error

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -125,6 +125,14 @@ type Client struct {
 	preparedSnapshotsMu sync.Mutex
 	preparedSnapshots   map[string]*preparedSnapshot
 
+	// networkSandboxes owns CNI-configured namespace bind mounts retained
+	// across task restart and compatible container replacement. It has a
+	// separate mutex because CNI work deliberately runs after c.mu is released.
+	networkSandboxesMu sync.Mutex
+	networkSandboxes   map[string]*networkSandbox
+	networkOpsMu       sync.Mutex
+	networkOps         map[string]*networkOperation
+
 	// appStopping tracks appIDs that are currently being stopped.
 	// Set before releasing c.mu in StopContainer; cleared in the cleanup phase.
 	// Checked by CreateContainerWithProgress to reject concurrent create/stop races
@@ -292,6 +300,8 @@ func NewClient(logger *zap.Logger, address string, proxyMgr *dbusproxy.Manager) 
 		warnedExposures:   make(map[string]struct{}),
 		serviceIPs:        make(map[string]map[string]string),
 		preparedSnapshots: make(map[string]*preparedSnapshot),
+		networkSandboxes:  make(map[string]*networkSandbox),
+		networkOps:        make(map[string]*networkOperation),
 		appStopping:       make(map[string]bool),
 		ros2ExecRefs:      make(map[string]int),
 		chunkIndex:        idx,
@@ -308,6 +318,10 @@ func NewClient(logger *zap.Logger, address string, proxyMgr *dbusproxy.Manager) 
 // D-Bus proxy processes.
 func (c *Client) Close() error {
 	c.discardAllPreparedSnapshots()
+	// Do not tear down retained network sandboxes here. Closing an agent client
+	// does not stop its containerd tasks; their nsfs bind mounts and CNI state
+	// must survive an agent restart so the next client can validate and adopt
+	// them. Explicit stop/delete paths remain the lifecycle boundary.
 	if c.proxyManager != nil {
 		c.proxyManager.StopAll()
 	}
@@ -958,9 +972,6 @@ func toCreateContainerProgress(progress UnpackProgress) *agentpb.CreateContainer
 }
 
 func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.CreateContainerRequest, appCfg *appconfig.AppConfig, onProgress services.ProgressFunc) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	ctx = c.withNamespace(ctx)
 
 	// Derive the app identity. appCfg.AppID is the authoritative source; fall
@@ -994,6 +1005,11 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 
 	// Both values are now validated; promote to short names for readability.
 	appID, serviceName := rawAppID, rawServiceName
+	containerName := ContainerName(appID, serviceName)
+	unlockNetwork := c.lockNetworkOperation(containerName)
+	defer unlockNetwork()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	// Reject creation while a concurrent StopContainer is tearing down this app.
 	// Without this check a new container could be created after resolveStopOrder
@@ -1003,7 +1019,19 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 		return fmt.Errorf("app %q is currently being stopped; retry after stop completes", appID)
 	}
 
-	containerName := ContainerName(appID, serviceName)
+	desiredNetworkIdentity := ""
+	if networkSandboxEligible(serviceName, appCfg.Entitlements) {
+		desiredNetworkIdentity = networkIdentity(appCfg.Isolation, appCfg.Entitlements)
+	}
+	var reusedNetworkSandbox *networkSandbox
+	reusedNetworkSandboxCommitted := false
+	defer func() {
+		// Validation/spec/snapshot/container failures after the old task was
+		// removed must not leave a CNI namespace detached from any container.
+		if reusedNetworkSandbox != nil && !reusedNetworkSandboxCommitted {
+			c.destroyNetworkSandbox(context.WithoutCancel(ctx), containerName)
+		}
+	}()
 
 	// Canonicalise the image reference so older CLIs sending Docker short
 	// names like "python:3.11-slim" still resolve correctly under containerd's
@@ -1045,8 +1073,27 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 		defer resumeRestarts()
 
 		oldHadSystemAPI := false
-		if labels, labelErr := existing.Labels(ctx); labelErr == nil {
-			oldHadSystemAPI = entitlementsContain(parseEntitlementsFromAnnotations(labels), appconfig.EntitlementNotifications)
+		if oldLabels, labelErr := existing.Labels(ctx); labelErr == nil {
+			oldHadSystemAPI = entitlementsContain(parseEntitlementsFromAnnotations(oldLabels), appconfig.EntitlementNotifications)
+			oldSpec, _ := existing.Spec(ctx)
+			if oldLabels[labelKeyNetworkIdentity] == desiredNetworkIdentity {
+				reusedNetworkSandbox, _ = c.reusableNetworkSandbox(ctx, containerName, desiredNetworkIdentity)
+				if reusedNetworkSandbox == nil && oldSpec != nil {
+					reusedNetworkSandbox, _ = c.recoverNetworkSandbox(ctx, existing, desiredNetworkIdentity, oldLabels, oldSpec)
+				}
+			}
+			if reusedNetworkSandbox == nil {
+				c.purgePersistedNetworkSandbox(ctx, existing, oldLabels, oldSpec)
+			}
+		}
+		if reusedNetworkSandbox == nil {
+			// Identity mismatch, unhealthy namespace, legacy container, or a
+			// non-CNI configuration: release every external network side effect
+			// before the old task disappears.
+			c.destroyNetworkSandbox(ctx, containerName)
+		} else {
+			c.logger.Debug("Retaining compatible network sandbox across container replacement",
+				zap.String("container_name", containerName), zap.String("netns", reusedNetworkSandbox.path))
 		}
 		c.logger.Info("Removing existing container", zap.String("container_name", containerName))
 		// Kill the old task's whole process group — not just init — and wait
@@ -1346,6 +1393,12 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 		}
 	}
 	labels := wendyLabels(appID, serviceName, version, req.GetRestartPolicy(), appCfg.Entitlements, appCfg.Isolation, dependsOn)
+	if desiredNetworkIdentity != "" {
+		labels[labelKeyNetworkIdentity] = desiredNetworkIdentity
+		if reusedNetworkSandbox != nil {
+			labels[labelKeyNetworkSandboxIP] = reusedNetworkSandbox.ip
+		}
+	}
 
 	// Publish the resolved ROS 2 configuration as a container label so the
 	// agent can discover ROS 2 containers at runtime and configure the CLI
@@ -1464,6 +1517,16 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 	// container creation with EEXIST.
 	localoci.DedupeDevices(spec)
 
+	// A retained namespace is injected only after the complete new runtime
+	// configuration has been validated and matched against the old network
+	// identity. runc will join this nsfs bind mount instead of creating a fresh
+	// network namespace, so StartContainer can safely skip CNI DEL+ADD.
+	if reusedNetworkSandbox != nil {
+		if err := localoci.JoinNetworkNamespace(spec, reusedNetworkSandbox.path); err != nil {
+			return fmt.Errorf("joining reusable network sandbox: %w", err)
+		}
+	}
+
 	// SECURITY (WDY-1102): backstop against any mount whose source resolves into
 	// containerd's runtime directory (the control socket is a host-escape vector).
 	// Runs on the fully assembled spec — entitlement, shared-SHM, and default
@@ -1521,6 +1584,7 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 	if err != nil {
 		return fmt.Errorf("creating container %q: %w", containerName, err)
 	}
+	reusedNetworkSandboxCommitted = true
 
 	// Container created successfully; keep its external socket resources running.
 	dbusProxyStarted = false
@@ -1612,6 +1676,8 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 	if err != nil {
 		return nil, fmt.Errorf("StartContainer: invalid app name: %w", err)
 	}
+	unlockNetwork := c.lockNetworkOperation(appName)
+	defer unlockNetwork()
 	// Hold c.mu for container lookup and task creation to prevent a concurrent
 	// DeleteContainer from removing the container between the label-based lookup
 	// and NewTask (TOCTOU, SOC2-CC6). Released before the streaming goroutine
@@ -1645,7 +1711,9 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 	// namespace joins, CNI per-service records) under the wrong identity.
 	// The labels written at create time are authoritative — prefer them,
 	// re-validating since labels are external state (SOC2-CC6, NIST-SI-10).
+	var containerLabels map[string]string
 	if labels, lerr := container.Labels(ctx); lerr == nil {
+		containerLabels = labels
 		if id := labels[labelKeyAppID]; id != "" && appconfig.ValidateAppID(id) == nil {
 			svc := labels[labelKeyServiceName]
 			if svc == "" || appconfig.ValidateServiceName(svc) == nil {
@@ -1676,11 +1744,48 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 	// starts again. The gate is the persisted spec's mesh resolv.conf mount
 	// itself (leak-free — see recreateMeshResolvConfForStart), so a Spec load
 	// failure just skips the hook.
-	if spec, serr := container.Spec(ctx); serr == nil {
-		c.recreateMeshResolvConfForStart(spec.Mounts)
+	storedSpec, storedSpecErr := container.Spec(ctx)
+	if storedSpecErr == nil {
+		c.recreateMeshResolvConfForStart(storedSpec.Mounts)
 	} else {
 		c.logger.Warn("mesh: could not load container spec to recreate resolv.conf before start",
-			zap.String("app_name", appName), zap.Error(serr))
+			zap.String("app_name", appName), zap.Error(storedSpecErr))
+	}
+
+	// Resolve network policy before NewTask. A sandbox is reusable only when
+	// both its health/identity checks pass and the stored OCI spec explicitly
+	// joins its bind mount. The second condition prevents skipping CNI for a
+	// legacy/private spec that would start in an unrelated fresh namespace.
+	isolation := c.getIsolation(appID)
+	entitlements := parseEntitlementsFromAnnotations(containerLabels)
+	needsBridge := needsCNIBridgeWiring(isolation, serviceName, entitlements)
+	identity, retainsBridge := networkIdentityFromLabels(containerLabels)
+	var reusedNetworkSandbox *networkSandbox
+	if retainsBridge {
+		if candidate, ok := c.reusableNetworkSandbox(ctx, appName, identity); ok &&
+			runtimeSpecJoinsNetworkSandbox(storedSpec, candidate.path) {
+			reusedNetworkSandbox = candidate
+		} else if candidate, ok := c.recoverNetworkSandbox(ctx, container, identity, containerLabels, storedSpec); ok {
+			reusedNetworkSandbox = candidate
+		} else {
+			c.destroyNetworkSandbox(ctx, appName)
+			c.purgePersistedNetworkSandbox(ctx, container, containerLabels, storedSpec)
+			if containerLabels[labelKeyNetworkSandboxIP] != "" || runtimeSpecHasNetworkNamespacePath(storedSpec) {
+				if err := c.persistNetworkNamespace(ctx, container, "", identity, ""); err != nil {
+					return nil, fmt.Errorf("clearing stale reusable network namespace for %q: %w", appName, err)
+				}
+			}
+		}
+	} else {
+		// Host/shared namespaces are never eligible, even if stale process
+		// memory claims a sandbox exists for this name.
+		c.destroyNetworkSandbox(ctx, appName)
+		c.purgePersistedNetworkSandbox(ctx, container, containerLabels, storedSpec)
+		if containerLabels[labelKeyNetworkSandboxIP] != "" || runtimeSpecHasNetworkNamespacePath(storedSpec) {
+			if err := c.persistNetworkNamespace(ctx, container, "", "", ""); err != nil {
+				return nil, fmt.Errorf("clearing ineligible reusable network namespace for %q: %w", appName, err)
+			}
+		}
 	}
 
 	if restartPolicy != nil {
@@ -1761,7 +1866,6 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 
 	// Track the primary PID for shared-namespace app groups.
 	// getIsolation requires c.mu (held here via muHeld).
-	isolation := c.getIsolation(appID)
 	if appconfig.IsSharedNamespaceIsolation(isolation) {
 		// Presence alone is not enough: a per-service stop leaves the group
 		// entry behind, so a dead PID must be replaced rather than kept.
@@ -1778,18 +1882,12 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 	// anchor below), because needsCNIBridgeWiring must also recognise a
 	// single-service "bridge"-mode app, which isolation+serviceName alone
 	// cannot detect (unlike a multi-service isolated app service).
-	var entitlements []appconfig.Entitlement
-	if labels, lerr := container.Labels(ctx); lerr == nil {
-		entitlements = parseEntitlementsFromAnnotations(labels)
-	}
-	needsBridge := needsCNIBridgeWiring(isolation, serviceName, entitlements)
-
 	// Anchor the network namespace with an open fd BEFORE releasing the mutex.
 	// This eliminates the TOCTOU race where a concurrent StopContainer could
 	// recycle the PID between mutex release and CNI ADD, causing the plugin to
 	// operate on the wrong process's netns (SOC2-CC6, NIST-SC-7, ISO27001-A.8).
 	var netnsRef *os.File
-	if needsBridge {
+	if needsBridge && reusedNetworkSandbox == nil {
 		nsPath := fmt.Sprintf("/proc/%d/ns/net", task.Pid())
 		var nsErr error
 		netnsRef, nsErr = os.Open(nsPath)
@@ -1815,8 +1913,19 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 	// /proc/self/fd/<n> reference that third-party CNI plugins may not honour.
 	// It also closes the fd (the bind-mount anchors the namespace independently).
 	// On Linux the bind-mount is used; on other platforms the fd path is the fallback.
-	if needsBridge && netnsRef != nil {
-		netnsPath, cleanupNetns := bindNetnsForCNI(appName, netnsRef)
+	if reusedNetworkSandbox != nil {
+		if !taskUsesNetworkSandbox(reusedNetworkSandbox.path, task.Pid()) {
+			c.destroyNetworkSandbox(ctx, appName)
+			_, _ = task.Delete(ctx, containerd.WithProcessKill)
+			return nil, fmt.Errorf("reusable network sandbox validation failed for app %q after task start", appID)
+		}
+		c.logger.Info("Reused CNI network sandbox",
+			zap.String(logfields.AppID, appID),
+			zap.String("container_id", appName),
+			zap.String("ip", reusedNetworkSandbox.ip))
+	} else if needsBridge && netnsRef != nil {
+		netnsPath, cleanupNetns, persistentNetns := bindNetnsForCNI(appName, netnsRef)
+		bridgeDNSHealthy := !retainsBridge
 		// Release any stale host-local IPAM reservation for this container ID
 		// before ADD (WDY-1834). The CNI allocation is keyed by container ID
 		// (== appName, which is stable across restart/redeploy), and
@@ -1837,7 +1946,7 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 			c.logger.Warn("CNI DEL before ADD (stale-allocation reclaim) failed (non-fatal)",
 				zap.String(logfields.AppID, appID), zap.Error(delErr))
 		}
-		ip, cniErr := c.CNIAdd(ctx, appID, appName, netnsPath)
+		ip, cniResult, cniErr := c.CNIAdd(ctx, appID, appName, netnsPath)
 		if cniErr != nil {
 			// Roll back any partial state the failed ADD left behind (e.g. a
 			// host-local IPAM allocation recorded before a later step, such as
@@ -1857,9 +1966,22 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 		} else {
 			// netnsPath (the bind-mount) must stay mounted through mesh egress
 			// setup below, which needs a live netns to install the service-CIDR
-			// route via nsenter (SetMeshRoute). It is unmounted at the end of
-			// this branch, after mesh wiring has had a chance to use it.
-			defer cleanupNetns()
+			// route via nsenter (SetMeshRoute). Until every subsequent setup step
+			// succeeds, a deferred rollback releases both IPAM and the bind mount.
+			networkReady := false
+			keepNetns := false
+			defer func() {
+				if !networkReady {
+					_ = c.CNIDel(context.WithoutCancel(ctx), appID, appName, netnsPath)
+					if needsGatewayDNS(isolation, entitlements) {
+						c.releaseMeshDNS(appName, appID)
+					}
+					c.teardownMeshEgress(entitlements, appName, appID, ip)
+					cleanupNetns()
+				} else if !keepNetns {
+					cleanupNetns()
+				}
+			}()
 
 			// /etc/hosts bookkeeping is specific to multi-service isolated app
 			// groups (sibling services resolve each other by name); a
@@ -1934,7 +2056,7 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 			// works), mirroring the rest of this block's error handling.
 			if _, ok := findBridgeEntitlement(entitlements); ok {
 				if gw, gwErr := meshGateway(appID); gwErr == nil {
-					c.ensureMeshDNS(appName, gw)
+					bridgeDNSHealthy = c.ensureMeshDNS(appName, gw)
 				} else {
 					c.logger.Warn("bridge: could not derive gateway for DNS listener",
 						zap.String(logfields.AppID, appID), zap.Error(gwErr))
@@ -1951,6 +2073,35 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 				_, _ = task.Delete(ctx, containerd.WithProcessKill)
 				return nil, fmt.Errorf("mesh egress setup failed for app %q: %w", appID, meshErr)
 			}
+
+			// All network configuration is now complete. Transfer ownership to the
+			// client map and persist the namespace path into container metadata so
+			// future NewTask calls join it without another CNI DEL+ADD cycle.
+			c.mu.Lock()
+			if c.appStopping[appID] {
+				c.mu.Unlock()
+				_, _ = task.Delete(ctx, containerd.WithProcessKill)
+				return nil, fmt.Errorf("app %q stopped during network sandbox setup; container not started", appID)
+			}
+			if retainsBridge && bridgeDNSHealthy && persistentNetns && containerLabels[labelKeyNetworkIdentity] != "" {
+				if err := writeNetworkSandboxResult(appName, cniResult); err == nil {
+					if err := c.persistNetworkNamespace(ctx, container, netnsPath, containerLabels[labelKeyNetworkIdentity], ip); err == nil {
+						c.registerNetworkSandbox(&networkSandbox{
+							appID: appID, serviceName: serviceName, containerID: appName,
+							identity: containerLabels[labelKeyNetworkIdentity], path: netnsPath, ip: ip, result: cniResult,
+							isolation: isolation, entitlements: append([]appconfig.Entitlement(nil), entitlements...), cleanup: cleanupNetns,
+						})
+						keepNetns = true
+					} else {
+						_ = os.Remove(networkSandboxResultPath(appName))
+						c.logger.Warn("Could not persist reusable network namespace", zap.String("container_id", appName), zap.Error(err))
+					}
+				} else {
+					c.logger.Warn("Could not persist reusable CNI result", zap.String("container_id", appName), zap.Error(err))
+				}
+			}
+			networkReady = true
+			c.mu.Unlock()
 		}
 	}
 
@@ -3334,12 +3485,30 @@ func (c *Client) stopOne(ctx context.Context, containerID string) error {
 		return fmt.Errorf("loading container %q: %w", containerID, err)
 	}
 
+	// Explicit stop is a lifecycle boundary: unlike crash-monitor restart or a
+	// compatible redeploy, it must release the retained namespace and all CNI,
+	// DNS, and mesh state even when the task has already exited.
+	labels, _ := container.Labels(ctx)
+	spec, _ := container.Spec(ctx)
+	desiredNetworkIdentity, _ := networkIdentityFromLabels(labels)
+	releasedSandbox := c.destroyNetworkSandbox(ctx, containerID)
+	if !releasedSandbox {
+		releasedSandbox = c.purgePersistedNetworkSandbox(ctx, container, labels, spec)
+	}
+	var clearSandboxErr error
+	if releasedSandbox {
+		if err := c.persistNetworkNamespace(ctx, container, "", desiredNetworkIdentity, ""); err != nil {
+			clearSandboxErr = fmt.Errorf("clearing reusable network namespace for %q: %w", containerID, err)
+			c.logger.Warn("Failed to clear reusable network metadata; continuing task termination", zap.String("container_id", containerID), zap.Error(err))
+		}
+	}
+
 	task, err := container.Task(ctx, nil)
 	if err != nil {
 		if errdefs.IsNotFound(err) {
-			return nil // No task running.
+			return clearSandboxErr // No task running.
 		}
-		return fmt.Errorf("getting task for %q: %w", containerID, err)
+		return errors.Join(clearSandboxErr, fmt.Errorf("getting task for %q: %w", containerID, err))
 	}
 
 	// For containers with bridge wiring — multi-service isolated app services
@@ -3371,7 +3540,7 @@ func (c *Client) stopOne(ctx context.Context, containerID string) error {
 			}
 		}
 
-		if needsCNIBridgeWiring(isolation, svcName, entitlements) {
+		if needsCNIBridgeWiring(isolation, svcName, entitlements) && !releasedSandbox {
 			netnsPath := fmt.Sprintf("/proc/%d/ns/net", task.Pid())
 			if cniErr := c.CNIDel(ctx, appID, containerID, netnsPath); cniErr != nil {
 				c.logger.Warn("CNI DEL failed during stop (non-fatal)",
@@ -3412,7 +3581,7 @@ func (c *Client) stopOne(ctx context.Context, containerID string) error {
 	// SIGKILL after the grace period. Group-wide signalling (not just init)
 	// ensures no descendant survives holding devices/ports (WDY-1818).
 	if err := c.terminateTask(ctx, task, containerID, syscall.SIGTERM, stopGracePeriod, killWaitTimeout); err != nil {
-		return err
+		return errors.Join(clearSandboxErr, err)
 	}
 
 	if c.proxyManager != nil {
@@ -3427,7 +3596,7 @@ func (c *Client) stopOne(ctx context.Context, containerID string) error {
 	// rationale).
 	go c.SyncCameraLoopbacks(context.WithoutCancel(ctx))
 
-	return nil
+	return clearSandboxErr
 }
 
 // StopContainer stops the containers addressed by name: a bare appID stops
@@ -3437,6 +3606,8 @@ func (c *Client) stopOne(ctx context.Context, containerID string) error {
 // the list query and the stop loop (TOCTOU, SOC2-CC6, NIST-AC-4).
 func (c *Client) StopContainer(ctx context.Context, name string) error {
 	ctx = c.withNamespace(ctx)
+	unlockNetwork := c.lockNetworkOperation(name)
+	defer unlockNetwork()
 
 	// Hold mutex only long enough to enumerate containers and resolve stop order.
 	// Releasing before stopOne prevents holding c.mu across potentially long
@@ -3632,6 +3803,15 @@ func ensureSharedSHM(appID string) (string, error) {
 // can batch image deletions across services. ctx must have the namespace set
 // and the caller must hold c.mu.
 func (c *Client) deleteOne(ctx context.Context, ctr containerd.Container, wantImg bool) (imgName string, err error) {
+	// Delete may be called without StopContainer first. Release an owned
+	// reusable sandbox even when there is no live task left to provide a procfs
+	// namespace path.
+	persistedLabels, _ := ctr.Labels(ctx)
+	persistedSpec, _ := ctr.Spec(ctx)
+	releasedSandbox := c.destroyNetworkSandbox(ctx, ctr.ID())
+	if !releasedSandbox {
+		releasedSandbox = c.purgePersistedNetworkSandbox(ctx, ctr, persistedLabels, persistedSpec)
+	}
 	// Mesh/bridge teardown for delete-without-stop: `wendy device apps remove`
 	// on a RUNNING meshed or bridge-mode app goes DeleteContainer → deleteOne
 	// without ever passing through stopOne, which would otherwise leak the
@@ -3660,7 +3840,7 @@ func (c *Client) deleteOne(ctx context.Context, ctr containerd.Container, wantIm
 		}
 		needsBridge = needsCNIBridgeWiring(isolation, svcName, entitlements)
 	}
-	if needsBridge {
+	if needsBridge && !releasedSandbox {
 		if needsGatewayDNS(isolation, entitlements) {
 			c.releaseMeshDNS(ctr.ID(), appID)
 		}
@@ -3677,7 +3857,7 @@ func (c *Client) deleteOne(ctx context.Context, ctr containerd.Container, wantIm
 		// create for the same appID/serviceName then fails CNI ADD with
 		// "duplicate allocation is not allowed" (WDY mesh: found via repeated
 		// remove+redeploy cycles during RemoteCam demo debugging).
-		if needsBridge {
+		if needsBridge && !releasedSandbox {
 			netnsPath := fmt.Sprintf("/proc/%d/ns/net", task.Pid())
 			if cniErr := c.CNIDel(ctx, appID, ctr.ID(), netnsPath); cniErr != nil {
 				c.logger.Warn("CNI DEL failed during delete (non-fatal)",
@@ -3716,6 +3896,8 @@ func (c *Client) deleteOne(ctx context.Context, ctr containerd.Container, wantIm
 // apps all service containers are removed. When deleteImage is true, each
 // distinct image is deleted once (services sharing an image are handled safely).
 func (c *Client) DeleteContainer(ctx context.Context, name string, deleteImage bool) error {
+	unlockNetwork := c.lockNetworkOperation(name)
+	defer unlockNetwork()
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -1678,10 +1678,10 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 	}
 	unlockNetwork := c.lockNetworkOperation(appName)
 	defer unlockNetwork()
-	// Hold c.mu for container lookup and task creation to prevent a concurrent
-	// DeleteContainer from removing the container between the label-based lookup
-	// and NewTask (TOCTOU, SOC2-CC6). Released before the streaming goroutine
-	// launch via the muHeld flag pattern.
+	// Hold c.mu for the initial container/metadata snapshot. It is released for
+	// sandbox health checks and CNI cleanup, then reacquired around NewTask so a
+	// concurrent DeleteContainer cannot remove the container between the final
+	// stop-state check and task creation (TOCTOU, SOC2-CC6).
 	c.mu.Lock()
 	muHeld := true
 	defer func() {
@@ -1732,6 +1732,13 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 	if c.appStopping[appID] {
 		return nil, fmt.Errorf("%w: %q", errAppStopping, appID)
 	}
+	isolation := c.getIsolation(appID)
+
+	// Sandbox verification can self-exec CNI CHECK, query netlink, and tear down
+	// mounts/IPAM. None of that may run under the global client mutex; the keyed
+	// network-operation lock above still serializes this container's lifecycle.
+	muHeld = false
+	c.mu.Unlock()
 
 	// Reboot resilience for meshed containers (C-final-review Fix 1): the
 	// container's OCI spec bind-mounts /etc/resolv.conf from a tmpfs path
@@ -1756,7 +1763,6 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 	// both its health/identity checks pass and the stored OCI spec explicitly
 	// joins its bind mount. The second condition prevents skipping CNI for a
 	// legacy/private spec that would start in an unrelated fresh namespace.
-	isolation := c.getIsolation(appID)
 	entitlements := parseEntitlementsFromAnnotations(containerLabels)
 	needsBridge := needsCNIBridgeWiring(isolation, serviceName, entitlements)
 	identity, retainsBridge := networkIdentityFromLabels(containerLabels)
@@ -1786,6 +1792,15 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 				return nil, fmt.Errorf("clearing ineligible reusable network namespace for %q: %w", appName, err)
 			}
 		}
+	}
+
+	// Re-enter the narrow task-creation critical section after all potentially
+	// slow sandbox validation and cleanup. StopContainer publishes appStopping
+	// under this mutex, so a stop that won the unlocked interval fails closed.
+	c.mu.Lock()
+	muHeld = true
+	if c.appStopping[appID] {
+		return nil, fmt.Errorf("%w: %q", errAppStopping, appID)
 	}
 
 	if restartPolicy != nil {
@@ -1861,8 +1876,18 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 		return nil, fmt.Errorf("starting task for %q: %w", appName, err)
 	}
 
-	c.logger.Info("Container started", zap.String("app_name", appName))
-	c.startPostStartAgentHook(postStartAgentCommand, appName)
+	// From this point through network setup, every failure must kill the task,
+	// close its unconsumed pipes, and record a did-not-start diagnostic. The
+	// post-start hook is intentionally delayed until network setup commits.
+	failStartedTask := func(cause error) error {
+		_, _ = task.Delete(taskCtx, containerd.WithProcessKill)
+		stdoutR.Close()
+		stdoutW.Close()
+		stderrR.Close()
+		stderrW.Close()
+		c.recordStartFailure(ctx, appName, cause)
+		return cause
+	}
 
 	// Track the primary PID for shared-namespace app groups.
 	// getIsolation requires c.mu (held here via muHeld).
@@ -1914,10 +1939,11 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 	// It also closes the fd (the bind-mount anchors the namespace independently).
 	// On Linux the bind-mount is used; on other platforms the fd path is the fallback.
 	if reusedNetworkSandbox != nil {
+		// Mandatory for both in-memory reuse and restart recovery: neither path
+		// may skip this post-start task<->namespace binding check.
 		if !taskUsesNetworkSandbox(reusedNetworkSandbox.path, task.Pid()) {
 			c.destroyNetworkSandbox(ctx, appName)
-			_, _ = task.Delete(ctx, containerd.WithProcessKill)
-			return nil, fmt.Errorf("reusable network sandbox validation failed for app %q after task start", appID)
+			return nil, failStartedTask(fmt.Errorf("reusable network sandbox validation failed for app %q after task start", appID))
 		}
 		c.logger.Info("Reused CNI network sandbox",
 			zap.String(logfields.AppID, appID),
@@ -1963,6 +1989,7 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 			}
 			cleanupNetns()
 			c.logger.Error("CNI ADD failed", zap.String(logfields.AppID, appID), zap.Error(cniErr))
+			return nil, failStartedTask(fmt.Errorf("CNI ADD failed for app %q: %w", appID, cniErr))
 		} else {
 			// netnsPath (the bind-mount) must stay mounted through mesh egress
 			// setup below, which needs a live netns to install the service-CIDR
@@ -2005,8 +2032,7 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 					c.mu.Unlock()
 					c.logger.Warn("CNI ADD: app already stopped before IP could be recorded, discarding IP",
 						zap.String(logfields.AppID, appID), zap.String("ip", ip))
-					_, _ = task.Delete(ctx, containerd.WithProcessKill)
-					return nil, fmt.Errorf("app %q stopped during CNI ADD; container not started", appID)
+					return nil, failStartedTask(fmt.Errorf("app %q stopped during CNI ADD; container not started", appID))
 				}
 				c.recordServiceIP(appID, serviceName, ip)
 				hostsPath, pathErr := safeJoin("/run/wendy/hosts", appID)
@@ -2020,8 +2046,7 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 					c.logger.Error("security: appID produces unsafe hosts path",
 						zap.String(logfields.AppID, appID), zap.Error(pathErr))
 					c.mu.Unlock()
-					_, _ = task.Delete(ctx, containerd.WithProcessKill)
-					return nil, fmt.Errorf("security: appID %q produces unsafe hosts path: %w", appID, pathErr)
+					return nil, failStartedTask(fmt.Errorf("security: appID %q produces unsafe hosts path: %w", appID, pathErr))
 				}
 				_ = writeHostsFile(hostsPath, c.serviceIPs[appID])
 				c.mu.Unlock()
@@ -2070,8 +2095,7 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 			if meshErr := c.applyMeshEgress(entitlements, appName, appID, netnsPath, ip); meshErr != nil {
 				c.logger.Error("mesh egress setup failed; failing container start",
 					zap.String("app_id", appID), zap.Error(meshErr))
-				_, _ = task.Delete(ctx, containerd.WithProcessKill)
-				return nil, fmt.Errorf("mesh egress setup failed for app %q: %w", appID, meshErr)
+				return nil, failStartedTask(fmt.Errorf("mesh egress setup failed for app %q: %w", appID, meshErr))
 			}
 
 			// All network configuration is now complete. Transfer ownership to the
@@ -2080,15 +2104,14 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 			c.mu.Lock()
 			if c.appStopping[appID] {
 				c.mu.Unlock()
-				_, _ = task.Delete(ctx, containerd.WithProcessKill)
-				return nil, fmt.Errorf("app %q stopped during network sandbox setup; container not started", appID)
+				return nil, failStartedTask(fmt.Errorf("app %q stopped during network sandbox setup; container not started", appID))
 			}
-			if retainsBridge && bridgeDNSHealthy && persistentNetns && containerLabels[labelKeyNetworkIdentity] != "" {
+			if retainsBridge && bridgeDNSHealthy && persistentNetns && identity != "" {
 				if err := writeNetworkSandboxResult(appName, cniResult); err == nil {
-					if err := c.persistNetworkNamespace(ctx, container, netnsPath, containerLabels[labelKeyNetworkIdentity], ip); err == nil {
+					if err := c.persistNetworkNamespace(ctx, container, netnsPath, identity, ip); err == nil {
 						c.registerNetworkSandbox(&networkSandbox{
 							appID: appID, serviceName: serviceName, containerID: appName,
-							identity: containerLabels[labelKeyNetworkIdentity], path: netnsPath, ip: ip, result: cniResult,
+							identity: identity, path: netnsPath, ip: ip, result: cniResult,
 							isolation: isolation, entitlements: append([]appconfig.Entitlement(nil), entitlements...), cleanup: cleanupNetns,
 						})
 						keepNetns = true
@@ -2104,6 +2127,9 @@ func (c *Client) StartContainer(ctx context.Context, appName, postStartAgentComm
 			c.mu.Unlock()
 		}
 	}
+
+	c.logger.Info("Container started", zap.String("app_name", appName))
+	c.startPostStartAgentHook(postStartAgentCommand, appName)
 
 	// Stream output from the pipes.
 	outputCh := make(chan services.ContainerOutput, 64)

--- a/go/internal/agent/containerd/cni.go
+++ b/go/internal/agent/containerd/cni.go
@@ -272,6 +272,20 @@ func buildBridgeCNIConfig(appID, subnet string) string {
 	return string(b)
 }
 
+func buildBridgeCNICheckConfig(appID, subnet, result string) (string, error) {
+	var prevResult any
+	if len(result) == 0 || len(result) > cniStdoutLimit || json.Unmarshal([]byte(result), &prevResult) != nil {
+		return "", fmt.Errorf("invalid CNI previous result")
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal([]byte(buildBridgeCNIConfig(appID, subnet)), &cfg); err != nil {
+		return "", err
+	}
+	cfg["prevResult"] = prevResult
+	b, err := json.Marshal(cfg)
+	return string(b), err
+}
+
 // cniStdoutLimit is the maximum bytes read from the CNI plugin's stdout.
 // A valid CNI ADD response is well under 1 KB; this cap prevents memory
 // exhaustion if the vendored plugin logic ever emits unexpectedly large
@@ -332,14 +346,14 @@ func warnSubnetCollision(logger *zap.Logger, appID, subnet string) {
 // ensureCNIBinDir in cmd/wendy-agent), so the vendored bridge plugin's IPAM
 // delegation (it execs "host-local" via CNI_PATH) also resolves back into
 // this same binary instead of a third-party binary.
-func (c *Client) CNIAdd(ctx context.Context, appID, containerID, netnsPath string) (string, error) {
+func (c *Client) CNIAdd(ctx context.Context, appID, containerID, netnsPath string) (string, string, error) {
 	if err := validateCNIInputs(appID, containerID, netnsPath); err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	subnet, err := allocateSubnet(appID)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	warnSubnetCollision(c.logger, appID, subnet)
 	cfgJSON := buildBridgeCNIConfig(appID, subnet)
@@ -349,7 +363,7 @@ func (c *Client) CNIAdd(ctx context.Context, appID, containerID, netnsPath strin
 	// prevents a kernel-level env truncation if a NUL ever reaches here via a
 	// future bypass (SOC2-CC6, NIST-SC-7, ISO27001-A.8).
 	if strings.ContainsRune(containerID, '\x00') || strings.ContainsRune(netnsPath, '\x00') {
-		return "", fmt.Errorf("CNI ADD: NUL byte in containerID or netnsPath rejected")
+		return "", "", fmt.Errorf("CNI ADD: NUL byte in containerID or netnsPath rejected")
 	}
 
 	// runAddOnce execs the vendored bridge plugin (via self-exec) for one ADD
@@ -413,15 +427,15 @@ func (c *Client) CNIAdd(ctx context.Context, appID, containerID, netnsPath strin
 			zap.String("stdout", sanitizeForLog(stdoutStr, 1024)),
 			zap.String("stderr", sanitizeForLog(stderrStr, 512)),
 			zap.Error(runErr))
-		return "", fmt.Errorf("CNI ADD failed for %s/%s; see agent logs for details", appID, containerID)
+		return "", "", fmt.Errorf("CNI ADD failed for %s/%s; see agent logs for details", appID, containerID)
 	}
 
 	var result cniResult
 	if err := json.Unmarshal([]byte(stdoutStr), &result); err != nil {
-		return "", fmt.Errorf("parsing CNI ADD result for %s/%s: %w", appID, containerID, err)
+		return "", "", fmt.Errorf("parsing CNI ADD result for %s/%s: %w", appID, containerID, err)
 	}
 	if len(result.IPs) == 0 {
-		return "", fmt.Errorf("CNI ADD returned no IPs for %s/%s", appID, containerID)
+		return "", "", fmt.Errorf("CNI ADD returned no IPs for %s/%s", appID, containerID)
 	}
 	rawIP, _, _ := strings.Cut(result.IPs[0].Address, "/")
 	// Validate and normalise the IP before using it in /etc/hosts bind-mounts.
@@ -429,14 +443,49 @@ func (c *Client) CNIAdd(ctx context.Context, appID, containerID, netnsPath strin
 	// poison the hosts file injected into sibling containers (SOC2-CC6, NIST-SC-7).
 	parsed := net.ParseIP(rawIP)
 	if parsed == nil {
-		return "", fmt.Errorf("CNI ADD returned invalid IP %q for %s/%s", rawIP, appID, containerID)
+		return "", "", fmt.Errorf("CNI ADD returned invalid IP %q for %s/%s", rawIP, appID, containerID)
 	}
 	ip := parsed.String()
 	c.logger.Info("CNI ADD: assigned IP",
 		zap.String("app_id", appID),
 		zap.String("container_id", containerID),
 		zap.String("ip", ip))
-	return ip, nil
+	return ip, stdoutStr, nil
+}
+
+// CNICheck asks the same vendored bridge and host-local plugins used for ADD
+// to verify the complete persisted setup before it is reused.
+func (c *Client) CNICheck(ctx context.Context, appID, containerID, netnsPath, result string) error {
+	if err := validateCNIInputs(appID, containerID, netnsPath); err != nil {
+		return err
+	}
+	subnet, err := allocateSubnet(appID)
+	if err != nil {
+		return err
+	}
+	cfgJSON, err := buildBridgeCNICheckConfig(appID, subnet, result)
+	if err != nil {
+		return err
+	}
+	cmd := exec.CommandContext(ctx, selfExePath)
+	cmd.Args = []string{"bridge"}
+	cmd.Dir = "/"
+	cmd.Stdin = strings.NewReader(cfgJSON)
+	cmd.Env = []string{
+		"PATH=" + CNIBinDir + cniSystemPathDirs,
+		"CNI_COMMAND=CHECK",
+		"CNI_CONTAINERID=" + containerID,
+		"CNI_NETNS=" + netnsPath,
+		"CNI_IFNAME=eth0",
+		"CNI_PATH=" + CNIBinDir,
+	}
+	var output bytes.Buffer
+	cmd.Stdout = &limitedWriter{w: &output, remaining: cniStdoutLimit, cap: cniStdoutLimit}
+	cmd.Stderr = &limitedWriter{w: &output, remaining: cniStdoutLimit, cap: cniStdoutLimit}
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("CNI CHECK failed for %s/%s: %w (%s)", appID, containerID, err, sanitizeForLog(output.String(), 512))
+	}
+	return nil
 }
 
 // limitedWriter is an io.Writer that returns an error if more than `cap`

--- a/go/internal/agent/containerd/cni_test.go
+++ b/go/internal/agent/containerd/cni_test.go
@@ -44,6 +44,25 @@ func TestBuildCNIConfig(t *testing.T) {
 	}
 }
 
+func TestBuildBridgeCNICheckConfigCarriesPreviousResult(t *testing.T) {
+	result := `{"cniVersion":"0.4.0","ips":[{"version":"4","address":"10.1.2.3/28","gateway":"10.1.2.1"}]}`
+	cfgJSON, err := buildBridgeCNICheckConfig("com.example.myapp", "10.1.2.0/28", result)
+	if err != nil {
+		t.Fatalf("build check config: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal([]byte(cfgJSON), &cfg); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	prev, ok := cfg["prevResult"].(map[string]any)
+	if !ok || prev["cniVersion"] != "0.4.0" {
+		t.Fatalf("prevResult not preserved: %#v", cfg["prevResult"])
+	}
+	if _, err := buildBridgeCNICheckConfig("com.example.myapp", "10.1.2.0/28", `{broken`); err == nil {
+		t.Fatal("malformed previous result was accepted")
+	}
+}
+
 func TestBridgeName(t *testing.T) {
 	// Short appID: direct embedding.
 	if got := bridgeName("myapp"); got != "wendy-br-myapp" {

--- a/go/internal/agent/containerd/mesh_wiring.go
+++ b/go/internal/agent/containerd/mesh_wiring.go
@@ -41,9 +41,9 @@ var _ meshDNSService = (*mesh.DNSServer)(nil)
 //
 // Best-effort: a failure only logs a warning (device-N hostnames won't
 // resolve; VIP literals still work) and takes no refcount.
-func (c *Client) ensureMeshDNS(containerName, gateway string) {
+func (c *Client) ensureMeshDNS(containerName, gateway string) bool {
 	if c.meshDNS == nil {
-		return
+		return false
 	}
 	// Idempotent per container: the monitor's restartSingle calls
 	// StartContainer directly with no intervening stopOne/teardownMeshEgress,
@@ -58,12 +58,12 @@ func (c *Client) ensureMeshDNS(containerName, gateway string) {
 	alreadyHeld := c.meshDNSHeld[containerName]
 	c.meshMu.Unlock()
 	if alreadyHeld {
-		return
+		return true
 	}
 	if err := c.meshDNS.EnsureListener(gateway); err != nil {
 		c.logger.Warn("mesh: DNS listener unavailable; device-N hostnames will not resolve",
 			zap.String("container", containerName), zap.String("gateway", gateway), zap.Error(err))
-		return
+		return false
 	}
 	c.meshMu.Lock()
 	if c.meshDNSHeld == nil {
@@ -71,6 +71,7 @@ func (c *Client) ensureMeshDNS(containerName, gateway string) {
 	}
 	c.meshDNSHeld[containerName] = true
 	c.meshMu.Unlock()
+	return true
 }
 
 // releaseMeshDNS drops the DNS-listener reference containerName holds, if

--- a/go/internal/agent/containerd/netns_linux.go
+++ b/go/internal/agent/containerd/netns_linux.go
@@ -5,6 +5,7 @@ package containerd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"golang.org/x/sys/unix"
 )
@@ -20,13 +21,13 @@ const cniNetnsBindDir = "/run/wendy/netns"
 //
 // On error, the function falls back to the fd-path approach (/proc/self/fd/<n>)
 // with the caller responsible for keeping netnsRef open until CNI completes.
-func bindNetnsForCNI(containerID string, netnsRef *os.File) (netnsPath string, cleanup func()) {
+func bindNetnsForCNI(containerID string, netnsRef *os.File) (netnsPath string, cleanup func(), persistent bool) {
 	// 0o700: owner-only, consistent with /run/wendy/cni and /run/wendy/shm.
 	// Network namespace bind-mount points must not be reachable by group-0
 	// daemons — opening a netns fd exposes network attack surface
 	// (SOC2-CC6, NIST-SI-10, ISO27001-A.8).
 	if err := os.MkdirAll(cniNetnsBindDir, 0o700); err != nil {
-		return fmt.Sprintf("/proc/self/fd/%d", netnsRef.Fd()), func() { netnsRef.Close() }
+		return fmt.Sprintf("/proc/self/fd/%d", netnsRef.Fd()), func() { netnsRef.Close() }, false
 	}
 	// Explicit chmod handles pre-existing directories with wider permissions.
 	_ = os.Chmod(cniNetnsBindDir, 0o700)
@@ -35,17 +36,22 @@ func bindNetnsForCNI(containerID string, netnsRef *os.File) (netnsPath string, c
 	// not escape the bind directory — stronger than filepath.Base alone.
 	bindPath, safeErr := safeJoin(cniNetnsBindDir, containerID)
 	if safeErr != nil {
-		return fmt.Sprintf("/proc/self/fd/%d", netnsRef.Fd()), func() { netnsRef.Close() }
+		return fmt.Sprintf("/proc/self/fd/%d", netnsRef.Fd()), func() { netnsRef.Close() }, false
 	}
 
 	// Create the bind point — must be a regular file (not a dir) for netns bind-mounts.
 	f, err := os.OpenFile(bindPath, os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil && !os.IsExist(err) {
-		return fmt.Sprintf("/proc/self/fd/%d", netnsRef.Fd()), func() { netnsRef.Close() }
+		return fmt.Sprintf("/proc/self/fd/%d", netnsRef.Fd()), func() { netnsRef.Close() }, false
 	}
 	if f != nil {
 		f.Close()
 	}
+	// A previous agent may have exited without running Client.Close. Never
+	// stack a new bind mount over that unowned namespace: detach it first, then
+	// mount the fd we just anchored. In-process live sandboxes do not reach this
+	// helper because StartContainer reuses them before attempting a new bind.
+	_ = unix.Unmount(bindPath, unix.MNT_DETACH)
 
 	// Bind-mount the anchored fd path to the stable bind point. Using the fd
 	// path as source ensures we mount the inode we already verified, not a
@@ -53,7 +59,7 @@ func bindNetnsForCNI(containerID string, netnsRef *os.File) (netnsPath string, c
 	srcPath := fmt.Sprintf("/proc/self/fd/%d", netnsRef.Fd())
 	if err := unix.Mount(srcPath, bindPath, "", unix.MS_BIND, ""); err != nil {
 		os.Remove(bindPath)
-		return fmt.Sprintf("/proc/self/fd/%d", netnsRef.Fd()), func() { netnsRef.Close() }
+		return fmt.Sprintf("/proc/self/fd/%d", netnsRef.Fd()), func() { netnsRef.Close() }, false
 	}
 
 	// The bind-mount anchors the namespace independently of the fd.
@@ -62,5 +68,13 @@ func bindNetnsForCNI(containerID string, netnsRef *os.File) (netnsPath string, c
 	return bindPath, func() {
 		unix.Unmount(bindPath, unix.MNT_DETACH) //nolint:errcheck
 		os.Remove(bindPath)
+	}, true
+}
+
+func cleanupNetworkSandboxPath(path string) {
+	if filepath.Dir(path) != cniNetnsBindDir {
+		return
 	}
+	unix.Unmount(path, unix.MNT_DETACH) //nolint:errcheck
+	os.Remove(path)
 }

--- a/go/internal/agent/containerd/netns_other.go
+++ b/go/internal/agent/containerd/netns_other.go
@@ -7,11 +7,15 @@ import (
 	"os"
 )
 
+const cniNetnsBindDir = "/run/wendy/netns"
+
 // bindNetnsForCNI falls back to the /proc/self/fd/<n> form on non-Linux
 // platforms. The bind-mount approach requires Linux mount namespaces; on
 // macOS (used for development and testing) the fallback is acceptable since
 // the CNI binary is never actually executed on non-Linux systems.
-func bindNetnsForCNI(containerID string, netnsRef *os.File) (netnsPath string, cleanup func()) {
+func bindNetnsForCNI(containerID string, netnsRef *os.File) (netnsPath string, cleanup func(), persistent bool) {
 	_ = containerID
-	return fmt.Sprintf("/proc/self/fd/%d", netnsRef.Fd()), func() { netnsRef.Close() }
+	return fmt.Sprintf("/proc/self/fd/%d", netnsRef.Fd()), func() { netnsRef.Close() }, false
 }
+
+func cleanupNetworkSandboxPath(_ string) {}

--- a/go/internal/agent/containerd/network_sandbox.go
+++ b/go/internal/agent/containerd/network_sandbox.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 
 	containerd "github.com/containerd/containerd/v2/client"
@@ -164,6 +165,37 @@ func (c *Client) lockNetworkOperation(containerID string) func() {
 			delete(c.networkOps, containerID)
 		}
 		c.networkOpsMu.Unlock()
+	}
+}
+
+// lockAdditionalNetworkOperations extends an already-held operation lock to a
+// set of concrete container IDs. Group stop/delete calls begin with the bare
+// app-ID lock, while per-service create/start calls use container IDs; holding
+// both key spaces is therefore required to serialize a whole-app lifecycle
+// operation against every member. Caller must hold heldKey's lock and must not
+// hold c.mu. Callers for one group share heldKey; sorting makes their additional
+// per-member acquisition order deterministic.
+func (c *Client) lockAdditionalNetworkOperations(heldKey string, containerIDs []string) func() {
+	unique := make(map[string]struct{}, len(containerIDs))
+	for _, containerID := range containerIDs {
+		if containerID != "" && containerID != heldKey {
+			unique[containerID] = struct{}{}
+		}
+	}
+	keys := make([]string, 0, len(unique))
+	for key := range unique {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	unlocks := make([]func(), 0, len(keys))
+	for _, key := range keys {
+		unlocks = append(unlocks, c.lockNetworkOperation(key))
+	}
+	return func() {
+		for i := len(unlocks) - 1; i >= 0; i-- {
+			unlocks[i]()
+		}
 	}
 }
 

--- a/go/internal/agent/containerd/network_sandbox.go
+++ b/go/internal/agent/containerd/network_sandbox.go
@@ -105,6 +105,15 @@ func networkIdentity(isolation string, entitlements []appconfig.Entitlement) str
 // Container labels are external state, so callers must not trust the stored
 // fingerprint without recomputing it from isolation and entitlements.
 func networkIdentityFromLabels(labels map[string]string) (string, bool) {
+	expected, eligible := desiredNetworkIdentityFromLabels(labels)
+	return expected, eligible && labels[labelKeyNetworkIdentity] == expected
+}
+
+// desiredNetworkIdentityFromLabels derives the fingerprint exclusively from
+// the policy-bearing labels. Unlike networkIdentityFromLabels it deliberately
+// ignores the persisted fingerprint, so write paths can never copy an
+// attacker-influenced identity value back into container metadata.
+func desiredNetworkIdentityFromLabels(labels map[string]string) (string, bool) {
 	appID, serviceName := labels[labelKeyAppID], labels[labelKeyServiceName]
 	if appconfig.ValidateAppID(appID) != nil || (serviceName != "" && appconfig.ValidateServiceName(serviceName) != nil) {
 		return "", false
@@ -114,7 +123,7 @@ func networkIdentityFromLabels(labels map[string]string) (string, bool) {
 		return "", false
 	}
 	expected := networkIdentity(labels[labelKeyIsolation], entitlements)
-	return expected, expected != "" && labels[labelKeyNetworkIdentity] == expected
+	return expected, expected != ""
 }
 
 func (c *Client) registerNetworkSandbox(s *networkSandbox) {
@@ -131,6 +140,10 @@ func (c *Client) registerNetworkSandbox(s *networkSandbox) {
 }
 
 func (c *Client) lockNetworkOperation(containerID string) func() {
+	// Lock ordering invariant: when an operation needs both locks, the keyed
+	// network-operation lock is always acquired before c.mu. Never call this
+	// helper while holding c.mu; reversing that order can deadlock StartContainer's
+	// metadata commit against create/stop/delete.
 	c.networkOpsMu.Lock()
 	if c.networkOps == nil {
 		c.networkOps = make(map[string]*networkOperation)
@@ -161,10 +174,20 @@ func (c *Client) reusableNetworkSandbox(ctx context.Context, containerID, identi
 	c.networkSandboxesMu.Lock()
 	s := c.networkSandboxes[containerID]
 	c.networkSandboxesMu.Unlock()
-	if s == nil || s.identity != identity || !networkSandboxHealthy(s.path, s.ip) || c.CNICheck(ctx, s.appID, s.containerID, s.path, s.result) != nil || !c.refreshBridgeDNS(s.containerID, s.appID) {
+	if s == nil || s.identity != identity || !networkSandboxHealthy(s.path, s.ip) {
+		return nil, false
+	}
+	if !networkSandboxChecksPassed(true, c.CNICheck(ctx, s.appID, s.containerID, s.path, s.result)) || !c.refreshBridgeDNS(s.containerID, s.appID) {
 		return nil, false
 	}
 	return s, true
+}
+
+// networkSandboxChecksPassed keeps the independent kernel-health and CNI CHECK
+// gates explicit. In particular, a healthy-looking namespace or persisted
+// prevResult can never compensate for a failed plugin CHECK.
+func networkSandboxChecksPassed(healthOK bool, cniCheckErr error) bool {
+	return healthOK && cniCheckErr == nil
 }
 
 // refreshBridgeDNS drops and reacquires this single-service bridge's listener.
@@ -271,7 +294,7 @@ func (c *Client) recoverNetworkSandbox(ctx context.Context, ctr containerd.Conta
 		return nil, false
 	}
 	result, err := readNetworkSandboxResult(ctr.ID())
-	if err != nil || c.CNICheck(ctx, appID, ctr.ID(), path, result) != nil {
+	if err != nil || !networkSandboxChecksPassed(true, c.CNICheck(ctx, appID, ctr.ID(), path, result)) {
 		return nil, false
 	}
 	if !c.refreshBridgeDNS(ctr.ID(), appID) {
@@ -346,15 +369,22 @@ func (c *Client) persistNetworkNamespace(ctx context.Context, ctr containerd.Con
 		if record.Labels == nil {
 			record.Labels = make(map[string]string)
 		}
+		// Recompute from the authoritative isolation/entitlement policy at the
+		// write boundary. The identity argument is only an intent/consistency
+		// check; it is never copied into metadata.
+		desiredIdentity, eligible := desiredNetworkIdentityFromLabels(record.Labels)
+		if identity != "" && (!eligible || identity != desiredIdentity) {
+			return fmt.Errorf("network identity changed while persisting reusable namespace")
+		}
 		if path == "" {
 			delete(record.Labels, labelKeyNetworkSandboxIP)
 			if identity == "" {
 				delete(record.Labels, labelKeyNetworkIdentity)
 			} else {
-				record.Labels[labelKeyNetworkIdentity] = identity
+				record.Labels[labelKeyNetworkIdentity] = desiredIdentity
 			}
 		} else {
-			record.Labels[labelKeyNetworkIdentity] = identity
+			record.Labels[labelKeyNetworkIdentity] = desiredIdentity
 			record.Labels[labelKeyNetworkSandboxIP] = ip
 		}
 		return nil

--- a/go/internal/agent/containerd/network_sandbox.go
+++ b/go/internal/agent/containerd/network_sandbox.go
@@ -186,6 +186,12 @@ func (c *Client) reusableNetworkSandbox(ctx context.Context, containerID, identi
 // networkSandboxChecksPassed keeps the independent kernel-health and CNI CHECK
 // gates explicit. In particular, a healthy-looking namespace or persisted
 // prevResult can never compensate for a failed plugin CHECK.
+//
+// SECURITY: the vendored bridge CHECK uses prevResult only as expected state;
+// it reopens both namespaces and queries live bridge/veth, address, and route
+// state, while vendored host-local CHECK reopens its allocation store. These
+// live checks are pinned by SECURITY comments at both CmdCheck implementations
+// and must remain mandatory on vendored-plugin upgrades.
 func networkSandboxChecksPassed(healthOK bool, cniCheckErr error) bool {
 	return healthOK && cniCheckErr == nil
 }

--- a/go/internal/agent/containerd/network_sandbox.go
+++ b/go/internal/agent/containerd/network_sandbox.go
@@ -1,0 +1,398 @@
+package containerd
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/core/containers"
+	"github.com/containerd/typeurl/v2"
+	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
+	"go.uber.org/zap"
+
+	localoci "github.com/wendylabsinc/wendy/go/internal/agent/oci"
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+const (
+	labelKeyNetworkIdentity  = "sh.wendy/network.identity"
+	labelKeyNetworkSandboxIP = "sh.wendy/network.sandbox.ip"
+)
+
+func networkSandboxPath(containerID string) string {
+	path, err := safeJoin(cniNetnsBindDir, containerID)
+	if err != nil {
+		return ""
+	}
+	return path
+}
+
+func networkSandboxResultPath(containerID string) string {
+	path, err := safeJoin(cniNetnsBindDir, containerID+".cni.json")
+	if err != nil {
+		return ""
+	}
+	return path
+}
+
+// networkSandboxEligible deliberately limits retention to the configuration
+// whose complete host and namespace state can be verified by CNI CHECK. Mesh
+// and multi-service networking retain their existing full DEL+ADD lifecycle.
+func networkSandboxEligible(serviceName string, entitlements []appconfig.Entitlement) bool {
+	if serviceName != "" {
+		return false
+	}
+	_, bridge := findBridgeEntitlement(entitlements)
+	_, mesh := findMeshEntitlement(entitlements)
+	return bridge && !mesh
+}
+
+// networkSandbox is a CNI-configured network namespace that outlives an
+// individual container task. cleanup owns the namespace bind mount.
+type networkSandbox struct {
+	appID        string
+	serviceName  string
+	containerID  string
+	identity     string
+	path         string
+	ip           string
+	result       string
+	isolation    string
+	entitlements []appconfig.Entitlement
+	cleanup      func()
+	once         sync.Once
+}
+
+// networkOperation is a reference-counted keyed mutex. Reference accounting
+// lets the client remove idle keys without racing a waiter that already chose
+// the same lock, avoiding unbounded growth across changing app IDs.
+type networkOperation struct {
+	mu   sync.Mutex
+	refs int
+}
+
+func (s *networkSandbox) close() {
+	if s != nil && s.cleanup != nil {
+		s.once.Do(s.cleanup)
+	}
+}
+
+// networkIdentity deliberately includes the complete entitlement set, not
+// only network entitlements. This is conservative: an entitlement-only change
+// gives up reuse even when it would happen to leave CNI unchanged, ensuring a
+// reused namespace can never outlive a security-policy change.
+func networkIdentity(isolation string, entitlements []appconfig.Entitlement) string {
+	payload, err := json.Marshal(struct {
+		Isolation    string                  `json:"isolation"`
+		Entitlements []appconfig.Entitlement `json:"entitlements"`
+	}{isolation, entitlements})
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:])
+}
+
+// networkIdentityFromLabels verifies that persisted desired-state labels
+// describe an eligible sandbox and have not drifted from their fingerprint.
+// Container labels are external state, so callers must not trust the stored
+// fingerprint without recomputing it from isolation and entitlements.
+func networkIdentityFromLabels(labels map[string]string) (string, bool) {
+	appID, serviceName := labels[labelKeyAppID], labels[labelKeyServiceName]
+	if appconfig.ValidateAppID(appID) != nil || (serviceName != "" && appconfig.ValidateServiceName(serviceName) != nil) {
+		return "", false
+	}
+	entitlements := parseEntitlementsFromAnnotations(labels)
+	if !networkSandboxEligible(serviceName, entitlements) {
+		return "", false
+	}
+	expected := networkIdentity(labels[labelKeyIsolation], entitlements)
+	return expected, expected != "" && labels[labelKeyNetworkIdentity] == expected
+}
+
+func (c *Client) registerNetworkSandbox(s *networkSandbox) {
+	if s == nil {
+		return
+	}
+	c.networkSandboxesMu.Lock()
+	old := c.networkSandboxes[s.containerID]
+	c.networkSandboxes[s.containerID] = s
+	c.networkSandboxesMu.Unlock()
+	if old != nil && old != s {
+		old.close()
+	}
+}
+
+func (c *Client) lockNetworkOperation(containerID string) func() {
+	c.networkOpsMu.Lock()
+	if c.networkOps == nil {
+		c.networkOps = make(map[string]*networkOperation)
+	}
+	op := c.networkOps[containerID]
+	if op == nil {
+		op = &networkOperation{}
+		c.networkOps[containerID] = op
+	}
+	op.refs++
+	c.networkOpsMu.Unlock()
+	op.mu.Lock()
+	return func() {
+		op.mu.Unlock()
+		c.networkOpsMu.Lock()
+		op.refs--
+		if op.refs == 0 && c.networkOps[containerID] == op {
+			delete(c.networkOps, containerID)
+		}
+		c.networkOpsMu.Unlock()
+	}
+}
+
+func (c *Client) reusableNetworkSandbox(ctx context.Context, containerID, identity string) (*networkSandbox, bool) {
+	if identity == "" {
+		return nil, false
+	}
+	c.networkSandboxesMu.Lock()
+	s := c.networkSandboxes[containerID]
+	c.networkSandboxesMu.Unlock()
+	if s == nil || s.identity != identity || !networkSandboxHealthy(s.path, s.ip) || c.CNICheck(ctx, s.appID, s.containerID, s.path, s.result) != nil || !c.refreshBridgeDNS(s.containerID, s.appID) {
+		return nil, false
+	}
+	return s, true
+}
+
+// refreshBridgeDNS drops and reacquires this single-service bridge's listener.
+// Rebinding proves the gateway address is still present and usable instead of
+// trusting only the agent's in-memory reference bookkeeping.
+func (c *Client) refreshBridgeDNS(containerID, appID string) bool {
+	gw, err := meshGateway(appID)
+	if err != nil {
+		return false
+	}
+	c.releaseMeshDNS(containerID, appID)
+	return c.ensureMeshDNS(containerID, gw)
+}
+
+func (c *Client) takeNetworkSandbox(containerID string) *networkSandbox {
+	c.networkSandboxesMu.Lock()
+	s := c.networkSandboxes[containerID]
+	delete(c.networkSandboxes, containerID)
+	c.networkSandboxesMu.Unlock()
+	return s
+}
+
+// destroyNetworkSandbox performs the complete external-state teardown for a
+// retained namespace. It is idempotent: ownership is removed from the map
+// before side effects begin, so concurrent/duplicate stop and delete paths do
+// not release IPAM, DNS, or mesh state twice.
+func (c *Client) destroyNetworkSandbox(ctx context.Context, containerID string) bool {
+	s := c.takeNetworkSandbox(containerID)
+	if s == nil {
+		return false
+	}
+	if err := c.CNIDel(ctx, s.appID, s.containerID, s.path); err != nil {
+		c.logger.Warn("CNI DEL failed while releasing reusable network sandbox (non-fatal)",
+			zap.String("container_id", s.containerID), zap.Error(err))
+	}
+	if needsGatewayDNS(s.isolation, s.entitlements) {
+		c.releaseMeshDNS(s.containerID, s.appID)
+	}
+	c.teardownMeshEgress(s.entitlements, s.containerID, s.appID, s.ip)
+	s.close()
+	_ = os.Remove(networkSandboxResultPath(containerID))
+	c.logger.Debug("Released reusable network sandbox", zap.String("container_id", s.containerID))
+	return true
+}
+
+func writeNetworkSandboxResult(containerID, result string) error {
+	path := networkSandboxResultPath(containerID)
+	if path == "" || result == "" {
+		return fmt.Errorf("invalid reusable network sandbox result")
+	}
+	if err := os.MkdirAll(cniNetnsBindDir, 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(cniNetnsBindDir, ".cni-result-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.WriteString(result); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+func readNetworkSandboxResult(containerID string) (string, error) {
+	b, err := os.ReadFile(networkSandboxResultPath(containerID))
+	if err != nil {
+		return "", err
+	}
+	if len(b) == 0 || len(b) > cniStdoutLimit || !json.Valid(b) {
+		return "", fmt.Errorf("invalid persisted CNI result")
+	}
+	return string(b), nil
+}
+
+// recoverNetworkSandbox reconstructs ownership after an agent restart. Every
+// persisted field is treated as untrusted and CNI CHECK must prove host-local
+// IPAM, bridge/veth attachment, and namespace addresses/routes.
+func (c *Client) recoverNetworkSandbox(ctx context.Context, ctr containerd.Container, identity string, labels map[string]string, spec *runtimespec.Spec) (*networkSandbox, bool) {
+	c.networkSandboxesMu.Lock()
+	alreadyTracked := c.networkSandboxes[ctr.ID()] != nil
+	c.networkSandboxesMu.Unlock()
+	if alreadyTracked {
+		return nil, false
+	}
+	appID, serviceName := labels[labelKeyAppID], labels[labelKeyServiceName]
+	entitlements := parseEntitlementsFromAnnotations(labels)
+	expectedIdentity, eligible := networkIdentityFromLabels(labels)
+	if !eligible || expectedIdentity != identity {
+		return nil, false
+	}
+	path := networkSandboxPath(ctr.ID())
+	ip := labels[labelKeyNetworkSandboxIP]
+	if path == "" || net.ParseIP(ip) == nil || !runtimeSpecJoinsNetworkSandbox(spec, path) || !networkSandboxHealthy(path, ip) {
+		return nil, false
+	}
+	result, err := readNetworkSandboxResult(ctr.ID())
+	if err != nil || c.CNICheck(ctx, appID, ctr.ID(), path, result) != nil {
+		return nil, false
+	}
+	if !c.refreshBridgeDNS(ctr.ID(), appID) {
+		return nil, false
+	}
+	s := &networkSandbox{appID: appID, serviceName: serviceName, containerID: ctr.ID(), identity: identity, path: path, ip: ip, result: result, isolation: labels[labelKeyIsolation], entitlements: entitlements, cleanup: func() { cleanupNetworkSandboxPath(path) }}
+	c.registerNetworkSandbox(s)
+	c.logger.Info("Recovered reusable network sandbox", zap.String("container_id", ctr.ID()), zap.String("ip", ip))
+	return s, true
+}
+
+// purgePersistedNetworkSandbox tears down restart-orphaned state that could
+// not be proven reusable. It is intentionally restricted to the canonical
+// owner-controlled bind path and valid persisted labels.
+func (c *Client) purgePersistedNetworkSandbox(ctx context.Context, ctr containerd.Container, labels map[string]string, spec *runtimespec.Spec) bool {
+	path := networkSandboxPath(ctr.ID())
+	_, pathErr := os.Lstat(path)
+	_, resultErr := os.Lstat(networkSandboxResultPath(ctr.ID()))
+	if path == "" || (!runtimeSpecJoinsNetworkSandbox(spec, path) && pathErr != nil && resultErr != nil) {
+		return false
+	}
+	appID := labels[labelKeyAppID]
+	if appconfig.ValidateAppID(appID) != nil {
+		appID, _, _ = ParseContainerName(ctr.ID())
+	}
+	if appconfig.ValidateAppID(appID) == nil {
+		_ = c.CNIDel(ctx, appID, ctr.ID(), path)
+		c.releaseMeshDNS(ctr.ID(), appID)
+	}
+	cleanupNetworkSandboxPath(path)
+	_ = os.Remove(networkSandboxResultPath(ctr.ID()))
+	return true
+}
+
+// persistNetworkNamespace updates the mutable container metadata so a later
+// NewTask joins the retained sandbox. An empty path restores the OCI default
+// of creating a fresh private network namespace. A verified non-empty
+// identity may be preserved across an explicit stop so the next start can
+// retain its newly-created namespace again; sandbox IP metadata is always
+// removed when path is empty.
+func (c *Client) persistNetworkNamespace(ctx context.Context, ctr containerd.Container, path, identity, ip string) error {
+	if path != "" && (path != networkSandboxPath(ctr.ID()) || filepath.Dir(path) != cniNetnsBindDir || identity == "" || net.ParseIP(ip) == nil) {
+		return fmt.Errorf("refusing to persist invalid reusable network namespace")
+	}
+	if path == "" && ip != "" {
+		return fmt.Errorf("refusing to persist sandbox IP without a network namespace")
+	}
+	spec, err := ctr.Spec(ctx)
+	if err != nil {
+		return fmt.Errorf("reading stored OCI spec: %w", err)
+	}
+	if spec.Linux == nil {
+		return fmt.Errorf("stored OCI spec has no Linux section")
+	}
+	found := false
+	for i := range spec.Linux.Namespaces {
+		if spec.Linux.Namespaces[i].Type == "network" {
+			spec.Linux.Namespaces[i].Path = path
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("stored OCI spec has no network namespace")
+	}
+	encoded, err := typeurl.MarshalAny(spec)
+	if err != nil {
+		return fmt.Errorf("encoding stored OCI spec: %w", err)
+	}
+	return ctr.Update(ctx, func(_ context.Context, _ *containerd.Client, record *containers.Container) error {
+		record.Spec = encoded
+		if record.Labels == nil {
+			record.Labels = make(map[string]string)
+		}
+		if path == "" {
+			delete(record.Labels, labelKeyNetworkSandboxIP)
+			if identity == "" {
+				delete(record.Labels, labelKeyNetworkIdentity)
+			} else {
+				record.Labels[labelKeyNetworkIdentity] = identity
+			}
+		} else {
+			record.Labels[labelKeyNetworkIdentity] = identity
+			record.Labels[labelKeyNetworkSandboxIP] = ip
+		}
+		return nil
+	})
+}
+
+func specJoinsNetworkSandbox(spec *localoci.Spec, path string) bool {
+	if spec == nil || spec.Linux == nil {
+		return false
+	}
+	for _, ns := range spec.Linux.Namespaces {
+		if ns.Type == "network" {
+			return ns.Path == path
+		}
+	}
+	return false
+}
+
+func runtimeSpecJoinsNetworkSandbox(spec *runtimespec.Spec, path string) bool {
+	if spec == nil || spec.Linux == nil {
+		return false
+	}
+	for _, ns := range spec.Linux.Namespaces {
+		if ns.Type == runtimespec.NetworkNamespace {
+			return ns.Path == path
+		}
+	}
+	return false
+}
+
+func runtimeSpecHasNetworkNamespacePath(spec *runtimespec.Spec) bool {
+	if spec == nil || spec.Linux == nil {
+		return false
+	}
+	for _, ns := range spec.Linux.Namespaces {
+		if ns.Type == runtimespec.NetworkNamespace {
+			return ns.Path != ""
+		}
+	}
+	return false
+}

--- a/go/internal/agent/containerd/network_sandbox_linux.go
+++ b/go/internal/agent/containerd/network_sandbox_linux.go
@@ -1,0 +1,65 @@
+//go:build linux
+
+package containerd
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+	"golang.org/x/sys/unix"
+)
+
+// networkSandboxHealthy fails closed unless path is an owner-controlled nsfs
+// bind mount containing an UP eth0 with the exact CNI-assigned address.
+func networkSandboxHealthy(path, expectedIP string) bool {
+	if filepath.Dir(path) != cniNetnsBindDir || expectedIP == "" {
+		return false
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	var stat unix.Statfs_t
+	if err := unix.Fstatfs(int(f.Fd()), &stat); err != nil || stat.Type != unix.NSFS_MAGIC {
+		return false
+	}
+	ns, err := netns.GetFromPath(path)
+	if err != nil {
+		return false
+	}
+	defer ns.Close()
+	h, err := netlink.NewHandleAt(ns)
+	if err != nil {
+		return false
+	}
+	defer h.Close()
+	link, err := h.LinkByName("eth0")
+	if err != nil || link.Attrs() == nil || link.Attrs().Flags&net.FlagUp == 0 {
+		return false
+	}
+	addrs, err := h.AddrList(link, netlink.FAMILY_ALL)
+	if err != nil {
+		return false
+	}
+	want := net.ParseIP(expectedIP)
+	for _, addr := range addrs {
+		if want != nil && addr.IP.Equal(want) {
+			return true
+		}
+	}
+	return false
+}
+
+func taskUsesNetworkSandbox(path string, pid uint32) bool {
+	sandbox, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	task, err := os.Stat(fmt.Sprintf("/proc/%d/ns/net", pid))
+	return err == nil && os.SameFile(sandbox, task)
+}

--- a/go/internal/agent/containerd/network_sandbox_other.go
+++ b/go/internal/agent/containerd/network_sandbox_other.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package containerd
+
+// Reusable network namespaces depend on Linux nsfs bind mounts and netlink.
+func networkSandboxHealthy(_, _ string) bool { return false }
+
+func taskUsesNetworkSandbox(_ string, _ uint32) bool { return false }

--- a/go/internal/agent/containerd/network_sandbox_test.go
+++ b/go/internal/agent/containerd/network_sandbox_test.go
@@ -1,6 +1,7 @@
 package containerd
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -62,6 +63,28 @@ func TestNetworkIdentityFromLabelsRecomputesFingerprint(t *testing.T) {
 	labels[labelKeyNetworkIdentity] = networkIdentity("isolated", bridge)
 	if _, ok := networkIdentityFromLabels(labels); ok {
 		t.Fatal("multi-service labels were accepted for sandbox retention")
+	}
+}
+
+func TestDesiredNetworkIdentityIgnoresPersistedFingerprint(t *testing.T) {
+	bridge := []appconfig.Entitlement{{Type: appconfig.EntitlementNetwork, Mode: "bridge"}}
+	labels := wendyLabels("com.example.app", "", "1", nil, bridge, "isolated", nil)
+	labels[labelKeyNetworkIdentity] = "attacker-controlled"
+	want := networkIdentity("isolated", bridge)
+	if got, ok := desiredNetworkIdentityFromLabels(labels); !ok || got != want {
+		t.Fatalf("derived identity = %q, %v; want %q, true", got, ok, want)
+	}
+}
+
+func TestNetworkSandboxChecksRequireCNICheck(t *testing.T) {
+	if networkSandboxChecksPassed(true, errors.New("CHECK rejected prevResult")) {
+		t.Fatal("healthy namespace was accepted after CNI CHECK failed")
+	}
+	if networkSandboxChecksPassed(false, nil) {
+		t.Fatal("unhealthy namespace was accepted after CNI CHECK passed")
+	}
+	if !networkSandboxChecksPassed(true, nil) {
+		t.Fatal("healthy namespace with successful CNI CHECK was rejected")
 	}
 }
 

--- a/go/internal/agent/containerd/network_sandbox_test.go
+++ b/go/internal/agent/containerd/network_sandbox_test.go
@@ -114,6 +114,41 @@ func TestNetworkOperationLockSerializesSameContainer(t *testing.T) {
 	}
 }
 
+func TestAdditionalNetworkOperationLocksSerializeGroupMembers(t *testing.T) {
+	c := &Client{networkOps: make(map[string]*networkOperation)}
+	unlockGroup := c.lockNetworkOperation("myapp")
+	unlockMembers := c.lockAdditionalNetworkOperations("myapp", []string{"myapp_api", "myapp", "myapp_worker", "myapp_api"})
+
+	acquired := make(chan string, 2)
+	for _, containerID := range []string{"myapp_api", "myapp_worker"} {
+		go func() {
+			defer c.lockNetworkOperation(containerID)()
+			acquired <- containerID
+		}()
+	}
+	select {
+	case containerID := <-acquired:
+		t.Fatalf("member operation %q entered during group lock", containerID)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	unlockMembers()
+	for range 2 {
+		select {
+		case <-acquired:
+		case <-time.After(time.Second):
+			t.Fatal("member operation did not proceed after group lock release")
+		}
+	}
+	unlockGroup()
+
+	c.networkOpsMu.Lock()
+	defer c.networkOpsMu.Unlock()
+	if len(c.networkOps) != 0 {
+		t.Fatalf("idle network lock entries leaked: %d", len(c.networkOps))
+	}
+}
+
 func TestSpecJoinsNetworkSandbox(t *testing.T) {
 	spec := &localoci.Spec{Linux: &localoci.Linux{Namespaces: []localoci.LinuxNamespace{
 		{Type: "network", Path: "/run/wendy/netns/myapp"},

--- a/go/internal/agent/containerd/network_sandbox_test.go
+++ b/go/internal/agent/containerd/network_sandbox_test.go
@@ -1,0 +1,147 @@
+package containerd
+
+import (
+	"testing"
+	"time"
+
+	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
+
+	localoci "github.com/wendylabsinc/wendy/go/internal/agent/oci"
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+func TestNetworkIdentityFailClosed(t *testing.T) {
+	base := []appconfig.Entitlement{{Type: appconfig.EntitlementNetwork, Mode: "bridge"}}
+	a := networkIdentity("isolated", base)
+	b := networkIdentity("isolated", append(base, appconfig.Entitlement{Type: appconfig.EntitlementGPIO, Pins: []int{17}}))
+	c := networkIdentity("shared-network", base)
+	if a == "" || len(a) != 64 {
+		t.Fatalf("identity = %q", a)
+	}
+	if a == b {
+		t.Fatal("entitlement change did not invalidate identity")
+	}
+	if a == c {
+		t.Fatal("isolation change did not invalidate identity")
+	}
+	if got := networkIdentity("isolated", base); got != a {
+		t.Fatalf("identity is not deterministic: %q != %q", got, a)
+	}
+}
+
+func TestNetworkSandboxEligibilityIsConservative(t *testing.T) {
+	bridge := []appconfig.Entitlement{{Type: appconfig.EntitlementNetwork, Mode: "bridge"}}
+	mesh := []appconfig.Entitlement{{Type: appconfig.EntitlementNetwork, Mode: "mesh"}}
+	if !networkSandboxEligible("", bridge) {
+		t.Fatal("single-service bridge should be eligible")
+	}
+	if networkSandboxEligible("api", bridge) {
+		t.Fatal("multi-service bridge must fail closed")
+	}
+	if networkSandboxEligible("", mesh) || networkSandboxEligible("", append(bridge, mesh...)) {
+		t.Fatal("mesh networking must fail closed")
+	}
+	if networkSandboxEligible("", nil) {
+		t.Fatal("host/default networking must fail closed")
+	}
+}
+
+func TestNetworkIdentityFromLabelsRecomputesFingerprint(t *testing.T) {
+	bridge := []appconfig.Entitlement{{Type: appconfig.EntitlementNetwork, Mode: "bridge"}}
+	labels := wendyLabels("com.example.app", "", "1", nil, bridge, "isolated", nil)
+	identity := networkIdentity("isolated", bridge)
+	labels[labelKeyNetworkIdentity] = identity
+	if got, ok := networkIdentityFromLabels(labels); !ok || got != identity {
+		t.Fatalf("verified identity = %q, %v; want %q, true", got, ok, identity)
+	}
+	labels[labelKeyIsolation] = "shared-network"
+	if _, ok := networkIdentityFromLabels(labels); ok {
+		t.Fatal("stale stored fingerprint was trusted after isolation changed")
+	}
+	labels = wendyLabels("com.example.app", "api", "1", nil, bridge, "isolated", nil)
+	labels[labelKeyNetworkIdentity] = networkIdentity("isolated", bridge)
+	if _, ok := networkIdentityFromLabels(labels); ok {
+		t.Fatal("multi-service labels were accepted for sandbox retention")
+	}
+}
+
+func TestNetworkOperationLockSerializesSameContainer(t *testing.T) {
+	c := &Client{networkOps: make(map[string]*networkOperation)}
+	unlock := c.lockNetworkOperation("myapp")
+	acquired := make(chan struct{})
+	go func() {
+		defer c.lockNetworkOperation("myapp")()
+		close(acquired)
+	}()
+	select {
+	case <-acquired:
+		t.Fatal("second network operation entered concurrently")
+	case <-time.After(20 * time.Millisecond):
+	}
+	unlock()
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("second network operation did not proceed after unlock")
+	}
+	c.networkOpsMu.Lock()
+	defer c.networkOpsMu.Unlock()
+	if len(c.networkOps) != 0 {
+		t.Fatalf("idle network lock entries leaked: %d", len(c.networkOps))
+	}
+}
+
+func TestSpecJoinsNetworkSandbox(t *testing.T) {
+	spec := &localoci.Spec{Linux: &localoci.Linux{Namespaces: []localoci.LinuxNamespace{
+		{Type: "network", Path: "/run/wendy/netns/myapp"},
+	}}}
+	if !specJoinsNetworkSandbox(spec, "/run/wendy/netns/myapp") {
+		t.Fatal("matching network namespace was not recognised")
+	}
+	if specJoinsNetworkSandbox(spec, "/run/wendy/netns/other") {
+		t.Fatal("mismatched network namespace was accepted")
+	}
+}
+
+func TestRuntimeSpecDetectsInvalidPersistedNetworkPath(t *testing.T) {
+	spec := &runtimespec.Spec{Linux: &runtimespec.Linux{Namespaces: []runtimespec.LinuxNamespace{
+		{Type: runtimespec.NetworkNamespace, Path: "/proc/self/ns/net"},
+	}}}
+	if !runtimeSpecHasNetworkNamespacePath(spec) {
+		t.Fatal("non-empty invalid network path was not marked stale")
+	}
+	if runtimeSpecJoinsNetworkSandbox(spec, "/run/wendy/netns/myapp") {
+		t.Fatal("invalid network path matched canonical sandbox")
+	}
+}
+
+func TestRegisterNetworkSandboxReleasesReplacedOwner(t *testing.T) {
+	c := &Client{networkSandboxes: make(map[string]*networkSandbox)}
+	closed := 0
+	first := &networkSandbox{containerID: "myapp", cleanup: func() { closed++ }}
+	second := &networkSandbox{containerID: "myapp"}
+	c.registerNetworkSandbox(first)
+	c.registerNetworkSandbox(second)
+	if closed != 1 {
+		t.Fatalf("old sandbox cleanup calls = %d, want 1", closed)
+	}
+	first.close()
+	if closed != 1 {
+		t.Fatalf("cleanup was not idempotent: calls = %d", closed)
+	}
+	if got := c.takeNetworkSandbox("myapp"); got != second {
+		t.Fatalf("registered sandbox = %#v, want second", got)
+	}
+}
+
+func TestNetworkSandboxPathRejectsTraversal(t *testing.T) {
+	if got := networkSandboxPath("../escape"); got != "" {
+		t.Fatalf("unsafe path = %q", got)
+	}
+	if got := networkSandboxPath("myapp"); got != "/run/wendy/netns/myapp" {
+		t.Fatalf("path = %q", got)
+	}
+	if got := networkSandboxResultPath("../escape"); got != "" {
+		t.Fatalf("unsafe result path = %q", got)
+	}
+}

--- a/go/internal/agent/oci/namespace.go
+++ b/go/internal/agent/oci/namespace.go
@@ -124,6 +124,28 @@ func JoinGroupNamespaces(spec *Spec, primaryPID uint32, isolation string) ([]*os
 	return anchors, nil
 }
 
+// JoinNetworkNamespace makes the container join an externally anchored network
+// namespace. The path must be a host path consumable by runc (for example a
+// bind mount under /run/wendy/netns), not an agent-local /proc/self/fd path.
+// Existing network namespace entries are updated in place so the resulting
+// spec remains deterministic.
+func JoinNetworkNamespace(spec *Spec, path string) error {
+	if spec.Linux == nil {
+		return fmt.Errorf("JoinNetworkNamespace: spec.Linux is nil")
+	}
+	if path == "" {
+		return fmt.Errorf("JoinNetworkNamespace: path must not be empty")
+	}
+	for i := range spec.Linux.Namespaces {
+		if spec.Linux.Namespaces[i].Type == "network" {
+			spec.Linux.Namespaces[i].Path = path
+			return nil
+		}
+	}
+	spec.Linux.Namespaces = append(spec.Linux.Namespaces, LinuxNamespace{Type: "network", Path: path})
+	return nil
+}
+
 // SharedSHMMount returns a bind-mount that maps hostSHMPath into /dev/shm.
 // Use this for shared-ipc isolation where all services share one shm segment.
 // hostSHMPath should be /run/wendy/shm/{appID}.

--- a/go/internal/agent/oci/namespace_test.go
+++ b/go/internal/agent/oci/namespace_test.go
@@ -174,6 +174,40 @@ func TestJoinGroupNamespaces_StaleProcess(t *testing.T) {
 	}
 }
 
+func TestJoinNetworkNamespace(t *testing.T) {
+	t.Run("updates existing entry", func(t *testing.T) {
+		spec := &Spec{Linux: &Linux{Namespaces: []LinuxNamespace{
+			{Type: "pid"},
+			{Type: "network"},
+		}}}
+		if err := JoinNetworkNamespace(spec, "/run/wendy/netns/myapp"); err != nil {
+			t.Fatal(err)
+		}
+		if got := spec.Linux.Namespaces[1].Path; got != "/run/wendy/netns/myapp" {
+			t.Fatalf("network path = %q", got)
+		}
+	})
+
+	t.Run("adds missing entry", func(t *testing.T) {
+		spec := &Spec{Linux: &Linux{}}
+		if err := JoinNetworkNamespace(spec, "/run/wendy/netns/myapp"); err != nil {
+			t.Fatal(err)
+		}
+		if len(spec.Linux.Namespaces) != 1 || spec.Linux.Namespaces[0].Type != "network" {
+			t.Fatalf("namespaces = %#v", spec.Linux.Namespaces)
+		}
+	})
+
+	t.Run("rejects invalid spec", func(t *testing.T) {
+		if err := JoinNetworkNamespace(&Spec{}, "/run/wendy/netns/myapp"); err == nil {
+			t.Fatal("expected nil Linux error")
+		}
+		if err := JoinNetworkNamespace(&Spec{Linux: &Linux{}}, ""); err == nil {
+			t.Fatal("expected empty path error")
+		}
+	})
+}
+
 func TestSharedSHMMount(t *testing.T) {
 	m := SharedSHMMount("/run/wendy/shm/com.example.app")
 	if m.Destination != "/dev/shm" {


### PR DESCRIPTION
## Summary

- retain CNI-configured namespaces across crash restarts and compatible container replacement for single-container `network: bridge` apps
- require an exact network identity plus nsfs/interface/IP checks, vendored bridge + host-local CNI `CHECK`, persisted bounded CNI result, stored OCI namespace path, and a healthy rebound DNS listener before reuse
- serialize per-container network lifecycle operations and adopt valid retained state safely after an agent restart
- guarantee explicit stop/delete cleanup and task termination even when metadata cleanup reports an error

Mesh, multi-service, host/shared/default networking, non-Linux targets, and fd-path fallback keep the existing fresh DEL+ADD lifecycle.

## Stack

Depends on #1807 for prepared writable snapshots; the two optimizations remove separate pieces of the same replace/start critical path.

## Validation

- `go test -race ./go/internal/agent/containerd ./go/internal/agent/oci`
- `go vet ./go/internal/agent/containerd ./go/internal/agent/oci`
- Linux amd64 CGO-disabled compile of affected packages
- `go test ./go/internal/agent/...`

## Follow-up validation

Benchmark bridge-mode p50/p95 on Pi, Jetson, and x86 devices. CNI `CHECK` covers the plugin-declared bridge, veth, IPAM, address, and route state; this intentionally does not extend reuse to Wendy mesh/iptables wiring.
