### PR TITLE
fix: Wendy Lite serial handshake sync, port contention, and picker ghost rows

### DIFF
--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -3414,12 +3414,19 @@ func hideLocalProviders(excludes map[string]bool) map[string]bool {
 	return merged
 }
 
+// unflashedLiteDedupKey keys a board with no Wendy Lite firmware by its port
+// rather than its synthetic display name, so the row it gets once it identifies
+// itself can supersede it.
+func unflashedLiteDedupKey(serialPort string) string {
+	return "wendy-lite-unflashed:" + serialPort
+}
+
 // externalProviderPickerItem builds the picker row for a device discovered
 // through an external provider. wendy-lite devices are presented as merged
 // devices (like LAN discoveries) so they share the LAN row layout.
 func externalProviderPickerItem(prov providers.DeviceProvider, dev *models.ExternalDevice) tui.PickerItem {
 	if prov.Key() == "wendy-lite" {
-		return tui.PickerItem{
+		item := tui.PickerItem{
 			Name:         dev.DisplayName,
 			DedupKey:     dev.DisplayName,
 			Type:         dev.ConnectionType() + " (Lite)",
@@ -3435,6 +3442,17 @@ func externalProviderPickerItem(prov providers.DeviceProvider, dev *models.Exter
 				Externals:       []*models.ExternalDevice{dev},
 			}},
 		}
+		if port := dev.ConnectionInfo["serialPort"]; port != "" {
+			if dev.ConnectionInfo["needsInstall"] == "true" {
+				item.DedupKey = unflashedLiteDedupKey(port)
+				// The branch sets no SortKey, so ordering falls back to the
+				// dedup key; pin it to the name to keep the row's position.
+				item.SortKey = strings.ToLower(dev.DisplayName)
+			} else {
+				item.Supersedes = unflashedLiteDedupKey(port)
+			}
+		}
+		return item
 	}
 	return tui.PickerItem{
 		Name:         dev.DisplayName,

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -2191,6 +2191,97 @@ func TestExternalProviderPickerItem(t *testing.T) {
 		if len(entry.mergedDevice.Externals) != 1 || entry.mergedDevice.Externals[0].ID != dev.ID {
 			t.Errorf("mergedDevice.Externals = %#v, want the source device", entry.mergedDevice.Externals)
 		}
+		// A LAN row carries no serial port, so it must not take part in the
+		// unflashed-row supersede at all.
+		if item.DedupKey != dev.DisplayName || item.Supersedes != "" {
+			t.Errorf("DedupKey = %q, Supersedes = %q, want the display name and no supersede",
+				item.DedupKey, item.Supersedes)
+		}
+	})
+
+	// An unflashed board and the same board once it identifies itself must share
+	// one row: the unflashed row is keyed by port so the identified one can
+	// retire it, instead of both display names sitting in the picker at once.
+	t.Run("unflashed USB device is keyed by port", func(t *testing.T) {
+		prov := &fakeProvider{key: "wendy-lite"}
+		dev := models.ExternalDevice{
+			ID:          "wendy-lite:/dev/cu.usbmodem2101",
+			DisplayName: "ESP32 (unflashed) — /dev/cu.usbmodem2101",
+			ProviderKey: "wendy-lite",
+			ConnectionInfo: map[string]string{
+				"type": "USB", "serialPort": "/dev/cu.usbmodem2101", "needsInstall": "true",
+			},
+		}
+		item := externalProviderPickerItem(prov, &dev)
+
+		if want := unflashedLiteDedupKey("/dev/cu.usbmodem2101"); item.DedupKey != want {
+			t.Errorf("DedupKey = %q, want %q", item.DedupKey, want)
+		}
+		if item.Supersedes != "" {
+			t.Errorf("Supersedes = %q, want empty on the unflashed row", item.Supersedes)
+		}
+		if want := strings.ToLower(dev.DisplayName); item.SortKey != want {
+			t.Errorf("SortKey = %q, want %q so the row keeps its position", item.SortKey, want)
+		}
+	})
+
+	t.Run("identified USB device supersedes the unflashed row", func(t *testing.T) {
+		prov := &fakeProvider{key: "wendy-lite"}
+		dev := models.ExternalDevice{
+			ID:          "wendy-lite:/dev/cu.usbmodem2101",
+			DisplayName: "Lite Board",
+			ProviderKey: "wendy-lite",
+			ConnectionInfo: map[string]string{
+				"type": "USB", "serialPort": "/dev/cu.usbmodem2101", "name": "lite-board",
+			},
+		}
+		item := externalProviderPickerItem(prov, &dev)
+
+		if item.DedupKey != dev.DisplayName {
+			t.Errorf("DedupKey = %q, want the display name so LAN/USB rows still merge", item.DedupKey)
+		}
+		if want := unflashedLiteDedupKey("/dev/cu.usbmodem2101"); item.Supersedes != want {
+			t.Errorf("Supersedes = %q, want %q", item.Supersedes, want)
+		}
+	})
+
+	// End to end over the picker: the reported bug was a board that stayed
+	// listed as unflashed after a later probe identified it.
+	t.Run("identified board replaces its unflashed row in the picker", func(t *testing.T) {
+		prov := &fakeProvider{key: "wendy-lite"}
+		const port = "/dev/cu.usbmodem2101"
+		unflashed := models.ExternalDevice{
+			ID:          "wendy-lite:" + port,
+			DisplayName: "ESP32 (unflashed) — " + port,
+			ProviderKey: "wendy-lite",
+			ConnectionInfo: map[string]string{
+				"type": "USB", "serialPort": port, "needsInstall": "true",
+			},
+		}
+		identified := models.ExternalDevice{
+			ID:          "wendy-lite:" + port,
+			DisplayName: "Lite Board",
+			ProviderKey: "wendy-lite",
+			ConnectionInfo: map[string]string{
+				"type": "USB", "serialPort": port, "name": "lite-board",
+			},
+		}
+
+		picker := tui.NewPicker()
+		updated, _ := picker.Update(tui.PickerAddMsg{
+			Items: []tui.PickerItem{externalProviderPickerItem(prov, &unflashed)},
+		})
+		updated, _ = updated.(tui.PickerModel).Update(tui.PickerAddMsg{
+			Items: []tui.PickerItem{externalProviderPickerItem(prov, &identified)},
+		})
+
+		view := updated.(tui.PickerModel).View()
+		if !strings.Contains(view, identified.DisplayName) {
+			t.Errorf("picker does not list the identified device:\n%s", view)
+		}
+		if strings.Contains(view, "unflashed") {
+			t.Errorf("picker still lists the superseded unflashed row:\n%s", view)
+		}
 	})
 
 	t.Run("other providers keep provider row layout", func(t *testing.T) {

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -35,6 +35,7 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 	"github.com/wendylabsinc/wendy/go/internal/shared/discovery"
 	"github.com/wendylabsinc/wendy/go/internal/shared/models"
+	"github.com/wendylabsinc/wendy/go/internal/shared/seriallock"
 	"github.com/wendylabsinc/wendy/go/internal/stagefile"
 	"github.com/wendylabsinc/wendy/go/internal/stagefile/gpu"
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
@@ -1722,6 +1723,37 @@ func deviceNeedsInstall(device models.ExternalDevice) bool {
 	return device.ConnectionInfo["needsInstall"] == "true"
 }
 
+var (
+	serialPortFreeBudget = 6 * time.Second // probe worst case: 3s handshake + 3s identity
+	serialPortFreePoll   = 200 * time.Millisecond
+)
+
+// waitForSerialPortFree reports whether port is free of an advisory lock, waiting
+// up to serialPortFreeBudget for a holder to release it. Only ErrLocked is waited
+// on; other Acquire failures aren't contention and the caller's own open reports
+// them better. Always true on Windows, where Acquire is a no-op.
+func waitForSerialPortFree(ctx context.Context, port string) bool {
+	deadline := time.Now().Add(serialPortFreeBudget)
+	for {
+		lock, err := seriallock.Acquire(port)
+		if err == nil {
+			lock.Release()
+			return true
+		}
+		if !errors.Is(err, seriallock.ErrLocked) {
+			return true
+		}
+		if !time.Now().Before(deadline) {
+			return false
+		}
+		select {
+		case <-time.After(serialPortFreePoll):
+		case <-ctx.Done():
+			return false
+		}
+	}
+}
+
 // offerLiteReinstallAndRebuild handles a provider build that failed because
 // the device cannot host the app: either its existing firmware does not
 // support the app's requirements (native or WASM apps), or it has no Wendy
@@ -1763,6 +1795,17 @@ func offerLiteReinstallAndRebuild(ctx context.Context, p providers.DeviceProvide
 			return nil, wrapped
 		}
 		return nil, err
+	}
+
+	if freshInstall {
+		// Improbable, but the picker's scanner may still be probing this port,
+		// so wait until the port is free. The lock is released immediately:
+		// installESP32Firmware takes its own, and flock is per-descriptor, so
+		// holding ours would block it.
+		port := device.ConnectionInfo["serialPort"]
+		if !waitForSerialPortFree(ctx, port) {
+			cliNotice("Serial port %s is still in use; attempting the install anyway.", port)
+		}
 	}
 
 	serialDevice := discovery.SerialPortInfo{

--- a/go/internal/cli/liteclient/link_direct.go
+++ b/go/internal/cli/liteclient/link_direct.go
@@ -55,28 +55,37 @@ func serialHandshake(port serialHandshakePort) error {
 		return fmt.Errorf("serial handshake: set timeout: %w", err)
 	}
 
-	// Send the sentinel immediately. Waiting for a quiet read timeout before
-	// the first send makes reconnecting after a physical reboot fail whenever
-	// boot or auto-started app logs keep the serial stream continuously
-	// readable for the entire 3-second handshake budget.
-	var randBytes [16]byte
-	if _, err := rand.Read(randBytes[:]); err != nil {
-		return fmt.Errorf("serial handshake: generate sentinel: %w", err)
-	}
-	sentinel := hex.EncodeToString(randBytes[:])
+	// Every send carries a fresh sentinel, and only the most recent one is
+	// matched below. The sentinel is a stream position marker, not a liveness
+	// probe: because the echo is FIFO, seeing the *latest* one come back proves
+	// nothing the host wrote earlier is still in flight, which is the
+	// precondition for switching to WendyCom mode. Repeating one sentinel would
+	// only prove that some send was echoed, leaving the echoes of the later
+	// sends queued for the frame parser, which rejects them as a bad magic byte.
+	var sentinel string
 	sendSentinel := func() error {
+		var randBytes [16]byte
+		if _, err := rand.Read(randBytes[:]); err != nil {
+			return fmt.Errorf("serial handshake: generate sentinel: %w", err)
+		}
+		sentinel = hex.EncodeToString(randBytes[:])
 		if _, err := port.Write([]byte(strings.Repeat(" ", 16) + sentinel)); err != nil {
 			return fmt.Errorf("serial handshake: send sentinel: %w", err)
 		}
 		return nil
 	}
+	// Send immediately. Waiting for a quiet read timeout before the first send
+	// makes reconnecting after a physical reboot fail whenever boot or
+	// auto-started app logs keep the serial stream continuously readable for
+	// the entire 3-second handshake budget.
 	if err := sendSentinel(); err != nil {
 		return err
 	}
 	// The mode switch may be applied asynchronously by the device after the
-	// escape command is consumed. Keep sending while draining output so at
-	// least one sentinel lands after that transition even if Read never times
-	// out because boot logs are continuous.
+	// escape command is consumed, and console mode swallows host input without
+	// echoing it. Keep sending while draining output so at least one sentinel
+	// lands after that transition even if Read never times out because boot
+	// logs are continuous.
 	nextSentinel := time.Now().Add(100 * time.Millisecond)
 
 	window := make([]byte, 0, 32)
@@ -94,8 +103,9 @@ func serialHandshake(port serialHandshakePort) error {
 			return fmt.Errorf("serial handshake: read: %w", err)
 		}
 		if n == 0 {
-			// The echo may have been lost while the device was switching modes;
-			// resend the same sentinel whenever the receive buffer goes quiet.
+			// The echo may have been lost while the device was switching modes,
+			// or to a dropped byte (USB Serial JTAG has no flow control);
+			// resend whenever the receive buffer goes quiet.
 			window = window[:0]
 			if err := sendSentinel(); err != nil {
 				return err
@@ -110,7 +120,7 @@ func serialHandshake(port serialHandshakePort) error {
 				copy(window, window[1:])
 				window[31] = oneByte[0]
 			}
-			if sentinel != "" && len(window) == 32 && string(window) == sentinel {
+			if len(window) == 32 && string(window) == sentinel {
 				if err := port.SetReadTimeout(serial.NoTimeout); err != nil {
 					return fmt.Errorf("serial handshake: clear timeout: %w", err)
 				}

--- a/go/internal/cli/liteclient/link_direct_test.go
+++ b/go/internal/cli/liteclient/link_direct_test.go
@@ -3,51 +3,71 @@ package liteclient
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 )
 
-// noisyHandshakePort models a freshly rebooted board whose boot/app logs keep
-// Read continuously ready. The sentinel echo is queued only after the host
-// sends it; trying to read before that fails the test immediately.
+// noisyHandshakePort models a freshly rebooted board over USB Serial JTAG.
+//
+// backlog is console output the device queued before echo mode took effect;
+// draining it one byte at a time keeps Read continuously ready, so the
+// handshake never sees the idle read the pre-65df7e0e implementation waited
+// for. backlogDelay paces that drain, letting the handshake's 100 ms resend
+// timer fire while echoes are still stuck behind the backlog.
+//
+// swallow models the mode switch being applied asynchronously: that many
+// sentinels are discarded unechoed (console mode does not echo host input)
+// before echo mode goes live.
 type noisyHandshakePort struct {
-	rx       []byte
-	writes   int
-	sentinel []byte
+	backlog      int           // console bytes still to emit before any echo
+	backlogDelay time.Duration // per-byte pacing while the backlog drains
+	swallow      int           // sentinels discarded before echo mode is live
+
+	sentinels    [][]byte // every sentinel written, in order
+	rx           []byte   // echoes, queued behind the backlog
+	modeSwitched bool
+	rxAtSwitch   int // bytes still unread when DLE m was written
 }
 
 func (p *noisyHandshakePort) Write(data []byte) (int, error) {
-	p.writes++
-	switch p.writes {
-	case 1:
-		want := []byte{escapeChar, escapeChar, escapeChar, escapeChar, 'e'}
-		if !bytes.Equal(data, want) {
-			return 0, errors.New("unexpected mode-switch write")
+	switch {
+	case bytes.Equal(data, []byte{escapeChar, escapeChar, escapeChar, escapeChar, 'e'}):
+		if len(p.sentinels) > 0 {
+			return 0, errors.New("echo mode switch written after a sentinel")
 		}
 		return len(data), nil
-	case 2:
-		if len(data) != 48 {
-			return 0, errors.New("unexpected sentinel write length")
-		}
-		p.sentinel = append([]byte(nil), data[16:]...)
-		p.rx = append([]byte("boot log traffic that never provides an idle read"), p.sentinel...)
-		return len(data), nil
-	case 3:
-		if !bytes.Equal(data, []byte{escapeChar, 'm'}) {
-			return 0, errors.New("unexpected WendyCom mode-switch write")
-		}
+	case bytes.Equal(data, []byte{escapeChar, 'm'}):
+		p.modeSwitched = true
+		p.rxAtSwitch = p.backlog + len(p.rx)
 		return len(data), nil
 	default:
-		return 0, errors.New("unexpected extra handshake write")
+		if len(data) != 48 {
+			return 0, fmt.Errorf("unexpected handshake write of %d bytes", len(data))
+		}
+		p.sentinels = append(p.sentinels, append([]byte(nil), data[16:]...))
+		if p.swallow > 0 {
+			p.swallow--
+			return len(data), nil
+		}
+		// Echo mode echoes every received byte, padding included.
+		p.rx = append(p.rx, data...)
+		return len(data), nil
 	}
 }
 
 func (p *noisyHandshakePort) Read(dst []byte) (int, error) {
-	if len(p.sentinel) == 0 {
-		return 0, errors.New("handshake read before sending sentinel")
+	if len(p.sentinels) == 0 {
+		return 0, errors.New("handshake read before sending a sentinel")
+	}
+	if p.backlog > 0 {
+		p.backlog--
+		time.Sleep(p.backlogDelay)
+		dst[0] = 'x'
+		return 1, nil
 	}
 	if len(p.rx) == 0 {
-		return 0, errors.New("sentinel echo was not detected")
+		return 0, nil // read timeout: nothing pending
 	}
 	dst[0] = p.rx[0]
 	p.rx = p.rx[1:]
@@ -57,11 +77,58 @@ func (p *noisyHandshakePort) Read(dst []byte) (int, error) {
 func (*noisyHandshakePort) SetReadTimeout(time.Duration) error { return nil }
 
 func TestSerialHandshakeSendsSentinelBeforeDrainingBootLogs(t *testing.T) {
-	port := &noisyHandshakePort{}
+	port := &noisyHandshakePort{backlog: 48}
 	if err := serialHandshake(port); err != nil {
 		t.Fatalf("serialHandshake() = %v", err)
 	}
-	if port.writes != 3 { // mode switch, sentinel, WendyCom mode switch
-		t.Fatalf("writes = %d, want 3", port.writes)
+	if !port.modeSwitched {
+		t.Fatal("handshake returned without switching to WendyCom mode")
+	}
+	if len(port.sentinels) != 1 {
+		t.Errorf("sent %d sentinels, want 1", len(port.sentinels))
+	}
+}
+
+// TestSerialHandshakeMatchesTheLastSentinelSent covers the guarantee the
+// sentinel exists for: on return, the stream is drained and both sides are in
+// sync. Matching any earlier sentinel leaves the later echoes queued, and the
+// WendyCom framer reads their leading padding as a frame header.
+func TestSerialHandshakeMatchesTheLastSentinelSent(t *testing.T) {
+	port := &noisyHandshakePort{backlog: 25, backlogDelay: 10 * time.Millisecond}
+	if err := serialHandshake(port); err != nil {
+		t.Fatalf("serialHandshake() = %v", err)
+	}
+	if len(port.sentinels) < 2 {
+		t.Fatalf("test did not exercise the race: only %d sentinel(s) sent", len(port.sentinels))
+	}
+	if !port.modeSwitched {
+		t.Fatal("handshake returned without switching to WendyCom mode")
+	}
+	if port.rxAtSwitch != 0 {
+		t.Errorf("%d unread byte(s) left in the stream at the mode switch, so an "+
+			"earlier sentinel was matched", port.rxAtSwitch)
+	}
+	seen := make(map[string]bool, len(port.sentinels))
+	for _, sentinel := range port.sentinels {
+		if seen[string(sentinel)] {
+			t.Fatalf("sentinel %q sent twice: a repeated sentinel cannot prove the stream drained", sentinel)
+		}
+		seen[string(sentinel)] = true
+	}
+}
+
+// TestSerialHandshakeResendsAfterSwallowedSentinels covers the device applying
+// the echo mode switch only after some sentinels have already been written and
+// silently dropped.
+func TestSerialHandshakeResendsAfterSwallowedSentinels(t *testing.T) {
+	port := &noisyHandshakePort{swallow: 2}
+	if err := serialHandshake(port); err != nil {
+		t.Fatalf("serialHandshake() = %v", err)
+	}
+	if len(port.sentinels) != 3 {
+		t.Errorf("sent %d sentinels, want 3 (two swallowed, one echoed)", len(port.sentinels))
+	}
+	if port.rxAtSwitch != 0 {
+		t.Errorf("%d unread byte(s) left in the stream at the mode switch", port.rxAtSwitch)
 	}
 }

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -142,6 +142,12 @@ type PickerItem struct {
 	// Items with the same DedupKey (case-insensitive) are merged via MergeItem.
 	DedupKey string
 
+	// Supersedes, when set, is the DedupKey of a row this item replaces. The
+	// existing row is dropped before this one is added, so a provisional
+	// identity can be retired by the real one without the two colliding on a
+	// shared key.
+	Supersedes string
+
 	// DefaultKeys are optional alternate identities compared against
 	// PickerModel.DefaultKey when rendering the default marker.
 	DefaultKeys []string
@@ -477,8 +483,21 @@ func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case PickerAddMsg:
 		changed := false
+		// Captured before any supersede removes a row, since currentCursorKey
+		// reads the pre-rebuild table against the mutated item slice.
+		cursorKey := m.currentCursorKey()
 		for _, item := range msg.Items {
 			key := strings.ToLower(pickerItemKey(item))
+			if superseded := strings.ToLower(item.Supersedes); superseded != "" && superseded != key {
+				if m.removeItemByKey(superseded) {
+					changed = true
+					if cursorKey == superseded {
+						// Keep the highlight on the replacement rather than
+						// letting it slide onto a neighbour mid-selection.
+						cursorKey = key
+					}
+				}
+			}
 			if idx, ok := m.seenIdx[key]; ok {
 				if m.MergeItem != nil {
 					m.MergeItem(&m.items[idx], item)
@@ -491,7 +510,7 @@ func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			changed = true
 		}
 		if changed {
-			m.refreshTable()
+			m.refreshTableWithCursorKey(cursorKey)
 		}
 
 	case PickerDoneMsg:
@@ -932,14 +951,7 @@ func (m *PickerModel) refreshTableWithCursorKey(cursorKey string) {
 		return ki < kj
 	})
 
-	// Rebuild seenIdx to reflect the new positions after sorting.
-	// Keys are always stored lowercase to match the lookup in Update.
-	for k := range m.seenIdx {
-		delete(m.seenIdx, k)
-	}
-	for i, item := range m.items {
-		m.seenIdx[strings.ToLower(pickerItemKey(item))] = i
-	}
+	m.rebuildSeenIdx()
 
 	visible := m.visibleItems()
 	hasDefaultCol := m.OnSetDefault != nil
@@ -989,6 +1001,30 @@ func pickerItemKey(item PickerItem) string {
 		return item.DedupKey
 	}
 	return item.Name
+}
+
+// rebuildSeenIdx re-derives the key index from the current item positions.
+// Keys are always stored lowercase to match the lookup in Update.
+func (m *PickerModel) rebuildSeenIdx() {
+	for k := range m.seenIdx {
+		delete(m.seenIdx, k)
+	}
+	for i, item := range m.items {
+		m.seenIdx[strings.ToLower(pickerItemKey(item))] = i
+	}
+}
+
+// removeItemByKey drops the row with the given lowercase dedup key, reporting
+// whether one was found.
+func (m *PickerModel) removeItemByKey(key string) bool {
+	for i, item := range m.items {
+		if strings.ToLower(pickerItemKey(item)) == key {
+			m.items = append(m.items[:i], m.items[i+1:]...)
+			m.rebuildSeenIdx()
+			return true
+		}
+	}
+	return false
 }
 
 // withSectionHeaders interleaves non-selectable section-header rows ahead of

--- a/go/internal/cli/tui/picker_test.go
+++ b/go/internal/cli/tui/picker_test.go
@@ -66,6 +66,76 @@ func TestPickerModel_DedupesItems(t *testing.T) {
 	}
 }
 
+func TestPickerModel_SupersedesReplacesRow(t *testing.T) {
+	m := NewPicker()
+
+	updated, _ := m.Update(PickerAddMsg{Items: []PickerItem{
+		{Name: "ESP32 (unflashed)", DedupKey: "unflashed:/dev/tty1", Value: "ghost"},
+	}})
+	pm := updated.(PickerModel)
+
+	updated, _ = pm.Update(PickerAddMsg{Items: []PickerItem{
+		{Name: "wendy-alpha", DedupKey: "wendy-alpha", Supersedes: "unflashed:/dev/tty1", Value: "real"},
+	}})
+	pm = updated.(PickerModel)
+
+	if got := len(pm.items); got != 1 {
+		t.Fatalf("expected the superseded row to be replaced, got %d items: %+v", got, pm.items)
+	}
+	if pm.items[0].Value != "real" {
+		t.Errorf("remaining item = %v, want the superseding one", pm.items[0].Value)
+	}
+	if _, ok := pm.seenIdx["unflashed:/dev/tty1"]; ok {
+		t.Error("superseded key still present in seenIdx")
+	}
+}
+
+func TestPickerModel_SupersedesUnknownKeyKeepsRows(t *testing.T) {
+	m := NewPicker()
+
+	updated, _ := m.Update(PickerAddMsg{Items: []PickerItem{
+		{Name: "wendy-alpha", DedupKey: "wendy-alpha", Value: "a"},
+	}})
+	pm := updated.(PickerModel)
+
+	updated, _ = pm.Update(PickerAddMsg{Items: []PickerItem{
+		{Name: "wendy-beta", DedupKey: "wendy-beta", Supersedes: "never-added", Value: "b"},
+	}})
+	pm = updated.(PickerModel)
+
+	if got := len(pm.items); got != 2 {
+		t.Fatalf("expected both rows to survive a no-op supersede, got %d", got)
+	}
+}
+
+func TestPickerModel_SupersedesKeepsCursorOnReplacement(t *testing.T) {
+	m := NewPicker()
+
+	// Two rows sorting either side of the replacement, so a cursor that fails
+	// to follow lands on a neighbour instead.
+	updated, _ := m.Update(PickerAddMsg{Items: []PickerItem{
+		{Name: "aaa", DedupKey: "aaa", Value: "aaa"},
+		{Name: "ESP32 (unflashed)", DedupKey: "mmm-unflashed", Value: "ghost"},
+		{Name: "zzz", DedupKey: "zzz", Value: "zzz"},
+	}})
+	pm := updated.(PickerModel)
+
+	updated, _ = pm.Update(tea.KeyMsg{Type: tea.KeyDown})
+	pm = updated.(PickerModel)
+	if got := pm.currentCursorKey(); got != "mmm-unflashed" {
+		t.Fatalf("cursor = %q, want it on the row about to be superseded", got)
+	}
+
+	updated, _ = pm.Update(PickerAddMsg{Items: []PickerItem{
+		{Name: "wendy-alpha", DedupKey: "mmm-real", Supersedes: "mmm-unflashed", Value: "real"},
+	}})
+	pm = updated.(PickerModel)
+
+	if got := pm.currentCursorKey(); got != "mmm-real" {
+		t.Errorf("cursor = %q, want it to follow onto the replacement", got)
+	}
+}
+
 func TestPickerModel_ShowsDescriptionColumnWhenPresent(t *testing.T) {
 	m := NewPickerWithTitle("Select a target")
 


### PR DESCRIPTION
Three related fixes in Wendy Lite discovery and connect, found while reading through `65df7e0ef` ("Fix lingering ghost entries").

## 1. Unique sentinel per serial handshake send (`4475ab25c`)

`65df7e0ef` made `serialHandshake` send its sentinel immediately and re-send every 100 ms while draining, so reconnecting to a board whose boot logs keep the stream readable no longer times out. But every re-send carried the **same** sentinel and the loop returns on the first window match, which drops the guarantee the sentinel exists for.

Per `wendy-com.md`, the sentinel is a stream position marker, not a liveness probe: because the echo is FIFO, seeing it come back proves everything written earlier was consumed. That only holds for the *last* sentinel sent.

Console mode swallows host input unechoed, so sentinels written before the device applies `DLE e` vanish while later ones are echoed in order. Matching the first echo leaves the rest queued; they arrive after `DLE m`, ahead of the device's COM-mode handshake frame. `readRawMessage` does not resynchronize, so the echo's leading padding is read as the magic byte and the connect fails with `unexpected magic byte: 0x20` — which, since `ErrSerialPortUnavailable` wraps only pre-open failures, surfaces the board as unresponsive and probably unflashed.

Now every send generates a fresh sentinel and only the most recent one can match.

## 2. Wait for the serial port before a fresh install (`06c12f990`)

An unflashed board is re-probed by `SerialDiscovery` on every scan cycle (a responsive one is skipped), and nothing joins those probes when the picker closes: `discoverCancel()` is fire-and-forget and `StopScan` only clears `repeatInterval`. So the flasher can reach `openLockedPort` while our own scanner still holds the flock — and `espflash.go` treats `errPortBusy` as non-retryable, failing immediately with a message that blames `idf.py monitor` for a lock we hold ourselves.

Wait up to 6 s (a probe's worst case: 3 s handshake + 3 s identity) for the port to become lockable. Best-effort by construction — the lock is released as soon as the port is seen free, since `installESP32Firmware` takes its own and flock is per-descriptor.

## 3. Replace the unflashed picker row (`d169e4dff`)

A board listed as `ESP32 (unflashed) — <port>` got a **second** row when a later probe identified it, rather than replacing the first. The leftover row sends the user into the install-offer flow for a board that is already flashed.

`externalProviderPickerItem` keys wendy-lite rows on `DisplayName`, which differs between the two states, so `PickerAddMsg` appended instead of merging. Keying on `ExternalDevice.ID` is not an option — DisplayName keying is what merges the LAN, USB and BLE rows for one physical device.

Adds `PickerItem.Supersedes` (mirroring `discovery.LANEvent.Supersedes`): the unflashed row is keyed by serial port, and the identified USB row supersedes that key while keeping its own display-name key, so cross-transport merging is unaffected.

## Testing

New unit tests for all three, each verified to fail against the pre-fix code:

- handshake: a fake port modelling a noisy freshly-rebooted board; without the fix it leaves 96 unread bytes (two extra echoes) in the stream at the mode switch.
- picker: an end-to-end case pushing both rows through a real picker; without the fix the view renders both `ESP32 (unflashed) — /dev/cu.usbmodem2101` and `Lite Board`.

`go vet` clean; `./internal/cli/tui/...`, `./internal/cli/liteclient/...`, `./internal/shared/discovery/...` and `./internal/cli/providers/...` all green. `./internal/cli/commands/...` has one failure, `TestBuildCmd_MultiService_BuildsFromManifestOnly`, which fails identically on `main` and is unrelated.

**Not yet verified on hardware** — worth doing before merge:
- reconnect to a board with a chatty auto-started app across ~20 reboots (fix 1)
- accept the install offer on an unflashed board repeatedly, so the scan tick lands inside the confirm prompt (fix 2)
- a board reachable over both USB and LAN still collapses to a single picker row (fix 3)

## Notes

Two assumptions behind fix 1 come from `wendy-com.md` rather than code, since the firmware is not in this repo: `USJ_MODE_CONSOLE` discards host input without echoing, and `DLE <x>` sequences are intercepted and never echoed. The second is something the pre-existing code already relies on for `DLE m`.

The upstream links of the discovery shutdown chain are left alone — the picker joining its discovery goroutines, and `DiscoverDevicesContinuous` joining in-flight probes before closing its channel. Note for that work: `WaitForIdle` cannot serve as the barrier, because `StartScan` bumps `scanStarted` once and every pass finishes the same generation, so it returns immediately in continuous mode regardless of probes in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)