### PR TITLE
fix(cli): retry T234 flashpkg identity read through post-unmount ENXIO (WDY-2621)

### DIFF
--- a/go/internal/cli/tegraflash/t234/retry_unix.go
+++ b/go/internal/cli/tegraflash/t234/retry_unix.go
@@ -1,0 +1,18 @@
+//go:build darwin || linux
+
+package t234
+
+import (
+	"errors"
+	"syscall"
+)
+
+// deviceNotReady reports whether err is the transient "device not configured"
+// state a raw disk node can report immediately after a force-unmount on macOS,
+// while diskarbitrationd finishes tearing down the volumes it auto-probed. The
+// node reappears within about a second, so callers re-open and retry rather
+// than abort the flash. ENODEV covers the equivalent "no such device" window a
+// freshly (re-)exported LUN can briefly present on Linux.
+func deviceNotReady(err error) bool {
+	return errors.Is(err, syscall.ENXIO) || errors.Is(err, syscall.ENODEV)
+}

--- a/go/internal/cli/tegraflash/t234/retry_windows.go
+++ b/go/internal/cli/tegraflash/t234/retry_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package t234
+
+// deviceNotReady is always false on Windows: the flash runs in-process there
+// (no sudo re-exec, no diskutil force-unmount race), and syscall.ENXIO/ENODEV
+// are not defined on that platform.
+func deviceNotReady(error) bool { return false }

--- a/go/internal/cli/tegraflash/t234/write.go
+++ b/go/internal/cli/tegraflash/t234/write.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 	"unicode/utf8"
 
 	backendfile "github.com/diskfs/go-diskfs/backend/file"
@@ -233,27 +234,72 @@ func writePlan(opts WriterOptions) error {
 	return nil
 }
 
+// openDevice opens the raw device for a dump read. It is a package var so tests
+// can substitute a device that reports the transient not-ready state.
+var openDevice = os.Open
+
+// dumpDeviceRetries bounds how many times dumpDevice re-opens a device that
+// reports deviceNotReady before giving up. dumpDeviceRetryDelay spaces the
+// attempts; it is a var so tests can drop it to zero.
+const dumpDeviceRetries = 5
+
+var dumpDeviceRetryDelay = 500 * time.Millisecond
+
 // dumpDevice copies the first DumpBytes of the device into DumpTo (used to
 // read the flashpkg filesystem back for the status report). The output file
 // is made world-readable so the unprivileged parent can parse it.
+//
+// The read is retried while the device reports deviceNotReady: on macOS the
+// flashpkg LUN's raw node can briefly return ENXIO ("device not configured")
+// right after the Stage 2 force-unmount, while diskarbitrationd finishes
+// tearing down the volumes it auto-probed. The node reappears within about a
+// second, so re-opening and retrying rides through it instead of aborting the
+// flash (WDY-2621).
 func dumpDevice(opts WriterOptions) error {
 	if opts.DumpBytes <= 0 {
 		return fmt.Errorf("--bytes must be positive with --dump")
 	}
-	dev, err := os.Open(opts.Device)
-	if err != nil {
-		return fmt.Errorf("opening %s (%s): %w", opts.Device, devOpenPrivilege, err)
-	}
-	defer dev.Close()
 	out, err := os.OpenFile(opts.DumpTo, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
 	if err != nil {
 		return err
 	}
 	defer out.Close()
+
+	var lastErr error
+	for attempt := 0; attempt < dumpDeviceRetries; attempt++ {
+		if attempt > 0 {
+			time.Sleep(dumpDeviceRetryDelay)
+			// Rewind the output so a partial read from the previous attempt
+			// is overwritten rather than appended to.
+			if _, err := out.Seek(0, io.SeekStart); err != nil {
+				return err
+			}
+			if err := out.Truncate(0); err != nil {
+				return err
+			}
+		}
+		lastErr = copyDumpOnce(out, opts)
+		if lastErr == nil {
+			return out.Sync()
+		}
+		if !deviceNotReady(lastErr) {
+			return lastErr
+		}
+	}
+	return lastErr
+}
+
+// copyDumpOnce performs one open+read of the raw device into out.
+func copyDumpOnce(out *os.File, opts WriterOptions) error {
+	dev, err := openDevice(opts.Device)
+	if err != nil {
+		return fmt.Errorf("opening %s (%s): %w", opts.Device, devOpenPrivilege, err)
+	}
+	defer dev.Close()
 	if _, err := io.CopyN(out, dev, opts.DumpBytes); err != nil {
 		return fmt.Errorf("reading %s: %w", opts.Device, err)
 	}
-	return out.Sync()
+	return nil
 }
 
 // copyFileAt writes path's contents to dev starting at offset, in

--- a/go/internal/cli/tegraflash/t234/write_retry_unix_test.go
+++ b/go/internal/cli/tegraflash/t234/write_retry_unix_test.go
@@ -1,0 +1,89 @@
+//go:build darwin || linux
+
+package t234
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestDeviceNotReady(t *testing.T) {
+	if !deviceNotReady(&os.PathError{Op: "open", Err: syscall.ENXIO}) {
+		t.Error("ENXIO should be treated as not-ready")
+	}
+	if !deviceNotReady(&os.PathError{Op: "read", Err: syscall.ENODEV}) {
+		t.Error("ENODEV should be treated as not-ready")
+	}
+	if deviceNotReady(&os.PathError{Op: "open", Err: syscall.ENOENT}) {
+		t.Error("ENOENT should not be treated as not-ready")
+	}
+	if deviceNotReady(nil) {
+		t.Error("nil should not be treated as not-ready")
+	}
+}
+
+// TestDumpDeviceRetriesOnNotReady proves dumpDevice re-opens the device while it
+// reports the transient not-ready state and produces the full contents once the
+// device is available (WDY-2621).
+func TestDumpDeviceRetriesOnNotReady(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "device.bin")
+	want := bytes.Repeat([]byte("wendy-flashpkg-"), 4096) // 60 KiB of known bytes
+	if err := os.WriteFile(src, want, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	origOpen, origDelay := openDevice, dumpDeviceRetryDelay
+	t.Cleanup(func() { openDevice, dumpDeviceRetryDelay = origOpen, origDelay })
+	dumpDeviceRetryDelay = 0
+
+	var calls int
+	openDevice = func(name string) (*os.File, error) {
+		calls++
+		if calls < 3 { // fail the first two opens with ENXIO
+			return nil, &os.PathError{Op: "open", Path: name, Err: syscall.ENXIO}
+		}
+		return os.Open(name)
+	}
+
+	out := filepath.Join(dir, "dump.bin")
+	if err := dumpDevice(WriterOptions{Device: src, DumpTo: out, DumpBytes: int64(len(want))}); err != nil {
+		t.Fatalf("dumpDevice: %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 open attempts (2 not-ready + 1 success), got %d", calls)
+	}
+	got, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("dumped %d bytes, want %d and equal contents", len(got), len(want))
+	}
+}
+
+// TestDumpDeviceGivesUpAfterRetries confirms a persistent not-ready device
+// eventually returns the error instead of looping forever.
+func TestDumpDeviceGivesUpAfterRetries(t *testing.T) {
+	dir := t.TempDir()
+	origOpen, origDelay := openDevice, dumpDeviceRetryDelay
+	t.Cleanup(func() { openDevice, dumpDeviceRetryDelay = origOpen, origDelay })
+	dumpDeviceRetryDelay = 0
+
+	var calls int
+	openDevice = func(name string) (*os.File, error) {
+		calls++
+		return nil, &os.PathError{Op: "open", Path: name, Err: syscall.ENXIO}
+	}
+
+	err := dumpDevice(WriterOptions{Device: "/dev/whatever", DumpTo: filepath.Join(dir, "dump.bin"), DumpBytes: 16})
+	if err == nil {
+		t.Fatal("expected an error after exhausting retries")
+	}
+	if calls != dumpDeviceRetries {
+		t.Errorf("expected %d attempts, got %d", dumpDeviceRetries, calls)
+	}
+}


### PR DESCRIPTION
## Problem
On macOS, `wendy os install` for a Jetson Orin / Orin Nano (USB recovery) aborts in **Stage 2** with:

`✗ reading device identity: ✗ reading /dev/rdiskN: read /dev/rdiskN: device not configured` (ENXIO)

This happens **before any destructive write**, so the device is safe — but the full recovery flash (the only path that updates **QSPI/bootloader**) can never complete. Blocks Ethan's documented recovery-install instructions on macOS.

## Root cause
`Stage2.run` force-unmounts the flashpkg LUN (`flash.go:106`, `diskutil unmountDisk force`), then `verifyDeviceIdentity` immediately reads the raw node via `dumpDevice` (`write.go`), which did a single `io.CopyN` with **no retry**. The force-unmount triggers a brief `diskarbitrationd` teardown, so the raw open/read that follows hits ENXIO. Observed live: the run where the unmount *succeeded* is the one that ENXIO'd (the earlier run failed the unmount via the #1744 flag bug and errored differently).

## Fix
- `dumpDevice` retries the open+read while the device reports **not-ready** (`ENXIO`/`ENODEV`) — 5 attempts, 500 ms settle, output rewound between attempts.
- `deviceNotReady` is split per-platform (`retry_unix.go` / `retry_windows.go`) so `syscall.ENXIO` never enters the Windows cross-compile gate.
- Test seam `openDevice` (mirrors the existing `scanUMSDisks` pattern); adds `write_retry_unix_test.go` covering retry-through-ENXIO, correct dumped contents, and give-up-after-N.

## Verification
- `gofmt -s` clean, `go vet` clean.
- Builds: native (darwin/arm64), **Windows cross-compile** (the CI gate), t234 linux package.
- `go test ./internal/cli/tegraflash/t234/ -race` green.
- ⚠️ **Not yet verified end-to-end on hardware** — needs a real Orin Nano recovery flash to confirm it rides through the live ENXIO.

## Not covered here
The macOS "disk you attached was not readable" dialog defaults to **Eject** (blue button), which also detaches the LUN if clicked. That's a separate user-facing footgun noted in WDY-2621.

Closes WDY-2621.

🤖 Generated with [Claude Code](https://claude.com/claude-code)