### PR TITLE
ci: require review for API surface changes

### DIFF
--- a/.github/workflows/api-review.yml
+++ b/.github/workflows/api-review.yml
@@ -42,6 +42,11 @@ jobs:
             base/go.sum
             head/go.sum
 
+      # Constructing the Cobra command tree compiles the full CLI, including
+      # its ALSA and libusb cgo dependencies.
+      - name: Install native CLI dependencies
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libusb-1.0-0-dev
+
       - name: Get changed files
         env:
           GH_TOKEN: ${{ github.token }}
@@ -74,6 +79,8 @@ jobs:
           if [[ ! -f "$detector_source" ]]; then
             # Bootstrap only: the PR that introduces this workflow cannot load
             # the detector from a base revision that predates it.
+            # SECURITY: This job is restricted above to same-repository PRs,
+            # so only repository writers can exercise this one-time fallback.
             detector_source="$HEAD_DIR/go/cmd/api-surface-snapshot/main.go"
             echo "::notice::Using the head API detector for the bootstrap PR"
           fi
@@ -87,6 +94,10 @@ jobs:
           # After the bootstrap PR, detector_source always comes from the
           # trusted base revision. The PR may change CLI code, but it cannot
           # change what the detector observes.
+          # SECURITY: Evaluating the head's Cobra surface necessarily loads its
+          # command package. The same-repository guard limits this to trusted
+          # writers; checkout credentials are not persisted, and GH_TOKEN is
+          # scoped only to the earlier changed-files step.
           trusted_detector="$(mktemp -d "$HEAD_DIR/go/cmd/api-surface-snapshot-ci.XXXXXX")"
           cp "$detector_source" "$trusted_detector/main.go"
           (

--- a/.github/workflows/api-review.yml
+++ b/.github/workflows/api-review.yml
@@ -14,11 +14,12 @@ jobs:
     name: Detect API surface changes
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: runs-on,runner=2cpu-linux-x64
+    outputs:
+      api-changed: ${{ steps.detect.outputs.api-changed }}
+      risk: ${{ steps.detect.outputs.risk }}
     permissions:
       contents: read
       pull-requests: read
-      api-changed: ${{ steps.detect.outputs.api-changed }}
-      risk: ${{ steps.detect.outputs.risk }}
     steps:
       - name: Check out base
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/api-review.yml
+++ b/.github/workflows/api-review.yml
@@ -1,0 +1,298 @@
+name: API Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  detect-api-changes:
+    name: Detect API surface changes
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: runs-on,runner=2cpu-linux-x64
+    permissions:
+      contents: read
+    outputs:
+      api-changed: ${{ steps.detect.outputs.api-changed }}
+      risk: ${{ steps.detect.outputs.risk }}
+    steps:
+      - name: Check out base
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+          persist-credentials: false
+
+      - name: Check out head
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: head
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: base/go.mod
+          cache-dependency-path: |
+            base/go.sum
+            head/go.sum
+
+      - name: Get changed files
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files?per_page=100" \
+            --jq '.[].filename' > "$RUNNER_TEMP/api-review-changed-files.txt"
+          test -s "$RUNNER_TEMP/api-review-changed-files.txt"
+
+      - name: Detect CLI and protobuf API changes
+        id: detect
+        env:
+          BASE_DIR: ${{ github.workspace }}/base
+          HEAD_DIR: ${{ github.workspace }}/head
+          CHANGED_FILES: ${{ runner.temp }}/api-review-changed-files.txt
+          ADDITIONS: ${{ github.event.pull_request.additions }}
+          DELETIONS: ${{ github.event.pull_request.deletions }}
+        run: |
+          set -euo pipefail
+
+          base_snapshot="$RUNNER_TEMP/base-cli-surface.json"
+          head_snapshot="$RUNNER_TEMP/head-cli-surface.json"
+          base_proto_manifest="$RUNNER_TEMP/base-protobuf.manifest"
+          head_proto_manifest="$RUNNER_TEMP/head-protobuf.manifest"
+          proto_diff="$RUNNER_TEMP/protobuf.diff"
+
+          detector_source="$BASE_DIR/go/cmd/api-surface-snapshot/main.go"
+          if [[ ! -f "$detector_source" ]]; then
+            # Bootstrap only: the PR that introduces this workflow cannot load
+            # the detector from a base revision that predates it.
+            detector_source="$HEAD_DIR/go/cmd/api-surface-snapshot/main.go"
+            echo "::notice::Using the head API detector for the bootstrap PR"
+          fi
+          base_detector="$(mktemp -d "$BASE_DIR/go/cmd/api-surface-snapshot-ci.XXXXXX")"
+          cp "$detector_source" "$base_detector/main.go"
+          (
+            cd "$BASE_DIR"
+            go run "./go/cmd/$(basename "$base_detector")" > "$base_snapshot"
+          )
+
+          # After the bootstrap PR, detector_source always comes from the
+          # trusted base revision. The PR may change CLI code, but it cannot
+          # change what the detector observes.
+          trusted_detector="$(mktemp -d "$HEAD_DIR/go/cmd/api-surface-snapshot-ci.XXXXXX")"
+          cp "$detector_source" "$trusted_detector/main.go"
+          (
+            cd "$HEAD_DIR"
+            go run "./go/cmd/$(basename "$trusted_detector")" > "$head_snapshot"
+          )
+
+          cli_changed=false
+          proto_changed=false
+          critical_flow_changed=false
+          cli_risk="$(
+            cd "$BASE_DIR"
+            go run "./go/cmd/$(basename "$base_detector")" compare "$base_snapshot" "$head_snapshot"
+          )"
+
+          if ! cmp -s "$base_snapshot" "$head_snapshot"; then
+            cli_changed=true
+          fi
+
+          protobuf_manifest() {
+            local checkout="$1"
+            (
+              cd "$checkout"
+              find . -path './.git' -prune -o -type f -name '*.proto' -print0 \
+                | sort -z \
+                | xargs -0 sha256sum
+            )
+          }
+          protobuf_manifest "$BASE_DIR" > "$base_proto_manifest"
+          protobuf_manifest "$HEAD_DIR" > "$head_proto_manifest"
+          diff_status=0
+          diff -u "$base_proto_manifest" "$head_proto_manifest" > "$proto_diff" || diff_status=$?
+          if [[ "$diff_status" == 1 ]]; then
+            proto_changed=true
+          elif [[ "$diff_status" != 0 ]]; then
+            echo "Could not compare protobuf manifests (diff exit $diff_status)" >&2
+            exit "$diff_status"
+          fi
+
+          risk="$cli_risk"
+          if [[ "$proto_changed" == true ]]; then
+            if (
+              cd "$HEAD_DIR"
+              sha256sum --check "$base_proto_manifest" --status
+            ); then
+              if [[ "$risk" == low ]]; then
+                risk=mid
+              fi
+            else
+              risk=high
+            fi
+          fi
+
+          line_changes=$((ADDITIONS + DELETIONS))
+          changed_file_count="$(wc -l < "$CHANGED_FILES" | tr -d ' ')"
+          if (( line_changes >= 1000 || changed_file_count >= 25 )); then
+            risk=high
+          elif [[ "$risk" == low ]] && (( line_changes >= 250 || changed_file_count >= 10 )); then
+            risk=mid
+          fi
+
+          critical_pattern='(^go/installer/|^go/internal/cli/commands/(apps_install|auth|cloud_run|deploy|device_osupdate|docker|fleet_run|helpers_cloudauth|os_cmd|os_install|os_provision|run|update|watch)[^/]*\.go$|^Proto/.*(auth|deploy|install|provision|update).*\.proto$)'
+          critical_files="$(rg -i "$critical_pattern" "$CHANGED_FILES" | rg -v '_test\.go$' || true)"
+          if [[ -n "$critical_files" ]]; then
+            critical_flow_changed=true
+            risk=high
+          fi
+
+          if [[ "$cli_changed" == true || "$proto_changed" == true ]]; then
+            echo "api-changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "api-changed=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "risk=$risk" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### API review detection"
+            echo
+            echo "| Surface | Changed |"
+            echo "| --- | --- |"
+            echo "| Wendy CLI commands and flags | $cli_changed |"
+            echo "| Protobuf definitions | $proto_changed |"
+            echo "| Critical install/deploy/auth/update flow | $critical_flow_changed |"
+            echo "| Changed files / lines | $changed_file_count / $line_changes |"
+            echo "| Testing risk | $risk |"
+            if [[ "$critical_flow_changed" == true ]]; then
+              echo
+              echo "#### Changed critical-flow files"
+              echo '```text'
+              echo "$critical_files"
+              echo '```'
+            fi
+            if [[ "$cli_changed" == true ]]; then
+              echo
+              echo '<details><summary>CLI surface diff</summary>'
+              echo
+              echo '```diff'
+              diff -u "$base_snapshot" "$head_snapshot" | sed -n '1,500p' || true
+              echo '```'
+              echo '</details>'
+            fi
+            if [[ "$proto_changed" == true ]]; then
+              echo
+              echo "#### Changed protobuf definitions"
+              echo '```diff'
+              cat "$proto_diff"
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  mark-api-review:
+    name: Label risk and request API review
+    needs: detect-api-changes
+    if: needs.detect-api-changes.result == 'success'
+    runs-on: runs-on,runner=2cpu-linux-x64
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Add label and request Joannis
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          API_CHANGED: ${{ needs.detect-api-changes.outputs.api-changed }}
+          RISK: ${{ needs.detect-api-changes.outputs.risk }}
+        with:
+          script: |
+            const apiLabel = {
+              name: 'api-review',
+              color: 'B60205',
+              description: 'Changes a public CLI or protobuf API surface',
+            };
+            const riskLabels = {
+              low: {
+                name: 'risk: low',
+                color: '0E8A16',
+                description: 'Low estimated risk; focused testing is sufficient',
+              },
+              mid: {
+                name: 'risk: mid',
+                color: 'FBCA04',
+                description: 'Medium estimated risk; test changes and adjacent workflows',
+              },
+              high: {
+                name: 'risk: high',
+                color: 'B60205',
+                description: 'High estimated risk; thoroughly test compatibility and affected workflows',
+              },
+            };
+            const pull_number = context.payload.pull_request.number;
+            const {owner, repo} = context.repo;
+
+            async function ensureLabel(label) {
+              try {
+                await github.rest.issues.getLabel({owner, repo, name: label.name});
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                await github.rest.issues.createLabel({owner, repo, ...label});
+              }
+            }
+
+            async function removeLabel(name) {
+              try {
+                await github.rest.issues.removeLabel({owner, repo, issue_number: pull_number, name});
+              } catch (error) {
+                if (error.status !== 404) throw error;
+              }
+            }
+
+            const risk = process.env.RISK;
+            if (!Object.hasOwn(riskLabels, risk)) {
+              throw new Error(`Unexpected testing risk: ${risk}`);
+            }
+            await ensureLabel(riskLabels[risk]);
+            for (const [level, label] of Object.entries(riskLabels)) {
+              if (level !== risk) await removeLabel(label.name);
+            }
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: pull_number,
+              labels: [riskLabels[risk].name],
+            });
+
+            if (process.env.API_CHANGED !== 'true') {
+              await removeLabel(apiLabel.name);
+              return;
+            }
+
+            await ensureLabel(apiLabel);
+            await github.rest.issues.addLabels({owner, repo, issue_number: pull_number, labels: [apiLabel.name]});
+
+            const reviewer = 'joannis';
+            if (context.payload.pull_request.user.login.toLowerCase() === reviewer) {
+              core.info('Joannis authored this pull request; GitHub does not allow self-review requests.');
+              return;
+            }
+
+            const pull = await github.rest.pulls.get({owner, repo, pull_number});
+            const alreadyRequested = pull.data.requested_reviewers.some(
+              ({login}) => login.toLowerCase() === reviewer,
+            );
+            if (!alreadyRequested) {
+              await github.rest.pulls.requestReviewers({
+                owner,
+                repo,
+                pull_number,
+                reviewers: [reviewer],
+              });
+            }

--- a/.github/workflows/api-review.yml
+++ b/.github/workflows/api-review.yml
@@ -149,7 +149,7 @@ jobs:
           fi
 
           critical_pattern='(^go/installer/|^go/internal/cli/commands/(apps_install|auth|cloud_run|deploy|device_osupdate|docker|fleet_run|helpers_cloudauth|os_cmd|os_install|os_provision|run|update|watch)[^/]*\.go$|^Proto/.*(auth|deploy|install|provision|update).*\.proto$)'
-          critical_files="$(rg -i "$critical_pattern" "$CHANGED_FILES" | rg -v '_test\.go$' || true)"
+          critical_files="$(grep -Ei "$critical_pattern" "$CHANGED_FILES" | grep -Ev '_test\.go$' || true)"
           if [[ -n "$critical_files" ]]; then
             critical_flow_changed=true
             risk=high

--- a/.github/workflows/api-review.yml
+++ b/.github/workflows/api-review.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: runs-on,runner=2cpu-linux-x64
     permissions:
       contents: read
-    outputs:
+      pull-requests: read
       api-changed: ${{ steps.detect.outputs.api-changed }}
       risk: ${{ steps.detect.outputs.risk }}
     steps:

--- a/go/cmd/api-surface-snapshot/main.go
+++ b/go/cmd/api-surface-snapshot/main.go
@@ -1,0 +1,294 @@
+// api-surface-snapshot prints the user-visible Wendy CLI surface in a stable
+// JSON form. CI compares snapshots from the base and head of a pull request so
+// additions, removals, and changes receive API review.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/wendylabsinc/wendy/go/internal/cli/commands"
+)
+
+type surface struct {
+	Commands []commandSurface `json:"commands"`
+}
+
+type commandSurface struct {
+	Path            string        `json:"path"`
+	Use             string        `json:"use"`
+	Aliases         []string      `json:"aliases,omitempty"`
+	SuggestFor      []string      `json:"suggest_for,omitempty"`
+	Short           string        `json:"short,omitempty"`
+	Long            string        `json:"long,omitempty"`
+	Example         string        `json:"example,omitempty"`
+	Deprecated      string        `json:"deprecated,omitempty"`
+	ValidArgs       []string      `json:"valid_args,omitempty"`
+	ArgAliases      []string      `json:"arg_aliases,omitempty"`
+	LocalFlags      []flagSurface `json:"local_flags,omitempty"`
+	PersistentFlags []flagSurface `json:"persistent_flags,omitempty"`
+}
+
+type flagSurface struct {
+	Name                string              `json:"name"`
+	Shorthand           string              `json:"shorthand,omitempty"`
+	Usage               string              `json:"usage,omitempty"`
+	Default             string              `json:"default,omitempty"`
+	NoOptDefault        string              `json:"no_opt_default,omitempty"`
+	Type                string              `json:"type"`
+	Deprecated          string              `json:"deprecated,omitempty"`
+	ShorthandDeprecated string              `json:"shorthand_deprecated,omitempty"`
+	Annotations         map[string][]string `json:"annotations,omitempty"`
+}
+
+func main() {
+	if len(os.Args) == 4 && os.Args[1] == "compare" {
+		base, err := readSurface(os.Args[2])
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		head, err := readSurface(os.Args[3])
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		fmt.Println(compareRisk(base, head))
+		return
+	}
+	if len(os.Args) != 1 {
+		fmt.Fprintln(os.Stderr, "usage: api-surface-snapshot [compare BASE.json HEAD.json]")
+		os.Exit(2)
+	}
+
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(snapshot(commands.NewRootCmd())); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func readSurface(path string) (surface, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return surface{}, fmt.Errorf("open CLI surface %q: %w", path, err)
+	}
+	defer file.Close()
+
+	var result surface
+	if err := json.NewDecoder(file).Decode(&result); err != nil {
+		return surface{}, fmt.Errorf("decode CLI surface %q: %w", path, err)
+	}
+	return result, nil
+}
+
+// compareRisk estimates how thoroughly an API change needs testing. Critical
+// install/deploy/auth/update flows and changes to an existing contract are
+// high-risk, purely additive contracts are mid-risk, and other help-only or
+// absent changes are low-risk.
+func compareRisk(base, head surface) string {
+	baseCommands := commandMap(base.Commands)
+	headCommands := commandMap(head.Commands)
+	added := false
+	for path, baseCommand := range baseCommands {
+		if !isCriticalCommand(path) {
+			continue
+		}
+		headCommand, exists := headCommands[path]
+		if !exists || !reflect.DeepEqual(baseCommand, headCommand) {
+			return "high"
+		}
+	}
+	for path := range headCommands {
+		if _, exists := baseCommands[path]; !exists && isCriticalCommand(path) {
+			return "high"
+		}
+	}
+
+	for path, baseCommand := range baseCommands {
+		headCommand, exists := headCommands[path]
+		if !exists {
+			return "high"
+		}
+		if !reflect.DeepEqual(commandContract(baseCommand), commandContract(headCommand)) {
+			return "high"
+		}
+		localAdded, localChanged := compareFlags(baseCommand.LocalFlags, headCommand.LocalFlags)
+		persistentAdded, persistentChanged := compareFlags(baseCommand.PersistentFlags, headCommand.PersistentFlags)
+		if localChanged || persistentChanged {
+			return "high"
+		}
+		added = added || localAdded || persistentAdded
+	}
+
+	for path := range headCommands {
+		if _, exists := baseCommands[path]; !exists {
+			added = true
+		}
+	}
+	if added {
+		return "mid"
+	}
+	return "low"
+}
+
+func isCriticalCommand(path string) bool {
+	critical := map[string]bool{
+		"auth": true, "enroll": true, "flash": true, "install": true,
+		"login": true, "provision": true, "run": true, "update": true,
+	}
+	for _, component := range strings.Fields(path) {
+		if critical[component] {
+			return true
+		}
+	}
+	return false
+}
+
+type commandContractSurface struct {
+	Use        string
+	Aliases    []string
+	SuggestFor []string
+	Deprecated string
+	ValidArgs  []string
+	ArgAliases []string
+}
+
+func commandContract(command commandSurface) commandContractSurface {
+	return commandContractSurface{
+		Use:        command.Use,
+		Aliases:    command.Aliases,
+		SuggestFor: command.SuggestFor,
+		Deprecated: command.Deprecated,
+		ValidArgs:  command.ValidArgs,
+		ArgAliases: command.ArgAliases,
+	}
+}
+
+type flagContractSurface struct {
+	Shorthand           string
+	Default             string
+	NoOptDefault        string
+	Type                string
+	Deprecated          string
+	ShorthandDeprecated string
+	Annotations         map[string][]string
+}
+
+func compareFlags(base, head []flagSurface) (added, changed bool) {
+	baseFlags := flagMap(base)
+	headFlags := flagMap(head)
+	for name, baseFlag := range baseFlags {
+		headFlag, exists := headFlags[name]
+		if !exists || !reflect.DeepEqual(flagContract(baseFlag), flagContract(headFlag)) {
+			return false, true
+		}
+	}
+	for name := range headFlags {
+		if _, exists := baseFlags[name]; !exists {
+			added = true
+		}
+	}
+	return added, false
+}
+
+func flagContract(flag flagSurface) flagContractSurface {
+	return flagContractSurface{
+		Shorthand:           flag.Shorthand,
+		Default:             flag.Default,
+		NoOptDefault:        flag.NoOptDefault,
+		Type:                flag.Type,
+		Deprecated:          flag.Deprecated,
+		ShorthandDeprecated: flag.ShorthandDeprecated,
+		Annotations:         flag.Annotations,
+	}
+}
+
+func commandMap(commands []commandSurface) map[string]commandSurface {
+	result := make(map[string]commandSurface, len(commands))
+	for _, command := range commands {
+		result[command.Path] = command
+	}
+	return result
+}
+
+func flagMap(flags []flagSurface) map[string]flagSurface {
+	result := make(map[string]flagSurface, len(flags))
+	for _, flag := range flags {
+		result[flag.Name] = flag
+	}
+	return result
+}
+
+func snapshot(root *cobra.Command) surface {
+	result := surface{}
+	var walk func(*cobra.Command)
+	walk = func(cmd *cobra.Command) {
+		if cmd.Hidden {
+			return
+		}
+
+		entry := commandSurface{
+			Path:            cmd.CommandPath(),
+			Use:             cmd.Use,
+			Aliases:         sortedCopy(cmd.Aliases),
+			SuggestFor:      sortedCopy(cmd.SuggestFor),
+			Short:           cmd.Short,
+			Long:            cmd.Long,
+			Example:         cmd.Example,
+			Deprecated:      cmd.Deprecated,
+			ValidArgs:       sortedCopy(cmd.ValidArgs),
+			ArgAliases:      sortedCopy(cmd.ArgAliases),
+			LocalFlags:      flags(cmd.LocalNonPersistentFlags()),
+			PersistentFlags: flags(cmd.PersistentFlags()),
+		}
+		result.Commands = append(result.Commands, entry)
+
+		for _, child := range cmd.Commands() {
+			walk(child)
+		}
+	}
+	walk(root)
+	sort.Slice(result.Commands, func(i, j int) bool {
+		return result.Commands[i].Path < result.Commands[j].Path
+	})
+	return result
+}
+
+func flags(flagSet *pflag.FlagSet) []flagSurface {
+	var result []flagSurface
+	flagSet.VisitAll(func(flag *pflag.Flag) {
+		if flag.Hidden {
+			return
+		}
+		result = append(result, flagSurface{
+			Name:                flag.Name,
+			Shorthand:           flag.Shorthand,
+			Usage:               flag.Usage,
+			Default:             flag.DefValue,
+			NoOptDefault:        flag.NoOptDefVal,
+			Type:                flag.Value.Type(),
+			Deprecated:          flag.Deprecated,
+			ShorthandDeprecated: flag.ShorthandDeprecated,
+			Annotations:         flag.Annotations,
+		})
+	})
+	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
+	return result
+}
+
+func sortedCopy(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	result := append([]string(nil), values...)
+	sort.Strings(result)
+	return result
+}

--- a/go/cmd/api-surface-snapshot/main_test.go
+++ b/go/cmd/api-surface-snapshot/main_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestSnapshotCapturesPublicCommandsAndFlags(t *testing.T) {
+	root := &cobra.Command{Use: "wendy", Short: "root help"}
+	root.PersistentFlags().StringP("device", "d", "", "target device")
+
+	run := &cobra.Command{
+		Use:       "run [path]",
+		Aliases:   []string{"deploy", "start"},
+		ValidArgs: []string{"."},
+	}
+	run.Flags().Bool("detach", false, "do not stream logs")
+	run.Flags().Bool("internal", false, "internal flag")
+	if err := run.Flags().MarkHidden("internal"); err != nil {
+		t.Fatal(err)
+	}
+	root.AddCommand(run)
+	root.AddCommand(&cobra.Command{Use: "secret", Hidden: true})
+
+	got := snapshot(root)
+	if len(got.Commands) != 2 {
+		t.Fatalf("snapshot contains %d commands, want 2: %#v", len(got.Commands), got)
+	}
+	if got.Commands[0].Path != "wendy" || got.Commands[1].Path != "wendy run" {
+		t.Fatalf("unexpected command paths: %q, %q", got.Commands[0].Path, got.Commands[1].Path)
+	}
+	if !reflect.DeepEqual(got.Commands[1].Aliases, []string{"deploy", "start"}) {
+		t.Fatalf("aliases = %#v", got.Commands[1].Aliases)
+	}
+	if len(got.Commands[0].PersistentFlags) != 1 || got.Commands[0].PersistentFlags[0].Name != "device" {
+		t.Fatalf("persistent flags = %#v", got.Commands[0].PersistentFlags)
+	}
+	if len(got.Commands[1].LocalFlags) != 1 || got.Commands[1].LocalFlags[0].Name != "detach" {
+		t.Fatalf("local flags = %#v", got.Commands[1].LocalFlags)
+	}
+}
+
+func TestSortedCopyDoesNotMutateCommandMetadata(t *testing.T) {
+	aliases := []string{"z", "a"}
+	got := sortedCopy(aliases)
+
+	if !reflect.DeepEqual(got, []string{"a", "z"}) {
+		t.Fatalf("sortedCopy() = %#v", got)
+	}
+	if !reflect.DeepEqual(aliases, []string{"z", "a"}) {
+		t.Fatalf("sortedCopy mutated input: %#v", aliases)
+	}
+}
+
+func TestCompareRisk(t *testing.T) {
+	base := surface{Commands: []commandSurface{
+		{
+			Path:  "wendy inspect",
+			Use:   "inspect [path]",
+			Short: "Inspect an app",
+			LocalFlags: []flagSurface{
+				{Name: "detach", Default: "false", Type: "bool", Usage: "Do not stream logs"},
+			},
+		},
+	}}
+
+	tests := []struct {
+		name string
+		head surface
+		want string
+	}{
+		{name: "unchanged", head: base, want: "low"},
+		{
+			name: "help only",
+			head: surface{Commands: []commandSurface{
+				{Path: "wendy inspect", Use: "inspect [path]", Short: "Inspect an application", LocalFlags: base.Commands[0].LocalFlags},
+			}},
+			want: "low",
+		},
+		{
+			name: "additive flag",
+			head: surface{Commands: []commandSurface{
+				{
+					Path: "wendy inspect", Use: "inspect [path]", Short: "Inspect an app",
+					LocalFlags: append(base.Commands[0].LocalFlags, flagSurface{Name: "verbose", Default: "false", Type: "bool"}),
+				},
+			}},
+			want: "mid",
+		},
+		{
+			name: "changed default",
+			head: surface{Commands: []commandSurface{
+				{
+					Path: "wendy inspect", Use: "inspect [path]", Short: "Inspect an app",
+					LocalFlags: []flagSurface{{Name: "detach", Default: "true", Type: "bool", Usage: "Do not stream logs"}},
+				},
+			}},
+			want: "high",
+		},
+		{name: "removed command", head: surface{}, want: "high"},
+		{
+			name: "critical flow help",
+			head: surface{Commands: []commandSurface{
+				{Path: "wendy install", Use: "install", Short: "Install WendyOS"},
+			}},
+			want: "high",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testBase := base
+			if test.name == "critical flow help" {
+				testBase = surface{Commands: []commandSurface{
+					{Path: "wendy install", Use: "install", Short: "Install the OS"},
+				}}
+			}
+			if got := compareRisk(testBase, test.head); got != test.want {
+				t.Fatalf("compareRisk() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- compare the public Cobra command/flag surface and every protobuf definition between a PR's base and head
- add or remove the `api-review` label and request Joannis when an API changes
- assign one mutually exclusive `risk: low`, `risk: mid`, or `risk: high` label from API compatibility, change size, and critical-flow paths
- force install, provisioning, deployment/run, authentication, flashing, and update changes to high risk
- keep PR code in a read-only detection job and perform labels/review requests in a separate write-only job

## Validation

- `go test ./go/cmd/api-surface-snapshot`
- `go vet ./go/cmd/api-surface-snapshot`
- `actionlint -config-file .github/actionlint.yaml -ignore 'label "runs-on,runner=2cpu-linux-x64" is unknown' .github/workflows/api-review.yml`
- bootstrap comparison against a clean `origin/main` archive
- `git diff --check`
