### PR TITLE
fix: identify macOS signer by fingerprint

### DIFF
--- a/swift/Scripts/SetupSigningCI.sh
+++ b/swift/Scripts/SetupSigningCI.sh
@@ -25,9 +25,13 @@ DEVELOPER_ID_CA_PATH="${TEMP_DIR}/developer-id-g2-ca.cer"
 DEVELOPER_ID_CA_URL="https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer"
 DEVELOPER_ID_CA_SHA256="f16cd3c54c7f83cea4bf1a3e6a0819c8aaa8e4a1528fd144715f350643d2df3a"
 NOTARY_PROFILE="${NOTARY_PROFILE:-wendy-notary-profile}"
+SIGNING_SETUP_COMPLETE=0
 
 cleanup() {
   rm -f "$CERT_PATH" "$KEY_PATH" "$DEVELOPER_ID_CA_PATH"
+  if [[ "$SIGNING_SETUP_COMPLETE" -ne 1 && -f "$KEYCHAIN_PATH" ]]; then
+    security delete-keychain "$KEYCHAIN_PATH" || true
+  fi
 }
 trap cleanup EXIT
 
@@ -61,8 +65,22 @@ security set-key-partition-list \
   -s \
   -k "$KEYCHAIN_PASSWORD" \
   "$KEYCHAIN_PATH"
-SIGNING_IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | awk -F '"' '/Developer ID Application/ { print $2; exit }')
-if [ -z "$SIGNING_IDENTITY" ]; then
+
+# codesign requires the identity's keychain to be on the user search list even
+# when --keychain names it explicitly. Preserve existing entries; deleting the
+# ephemeral keychain after the build removes only this added entry.
+KEYCHAIN_SEARCH_LIST=("$KEYCHAIN_PATH")
+while IFS= read -r keychain; do
+  keychain="${keychain#*\"}"
+  keychain="${keychain%\"*}"
+  if [[ -n "$keychain" && "$keychain" != "$KEYCHAIN_PATH" ]]; then
+    KEYCHAIN_SEARCH_LIST+=("$keychain")
+  fi
+done < <(security list-keychains -d user)
+security list-keychains -d user -s "${KEYCHAIN_SEARCH_LIST[@]}"
+
+SIGNING_IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | awk '/Developer ID Application/ { print $2; exit }')
+if [[ ! "$SIGNING_IDENTITY" =~ ^[[:xdigit:]]{40}$ ]]; then
   echo "::error::Could not find a Developer ID Application identity in the imported certificate"
   exit 1
 fi
@@ -81,4 +99,5 @@ if [ -n "${GITHUB_OUTPUT:-}" ]; then
   } >> "$GITHUB_OUTPUT"
 fi
 
-echo "Imported signing identity: $SIGNING_IDENTITY"
+SIGNING_SETUP_COMPLETE=1
+echo "Imported Developer ID signing identity"


### PR DESCRIPTION
> **In plain terms:** Mac release builds currently finish compiling but then lose access to the valid signing certificate before signing begins. This keeps CI's temporary signing keychain available for the whole build and selects the exact certificate instead of relying on its display name.

## Summary
- Add the ephemeral signing keychain to the user search list while preserving every existing entry, as required by `codesign` even when `--keychain` is supplied.
- Export the valid Developer ID identity's certificate fingerprint instead of its display name.
- Delete the ephemeral keychain on setup failure; normal post-build deletion also removes only its temporary search-list entry.
- Keep logs generic rather than printing the selected signing identity.

## Tests
- `bash -n swift/Scripts/SetupSigningCI.sh`
- `shellcheck swift/Scripts/SetupSigningCI.sh`
- `git diff --check`
- Synthetic identity-fingerprint parser check
- Live parsing of the current macOS user keychain search list
- Controlled non-publishing workflow [33103762403](https://github.com/wendylabsinc/WendyOS/actions/runs/33103762403): passed
  - Developer ID signing completed on `wendy-developer-macos-26-01`
  - Apple notarization returned `Accepted`
  - Stapling and Gatekeeper validation passed
  - The full controlled workflow completed successfully

## Context
- Run 33100059440 and its rerun both import the certificate chain and key, validate notary credentials, and complete the unsigned Xcode build before `codesign` reports that the identity cannot be found.
- Both attempts ran on the existing `wendy-developer-macos-26-01` runner, so the newly added second runner is not the cause of this specific failure.
- Controlled run 33102614988 proved fingerprint selection alone was insufficient. The `codesign` manual requires the identity keychain to also be on the user's search list; the previous successful run depended on stale persistent-runner search-list state left before #1791.
