### PR TITLE
feat(agent): expose ROS 2 video topics as cameras

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -350,12 +350,35 @@ Cameras come in three transports, and `wendy device camera` treats them alike:
 | `usb` | `/dev/videoN`, `uvcvideo` and friends | native V4L2 H.264, GStreamer fallback |
 | `csi` | ribbon sensor, `tegra-*` / `unicam` | GStreamer (`libcamerasrc`, `nvarguscamerasrc` on Jetson) |
 | `ip` | network camera over Real Time Streaming Protocol (RTSP) | GStreamer depayload, no transcode |
+| `ros2` | `sensor_msgs/Image`, `sensor_msgs/CompressedImage`, or Unitree Go2 `/frontvideostream` | DDS subscriber into `/dev/video128`–`/dev/video199` |
 
 ```sh
 wendy device camera list          # every camera, whatever the transport
 wendy device camera view          # picker when several exist, silent when one
 wendy device camera view --id 203
 ```
+
+### ROS 2 cameras
+
+The agent discovers image writers in every running Wendy ROS 2 app without
+changing the app's discovery scope: for the default app-local scope it creates
+its DDS sockets inside that app's network namespace. It also watches domain 0
+on wired device interfaces for robot-native feeds. Supported messages are
+`sensor_msgs/msg/Image`, `sensor_msgs/msg/CompressedImage`, and Unitree's
+`unitree_go/msg/Go2FrontVideoData`; the last one makes a Go2's
+`/frontvideostream` appear as **Unitree Go2 front camera**.
+
+Each topic receives a stable ID in the 128–199 band and a matching
+v4l2loopback node. It appears in the normal commands:
+
+```sh
+wendy device camera list
+wendy device camera view --id 128
+```
+
+Raw ROS images are converted to MJPEG; compressed JPEG feeds, including the
+Go2's 720p field, stay compressed on the way into the loopback device. Large
+DDS samples are reassembled from bounded RTPS DATA_FRAG sets in the agent.
 
 ### Network cameras
 

--- a/Proto/wendy/agent/services/v1/wendy_agent_v1_video_service.proto
+++ b/Proto/wendy/agent/services/v1/wendy_agent_v1_video_service.proto
@@ -23,6 +23,7 @@ message VideoDevice {
     string mac              = 9; // stable identity for network cameras; empty for local cameras
     bool has_credentials    = 10; // the agent holds a login for this camera
     bool online             = 11; // the most recent probe reached this camera
+    string topic            = 12; // ROS 2 image topic, e.g. "/camera/image_raw"; empty for other transports
 }
 
 enum VideoTransport {
@@ -30,6 +31,7 @@ enum VideoTransport {
     VIDEO_TRANSPORT_USB     = 1;
     VIDEO_TRANSPORT_CSI     = 2;
     VIDEO_TRANSPORT_IP      = 3;
+    VIDEO_TRANSPORT_ROS2    = 4;
 }
 
 message ListVideoDevicesRequest {}

--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -310,7 +310,11 @@ func main() {
 
 	startROS2BatteryMonitor(ctx, logger, configPath)
 
-	videoSvc := services.NewVideoService(ctx, logger)
+	var videoROSRuntime []services.ROS2Runtime
+	if ctrdClient != nil {
+		videoROSRuntime = append(videoROSRuntime, ctrdClient)
+	}
+	videoSvc := services.NewVideoService(ctx, logger, videoROSRuntime...)
 	defer videoSvc.Shutdown()
 	// Network cameras have to be found before they can be listed, so probe
 	// periodically rather than only when a client asks.

--- a/go/internal/agent/containerd/network_sandbox_test.go
+++ b/go/internal/agent/containerd/network_sandbox_test.go
@@ -93,7 +93,8 @@ func TestNetworkOperationLockSerializesSameContainer(t *testing.T) {
 	unlock := c.lockNetworkOperation("myapp")
 	acquired := make(chan struct{})
 	go func() {
-		defer c.lockNetworkOperation("myapp")()
+		unlock := c.lockNetworkOperation("myapp")
+		unlock()
 		close(acquired)
 	}()
 	select {
@@ -122,7 +123,8 @@ func TestAdditionalNetworkOperationLocksSerializeGroupMembers(t *testing.T) {
 	acquired := make(chan string, 2)
 	for _, containerID := range []string{"myapp_api", "myapp_worker"} {
 		go func() {
-			defer c.lockNetworkOperation(containerID)()
+			unlock := c.lockNetworkOperation(containerID)
+			unlock()
 			acquired <- containerID
 		}()
 	}

--- a/go/internal/agent/ipcam/loopback.go
+++ b/go/internal/agent/ipcam/loopback.go
@@ -263,10 +263,11 @@ func (l *Loopback) detect() error {
 	return nil
 }
 
-// sweepAutoCreatedNodes removes any loopback device numbered below the
-// reserved camera-ID band (see registry.go's IDBandStart).
+// sweepAutoCreatedNodes removes any loopback device numbered below Wendy's
+// complete virtual-camera band. ROS 2 cameras occupy 128-199 and IP cameras
+// occupy 200-255, so neither kind may be swept as an auto-created node.
 func (l *Loopback) sweepAutoCreatedNodes() {
-	for nr := 0; nr < IDBandStart; nr++ {
+	for nr := 0; nr < LoopbackBandStart; nr++ {
 		if !l.deps.nodeExists(nr) {
 			continue
 		}
@@ -298,17 +299,31 @@ func (l *Loopback) EnsureNodes(ctx context.Context) error {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		nr := int(cam.ID)
-		if l.deps.nodeExists(nr) {
-			continue
-		}
-		label := fmt.Sprintf("Wendy IP camera %d", cam.ID)
-		if err := l.deps.addNode(nr, label); err != nil {
+		if err := l.EnsureNode(ctx, cam.ID, fmt.Sprintf("Wendy IP camera %d", cam.ID)); err != nil {
 			l.logger.Warn("creating v4l2loopback node", zap.Uint32("cameraId", cam.ID), zap.Error(err))
-			continue
 		}
 	}
 	return nil
+}
+
+// EnsureNode creates one Wendy-managed v4l2loopback device. It is shared by
+// the IP-camera supervisor and the ROS 2 camera bridge so module detection and
+// the control-device ABI have one owner.
+func (l *Loopback) EnsureNode(ctx context.Context, id uint32, label string) error {
+	if id < LoopbackBandStart || id > IDBandEnd {
+		return fmt.Errorf("camera ID %d is outside Wendy's loopback band", id)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := l.Available(); err != nil {
+		return err
+	}
+	nr := int(id)
+	if l.deps.nodeExists(nr) {
+		return nil
+	}
+	return l.deps.addNode(nr, label)
 }
 
 // NodePath returns the loopback device path for a camera and whether it

--- a/go/internal/agent/ipcam/registry.go
+++ b/go/internal/agent/ipcam/registry.go
@@ -26,8 +26,12 @@ import (
 // The allocated number is also the v4l2loopback node number a camera will get
 // when container parity lands, so the ID a user learns now does not change.
 const (
-	IDBandStart = 200
-	IDBandEnd   = 255
+	// LoopbackBandStart is the first device number reserved for Wendy-managed
+	// virtual cameras. ROS 2 cameras use 128-199; network cameras retain the
+	// original 200-255 stable-ID band.
+	LoopbackBandStart = 128
+	IDBandStart       = 200
+	IDBandEnd         = 255
 )
 
 // ErrBandExhausted is returned when every ID in the reserved band is taken.

--- a/go/internal/agent/ros2camera/frame.go
+++ b/go/internal/agent/ros2camera/frame.go
@@ -9,7 +9,6 @@ import (
 	"image"
 	"image/color"
 	"image/jpeg"
-	_ "image/png"
 	"strings"
 
 	"github.com/wendylabsinc/wendy/go/internal/rtps/cdr"
@@ -19,6 +18,8 @@ const (
 	TypeImage           = "sensor_msgs::msg::dds_::Image_"
 	TypeCompressedImage = "sensor_msgs::msg::dds_::CompressedImage_"
 	TypeGo2FrontVideo   = "unitree_go::msg::dds_::Go2FrontVideoData_"
+	maxFrameDimension   = 4096
+	maxFramePixels      = 4096 * 2160
 )
 
 var ErrUnsupportedEncoding = errors.New("unsupported ROS 2 image encoding")
@@ -77,21 +78,30 @@ func skipHeader(d *cdr.Decoder) error {
 }
 
 func jpegDimensions(frame []byte) ([]byte, int, int, error) {
+	// CompressedImage permits other formats, but this bridge promises MJPEG and
+	// should never decompress attacker-controlled PNG or WebP payloads merely to
+	// convert them. JPEG header parsing is bounded and the bytes pass through.
+	if len(frame) < 2 || frame[0] != 0xff || frame[1] != 0xd8 {
+		return nil, 0, 0, fmt.Errorf("%w: compressed frame is not JPEG", ErrUnsupportedEncoding)
+	}
 	cfg, format, err := image.DecodeConfig(bytes.NewReader(frame))
 	if err != nil {
 		return nil, 0, 0, fmt.Errorf("decoding compressed image header: %w", err)
 	}
-	if cfg.Width <= 0 || cfg.Height <= 0 || cfg.Width > 8192 || cfg.Height > 8192 {
-		return nil, 0, 0, fmt.Errorf("invalid compressed image dimensions %dx%d", cfg.Width, cfg.Height)
+	if format != "jpeg" {
+		return nil, 0, 0, fmt.Errorf("%w: compressed frame format %s", ErrUnsupportedEncoding, format)
 	}
-	if format == "jpeg" {
-		return frame, cfg.Width, cfg.Height, nil
+	if err := validateDimensions(cfg.Width, cfg.Height); err != nil {
+		return nil, 0, 0, err
 	}
-	img, _, err := image.Decode(bytes.NewReader(frame))
-	if err != nil {
-		return nil, 0, 0, fmt.Errorf("decoding compressed image: %w", err)
+	return frame, cfg.Width, cfg.Height, nil
+}
+
+func validateDimensions(width, height int) error {
+	if width <= 0 || height <= 0 || width > maxFrameDimension || height > maxFrameDimension || uint64(width)*uint64(height) > maxFramePixels {
+		return fmt.Errorf("invalid image dimensions %dx%d", width, height)
 	}
-	return encodeJPEG(img)
+	return nil
 }
 
 func decodeCompressedImage(payload []byte) ([]byte, int, int, error) {
@@ -170,11 +180,14 @@ func decodeRawImage(payload []byte) ([]byte, int, int, error) {
 	if err != nil {
 		return nil, 0, 0, fmt.Errorf("step: %w", err)
 	}
+	if err := validateDimensions(int(width), int(height)); err != nil {
+		return nil, 0, 0, err
+	}
 	data, err := d.Bytes()
 	if err != nil {
 		return nil, 0, 0, fmt.Errorf("data: %w", err)
 	}
-	if width == 0 || height == 0 || width > 8192 || height > 8192 || uint64(step)*uint64(height) > uint64(len(data)) {
+	if uint64(step)*uint64(height) > uint64(len(data)) {
 		return nil, 0, 0, errors.New("invalid ROS 2 image dimensions")
 	}
 

--- a/go/internal/agent/ros2camera/frame.go
+++ b/go/internal/agent/ros2camera/frame.go
@@ -1,0 +1,246 @@
+// Package ros2camera discovers ROS 2 image writers and exposes their frames as
+// ordinary V4L2 cameras through Wendy's v4l2loopback support.
+package ros2camera
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"image"
+	"image/color"
+	"image/jpeg"
+	_ "image/png"
+	"strings"
+
+	"github.com/wendylabsinc/wendy/go/internal/rtps/cdr"
+)
+
+const (
+	TypeImage           = "sensor_msgs::msg::dds_::Image_"
+	TypeCompressedImage = "sensor_msgs::msg::dds_::CompressedImage_"
+	TypeGo2FrontVideo   = "unitree_go::msg::dds_::Go2FrontVideoData_"
+)
+
+var ErrUnsupportedEncoding = errors.New("unsupported ROS 2 image encoding")
+
+// SupportsType reports whether typeName carries a video frame this package can
+// decode. DDS and ros2cli spellings are both accepted.
+func SupportsType(typeName string) bool {
+	switch typeName {
+	case TypeImage, "sensor_msgs/msg/Image",
+		TypeCompressedImage, "sensor_msgs/msg/CompressedImage",
+		TypeGo2FrontVideo, "unitree_go/msg/Go2FrontVideoData":
+		return true
+	default:
+		return false
+	}
+}
+
+// TopicName turns ROS 2's DDS wire spelling (rt/foo) into the spelling users
+// pass to ros2cli (/foo).
+func TopicName(topic string) string {
+	topic = strings.TrimPrefix(topic, "rt/")
+	if !strings.HasPrefix(topic, "/") {
+		topic = "/" + topic
+	}
+	return topic
+}
+
+// DecodeJPEG extracts a frame from a serialized ROS 2 sample and returns a
+// complete JPEG plus its dimensions. CompressedImage and the Go2's native
+// front-video message stay compressed; raw Image frames are converted with the
+// standard library so the v4l2loopback writer has one stable MJPEG format.
+func DecodeJPEG(typeName string, payload []byte) ([]byte, int, int, error) {
+	switch typeName {
+	case TypeCompressedImage, "sensor_msgs/msg/CompressedImage":
+		return decodeCompressedImage(payload)
+	case TypeImage, "sensor_msgs/msg/Image":
+		return decodeRawImage(payload)
+	case TypeGo2FrontVideo, "unitree_go/msg/Go2FrontVideoData":
+		return decodeGo2FrontVideo(payload)
+	default:
+		return nil, 0, 0, fmt.Errorf("%w: message type %s", ErrUnsupportedEncoding, typeName)
+	}
+}
+
+func skipHeader(d *cdr.Decoder) error {
+	if _, err := d.Int32(); err != nil {
+		return fmt.Errorf("header.stamp.sec: %w", err)
+	}
+	if _, err := d.Uint32(); err != nil {
+		return fmt.Errorf("header.stamp.nanosec: %w", err)
+	}
+	if err := d.SkipString(); err != nil {
+		return fmt.Errorf("header.frame_id: %w", err)
+	}
+	return nil
+}
+
+func jpegDimensions(frame []byte) ([]byte, int, int, error) {
+	cfg, format, err := image.DecodeConfig(bytes.NewReader(frame))
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("decoding compressed image header: %w", err)
+	}
+	if cfg.Width <= 0 || cfg.Height <= 0 || cfg.Width > 8192 || cfg.Height > 8192 {
+		return nil, 0, 0, fmt.Errorf("invalid compressed image dimensions %dx%d", cfg.Width, cfg.Height)
+	}
+	if format == "jpeg" {
+		return frame, cfg.Width, cfg.Height, nil
+	}
+	img, _, err := image.Decode(bytes.NewReader(frame))
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("decoding compressed image: %w", err)
+	}
+	return encodeJPEG(img)
+}
+
+func decodeCompressedImage(payload []byte) ([]byte, int, int, error) {
+	d, err := cdr.NewDecoder(payload)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	if err := skipHeader(d); err != nil {
+		return nil, 0, 0, err
+	}
+	if _, err := d.String(); err != nil { // format (jpeg/png plus optional transport metadata)
+		return nil, 0, 0, fmt.Errorf("format: %w", err)
+	}
+	frame, err := d.Bytes()
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("data: %w", err)
+	}
+	return jpegDimensions(frame)
+}
+
+func decodeGo2FrontVideo(payload []byte) ([]byte, int, int, error) {
+	d, err := cdr.NewDecoder(payload)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	if _, err := d.Uint64(); err != nil {
+		return nil, 0, 0, fmt.Errorf("time_frame: %w", err)
+	}
+	video720p, err := d.Bytes()
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("video720p: %w", err)
+	}
+	video360p, err := d.Bytes()
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("video360p: %w", err)
+	}
+	video180p, err := d.Bytes()
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("video180p: %w", err)
+	}
+	// Prefer the native 720p stream, falling back in descending resolution for
+	// firmware variants that leave one of the three fields empty.
+	for _, frame := range [][]byte{video720p, video360p, video180p} {
+		if len(frame) != 0 {
+			return jpegDimensions(frame)
+		}
+	}
+	return nil, 0, 0, errors.New("Go2 front-video sample contains no image")
+}
+
+func decodeRawImage(payload []byte) ([]byte, int, int, error) {
+	d, err := cdr.NewDecoder(payload)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	if err := skipHeader(d); err != nil {
+		return nil, 0, 0, err
+	}
+	height, err := d.Uint32()
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("height: %w", err)
+	}
+	width, err := d.Uint32()
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("width: %w", err)
+	}
+	encoding, err := d.String()
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("encoding: %w", err)
+	}
+	bigEndian, err := d.Uint8()
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("is_bigendian: %w", err)
+	}
+	step, err := d.Uint32()
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("step: %w", err)
+	}
+	data, err := d.Bytes()
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("data: %w", err)
+	}
+	if width == 0 || height == 0 || width > 8192 || height > 8192 || uint64(step)*uint64(height) > uint64(len(data)) {
+		return nil, 0, 0, errors.New("invalid ROS 2 image dimensions")
+	}
+
+	var img image.Image
+	switch strings.ToLower(encoding) {
+	case "mono8", "8uc1":
+		if step < width {
+			return nil, 0, 0, errors.New("ROS 2 image step is smaller than one row")
+		}
+		gray := image.NewGray(image.Rect(0, 0, int(width), int(height)))
+		for y := 0; y < int(height); y++ {
+			copy(gray.Pix[y*gray.Stride:y*gray.Stride+int(width)], data[y*int(step):y*int(step)+int(width)])
+		}
+		img = gray
+	case "mono16", "16uc1":
+		if step < width*2 {
+			return nil, 0, 0, errors.New("ROS 2 image step is smaller than one row")
+		}
+		gray := image.NewGray(image.Rect(0, 0, int(width), int(height)))
+		for y := 0; y < int(height); y++ {
+			row := data[y*int(step):]
+			for x := 0; x < int(width); x++ {
+				if bigEndian != 0 {
+					gray.SetGray(x, y, color.Gray{Y: row[x*2]})
+				} else {
+					gray.SetGray(x, y, color.Gray{Y: row[x*2+1]})
+				}
+			}
+		}
+		img = gray
+	case "rgb8", "bgr8", "rgba8", "bgra8":
+		channels := 3
+		if strings.Contains(strings.ToLower(encoding), "a") {
+			channels = 4
+		}
+		if step < width*uint32(channels) {
+			return nil, 0, 0, errors.New("ROS 2 image step is smaller than one row")
+		}
+		rgba := image.NewRGBA(image.Rect(0, 0, int(width), int(height)))
+		bgr := strings.HasPrefix(strings.ToLower(encoding), "bgr")
+		for y := 0; y < int(height); y++ {
+			row := data[y*int(step):]
+			for x := 0; x < int(width); x++ {
+				i := x * channels
+				r, g, b := row[i], row[i+1], row[i+2]
+				if bgr {
+					r, b = b, r
+				}
+				// Camera alpha channels are transport padding in practice. JPEG has
+				// no alpha, so keep the color fully opaque rather than premultiplying
+				// dark pixels when a publisher leaves alpha at zero.
+				rgba.SetRGBA(x, y, color.RGBA{R: r, G: g, B: b, A: 255})
+			}
+		}
+		img = rgba
+	default:
+		return nil, 0, 0, fmt.Errorf("%w: %s", ErrUnsupportedEncoding, encoding)
+	}
+	return encodeJPEG(img)
+}
+
+func encodeJPEG(img image.Image) ([]byte, int, int, error) {
+	var out bytes.Buffer
+	if err := jpeg.Encode(&out, img, &jpeg.Options{Quality: 85}); err != nil {
+		return nil, 0, 0, fmt.Errorf("encoding JPEG: %w", err)
+	}
+	b := img.Bounds()
+	return out.Bytes(), b.Dx(), b.Dy(), nil
+}

--- a/go/internal/agent/ros2camera/frame.go
+++ b/go/internal/agent/ros2camera/frame.go
@@ -20,6 +20,7 @@ const (
 	TypeGo2FrontVideo   = "unitree_go::msg::dds_::Go2FrontVideoData_"
 	maxFrameDimension   = 4096
 	maxFramePixels      = 4096 * 2160
+	maxRawFramePixels   = 1920 * 1080
 )
 
 var ErrUnsupportedEncoding = errors.New("unsupported ROS 2 image encoding")
@@ -182,6 +183,11 @@ func decodeRawImage(payload []byte) ([]byte, int, int, error) {
 	}
 	if err := validateDimensions(int(width), int(height)); err != nil {
 		return nil, 0, 0, err
+	}
+	// SECURITY: Raw frames require a full colorspace conversion and JPEG encode,
+	// unlike compressed frames. Bound that CPU and allocation path to 1080p.
+	if uint64(width)*uint64(height) > maxRawFramePixels {
+		return nil, 0, 0, fmt.Errorf("raw image dimensions %dx%d exceed the 1080p pixel budget", width, height)
 	}
 	data, err := d.Bytes()
 	if err != nil {

--- a/go/internal/agent/ros2camera/frame_test.go
+++ b/go/internal/agent/ros2camera/frame_test.go
@@ -3,9 +3,12 @@ package ros2camera
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"image"
 	"image/color"
 	"image/jpeg"
+	"image/png"
+	"strings"
 	"testing"
 )
 
@@ -66,6 +69,34 @@ func TestDecodeCompressedImagePreservesJPEG(t *testing.T) {
 	}
 	if !bytes.Equal(got, want) || width != 3 || height != 2 {
 		t.Fatalf("got %dx%d, %d bytes; want 3x2, %d bytes", width, height, len(got), len(want))
+	}
+}
+
+func TestDecodeCompressedImageRejectsNonJPEG(t *testing.T) {
+	var frame bytes.Buffer
+	if err := png.Encode(&frame, image.NewRGBA(image.Rect(0, 0, 2, 2))); err != nil {
+		t.Fatal(err)
+	}
+	c := newCDRBuilder()
+	c.header()
+	c.str("png")
+	c.bytes(frame.Bytes())
+	if _, _, _, err := DecodeJPEG(TypeCompressedImage, c.b); !errors.Is(err, ErrUnsupportedEncoding) {
+		t.Fatalf("error = %v; want ErrUnsupportedEncoding", err)
+	}
+}
+
+func TestDecodeRawImageRejectsOversizedDimensions(t *testing.T) {
+	c := newCDRBuilder()
+	c.header()
+	c.u32(1)
+	c.u32(maxFrameDimension + 1)
+	c.str("mono8")
+	c.u8(0)
+	c.u32(maxFrameDimension + 1)
+	c.bytes(nil)
+	if _, _, _, err := DecodeJPEG(TypeImage, c.b); err == nil || !strings.Contains(err.Error(), "invalid image dimensions") {
+		t.Fatalf("error = %v; want invalid image dimensions", err)
 	}
 }
 

--- a/go/internal/agent/ros2camera/frame_test.go
+++ b/go/internal/agent/ros2camera/frame_test.go
@@ -1,0 +1,123 @@
+package ros2camera
+
+import (
+	"bytes"
+	"encoding/binary"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"testing"
+)
+
+type cdrBuilder struct{ b []byte }
+
+func newCDRBuilder() *cdrBuilder { return &cdrBuilder{b: []byte{0, 1, 0, 0}} }
+func (c *cdrBuilder) align(n int) {
+	body := len(c.b) - 4
+	for body%n != 0 {
+		c.b = append(c.b, 0)
+		body++
+	}
+}
+func (c *cdrBuilder) u8(v byte) { c.b = append(c.b, v) }
+func (c *cdrBuilder) u32(v uint32) {
+	c.align(4)
+	c.b = binary.LittleEndian.AppendUint32(c.b, v)
+}
+func (c *cdrBuilder) u64(v uint64) {
+	c.align(8)
+	c.b = binary.LittleEndian.AppendUint64(c.b, v)
+}
+func (c *cdrBuilder) str(v string) {
+	c.u32(uint32(len(v) + 1))
+	c.b = append(c.b, v...)
+	c.b = append(c.b, 0)
+}
+func (c *cdrBuilder) bytes(v []byte) {
+	c.u32(uint32(len(v)))
+	c.b = append(c.b, v...)
+}
+func (c *cdrBuilder) header() {
+	c.u32(1)
+	c.u32(2)
+	c.str("camera")
+}
+
+func testJPEG(t *testing.T, width, height int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	img.SetRGBA(0, 0, color.RGBA{R: 255, A: 255})
+	var out bytes.Buffer
+	if err := jpeg.Encode(&out, img, nil); err != nil {
+		t.Fatal(err)
+	}
+	return out.Bytes()
+}
+
+func TestDecodeCompressedImagePreservesJPEG(t *testing.T) {
+	want := testJPEG(t, 3, 2)
+	c := newCDRBuilder()
+	c.header()
+	c.str("jpeg")
+	c.bytes(want)
+	got, width, height, err := DecodeJPEG(TypeCompressedImage, c.b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) || width != 3 || height != 2 {
+		t.Fatalf("got %dx%d, %d bytes; want 3x2, %d bytes", width, height, len(got), len(want))
+	}
+}
+
+func TestDecodeGo2FrontVideoPrefers720p(t *testing.T) {
+	want := testJPEG(t, 4, 3)
+	c := newCDRBuilder()
+	c.u64(42)
+	c.bytes(want)
+	c.bytes(nil)
+	c.bytes(nil)
+	got, width, height, err := DecodeJPEG(TypeGo2FrontVideo, c.b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) || width != 4 || height != 3 {
+		t.Fatalf("got %dx%d, %d bytes", width, height, len(got))
+	}
+}
+
+func TestDecodeRawBGR8(t *testing.T) {
+	c := newCDRBuilder()
+	c.header()
+	c.u32(1) // height
+	c.u32(2) // width
+	c.str("bgr8")
+	c.u8(0)
+	c.u32(6)
+	c.bytes([]byte{0, 0, 255, 0, 255, 0})
+	got, width, height, err := DecodeJPEG(TypeImage, c.b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if width != 2 || height != 1 {
+		t.Fatalf("dimensions = %dx%d", width, height)
+	}
+	img, err := jpeg.Decode(bytes.NewReader(got))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, g, b, _ := img.At(0, 0).RGBA()
+	if r <= g || r <= b {
+		t.Fatalf("first BGR pixel was not converted to red: r=%d g=%d b=%d", r, g, b)
+	}
+}
+
+func TestTopicAndTypeRecognition(t *testing.T) {
+	if got := TopicName("rt/frontvideostream"); got != "/frontvideostream" {
+		t.Fatalf("TopicName = %q", got)
+	}
+	for _, typ := range []string{TypeImage, TypeCompressedImage, TypeGo2FrontVideo, "sensor_msgs/msg/Image"} {
+		if !SupportsType(typ) {
+			t.Errorf("SupportsType(%q) = false", typ)
+		}
+	}
+}

--- a/go/internal/agent/ros2camera/frame_test.go
+++ b/go/internal/agent/ros2camera/frame_test.go
@@ -100,6 +100,20 @@ func TestDecodeRawImageRejectsOversizedDimensions(t *testing.T) {
 	}
 }
 
+func TestDecodeRawImageRejectsMoreThan1080p(t *testing.T) {
+	c := newCDRBuilder()
+	c.header()
+	c.u32(1081)
+	c.u32(1920)
+	c.str("mono8")
+	c.u8(0)
+	c.u32(1920)
+	c.bytes(nil)
+	if _, _, _, err := DecodeJPEG(TypeImage, c.b); err == nil || !strings.Contains(err.Error(), "1080p pixel budget") {
+		t.Fatalf("error = %v; want raw-frame pixel budget rejection", err)
+	}
+}
+
 func TestDecodeGo2FrontVideoPrefers720p(t *testing.T) {
 	want := testJPEG(t, 4, 3)
 	c := newCDRBuilder()

--- a/go/internal/agent/ros2camera/manager.go
+++ b/go/internal/agent/ros2camera/manager.go
@@ -18,6 +18,8 @@ import (
 const (
 	reconcileInterval = time.Minute
 	firstFrameTimeout = 15 * time.Second
+	minFrameInterval  = 30 * time.Millisecond
+	maxTopicLength    = 255
 )
 
 // Loopback is the shared v4l2loopback control surface owned by ipcam.Loopback.
@@ -34,9 +36,9 @@ type Graph struct {
 	InstanceKey         string
 	DomainID            int
 	NetworkNamespacePID uint32
-	// Verify confirms that InstanceKey still owns NetworkNamespacePID after
-	// the namespace sockets have been opened. This closes the PID-reuse window
-	// without publishing any DDS traffic in an unverified namespace.
+	// Verify confirms that InstanceKey still owns NetworkNamespacePID after the
+	// namespace is entered but before sockets are opened, and once more before
+	// discovery starts.
 	Verify func(context.Context) bool
 }
 
@@ -78,6 +80,7 @@ type cameraState struct {
 	loggedError bool
 	active      bool
 	viewRefs    int
+	lastFrame   time.Time
 }
 
 // Manager owns DDS discovery and the frame pumps feeding ROS 2 loopback nodes.
@@ -147,7 +150,7 @@ func (m *Manager) reconcile(ctx context.Context) {
 	// including the Go2's /frontvideostream publisher.
 	for _, iface := range eligibleInterfaces() {
 		desired[participantKey(iface, 0, 0, "host")] = true
-		m.ensureParticipant(iface, 0, 0, "host", "host", nil)
+		m.ensureParticipant(iface, 0, 0, "host:"+iface, "host", nil)
 	}
 	complete := m.graphs == nil
 	if m.graphs != nil {
@@ -186,7 +189,14 @@ func (m *Manager) ensureParticipant(iface string, domain int, netnsPID uint32, g
 		return
 	}
 	m.mu.Unlock()
-	p, err := rtps.NewParticipant(rtps.Config{DomainID: domain, Interface: iface, NetworkNamespacePID: netnsPID})
+	var verifyNamespace func() bool
+	if verify != nil {
+		verifyNamespace = func() bool { return verify(m.ctx) }
+	}
+	p, err := rtps.NewParticipant(rtps.Config{
+		DomainID: domain, Interface: iface, NetworkNamespacePID: netnsPID,
+		VerifyNetworkNamespace: verifyNamespace,
+	})
 	if err != nil {
 		m.logger.Debug("starting ROS 2 camera discovery failed", zap.String("interface", iface), zap.Int("domain_id", domain), zap.Uint32("network_namespace_pid", netnsPID), zap.Error(err))
 		return
@@ -269,6 +279,10 @@ func (m *Manager) registerEndpoint(p *participantState, endpoint rtps.Endpoint) 
 		return
 	}
 	topic := TopicName(endpoint.Topic)
+	if !validTopicName(topic) {
+		m.logger.Debug("ignoring ROS 2 camera with invalid topic name")
+		return
+	}
 	// Namespace identity prevents two isolated apps that happen to use the same
 	// domain and topic name from collapsing into one camera.
 	key := fmt.Sprintf("graph=%s;domain=%d;topic=%s", p.graphKey, p.domainID, topic)
@@ -323,6 +337,20 @@ func nameForNode(name string, id uint32) string {
 	return label
 }
 
+func validTopicName(topic string) bool {
+	if len(topic) < 2 || len(topic) > maxTopicLength || topic[0] != '/' {
+		return false
+	}
+	for i := 1; i < len(topic); i++ {
+		c := topic[i]
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '/' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
 func (m *Manager) ensureSubscribed(cam *cameraState) error {
 	m.mu.Lock()
 	if cam.subscribed {
@@ -364,13 +392,21 @@ func (m *Manager) handleSample(sample rtps.Sample) {
 	}
 	cam.pumpMu.Lock()
 	defer cam.pumpMu.Unlock()
+	path, ok := m.loopback.NodePath(cam.ID)
+	if !ok {
+		return
+	}
+	now := time.Now()
+	m.mu.Lock()
+	if !cam.lastFrame.IsZero() && now.Sub(cam.lastFrame) < minFrameInterval {
+		m.mu.Unlock()
+		return
+	}
+	cam.lastFrame = now
+	m.mu.Unlock()
 	frame, width, height, err := DecodeJPEG(typeName, sample.Payload)
 	if err != nil {
 		m.logCameraErrorOnce(cam, "decoding ROS 2 camera frame failed", err)
-		return
-	}
-	path, ok := m.loopback.NodePath(cam.ID)
-	if !ok {
 		return
 	}
 	m.mu.Lock()

--- a/go/internal/agent/ros2camera/manager.go
+++ b/go/internal/agent/ros2camera/manager.go
@@ -19,7 +19,11 @@ const (
 	reconcileInterval = time.Minute
 	firstFrameTimeout = 15 * time.Second
 	minFrameInterval  = 30 * time.Millisecond
+	mediumRawInterval = 60 * time.Millisecond
+	largeRawInterval  = 100 * time.Millisecond
 	maxTopicLength    = 255
+	mediumRawBytes    = 2 * 1024 * 1024
+	largeRawBytes     = 4 * 1024 * 1024
 )
 
 // Loopback is the shared v4l2loopback control surface owned by ipcam.Loopback.
@@ -36,9 +40,9 @@ type Graph struct {
 	InstanceKey         string
 	DomainID            int
 	NetworkNamespacePID uint32
-	// Verify confirms that InstanceKey still owns NetworkNamespacePID after the
-	// namespace is entered but before sockets are opened, and once more before
-	// discovery starts.
+	// Verify confirms that InstanceKey still owns NetworkNamespacePID after a
+	// stable namespace handle is captured but before it is entered, and once
+	// more before discovery starts.
 	Verify func(context.Context) bool
 }
 
@@ -148,6 +152,9 @@ func (m *Manager) reconcile(ctx context.Context) {
 	desired := map[string]bool{}
 	// Domain zero on physical wired interfaces covers robot-native graphs,
 	// including the Go2's /frontvideostream publisher.
+	// SECURITY: Domain 0 on these interfaces is intentionally a trusted robot-LAN
+	// boundary because standard ROS 2 discovery has no source authentication.
+	// The operator-facing docs require untrusted peers to be segmented away.
 	for _, iface := range eligibleInterfaces() {
 		desired[participantKey(iface, 0, 0, "host")] = true
 		m.ensureParticipant(iface, 0, 0, "host:"+iface, "host", nil)
@@ -398,7 +405,8 @@ func (m *Manager) handleSample(sample rtps.Sample) {
 	}
 	now := time.Now()
 	m.mu.Lock()
-	if !cam.lastFrame.IsZero() && now.Sub(cam.lastFrame) < minFrameInterval {
+	interval := frameInterval(typeName, len(sample.Payload))
+	if !cam.lastFrame.IsZero() && now.Sub(cam.lastFrame) < interval {
 		m.mu.Unlock()
 		return
 	}
@@ -425,6 +433,22 @@ func (m *Manager) handleSample(sample rtps.Sample) {
 		cam.readyClosed = true
 	}
 	m.mu.Unlock()
+}
+
+func frameInterval(typeName string, payloadBytes int) time.Duration {
+	if typeName != TypeImage && typeName != "sensor_msgs/msg/Image" {
+		return minFrameInterval
+	}
+	// SECURITY: Large raw samples are expensive to convert and encode. Apply a
+	// per-writer byte-size budget while leaving compressed JPEG passthrough at
+	// normal camera frame rates.
+	if payloadBytes > largeRawBytes {
+		return largeRawInterval
+	}
+	if payloadBytes > mediumRawBytes {
+		return mediumRawInterval
+	}
+	return minFrameInterval
 }
 
 func (m *Manager) logCameraErrorOnce(cam *cameraState, message string, err error) {

--- a/go/internal/agent/ros2camera/manager.go
+++ b/go/internal/agent/ros2camera/manager.go
@@ -1,0 +1,612 @@
+package ros2camera
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/wendylabsinc/wendy/go/internal/rtps"
+)
+
+const (
+	reconcileInterval = time.Minute
+	firstFrameTimeout = 15 * time.Second
+)
+
+// Loopback is the shared v4l2loopback control surface owned by ipcam.Loopback.
+type Loopback interface {
+	EnsureNode(ctx context.Context, id uint32, label string) error
+	NodePath(id uint32) (string, bool)
+}
+
+// Graph identifies an app-local ROS 2 graph. Participants are created inside
+// NetworkNamespacePID for both loopback-only and externally reachable ROS 2
+// discovery, without exposing either graph to the host namespace.
+type Graph struct {
+	Key                 string
+	InstanceKey         string
+	DomainID            int
+	NetworkNamespacePID uint32
+	// Verify confirms that InstanceKey still owns NetworkNamespacePID after
+	// the namespace sockets have been opened. This closes the PID-reuse window
+	// without publishing any DDS traffic in an unverified namespace.
+	Verify func(context.Context) bool
+}
+
+type GraphSource func(context.Context) ([]Graph, error)
+
+type cameraWriter interface {
+	WriteJPEG(frame []byte, width, height int) error
+	Close() error
+}
+
+type Camera struct {
+	ID        uint32
+	Name      string
+	Topic     string
+	Type      string
+	DomainID  int
+	Interface string
+	Path      string
+}
+
+type participantState struct {
+	participant *rtps.Participant
+	cancel      context.CancelFunc
+	iface       string
+	domainID    int
+	netnsPID    uint32
+	graphKey    string
+}
+
+type cameraState struct {
+	Camera
+	pumpMu      sync.Mutex
+	endpoint    rtps.Endpoint
+	participant *rtps.Participant
+	subscribed  bool
+	ready       chan struct{}
+	readyClosed bool
+	writer      cameraWriter
+	loggedError bool
+	active      bool
+	viewRefs    int
+}
+
+// Manager owns DDS discovery and the frame pumps feeding ROS 2 loopback nodes.
+type Manager struct {
+	ctx       context.Context
+	cancel    context.CancelFunc
+	logger    *zap.Logger
+	loopback  Loopback
+	graphs    GraphSource
+	registry  *registry
+	newWriter func(string) cameraWriter
+
+	mu           sync.Mutex
+	participants map[string]*participantState
+	cameras      map[uint32]*cameraState
+	byKey        map[string]*cameraState
+	byWriter     map[rtps.GUID]*cameraState
+	containerUse bool
+	started      bool
+	wg           sync.WaitGroup
+}
+
+func NewManager(ctx context.Context, logger *zap.Logger, loopback Loopback, registryPath string, graphs GraphSource) *Manager {
+	ctx, cancel := context.WithCancel(ctx)
+	r := newRegistry(registryPath)
+	if err := r.load(); err != nil {
+		logger.Warn("loading ROS 2 camera registry failed", zap.Error(err))
+	}
+	return &Manager{
+		ctx: ctx, cancel: cancel, logger: logger, loopback: loopback, graphs: graphs,
+		registry: r, newWriter: newFrameWriter,
+		participants: map[string]*participantState{}, cameras: map[uint32]*cameraState{},
+		byKey: map[string]*cameraState{}, byWriter: map[rtps.GUID]*cameraState{},
+	}
+}
+
+func (m *Manager) Start() {
+	m.mu.Lock()
+	if m.started {
+		m.mu.Unlock()
+		return
+	}
+	m.started = true
+	m.mu.Unlock()
+	m.wg.Add(1)
+	go func() {
+		defer m.wg.Done()
+		m.reconcile(m.ctx)
+		ticker := time.NewTicker(reconcileInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-m.ctx.Done():
+				return
+			case <-ticker.C:
+				m.reconcile(m.ctx)
+			}
+		}
+	}()
+}
+
+func (m *Manager) Refresh(ctx context.Context) { m.reconcile(ctx) }
+
+func (m *Manager) reconcile(ctx context.Context) {
+	desired := map[string]bool{}
+	// Domain zero on physical wired interfaces covers robot-native graphs,
+	// including the Go2's /frontvideostream publisher.
+	for _, iface := range eligibleInterfaces() {
+		desired[participantKey(iface, 0, 0, "host")] = true
+		m.ensureParticipant(iface, 0, 0, "host", "host", nil)
+	}
+	complete := m.graphs == nil
+	if m.graphs != nil {
+		if found, err := m.graphs(ctx); err == nil {
+			complete = true
+			for _, graph := range found {
+				if graph.DomainID >= 0 && graph.DomainID <= 232 && graph.NetworkNamespacePID != 0 {
+					// App scope binds DDS to loopback; host scope selects a normal
+					// interface. Start one participant for each selection inside the
+					// namespace because the resolved discovery scope is intentionally
+					// not exposed outside container configuration.
+					for _, iface := range []string{"lo", ""} {
+						desired[participantKey(iface, graph.DomainID, graph.NetworkNamespacePID, graph.InstanceKey)] = true
+						m.ensureParticipant(iface, graph.DomainID, graph.NetworkNamespacePID, graph.Key, graph.InstanceKey, graph.Verify)
+					}
+				}
+			}
+		} else {
+			m.logger.Debug("listing ROS 2 camera graphs failed", zap.Error(err))
+		}
+	}
+	if complete {
+		m.stopStaleParticipants(desired)
+	}
+}
+
+func participantKey(iface string, domain int, netnsPID uint32, instanceKey string) string {
+	return fmt.Sprintf("%s:%d:%s:%d", instanceKey, netnsPID, iface, domain)
+}
+
+func (m *Manager) ensureParticipant(iface string, domain int, netnsPID uint32, graphKey, instanceKey string, verify func(context.Context) bool) {
+	key := participantKey(iface, domain, netnsPID, instanceKey)
+	m.mu.Lock()
+	if _, ok := m.participants[key]; ok {
+		m.mu.Unlock()
+		return
+	}
+	m.mu.Unlock()
+	p, err := rtps.NewParticipant(rtps.Config{DomainID: domain, Interface: iface, NetworkNamespacePID: netnsPID})
+	if err != nil {
+		m.logger.Debug("starting ROS 2 camera discovery failed", zap.String("interface", iface), zap.Int("domain_id", domain), zap.Uint32("network_namespace_pid", netnsPID), zap.Error(err))
+		return
+	}
+	if verify != nil && !verify(m.ctx) {
+		p.Close() //nolint:errcheck
+		m.logger.Debug("discarding ROS 2 camera namespace after container changed", zap.String("instance", instanceKey), zap.Uint32("network_namespace_pid", netnsPID))
+		return
+	}
+	participantCtx, cancel := context.WithCancel(m.ctx)
+	state := &participantState{participant: p, cancel: cancel, iface: iface, domainID: domain, netnsPID: netnsPID, graphKey: graphKey}
+	m.mu.Lock()
+	if _, raced := m.participants[key]; raced {
+		m.mu.Unlock()
+		cancel()
+		p.Close() //nolint:errcheck
+		return
+	}
+	m.participants[key] = state
+	m.mu.Unlock()
+
+	m.wg.Add(2)
+	go func() { defer m.wg.Done(); p.Run(participantCtx) }()
+	go func() {
+		defer m.wg.Done()
+		for {
+			select {
+			case <-participantCtx.Done():
+				return
+			case endpoint := <-p.Discovered():
+				m.registerEndpoint(state, endpoint)
+			case sample := <-p.Samples():
+				m.handleSample(sample)
+			}
+		}
+	}()
+}
+
+func (m *Manager) stopStaleParticipants(desired map[string]bool) {
+	m.mu.Lock()
+	var stale []*participantState
+	type staleCamera struct {
+		camera      *cameraState
+		participant *rtps.Participant
+	}
+	var staleCameras []staleCamera
+	for key, participant := range m.participants {
+		if desired[key] {
+			continue
+		}
+		delete(m.participants, key)
+		stale = append(stale, participant)
+		for _, cam := range m.cameras {
+			if cam.participant == participant.participant {
+				cam.active = false
+				staleCameras = append(staleCameras, staleCamera{camera: cam, participant: participant.participant})
+			}
+		}
+	}
+	m.mu.Unlock()
+	for _, participant := range stale {
+		participant.cancel()
+	}
+	for _, item := range staleCameras {
+		item.camera.pumpMu.Lock()
+		m.mu.Lock()
+		if !item.camera.active && item.camera.participant == item.participant && item.camera.writer != nil {
+			_ = item.camera.writer.Close()
+			item.camera.writer = nil
+			item.camera.ready = make(chan struct{})
+			item.camera.readyClosed = false
+		}
+		m.mu.Unlock()
+		item.camera.pumpMu.Unlock()
+	}
+}
+
+func (m *Manager) registerEndpoint(p *participantState, endpoint rtps.Endpoint) {
+	if !SupportsType(endpoint.Type) {
+		return
+	}
+	topic := TopicName(endpoint.Topic)
+	// Namespace identity prevents two isolated apps that happen to use the same
+	// domain and topic name from collapsing into one camera.
+	key := fmt.Sprintf("graph=%s;domain=%d;topic=%s", p.graphKey, p.domainID, topic)
+	id, err := m.registry.idFor(key)
+	if err != nil {
+		m.logger.Warn("allocating ROS 2 camera ID failed", zap.String("topic", topic), zap.Error(err))
+		return
+	}
+
+	m.mu.Lock()
+	cam := m.byKey[key]
+	if cam == nil {
+		name := "ROS 2 " + topic
+		if endpoint.Type == TypeGo2FrontVideo || endpoint.Type == "unitree_go/msg/Go2FrontVideoData" {
+			name = "Unitree Go2 front camera"
+		}
+		cam = &cameraState{Camera: Camera{ID: id, Name: name, Topic: topic, Type: endpoint.Type, DomainID: p.domainID, Interface: p.iface}, ready: make(chan struct{})}
+		m.byKey[key], m.cameras[id] = cam, cam
+	}
+	if cam.participant == p.participant && cam.endpoint.GUID == endpoint.GUID {
+		cam.active = true
+		m.mu.Unlock()
+		return
+	}
+	if cam.endpoint.GUID != (rtps.GUID{}) {
+		delete(m.byWriter, cam.endpoint.GUID)
+	}
+	cam.endpoint, cam.participant = endpoint, p.participant
+	cam.Type, cam.Interface = endpoint.Type, p.iface
+	cam.active = true
+	cam.subscribed = false
+	m.byWriter[endpoint.GUID] = cam
+	wanted := m.containerUse || cam.viewRefs > 0
+	m.mu.Unlock()
+
+	if m.loopback != nil {
+		if err := m.loopback.EnsureNode(m.ctx, id, nameForNode(cam.Name, id)); err != nil {
+			m.logger.Debug("creating ROS 2 camera loopback failed", zap.Uint32("camera_id", id), zap.Error(err))
+		}
+	}
+	if wanted {
+		m.ensureSubscribed(cam)
+	}
+}
+
+func nameForNode(name string, id uint32) string {
+	const max = 31
+	label := fmt.Sprintf("Wendy ROS2 camera %d", id)
+	if len(name) <= max {
+		label = name
+	}
+	return label
+}
+
+func (m *Manager) ensureSubscribed(cam *cameraState) error {
+	m.mu.Lock()
+	if cam.subscribed {
+		m.mu.Unlock()
+		return nil
+	}
+	p, endpoint := cam.participant, cam.endpoint
+	if p == nil {
+		m.mu.Unlock()
+		return errors.New("ROS 2 camera publisher is unavailable")
+	}
+	cam.subscribed = true
+	m.mu.Unlock()
+	if err := p.Subscribe(endpoint); err != nil {
+		m.mu.Lock()
+		if cam.participant == p && cam.endpoint.GUID == endpoint.GUID {
+			cam.subscribed = false
+		}
+		m.mu.Unlock()
+		return err
+	}
+	return nil
+}
+
+func (m *Manager) handleSample(sample rtps.Sample) {
+	m.mu.Lock()
+	cam := m.byWriter[sample.Writer]
+	wanted := cam != nil && (cam.viewRefs > 0 || m.containerUse)
+	typeName := ""
+	if cam != nil {
+		typeName = cam.Type
+	}
+	m.mu.Unlock()
+	if !wanted {
+		return
+	}
+	if m.loopback == nil {
+		return
+	}
+	cam.pumpMu.Lock()
+	defer cam.pumpMu.Unlock()
+	frame, width, height, err := DecodeJPEG(typeName, sample.Payload)
+	if err != nil {
+		m.logCameraErrorOnce(cam, "decoding ROS 2 camera frame failed", err)
+		return
+	}
+	path, ok := m.loopback.NodePath(cam.ID)
+	if !ok {
+		return
+	}
+	m.mu.Lock()
+	if cam.writer == nil {
+		cam.writer = m.newWriter(path)
+	}
+	w := cam.writer
+	m.mu.Unlock()
+	if err := w.WriteJPEG(frame, width, height); err != nil {
+		m.logCameraErrorOnce(cam, "writing ROS 2 camera loopback failed", err)
+		return
+	}
+	m.mu.Lock()
+	if !cam.readyClosed {
+		close(cam.ready)
+		cam.readyClosed = true
+	}
+	m.mu.Unlock()
+}
+
+func (m *Manager) logCameraErrorOnce(cam *cameraState, message string, err error) {
+	m.mu.Lock()
+	if cam.loggedError {
+		m.mu.Unlock()
+		return
+	}
+	cam.loggedError = true
+	m.mu.Unlock()
+	m.logger.Warn(message, zap.Uint32("camera_id", cam.ID), zap.String("topic", cam.Topic), zap.Error(err))
+}
+
+func (m *Manager) List() []Camera {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]Camera, 0, len(m.cameras))
+	for _, state := range m.cameras {
+		if !state.active {
+			continue
+		}
+		cam := state.Camera
+		if m.loopback != nil {
+			cam.Path, _ = m.loopback.NodePath(cam.ID)
+		}
+		out = append(out, cam)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+func (m *Manager) Get(id uint32) (Camera, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	state := m.cameras[id]
+	if state == nil || !state.active {
+		return Camera{}, false
+	}
+	cam := state.Camera
+	if m.loopback != nil {
+		cam.Path, _ = m.loopback.NodePath(id)
+	}
+	return cam, true
+}
+
+// Acquire starts the DDS subscription and waits until the loopback writer has
+// configured the node with its first frame. Waiting avoids opening an
+// exclusive-caps v4l2loopback node while it still advertises OUTPUT-only.
+func (m *Manager) Acquire(ctx context.Context, id uint32) (Camera, func(), error) {
+	m.mu.Lock()
+	cam := m.cameras[id]
+	if cam != nil && cam.active {
+		cam.viewRefs++
+	} else {
+		cam = nil
+	}
+	m.mu.Unlock()
+	if cam == nil {
+		return Camera{}, nil, fmt.Errorf("ROS 2 camera %d not found", id)
+	}
+	if m.loopback == nil {
+		m.release(cam)
+		return Camera{}, nil, errors.New("ROS 2 loopback camera support unavailable")
+	}
+	if err := m.loopback.EnsureNode(ctx, id, nameForNode(cam.Name, id)); err != nil {
+		m.release(cam)
+		return Camera{}, nil, err
+	}
+	if err := m.ensureSubscribed(cam); err != nil {
+		m.release(cam)
+		return Camera{}, nil, err
+	}
+	m.mu.Lock()
+	ready := cam.ready
+	m.mu.Unlock()
+	timer := time.NewTimer(firstFrameTimeout)
+	defer timer.Stop()
+	select {
+	case <-ready:
+	case <-ctx.Done():
+		m.release(cam)
+		return Camera{}, nil, ctx.Err()
+	case <-timer.C:
+		m.release(cam)
+		return Camera{}, nil, fmt.Errorf("timed out waiting for the first frame on %s", cam.Topic)
+	}
+	result, ok := m.Get(id)
+	if !ok {
+		m.release(cam)
+		return Camera{}, nil, errors.New("ROS 2 camera publisher stopped before streaming began")
+	}
+	var once sync.Once
+	return result, func() { once.Do(func() { m.release(cam) }) }, nil
+}
+
+func (m *Manager) release(cam *cameraState) {
+	cam.pumpMu.Lock()
+	defer cam.pumpMu.Unlock()
+	m.mu.Lock()
+	if cam.viewRefs > 0 {
+		cam.viewRefs--
+	}
+	wanted := cam.viewRefs > 0 || m.containerUse
+	if !wanted && cam.writer != nil {
+		_ = cam.writer.Close()
+		cam.writer = nil
+		cam.ready = make(chan struct{})
+		cam.readyClosed = false
+	}
+	m.mu.Unlock()
+}
+
+func (m *Manager) EnsureNodes(ctx context.Context) {
+	if m.loopback == nil {
+		return
+	}
+	for _, cam := range m.List() {
+		if err := m.loopback.EnsureNode(ctx, cam.ID, nameForNode(cam.Name, cam.ID)); err != nil {
+			m.logger.Debug("ensuring ROS 2 camera loopback failed", zap.Uint32("camera_id", cam.ID), zap.Error(err))
+		}
+	}
+}
+
+func (m *Manager) SetContainerConsumers(names []string) {
+	m.mu.Lock()
+	m.containerUse = len(names) != 0
+	wanted := m.containerUse
+	cameras := make([]*cameraState, 0, len(m.cameras))
+	for _, cam := range m.cameras {
+		if cam.active {
+			cameras = append(cameras, cam)
+		}
+	}
+	m.mu.Unlock()
+	if wanted {
+		for _, cam := range cameras {
+			if err := m.ensureSubscribed(cam); err != nil {
+				m.logger.Debug("subscribing to ROS 2 camera failed", zap.Uint32("camera_id", cam.ID), zap.Error(err))
+			}
+		}
+	} else {
+		for _, cam := range cameras {
+			cam.pumpMu.Lock()
+			m.mu.Lock()
+			if cam.viewRefs == 0 && cam.writer != nil {
+				_ = cam.writer.Close()
+				cam.writer = nil
+				cam.ready = make(chan struct{})
+				cam.readyClosed = false
+			}
+			m.mu.Unlock()
+			cam.pumpMu.Unlock()
+		}
+	}
+}
+
+func (m *Manager) Shutdown() {
+	m.cancel()
+	m.wg.Wait()
+	m.mu.Lock()
+	cameras := make([]*cameraState, 0, len(m.cameras))
+	for _, cam := range m.cameras {
+		cameras = append(cameras, cam)
+	}
+	m.mu.Unlock()
+	for _, cam := range cameras {
+		cam.pumpMu.Lock()
+		m.mu.Lock()
+		if cam.writer != nil {
+			_ = cam.writer.Close()
+			cam.writer = nil
+		}
+		m.mu.Unlock()
+		cam.pumpMu.Unlock()
+	}
+}
+
+func eligibleInterfaces() []string {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 || iface.Flags&net.FlagMulticast == 0 || virtualInterface(iface.Name) || wirelessInterface(iface.Name) {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			if ipnet, ok := addr.(*net.IPNet); ok && ipnet.IP.To4() != nil {
+				out = append(out, iface.Name)
+				break
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func virtualInterface(name string) bool {
+	name = strings.ToLower(name)
+	for _, prefix := range []string{"docker", "br-", "veth", "cni", "flannel", "virbr", "kube", "nerdctl", "tap", "tun"} {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func wirelessInterface(name string) bool {
+	name = strings.ToLower(name)
+	for _, prefix := range []string{"wl", "wifi", "ath", "ra"} {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/go/internal/agent/ros2camera/manager_test.go
+++ b/go/internal/agent/ros2camera/manager_test.go
@@ -1,0 +1,117 @@
+package ros2camera
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/wendylabsinc/wendy/go/internal/rtps"
+)
+
+type fakeLoopback struct {
+	mu    sync.Mutex
+	paths map[uint32]string
+}
+
+func (f *fakeLoopback) EnsureNode(_ context.Context, id uint32, _ string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.paths == nil {
+		f.paths = map[uint32]string{}
+	}
+	f.paths[id] = fmt.Sprintf("/dev/video%d", id)
+	return nil
+}
+func (f *fakeLoopback) NodePath(id uint32) (string, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	p, ok := f.paths[id]
+	return p, ok
+}
+
+type fakeWriter struct {
+	frames int
+	width  int
+	height int
+}
+
+func (w *fakeWriter) WriteJPEG(_ []byte, width, height int) error {
+	w.frames++
+	w.width, w.height = width, height
+	return nil
+}
+func (*fakeWriter) Close() error { return nil }
+
+func TestManagerRegistersROS2AndGo2CamerasWithStableIDs(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ros2-cameras.json")
+	loop := &fakeLoopback{}
+	m := NewManager(context.Background(), zap.NewNop(), loop, path, nil)
+	t.Cleanup(m.Shutdown)
+	p := &participantState{iface: "eth0", domainID: 0}
+	m.registerEndpoint(p, rtps.Endpoint{Topic: "rt/frontvideostream", Type: TypeGo2FrontVideo, GUID: rtps.GUID{EntityID: 1}})
+	m.registerEndpoint(p, rtps.Endpoint{Topic: "rt/camera/image_raw", Type: TypeImage, GUID: rtps.GUID{EntityID: 2}})
+
+	cameras := m.List()
+	if len(cameras) != 2 {
+		t.Fatalf("cameras = %+v", cameras)
+	}
+	if cameras[0].ID != IDBandStart || cameras[0].Name != "Unitree Go2 front camera" || cameras[0].Topic != "/frontvideostream" || cameras[0].Path != "/dev/video128" {
+		t.Fatalf("Go2 camera = %+v", cameras[0])
+	}
+
+	// A fresh manager reading the registry must retain the topic's device ID.
+	m2 := NewManager(context.Background(), zap.NewNop(), &fakeLoopback{}, path, nil)
+	t.Cleanup(m2.Shutdown)
+	m2.registerEndpoint(p, rtps.Endpoint{Topic: "rt/frontvideostream", Type: TypeGo2FrontVideo, GUID: rtps.GUID{EntityID: 3}})
+	got := m2.List()
+	if len(got) != 1 || got[0].ID != cameras[0].ID {
+		t.Fatalf("reloaded camera = %+v, want stable ID %d", got, cameras[0].ID)
+	}
+}
+
+func TestManagerPumpsCompressedImageToLoopback(t *testing.T) {
+	loop := &fakeLoopback{}
+	m := NewManager(context.Background(), zap.NewNop(), loop, filepath.Join(t.TempDir(), "registry.json"), nil)
+	t.Cleanup(m.Shutdown)
+	writer := &fakeWriter{}
+	m.newWriter = func(string) cameraWriter { return writer }
+	m.containerUse = true
+	guid := rtps.GUID{EntityID: 7}
+	m.registerEndpoint(&participantState{iface: "eth0", domainID: 0}, rtps.Endpoint{Topic: "rt/camera/compressed", Type: TypeCompressedImage, GUID: guid})
+
+	jpegFrame := testJPEG(t, 5, 4)
+	c := newCDRBuilder()
+	c.header()
+	c.str("jpeg")
+	c.bytes(jpegFrame)
+	m.handleSample(rtps.Sample{Writer: guid, Payload: c.b})
+
+	if writer.frames != 1 || writer.width != 5 || writer.height != 4 {
+		t.Fatalf("writer = %+v", writer)
+	}
+}
+
+func TestManagerRediscoveryDoesNotResetSubscription(t *testing.T) {
+	m := NewManager(context.Background(), zap.NewNop(), &fakeLoopback{}, filepath.Join(t.TempDir(), "registry.json"), nil)
+	t.Cleanup(m.Shutdown)
+	p := &participantState{iface: "eth0", domainID: 0}
+	first := rtps.GUID{EntityID: 7}
+	m.registerEndpoint(p, rtps.Endpoint{Topic: "rt/camera/compressed", Type: TypeCompressedImage, GUID: first})
+
+	cam := m.cameras[IDBandStart]
+	cam.subscribed = true
+	m.registerEndpoint(p, rtps.Endpoint{Topic: "rt/camera/compressed", Type: TypeCompressedImage, GUID: first})
+	if !cam.subscribed {
+		t.Fatal("duplicate endpoint announcement reset the active subscription")
+	}
+
+	second := rtps.GUID{EntityID: 8}
+	m.registerEndpoint(p, rtps.Endpoint{Topic: "rt/camera/compressed", Type: TypeCompressedImage, GUID: second})
+	if m.byWriter[first] != nil || m.byWriter[second] != cam {
+		t.Fatalf("writer index was not replaced: old=%p new=%p camera=%p", m.byWriter[first], m.byWriter[second], cam)
+	}
+}

--- a/go/internal/agent/ros2camera/manager_test.go
+++ b/go/internal/agent/ros2camera/manager_test.go
@@ -115,6 +115,18 @@ func TestManagerSkipsDecodeWhenLoopbackNodeIsMissing(t *testing.T) {
 	}
 }
 
+func TestFrameIntervalBudgetsLargeRawFrames(t *testing.T) {
+	if got := frameInterval(TypeCompressedImage, largeRawBytes+1); got != minFrameInterval {
+		t.Fatalf("compressed interval = %s; want %s", got, minFrameInterval)
+	}
+	if got := frameInterval(TypeImage, mediumRawBytes+1); got != mediumRawInterval {
+		t.Fatalf("medium raw interval = %s; want %s", got, mediumRawInterval)
+	}
+	if got := frameInterval(TypeImage, largeRawBytes+1); got != largeRawInterval {
+		t.Fatalf("large raw interval = %s; want %s", got, largeRawInterval)
+	}
+}
+
 func TestManagerKeepsHostInterfacesDistinct(t *testing.T) {
 	m := NewManager(context.Background(), zap.NewNop(), &fakeLoopback{}, filepath.Join(t.TempDir(), "registry.json"), nil)
 	t.Cleanup(m.Shutdown)

--- a/go/internal/agent/ros2camera/manager_test.go
+++ b/go/internal/agent/ros2camera/manager_test.go
@@ -89,9 +89,55 @@ func TestManagerPumpsCompressedImageToLoopback(t *testing.T) {
 	c.str("jpeg")
 	c.bytes(jpegFrame)
 	m.handleSample(rtps.Sample{Writer: guid, Payload: c.b})
+	m.handleSample(rtps.Sample{Writer: guid, Payload: c.b})
 
 	if writer.frames != 1 || writer.width != 5 || writer.height != 4 {
 		t.Fatalf("writer = %+v", writer)
+	}
+}
+
+func TestManagerSkipsDecodeWhenLoopbackNodeIsMissing(t *testing.T) {
+	loop := &fakeLoopback{}
+	m := NewManager(context.Background(), zap.NewNop(), loop, filepath.Join(t.TempDir(), "registry.json"), nil)
+	t.Cleanup(m.Shutdown)
+	m.containerUse = true
+	guid := rtps.GUID{EntityID: 7}
+	m.registerEndpoint(&participantState{iface: "eth0", domainID: 0, graphKey: "host:eth0"}, rtps.Endpoint{
+		Topic: "rt/camera/compressed", Type: TypeCompressedImage, GUID: guid,
+	})
+	loop.mu.Lock()
+	delete(loop.paths, IDBandStart)
+	loop.mu.Unlock()
+
+	m.handleSample(rtps.Sample{Writer: guid, Payload: []byte("not CDR")})
+	if m.cameras[IDBandStart].loggedError {
+		t.Fatal("missing loopback node should skip decoding without logging a decode error")
+	}
+}
+
+func TestManagerKeepsHostInterfacesDistinct(t *testing.T) {
+	m := NewManager(context.Background(), zap.NewNop(), &fakeLoopback{}, filepath.Join(t.TempDir(), "registry.json"), nil)
+	t.Cleanup(m.Shutdown)
+	topic := "rt/camera/compressed"
+	m.registerEndpoint(&participantState{iface: "eth0", domainID: 0, graphKey: "host:eth0"}, rtps.Endpoint{
+		Topic: topic, Type: TypeCompressedImage, GUID: rtps.GUID{EntityID: 1},
+	})
+	m.registerEndpoint(&participantState{iface: "eth1", domainID: 0, graphKey: "host:eth1"}, rtps.Endpoint{
+		Topic: topic, Type: TypeCompressedImage, GUID: rtps.GUID{EntityID: 2},
+	})
+	if cameras := m.List(); len(cameras) != 2 || cameras[0].ID == cameras[1].ID {
+		t.Fatalf("cameras = %+v; want distinct cameras for each host interface", cameras)
+	}
+}
+
+func TestManagerRejectsUnsafeTopicNames(t *testing.T) {
+	m := NewManager(context.Background(), zap.NewNop(), &fakeLoopback{}, filepath.Join(t.TempDir(), "registry.json"), nil)
+	t.Cleanup(m.Shutdown)
+	m.registerEndpoint(&participantState{iface: "eth0", domainID: 0, graphKey: "host:eth0"}, rtps.Endpoint{
+		Topic: "rt/camera\nforged", Type: TypeCompressedImage, GUID: rtps.GUID{EntityID: 1},
+	})
+	if cameras := m.List(); len(cameras) != 0 {
+		t.Fatalf("unsafe topic was registered: %+v", cameras)
 	}
 }
 

--- a/go/internal/agent/ros2camera/registry.go
+++ b/go/internal/agent/ros2camera/registry.go
@@ -1,0 +1,105 @@
+package ros2camera
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+)
+
+const (
+	IDBandStart = 128
+	IDBandEnd   = 199
+)
+
+type assignment struct {
+	Key string `json:"key"`
+	ID  uint32 `json:"id"`
+}
+
+type registry struct {
+	path string
+	mu   sync.Mutex
+	ids  map[string]uint32
+}
+
+func newRegistry(path string) *registry { return &registry{path: path, ids: map[string]uint32{}} }
+
+func (r *registry) load() error {
+	data, err := os.ReadFile(r.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("reading ROS 2 camera registry: %w", err)
+	}
+	var entries []assignment
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return fmt.Errorf("parsing ROS 2 camera registry: %w", err)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	used := map[uint32]bool{}
+	for _, entry := range entries {
+		if entry.Key == "" || entry.ID < IDBandStart || entry.ID > IDBandEnd || used[entry.ID] {
+			continue
+		}
+		r.ids[entry.Key] = entry.ID
+		used[entry.ID] = true
+	}
+	return nil
+}
+
+func (r *registry) idFor(key string) (uint32, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if id, ok := r.ids[key]; ok {
+		return id, nil
+	}
+	used := map[uint32]bool{}
+	for _, id := range r.ids {
+		used[id] = true
+	}
+	var id uint32
+	for candidate := uint32(IDBandStart); candidate <= IDBandEnd; candidate++ {
+		if !used[candidate] {
+			id = candidate
+			break
+		}
+	}
+	if id == 0 {
+		return 0, errors.New("no free ROS 2 camera device IDs")
+	}
+	r.ids[key] = id
+	if err := r.saveLocked(); err != nil {
+		delete(r.ids, key)
+		return 0, err
+	}
+	return id, nil
+}
+
+func (r *registry) saveLocked() error {
+	entries := make([]assignment, 0, len(r.ids))
+	for key, id := range r.ids {
+		entries = append(entries, assignment{Key: key, ID: id})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].ID < entries[j].ID })
+	data, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(r.path), 0o755); err != nil {
+		return err
+	}
+	tmp := r.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, r.path); err != nil {
+		return err
+	}
+	return nil
+}

--- a/go/internal/agent/ros2camera/writer_linux.go
+++ b/go/internal/agent/ros2camera/writer_linux.go
@@ -1,0 +1,106 @@
+//go:build linux
+
+package ros2camera
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	v4l2BufTypeVideoOutput = 2
+	v4l2PixFmtMJPEG        = 0x47504a4d // MJPG
+	v4l2FieldNone          = 1
+	vidiocSFmt             = 0xc0d05605
+)
+
+type v4l2Format struct {
+	Type         uint32
+	_            [4]byte // align the v4l2_format union to 8 bytes on 64-bit Linux
+	Width        uint32
+	Height       uint32
+	PixelFormat  uint32
+	Field        uint32
+	BytesPerLine uint32
+	SizeImage    uint32
+	Colorspace   uint32
+	Priv         uint32
+	Flags        uint32
+	Enc          uint32
+	Quantization uint32
+	XferFunc     uint32
+	_            [152]byte
+}
+
+// VIDIOC_S_FMT encodes a 208-byte argument, and the anonymous format union
+// starts at byte 8 on Linux's 64-bit UAPI. Keep both properties compile-time
+// checked: a subtly wrong layout can make the ioctl succeed with shifted
+// dimensions and is otherwise very difficult to diagnose on a device.
+var (
+	_ [208 - unsafe.Sizeof(v4l2Format{})]byte
+	_ [unsafe.Sizeof(v4l2Format{}) - 208]byte
+	_ [8 - unsafe.Offsetof(v4l2Format{}.Width)]byte
+	_ [unsafe.Offsetof(v4l2Format{}.Width) - 8]byte
+)
+
+type frameWriter struct {
+	path          string
+	file          *os.File
+	width, height int
+}
+
+func newFrameWriter(path string) cameraWriter { return &frameWriter{path: path} }
+
+func (w *frameWriter) WriteJPEG(frame []byte, width, height int) error {
+	if width <= 0 || height <= 0 || width > 8192 || height > 8192 {
+		return fmt.Errorf("invalid frame dimensions %dx%d", width, height)
+	}
+	if w.file == nil {
+		fd, err := unix.Open(w.path, unix.O_WRONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+		if err != nil {
+			return fmt.Errorf("opening ROS 2 camera loopback %s: %w", w.path, err)
+		}
+		w.file = os.NewFile(uintptr(fd), w.path)
+	}
+	if w.width != width || w.height != height {
+		format := v4l2Format{
+			Type:        v4l2BufTypeVideoOutput,
+			Width:       uint32(width),
+			Height:      uint32(height),
+			PixelFormat: v4l2PixFmtMJPEG,
+			Field:       v4l2FieldNone,
+			// Compressed frame sizes vary with scene complexity. Reserve the
+			// uncompressed RGB bound rather than sizing the loopback buffer from
+			// the first (possibly unusually small) JPEG.
+			SizeImage: uint32(width * height * 3),
+		}
+		if _, _, errno := unix.Syscall(unix.SYS_IOCTL, w.file.Fd(), vidiocSFmt, uintptr(unsafe.Pointer(&format))); errno != 0 {
+			return fmt.Errorf("configuring ROS 2 camera loopback %s: %w", w.path, errno)
+		}
+		w.width, w.height = width, height
+	}
+	for len(frame) > 0 {
+		n, err := w.file.Write(frame)
+		if err != nil {
+			return fmt.Errorf("writing ROS 2 camera frame: %w", err)
+		}
+		if n == 0 {
+			return errors.New("writing ROS 2 camera frame made no progress")
+		}
+		frame = frame[n:]
+	}
+	return nil
+}
+
+func (w *frameWriter) Close() error {
+	if w.file == nil {
+		return nil
+	}
+	err := w.file.Close()
+	w.file = nil
+	return err
+}

--- a/go/internal/agent/ros2camera/writer_other.go
+++ b/go/internal/agent/ros2camera/writer_other.go
@@ -1,0 +1,13 @@
+//go:build !linux
+
+package ros2camera
+
+import "errors"
+
+type unsupportedWriter struct{}
+
+func newFrameWriter(string) cameraWriter { return &unsupportedWriter{} }
+func (*unsupportedWriter) WriteJPEG([]byte, int, int) error {
+	return errors.New("ROS 2 loopback cameras require Linux")
+}
+func (*unsupportedWriter) Close() error { return nil }

--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -28,6 +28,7 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/agent/board"
 	"github.com/wendylabsinc/wendy/go/internal/agent/camera"
 	"github.com/wendylabsinc/wendy/go/internal/agent/ipcam"
+	"github.com/wendylabsinc/wendy/go/internal/agent/ros2camera"
 	"github.com/wendylabsinc/wendy/go/internal/shared/streamreason"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
@@ -418,12 +419,13 @@ func (h *deviceHub) broadcast(frame *videoFrame) bool {
 	return true
 }
 
-// videoSourceKind distinguishes a local V4L2 node from a network camera.
+// videoSourceKind distinguishes physical/local V4L2, network, and ROS 2 cameras.
 type videoSourceKind int
 
 const (
 	sourceV4L2 videoSourceKind = iota
 	sourceIP
+	sourceROS2
 )
 
 // videoSource is what a device ID resolves to. Introducing it removes the
@@ -445,11 +447,12 @@ const ipHubKeyPrefix = "ip:"
 // the same way TEGRA_FIRMWARE_MISMATCH becomes an os install hint.
 const reasonIPCameraNoCredentials = streamreason.IPCameraNoCredentials
 
-// State paths for network cameras, under the agent's existing state directory.
+// State paths for virtual cameras, under the agent's existing state directory.
 // Declared as vars so tests can point them at a temporary directory.
 var (
-	ipcamRegistryPath   = "/var/lib/wendy/cameras.json"
-	ipcamCredentialPath = "/var/lib/wendy/camera-credentials.json"
+	ipcamRegistryPath      = "/var/lib/wendy/cameras.json"
+	ipcamCredentialPath    = "/var/lib/wendy/camera-credentials.json"
+	ros2CameraRegistryPath = "/var/lib/wendy/ros2-cameras.json"
 )
 
 // cameraLoopback is the seam VideoService uses to reach the v4l2loopback node
@@ -468,6 +471,7 @@ type cameraLoopback interface {
 	SetContainerConsumers(containerIDs []string)
 	CredentialsChanged(camID uint32)
 	RemoveCamera(camID uint32)
+	EnsureNode(ctx context.Context, id uint32, label string) error
 	Shutdown()
 }
 
@@ -486,6 +490,7 @@ type VideoService struct {
 	discoverer  *ipcam.Discoverer
 	links       *ipcam.LinkManager
 	loopback    cameraLoopback
+	ros2Cameras *ros2camera.Manager
 
 	// runGStreamer is the injection seam for the network capture subprocess.
 	runGStreamer func(ctx context.Context, args []string, onFrame func([]byte)) error
@@ -522,7 +527,7 @@ type VideoService struct {
 
 // NewVideoService creates a VideoService whose producer goroutines are tied to ctx.
 // Call Shutdown to cancel all active producers and wait for them to exit.
-func NewVideoService(ctx context.Context, logger *zap.Logger) *VideoService {
+func NewVideoService(ctx context.Context, logger *zap.Logger, rosRuntime ...ROS2Runtime) *VideoService {
 	svcCtx, cancel := context.WithCancel(ctx)
 	svc := &VideoService{
 		logger: logger,
@@ -583,6 +588,42 @@ func NewVideoService(ctx context.Context, logger *zap.Logger) *VideoService {
 		func(ctx context.Context, args []string) error {
 			return svc.runGStreamer(ctx, args, func([]byte) {})
 		})
+	var graphs ros2camera.GraphSource
+	if len(rosRuntime) != 0 && rosRuntime[0] != nil {
+		graphs = func(ctx context.Context) ([]ros2camera.Graph, error) {
+			targets, err := rosRuntime[0].FindROS2Containers(ctx)
+			if err != nil {
+				return nil, err
+			}
+			out := make([]ros2camera.Graph, 0, len(targets))
+			for _, target := range targets {
+				if target.Running && target.TaskPID != 0 {
+					target := target
+					key := target.AppID
+					if key == "" {
+						key = target.ContainerID
+					}
+					out = append(out, ros2camera.Graph{
+						Key: key, InstanceKey: target.ContainerID, DomainID: target.DomainID, NetworkNamespacePID: target.TaskPID,
+						Verify: func(ctx context.Context) bool {
+							current, err := rosRuntime[0].FindROS2Containers(ctx)
+							if err != nil {
+								return false
+							}
+							for _, candidate := range current {
+								if candidate.ContainerID == target.ContainerID && candidate.Running && candidate.TaskPID == target.TaskPID {
+									return true
+								}
+							}
+							return false
+						},
+					})
+				}
+			}
+			return out, nil
+		}
+	}
+	svc.ros2Cameras = ros2camera.NewManager(svcCtx, logger, svc.loopback, ros2CameraRegistryPath, graphs)
 	return svc
 }
 
@@ -599,6 +640,9 @@ const discoveryInterval = 60 * time.Second
 // answers a discovery probe. See ipcam.LinkGuard for the conditions under which
 // the agent is willing to be that server.
 func (s *VideoService) StartDiscovery() {
+	if s.ros2Cameras != nil {
+		s.ros2Cameras.Start()
+	}
 	if s.links != nil {
 		s.wg.Add(1)
 		go func() {
@@ -637,6 +681,9 @@ func (s *VideoService) StartDiscovery() {
 // shuttingDown check could still start a new supervisor moments after ctx
 // cancellation fires but before Loopback.Shutdown gets a chance to run.
 func (s *VideoService) Shutdown() {
+	if s.ros2Cameras != nil {
+		s.ros2Cameras.Shutdown()
+	}
 	if s.loopback != nil {
 		s.loopback.Shutdown()
 	}
@@ -672,7 +719,7 @@ func (s *VideoService) listCameras(ctx context.Context) ([]*agentpb.VideoDevice,
 		// EnsureNodes has created one, it would otherwise glob-enumerate here
 		// too and double-list the camera: once (correctly) from listIPCameras
 		// below and once (bogusly) as an indistinguishable local device.
-		if id >= uint64(ipcam.IDBandStart) && id <= uint64(ipcam.IDBandEnd) {
+		if id >= uint64(ipcam.LoopbackBandStart) && id <= uint64(ipcam.IDBandEnd) {
 			continue
 		}
 		if !s.hasVideoCapture(path) {
@@ -709,8 +756,25 @@ func (s *VideoService) listCameras(ctx context.Context) ([]*agentpb.VideoDevice,
 			devices[csiDeviceIdxs[0]].LibcameraId = id
 		}
 	}
+	devices = append(devices, s.listROS2Cameras()...)
 	devices = append(devices, s.listIPCameras()...)
 	return devices, nil
+}
+
+func (s *VideoService) listROS2Cameras() []*agentpb.VideoDevice {
+	if s.ros2Cameras == nil {
+		return nil
+	}
+	cameras := s.ros2Cameras.List()
+	out := make([]*agentpb.VideoDevice, 0, len(cameras))
+	for _, cam := range cameras {
+		out = append(out, &agentpb.VideoDevice{
+			Id: cam.ID, Name: cam.Name, Path: cam.Path,
+			Transport: agentpb.VideoTransport_VIDEO_TRANSPORT_ROS2,
+			Topic:     cam.Topic, Online: true,
+		})
+	}
+	return out
 }
 
 // listIPCameras renders registered network cameras as VideoDevices. Path stays
@@ -758,6 +822,16 @@ func (s *VideoService) ListVideoDevices(ctx context.Context, _ *agentpb.ListVide
 // resolveSource maps a device ID onto the thing it names. IDs in the network
 // camera band resolve through the registry; everything else is a V4L2 node.
 func (s *VideoService) resolveSource(devID uint32) (videoSource, error) {
+	if devID >= ros2camera.IDBandStart && devID <= ros2camera.IDBandEnd {
+		if s.ros2Cameras == nil {
+			return videoSource{}, status.Errorf(codes.NotFound, "camera %d not found", devID)
+		}
+		cam, ok := s.ros2Cameras.Get(devID)
+		if !ok {
+			return videoSource{}, status.Errorf(codes.NotFound, "camera %d not found", devID)
+		}
+		return videoSource{kind: sourceROS2, key: fmt.Sprintf("ros2:%d", devID), path: cam.Path}, nil
+	}
 	if devID >= ipcam.IDBandStart && devID <= ipcam.IDBandEnd {
 		if s.registry == nil {
 			return videoSource{}, status.Errorf(codes.NotFound, "camera %d not found", devID)
@@ -841,7 +915,13 @@ func (s *VideoService) EnsureCameraNodes(ctx context.Context) error {
 	if s.loopback == nil {
 		return nil
 	}
-	return s.loopback.EnsureNodes(ctx)
+	if err := s.loopback.EnsureNodes(ctx); err != nil {
+		return err
+	}
+	if s.ros2Cameras != nil {
+		s.ros2Cameras.EnsureNodes(ctx)
+	}
+	return nil
 }
 
 // SetCameraContainerConsumers tells the loopback manager which entitled
@@ -853,6 +933,9 @@ func (s *VideoService) SetCameraContainerConsumers(ctx context.Context, containe
 		return
 	}
 	s.loopback.SetContainerConsumers(containerIDs)
+	if s.ros2Cameras != nil {
+		s.ros2Cameras.SetContainerConsumers(containerIDs)
+	}
 }
 
 // RefreshCameras runs one discovery round and returns the full camera listing.
@@ -862,6 +945,9 @@ func (s *VideoService) RefreshCameras(ctx context.Context, _ *agentpb.RefreshCam
 			// A failed probe still leaves previously discovered cameras listable.
 			s.logger.Warn("camera discovery failed", zap.Error(err))
 		}
+	}
+	if s.ros2Cameras != nil {
+		s.ros2Cameras.Refresh(ctx)
 	}
 	devices, err := s.listCameras(ctx)
 	if err != nil {
@@ -1317,6 +1403,17 @@ func (s *VideoService) StreamVideo(req *agentpb.StreamVideoRequest, stream grpc.
 		// V4L2 resolution allowlist does not apply. Width instead selects which
 		// of the camera's streams to open.
 		return s.streamIPCamera(stream, src, req)
+	}
+	if src.kind == sourceROS2 {
+		cam, release, err := s.ros2Cameras.Acquire(ctx, devID)
+		if err != nil {
+			return status.Errorf(codes.Unavailable, "starting ROS 2 camera %d: %v", devID, err)
+		}
+		defer release()
+		src.path = cam.Path
+		if src.path == "" {
+			return status.Errorf(codes.Unavailable, "ROS 2 camera %d has no loopback device", devID)
+		}
 	}
 
 	path := src.path

--- a/go/internal/agent/services/video_service_ipcam_test.go
+++ b/go/internal/agent/services/video_service_ipcam_test.go
@@ -64,6 +64,15 @@ func (f *fakeLoopback) EnsureNodes(context.Context) error {
 	return f.ensureNodesErr
 }
 
+func (f *fakeLoopback) EnsureNode(_ context.Context, id uint32, _ string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.ensureNodesErr == nil {
+		f.nodePaths[id] = fmt.Sprintf("/dev/video%d", id)
+	}
+	return f.ensureNodesErr
+}
+
 func (f *fakeLoopback) NodePath(camID uint32) (string, bool) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/go/internal/cli/assets/docs/hardware/camera.mdx
+++ b/go/internal/cli/assets/docs/hardware/camera.mdx
@@ -1,6 +1,6 @@
 ---
 title: Camera Access
-description: Use USB and CSI cameras from WendyOS apps
+description: Use USB, CSI, IP, and ROS 2 cameras from WendyOS apps
 ---
 
 ## Camera Access
@@ -23,7 +23,7 @@ Use the device camera commands to see which cameras WendyOS can see:
 wendy device camera list
 ```
 
-The output includes a device ID, transport type (`usb`, `csi`, or `ip`), name, and — for local cameras — a path such as `/dev/video0`. Network cameras show their address instead of a path; see [IP Cameras](#ip-cameras) below. Use the ID with view commands:
+The output includes a device ID, transport type (`usb`, `csi`, `ip`, or `ros2`), name, and — for local cameras — a path such as `/dev/video0`. Network cameras show their address, while ROS 2 cameras show their topic. Use the ID with view commands:
 
 ```bash
 wendy device camera view --id 0
@@ -46,6 +46,32 @@ For broad hardware inspection, filter the device capability list:
 ```bash
 wendy device hardware list --category camera
 ```
+
+## ROS 2 Camera Topics
+
+The WendyOS agent automatically presents ROS 2 video publishers as ordinary
+cameras. It recognizes `sensor_msgs/msg/Image` and
+`sensor_msgs/msg/CompressedImage`, allocates each topic a stable ID from
+`128`–`199`, and feeds a matching `/dev/video<ID>` v4l2loopback device. The
+topic then works with the same commands as a USB camera:
+
+```bash
+wendy device camera list
+wendy device camera view --id 128
+```
+
+App-local ROS 2 graphs stay app-local. The agent creates its DDS reader inside
+the running app's network namespace instead of changing the app's discovery
+scope. Host/robot feeds on domain 0 are discovered on wired interfaces.
+
+Unitree Go2 robots receive special handling: the native
+`unitree_go/msg/Go2FrontVideoData` publisher on `/frontvideostream` appears as
+**Unitree Go2 front camera**. Wendy uses its 720p JPEG field when available and
+falls back to the lower-resolution fields on firmware that leaves it empty.
+
+ROS 2 camera mirroring requires the WendyOS `v4l2loopback` module. If the
+running image does not include it, the agent logs the missing-module error and
+the ROS 2 feed cannot be opened as a camera.
 
 ## IP Cameras
 

--- a/go/internal/cli/assets/docs/hardware/camera.mdx
+++ b/go/internal/cli/assets/docs/hardware/camera.mdx
@@ -50,7 +50,7 @@ wendy device hardware list --category camera
 ## ROS 2 Camera Topics
 
 The WendyOS agent automatically presents ROS 2 video publishers as ordinary
-cameras. It recognizes `sensor_msgs/msg/Image` and
+cameras. It recognizes `sensor_msgs/msg/Image` and JPEG-encoded
 `sensor_msgs/msg/CompressedImage`, allocates each topic a stable ID from
 `128`–`199`, and feeds a matching `/dev/video<ID>` v4l2loopback device. The
 topic then works with the same commands as a USB camera:
@@ -63,6 +63,13 @@ wendy device camera view --id 128
 App-local ROS 2 graphs stay app-local. The agent creates its DDS reader inside
 the running app's network namespace instead of changing the app's discovery
 scope. Host/robot feeds on domain 0 are discovered on wired interfaces.
+
+<Callout type="warning">
+  DDS discovery on host-facing wired interfaces is unauthenticated. WendyOS
+  treats peers on those robot networks as trusted: any peer publishing a
+  supported image topic on domain 0 can appear as a camera. Keep untrusted
+  devices on a separate network segment.
+</Callout>
 
 Unitree Go2 robots receive special handling: the native
 `unitree_go/msg/Go2FrontVideoData` publisher on `/frontvideostream` appears as

--- a/go/internal/cli/commands/camera.go
+++ b/go/internal/cli/commands/camera.go
@@ -126,6 +126,8 @@ func transportLabel(t agentpb.VideoTransport) string {
 		return "csi"
 	case agentpb.VideoTransport_VIDEO_TRANSPORT_IP:
 		return "ip"
+	case agentpb.VideoTransport_VIDEO_TRANSPORT_ROS2:
+		return "ros2"
 	default:
 		return "-"
 	}

--- a/go/internal/cli/commands/camera_picker.go
+++ b/go/internal/cli/commands/camera_picker.go
@@ -60,6 +60,9 @@ func cameraWhere(d *agentpb.VideoDevice) string {
 	if d.GetTransport() == agentpb.VideoTransport_VIDEO_TRANSPORT_IP {
 		return d.GetAddress()
 	}
+	if d.GetTransport() == agentpb.VideoTransport_VIDEO_TRANSPORT_ROS2 {
+		return d.GetTopic()
+	}
 	return d.GetPath()
 }
 

--- a/go/internal/cli/commands/camera_picker_test.go
+++ b/go/internal/cli/commands/camera_picker_test.go
@@ -27,6 +27,10 @@ func usbCam(id uint32, name string) *agentpb.VideoDevice {
 	}
 }
 
+func rosCam(id uint32, topic string) *agentpb.VideoDevice {
+	return &agentpb.VideoDevice{Id: id, Name: "ROS 2 " + topic, Topic: topic, Path: "/dev/video128", Transport: agentpb.VideoTransport_VIDEO_TRANSPORT_ROS2, Online: true}
+}
+
 // An explicit --id must never open the picker, even with several cameras.
 func TestResolveCameraIDExplicitWins(t *testing.T) {
 	devices := []*agentpb.VideoDevice{usbCam(0, "webcam"), ipCam(200, "RLC-520A", "10.98.0.50")}
@@ -168,6 +172,19 @@ func TestCameraStatus(t *testing.T) {
 	}
 	if got := cameraStatus(ipCam(200, "RLC-520A", "10.98.0.50")); got != "ready" {
 		t.Fatalf("status = %q, want ready", got)
+	}
+}
+
+func TestROS2CameraColumns(t *testing.T) {
+	cam := rosCam(128, "/front_camera/image/compressed")
+	if got := transportLabel(cam.GetTransport()); got != "ros2" {
+		t.Fatalf("transport = %q", got)
+	}
+	if got := cameraWhere(cam); got != "/front_camera/image/compressed" {
+		t.Fatalf("where = %q", got)
+	}
+	if got := cameraStatus(cam); got != "ready" {
+		t.Fatalf("status = %q", got)
 	}
 }
 

--- a/go/internal/rtps/cdr/decoder.go
+++ b/go/internal/rtps/cdr/decoder.go
@@ -1,6 +1,6 @@
 // Package cdr decodes classic CDR (XCDR1) payloads, the wire format ROS 2
-// uses for user data on DDS. It is decode-only and covers exactly the subset
-// the battery messages need.
+// uses for user data on DDS. It is decode-only and covers the subset used by
+// Wendy's ROS 2 telemetry and camera messages.
 package cdr
 
 import (
@@ -113,6 +113,15 @@ func (d *Decoder) Int32() (int32, error) {
 	return int32(v), err
 }
 
+// Uint64 reads an 8-byte unsigned integer, aligned to 8.
+func (d *Decoder) Uint64() (uint64, error) {
+	b, err := d.take(8)
+	if err != nil {
+		return 0, err
+	}
+	return d.order.Uint64(b), nil
+}
+
 // Float32 reads an IEEE-754 single, aligned to 4.
 func (d *Decoder) Float32() (float32, error) {
 	v, err := d.Uint32()
@@ -147,6 +156,22 @@ func (d *Decoder) String() (string, error) {
 func (d *Decoder) SkipString() error {
 	_, err := d.String()
 	return err
+}
+
+// Bytes reads a sequence<uint8>: a uint32 element count followed by the bytes.
+// The returned slice aliases the serialized payload and is valid for as long as
+// the Decoder's input remains live.
+func (d *Decoder) Bytes() ([]byte, error) {
+	n, err := d.Uint32()
+	if err != nil {
+		return nil, err
+	}
+	if uint64(n) > uint64(len(d.buf)-d.pos) {
+		return nil, ErrShort
+	}
+	b := d.buf[d.pos : d.pos+int(n)]
+	d.pos += int(n)
+	return b, nil
 }
 
 // SkipBytes aligns to align, then steps over n bytes. Use it for fixed-size

--- a/go/internal/rtps/netns_linux.go
+++ b/go/internal/rtps/netns_linux.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func withNetworkNamespace(pid uint32, fn func() error) (err error) {
+func withNetworkNamespace(pid uint32, verify func() bool, fn func() error) (err error) {
 	if pid == 0 {
 		return fn()
 	}
@@ -35,6 +35,13 @@ func withNetworkNamespace(pid uint32, fn func() error) (err error) {
 		return fmt.Errorf("rtps: opening network namespace for pid %d: %w", pid, err)
 	}
 	defer target.Close() //nolint:errcheck
+	// The namespace fd is a stable reference even if the process exits. Verify
+	// container ownership after capturing it but before setns: a recycled PID is
+	// rejected without entering its namespace, while an exit after this check
+	// cannot redirect us to a different namespace.
+	if err := verifyNamespaceTarget(pid, verify); err != nil {
+		return err
+	}
 	if err := unix.Setns(int(target.Fd()), unix.CLONE_NEWNET); err != nil {
 		return fmt.Errorf("rtps: entering network namespace for pid %d: %w", pid, err)
 	}

--- a/go/internal/rtps/netns_linux.go
+++ b/go/internal/rtps/netns_linux.go
@@ -1,0 +1,52 @@
+//go:build linux
+
+package rtps
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	"golang.org/x/sys/unix"
+)
+
+func withNetworkNamespace(pid uint32, fn func() error) (err error) {
+	if pid == 0 {
+		return fn()
+	}
+	runtime.LockOSThread()
+	restored := true
+	defer func() {
+		// Never return a thread that is still inside an app namespace to the Go
+		// scheduler. Keeping it locked is safer than letting unrelated agent work
+		// inherit the wrong network namespace after a failed restore.
+		if restored {
+			runtime.UnlockOSThread()
+		}
+	}()
+
+	host, err := os.Open("/proc/self/ns/net")
+	if err != nil {
+		return fmt.Errorf("rtps: opening host network namespace: %w", err)
+	}
+	defer host.Close() //nolint:errcheck
+	target, err := os.Open(fmt.Sprintf("/proc/%d/ns/net", pid))
+	if err != nil {
+		return fmt.Errorf("rtps: opening network namespace for pid %d: %w", pid, err)
+	}
+	defer target.Close() //nolint:errcheck
+	if err := unix.Setns(int(target.Fd()), unix.CLONE_NEWNET); err != nil {
+		return fmt.Errorf("rtps: entering network namespace for pid %d: %w", pid, err)
+	}
+	restored = false
+	defer func() {
+		if restoreErr := unix.Setns(int(host.Fd()), unix.CLONE_NEWNET); restoreErr != nil {
+			if err == nil {
+				err = fmt.Errorf("rtps: restoring host network namespace: %w", restoreErr)
+			}
+			return
+		}
+		restored = true
+	}()
+	return fn()
+}

--- a/go/internal/rtps/netns_linux.go
+++ b/go/internal/rtps/netns_linux.go
@@ -48,9 +48,7 @@ func withNetworkNamespace(pid uint32, verify func() bool, fn func() error) (err 
 	restored = false
 	defer func() {
 		if restoreErr := unix.Setns(int(host.Fd()), unix.CLONE_NEWNET); restoreErr != nil {
-			if err == nil {
-				err = fmt.Errorf("rtps: restoring host network namespace: %w", restoreErr)
-			}
+			err = combineNamespaceRestoreError(err, restoreErr)
 			return
 		}
 		restored = true

--- a/go/internal/rtps/netns_other.go
+++ b/go/internal/rtps/netns_other.go
@@ -4,7 +4,7 @@ package rtps
 
 import "errors"
 
-func withNetworkNamespace(pid uint32, fn func() error) error {
+func withNetworkNamespace(pid uint32, _ func() bool, fn func() error) error {
 	if pid != 0 {
 		return errors.New("rtps: network namespaces require Linux")
 	}

--- a/go/internal/rtps/netns_other.go
+++ b/go/internal/rtps/netns_other.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package rtps
+
+import "errors"
+
+func withNetworkNamespace(pid uint32, fn func() error) error {
+	if pid != 0 {
+		return errors.New("rtps: network namespaces require Linux")
+	}
+	return fn()
+}

--- a/go/internal/rtps/participant.go
+++ b/go/internal/rtps/participant.go
@@ -35,6 +35,7 @@ const (
 	maxFragmentSets    = 8
 	maxFragmentBytes   = 64 * 1024 * 1024
 	fragmentSetTTL     = 30 * time.Second
+	fragmentSweep      = fragmentSetTTL / 2
 )
 
 // Endpoint is a remote writer discovered over SEDP.
@@ -79,6 +80,10 @@ type Config struct {
 	// thread returns to the host namespace, allowing the Wendy agent to inspect
 	// app-local ROS 2 graphs without weakening their isolation.
 	NetworkNamespacePID uint32
+	// VerifyNetworkNamespace runs after entering NetworkNamespacePID and before
+	// any socket is opened. It lets callers reject a PID that was recycled after
+	// they enumerated the target process.
+	VerifyNetworkNamespace func() bool
 	// Logf, when set, receives progress lines. Discovery failures are usually
 	// silent by nature, so this is the only way to see what happened.
 	Logf func(format string, args ...any)
@@ -150,6 +155,9 @@ type Participant struct {
 	// never matches and no data ever flows.
 	subAnnounce [][]byte
 
+	// fragmentsMu isolates potentially large fragment copies from participant
+	// bookkeeping such as subscription changes and discovery updates.
+	fragmentsMu sync.Mutex
 	// fragments holds bounded in-flight DATA_FRAG samples. Camera messages are
 	// routinely larger than one UDP datagram; without this reassembly the DDS
 	// reader can discover image topics but can never receive a frame from them.
@@ -239,11 +247,18 @@ func NewParticipant(cfg Config) (*Participant, error) {
 	// The first two octets of a GUID prefix are conventionally the vendor ID.
 	p.prefix[0], p.prefix[1] = 0x01, 0x0f
 
-	if err := withNetworkNamespace(cfg.NetworkNamespacePID, p.openSockets); err != nil {
+	if err := withNetworkNamespace(cfg.NetworkNamespacePID, p.openVerifiedSockets); err != nil {
 		_ = p.Close()
 		return nil, err
 	}
 	return p, nil
+}
+
+func (p *Participant) openVerifiedSockets() error {
+	if p.cfg.NetworkNamespacePID != 0 && p.cfg.VerifyNetworkNamespace != nil && !p.cfg.VerifyNetworkNamespace() {
+		return fmt.Errorf("rtps: network namespace process %d changed", p.cfg.NetworkNamespacePID)
+	}
+	return p.openSockets()
 }
 
 func (p *Participant) openSockets() error {
@@ -352,14 +367,46 @@ func (p *Participant) Samples() <-chan Sample { return p.samples }
 // re-announces on a timer.
 func (p *Participant) Run(ctx context.Context) {
 	var wg sync.WaitGroup
-	wg.Add(3)
+	wg.Add(4)
 	go func() { defer wg.Done(); p.readLoop(ctx, p.mcast, true) }()
 	go func() { defer wg.Done(); p.readLoop(ctx, p.ucast, false) }()
 	go func() { defer wg.Done(); p.announceLoop(ctx) }()
+	go func() { defer wg.Done(); p.fragmentCleanupLoop(ctx) }()
 
 	<-ctx.Done()
 	p.Close()
 	wg.Wait()
+	p.fragmentsMu.Lock()
+	p.fragments = make(map[fragmentKey]*fragmentSet)
+	p.fragmentBytes = 0
+	p.fragmentsMu.Unlock()
+}
+
+func (p *Participant) fragmentCleanupLoop(ctx context.Context) {
+	t := time.NewTicker(fragmentSweep)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-t.C:
+			p.expireFragmentSets(now)
+		}
+	}
+}
+
+func (p *Participant) expireFragmentSets(now time.Time) {
+	p.fragmentsMu.Lock()
+	p.dropExpiredFragmentSetsLocked(now)
+	p.fragmentsMu.Unlock()
+}
+
+func (p *Participant) dropExpiredFragmentSetsLocked(now time.Time) {
+	for key, set := range p.fragments {
+		if now.Sub(set.updated) > fragmentSetTTL {
+			p.dropFragmentSetLocked(key)
+		}
+	}
 }
 
 func (p *Participant) announceLoop(ctx context.Context) {
@@ -451,7 +498,7 @@ func (p *Participant) handle(pkt []byte, src *net.UDPAddr) {
 			// Builtin discovery traffic is small DATA, never DATA_FRAG. Treat a
 			// fragmented builtin writer as malformed instead of feeding it to the
 			// user-data reassembler.
-			if f.WriterID == entitySPDPWriter || f.WriterID == entitySEDPPubWriter {
+			if f.WriterID == entitySPDPWriter || f.WriterID == entitySEDPPubWriter || f.WriterID == entitySEDPSubWriter {
 				p.statDataErr.Add(1)
 				continue
 			}
@@ -656,7 +703,7 @@ func (p *Participant) deliverUserData(writer GUID, sn SequenceNumber, payload []
 // through the same subscription filter as ordinary DATA. Old/incomplete sets
 // are discarded so a publisher disappearing mid-frame cannot retain memory.
 func (p *Participant) handleUserDataFrag(prefix GUIDPrefix, f *DataFragSubmessage) {
-	if f.SampleSize > maxSampleSize {
+	if f.SampleSize == 0 || f.FragmentStartingNum == 0 || f.FragmentSize == 0 || f.FragmentsInSubmessage == 0 || f.SampleSize > maxSampleSize {
 		p.statDataErr.Add(1)
 		return
 	}
@@ -666,20 +713,24 @@ func (p *Participant) handleUserDataFrag(prefix GUIDPrefix, f *DataFragSubmessag
 		p.mu.Unlock()
 		return
 	}
-
-	now := time.Now()
-	for key, set := range p.fragments {
-		if now.Sub(set.updated) > fragmentSetTTL {
-			p.dropFragmentSetLocked(key)
-		}
+	p.mu.Unlock()
+	payload, complete := p.addUserDataFrag(writer, f)
+	if complete {
+		p.deliverUserData(writer, f.WriterSN, payload)
 	}
+}
+
+func (p *Participant) addUserDataFrag(writer GUID, f *DataFragSubmessage) ([]byte, bool) {
+	now := time.Now()
+	p.fragmentsMu.Lock()
+	defer p.fragmentsMu.Unlock()
+	p.dropExpiredFragmentSetsLocked(now)
 	key := fragmentKey{writer: writer, sn: f.WriterSN}
 	set := p.fragments[key]
 	fragmentCount := (int(f.SampleSize) + int(f.FragmentSize) - 1) / int(f.FragmentSize)
 	if fragmentCount > maxSampleFragments {
-		p.mu.Unlock()
 		p.statDataErr.Add(1)
-		return
+		return nil, false
 	}
 	if set == nil {
 		for len(p.fragments) >= maxFragmentSets || p.fragmentBytes+int(f.SampleSize) > maxFragmentBytes {
@@ -702,9 +753,8 @@ func (p *Participant) handleUserDataFrag(prefix GUIDPrefix, f *DataFragSubmessag
 		p.fragmentBytes += len(set.buf)
 	} else if len(set.buf) != int(f.SampleSize) || set.fragmentSize != int(f.FragmentSize) {
 		p.dropFragmentSetLocked(key)
-		p.mu.Unlock()
 		p.statDataErr.Add(1)
-		return
+		return nil, false
 	}
 
 	start := int(f.FragmentStartingNum) - 1
@@ -735,21 +785,18 @@ func (p *Participant) handleUserDataFrag(prefix GUIDPrefix, f *DataFragSubmessag
 	set.updated = now
 	if !valid {
 		p.dropFragmentSetLocked(key)
-		p.mu.Unlock()
 		p.statDataErr.Add(1)
-		return
+		return nil, false
 	}
 	if set.receivedCount != len(set.received) {
-		p.mu.Unlock()
-		return
+		return nil, false
 	}
 	payload := set.buf
 	p.dropFragmentSetLocked(key)
-	p.mu.Unlock()
-
-	p.deliverUserData(writer, f.WriterSN, payload)
+	return payload, true
 }
 
+// dropFragmentSetLocked requires fragmentsMu.
 func (p *Participant) dropFragmentSetLocked(key fragmentKey) {
 	if set := p.fragments[key]; set != nil {
 		p.fragmentBytes -= len(set.buf)

--- a/go/internal/rtps/participant.go
+++ b/go/internal/rtps/participant.go
@@ -247,18 +247,18 @@ func NewParticipant(cfg Config) (*Participant, error) {
 	// The first two octets of a GUID prefix are conventionally the vendor ID.
 	p.prefix[0], p.prefix[1] = 0x01, 0x0f
 
-	if err := withNetworkNamespace(cfg.NetworkNamespacePID, p.openVerifiedSockets); err != nil {
+	if err := withNetworkNamespace(cfg.NetworkNamespacePID, cfg.VerifyNetworkNamespace, p.openSockets); err != nil {
 		_ = p.Close()
 		return nil, err
 	}
 	return p, nil
 }
 
-func (p *Participant) openVerifiedSockets() error {
-	if p.cfg.NetworkNamespacePID != 0 && p.cfg.VerifyNetworkNamespace != nil && !p.cfg.VerifyNetworkNamespace() {
-		return fmt.Errorf("rtps: network namespace process %d changed", p.cfg.NetworkNamespacePID)
+func verifyNamespaceTarget(pid uint32, verify func() bool) error {
+	if verify != nil && !verify() {
+		return fmt.Errorf("rtps: network namespace process %d changed", pid)
 	}
-	return p.openSockets()
+	return nil
 }
 
 func (p *Participant) openSockets() error {

--- a/go/internal/rtps/participant.go
+++ b/go/internal/rtps/participant.go
@@ -28,8 +28,13 @@ func spdpMulticastPort(domainID int) int { return portBase + domainIDGain*domain
 // duration advertised is comfortably longer so a dropped packet does not evict
 // us from a peer's participant table.
 const (
-	announceInterval = 30 * time.Second
-	leaseSeconds     = 30
+	announceInterval   = 30 * time.Second
+	leaseSeconds       = 30
+	maxSampleSize      = 16 * 1024 * 1024
+	maxSampleFragments = 64 * 1024
+	maxFragmentSets    = 8
+	maxFragmentBytes   = 64 * 1024 * 1024
+	fragmentSetTTL     = 30 * time.Second
 )
 
 // Endpoint is a remote writer discovered over SEDP.
@@ -49,6 +54,19 @@ type Sample struct {
 	Payload []byte // serialized payload including its encapsulation header
 }
 
+type fragmentKey struct {
+	writer GUID
+	sn     SequenceNumber
+}
+
+type fragmentSet struct {
+	buf           []byte
+	received      []bool
+	receivedCount int
+	fragmentSize  int
+	updated       time.Time
+}
+
 // Config parameterises a Participant.
 type Config struct {
 	DomainID int
@@ -56,6 +74,11 @@ type Config struct {
 	// means every multicast-capable interface, which is rarely what you want on
 	// a robot with both a WiFi and an internal network.
 	Interface string
+	// NetworkNamespacePID creates the participant's sockets in the network
+	// namespace of this process. The sockets remain attached after the creating
+	// thread returns to the host namespace, allowing the Wendy agent to inspect
+	// app-local ROS 2 graphs without weakening their isolation.
+	NetworkNamespacePID uint32
 	// Logf, when set, receives progress lines. Discovery failures are usually
 	// silent by nature, so this is the only way to see what happened.
 	Logf func(format string, args ...any)
@@ -126,6 +149,12 @@ type Participant struct {
 	// or arrives before the peer has finished discovering us, the subscription
 	// never matches and no data ever flows.
 	subAnnounce [][]byte
+
+	// fragments holds bounded in-flight DATA_FRAG samples. Camera messages are
+	// routinely larger than one UDP datagram; without this reassembly the DDS
+	// reader can discover image topics but can never receive a frame from them.
+	fragments     map[fragmentKey]*fragmentSet
+	fragmentBytes int
 }
 
 // WriterHistogram reports how many DATA and HEARTBEAT submessages arrived per
@@ -196,10 +225,13 @@ func NewParticipant(cfg Config) (*Participant, error) {
 		seenData:    map[uint32]int{},
 		seenHB:      map[uint32]int{},
 		unmatched:   map[GUID]int{},
-		samples:     make(chan Sample, 64),
+		// Four maximum-sized image samples cap queued payload memory at 64 MiB;
+		// the channel is lossy by design, so a slow consumer gets newer frames.
+		samples:     make(chan Sample, 4),
 		discov:      make(chan Endpoint, 32),
 		nextEntity:  1,
 		seqByWriter: map[uint32]SequenceNumber{},
+		fragments:   map[fragmentKey]*fragmentSet{},
 	}
 	if _, err := rand.Read(p.prefix[:]); err != nil {
 		return nil, fmt.Errorf("rtps: generating GUID prefix: %w", err)
@@ -207,16 +239,24 @@ func NewParticipant(cfg Config) (*Participant, error) {
 	// The first two octets of a GUID prefix are conventionally the vendor ID.
 	p.prefix[0], p.prefix[1] = 0x01, 0x0f
 
-	iface, err := p.resolveInterface()
-	if err != nil {
+	if err := withNetworkNamespace(cfg.NetworkNamespacePID, p.openSockets); err != nil {
+		_ = p.Close()
 		return nil, err
 	}
+	return p, nil
+}
 
-	mport := spdpMulticastPort(cfg.DomainID)
+func (p *Participant) openSockets() error {
+	iface, err := p.resolveInterface()
+	if err != nil {
+		return err
+	}
+
+	mport := spdpMulticastPort(p.cfg.DomainID)
 	group := &net.UDPAddr{IP: net.ParseIP(spdpMulticastAddr), Port: mport}
 	mc, err := net.ListenMulticastUDP("udp4", iface, group)
 	if err != nil {
-		return nil, fmt.Errorf("rtps: joining %s:%d: %w", spdpMulticastAddr, mport, err)
+		return fmt.Errorf("rtps: joining %s:%d: %w", spdpMulticastAddr, mport, err)
 	}
 	_ = mc.SetReadBuffer(2 << 20)
 	p.mcast = mc
@@ -224,16 +264,11 @@ func NewParticipant(cfg Config) (*Participant, error) {
 	uc, err := net.ListenUDP("udp4", &net.UDPAddr{IP: p.local, Port: 0})
 	if err != nil {
 		mc.Close()
-		return nil, fmt.Errorf("rtps: binding unicast socket: %w", err)
+		return fmt.Errorf("rtps: binding unicast socket: %w", err)
 	}
 	_ = uc.SetReadBuffer(4 << 20)
 	p.ucast = uc
 
-	// Pin outbound multicast to the same interface. Binding the socket's source
-	// address is not enough: Linux selects the egress interface for a multicast
-	// destination from IP_MULTICAST_IF and the route table, so on a device with
-	// both WiFi and a robot network the announcements otherwise leave by the
-	// wrong one and nothing ever discovers us.
 	if err := ipv4.NewPacketConn(uc).SetMulticastInterface(iface); err != nil {
 		p.logf("warning: pinning multicast egress to %s failed: %v", iface.Name, err)
 	} else {
@@ -242,10 +277,9 @@ func NewParticipant(cfg Config) (*Participant, error) {
 	if err := ipv4.NewPacketConn(uc).SetMulticastTTL(4); err != nil {
 		p.logf("warning: setting multicast TTL failed: %v", err)
 	}
-
 	p.logf("participant %x on domain %d, unicast %s, multicast %s:%d",
-		p.prefix, cfg.DomainID, uc.LocalAddr(), spdpMulticastAddr, mport)
-	return p, nil
+		p.prefix, p.cfg.DomainID, uc.LocalAddr(), spdpMulticastAddr, mport)
+	return nil
 }
 
 // resolveInterface picks the interface to bind multicast to and records its
@@ -407,6 +441,22 @@ func (p *Participant) handle(pkt []byte, src *net.UDPAddr) {
 				p.statUserData.Add(1)
 				p.handleUserData(msg.Prefix, d)
 			}
+		case subDATAFRAG:
+			p.statData.Add(1)
+			f, err := ParseDataFrag(s)
+			if err != nil {
+				p.statDataErr.Add(1)
+				continue
+			}
+			// Builtin discovery traffic is small DATA, never DATA_FRAG. Treat a
+			// fragmented builtin writer as malformed instead of feeding it to the
+			// user-data reassembler.
+			if f.WriterID == entitySPDPWriter || f.WriterID == entitySEDPPubWriter {
+				p.statDataErr.Add(1)
+				continue
+			}
+			p.statUserData.Add(1)
+			p.handleUserDataFrag(msg.Prefix, f)
 		}
 	}
 }
@@ -574,7 +624,10 @@ func (p *Participant) handleSEDPPublication(d *DataSubmessage) {
 // running — which shows up as spurious "payload too short" errors from small
 // messages of entirely unrelated topics.
 func (p *Participant) handleUserData(prefix GUIDPrefix, d *DataSubmessage) {
-	writer := GUID{Prefix: prefix, EntityID: d.WriterID}
+	p.deliverUserData(GUID{Prefix: prefix, EntityID: d.WriterID}, d.WriterSN, d.Payload)
+}
+
+func (p *Participant) deliverUserData(writer GUID, sn SequenceNumber, payload []byte) {
 	p.mu.Lock()
 	_, subscribed := p.subWriters[writer]
 	p.mu.Unlock()
@@ -589,13 +642,118 @@ func (p *Participant) handleUserData(prefix GUIDPrefix, d *DataSubmessage) {
 		return
 	}
 	s := Sample{
-		Writer:  GUID{Prefix: prefix, EntityID: d.WriterID},
-		SN:      d.WriterSN,
-		Payload: d.Payload,
+		Writer:  writer,
+		SN:      sn,
+		Payload: payload,
 	}
 	select {
 	case p.samples <- s:
 	default: // drop rather than block the read loop; the newest sample wins
+	}
+}
+
+// handleUserDataFrag reassembles one bounded serialized sample and delivers it
+// through the same subscription filter as ordinary DATA. Old/incomplete sets
+// are discarded so a publisher disappearing mid-frame cannot retain memory.
+func (p *Participant) handleUserDataFrag(prefix GUIDPrefix, f *DataFragSubmessage) {
+	if f.SampleSize > maxSampleSize {
+		p.statDataErr.Add(1)
+		return
+	}
+	writer := GUID{Prefix: prefix, EntityID: f.WriterID}
+	p.mu.Lock()
+	if _, subscribed := p.subWriters[writer]; !subscribed {
+		p.mu.Unlock()
+		return
+	}
+
+	now := time.Now()
+	for key, set := range p.fragments {
+		if now.Sub(set.updated) > fragmentSetTTL {
+			p.dropFragmentSetLocked(key)
+		}
+	}
+	key := fragmentKey{writer: writer, sn: f.WriterSN}
+	set := p.fragments[key]
+	fragmentCount := (int(f.SampleSize) + int(f.FragmentSize) - 1) / int(f.FragmentSize)
+	if fragmentCount > maxSampleFragments {
+		p.mu.Unlock()
+		p.statDataErr.Add(1)
+		return
+	}
+	if set == nil {
+		for len(p.fragments) >= maxFragmentSets || p.fragmentBytes+int(f.SampleSize) > maxFragmentBytes {
+			var oldestKey fragmentKey
+			var oldest time.Time
+			for candidate, existing := range p.fragments {
+				if oldest.IsZero() || existing.updated.Before(oldest) {
+					oldestKey, oldest = candidate, existing.updated
+				}
+			}
+			p.dropFragmentSetLocked(oldestKey)
+		}
+		set = &fragmentSet{
+			buf:          make([]byte, int(f.SampleSize)),
+			received:     make([]bool, fragmentCount),
+			fragmentSize: int(f.FragmentSize),
+			updated:      now,
+		}
+		p.fragments[key] = set
+		p.fragmentBytes += len(set.buf)
+	} else if len(set.buf) != int(f.SampleSize) || set.fragmentSize != int(f.FragmentSize) {
+		p.dropFragmentSetLocked(key)
+		p.mu.Unlock()
+		p.statDataErr.Add(1)
+		return
+	}
+
+	start := int(f.FragmentStartingNum) - 1
+	payloadPos := 0
+	valid := true
+	for i := 0; i < int(f.FragmentsInSubmessage); i++ {
+		fragmentIndex := start + i
+		if fragmentIndex < 0 || fragmentIndex >= len(set.received) {
+			valid = false
+			break
+		}
+		offset := fragmentIndex * set.fragmentSize
+		n := set.fragmentSize
+		if remaining := len(set.buf) - offset; n > remaining {
+			n = remaining
+		}
+		if n < 0 || payloadPos+n > len(f.Payload) {
+			valid = false
+			break
+		}
+		copy(set.buf[offset:offset+n], f.Payload[payloadPos:payloadPos+n])
+		payloadPos += n
+		if !set.received[fragmentIndex] {
+			set.received[fragmentIndex] = true
+			set.receivedCount++
+		}
+	}
+	set.updated = now
+	if !valid {
+		p.dropFragmentSetLocked(key)
+		p.mu.Unlock()
+		p.statDataErr.Add(1)
+		return
+	}
+	if set.receivedCount != len(set.received) {
+		p.mu.Unlock()
+		return
+	}
+	payload := set.buf
+	p.dropFragmentSetLocked(key)
+	p.mu.Unlock()
+
+	p.deliverUserData(writer, f.WriterSN, payload)
+}
+
+func (p *Participant) dropFragmentSetLocked(key fragmentKey) {
+	if set := p.fragments[key]; set != nil {
+		p.fragmentBytes -= len(set.buf)
+		delete(p.fragments, key)
 	}
 }
 

--- a/go/internal/rtps/participant.go
+++ b/go/internal/rtps/participant.go
@@ -3,6 +3,7 @@ package rtps
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"net"
 	"sync"
@@ -259,6 +260,13 @@ func verifyNamespaceTarget(pid uint32, verify func() bool) error {
 		return fmt.Errorf("rtps: network namespace process %d changed", pid)
 	}
 	return nil
+}
+
+func combineNamespaceRestoreError(operationErr, restoreErr error) error {
+	if restoreErr == nil {
+		return operationErr
+	}
+	return errors.Join(operationErr, fmt.Errorf("rtps: restoring host network namespace: %w", restoreErr))
 }
 
 func (p *Participant) openSockets() error {

--- a/go/internal/rtps/wire.go
+++ b/go/internal/rtps/wire.go
@@ -3,8 +3,8 @@
 //
 // It is not a DDS implementation. There is no reliable-reader state machine
 // (a BEST_EFFORT reader matches a RELIABLE writer under the RxO rule, which is
-// what ROS 2's default QoS offers), no DATA_FRAG reassembly, no security, no
-// content filtering, and no instance/dispose handling.
+// what ROS 2's default QoS offers), bounded DATA_FRAG reassembly, no security,
+// no content filtering, and no instance/dispose handling.
 package rtps
 
 import (
@@ -29,6 +29,7 @@ const (
 	subINFO_SRC  = 0x0c
 	subINFO_DST  = 0x0e
 	subDATA      = 0x15
+	subDATAFRAG  = 0x16
 )
 
 // Builtin entity IDs. The suffix encodes the entity kind, so these constants
@@ -203,6 +204,21 @@ type DataSubmessage struct {
 	Payload   []byte // serialized payload, including its encapsulation header
 }
 
+// DataFragSubmessage is a parsed DATA_FRAG submessage. Fragment numbers are
+// one-based, as they are on the RTPS wire. Payload contains the serialized
+// bytes carried by the consecutive fragments in this submessage.
+type DataFragSubmessage struct {
+	ReaderID              uint32
+	WriterID              uint32
+	WriterSN              SequenceNumber
+	FragmentStartingNum   uint32
+	FragmentsInSubmessage uint16
+	FragmentSize          uint16
+	SampleSize            uint32
+	InlineQoS             []byte
+	Payload               []byte
+}
+
 // ParseData decodes a DATA submessage body.
 //
 // Layout: extraFlags(2) octetsToInlineQos(2) readerId(4) writerId(4)
@@ -253,6 +269,46 @@ func ParseData(s Submessage) (*DataSubmessage, error) {
 		d.Payload = b[pos:]
 	}
 	return d, nil
+}
+
+// ParseDataFrag decodes a DATA_FRAG submessage body (RTPS 2.3, 8.3.7.3.4).
+// octetsToInlineQos has the same origin as DATA: immediately after the field
+// itself, so a stock header's value 28 lands at byte offset 32.
+func ParseDataFrag(s Submessage) (*DataFragSubmessage, error) {
+	b, order := s.Body, s.Endian
+	if len(b) < 32 {
+		return nil, ErrShort
+	}
+	octetsToInlineQos := int(order.Uint16(b[2:4]))
+	f := &DataFragSubmessage{
+		ReaderID:              binary.BigEndian.Uint32(b[4:8]),
+		WriterID:              binary.BigEndian.Uint32(b[8:12]),
+		FragmentStartingNum:   order.Uint32(b[20:24]),
+		FragmentsInSubmessage: order.Uint16(b[24:26]),
+		FragmentSize:          order.Uint16(b[26:28]),
+		SampleSize:            order.Uint32(b[28:32]),
+	}
+	hi := int64(int32(order.Uint32(b[12:16])))
+	lo := int64(order.Uint32(b[16:20]))
+	f.WriterSN = SequenceNumber(hi<<32 | lo)
+
+	if f.FragmentStartingNum == 0 || f.FragmentsInSubmessage == 0 || f.FragmentSize == 0 || f.SampleSize == 0 {
+		return nil, errors.New("rtps: invalid DATA_FRAG dimensions")
+	}
+	pos := 4 + octetsToInlineQos
+	if pos < 32 || pos > len(b) {
+		return nil, fmt.Errorf("rtps: DATA_FRAG octetsToInlineQos %d out of range", octetsToInlineQos)
+	}
+	if s.Flags&0x02 != 0 {
+		n, err := parameterListLength(b[pos:], order)
+		if err != nil {
+			return nil, fmt.Errorf("rtps: DATA_FRAG inline QoS: %w", err)
+		}
+		f.InlineQoS = b[pos : pos+n]
+		pos += n
+	}
+	f.Payload = b[pos:]
+	return f, nil
 }
 
 // buildMessage assembles a datagram: the RTPS header followed by submessages.

--- a/go/internal/rtps/wire_test.go
+++ b/go/internal/rtps/wire_test.go
@@ -2,7 +2,9 @@ package rtps
 
 import (
 	"encoding/binary"
+	"strings"
 	"testing"
+	"time"
 )
 
 // dataSubmessage builds a little-endian DATA submessage carrying payload,
@@ -177,6 +179,49 @@ func TestParticipant_ReassemblesDataFragOutOfOrder(t *testing.T) {
 		}
 	default:
 		t.Fatal("completed fragmented sample was not delivered")
+	}
+}
+
+func TestParticipant_ExpiresIncompleteDataFragWithoutMoreTraffic(t *testing.T) {
+	key := fragmentKey{writer: GUID{EntityID: 0x00032102}, sn: 9}
+	p := &Participant{
+		fragments: map[fragmentKey]*fragmentSet{
+			key: {buf: make([]byte, 32), updated: time.Now().Add(-fragmentSetTTL - time.Second)},
+		},
+		fragmentBytes: 32,
+	}
+	p.expireFragmentSets(time.Now())
+	if len(p.fragments) != 0 || p.fragmentBytes != 0 {
+		t.Fatalf("expired fragments retained: sets=%d bytes=%d", len(p.fragments), p.fragmentBytes)
+	}
+}
+
+func TestParticipant_RejectsFragmentedBuiltinSubscriptionWriter(t *testing.T) {
+	remote := GUIDPrefix{9}
+	p := &Participant{prefix: GUIDPrefix{1}}
+	sub := dataFragSubmessage(0, entitySEDPSubWriter, 1, 1, 1, 4, 4, []byte("data"))
+	p.handle(rtpsDatagram(remote, sub), nil)
+	stats := p.Stats()
+	if stats.DataParseErrors != 1 || stats.UserDataMessages != 0 {
+		t.Fatalf("stats = %+v; want one parse error and no user data", stats)
+	}
+}
+
+func TestParticipant_VerifiesNamespaceBeforeOpeningSockets(t *testing.T) {
+	called := false
+	p := &Participant{cfg: Config{
+		NetworkNamespacePID: 42,
+		VerifyNetworkNamespace: func() bool {
+			called = true
+			return false
+		},
+	}}
+	err := p.openVerifiedSockets()
+	if !called || err == nil || !strings.Contains(err.Error(), "process 42 changed") {
+		t.Fatalf("called=%v error=%v; want verifier rejection before socket setup", called, err)
+	}
+	if p.mcast != nil || p.ucast != nil {
+		t.Fatal("namespace verifier rejection still opened RTPS sockets")
 	}
 }
 

--- a/go/internal/rtps/wire_test.go
+++ b/go/internal/rtps/wire_test.go
@@ -2,6 +2,7 @@ package rtps
 
 import (
 	"encoding/binary"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -215,6 +216,15 @@ func TestParticipant_VerifiesNamespaceTargetBeforeEntry(t *testing.T) {
 	})
 	if !called || err == nil || !strings.Contains(err.Error(), "process 42 changed") {
 		t.Fatalf("called=%v error=%v; want verifier rejection before namespace entry", called, err)
+	}
+}
+
+func TestParticipant_PreservesOperationAndNamespaceRestoreErrors(t *testing.T) {
+	operationErr := errors.New("opening sockets")
+	restoreErr := errors.New("setns host")
+	err := combineNamespaceRestoreError(operationErr, restoreErr)
+	if !errors.Is(err, operationErr) || !errors.Is(err, restoreErr) {
+		t.Fatalf("combined error = %v; want both operation and restore errors", err)
 	}
 }
 

--- a/go/internal/rtps/wire_test.go
+++ b/go/internal/rtps/wire_test.go
@@ -24,6 +24,21 @@ func dataSubmessage(readerID, writerID uint32, sn uint64, payload []byte) []byte
 	return append(out, body...)
 }
 
+func dataFragSubmessage(readerID, writerID uint32, sn uint64, start uint32, count, fragmentSize uint16, sampleSize uint32, payload []byte) []byte {
+	body := make([]byte, 32)
+	binary.LittleEndian.PutUint16(body[2:4], 28)
+	binary.BigEndian.PutUint32(body[4:8], readerID)
+	binary.BigEndian.PutUint32(body[8:12], writerID)
+	binary.LittleEndian.PutUint32(body[12:16], uint32(sn>>32))
+	binary.LittleEndian.PutUint32(body[16:20], uint32(sn))
+	binary.LittleEndian.PutUint32(body[20:24], start)
+	binary.LittleEndian.PutUint16(body[24:26], count)
+	binary.LittleEndian.PutUint16(body[26:28], fragmentSize)
+	binary.LittleEndian.PutUint32(body[28:32], sampleSize)
+	body = append(body, payload...)
+	return buildSubmessage(subDATAFRAG, 0, body)
+}
+
 func rtpsDatagram(prefix GUIDPrefix, subs ...[]byte) []byte {
 	out := []byte{'R', 'T', 'P', 'S', 2, 2, 0x01, 0x0f}
 	out = append(out, prefix[:]...)
@@ -115,6 +130,53 @@ func TestParseData_SequenceNumberIsHighLow(t *testing.T) {
 	}
 	if d.WriterSN != SequenceNumber(1<<32|2) {
 		t.Errorf("WriterSN = %d, want %d", d.WriterSN, int64(1<<32|2))
+	}
+}
+
+func TestParseDataFrag(t *testing.T) {
+	sub := dataFragSubmessage(0, 0x00032102, 1<<32|7, 3, 2, 1024, 5000, []byte("fragment bytes"))
+	msg, err := ParseMessage(rtpsDatagram(GUIDPrefix{}, sub))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := ParseDataFrag(msg.Submessages[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.WriterID != 0x00032102 || f.WriterSN != SequenceNumber(1<<32|7) ||
+		f.FragmentStartingNum != 3 || f.FragmentsInSubmessage != 2 ||
+		f.FragmentSize != 1024 || f.SampleSize != 5000 || string(f.Payload) != "fragment bytes" {
+		t.Fatalf("parsed DATA_FRAG = %+v payload=%q", f, f.Payload)
+	}
+}
+
+func TestParticipant_ReassemblesDataFragOutOfOrder(t *testing.T) {
+	writer := GUID{EntityID: 0x00032102}
+	p := &Participant{
+		subWriters: map[GUID]struct{}{writer: {}},
+		fragments:  map[fragmentKey]*fragmentSet{},
+		samples:    make(chan Sample, 1),
+		unmatched:  map[GUID]int{},
+	}
+	p.handleUserDataFrag(writer.Prefix, &DataFragSubmessage{
+		WriterID: writer.EntityID, WriterSN: 9, FragmentStartingNum: 2,
+		FragmentsInSubmessage: 1, FragmentSize: 4, SampleSize: 10, Payload: []byte("efgh"),
+	})
+	p.handleUserDataFrag(writer.Prefix, &DataFragSubmessage{
+		WriterID: writer.EntityID, WriterSN: 9, FragmentStartingNum: 1,
+		FragmentsInSubmessage: 1, FragmentSize: 4, SampleSize: 10, Payload: []byte("abcd"),
+	})
+	p.handleUserDataFrag(writer.Prefix, &DataFragSubmessage{
+		WriterID: writer.EntityID, WriterSN: 9, FragmentStartingNum: 3,
+		FragmentsInSubmessage: 1, FragmentSize: 4, SampleSize: 10, Payload: []byte("ij"),
+	})
+	select {
+	case sample := <-p.samples:
+		if string(sample.Payload) != "abcdefghij" {
+			t.Fatalf("payload = %q", sample.Payload)
+		}
+	default:
+		t.Fatal("completed fragmented sample was not delivered")
 	}
 }
 

--- a/go/internal/rtps/wire_test.go
+++ b/go/internal/rtps/wire_test.go
@@ -207,21 +207,14 @@ func TestParticipant_RejectsFragmentedBuiltinSubscriptionWriter(t *testing.T) {
 	}
 }
 
-func TestParticipant_VerifiesNamespaceBeforeOpeningSockets(t *testing.T) {
+func TestParticipant_VerifiesNamespaceTargetBeforeEntry(t *testing.T) {
 	called := false
-	p := &Participant{cfg: Config{
-		NetworkNamespacePID: 42,
-		VerifyNetworkNamespace: func() bool {
-			called = true
-			return false
-		},
-	}}
-	err := p.openVerifiedSockets()
+	err := verifyNamespaceTarget(42, func() bool {
+		called = true
+		return false
+	})
 	if !called || err == nil || !strings.Contains(err.Error(), "process 42 changed") {
-		t.Fatalf("called=%v error=%v; want verifier rejection before socket setup", called, err)
-	}
-	if p.mcast != nil || p.ucast != nil {
-		t.Fatal("namespace verifier rejection still opened RTPS sockets")
+		t.Fatalf("called=%v error=%v; want verifier rejection before namespace entry", called, err)
 	}
 }
 

--- a/go/proto/gen/agentpb/wendy_agent_v1_video_service.pb.go
+++ b/go/proto/gen/agentpb/wendy_agent_v1_video_service.pb.go
@@ -28,6 +28,7 @@ const (
 	VideoTransport_VIDEO_TRANSPORT_USB     VideoTransport = 1
 	VideoTransport_VIDEO_TRANSPORT_CSI     VideoTransport = 2
 	VideoTransport_VIDEO_TRANSPORT_IP      VideoTransport = 3
+	VideoTransport_VIDEO_TRANSPORT_ROS2    VideoTransport = 4
 )
 
 // Enum value maps for VideoTransport.
@@ -37,12 +38,14 @@ var (
 		1: "VIDEO_TRANSPORT_USB",
 		2: "VIDEO_TRANSPORT_CSI",
 		3: "VIDEO_TRANSPORT_IP",
+		4: "VIDEO_TRANSPORT_ROS2",
 	}
 	VideoTransport_value = map[string]int32{
 		"VIDEO_TRANSPORT_UNKNOWN": 0,
 		"VIDEO_TRANSPORT_USB":     1,
 		"VIDEO_TRANSPORT_CSI":     2,
 		"VIDEO_TRANSPORT_IP":      3,
+		"VIDEO_TRANSPORT_ROS2":    4,
 	}
 )
 
@@ -184,6 +187,7 @@ type VideoDevice struct {
 	Mac            string                 `protobuf:"bytes,9,opt,name=mac,proto3" json:"mac,omitempty"`                                                          // stable identity for network cameras; empty for local cameras
 	HasCredentials bool                   `protobuf:"varint,10,opt,name=has_credentials,json=hasCredentials,proto3" json:"has_credentials,omitempty"`            // the agent holds a login for this camera
 	Online         bool                   `protobuf:"varint,11,opt,name=online,proto3" json:"online,omitempty"`                                                  // the most recent probe reached this camera
+	Topic          string                 `protobuf:"bytes,12,opt,name=topic,proto3" json:"topic,omitempty"`                                                     // ROS 2 image topic, e.g. "/camera/image_raw"; empty for other transports
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -293,6 +297,13 @@ func (x *VideoDevice) GetOnline() bool {
 		return x.Online
 	}
 	return false
+}
+
+func (x *VideoDevice) GetTopic() string {
+	if x != nil {
+		return x.Topic
+	}
+	return ""
 }
 
 type ListVideoDevicesRequest struct {
@@ -875,7 +886,7 @@ var File_wendy_agent_services_v1_wendy_agent_v1_video_service_proto protoreflect
 
 const file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDesc = "" +
 	"\n" +
-	":wendy/agent/services/v1/wendy_agent_v1_video_service.proto\x12\x17wendy.agent.services.v1\"\xca\x02\n" +
+	":wendy/agent/services/v1/wendy_agent_v1_video_service.proto\x12\x17wendy.agent.services.v1\"\xe0\x02\n" +
 	"\vVideoDevice\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\rR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x12\n" +
@@ -888,7 +899,8 @@ const file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDesc = 
 	"\x03mac\x18\t \x01(\tR\x03mac\x12'\n" +
 	"\x0fhas_credentials\x18\n" +
 	" \x01(\bR\x0ehasCredentials\x12\x16\n" +
-	"\x06online\x18\v \x01(\bR\x06online\"\x19\n" +
+	"\x06online\x18\v \x01(\bR\x06online\x12\x14\n" +
+	"\x05topic\x18\f \x01(\tR\x05topic\"\x19\n" +
 	"\x17ListVideoDevicesRequest\"Z\n" +
 	"\x18ListVideoDevicesResponse\x12>\n" +
 	"\adevices\x18\x01 \x03(\v2$.wendy.agent.services.v1.VideoDeviceR\adevices\"}\n" +
@@ -923,12 +935,13 @@ const file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDesc = 
 	"VideoFrame\x12\x12\n" +
 	"\x04data\x18\x01 \x01(\fR\x04data\x12!\n" +
 	"\ftimestamp_ns\x18\x02 \x01(\x04R\vtimestampNs\x129\n" +
-	"\x05codec\x18\x03 \x01(\x0e2#.wendy.agent.services.v1.VideoCodecR\x05codec*w\n" +
+	"\x05codec\x18\x03 \x01(\x0e2#.wendy.agent.services.v1.VideoCodecR\x05codec*\x91\x01\n" +
 	"\x0eVideoTransport\x12\x1b\n" +
 	"\x17VIDEO_TRANSPORT_UNKNOWN\x10\x00\x12\x17\n" +
 	"\x13VIDEO_TRANSPORT_USB\x10\x01\x12\x17\n" +
 	"\x13VIDEO_TRANSPORT_CSI\x10\x02\x12\x16\n" +
-	"\x12VIDEO_TRANSPORT_IP\x10\x03*7\n" +
+	"\x12VIDEO_TRANSPORT_IP\x10\x03\x12\x18\n" +
+	"\x14VIDEO_TRANSPORT_ROS2\x10\x04*7\n" +
 	"\n" +
 	"VideoCodec\x12\x14\n" +
 	"\x10VIDEO_CODEC_H264\x10\x00\x12\x13\n" +


### PR DESCRIPTION
## Summary

- discover ROS 2 image publishers on robot-facing domain 0 interfaces and inside each running Wendy ROS 2 app's network namespace
- expose each topic as a stable v4l2loopback camera in the `/dev/video128`–`/dev/video199` band, with demand-driven frame pumping through the existing video service
- make ROS 2 cameras appear in `wendy device camera list` and stream through `wendy device camera view`
- support `sensor_msgs/msg/Image`, `sensor_msgs/msg/CompressedImage`, and Unitree Go2 `unitree_go/msg/Go2FrontVideoData` (`/frontvideostream`)
- add bounded RTPS `DATA_FRAG` reassembly for camera-sized DDS samples

## Implementation notes

Compressed JPEG messages are passed through to the loopback node. Common raw encodings (`mono8`, `mono16`, `rgb8`, `bgr8`, `rgba8`, and `bgra8`) are converted to MJPEG. Go2 front-video samples prefer the 720p field and fall back to 360p or 180p.

App-scoped discovery creates only the DDS sockets inside the app network namespace, then verifies the container identity/PID before publishing discovery traffic. Fragment and queued-sample memory are bounded.

## Validation

- `go test -race ./internal/rtps/... ./internal/agent/ros2camera ./internal/agent/services`
- `go test ./internal/agent/containerd ./internal/agent/ipcam`
- `go vet ./internal/rtps/... ./internal/agent/ros2camera ./internal/agent/services ./cmd/wendy-agent`
- Linux ARM64 build: `GOOS=linux GOARCH=arm64 go build ./cmd/wendy-agent`
- focused ROS 2 camera CLI tests pass
- `go test ./...` passes except the existing macOS temp-path alias assertion in `TestBuildCmd_MultiService_BuildsFromManifestOnly` (`/private/var/...` vs `/var/...`)