### PR TITLE
ci: select Wendy-owned self-hosted macOS runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,7 +5,8 @@ self-hosted-runner:
     - Linux
     - X64
     - macOS
-    - macos-26
+    - wendy-linux
+    - wendy-macos-26
 
 config-variables: null
 

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,7 +5,6 @@ self-hosted-runner:
     - Linux
     - X64
     - macOS
-    - wendy-linux
     - wendy-macos-26
 
 config-variables: null

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -265,7 +265,7 @@ jobs:
     name: ${{ matrix.artifact-name }}
     runs-on:
       group: wendy-developer
-      labels: [self-hosted, macOS, ARM64]
+      labels: [self-hosted, macOS, ARM64, wendy-macos-26]
     needs: [determine-version]
     # Attest SLSA build provenance in the job that produces the archive, so the
     # provenance reflects the actual build environment (not a downstream job).
@@ -341,7 +341,7 @@ jobs:
     name: wendy-agent-macos-app
     runs-on:
       group: wendy-developer
-      labels: [self-hosted, macOS, ARM64]
+      labels: [self-hosted, macOS, ARM64, wendy-macos-26]
     timeout-minutes: 45
     needs: [determine-version]
     steps:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -404,7 +404,7 @@ jobs:
       (inputs.platform == 'all' || inputs.platform == 'linux')
     runs-on:
       group: wendy-developer
-      labels: [self-hosted, Linux, wendy-linux]
+      labels: [self-hosted, Linux]
     concurrency:
       group: device-${{ matrix.hostname }}
       cancel-in-progress: false

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -56,7 +56,7 @@ jobs:
     if: inputs.jobs == 'all' || inputs.jobs == 'discover' || inputs.jobs == 'integration'
     runs-on:
       group: wendy-developer
-      labels: [self-hosted, '${{ matrix.runner.os }}', '${{ matrix.runner.arch }}']
+      labels: [self-hosted, '${{ matrix.runner.os }}', '${{ matrix.runner.arch }}', '${{ matrix.runner.wendy_label }}']
     timeout-minutes: 10
     outputs:
       matrix: ${{ steps.explicit.outputs.matrix || steps.scan.outputs.matrix || '[]' }}
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         runner:
-          - { name: macOS, os: macOS, arch: ARM64 }
+          - { name: macOS, os: macOS, arch: ARM64, wendy_label: wendy-macos-26 }
     steps:
       - name: Resolve explicit device
         id: explicit
@@ -245,7 +245,7 @@ jobs:
       (inputs.platform == 'all' || inputs.platform == 'macos')
     runs-on:
       group: wendy-developer
-      labels: [self-hosted, macOS, ARM64]
+      labels: [self-hosted, macOS, ARM64, wendy-macos-26]
     concurrency:
       group: device-${{ matrix.hostname }}
       cancel-in-progress: false
@@ -404,7 +404,7 @@ jobs:
       (inputs.platform == 'all' || inputs.platform == 'linux')
     runs-on:
       group: wendy-developer
-      labels: [self-hosted, Linux]
+      labels: [self-hosted, Linux, wendy-linux]
     concurrency:
       group: device-${{ matrix.hostname }}
       cancel-in-progress: false

--- a/.github/workflows/nightly-os-update.yml
+++ b/.github/workflows/nightly-os-update.yml
@@ -17,7 +17,7 @@ jobs:
     name: Discover devices
     runs-on:
       group: wendy-developer
-      labels: [self-hosted, macOS, ARM64]
+      labels: [self-hosted, macOS, ARM64, wendy-macos-26]
     outputs:
       matrix: ${{ steps.scan.outputs.matrix }}
     steps:
@@ -59,7 +59,7 @@ jobs:
     if: needs.discover.outputs.matrix != '[]'
     runs-on:
       group: wendy-developer
-      labels: [self-hosted, macOS, ARM64]
+      labels: [self-hosted, macOS, ARM64, wendy-macos-26]
     concurrency:
       group: device-${{ matrix.hostname }}
       cancel-in-progress: false

--- a/.github/workflows/swift-e2e-tests.yml
+++ b/.github/workflows/swift-e2e-tests.yml
@@ -125,7 +125,7 @@ jobs:
   #   name: macOS 26 → Ubuntu 24
   #   needs: swift-e2e-local-ubuntu
   #   if: ${{ inputs.target_group == '' || inputs.target_group == 'all' }}
-  #   runs-on: [self-hosted, macos-26]
+  #   runs-on: [self-hosted, macOS, ARM64, wendy-macos-26]
   #   concurrency:
   #     group: device-ubuntu-24
   #     cancel-in-progress: false
@@ -137,7 +137,7 @@ jobs:
   #       with:
   #         tests: ${{ inputs.tests || '' }}
   #         target_id: macos-ubuntu-24
-  #         runner_id: macos-26
+  #         runner_id: wendy-macos-26
   #         cli_os: macOS
   #         device_address: ${{ vars.SWIFT_E2E_UBUNTU_24_DEVICE_ADDRESS }}
   #         agent_os: linux
@@ -151,7 +151,7 @@ jobs:
   #   name: macOS 26 → Jetson Orin Nano
   #   needs: swift-e2e-local-ubuntu
   #   if: ${{ inputs.target_group == '' || inputs.target_group == 'all' }}
-  #   runs-on: [self-hosted, macos-26]
+  #   runs-on: [self-hosted, macOS, ARM64, wendy-macos-26]
   #   concurrency:
   #     group: device-jetson-orin-nano
   #     cancel-in-progress: false
@@ -163,7 +163,7 @@ jobs:
   #       with:
   #         tests: ${{ inputs.tests || '' }}
   #         target_id: macos-jetson-orin-nano
-  #         runner_id: macos-26
+  #         runner_id: wendy-macos-26
   #         cli_os: macOS
   #         device_address: ${{ vars.SWIFT_E2E_JETSON_ORIN_NANO_DEVICE_ADDRESS }}
   #         agent_os: wendyOS
@@ -326,7 +326,7 @@ jobs:
   #   name: macOS 26 → Mac mini
   #   needs: swift-e2e-local-macos
   #   if: ${{ inputs.target_group == '' || inputs.target_group == 'all' }}
-  #   runs-on: [self-hosted, macos-26]
+  #   runs-on: [self-hosted, macOS, ARM64, wendy-macos-26]
   #   concurrency:
   #     group: device-mac-mini
   #     cancel-in-progress: false
@@ -338,7 +338,7 @@ jobs:
   #       with:
   #         tests: ${{ inputs.tests || '' }}
   #         target_id: macos-mac-mini
-  #         runner_id: macos-26
+  #         runner_id: wendy-macos-26
   #         cli_os: macOS
   #         device_address: mac-mini.local
   #         agent_os: macOS
@@ -376,7 +376,7 @@ jobs:
   #   name: macOS 26 → Raspberry Pi 5
   #   needs: swift-e2e-local-ubuntu
   #   if: ${{ inputs.target_group == '' || inputs.target_group == 'all' }}
-  #   runs-on: [self-hosted, macos-26]
+  #   runs-on: [self-hosted, macOS, ARM64, wendy-macos-26]
   #   concurrency:
   #     group: device-raspberry-pi-5
   #     cancel-in-progress: false
@@ -388,7 +388,7 @@ jobs:
   #       with:
   #         tests: ${{ inputs.tests || '' }}
   #         target_id: macos-raspberry-pi-5
-  #         runner_id: macos-26
+  #         runner_id: wendy-macos-26
   #         cli_os: macOS
   #         device_address: wendyos-raspberry-pi-5.local
   #         agent_os: wendyOS

--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -234,7 +234,7 @@ jobs:
       matrix:
         runner:
           - { name: macOS, labels: [self-hosted, macOS, ARM64, wendy-macos-26] }
-          - { name: Linux, labels: [self-hosted, Linux, X64, wendy-linux] }
+          - { name: Linux, labels: [self-hosted, Linux, X64] }
         hostname: ${{ fromJson(needs.resolve-deploy-devices.outputs.matrix) }}
     env:
       INPUT_HOSTNAME: ${{ matrix.hostname }}

--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -115,7 +115,7 @@ jobs:
     if: inputs.deploy == true
     runs-on:
       group: wendy-developer
-      labels: [self-hosted, macOS, ARM64]
+      labels: [self-hosted, macOS, ARM64, wendy-macos-26]
     timeout-minutes: 10
     outputs:
       matrix: ${{ steps.explicit.outputs.matrix || steps.scan.outputs.matrix || '[]' }}
@@ -233,8 +233,8 @@ jobs:
       fail-fast: false
       matrix:
         runner:
-          - { name: macOS, labels: [self-hosted, macOS, ARM64] }
-          - { name: Linux, labels: [self-hosted, Linux, X64] }
+          - { name: macOS, labels: [self-hosted, macOS, ARM64, wendy-macos-26] }
+          - { name: Linux, labels: [self-hosted, Linux, X64, wendy-linux] }
         hostname: ${{ fromJson(needs.resolve-deploy-devices.outputs.matrix) }}
     env:
       INPUT_HOSTNAME: ${{ matrix.hostname }}


### PR DESCRIPTION
> **In plain terms:** GitHub's `macos-26` name can mean a hosted Mac, but a persistent Wendy runner was using the same name. Private macOS jobs now request a Wendy-specific label, so hosted jobs stay on GitHub's disposable machines and private jobs reach the intended Wendy Mac.

## Summary
- Require `wendy-macos-26` on self-hosted macOS jobs.
- Preserve the `wendy-developer` runner group and GitHub's default OS and architecture constraints.
- Update dormant self-hosted macOS examples and actionlint's custom-label inventory.
- Leave Linux routing and active GitHub-hosted `runs-on: macos-26` jobs unchanged.

## Tests
- `actionlint -shellcheck '' -ignore 'label ".*" is unknown'` on every changed workflow
- YAML parse validation on every changed workflow
- Verified no bare `macos-26` remains in a self-hosted selector
- Verified the net diff contains no `wendy-linux` changes
- `git diff --check`

## Rollout
- Keep `wendy-macos-26` available on the self-hosted macOS runner before merge.
- After this selector is deployed, remove bare `macos-26` from that runner.
