### PR TITLE
feat(data): two-plane camera path with a kernel-observed frame identity binding

### DIFF
--- a/Examples/WendyDataModelApp/proto/wendy/agent/apps/v1/sensor_service.proto
+++ b/Examples/WendyDataModelApp/proto/wendy/agent/apps/v1/sensor_service.proto
@@ -42,6 +42,27 @@ service SensorService {
   // episode capture adapter uses, so subscribing never takes a device away from
   // capture (or from another app).
   rpc Subscribe(SensorSubscribeRequest) returns (stream SensorSample);
+  // SubscribeFrameIdentity streams the identity of each frame the agent wrote to
+  // a source's v4l2loopback node, carrying NO pixels.
+  //
+  // This is the control plane of the two-plane camera path. An app that wants to
+  // use ordinary tooling reads the pixels from the loopback node with ffmpeg or
+  // GStreamer (the data plane) and joins them to harness identity through this
+  // stream, instead of receiving frames over gRPC. Because the node is fed from
+  // the same producer hub that episode capture consumes, the frame the app
+  // scores is provably the frame the episode recorded, which is not true of an
+  // app that opens the camera device itself.
+  //
+  // The join key is loopback_sequence, which an app reads from the
+  // v4l2_buffer.sequence of the buffer it dequeued. See FrameIdentity for why
+  // that number is assigned by the kernel rather than chosen by the agent, and
+  // for what a consumer must do about dropped frames.
+  //
+  // This grants strictly less than Subscribe, which already carries every
+  // identity field below alongside the payload. It does NOT grant the loopback
+  // node itself: reading the node is a device-node grant and remains the
+  // separate camera entitlement. An app needs both to use the two-plane path.
+  rpc SubscribeFrameIdentity(FrameIdentitySubscribeRequest) returns (stream FrameIdentity);
 }
 
 message SensorSource {
@@ -56,6 +77,16 @@ message SensorSource {
   // omitted: a caller must be able to tell "not available to models" from
   // "does not exist".
   bool subscribable = 6;
+  // loopback_node_path is the v4l2loopback device node carrying this source's
+  // frames on the two-plane data path, for example "/dev/video200". Empty when
+  // the source has no such node, which is the normal case: a node exists only
+  // for a source whose frames can be identified frame-for-frame, and only while
+  // an app entitled to BOTH sensor-read and camera is running.
+  //
+  // An empty value is not an error and an app must handle it: it means the
+  // two-plane path is unavailable for this source and the app should fall back
+  // to Subscribe, which always works.
+  string loopback_node_path = 7;
 }
 message SensorSourcesRequest {}
 message SensorSourcesResponse { repeated SensorSource sources = 1; }
@@ -96,4 +127,81 @@ message SensorSample {
   uint64 dropped_before = 8;
   // boot_id is the kernel boot the timestamps belong to.
   string boot_id = 9;
+}
+
+message FrameIdentitySubscribeRequest {
+  // source_ids are the sources whose frame identities to stream, as reported by
+  // Sources. At least one is required.
+  repeated string source_ids = 1;
+  // model optionally names the model consuming the frames, recorded in the
+  // episode's model-input ledger exactly as SensorSubscribeRequest.model is.
+  string model = 2;
+}
+
+// FrameIdentity names one frame the agent wrote to a source's v4l2loopback node.
+// It carries no pixels: the pixels are on the node.
+//
+// # Why loopback_sequence is the kernel's number and not ours
+//
+// The natural design would be for the agent to stamp sample_id directly into
+// v4l2_buffer.sequence, so a consumer reads the harness identifier straight off
+// the buffer. The v4l2loopback module makes that impossible: its QBUF handler
+// overwrites the sequence of any queued output buffer with its own internal
+// write counter, discarding whatever the writer supplied. There is no option or
+// flag that disables it.
+//
+// So the agent does the opposite. It reads back the sequence the kernel assigned
+// (QBUF returns it), and publishes the resulting mapping on this stream. A
+// consumer takes v4l2_buffer.sequence off the frame it dequeued and finds the
+// FrameIdentity carrying the same value. The number is therefore authoritative
+// and requires no assumption that frames arrive in a particular order, which is
+// what makes the join trustworthy.
+//
+// # Dropped frames: two different losses, two different signals
+//
+// A consumer that watches only one of these will believe frames were delivered
+// that were not. Both must be checked.
+//
+//  1. The agent could not keep up feeding the node. Those samples never reached
+//     the node at all, so loopback_sequence stays DENSE across the loss and
+//     shows no gap. The loss appears only here, as a jump in sample_id, and is
+//     counted exactly by dropped_before.
+//
+//  2. The application could not keep up reading the node. v4l2loopback
+//     fast-forwards an overrun reader rather than blocking it, so the
+//     application's next dequeued buffer has a sequence that JUMPED. This loss
+//     is invisible on this stream, because the agent did write those frames. The
+//     application detects it by comparing the sequence of consecutive dequeued
+//     buffers: the difference minus one is the number it missed.
+//
+// In short: a sample_id jump means the agent fell behind, a sequence jump means
+// the reader fell behind, and both can happen at once.
+//
+// A frame the agent failed to write appears in neither: it consumes no sequence
+// and produces no FrameIdentity, so it is absent rather than reported as lost.
+message FrameIdentity {
+  string source_id = 1;
+  // sample_id is the same identifier SensorSample.sample_id carries and the same
+  // one the episode capture index and the model-input ledger record, so a frame
+  // scored off the loopback node can be joined to what the episode kept.
+  uint64 sample_id = 2;
+  // boottime_nanos and timestamp_uncertainty_nanos are the agent's bracketed
+  // CLOCK_BOOTTIME receipt of this sample and the bracket half-width, identical
+  // to the values SensorSample reports for the same sample.
+  int64 boottime_nanos = 3;
+  int64 timestamp_uncertainty_nanos = 4;
+  // loopback_sequence is the v4l2_buffer.sequence the KERNEL assigned to this
+  // frame on the node. It is the join key: match it against the sequence of the
+  // buffer dequeued from the node. See the message comment for why the agent
+  // cannot choose this value.
+  uint32 loopback_sequence = 5;
+  // dropped_before counts samples lost between the producer and the node since
+  // the previous frame written. It is the ONLY report of loss case 1 above,
+  // because that loss leaves no gap in loopback_sequence.
+  uint64 dropped_before = 6;
+  // boot_id is the kernel boot the timestamps belong to.
+  string boot_id = 7;
+  // node_path is the v4l2loopback node this frame was written to, so an app
+  // subscribing to several sources knows which node each identity belongs to.
+  string node_path = 8;
 }

--- a/Proto/wendy/agent/apps/v1/sensor_service.proto
+++ b/Proto/wendy/agent/apps/v1/sensor_service.proto
@@ -42,6 +42,27 @@ service SensorService {
   // episode capture adapter uses, so subscribing never takes a device away from
   // capture (or from another app).
   rpc Subscribe(SensorSubscribeRequest) returns (stream SensorSample);
+  // SubscribeFrameIdentity streams the identity of each frame the agent wrote to
+  // a source's v4l2loopback node, carrying NO pixels.
+  //
+  // This is the control plane of the two-plane camera path. An app that wants to
+  // use ordinary tooling reads the pixels from the loopback node with ffmpeg or
+  // GStreamer (the data plane) and joins them to harness identity through this
+  // stream, instead of receiving frames over gRPC. Because the node is fed from
+  // the same producer hub that episode capture consumes, the frame the app
+  // scores is provably the frame the episode recorded, which is not true of an
+  // app that opens the camera device itself.
+  //
+  // The join key is loopback_sequence, which an app reads from the
+  // v4l2_buffer.sequence of the buffer it dequeued. See FrameIdentity for why
+  // that number is assigned by the kernel rather than chosen by the agent, and
+  // for what a consumer must do about dropped frames.
+  //
+  // This grants strictly less than Subscribe, which already carries every
+  // identity field below alongside the payload. It does NOT grant the loopback
+  // node itself: reading the node is a device-node grant and remains the
+  // separate camera entitlement. An app needs both to use the two-plane path.
+  rpc SubscribeFrameIdentity(FrameIdentitySubscribeRequest) returns (stream FrameIdentity);
 }
 
 message SensorSource {
@@ -56,6 +77,16 @@ message SensorSource {
   // omitted: a caller must be able to tell "not available to models" from
   // "does not exist".
   bool subscribable = 6;
+  // loopback_node_path is the v4l2loopback device node carrying this source's
+  // frames on the two-plane data path, for example "/dev/video200". Empty when
+  // the source has no such node, which is the normal case: a node exists only
+  // for a source whose frames can be identified frame-for-frame, and only while
+  // an app entitled to BOTH sensor-read and camera is running.
+  //
+  // An empty value is not an error and an app must handle it: it means the
+  // two-plane path is unavailable for this source and the app should fall back
+  // to Subscribe, which always works.
+  string loopback_node_path = 7;
 }
 message SensorSourcesRequest {}
 message SensorSourcesResponse { repeated SensorSource sources = 1; }
@@ -96,4 +127,81 @@ message SensorSample {
   uint64 dropped_before = 8;
   // boot_id is the kernel boot the timestamps belong to.
   string boot_id = 9;
+}
+
+message FrameIdentitySubscribeRequest {
+  // source_ids are the sources whose frame identities to stream, as reported by
+  // Sources. At least one is required.
+  repeated string source_ids = 1;
+  // model optionally names the model consuming the frames, recorded in the
+  // episode's model-input ledger exactly as SensorSubscribeRequest.model is.
+  string model = 2;
+}
+
+// FrameIdentity names one frame the agent wrote to a source's v4l2loopback node.
+// It carries no pixels: the pixels are on the node.
+//
+// # Why loopback_sequence is the kernel's number and not ours
+//
+// The natural design would be for the agent to stamp sample_id directly into
+// v4l2_buffer.sequence, so a consumer reads the harness identifier straight off
+// the buffer. The v4l2loopback module makes that impossible: its QBUF handler
+// overwrites the sequence of any queued output buffer with its own internal
+// write counter, discarding whatever the writer supplied. There is no option or
+// flag that disables it.
+//
+// So the agent does the opposite. It reads back the sequence the kernel assigned
+// (QBUF returns it), and publishes the resulting mapping on this stream. A
+// consumer takes v4l2_buffer.sequence off the frame it dequeued and finds the
+// FrameIdentity carrying the same value. The number is therefore authoritative
+// and requires no assumption that frames arrive in a particular order, which is
+// what makes the join trustworthy.
+//
+// # Dropped frames: two different losses, two different signals
+//
+// A consumer that watches only one of these will believe frames were delivered
+// that were not. Both must be checked.
+//
+//  1. The agent could not keep up feeding the node. Those samples never reached
+//     the node at all, so loopback_sequence stays DENSE across the loss and
+//     shows no gap. The loss appears only here, as a jump in sample_id, and is
+//     counted exactly by dropped_before.
+//
+//  2. The application could not keep up reading the node. v4l2loopback
+//     fast-forwards an overrun reader rather than blocking it, so the
+//     application's next dequeued buffer has a sequence that JUMPED. This loss
+//     is invisible on this stream, because the agent did write those frames. The
+//     application detects it by comparing the sequence of consecutive dequeued
+//     buffers: the difference minus one is the number it missed.
+//
+// In short: a sample_id jump means the agent fell behind, a sequence jump means
+// the reader fell behind, and both can happen at once.
+//
+// A frame the agent failed to write appears in neither: it consumes no sequence
+// and produces no FrameIdentity, so it is absent rather than reported as lost.
+message FrameIdentity {
+  string source_id = 1;
+  // sample_id is the same identifier SensorSample.sample_id carries and the same
+  // one the episode capture index and the model-input ledger record, so a frame
+  // scored off the loopback node can be joined to what the episode kept.
+  uint64 sample_id = 2;
+  // boottime_nanos and timestamp_uncertainty_nanos are the agent's bracketed
+  // CLOCK_BOOTTIME receipt of this sample and the bracket half-width, identical
+  // to the values SensorSample reports for the same sample.
+  int64 boottime_nanos = 3;
+  int64 timestamp_uncertainty_nanos = 4;
+  // loopback_sequence is the v4l2_buffer.sequence the KERNEL assigned to this
+  // frame on the node. It is the join key: match it against the sequence of the
+  // buffer dequeued from the node. See the message comment for why the agent
+  // cannot choose this value.
+  uint32 loopback_sequence = 5;
+  // dropped_before counts samples lost between the producer and the node since
+  // the previous frame written. It is the ONLY report of loss case 1 above,
+  // because that loss leaves no gap in loopback_sequence.
+  uint64 dropped_before = 6;
+  // boot_id is the kernel boot the timestamps belong to.
+  string boot_id = 7;
+  // node_path is the v4l2loopback node this frame was written to, so an app
+  // subscribing to several sources knows which node each identity belongs to.
+  string node_path = 8;
 }

--- a/go/internal/agent/containerd/camera_wiring.go
+++ b/go/internal/agent/containerd/camera_wiring.go
@@ -26,6 +26,11 @@ type CameraLoopbackProvider interface {
 	// containers entitled to camera access, so the loopback manager can
 	// start or stop its pumps to match.
 	SetCameraContainerConsumers(ctx context.Context, containerIDs []string)
+	// SetTwoPlaneContainerConsumers replaces, wholesale, the set of running
+	// containers entitled to the TWO-PLANE camera path, which is a strictly
+	// narrower set: it requires both sensor-read and camera. See
+	// twoPlaneConsumerNames for why both.
+	SetTwoPlaneContainerConsumers(ctx context.Context, containerIDs []string)
 }
 
 // Compile-time check that *services.VideoService satisfies CameraLoopbackProvider
@@ -73,6 +78,64 @@ func cameraConsumerNames(infos []containerCameraInfo) []string {
 		}
 		entitlements := parseEntitlementsFromAnnotations(info.labels)
 		if entitlementsContain(entitlements, appconfig.EntitlementCamera) || entitlementsContain(entitlements, appconfig.EntitlementVideo) {
+			names = append(names, info.name)
+		}
+	}
+	return names
+}
+
+// twoPlaneConsumerNames returns the names of containers entitled to the
+// two-plane camera path: a Running task holding BOTH the sensor-read entitlement
+// and the camera entitlement (or its deprecated alias, video).
+//
+// # Why both, and why neither alone is enough
+//
+// The two-plane path has two halves, and they are grants of different kinds.
+//
+// The data plane is a v4l2loopback device node the app opens and reads. That is
+// a device-node grant, and device-node grants are what the camera entitlement
+// is. The sensor-read entitlement documents itself as granting "no device nodes;
+// raw device access remains the separate camera entitlement", and honouring
+// that sentence is the point: if holding sensors alone caused a readable
+// /dev/video* to appear in the container, sensors would have silently become a
+// device-access entitlement. So sensors alone must not create a node, and does
+// not here.
+//
+// The control plane is the frame identity stream, which carries source id,
+// sample id, canonical time, uncertainty and a sequence number. That is strictly
+// LESS than SensorService.Subscribe already gives an app holding sensors, which
+// carries every one of those fields plus the pixels. It widens nothing, so it
+// belongs to sensors and needs no new grant.
+//
+// Camera alone is not enough either, and this is the more interesting half. An
+// app holding only camera can already open the physical device today. What it
+// cannot do is prove which frame it saw: it is an independent second reader, so
+// the frame it scored is not provably the frame the episode recorded. Handing
+// such an app a hub-fed node without the identity stream would give it
+// better-looking pixels with the same unprovable join, which is the very defect
+// the harness exists to remove. The identity stream is what makes the node worth
+// having, and that stream is a sensors grant.
+//
+// Requiring both is therefore not belt-and-braces caution: each entitlement
+// covers exactly one plane, and one plane on its own does not deliver the
+// property. An app holding one of the two keeps precisely the behaviour it has
+// today, and nothing it already had is taken away.
+func twoPlaneConsumerNames(infos []containerCameraInfo) []string {
+	var names []string
+	for _, info := range infos {
+		if !info.running {
+			continue
+		}
+		appID := info.labels[labelKeyAppID]
+		serviceName := info.labels[labelKeyServiceName]
+		if appconfig.ValidateAppID(appID) != nil || (serviceName != "" && appconfig.ValidateServiceName(serviceName) != nil) {
+			continue
+		}
+		entitlements := parseEntitlementsFromAnnotations(info.labels)
+		hasCamera := entitlementsContain(entitlements, appconfig.EntitlementCamera) ||
+			entitlementsContain(entitlements, appconfig.EntitlementVideo)
+		hasSensorRead := entitlementsContain(entitlements, appconfig.EntitlementSensorRead)
+		if hasCamera && hasSensorRead {
 			names = append(names, info.name)
 		}
 	}
@@ -142,6 +205,7 @@ func (c *Client) SyncCameraLoopbacks(ctx context.Context) {
 		c.logger.Warn("camera loopback sync: ensuring camera nodes failed", zap.Error(err))
 	}
 	c.cameraLoopbackProvider.SetCameraContainerConsumers(ctx, names)
+	c.cameraLoopbackProvider.SetTwoPlaneContainerConsumers(ctx, twoPlaneConsumerNames(infos))
 }
 
 // RunCameraLoopbackSync runs SyncCameraLoopbacks on a fixed interval until ctx

--- a/go/internal/agent/containerd/camera_wiring_test.go
+++ b/go/internal/agent/containerd/camera_wiring_test.go
@@ -144,3 +144,120 @@ func TestShouldEnsureCameraNodes(t *testing.T) {
 		})
 	}
 }
+
+// TestTwoPlaneConsumerNames_RequiresBothEntitlements pins the entitlement
+// decision for the two-plane camera path: a container qualifies only when it
+// holds BOTH sensors and camera (or the deprecated video alias).
+//
+// The two negative cases in the middle are the ones that matter. Sensors alone
+// must not qualify, because qualifying would cause a readable /dev/video* node
+// to be created for an entitlement that documents itself as granting no device
+// nodes. Camera alone must not qualify either, because a hub-fed node without
+// the identity stream gives an app the same unprovable frame join it already
+// has, which is the defect the harness exists to remove.
+func TestTwoPlaneConsumerNames_RequiresBothEntitlements(t *testing.T) {
+	bothLabels := map[string]string{
+		labelKeyAppID:                      "modelapp",
+		"sh.wendy/entitlement.camera":      `{"mode":"detect"}`,
+		"sh.wendy/entitlement.sensor-read": `{}`,
+	}
+	bothViaVideoAlias := map[string]string{
+		labelKeyAppID:                      "aliasapp",
+		"sh.wendy/entitlement.video":       `{"mode":"detect"}`,
+		"sh.wendy/entitlement.sensor-read": `{}`,
+	}
+	sensorsOnly := map[string]string{
+		labelKeyAppID:                      "sensorapp",
+		"sh.wendy/entitlement.sensor-read": `{}`,
+	}
+	cameraOnly := map[string]string{
+		labelKeyAppID:                 "camapp",
+		"sh.wendy/entitlement.camera": `{"mode":"detect"}`,
+	}
+	invalidAppID := map[string]string{
+		labelKeyAppID:                      "bad app id!",
+		"sh.wendy/entitlement.camera":      `{"mode":"detect"}`,
+		"sh.wendy/entitlement.sensor-read": `{}`,
+	}
+
+	tests := []struct {
+		name  string
+		infos []containerCameraInfo
+		want  []string
+	}{
+		{
+			name:  "sensors and camera, running -> in",
+			infos: []containerCameraInfo{{name: "modelapp", labels: bothLabels, running: true}},
+			want:  []string{"modelapp"},
+		},
+		{
+			name:  "sensors and deprecated video alias, running -> in",
+			infos: []containerCameraInfo{{name: "aliasapp", labels: bothViaVideoAlias, running: true}},
+			want:  []string{"aliasapp"},
+		},
+		{
+			// Qualifying here would silently turn sensors into a device-node grant.
+			name:  "sensors alone -> out",
+			infos: []containerCameraInfo{{name: "sensorapp", labels: sensorsOnly, running: true}},
+			want:  nil,
+		},
+		{
+			// Qualifying here would hand over pixels with no way to name them.
+			name:  "camera alone -> out",
+			infos: []containerCameraInfo{{name: "camapp", labels: cameraOnly, running: true}},
+			want:  nil,
+		},
+		{
+			name:  "both entitlements but stopped -> out",
+			infos: []containerCameraInfo{{name: "modelapp", labels: bothLabels, running: false}},
+			want:  nil,
+		},
+		{
+			name:  "invalid appID label -> out",
+			infos: []containerCameraInfo{{name: "brokenapp", labels: invalidAppID, running: true}},
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := twoPlaneConsumerNames(tt.infos)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("twoPlaneConsumerNames() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTwoPlaneConsumerNames_IsSubsetOfCameraConsumers pins the containment
+// relation the design depends on: every two-plane consumer is also a camera
+// consumer, so the narrower path can never entitle a container the existing
+// camera path would not.
+func TestTwoPlaneConsumerNames_IsSubsetOfCameraConsumers(t *testing.T) {
+	infos := []containerCameraInfo{
+		{name: "both", labels: map[string]string{
+			labelKeyAppID:                      "both",
+			"sh.wendy/entitlement.camera":      `{"mode":"detect"}`,
+			"sh.wendy/entitlement.sensor-read": `{}`,
+		}, running: true},
+		{name: "camonly", labels: map[string]string{
+			labelKeyAppID:                 "camonly",
+			"sh.wendy/entitlement.camera": `{"mode":"detect"}`,
+		}, running: true},
+		{name: "sensoronly", labels: map[string]string{
+			labelKeyAppID:                      "sensoronly",
+			"sh.wendy/entitlement.sensor-read": `{}`,
+		}, running: true},
+	}
+
+	cameras := map[string]bool{}
+	for _, n := range cameraConsumerNames(infos) {
+		cameras[n] = true
+	}
+	for _, n := range twoPlaneConsumerNames(infos) {
+		if !cameras[n] {
+			t.Errorf("%q is a two-plane consumer but not a camera consumer; the two-plane "+
+				"path must never entitle a container the camera path would not", n)
+		}
+	}
+}

--- a/go/internal/agent/ipcam/loopback.go
+++ b/go/internal/agent/ipcam/loopback.go
@@ -739,3 +739,72 @@ func (l *Loopback) fireIdleGrace(camID uint32, cp *camPump, gen uint64) {
 
 	supCancel()
 }
+
+// Auxiliary nodes: v4l2loopback nodes that are NOT backed by a registered
+// network camera.
+//
+// The two-plane camera path needs a node for a LOCAL camera, fed from the
+// agent's own producer hub rather than from an RTSP pump. Everything above is
+// keyed to the network camera registry (the node number IS the camera's
+// registry ID), so those nodes have no registry entry to hang off. Rather than
+// stand up a second node manager beside this one, they reuse the same module
+// detection, the same create and remove primitives, and the same "module
+// missing is not an error" posture. Only the numbering and the lifetime differ,
+// and both belong to the caller.
+
+// AllocateAuxNodeNumber returns a free v4l2loopback node number for a node that
+// has no camera registry entry, or ErrBandExhausted if there is none.
+//
+// Numbers come from the TOP of the same reserved band the registry allocates
+// from, downward, because the registry allocates the lowest free number upward.
+// The two therefore only meet once the band is genuinely full, and a number
+// already held by a registered camera or by an existing node is skipped
+// outright, so the two allocators cannot hand out the same number.
+//
+// The band is capped by the kernel's VIDEO_NUM_DEVICES of 256, so there is no
+// room above it to give auxiliary nodes a band of their own. Sharing with a
+// skip check is the honest option; silently reusing a camera's number would
+// point an app at the wrong camera's frames.
+func (l *Loopback) AllocateAuxNodeNumber() (int, error) {
+	taken := map[int]struct{}{}
+	for _, cam := range l.reg.List() {
+		taken[int(cam.ID)] = struct{}{}
+	}
+	for nr := IDBandEnd; nr >= IDBandStart; nr-- {
+		if _, ok := taken[nr]; ok {
+			continue
+		}
+		if l.deps.nodeExists(nr) {
+			continue
+		}
+		return nr, nil
+	}
+	return 0, ErrBandExhausted
+}
+
+// EnsureAuxNode creates the node at nr if it does not already exist.
+//
+// Like EnsureNodes it is idempotent and treats a missing module as "nothing to
+// do" rather than an error, so a build without v4l2loopback simply has no data
+// plane instead of failing container start.
+func (l *Loopback) EnsureAuxNode(_ context.Context, nr int, label string) error {
+	if err := l.Available(); err != nil {
+		return nil
+	}
+	if l.deps.nodeExists(nr) {
+		return nil
+	}
+	return l.deps.addNode(nr, label)
+}
+
+// RemoveAuxNode deletes the node at nr. Unlike RemoveCamera there is no pump
+// supervisor to stop first: an auxiliary node's pump is owned by whoever created
+// it, and must already have been stopped before this is called.
+func (l *Loopback) RemoveAuxNode(nr int) {
+	if err := l.Available(); err != nil {
+		return
+	}
+	if err := l.deps.removeNode(nr); err != nil {
+		l.logger.Warn("removing auxiliary v4l2loopback node", zap.Int("nr", nr), zap.Error(err))
+	}
+}

--- a/go/internal/agent/ipcam/loopback_test.go
+++ b/go/internal/agent/ipcam/loopback_test.go
@@ -1356,3 +1356,73 @@ func TestLoopback_LogsNodeNotReadyOnceThenStaysQuiet(t *testing.T) {
 		t.Fatalf("warnings logged = %d across multiple node-not-ready retries, want exactly 1: %v", len(entries), entries)
 	}
 }
+
+// TestAllocateAuxNodeNumber_TopDownAndSkipsTaken pins the auxiliary node
+// allocator's collision avoidance.
+//
+// Auxiliary nodes (the two-plane camera data path) and registered network
+// cameras share one reserved band, because the kernel's VIDEO_NUM_DEVICES of 256
+// leaves no room for a second one. They must never be handed the same number: an
+// auxiliary node reusing a camera's number would point an app at the wrong
+// camera's frames. The allocator therefore works DOWN from the top of the band
+// while the registry allocates UP from the bottom, and skips anything already
+// taken by a camera or by an existing node.
+func TestAllocateAuxNodeNumber_TopDownAndSkipsTaken(t *testing.T) {
+	h := newLoopbackHarness()
+	h.controlExists = true
+	l, reg := newTestLoopback(t, h)
+
+	// A fresh device allocates from the top of the band.
+	nr, err := l.AllocateAuxNodeNumber()
+	if err != nil {
+		t.Fatalf("AllocateAuxNodeNumber: %v", err)
+	}
+	if nr != IDBandEnd {
+		t.Errorf("first allocation = %d, want %d (top of the band)", nr, IDBandEnd)
+	}
+
+	// A registered camera's number must be skipped even though nothing has
+	// created its node yet: the registry owns that number already.
+	cam, err := reg.Upsert(Camera{MAC: "aa:bb:cc:dd:ee:ff", Address: "10.0.0.5"})
+	if err != nil {
+		t.Fatalf("registry upsert: %v", err)
+	}
+	h.setNodeExists(IDBandEnd, true) // the node we just allocated now exists
+	// Force the camera to the top of the band so the two allocators collide.
+	reg.mu.Lock()
+	for mac, c := range reg.by {
+		c.ID = uint32(IDBandEnd - 1)
+		reg.by[mac] = c
+	}
+	reg.mu.Unlock()
+	_ = cam
+
+	nr, err = l.AllocateAuxNodeNumber()
+	if err != nil {
+		t.Fatalf("AllocateAuxNodeNumber: %v", err)
+	}
+	if nr == IDBandEnd {
+		t.Error("allocator reused a number whose node already exists")
+	}
+	if nr == IDBandEnd-1 {
+		t.Error("allocator handed out a number already held by a registered camera")
+	}
+	if nr != IDBandEnd-2 {
+		t.Errorf("allocation = %d, want %d", nr, IDBandEnd-2)
+	}
+}
+
+// TestAllocateAuxNodeNumber_BandExhausted pins that a full band is a clean
+// refusal rather than a number outside it. The band's ceiling is the kernel's,
+// so there is nothing above it to fall back to.
+func TestAllocateAuxNodeNumber_BandExhausted(t *testing.T) {
+	h := newLoopbackHarness()
+	h.controlExists = true
+	l, _ := newTestLoopback(t, h)
+	for nr := IDBandStart; nr <= IDBandEnd; nr++ {
+		h.setNodeExists(nr, true)
+	}
+	if _, err := l.AllocateAuxNodeNumber(); !errors.Is(err, ErrBandExhausted) {
+		t.Errorf("AllocateAuxNodeNumber() error = %v, want ErrBandExhausted", err)
+	}
+}

--- a/go/internal/agent/services/hub_loopback_binding.go
+++ b/go/internal/agent/services/hub_loopback_binding.go
@@ -1,0 +1,335 @@
+package services
+
+import (
+	"sync"
+
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+// The two-plane camera path, and why the frame identity binding is shaped the
+// way it is.
+//
+// An application that wants to use ordinary tooling (ffmpeg, GStreamer) cannot
+// consume SensorService.Subscribe without a bespoke gRPC integration, and the
+// camera entitlement's raw device node makes the app an INDEPENDENT second
+// reader of the camera, so the frame a model scores is not provably the frame
+// the episode recorded. The two-plane path fixes both: one producer, two
+// planes.
+//
+//   - Data plane: a v4l2loopback node fed from the SAME producer hub that
+//     episode capture and gRPC subscribers already consume. The app reads that
+//     node with any standard tool, unmodified.
+//   - Control plane: the existing SensorService stream carries identity only
+//     (source id, sample id, canonical boottime, uncertainty). The pixels never
+//     travel that way, so per-frame gRPC framing cost stays negligible.
+//
+// The binding between them is this file's subject.
+//
+// # Why sample_id cannot be written into v4l2_buffer.sequence
+//
+// The obvious design is to stamp our sample_id into v4l2_buffer.sequence on the
+// buffer we queue, so a consumer reading the loopback reads our identifier back
+// out directly. THAT DOES NOT WORK, and the reason is in the v4l2loopback
+// module rather than in anything we control.
+//
+// In v4l2loopback's VIDIOC_QBUF handler for V4L2_BUF_TYPE_VIDEO_OUTPUT, the
+// sequence field of the queued buffer is overwritten unconditionally:
+//
+//	bufd->buffer.sequence = dev->write_position;
+//
+// (and identically in the write() path). dev->write_position is the module's
+// own monotonic count of frames written to that node. Whatever sequence value a
+// writer supplies is discarded. There is no module option, format flag, or
+// ioctl that disables this. So a design that says "sequence IS the sample id"
+// would be claiming a guarantee the kernel actively prevents us from keeping.
+//
+// # What is sound instead: observe the kernel's number, publish the mapping
+//
+// The same QBUF handler copies the buffer struct back out to userspace after
+// stamping it, and does so BEFORE the write position is advanced:
+//
+//	bufd->buffer.sequence = dev->write_position;
+//	set_queued(bufd->buffer.flags);
+//	*buf = bufd->buffer;          // <- returned to the writer
+//	buffer_written(dev, bufd);    // <- this is what does ++dev->write_position
+//
+// So the writer LEARNS, from the ioctl it just issued, the exact sequence the
+// kernel assigned to the frame it just wrote. That value is authoritative, it
+// requires no assumption that the counter started at zero (it does not reset
+// per open, only at device creation), and it does not depend on arrival order
+// or on counting frames ourselves.
+//
+// The binding is therefore inverted relative to the naive design: the pump does
+// not choose the sequence, it observes the one the kernel chose, and records
+// (loopback sequence -> sample identity) in the table below. The control plane
+// publishes that mapping. An app reading the loopback takes the sequence off the
+// buffer it dequeued and looks it up.
+//
+// # What a consumer sees when frames are dropped
+//
+// There are two independent drop points, and they are detected by two DIFFERENT
+// signals. Conflating them is the main way a consumer of this API can fool
+// itself, so both are spelled out here and both are represented in the record.
+//
+//  1. Hub -> pump. The hub drops frames for a subscriber that is not reading
+//     fast enough (deviceHub.broadcast's non-blocking send, counted per
+//     subscriber in subDrops). Those frames are never written to the loopback at
+//     all. The loopback sequence therefore stays DENSE across such a drop: the
+//     kernel counts only what we actually wrote, so a consumer watching only
+//     v4l2_buffer.sequence sees no gap and would wrongly conclude nothing was
+//     lost. What does change is sample_id, which jumps. This is why every
+//     binding carries HubDropsBefore, and why the control plane reports the
+//     sample_id: a gap here is visible ONLY on the control plane.
+//
+//  2. Pump -> app. The application reading the loopback node is not keeping up,
+//     and the module's ring overruns. v4l2loopback handles this in
+//     get_capture_buffer by fast-forwarding the reader rather than blocking:
+//
+//     if (dev->write_position > opener->read_position + dev->used_buffer_count)
+//     opener->read_position = dev->write_position - 1;
+//
+//     The reader's next dequeued buffer therefore carries a sequence that has
+//     JUMPED. Frames the pump genuinely wrote never reached this reader. This
+//     gap IS visible on the data plane: consecutive dequeued buffers differ in
+//     sequence by more than one, and the difference minus one is exactly the
+//     number of frames that reader missed. sequenceGap below computes it.
+//
+// Stated as a rule for consumers: a jump in sample_id with dense sequence means
+// the agent could not keep up feeding the node; a jump in sequence means the
+// application could not keep up reading it. Both can happen at once, and they
+// are additive, not alternatives.
+//
+// A third case is not a drop and must not be reported as one: if the pump fails
+// to write a frame, it records no binding and the kernel never advances its
+// counter, so the frame is simply absent from both planes rather than appearing
+// as a lost one.
+
+// loopbackBinding is one recorded correspondence between a frame the pump wrote
+// to a v4l2loopback node and the harness identity of the sample it came from.
+//
+// LoopbackSequence is the value the KERNEL assigned and handed back on QBUF, not
+// a value we chose (see the file comment). Everything else is copied from the
+// hub frame, so a consumer that resolves a sequence gets exactly the identity
+// the episode index and the model-input ledger recorded for the same sample.
+type loopbackBinding struct {
+	// LoopbackSequence is the kernel-assigned v4l2_buffer.sequence, as read back
+	// from the VIDIOC_QBUF that queued this frame on the node's OUTPUT queue.
+	LoopbackSequence uint32
+	// SampleID is the producer hub's identity for this sample within its source.
+	// It is the join key to the episode capture index and the model-input ledger.
+	SampleID uint64
+	// BootNanos is the agent's bracketed CLOCK_BOOTTIME receipt of the sample and
+	// UncertaintyNanos the bracket half-width, both copied verbatim from the hub
+	// frame so every plane reports the same canonical time for the same sample.
+	BootNanos        int64
+	UncertaintyNanos int64
+	// HubDropsBefore counts samples the hub dropped for the pump since the
+	// previously written frame. It is the ONLY signal for case 1 in the file
+	// comment: those samples never reached the node, so the loopback sequence
+	// does not gap and cannot report them.
+	HubDropsBefore uint64
+}
+
+// loopbackBindingRetention is how many recent bindings the table keeps.
+//
+// Sized for the join to succeed, not for history: an application reads the
+// loopback and the control plane concurrently, so it resolves a sequence within
+// a few frames of the pump recording it. A few seconds of slack at ordinary
+// frame rates is ample, and the bound is what stops a long-running pump from
+// growing without limit. Lookups older than this fail closed (found=false)
+// rather than returning a guess.
+const loopbackBindingRetention = 256
+
+// loopbackBindingTable records recent (loopback sequence -> sample identity)
+// bindings for one node and resolves lookups against them.
+//
+// It is a bounded ring with a sequence index rather than a plain slice offset
+// calculation. The arithmetic shortcut would be to assume sequences are dense
+// and index by difference from the newest, but that assumes we are the only
+// writer on the node; dev->write_position advances for ANY writer. Indexing
+// explicitly costs one map entry per frame and stays correct if that assumption
+// is ever violated, which matters because the failure mode of the shortcut is
+// silently resolving a sequence to the wrong sample: exactly the
+// misattribution this whole path exists to prevent.
+//
+// Safe for concurrent use: the pump records, the control plane looks up.
+type loopbackBindingTable struct {
+	mu sync.Mutex
+	// ring holds up to len(ring) bindings, oldest evicted first.
+	ring []loopbackBinding
+	// index maps a loopback sequence to its position in ring. Entries are removed
+	// when the slot they point at is overwritten.
+	index map[uint32]int
+	// next is the ring slot the next recorded binding will occupy.
+	next int
+	// count is how many slots are populated, saturating at len(ring).
+	count int
+	// haveNewest reports whether newest holds a real sequence yet, so that a
+	// genuine sequence of 0 is not mistaken for "nothing recorded".
+	haveNewest bool
+	newest     uint32
+}
+
+// newLoopbackBindingTable returns a table retaining the most recent retain
+// bindings. A retain of zero or less uses loopbackBindingRetention.
+func newLoopbackBindingTable(retain int) *loopbackBindingTable {
+	if retain <= 0 {
+		retain = loopbackBindingRetention
+	}
+	return &loopbackBindingTable{
+		ring:  make([]loopbackBinding, retain),
+		index: make(map[uint32]int, retain),
+	}
+}
+
+// Record stores one binding, evicting the oldest if the table is full.
+//
+// Recording the same sequence twice replaces the older entry's index mapping, so
+// a lookup always resolves to the most recently recorded sample for that
+// sequence. That only arises if the kernel counter wraps a full 2^32 within the
+// retention window, which cannot happen at any real frame rate, or if another
+// process is writing to the node, which the index exists to survive.
+func (t *loopbackBindingTable) Record(b loopbackBinding) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Evict the entry currently occupying this slot, if any. Guarded on count so
+	// that an untouched slot's zero value cannot delete a live sequence-0 entry.
+	if t.count == len(t.ring) {
+		delete(t.index, t.ring[t.next].LoopbackSequence)
+	}
+	t.ring[t.next] = b
+	t.index[b.LoopbackSequence] = t.next
+	t.next = (t.next + 1) % len(t.ring)
+	if t.count < len(t.ring) {
+		t.count++
+	}
+	if !t.haveNewest || sequenceAfter(b.LoopbackSequence, t.newest) {
+		t.newest, t.haveNewest = b.LoopbackSequence, true
+	}
+}
+
+// Lookup resolves a loopback sequence to the sample it carried.
+//
+// Returns found=false for a sequence that was never recorded or has aged out of
+// the retention window. It deliberately does NOT interpolate or return a nearest
+// match: a consumer joining model output to episode input must be told "I cannot
+// name this frame" rather than handed a plausible neighbour.
+func (t *loopbackBindingTable) Lookup(seq uint32) (loopbackBinding, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	pos, ok := t.index[seq]
+	if !ok {
+		return loopbackBinding{}, false
+	}
+	return t.ring[pos], true
+}
+
+// Newest returns the most recently recorded binding, if any. It exists so the
+// control plane can attach the current sequence to an outgoing sample without
+// the pump and the stream having to share more state than the table.
+func (t *loopbackBindingTable) Newest() (loopbackBinding, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if !t.haveNewest {
+		return loopbackBinding{}, false
+	}
+	pos, ok := t.index[t.newest]
+	if !ok {
+		return loopbackBinding{}, false
+	}
+	return t.ring[pos], true
+}
+
+// Len reports how many bindings are currently retained.
+func (t *loopbackBindingTable) Len() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.count
+}
+
+// sequenceAfter reports whether a is later than b on the 32-bit sequence
+// circle, tolerating wrap.
+//
+// v4l2_buffer.sequence is __u32 and the kernel's write_position is not reset per
+// open, so a long-lived node can wrap. Comparing with plain > would order
+// 0xFFFFFFFF before 0x00000001 wrongly. The signed-difference form treats any
+// distance under 2^31 as "forward", which is correct for a counter that never
+// advances by anything close to that between observations.
+func sequenceAfter(a, b uint32) bool {
+	return int32(a-b) > 0
+}
+
+// sequenceGap reports how many frames a reader missed between two CONSECUTIVELY
+// DEQUEUED loopback buffers, given their kernel-assigned sequences.
+//
+// This is case 2 from the file comment, and it is the reader's own drop signal:
+// v4l2loopback fast-forwards an overrun reader instead of blocking it, so the
+// jump in sequence is exactly the loss. A normal delivery differs by one and
+// yields zero.
+//
+// Returns 0 when curr is not after prev, which covers both a repeated buffer
+// (v4l2loopback re-serves the newest frame to a reader that has caught up, so
+// the same sequence can be dequeued twice) and any out-of-order observation. A
+// repeat is not a loss and must not be reported as one.
+func sequenceGap(prev, curr uint32) uint64 {
+	if !sequenceAfter(curr, prev) {
+		return 0
+	}
+	return uint64(curr-prev) - 1
+}
+
+// frameBindableToLoopback reports whether a hub frame can be written to a
+// v4l2loopback node in a way that preserves the one-frame-in-one-frame-out
+// correspondence the binding depends on, and explains the refusal when it
+// cannot.
+//
+// This predicate is where the honest scope of the feature is enforced, so the
+// reasoning is worth stating in full.
+//
+// The binding is only meaningful if each frame the pump takes off the hub
+// becomes exactly one frame on the node. Two things break that:
+//
+//   - A frame that is not a whole access unit. auAligned is set only by the
+//     native V4L2 producer, which delivers one V4L2 buffer per encoded frame.
+//     The GStreamer and IP camera producers read a byte stream from a pipe, so
+//     their frames are arbitrary chunk-sized slices that can begin or end
+//     mid-access-unit. Writing those to a node frame-for-frame produces buffers
+//     that are not frames, and a sequence that counts chunks rather than
+//     pictures. There is no binding to be had, so we refuse rather than publish
+//     a sequence that means nothing.
+//
+//   - A decoder placed between the hub and the node. Feeding the raw-pixel
+//     consumers (notably OpenCV's default V4L capture, which will not accept a
+//     compressed fourcc) would mean decoding H.264 in the pump and writing raw
+//     frames. A decoder does not preserve the correspondence: B-frame
+//     reordering means the Nth frame in is not the Nth frame out, and a decoder
+//     may drop or emit frames on its own. The Nth-write-is-the-Nth-sample
+//     inference would then be silently wrong. So this path does not decode, and
+//     consequently does not serve raw-pixel consumers at all. That is a real
+//     limitation of the feature, not an omission to be patched later by adding a
+//     decoder: adding one would destroy the guarantee the feature exists to
+//     make.
+//
+// What remains is the sound subset: whole compressed access units written to a
+// node advertising the matching compressed fourcc, consumed by tools that accept
+// one (ffmpeg and GStreamer do).
+func frameBindableToLoopback(frame *videoFrame) (ok bool, reason string) {
+	switch {
+	case frame == nil:
+		return false, "no frame"
+	case len(frame.data) == 0:
+		return false, "empty frame"
+	case !frame.auAligned:
+		// Refusing here is the difference between a sequence that names pictures
+		// and one that names arbitrary byte chunks.
+		return false, "source delivers an unaligned byte stream, not whole access units; " +
+			"a loopback sequence over it would not identify frames"
+	case frame.codec != agentpb.VideoCodec_VIDEO_CODEC_H264:
+		// Only H.264 has a settled V4L2 pixel format we can advertise on the node
+		// (V4L2_PIX_FMT_H264). VP8 arrives from the hub inside a WebM container
+		// rather than as bare frames, so it is not a per-frame payload at all.
+		return false, "only h264 access units can be written to a loopback node frame-for-frame"
+	}
+	return true, ""
+}

--- a/go/internal/agent/services/hub_loopback_binding_test.go
+++ b/go/internal/agent/services/hub_loopback_binding_test.go
@@ -1,0 +1,302 @@
+package services
+
+import (
+	"math"
+	"sync"
+	"testing"
+
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+// TestBindingTableResolvesSequenceToSample is the base case: what the pump
+// recorded is what a consumer resolves, field for field. The identity fields
+// must survive the round trip exactly, because a consumer joins episode capture
+// and the model-input ledger on them.
+func TestBindingTableResolvesSequenceToSample(t *testing.T) {
+	table := newLoopbackBindingTable(8)
+	want := loopbackBinding{
+		LoopbackSequence: 41,
+		SampleID:         1007,
+		BootNanos:        1234567890,
+		UncertaintyNanos: 1500,
+		HubDropsBefore:   0,
+	}
+	table.Record(want)
+
+	got, ok := table.Lookup(41)
+	if !ok {
+		t.Fatalf("Lookup(41) not found after Record")
+	}
+	if got != want {
+		t.Errorf("Lookup(41) = %+v, want %+v", got, want)
+	}
+}
+
+// TestBindingTableUnknownSequenceFailsClosed pins the deliberate refusal to
+// guess. A consumer asking about a frame we never wrote, or one that has aged
+// out, must be told so rather than handed a neighbouring sample: a wrong join
+// is worse than an absent one, because it silently misattributes which frame a
+// model scored.
+func TestBindingTableUnknownSequenceFailsClosed(t *testing.T) {
+	table := newLoopbackBindingTable(4)
+	table.Record(loopbackBinding{LoopbackSequence: 10, SampleID: 100})
+	table.Record(loopbackBinding{LoopbackSequence: 11, SampleID: 101})
+
+	for _, seq := range []uint32{0, 9, 12, 4096} {
+		if got, ok := table.Lookup(seq); ok {
+			t.Errorf("Lookup(%d) = %+v, want not found", seq, got)
+		}
+	}
+}
+
+// TestBindingTableEvictsOldestAndDoesNotResurrect covers the bound on retention.
+// The ring must drop the oldest binding AND drop its index entry, or a lookup
+// would resolve a stale slot and name the wrong sample.
+func TestBindingTableEvictsOldestAndDoesNotResurrect(t *testing.T) {
+	const retain = 4
+	table := newLoopbackBindingTable(retain)
+	for i := 0; i < retain*2; i++ {
+		table.Record(loopbackBinding{LoopbackSequence: uint32(i), SampleID: uint64(1000 + i)})
+	}
+
+	if got := table.Len(); got != retain {
+		t.Errorf("Len() = %d, want %d", got, retain)
+	}
+	// The first `retain` sequences must be gone, not merely shadowed.
+	for i := 0; i < retain; i++ {
+		if got, ok := table.Lookup(uint32(i)); ok {
+			t.Errorf("Lookup(%d) = %+v, want evicted", i, got)
+		}
+	}
+	// The most recent `retain` must all still resolve to their own sample.
+	for i := retain; i < retain*2; i++ {
+		got, ok := table.Lookup(uint32(i))
+		if !ok {
+			t.Fatalf("Lookup(%d) not found, want retained", i)
+		}
+		if got.SampleID != uint64(1000+i) {
+			t.Errorf("Lookup(%d).SampleID = %d, want %d", i, got.SampleID, 1000+i)
+		}
+	}
+}
+
+// TestBindingSurvivesHubDroppedFrames is drop case 1 from the file comment, and
+// the reason HubDropsBefore exists.
+//
+// When the hub drops frames for the pump, those samples never reach the node.
+// The kernel counts only what we wrote, so the loopback sequence stays DENSE
+// while sample_id jumps. A consumer watching only the sequence would conclude
+// nothing was lost. This test pins both halves: the sequence really is dense,
+// and the binding still names the correct (non-contiguous) sample ids and
+// reports the loss.
+func TestBindingSurvivesHubDroppedFrames(t *testing.T) {
+	table := newLoopbackBindingTable(16)
+
+	// The hub delivered samples 500, 501, then dropped 502-504, then 505.
+	// The pump wrote three frames, so the kernel assigned three dense sequences.
+	table.Record(loopbackBinding{LoopbackSequence: 70, SampleID: 500, HubDropsBefore: 0})
+	table.Record(loopbackBinding{LoopbackSequence: 71, SampleID: 501, HubDropsBefore: 0})
+	table.Record(loopbackBinding{LoopbackSequence: 72, SampleID: 505, HubDropsBefore: 3})
+
+	// Sequence is dense across the drop: this is exactly why the data plane
+	// alone cannot report a hub-side loss.
+	for i, wantSample := range map[uint32]uint64{70: 500, 71: 501, 72: 505} {
+		got, ok := table.Lookup(i)
+		if !ok {
+			t.Fatalf("Lookup(%d) not found", i)
+		}
+		if got.SampleID != wantSample {
+			t.Errorf("Lookup(%d).SampleID = %d, want %d", i, got.SampleID, wantSample)
+		}
+	}
+
+	// The loss is recoverable only from the control plane's record.
+	got, _ := table.Lookup(72)
+	if got.HubDropsBefore != 3 {
+		t.Errorf("Lookup(72).HubDropsBefore = %d, want 3", got.HubDropsBefore)
+	}
+	// And the sample_id jump is the corroborating signal.
+	prev, _ := table.Lookup(71)
+	if delta := got.SampleID - prev.SampleID - 1; delta != got.HubDropsBefore {
+		t.Errorf("sample_id gap %d disagrees with HubDropsBefore %d", delta, got.HubDropsBefore)
+	}
+}
+
+// TestSequenceGapDetectsReaderDroppedFrames is drop case 2: the application
+// reading the node fell behind and v4l2loopback fast-forwarded it. Here the gap
+// IS on the data plane, and it is the reader's only honest loss signal.
+func TestSequenceGapDetectsReaderDroppedFrames(t *testing.T) {
+	tests := []struct {
+		name       string
+		prev, curr uint32
+		want       uint64
+	}{
+		{name: "consecutive delivery loses nothing", prev: 10, curr: 11, want: 0},
+		{name: "one frame skipped", prev: 10, curr: 12, want: 1},
+		{name: "reader fast-forwarded past many", prev: 10, curr: 400, want: 389},
+		// v4l2loopback re-serves the newest frame to a reader that has caught up,
+		// so the same sequence can be dequeued twice. That is a repeat, not a loss.
+		{name: "repeated buffer is not a loss", prev: 10, curr: 10, want: 0},
+		{name: "out-of-order observation is not a loss", prev: 10, curr: 9, want: 0},
+		// The counter is __u32 and is not reset per open, so a long-lived node
+		// wraps. The gap must stay correct across the wrap rather than becoming
+		// a ~4 billion frame phantom loss.
+		{name: "wrap is not a phantom loss", prev: math.MaxUint32, curr: 0, want: 0},
+		{name: "gap spanning the wrap", prev: math.MaxUint32 - 2, curr: 1, want: 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sequenceGap(tt.prev, tt.curr); got != tt.want {
+				t.Errorf("sequenceGap(%d, %d) = %d, want %d", tt.prev, tt.curr, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBindingTableResolvesAcrossSequenceWrap pins that a table spanning the
+// 32-bit wrap still resolves both sides, and that Newest picks the genuinely
+// newest rather than the numerically largest.
+func TestBindingTableResolvesAcrossSequenceWrap(t *testing.T) {
+	table := newLoopbackBindingTable(8)
+	seqs := []uint32{math.MaxUint32 - 1, math.MaxUint32, 0, 1}
+	for i, seq := range seqs {
+		table.Record(loopbackBinding{LoopbackSequence: seq, SampleID: uint64(900 + i)})
+	}
+
+	for i, seq := range seqs {
+		got, ok := table.Lookup(seq)
+		if !ok {
+			t.Fatalf("Lookup(%d) not found across wrap", seq)
+		}
+		if got.SampleID != uint64(900+i) {
+			t.Errorf("Lookup(%d).SampleID = %d, want %d", seq, got.SampleID, 900+i)
+		}
+	}
+
+	newest, ok := table.Newest()
+	if !ok {
+		t.Fatal("Newest() not found")
+	}
+	if newest.LoopbackSequence != 1 || newest.SampleID != 903 {
+		t.Errorf("Newest() = seq %d sample %d, want seq 1 sample 903 (wrap-aware, not numeric max)",
+			newest.LoopbackSequence, newest.SampleID)
+	}
+}
+
+// TestSequenceAfterHandlesWrap pins the ordering primitive the rest depends on.
+func TestSequenceAfterHandlesWrap(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b uint32
+		want bool
+	}{
+		{name: "plainly after", a: 5, b: 4, want: true},
+		{name: "plainly before", a: 4, b: 5, want: false},
+		{name: "equal is not after", a: 5, b: 5, want: false},
+		{name: "just past the wrap is after", a: 0, b: math.MaxUint32, want: true},
+		{name: "just before the wrap is not after", a: math.MaxUint32, b: 0, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sequenceAfter(tt.a, tt.b); got != tt.want {
+				t.Errorf("sequenceAfter(%d, %d) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNewestOnEmptyTable pins that an untouched table reports nothing rather
+// than a zero-valued binding that would resolve sequence 0 to sample 0.
+func TestNewestOnEmptyTable(t *testing.T) {
+	table := newLoopbackBindingTable(4)
+	if got, ok := table.Newest(); ok {
+		t.Errorf("Newest() on empty table = %+v, want not found", got)
+	}
+	if got, ok := table.Lookup(0); ok {
+		t.Errorf("Lookup(0) on empty table = %+v, want not found", got)
+	}
+}
+
+// TestBindingTableSequenceZeroIsRecordable guards the eviction bookkeeping: a
+// genuine sequence of 0 must be distinguishable from an untouched ring slot,
+// whose zero value also has LoopbackSequence 0.
+func TestBindingTableSequenceZeroIsRecordable(t *testing.T) {
+	table := newLoopbackBindingTable(4)
+	table.Record(loopbackBinding{LoopbackSequence: 0, SampleID: 77})
+	table.Record(loopbackBinding{LoopbackSequence: 1, SampleID: 78})
+
+	got, ok := table.Lookup(0)
+	if !ok {
+		t.Fatal("Lookup(0) not found; a real sequence 0 was mistaken for an empty slot")
+	}
+	if got.SampleID != 77 {
+		t.Errorf("Lookup(0).SampleID = %d, want 77", got.SampleID)
+	}
+}
+
+// TestBindingTableConcurrentRecordAndLookup exercises the intended access
+// pattern (pump records, control plane looks up) under -race.
+func TestBindingTableConcurrentRecordAndLookup(t *testing.T) {
+	table := newLoopbackBindingTable(64)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 2000; i++ {
+			table.Record(loopbackBinding{LoopbackSequence: uint32(i), SampleID: uint64(i)})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 2000; i++ {
+			if b, ok := table.Lookup(uint32(i)); ok && b.SampleID != uint64(i) {
+				t.Errorf("Lookup(%d) resolved to sample %d", i, b.SampleID)
+			}
+			table.Newest()
+		}
+	}()
+	wg.Wait()
+}
+
+// TestFrameBindableToLoopback pins the honest scope of the feature: which hub
+// frames can be written frame-for-frame, and which are refused because no sound
+// binding exists for them.
+func TestFrameBindableToLoopback(t *testing.T) {
+	tests := []struct {
+		name  string
+		frame *videoFrame
+		want  bool
+	}{
+		{
+			name:  "whole h264 access unit is bindable",
+			frame: &videoFrame{data: []byte{0, 0, 1}, auAligned: true, codec: agentpb.VideoCodec_VIDEO_CODEC_H264},
+			want:  true,
+		},
+		{
+			// The GStreamer and IP camera producers deliver arbitrary chunks of a
+			// byte stream. A sequence counted over those names chunks, not frames.
+			name:  "unaligned byte stream chunk is refused",
+			frame: &videoFrame{data: []byte{0, 0, 1}, auAligned: false, codec: agentpb.VideoCodec_VIDEO_CODEC_H264},
+			want:  false,
+		},
+		{
+			// VP8 arrives inside a WebM container, so it is not a per-frame payload.
+			name:  "vp8 in webm is refused",
+			frame: &videoFrame{data: []byte{1}, auAligned: true, codec: agentpb.VideoCodec_VIDEO_CODEC_VP8},
+			want:  false,
+		},
+		{name: "empty frame is refused", frame: &videoFrame{data: nil, auAligned: true}, want: false},
+		{name: "nil frame is refused", frame: nil, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, reason := frameBindableToLoopback(tt.frame)
+			if got != tt.want {
+				t.Errorf("frameBindableToLoopback() = %v (%q), want %v", got, reason, tt.want)
+			}
+			if !got && reason == "" {
+				t.Error("refusal must carry a reason a caller can log")
+			}
+		})
+	}
+}

--- a/go/internal/agent/services/hub_loopback_pump.go
+++ b/go/internal/agent/services/hub_loopback_pump.go
@@ -1,0 +1,239 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	"go.uber.org/zap"
+)
+
+// loopbackFrameWriter is the seam between the pump and the v4l2loopback node.
+//
+// It exists so the part of this feature that can be reasoned about and tested
+// on any platform (which frames are bindable, what the pump records, how drops
+// are accounted) is separated from the part that can only be exercised on a
+// Linux device with the module loaded (the ioctls themselves). Tests inject a
+// fake; the Linux build injects the real V4L2 OUTPUT writer.
+type loopbackFrameWriter interface {
+	// WriteFrame queues one whole access unit on the node's OUTPUT queue and
+	// returns the sequence the KERNEL assigned to it.
+	//
+	// Returning the kernel's value rather than accepting one from the caller is
+	// the whole basis of the binding: v4l2loopback overwrites any sequence a
+	// writer supplies with its own write_position, and hands the result back on
+	// the same ioctl. See hub_loopback_binding.go for the full reasoning.
+	WriteFrame(data []byte) (sequence uint32, err error)
+	// Close releases the node. The node itself outlives the writer.
+	Close() error
+}
+
+// openLoopbackFrameWriter opens a node for writing. Implemented per platform;
+// non-Linux builds return an error, which makes the whole data plane a no-op
+// there rather than a compile break.
+var openLoopbackFrameWriter = openLoopbackFrameWriterPlatform
+
+// errLoopbackDataPlaneUnsupported is returned by the pump when the running build
+// or the source cannot support a sound binding. It is deliberately a refusal
+// rather than a degraded mode.
+var errLoopbackDataPlaneUnsupported = errors.New("two-plane camera data path unavailable on this build")
+
+// hubLoopbackPump feeds one v4l2loopback node from the producer hub and records
+// the identity binding for every frame it writes.
+//
+// It is ONE MORE SUBSCRIBER of the existing hub, exactly like a gRPC sensor
+// subscriber or the episode capture adapter. It never opens the camera itself.
+// That is the property the whole two-plane design rests on: because the pixels
+// on the node came off the same producer that fed episode capture, the frame an
+// app scores is provably the frame the episode recorded, which is not true of
+// the camera entitlement's independent second reader.
+type hubLoopbackPump struct {
+	logger *zap.Logger
+	// sourceID is the canonical harness identifier of the camera being pumped,
+	// used only for logging and for the control plane to match a node to a
+	// SensorService source.
+	sourceID string
+	// nodePath is the v4l2loopback node being fed.
+	nodePath string
+	// bindings is the published mapping this pump maintains. The control plane
+	// reads it concurrently.
+	bindings *loopbackBindingTable
+
+	// mu guards the identity subscriber set.
+	mu     sync.Mutex
+	subs   map[int]chan loopbackBinding
+	nextID int
+}
+
+// identitySubscriberBuffer is the per-subscriber queue depth for the control
+// plane. Identities are a few dozen bytes each, so this is cheap, and the depth
+// is what lets a briefly stalled gRPC stream catch up without losing any.
+const identitySubscriberBuffer = 256
+
+// newHubLoopbackPump creates a pump for one source and node.
+func newHubLoopbackPump(logger *zap.Logger, sourceID, nodePath string) *hubLoopbackPump {
+	return &hubLoopbackPump{
+		logger:   logger,
+		sourceID: sourceID,
+		nodePath: nodePath,
+		bindings: newLoopbackBindingTable(loopbackBindingRetention),
+		subs:     map[int]chan loopbackBinding{},
+	}
+}
+
+// subscribeIdentities registers a control-plane subscriber and returns its
+// channel plus a cancel function that unregisters and closes it.
+func (p *hubLoopbackPump) subscribeIdentities() (<-chan loopbackBinding, func()) {
+	ch := make(chan loopbackBinding, identitySubscriberBuffer)
+	p.mu.Lock()
+	id := p.nextID
+	p.nextID++
+	p.subs[id] = ch
+	p.mu.Unlock()
+
+	var once sync.Once
+	return ch, func() {
+		once.Do(func() {
+			p.mu.Lock()
+			delete(p.subs, id)
+			p.mu.Unlock()
+			close(ch)
+		})
+	}
+}
+
+// publishIdentity fans one binding out to the control-plane subscribers.
+//
+// Sends are non-blocking. A subscriber that cannot keep up loses identities
+// rather than stalling the pump, because blocking here would stall the DATA
+// plane: frames would stop reaching the node for every reader, so one slow gRPC
+// client could freeze the camera for everyone. The cost of dropping is bounded
+// and fails closed: the app simply cannot resolve those sequences and must treat
+// the frames as unidentified, which is the correct outcome. It never yields a
+// wrong identity.
+func (p *hubLoopbackPump) publishIdentity(b loopbackBinding) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for id, ch := range p.subs {
+		select {
+		case ch <- b:
+		default:
+			p.logger.Warn("two-plane: frame identity subscriber is behind; dropping an identity",
+				zap.String("source", p.sourceID), zap.Int("subscriber", id))
+		}
+	}
+}
+
+// Bindings exposes the pump's mapping so the control plane can resolve a
+// sequence, and so tests can assert what was recorded.
+func (p *hubLoopbackPump) Bindings() *loopbackBindingTable { return p.bindings }
+
+// Run joins the hub for src and pumps frames to the node until ctx is done or
+// the producer stops.
+//
+// Stream parameters are deliberately NOT asserted, for the same reason
+// SubscribeSensor does not assert them: a data-plane consumer must never take a
+// running stream away from a viewer or from episode capture. An empty request
+// also matches the parameters episode capture uses by default, so the common
+// case joins the one existing hub rather than forcing a second producer.
+func (p *hubLoopbackPump) Run(ctx context.Context, svc *VideoService, src videoSource, devID uint32) error {
+	writer, err := openLoopbackFrameWriter(p.nodePath)
+	if err != nil {
+		return fmt.Errorf("opening loopback node %s: %w", p.nodePath, err)
+	}
+	defer func() {
+		if cerr := writer.Close(); cerr != nil {
+			p.logger.Warn("two-plane: closing loopback node failed",
+				zap.String("node", p.nodePath), zap.Error(cerr))
+		}
+	}()
+
+	hub, subID, frames, err := svc.joinHub(ctx, src.key, &agentpb.StreamVideoRequest{DeviceId: devID})
+	if err != nil {
+		return fmt.Errorf("joining producer hub for %s: %w", p.sourceID, err)
+	}
+	defer hub.unsubscribe(subID)
+
+	return p.pump(ctx, hub, subID, frames, writer)
+}
+
+// pump is the frame loop, split out from Run so tests can drive it with a fake
+// hub subscription and a fake writer without any device or kernel module.
+func (p *hubLoopbackPump) pump(ctx context.Context, hub *deviceHub, subID int, frames <-chan *videoFrame, writer loopbackFrameWriter) error {
+	// lastDrops is the hub's running drop total for this subscriber as of the
+	// previously WRITTEN frame, so each binding reports the drops since it. This
+	// is drop case 1 from hub_loopback_binding.go: those samples never reach the
+	// node, so the loopback sequence does not gap and cannot report them. If the
+	// pump did not carry this number across, a hub-side loss would be invisible
+	// on both planes.
+	//
+	// One honest limit on the attribution, shared with the gRPC sensor path
+	// (cameraSensorSubscription.Next does exactly the same thing): the counter is
+	// read when the pump CONSUMES a frame, not when the hub queued it. The
+	// subscriber channel is buffered, so a drop that happens while frames are
+	// still sitting in that buffer is attributed to the next frame the pump
+	// consumes rather than to the frame it actually preceded. The RUNNING TOTAL
+	// is exact and no loss is ever unreported; only the frame a given loss is
+	// charged to can be off by up to the channel depth. Reporting the drop
+	// against the wrong neighbouring frame is tolerable; silently losing the
+	// count would not be. Making it exact would mean stamping the drop count onto
+	// the frame at broadcast, which is a change to shared hub behaviour that the
+	// gRPC sensor path and episode capture would also have to absorb.
+	var lastDrops uint64
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case frame, ok := <-frames:
+			if !ok {
+				if err := hub.terminalErr(); err != nil {
+					return err
+				}
+				return nil
+			}
+			if bindable, reason := frameBindableToLoopback(frame); !bindable {
+				// Fail closed rather than writing something the sequence cannot
+				// name. Publishing a node whose frames have no resolvable identity
+				// would hand an app exactly the unprovable join the two-plane path
+				// exists to eliminate.
+				p.logger.Warn("two-plane: source cannot support a frame identity binding; stopping pump",
+					zap.String("source", p.sourceID),
+					zap.String("node", p.nodePath),
+					zap.String("reason", reason))
+				return fmt.Errorf("source %s: %s", p.sourceID, reason)
+			}
+
+			drops := hub.drops(subID)
+			delta := drops - lastDrops
+
+			seq, err := writer.WriteFrame(frame.data)
+			if err != nil {
+				// A failed write is NOT a dropped frame: the kernel did not advance
+				// its counter and we record no binding, so the sample is simply
+				// absent from both planes rather than appearing as a loss. Keep
+				// lastDrops unadvanced so the next successful write still reports
+				// every hub drop since the last frame that actually reached the node.
+				p.logger.Warn("two-plane: writing frame to loopback node failed",
+					zap.String("node", p.nodePath),
+					zap.Uint64("sample_id", frame.sampleID),
+					zap.Error(err))
+				continue
+			}
+			lastDrops = drops
+
+			binding := loopbackBinding{
+				LoopbackSequence: seq,
+				SampleID:         frame.sampleID,
+				BootNanos:        frame.receiptBootNanos,
+				UncertaintyNanos: frame.receiptUncertaintyNanos,
+				HubDropsBefore:   delta,
+			}
+			// Record before publishing, so a subscriber that reacts to the
+			// identity can always resolve it in the table too.
+			p.bindings.Record(binding)
+			p.publishIdentity(binding)
+		}
+	}
+}

--- a/go/internal/agent/services/hub_loopback_pump_test.go
+++ b/go/internal/agent/services/hub_loopback_pump_test.go
@@ -1,0 +1,332 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	"go.uber.org/zap"
+)
+
+// fakeLoopbackWriter stands in for the v4l2loopback node.
+//
+// It hands back sequences starting from a NON-ZERO base on purpose. The kernel's
+// write_position is reset only when the device is created, not per open, so a
+// pump attaching to a node that has been written before starts partway up the
+// counter. A pump that quietly numbered frames itself would pass a test whose
+// fake started at zero and then misattribute every frame in production, so the
+// fake refuses to make that bug invisible.
+type fakeLoopbackWriter struct {
+	nextSeq uint32
+	writes  [][]byte
+	// failOn holds write indices (0-based) that should return an error.
+	failOn map[int]bool
+	closed bool
+}
+
+func newFakeLoopbackWriter(base uint32) *fakeLoopbackWriter {
+	return &fakeLoopbackWriter{nextSeq: base, failOn: map[int]bool{}}
+}
+
+func (f *fakeLoopbackWriter) WriteFrame(data []byte) (uint32, error) {
+	if f.failOn[len(f.writes)] {
+		f.writes = append(f.writes, nil)
+		return 0, errors.New("simulated write failure")
+	}
+	f.writes = append(f.writes, append([]byte(nil), data...))
+	seq := f.nextSeq
+	// The kernel advances its counter only for a frame it actually accepted.
+	f.nextSeq++
+	return seq, nil
+}
+
+func (f *fakeLoopbackWriter) Close() error { f.closed = true; return nil }
+
+// newPumpTestHub builds a deviceHub with one subscriber registered through the
+// hub's own subscribe(), so the pump's drop accounting reads exactly the
+// bookkeeping the real hub keeps rather than a hand-built approximation of it.
+func newPumpTestHub(t *testing.T) (*deviceHub, int, chan *videoFrame) {
+	t.Helper()
+	hub, cancel := newTestHub(t)
+	t.Cleanup(cancel)
+	subID, frames, err := hub.subscribe()
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	return hub, subID, frames
+}
+
+// waitForBindings blocks until the pump has recorded n bindings.
+//
+// The drop tests need this because the hub's drop counter is read when the pump
+// CONSUMES a frame, not when the hub queued it (this is the same accounting
+// cameraSensorSubscription.Next does, deliberately). Staging all the frames and
+// all the drops up front would therefore attribute drops to whichever frame the
+// pump happened to reach first, which says nothing about the real behaviour.
+// Interleaving the way the hub actually would is the only way these tests mean
+// anything.
+func waitForBindings(t *testing.T, pump *hubLoopbackPump, n int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if pump.Bindings().Len() >= n {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d bindings; have %d", n, pump.Bindings().Len())
+}
+
+func bindableFrame(sampleID uint64, boot, unc int64) *videoFrame {
+	return &videoFrame{
+		data:                    []byte{0, 0, 0, 1, 0x65, byte(sampleID)},
+		codec:                   agentpb.VideoCodec_VIDEO_CODEC_H264,
+		auAligned:               true,
+		sampleID:                sampleID,
+		receiptBootNanos:        boot,
+		receiptUncertaintyNanos: unc,
+	}
+}
+
+// TestPumpBindsKernelSequenceNotArrivalOrder is the central assertion of the
+// whole feature: the recorded sequence is the one the WRITER (standing in for
+// the kernel) returned, not a number the pump derived from arrival order.
+func TestPumpBindsKernelSequenceNotArrivalOrder(t *testing.T) {
+	hub, subID, frames := newPumpTestHub(t)
+	writer := newFakeLoopbackWriter(9000)
+	pump := newHubLoopbackPump(zap.NewNop(), "v4l2:/dev/video0", "/dev/video200")
+
+	frames <- bindableFrame(1, 111, 5)
+	frames <- bindableFrame(2, 222, 5)
+	close(frames)
+
+	if err := pump.pump(context.Background(), hub, subID, frames, writer); err != nil {
+		t.Fatalf("pump returned %v, want nil on producer stop", err)
+	}
+
+	for seq, wantSample := range map[uint32]uint64{9000: 1, 9001: 2} {
+		got, ok := pump.Bindings().Lookup(seq)
+		if !ok {
+			t.Fatalf("Lookup(%d) not found; the pump did not use the kernel-assigned sequence", seq)
+		}
+		if got.SampleID != wantSample {
+			t.Errorf("Lookup(%d).SampleID = %d, want %d", seq, got.SampleID, wantSample)
+		}
+	}
+	// A pump that numbered frames itself would have recorded 0 and 1.
+	if _, ok := pump.Bindings().Lookup(0); ok {
+		t.Error("pump recorded a sequence of its own rather than the kernel's")
+	}
+}
+
+// TestPumpCarriesCanonicalIdentity pins that the binding reproduces the hub's
+// canonical time and uncertainty verbatim, so every plane reports the same
+// numbers for the same sample.
+func TestPumpCarriesCanonicalIdentity(t *testing.T) {
+	hub, subID, frames := newPumpTestHub(t)
+	writer := newFakeLoopbackWriter(1)
+	pump := newHubLoopbackPump(zap.NewNop(), "v4l2:/dev/video0", "/dev/video200")
+
+	frames <- bindableFrame(42, 1234567890123, 750)
+	close(frames)
+	if err := pump.pump(context.Background(), hub, subID, frames, writer); err != nil {
+		t.Fatalf("pump returned %v", err)
+	}
+
+	got, ok := pump.Bindings().Lookup(1)
+	if !ok {
+		t.Fatal("binding not recorded")
+	}
+	if got.BootNanos != 1234567890123 || got.UncertaintyNanos != 750 {
+		t.Errorf("binding carried boot=%d unc=%d, want 1234567890123/750",
+			got.BootNanos, got.UncertaintyNanos)
+	}
+}
+
+// TestPumpReportsHubDroppedFrames is drop case 1: the hub dropped frames for the
+// pump, so those samples never reached the node.
+//
+// The loopback sequence stays DENSE across the loss, which is exactly why the
+// data plane alone cannot report it and why the binding must carry the count.
+// This is the dropped-frame case the design has to survive.
+func TestPumpReportsHubDroppedFrames(t *testing.T) {
+	hub, subID, frames := newPumpTestHub(t)
+	writer := newFakeLoopbackWriter(500)
+	pump := newHubLoopbackPump(zap.NewNop(), "v4l2:/dev/video0", "/dev/video200")
+
+	// The hub delivered sample 1, then dropped three, then delivered sample 5.
+	// The drops are recorded only once the pump has consumed sample 1, which is
+	// how they would really accumulate: the hub fails to send while the pump is
+	// busy with the previous frame.
+	done := make(chan error, 1)
+	go func() { done <- pump.pump(context.Background(), hub, subID, frames, writer) }()
+
+	frames <- bindableFrame(1, 100, 1)
+	waitForBindings(t, pump, 1)
+	hub.mu.Lock()
+	hub.subDrops[subID] = 3
+	hub.mu.Unlock()
+	frames <- bindableFrame(5, 200, 1)
+	waitForBindings(t, pump, 2)
+	close(frames)
+
+	if err := <-done; err != nil {
+		t.Fatalf("pump returned %v", err)
+	}
+
+	first, ok := pump.Bindings().Lookup(500)
+	if !ok {
+		t.Fatal("first binding missing")
+	}
+	second, ok := pump.Bindings().Lookup(501)
+	if !ok {
+		t.Fatal("second binding missing")
+	}
+
+	// The sequence is dense: the kernel counted only what we wrote.
+	if second.LoopbackSequence-first.LoopbackSequence != 1 {
+		t.Errorf("sequence gapped across a hub-side drop (%d -> %d); it must stay dense, "+
+			"which is why the control plane has to report the loss",
+			first.LoopbackSequence, second.LoopbackSequence)
+	}
+	// The loss is recoverable only from the recorded count.
+	if second.HubDropsBefore != 3 {
+		t.Errorf("HubDropsBefore = %d, want 3", second.HubDropsBefore)
+	}
+	// And it agrees with the sample_id jump, the corroborating signal.
+	if gap := second.SampleID - first.SampleID - 1; gap != second.HubDropsBefore {
+		t.Errorf("sample_id gap %d disagrees with HubDropsBefore %d", gap, second.HubDropsBefore)
+	}
+}
+
+// TestPumpWriteFailureIsNotADroppedFrame pins that a failed write leaves the
+// sample absent from both planes rather than appearing as a loss, and that the
+// hub drops accumulated before it are still attributed to the next frame that
+// actually reached the node.
+func TestPumpWriteFailureIsNotADroppedFrame(t *testing.T) {
+	hub, subID, frames := newPumpTestHub(t)
+	writer := newFakeLoopbackWriter(10)
+	writer.failOn[1] = true // the second write fails
+	pump := newHubLoopbackPump(zap.NewNop(), "v4l2:/dev/video0", "/dev/video200")
+
+	done := make(chan error, 1)
+	go func() { done <- pump.pump(context.Background(), hub, subID, frames, writer) }()
+
+	frames <- bindableFrame(1, 100, 1)
+	waitForBindings(t, pump, 1)
+	hub.mu.Lock()
+	hub.subDrops[subID] = 2 // two samples lost after frame 1 was consumed
+	hub.mu.Unlock()
+	frames <- bindableFrame(4, 200, 1) // this write fails, so it records nothing
+	frames <- bindableFrame(5, 300, 1)
+	waitForBindings(t, pump, 2)
+	close(frames)
+
+	if err := <-done; err != nil {
+		t.Fatalf("pump returned %v; a write failure must not stop the pump", err)
+	}
+
+	// The failed frame consumed no sequence, so the next frame got the next one.
+	if _, ok := pump.Bindings().Lookup(11); !ok {
+		t.Fatal("frame after a failed write did not get the next kernel sequence")
+	}
+	got, _ := pump.Bindings().Lookup(11)
+	if got.SampleID != 5 {
+		t.Errorf("sequence 11 resolved to sample %d, want 5", got.SampleID)
+	}
+	// Sample 4 was never written, so nothing may name it.
+	if pump.Bindings().Len() != 2 {
+		t.Errorf("recorded %d bindings, want 2: a failed write must record none", pump.Bindings().Len())
+	}
+	// The drops that accumulated before the failed write are still reported,
+	// rather than being lost along with it.
+	if got.HubDropsBefore != 2 {
+		t.Errorf("HubDropsBefore = %d, want 2 (drops before a failed write must carry forward)", got.HubDropsBefore)
+	}
+}
+
+// TestPumpRefusesUnbindableSource pins the fail-closed behaviour: a source whose
+// frames cannot be identified stops the pump rather than publishing a node whose
+// sequences name nothing.
+func TestPumpRefusesUnbindableSource(t *testing.T) {
+	hub, subID, frames := newPumpTestHub(t)
+	writer := newFakeLoopbackWriter(1)
+	pump := newHubLoopbackPump(zap.NewNop(), "ipcamera:200", "/dev/video200")
+
+	// An IP camera producer's frame: an arbitrary chunk of a byte stream.
+	frames <- &videoFrame{
+		data:      []byte{1, 2, 3},
+		codec:     agentpb.VideoCodec_VIDEO_CODEC_H264,
+		auAligned: false,
+		sampleID:  1,
+	}
+
+	err := pump.pump(context.Background(), hub, subID, frames, writer)
+	if err == nil {
+		t.Fatal("pump accepted an unbindable source; it must refuse rather than publish meaningless sequences")
+	}
+	if len(writer.writes) != 0 {
+		t.Errorf("pump wrote %d frames for an unbindable source, want 0", len(writer.writes))
+	}
+	if pump.Bindings().Len() != 0 {
+		t.Errorf("pump recorded %d bindings for an unbindable source, want 0", pump.Bindings().Len())
+	}
+}
+
+// TestPumpStopsOnContextCancel pins clean shutdown.
+func TestPumpStopsOnContextCancel(t *testing.T) {
+	hub, subID, frames := newPumpTestHub(t)
+	writer := newFakeLoopbackWriter(1)
+	pump := newHubLoopbackPump(zap.NewNop(), "v4l2:/dev/video0", "/dev/video200")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := pump.pump(ctx, hub, subID, frames, writer); !errors.Is(err, context.Canceled) {
+		t.Errorf("pump returned %v, want context.Canceled", err)
+	}
+}
+
+// TestPumpPropagatesProducerError pins that a producer failure surfaces rather
+// than looking like a graceful stop, so a supervisor can back off and retry.
+func TestPumpPropagatesProducerError(t *testing.T) {
+	hub, subID, frames := newPumpTestHub(t)
+	writer := newFakeLoopbackWriter(1)
+	pump := newHubLoopbackPump(zap.NewNop(), "v4l2:/dev/video0", "/dev/video200")
+
+	wantErr := errors.New("camera went away")
+	hub.mu.Lock()
+	hub.err = wantErr
+	hub.mu.Unlock()
+	close(frames)
+
+	if err := pump.pump(context.Background(), hub, subID, frames, writer); !errors.Is(err, wantErr) {
+		t.Errorf("pump returned %v, want %v", err, wantErr)
+	}
+}
+
+// TestPumpWritesFramePayloadVerbatim pins that the bytes on the node are the
+// bytes the hub broadcast. If the pump altered them, an app scoring the node
+// would not be scoring the frame the episode recorded, which is the entire
+// property the two-plane path exists to provide.
+func TestPumpWritesFramePayloadVerbatim(t *testing.T) {
+	hub, subID, frames := newPumpTestHub(t)
+	writer := newFakeLoopbackWriter(1)
+	pump := newHubLoopbackPump(zap.NewNop(), "v4l2:/dev/video0", "/dev/video200")
+
+	frame := bindableFrame(7, 1, 1)
+	want := append([]byte(nil), frame.data...)
+	frames <- frame
+	close(frames)
+
+	if err := pump.pump(context.Background(), hub, subID, frames, writer); err != nil {
+		t.Fatalf("pump returned %v", err)
+	}
+	if len(writer.writes) != 1 {
+		t.Fatalf("wrote %d frames, want 1", len(writer.writes))
+	}
+	if string(writer.writes[0]) != string(want) {
+		t.Errorf("wrote %v, want %v (payload must reach the node unaltered)", writer.writes[0], want)
+	}
+}

--- a/go/internal/agent/services/hub_loopback_writer.go
+++ b/go/internal/agent/services/hub_loopback_writer.go
@@ -1,0 +1,238 @@
+package services
+
+import (
+	"fmt"
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// The V4L2 OUTPUT writer for the two-plane data path.
+//
+// UNVERIFIED ON HARDWARE. The ioctl sequence, the buffer strategy and the
+// sequence read-back in this file were derived from the kernel's videodev2.h
+// and from v4l2loopback 0.15.4's own source, but none of it has been exercised
+// against a live node on a device. It is the part of this feature most likely
+// to need adjustment, and it deliberately carries the least logic: everything
+// that can be reasoned about without a kernel module lives in
+// hub_loopback_binding.go and hub_loopback_pump.go, which are covered by tests.
+//
+// It reuses the V4L2 vocabulary video_service.go already established for the
+// capture path (the vidioc* request numbers, v4l2Buf and its offset accessors,
+// v4l2ReqBuffers, v4l2Format). Only the OUTPUT buffer type below is new. The
+// offset-accessor style is not a stylistic choice copied for its own sake: it
+// is how the existing code avoids depending on Go's struct layout matching a C
+// struct that contains a union and an alignment-forcing struct timeval.
+//
+// # Why this is a hand-written writer and not a GStreamer v4l2sink
+//
+// The existing network-camera pump (ipcam.Loopback) feeds its nodes with a
+// GStreamer pipeline ending in v4l2sink, and reusing it here would have been
+// less code. It cannot work for this purpose. The binding depends on reading
+// back the sequence the kernel assigned to each frame, which VIDIOC_QBUF
+// returns in its own argument; a GStreamer sink issues that ioctl internally
+// and surfaces nothing. Inferring the sequence instead, by counting frames
+// pushed into the pipeline, is exactly the arrival-order assumption that must
+// not be made: an intervening decoder reorders (B-frames) and may drop frames,
+// so the Nth frame in is not the Nth frame out.
+//
+// # Why buffers are round-robined and never dequeued
+//
+// This is not general V4L2 practice, but it is correct for this module.
+// v4l2loopback's vidioc_qbuf validates only is_allocated() and the memory type
+// for an OUTPUT buffer; it does not reject one still marked queued or done, so
+// a buffer can be re-queued directly. Avoiding the dequeue also avoids
+// depending on output-queue dequeue semantics, which differ between this module
+// and a real output device.
+//
+// The mmap'd region is the module's own image buffer, so a reader sees the
+// bytes we write with no intervening copy. With loopbackOutputBuffers buffers a
+// given one is reused only after that many further frames, which bounds the
+// window in which a slow reader could see a buffer change under it.
+
+const (
+	// v4l2BufTypeVideoOutput is V4L2_BUF_TYPE_VIDEO_OUTPUT, the counterpart of
+	// the capture path's v4l2BufTypeVideoCapture.
+	v4l2BufTypeVideoOutput = 2
+
+	// loopbackOutputBuffers is how many buffers the node's OUTPUT queue holds.
+	// Four is the conventional minimum that still lets a reader lag a few frames
+	// before a buffer is reused underneath it.
+	loopbackOutputBuffers = 4
+
+	// loopbackNodeWidth and loopbackNodeHeight are the dimensions advertised on
+	// the node. They are metadata on a compressed node: a decoder takes the real
+	// picture size from the bitstream's own parameter sets. V4L2 requires a
+	// complete format, so a conventional size is set and sizeimage, which is
+	// what actually constrains a frame, is set from the hub's own per-frame cap.
+	loopbackNodeWidth  = 1920
+	loopbackNodeHeight = 1080
+)
+
+// v4l2BufLength reads the length field of a v4l2_buffer (offset 72), which
+// QUERYBUF fills in with the size of the buffer to map. video_service.go reads
+// the same offset inline; it is named here because this file reads it too.
+func v4l2BufLength(b *v4l2Buf) uint32 { return *(*uint32)(unsafe.Pointer(&b[72])) }
+
+// v4l2BufSetBytesUsed writes the bytesused field (offset 8): how many bytes of
+// the buffer this frame actually occupies.
+func v4l2BufSetBytesUsed(b *v4l2Buf, n uint32) { *(*uint32)(unsafe.Pointer(&b[8])) = n }
+
+// v4l2BufSetField writes the field field (offset 16).
+func v4l2BufSetField(b *v4l2Buf, f uint32) { *(*uint32)(unsafe.Pointer(&b[16])) = f }
+
+// v4l2OutputWriter writes whole access units to one v4l2loopback node and
+// reports the sequence the kernel assigned to each.
+type v4l2OutputWriter struct {
+	file    *os.File
+	buffers [][]byte
+	// next is the round-robin index of the buffer the next frame will use.
+	next int
+	// streaming records whether VIDIOC_STREAMON succeeded, so Close only turns
+	// off a stream that was actually turned on.
+	streaming bool
+}
+
+// openLoopbackFrameWriterPlatform opens a v4l2loopback node's OUTPUT queue and
+// prepares it to receive H.264 access units.
+//
+// On a platform or build without the node this simply fails to open the path,
+// which is the correct outcome: the data plane is unavailable and the pump
+// reports so, while the control plane is untouched.
+func openLoopbackFrameWriterPlatform(path string) (loopbackFrameWriter, error) {
+	// V4L2 requires read-write access for the OUTPUT queue even though this side
+	// only ever writes.
+	file, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return nil, fmt.Errorf("opening %s: %w", path, err)
+	}
+	w := &v4l2OutputWriter{file: file}
+	if err := w.configure(); err != nil {
+		_ = w.Close()
+		return nil, err
+	}
+	return w, nil
+}
+
+// configure runs S_FMT, REQBUFS, QUERYBUF plus mmap, and STREAMON.
+func (w *v4l2OutputWriter) configure() error {
+	fd := uintptr(w.file.Fd())
+	name := w.file.Name()
+
+	var vfmt v4l2Format
+	vfmt.Type = v4l2BufTypeVideoOutput
+	vfmt.Width = loopbackNodeWidth
+	vfmt.Height = loopbackNodeHeight
+	// A compressed fourcc, because the producer hub carries compressed access
+	// units and this path deliberately does not decode: a decoder would destroy
+	// the frame correspondence the binding depends on (see
+	// frameBindableToLoopback). Consumers that accept a compressed fourcc
+	// (ffmpeg, GStreamer) can read the node; consumers that insist on raw pixels
+	// cannot, and that is a stated limit of the feature rather than a gap.
+	vfmt.PixelFormat = v4l2PixFmtH264
+	vfmt.Field = v4l2FieldNone
+	vfmt.SizeImage = maxFrameBytes
+	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, fd, vidiocSFmt, uintptr(unsafe.Pointer(&vfmt))); errno != 0 {
+		return fmt.Errorf("VIDIOC_S_FMT on %s: %w", name, errno)
+	}
+
+	var req v4l2ReqBuffers
+	req.Count = loopbackOutputBuffers
+	req.Type = v4l2BufTypeVideoOutput
+	req.Memory = v4l2MemoryMmap
+	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, fd, vidiocReqbufs, uintptr(unsafe.Pointer(&req))); errno != 0 {
+		return fmt.Errorf("VIDIOC_REQBUFS on %s: %w", name, errno)
+	}
+	if req.Count == 0 {
+		return fmt.Errorf("VIDIOC_REQBUFS on %s allocated no buffers", name)
+	}
+
+	for i := uint32(0); i < req.Count; i++ {
+		var qbuf v4l2Buf
+		qbuf.setIndex(i)
+		qbuf.setType(v4l2BufTypeVideoOutput)
+		qbuf.setMemory(v4l2MemoryMmap)
+		if _, _, errno := unix.Syscall(unix.SYS_IOCTL, fd, vidiocQuerybuf, uintptr(unsafe.Pointer(&qbuf))); errno != 0 {
+			return fmt.Errorf("VIDIOC_QUERYBUF %d on %s: %w", i, name, errno)
+		}
+		mem, err := unix.Mmap(int(fd), int64(qbuf.offset()), int(v4l2BufLength(&qbuf)),
+			unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
+		if err != nil {
+			return fmt.Errorf("mmap buffer %d on %s: %w", i, name, err)
+		}
+		w.buffers = append(w.buffers, mem)
+	}
+
+	// Buffers are NOT queued here, unlike the capture path. On the output side a
+	// queued buffer is a written frame, so queueing at setup would publish
+	// loopbackOutputBuffers frames of uninitialised memory, each consuming a
+	// kernel sequence that no binding names.
+	bufType := int32(v4l2BufTypeVideoOutput)
+	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, fd, vidiocStreamon, uintptr(unsafe.Pointer(&bufType))); errno != 0 {
+		return fmt.Errorf("VIDIOC_STREAMON on %s: %w", name, errno)
+	}
+	w.streaming = true
+	return nil
+}
+
+// WriteFrame copies one access unit into the next buffer and queues it,
+// returning the sequence the kernel assigned.
+//
+// The returned value is read back out of the ioctl's own buffer struct, and
+// that is the entire basis of the binding: v4l2loopback overwrites whatever
+// sequence a writer supplies with its internal write_position and copies the
+// result back before advancing that counter, so this value names THIS frame and
+// is authoritative. Nothing here may substitute a locally computed number for
+// it; doing so would reintroduce precisely the arrival-order assumption the
+// design exists to avoid.
+func (w *v4l2OutputWriter) WriteFrame(data []byte) (uint32, error) {
+	if len(w.buffers) == 0 {
+		return 0, fmt.Errorf("loopback node %s has no buffers", w.file.Name())
+	}
+	idx := w.next
+	mem := w.buffers[idx]
+	if len(data) > len(mem) {
+		// Refuse rather than truncate. Half an access unit written under a valid
+		// sequence would give a consumer a resolvable identity for a frame that
+		// cannot be decoded, which is worse than the frame simply being absent.
+		return 0, fmt.Errorf("frame of %d bytes exceeds loopback buffer size %d", len(data), len(mem))
+	}
+	copy(mem, data)
+
+	var qbuf v4l2Buf
+	qbuf.setIndex(uint32(idx))
+	qbuf.setType(v4l2BufTypeVideoOutput)
+	qbuf.setMemory(v4l2MemoryMmap)
+	v4l2BufSetBytesUsed(&qbuf, uint32(len(data)))
+	v4l2BufSetField(&qbuf, v4l2FieldNone)
+	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(w.file.Fd()), vidiocQbuf, uintptr(unsafe.Pointer(&qbuf))); errno != 0 {
+		return 0, fmt.Errorf("VIDIOC_QBUF on %s: %w", w.file.Name(), errno)
+	}
+	w.next = (w.next + 1) % len(w.buffers)
+	return qbuf.sequence(), nil
+}
+
+// Close turns the stream off, unmaps the buffers and closes the node. The node
+// itself is left in place; only this writer's use of it ends, mirroring
+// ipcam.Loopback.Shutdown, which also stops pumps without removing nodes.
+func (w *v4l2OutputWriter) Close() error {
+	var firstErr error
+	if w.streaming {
+		bufType := int32(v4l2BufTypeVideoOutput)
+		if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(w.file.Fd()), vidiocStreamoff, uintptr(unsafe.Pointer(&bufType))); errno != 0 {
+			firstErr = fmt.Errorf("VIDIOC_STREAMOFF on %s: %w", w.file.Name(), errno)
+		}
+		w.streaming = false
+	}
+	for _, mem := range w.buffers {
+		if err := unix.Munmap(mem); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	w.buffers = nil
+	if err := w.file.Close(); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
+}

--- a/go/internal/agent/services/sensor_service.go
+++ b/go/internal/agent/services/sensor_service.go
@@ -159,6 +159,9 @@ func (s *SensorService) Sources(ctx context.Context, _ *appspbv1.SensorSourcesRe
 		response.Sources = append(response.Sources, &appspbv1.SensorSource{
 			Id: source.ID, Kind: source.Kind, ClockDomain: source.ClockDomain,
 			Healthy: source.Healthy, Detail: detail, Subscribable: subscribable,
+			// Empty unless a two-plane data path is running for this source; an
+			// app must treat that as "use Subscribe instead", not as an error.
+			LoopbackNodePath: s.loopbackNodePathFor(source.ID),
 		})
 	}
 	return response, nil

--- a/go/internal/agent/services/sensor_service_frame_identity.go
+++ b/go/internal/agent/services/sensor_service_frame_identity.go
@@ -1,0 +1,171 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/data"
+	appspbv1 "github.com/wendylabsinc/wendy/go/proto/gen/appspb/v1"
+)
+
+// frameIdentityProvider is the optional half of a sensorProvider that also
+// serves the two-plane data path's control plane. A provider that has no
+// v4l2loopback data path simply does not implement it, and its sources report
+// no node.
+type frameIdentityProvider interface {
+	// SubscribeFrameIdentity streams the identity of frames written to the
+	// source's node. It must NOT create a data path as a side effect.
+	SubscribeFrameIdentity(ctx context.Context, sourceID string) (frameIdentitySubscription, error)
+	// TwoPlaneNodePath reports the node carrying the source's frames, if any.
+	TwoPlaneNodePath(sourceID string) (string, bool)
+}
+
+// frameIdentityProviderFor resolves the provider that can stream a source's
+// frame identities, or nil if none can.
+func (s *SensorService) frameIdentityProviderFor(sourceID string) frameIdentityProvider {
+	for _, provider := range s.providerSnapshot() {
+		if !provider.SupportsSensorSource(sourceID) {
+			continue
+		}
+		if fip, ok := provider.(frameIdentityProvider); ok {
+			return fip
+		}
+	}
+	return nil
+}
+
+// SubscribeFrameIdentity streams frame identities for the requested sources.
+//
+// This is the control plane of the two-plane camera path: it carries identity
+// only, never pixels, so an app reading the v4l2loopback node with ordinary
+// tooling can name the frames it scored. See the FrameIdentity proto comment for
+// the join and for what dropped frames look like on each plane.
+//
+// # Why deliveries are not teed into the model-input ledger
+//
+// Subscribe records every sample it hands to a model, because handing a sample
+// over the stream IS the delivery. That is not true here. Publishing an identity
+// says the agent wrote a frame to the node; it does not say the app read it. An
+// app that fell behind has frames fast-forwarded past it by v4l2loopback and
+// never sees them, while the identity for each was published all the same.
+// Recording those as model inputs would make the episode assert a delivery that
+// may not have happened, which is exactly the kind of record that is worse than
+// no record at all. An app that wants its consumption in the ledger must report
+// what it actually read, which it can do precisely because this stream gives it
+// the sample_id for each frame.
+func (s *SensorService) SubscribeFrameIdentity(req *appspbv1.FrameIdentitySubscribeRequest, stream appspbv1.SensorService_SubscribeFrameIdentityServer) error {
+	sourceIDs, err := normalizeSubscribeSources(req.GetSourceIds())
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithCancel(stream.Context())
+	defer cancel()
+
+	identities := make(chan FrameIdentitySample, sensorFanInBuffer*len(sourceIDs))
+	var wg sync.WaitGroup
+	fatal := make(chan error, len(sourceIDs))
+
+	for _, sourceID := range sourceIDs {
+		if !s.permitted(sourceID) {
+			cancel()
+			wg.Wait()
+			return status.Errorf(codes.PermissionDenied, "this app's sensor-read entitlement does not list source %q", sourceID)
+		}
+		provider := s.frameIdentityProviderFor(sourceID)
+		if provider == nil {
+			cancel()
+			wg.Wait()
+			return status.Errorf(codes.NotFound, "source %q is not available to model subscribers", sourceID)
+		}
+		subscription, err := provider.SubscribeFrameIdentity(ctx, sourceID)
+		if err != nil {
+			cancel()
+			wg.Wait()
+			return err
+		}
+		wg.Add(1)
+		go func(sourceID string, subscription frameIdentitySubscription) {
+			defer wg.Done()
+			defer subscription.Close()
+			for {
+				identity, err := subscription.Next(ctx)
+				if err != nil {
+					if ctx.Err() == nil {
+						fatal <- fmt.Errorf("source %s: %w", sourceID, err)
+					}
+					return
+				}
+				identity.SourceID = sourceID
+				select {
+				case identities <- identity:
+				case <-ctx.Done():
+					return
+				}
+				// Unlike Subscribe there is no non-blocking drop here. An
+				// identity is a few dozen bytes, and losing one costs the app the
+				// ability to name a frame it may have scored. The pump already
+				// drops for a subscriber that falls badly behind
+				// (hubLoopbackPump.publishIdentity), which is the bound that
+				// keeps memory finite; adding a second silent drop on top of it
+				// would only make the loss harder to explain.
+			}
+		}(sourceID, subscription)
+	}
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(identities); close(done) }()
+	defer func() { cancel(); <-done }()
+
+	for {
+		select {
+		case err := <-fatal:
+			return status.Error(codes.Unavailable, err.Error())
+		case <-ctx.Done():
+			return nil
+		case identity, ok := <-identities:
+			if !ok {
+				select {
+				case err := <-fatal:
+					return status.Error(codes.Unavailable, err.Error())
+				default:
+					return nil
+				}
+			}
+			if err := stream.Send(frameIdentityMessage(identity)); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// frameIdentityMessage converts one identity to the wire form.
+func frameIdentityMessage(identity FrameIdentitySample) *appspbv1.FrameIdentity {
+	return &appspbv1.FrameIdentity{
+		SourceId:                  identity.SourceID,
+		SampleId:                  identity.SampleID,
+		BoottimeNanos:             identity.BootNanos,
+		TimestampUncertaintyNanos: identity.UncertaintyNanos,
+		LoopbackSequence:          identity.LoopbackSequence,
+		DroppedBefore:             identity.DroppedBefore,
+		BootId:                    data.BootID(),
+		NodePath:                  identity.NodePath,
+	}
+}
+
+// loopbackNodePathFor reports the data path node for a source, for Sources to
+// advertise. An empty result is the normal case and not an error.
+func (s *SensorService) loopbackNodePathFor(sourceID string) string {
+	provider := s.frameIdentityProviderFor(sourceID)
+	if provider == nil {
+		return ""
+	}
+	path, ok := provider.TwoPlaneNodePath(sourceID)
+	if !ok {
+		return ""
+	}
+	return path
+}

--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -551,6 +551,12 @@ type cameraLoopback interface {
 	CredentialsChanged(camID uint32)
 	RemoveCamera(camID uint32)
 	Shutdown()
+	// Auxiliary nodes back the two-plane camera data path: v4l2loopback nodes
+	// fed from the producer hub rather than from a registered network camera.
+	// See video_service_two_plane.go.
+	AllocateAuxNodeNumber() (int, error)
+	EnsureAuxNode(ctx context.Context, nr int, label string) error
+	RemoveAuxNode(nr int)
 }
 
 // VideoService implements agentpb.WendyVideoServiceServer.
@@ -568,6 +574,9 @@ type VideoService struct {
 	discoverer  *ipcam.Discoverer
 	links       *ipcam.LinkManager
 	loopback    cameraLoopback
+
+	// twoPlaneState holds the two-plane camera data path's nodes and pumps.
+	twoPlaneState
 
 	// runGStreamer is the injection seam for the network capture subprocess.
 	runGStreamer func(ctx context.Context, args []string, onFrame func([]byte)) error
@@ -724,6 +733,11 @@ func (s *VideoService) StartDiscovery() {
 // shuttingDown check could still start a new supervisor moments after ctx
 // cancellation fires but before Loopback.Shutdown gets a chance to run.
 func (s *VideoService) Shutdown() {
+	// Two-plane pumps go first, and are waited for, because each one holds a hub
+	// subscription and an open v4l2loopback node. Cancelling s.ctx alone would
+	// stop them eventually but would not wait, so a pump could still be
+	// releasing its node after Shutdown returned.
+	s.stopAllTwoPlane()
 	if s.loopback != nil {
 		s.loopback.Shutdown()
 	}

--- a/go/internal/agent/services/video_service_ipcam_test.go
+++ b/go/internal/agent/services/video_service_ipcam_test.go
@@ -41,6 +41,14 @@ type fakeLoopback struct {
 	credChanged        []uint32
 	removed            []uint32
 	shutdownCalled     bool
+
+	// Auxiliary-node state backs the two-plane camera data path. auxNext is the
+	// number the next allocation hands out; auxErr forces the band-exhausted
+	// path; auxCreated and auxRemoved record the calls.
+	auxNext    int
+	auxErr     error
+	auxCreated []int
+	auxRemoved []int
 }
 
 func newFakeLoopback() *fakeLoopback {
@@ -49,6 +57,33 @@ func newFakeLoopback() *fakeLoopback {
 		acquireCount: make(map[uint32]int),
 		releaseCount: make(map[uint32]int),
 	}
+}
+
+func (f *fakeLoopback) AllocateAuxNodeNumber() (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.auxErr != nil {
+		return 0, f.auxErr
+	}
+	if f.auxNext == 0 {
+		f.auxNext = 255
+	}
+	nr := f.auxNext
+	f.auxNext--
+	return nr, nil
+}
+
+func (f *fakeLoopback) EnsureAuxNode(_ context.Context, nr int, _ string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.auxCreated = append(f.auxCreated, nr)
+	return nil
+}
+
+func (f *fakeLoopback) RemoveAuxNode(nr int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.auxRemoved = append(f.auxRemoved, nr)
 }
 
 func (f *fakeLoopback) Available() error {

--- a/go/internal/agent/services/video_service_two_plane.go
+++ b/go/internal/agent/services/video_service_two_plane.go
@@ -1,0 +1,275 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/ipcam"
+)
+
+// The two-plane data path's node and pump lifecycle.
+//
+// This deliberately mirrors the shape of the network-camera loopback wiring
+// (EnsureCameraNodes / SetCameraContainerConsumers, backed by ipcam.Loopback)
+// rather than introducing a second, differently-shaped mechanism: demand comes
+// from container truth, is replaced wholesale rather than incrementally, and is
+// entirely best-effort so a data-plane problem can never break container
+// management.
+//
+// What is new is where the frames come from. The network-camera pumps source an
+// RTSP stream through GStreamer; these source the agent's OWN producer hub, so
+// the node carries exactly the frames episode capture and the gRPC sensor
+// subscribers see.
+
+// FrameIdentitySample is one frame identity handed to the control plane. It is
+// the harness-internal form of appspbv1.FrameIdentity and carries no pixels.
+type FrameIdentitySample struct {
+	SourceID         string
+	SampleID         uint64
+	BootNanos        int64
+	UncertaintyNanos int64
+	// LoopbackSequence is the kernel-assigned v4l2_buffer.sequence for this
+	// frame on the node. It is the join key an app matches against the buffer it
+	// dequeued.
+	LoopbackSequence uint32
+	DroppedBefore    uint64
+	NodePath         string
+}
+
+// frameIdentitySubscription is one live subscription to a source's frame
+// identities.
+type frameIdentitySubscription interface {
+	Next(ctx context.Context) (FrameIdentitySample, error)
+	Close()
+}
+
+// errNoDataPlane reports that a source has no v4l2loopback node, which is the
+// normal state rather than a fault: a node exists only while an app entitled to
+// both sensor-read and camera is running, and only for a source whose frames can be
+// identified frame-for-frame.
+var errNoDataPlane = errors.New("source has no two-plane data path")
+
+// twoPlaneNode is one running node plus the pump feeding it.
+type twoPlaneNode struct {
+	pump   *hubLoopbackPump
+	cancel context.CancelFunc
+	done   chan struct{}
+	nodeNr int
+	path   string
+}
+
+// SetTwoPlaneContainerConsumers replaces, wholesale, the set of running
+// containers entitled to the two-plane camera path, starting or stopping nodes
+// and pumps to match.
+//
+// The caller decides entitlement (see containerd.twoPlaneConsumerNames, which
+// requires BOTH sensors and camera). This end only honours the resulting demand.
+// Demand is not per-source, matching the existing camera loopback behaviour: the
+// entitlements are device-wide, not per-device-node.
+func (s *VideoService) SetTwoPlaneContainerConsumers(ctx context.Context, containerIDs []string) {
+	s.twoPlaneMu.Lock()
+	s.twoPlaneDemand = len(containerIDs) > 0
+	demand := s.twoPlaneDemand
+	s.twoPlaneMu.Unlock()
+
+	if !demand {
+		s.stopAllTwoPlane()
+		return
+	}
+	s.ensureTwoPlaneForLocalCameras(ctx)
+}
+
+// ensureTwoPlaneForLocalCameras starts a node and pump for every local camera
+// that does not already have one.
+//
+// Only local V4L2 cameras are candidates. A network camera already reaches
+// containers through the existing ipcam loopback path, and its producer
+// delivers an unaligned byte stream that frameBindableToLoopback refuses
+// anyway, so it could not carry a frame identity binding.
+func (s *VideoService) ensureTwoPlaneForLocalCameras(ctx context.Context) {
+	if s.loopback == nil {
+		return
+	}
+	devices, err := s.listCameras(ctx)
+	if err != nil {
+		s.logger.Warn("two-plane: listing cameras failed", zap.Error(err))
+		return
+	}
+	for _, dev := range devices {
+		if dev.GetId() >= uint32(ipcam.IDBandStart) {
+			continue // a network camera, served by the existing loopback path
+		}
+		sourceID := "v4l2:" + dev.GetPath()
+		if err := s.ensureTwoPlaneNode(ctx, sourceID, dev.GetId()); err != nil {
+			s.logger.Warn("two-plane: starting data path failed",
+				zap.String("source", sourceID), zap.Error(err))
+		}
+	}
+}
+
+// ensureTwoPlaneNode allocates a node and starts its pump for one source, if it
+// does not already have one running.
+func (s *VideoService) ensureTwoPlaneNode(ctx context.Context, sourceID string, devID uint32) error {
+	s.twoPlaneMu.Lock()
+	if s.twoPlane == nil {
+		s.twoPlane = map[string]*twoPlaneNode{}
+	}
+	if _, running := s.twoPlane[sourceID]; running {
+		s.twoPlaneMu.Unlock()
+		return nil
+	}
+	s.twoPlaneMu.Unlock()
+
+	src, err := s.resolveSource(devID)
+	if err != nil {
+		return err
+	}
+
+	nodeNr, err := s.loopback.AllocateAuxNodeNumber()
+	if err != nil {
+		return fmt.Errorf("allocating a loopback node: %w", err)
+	}
+	label := fmt.Sprintf("Wendy sensor %d", devID)
+	if err := s.loopback.EnsureAuxNode(ctx, nodeNr, label); err != nil {
+		return fmt.Errorf("creating loopback node %d: %w", nodeNr, err)
+	}
+	path := fmt.Sprintf("/dev/video%d", nodeNr)
+
+	// The pump's context is derived from the service's, not from the caller's:
+	// the caller here is a container lifecycle nudge whose context ends with the
+	// nudge, while the pump must outlive it and stop only on explicit demand
+	// withdrawal or service shutdown.
+	pumpCtx, cancel := context.WithCancel(s.ctx)
+	pump := newHubLoopbackPump(s.logger, sourceID, path)
+	node := &twoPlaneNode{pump: pump, cancel: cancel, done: make(chan struct{}), nodeNr: nodeNr, path: path}
+
+	s.twoPlaneMu.Lock()
+	if _, running := s.twoPlane[sourceID]; running {
+		// Lost a race with a concurrent nudge; the other one owns the node.
+		s.twoPlaneMu.Unlock()
+		cancel()
+		s.loopback.RemoveAuxNode(nodeNr)
+		return nil
+	}
+	s.twoPlane[sourceID] = node
+	s.twoPlaneMu.Unlock()
+
+	go func() {
+		defer close(node.done)
+		err := pump.Run(pumpCtx, s, src, devID)
+		if err != nil && !errors.Is(err, context.Canceled) {
+			// A pump that stops on its own is not retried here. The usual reason
+			// is frameBindableToLoopback refusing the source, which will refuse it
+			// again on every retry, so a retry loop would spin producing nothing.
+			// The node is left in place but idle, and the source reports no data
+			// plane, which is the honest state.
+			s.logger.Warn("two-plane: pump stopped",
+				zap.String("source", sourceID), zap.String("node", path), zap.Error(err))
+		}
+		s.twoPlaneMu.Lock()
+		if cur, ok := s.twoPlane[sourceID]; ok && cur == node {
+			delete(s.twoPlane, sourceID)
+		}
+		s.twoPlaneMu.Unlock()
+		s.loopback.RemoveAuxNode(nodeNr)
+	}()
+	return nil
+}
+
+// stopAllTwoPlane cancels every running pump and waits for each to release its
+// node, so a subsequent allocation cannot hand out a number still in use.
+func (s *VideoService) stopAllTwoPlane() {
+	s.twoPlaneMu.Lock()
+	nodes := make([]*twoPlaneNode, 0, len(s.twoPlane))
+	for _, n := range s.twoPlane {
+		nodes = append(nodes, n)
+	}
+	s.twoPlaneMu.Unlock()
+
+	for _, n := range nodes {
+		n.cancel()
+	}
+	for _, n := range nodes {
+		<-n.done
+	}
+}
+
+// TwoPlaneNodePath reports the v4l2loopback node carrying a source's frames on
+// the data path, if one is running.
+func (s *VideoService) TwoPlaneNodePath(sourceID string) (string, bool) {
+	s.twoPlaneMu.Lock()
+	defer s.twoPlaneMu.Unlock()
+	node, ok := s.twoPlane[sourceID]
+	if !ok {
+		return "", false
+	}
+	return node.path, true
+}
+
+// SubscribeFrameIdentity streams the identity of frames written to a source's
+// node. It is the control plane half of the two-plane path.
+//
+// It does NOT start a data plane: a source without a running node returns
+// FailedPrecondition rather than quietly creating one, because creating a node
+// is a device-node grant question that belongs to the entitlement wiring, not to
+// whoever happens to subscribe.
+func (s *VideoService) SubscribeFrameIdentity(ctx context.Context, sourceID string) (frameIdentitySubscription, error) {
+	if _, err := s.resolveSensorSource(sourceID); err != nil {
+		return nil, err
+	}
+	s.twoPlaneMu.Lock()
+	node, ok := s.twoPlane[sourceID]
+	s.twoPlaneMu.Unlock()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"source %q has no two-plane data path; subscribe to samples instead", sourceID)
+	}
+	ch, cancel := node.pump.subscribeIdentities()
+	return &pumpIdentitySubscription{sourceID: sourceID, nodePath: node.path, ch: ch, cancel: cancel}, nil
+}
+
+// pumpIdentitySubscription adapts one pump identity subscription to the
+// control-plane contract.
+type pumpIdentitySubscription struct {
+	sourceID string
+	nodePath string
+	ch       <-chan loopbackBinding
+	cancel   func()
+}
+
+func (p *pumpIdentitySubscription) Next(ctx context.Context) (FrameIdentitySample, error) {
+	select {
+	case <-ctx.Done():
+		return FrameIdentitySample{}, ctx.Err()
+	case b, ok := <-p.ch:
+		if !ok {
+			return FrameIdentitySample{}, errNoDataPlane
+		}
+		return FrameIdentitySample{
+			SourceID:         p.sourceID,
+			SampleID:         b.SampleID,
+			BootNanos:        b.BootNanos,
+			UncertaintyNanos: b.UncertaintyNanos,
+			LoopbackSequence: b.LoopbackSequence,
+			DroppedBefore:    b.HubDropsBefore,
+			NodePath:         p.nodePath,
+		}, nil
+	}
+}
+
+func (p *pumpIdentitySubscription) Close() { p.cancel() }
+
+// twoPlaneState is the VideoService state this file owns. It is embedded rather
+// than declared inline in VideoService so the two-plane path's state stays
+// visibly separable from the rest of the service.
+type twoPlaneState struct {
+	twoPlaneMu     sync.Mutex
+	twoPlane       map[string]*twoPlaneNode
+	twoPlaneDemand bool
+}

--- a/go/proto/gen/appspb/v1/sensor_service.pb.go
+++ b/go/proto/gen/appspb/v1/sensor_service.pb.go
@@ -46,9 +46,19 @@ type SensorSource struct {
 	// listed with subscribable=false and a detail saying why, rather than
 	// omitted: a caller must be able to tell "not available to models" from
 	// "does not exist".
-	Subscribable  bool `protobuf:"varint,6,opt,name=subscribable,proto3" json:"subscribable,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Subscribable bool `protobuf:"varint,6,opt,name=subscribable,proto3" json:"subscribable,omitempty"`
+	// loopback_node_path is the v4l2loopback device node carrying this source's
+	// frames on the two-plane data path, for example "/dev/video200". Empty when
+	// the source has no such node, which is the normal case: a node exists only
+	// for a source whose frames can be identified frame-for-frame, and only while
+	// an app entitled to BOTH sensors and camera is running.
+	//
+	// An empty value is not an error and an app must handle it: it means the
+	// two-plane path is unavailable for this source and the app should fall back
+	// to Subscribe, which always works.
+	LoopbackNodePath string `protobuf:"bytes,7,opt,name=loopback_node_path,json=loopbackNodePath,proto3" json:"loopback_node_path,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *SensorSource) Reset() {
@@ -121,6 +131,13 @@ func (x *SensorSource) GetSubscribable() bool {
 		return x.Subscribable
 	}
 	return false
+}
+
+func (x *SensorSource) GetLoopbackNodePath() string {
+	if x != nil {
+		return x.LoopbackNodePath
+	}
+	return ""
 }
 
 type SensorSourcesRequest struct {
@@ -384,18 +401,232 @@ func (x *SensorSample) GetBootId() string {
 	return ""
 }
 
+type FrameIdentitySubscribeRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// source_ids are the sources whose frame identities to stream, as reported by
+	// Sources. At least one is required.
+	SourceIds []string `protobuf:"bytes,1,rep,name=source_ids,json=sourceIds,proto3" json:"source_ids,omitempty"`
+	// model optionally names the model consuming the frames, recorded in the
+	// episode's model-input ledger exactly as SensorSubscribeRequest.model is.
+	Model         string `protobuf:"bytes,2,opt,name=model,proto3" json:"model,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FrameIdentitySubscribeRequest) Reset() {
+	*x = FrameIdentitySubscribeRequest{}
+	mi := &file_wendy_agent_apps_v1_sensor_service_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FrameIdentitySubscribeRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FrameIdentitySubscribeRequest) ProtoMessage() {}
+
+func (x *FrameIdentitySubscribeRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_apps_v1_sensor_service_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FrameIdentitySubscribeRequest.ProtoReflect.Descriptor instead.
+func (*FrameIdentitySubscribeRequest) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_apps_v1_sensor_service_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *FrameIdentitySubscribeRequest) GetSourceIds() []string {
+	if x != nil {
+		return x.SourceIds
+	}
+	return nil
+}
+
+func (x *FrameIdentitySubscribeRequest) GetModel() string {
+	if x != nil {
+		return x.Model
+	}
+	return ""
+}
+
+// FrameIdentity names one frame the agent wrote to a source's v4l2loopback node.
+// It carries no pixels: the pixels are on the node.
+//
+// # Why loopback_sequence is the kernel's number and not ours
+//
+// The natural design would be for the agent to stamp sample_id directly into
+// v4l2_buffer.sequence, so a consumer reads the harness identifier straight off
+// the buffer. The v4l2loopback module makes that impossible: its QBUF handler
+// overwrites the sequence of any queued output buffer with its own internal
+// write counter, discarding whatever the writer supplied. There is no option or
+// flag that disables it.
+//
+// So the agent does the opposite. It reads back the sequence the kernel assigned
+// (QBUF returns it), and publishes the resulting mapping on this stream. A
+// consumer takes v4l2_buffer.sequence off the frame it dequeued and finds the
+// FrameIdentity carrying the same value. The number is therefore authoritative
+// and requires no assumption that frames arrive in a particular order, which is
+// what makes the join trustworthy.
+//
+// # Dropped frames: two different losses, two different signals
+//
+// A consumer that watches only one of these will believe frames were delivered
+// that were not. Both must be checked.
+//
+//  1. The agent could not keep up feeding the node. Those samples never reached
+//     the node at all, so loopback_sequence stays DENSE across the loss and
+//     shows no gap. The loss appears only here, as a jump in sample_id, and is
+//     counted exactly by dropped_before.
+//
+//  2. The application could not keep up reading the node. v4l2loopback
+//     fast-forwards an overrun reader rather than blocking it, so the
+//     application's next dequeued buffer has a sequence that JUMPED. This loss
+//     is invisible on this stream, because the agent did write those frames. The
+//     application detects it by comparing the sequence of consecutive dequeued
+//     buffers: the difference minus one is the number it missed.
+//
+// In short: a sample_id jump means the agent fell behind, a sequence jump means
+// the reader fell behind, and both can happen at once.
+//
+// A frame the agent failed to write appears in neither: it consumes no sequence
+// and produces no FrameIdentity, so it is absent rather than reported as lost.
+type FrameIdentity struct {
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	SourceId string                 `protobuf:"bytes,1,opt,name=source_id,json=sourceId,proto3" json:"source_id,omitempty"`
+	// sample_id is the same identifier SensorSample.sample_id carries and the same
+	// one the episode capture index and the model-input ledger record, so a frame
+	// scored off the loopback node can be joined to what the episode kept.
+	SampleId uint64 `protobuf:"varint,2,opt,name=sample_id,json=sampleId,proto3" json:"sample_id,omitempty"`
+	// boottime_nanos and timestamp_uncertainty_nanos are the agent's bracketed
+	// CLOCK_BOOTTIME receipt of this sample and the bracket half-width, identical
+	// to the values SensorSample reports for the same sample.
+	BoottimeNanos             int64 `protobuf:"varint,3,opt,name=boottime_nanos,json=boottimeNanos,proto3" json:"boottime_nanos,omitempty"`
+	TimestampUncertaintyNanos int64 `protobuf:"varint,4,opt,name=timestamp_uncertainty_nanos,json=timestampUncertaintyNanos,proto3" json:"timestamp_uncertainty_nanos,omitempty"`
+	// loopback_sequence is the v4l2_buffer.sequence the KERNEL assigned to this
+	// frame on the node. It is the join key: match it against the sequence of the
+	// buffer dequeued from the node. See the message comment for why the agent
+	// cannot choose this value.
+	LoopbackSequence uint32 `protobuf:"varint,5,opt,name=loopback_sequence,json=loopbackSequence,proto3" json:"loopback_sequence,omitempty"`
+	// dropped_before counts samples lost between the producer and the node since
+	// the previous frame written. It is the ONLY report of loss case 1 above,
+	// because that loss leaves no gap in loopback_sequence.
+	DroppedBefore uint64 `protobuf:"varint,6,opt,name=dropped_before,json=droppedBefore,proto3" json:"dropped_before,omitempty"`
+	// boot_id is the kernel boot the timestamps belong to.
+	BootId string `protobuf:"bytes,7,opt,name=boot_id,json=bootId,proto3" json:"boot_id,omitempty"`
+	// node_path is the v4l2loopback node this frame was written to, so an app
+	// subscribing to several sources knows which node each identity belongs to.
+	NodePath      string `protobuf:"bytes,8,opt,name=node_path,json=nodePath,proto3" json:"node_path,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FrameIdentity) Reset() {
+	*x = FrameIdentity{}
+	mi := &file_wendy_agent_apps_v1_sensor_service_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FrameIdentity) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FrameIdentity) ProtoMessage() {}
+
+func (x *FrameIdentity) ProtoReflect() protoreflect.Message {
+	mi := &file_wendy_agent_apps_v1_sensor_service_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FrameIdentity.ProtoReflect.Descriptor instead.
+func (*FrameIdentity) Descriptor() ([]byte, []int) {
+	return file_wendy_agent_apps_v1_sensor_service_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *FrameIdentity) GetSourceId() string {
+	if x != nil {
+		return x.SourceId
+	}
+	return ""
+}
+
+func (x *FrameIdentity) GetSampleId() uint64 {
+	if x != nil {
+		return x.SampleId
+	}
+	return 0
+}
+
+func (x *FrameIdentity) GetBoottimeNanos() int64 {
+	if x != nil {
+		return x.BoottimeNanos
+	}
+	return 0
+}
+
+func (x *FrameIdentity) GetTimestampUncertaintyNanos() int64 {
+	if x != nil {
+		return x.TimestampUncertaintyNanos
+	}
+	return 0
+}
+
+func (x *FrameIdentity) GetLoopbackSequence() uint32 {
+	if x != nil {
+		return x.LoopbackSequence
+	}
+	return 0
+}
+
+func (x *FrameIdentity) GetDroppedBefore() uint64 {
+	if x != nil {
+		return x.DroppedBefore
+	}
+	return 0
+}
+
+func (x *FrameIdentity) GetBootId() string {
+	if x != nil {
+		return x.BootId
+	}
+	return ""
+}
+
+func (x *FrameIdentity) GetNodePath() string {
+	if x != nil {
+		return x.NodePath
+	}
+	return ""
+}
+
 var File_wendy_agent_apps_v1_sensor_service_proto protoreflect.FileDescriptor
 
 const file_wendy_agent_apps_v1_sensor_service_proto_rawDesc = "" +
 	"\n" +
-	"(wendy/agent/apps/v1/sensor_service.proto\x12\x13wendy.agent.apps.v1\"\xab\x01\n" +
+	"(wendy/agent/apps/v1/sensor_service.proto\x12\x13wendy.agent.apps.v1\"\xd9\x01\n" +
 	"\fSensorSource\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04kind\x18\x02 \x01(\tR\x04kind\x12!\n" +
 	"\fclock_domain\x18\x03 \x01(\tR\vclockDomain\x12\x18\n" +
 	"\ahealthy\x18\x04 \x01(\bR\ahealthy\x12\x16\n" +
 	"\x06detail\x18\x05 \x01(\tR\x06detail\x12\"\n" +
-	"\fsubscribable\x18\x06 \x01(\bR\fsubscribable\"\x16\n" +
+	"\fsubscribable\x18\x06 \x01(\bR\fsubscribable\x12,\n" +
+	"\x12loopback_node_path\x18\a \x01(\tR\x10loopbackNodePath\"\x16\n" +
 	"\x14SensorSourcesRequest\"T\n" +
 	"\x15SensorSourcesResponse\x12;\n" +
 	"\asources\x18\x01 \x03(\v2!.wendy.agent.apps.v1.SensorSourceR\asources\"M\n" +
@@ -412,10 +643,24 @@ const file_wendy_agent_apps_v1_sensor_service_proto_rawDesc = "" +
 	"\bencoding\x18\x06 \x01(\tR\bencoding\x124\n" +
 	"\x16payload_self_contained\x18\a \x01(\bR\x14payloadSelfContained\x12%\n" +
 	"\x0edropped_before\x18\b \x01(\x04R\rdroppedBefore\x12\x17\n" +
-	"\aboot_id\x18\t \x01(\tR\x06bootId2\xd0\x01\n" +
+	"\aboot_id\x18\t \x01(\tR\x06bootId\"T\n" +
+	"\x1dFrameIdentitySubscribeRequest\x12\x1d\n" +
+	"\n" +
+	"source_ids\x18\x01 \x03(\tR\tsourceIds\x12\x14\n" +
+	"\x05model\x18\x02 \x01(\tR\x05model\"\xba\x02\n" +
+	"\rFrameIdentity\x12\x1b\n" +
+	"\tsource_id\x18\x01 \x01(\tR\bsourceId\x12\x1b\n" +
+	"\tsample_id\x18\x02 \x01(\x04R\bsampleId\x12%\n" +
+	"\x0eboottime_nanos\x18\x03 \x01(\x03R\rboottimeNanos\x12>\n" +
+	"\x1btimestamp_uncertainty_nanos\x18\x04 \x01(\x03R\x19timestampUncertaintyNanos\x12+\n" +
+	"\x11loopback_sequence\x18\x05 \x01(\rR\x10loopbackSequence\x12%\n" +
+	"\x0edropped_before\x18\x06 \x01(\x04R\rdroppedBefore\x12\x17\n" +
+	"\aboot_id\x18\a \x01(\tR\x06bootId\x12\x1b\n" +
+	"\tnode_path\x18\b \x01(\tR\bnodePath2\xc4\x02\n" +
 	"\rSensorService\x12`\n" +
 	"\aSources\x12).wendy.agent.apps.v1.SensorSourcesRequest\x1a*.wendy.agent.apps.v1.SensorSourcesResponse\x12]\n" +
-	"\tSubscribe\x12+.wendy.agent.apps.v1.SensorSubscribeRequest\x1a!.wendy.agent.apps.v1.SensorSample0\x01B?Z=github.com/wendylabsinc/wendy/go/proto/gen/appspb/v1;appspbv1b\x06proto3"
+	"\tSubscribe\x12+.wendy.agent.apps.v1.SensorSubscribeRequest\x1a!.wendy.agent.apps.v1.SensorSample0\x01\x12r\n" +
+	"\x16SubscribeFrameIdentity\x122.wendy.agent.apps.v1.FrameIdentitySubscribeRequest\x1a\".wendy.agent.apps.v1.FrameIdentity0\x01B?Z=github.com/wendylabsinc/wendy/go/proto/gen/appspb/v1;appspbv1b\x06proto3"
 
 var (
 	file_wendy_agent_apps_v1_sensor_service_proto_rawDescOnce sync.Once
@@ -429,22 +674,26 @@ func file_wendy_agent_apps_v1_sensor_service_proto_rawDescGZIP() []byte {
 	return file_wendy_agent_apps_v1_sensor_service_proto_rawDescData
 }
 
-var file_wendy_agent_apps_v1_sensor_service_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_wendy_agent_apps_v1_sensor_service_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
 var file_wendy_agent_apps_v1_sensor_service_proto_goTypes = []any{
-	(*SensorSource)(nil),           // 0: wendy.agent.apps.v1.SensorSource
-	(*SensorSourcesRequest)(nil),   // 1: wendy.agent.apps.v1.SensorSourcesRequest
-	(*SensorSourcesResponse)(nil),  // 2: wendy.agent.apps.v1.SensorSourcesResponse
-	(*SensorSubscribeRequest)(nil), // 3: wendy.agent.apps.v1.SensorSubscribeRequest
-	(*SensorSample)(nil),           // 4: wendy.agent.apps.v1.SensorSample
+	(*SensorSource)(nil),                  // 0: wendy.agent.apps.v1.SensorSource
+	(*SensorSourcesRequest)(nil),          // 1: wendy.agent.apps.v1.SensorSourcesRequest
+	(*SensorSourcesResponse)(nil),         // 2: wendy.agent.apps.v1.SensorSourcesResponse
+	(*SensorSubscribeRequest)(nil),        // 3: wendy.agent.apps.v1.SensorSubscribeRequest
+	(*SensorSample)(nil),                  // 4: wendy.agent.apps.v1.SensorSample
+	(*FrameIdentitySubscribeRequest)(nil), // 5: wendy.agent.apps.v1.FrameIdentitySubscribeRequest
+	(*FrameIdentity)(nil),                 // 6: wendy.agent.apps.v1.FrameIdentity
 }
 var file_wendy_agent_apps_v1_sensor_service_proto_depIdxs = []int32{
 	0, // 0: wendy.agent.apps.v1.SensorSourcesResponse.sources:type_name -> wendy.agent.apps.v1.SensorSource
 	1, // 1: wendy.agent.apps.v1.SensorService.Sources:input_type -> wendy.agent.apps.v1.SensorSourcesRequest
 	3, // 2: wendy.agent.apps.v1.SensorService.Subscribe:input_type -> wendy.agent.apps.v1.SensorSubscribeRequest
-	2, // 3: wendy.agent.apps.v1.SensorService.Sources:output_type -> wendy.agent.apps.v1.SensorSourcesResponse
-	4, // 4: wendy.agent.apps.v1.SensorService.Subscribe:output_type -> wendy.agent.apps.v1.SensorSample
-	3, // [3:5] is the sub-list for method output_type
-	1, // [1:3] is the sub-list for method input_type
+	5, // 3: wendy.agent.apps.v1.SensorService.SubscribeFrameIdentity:input_type -> wendy.agent.apps.v1.FrameIdentitySubscribeRequest
+	2, // 4: wendy.agent.apps.v1.SensorService.Sources:output_type -> wendy.agent.apps.v1.SensorSourcesResponse
+	4, // 5: wendy.agent.apps.v1.SensorService.Subscribe:output_type -> wendy.agent.apps.v1.SensorSample
+	6, // 6: wendy.agent.apps.v1.SensorService.SubscribeFrameIdentity:output_type -> wendy.agent.apps.v1.FrameIdentity
+	4, // [4:7] is the sub-list for method output_type
+	1, // [1:4] is the sub-list for method input_type
 	1, // [1:1] is the sub-list for extension type_name
 	1, // [1:1] is the sub-list for extension extendee
 	0, // [0:1] is the sub-list for field type_name
@@ -461,7 +710,7 @@ func file_wendy_agent_apps_v1_sensor_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_wendy_agent_apps_v1_sensor_service_proto_rawDesc), len(file_wendy_agent_apps_v1_sensor_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   5,
+			NumMessages:   7,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/go/proto/gen/appspb/v1/sensor_service_grpc.pb.go
+++ b/go/proto/gen/appspb/v1/sensor_service_grpc.pb.go
@@ -32,8 +32,9 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	SensorService_Sources_FullMethodName   = "/wendy.agent.apps.v1.SensorService/Sources"
-	SensorService_Subscribe_FullMethodName = "/wendy.agent.apps.v1.SensorService/Subscribe"
+	SensorService_Sources_FullMethodName                = "/wendy.agent.apps.v1.SensorService/Sources"
+	SensorService_Subscribe_FullMethodName              = "/wendy.agent.apps.v1.SensorService/Subscribe"
+	SensorService_SubscribeFrameIdentity_FullMethodName = "/wendy.agent.apps.v1.SensorService/SubscribeFrameIdentity"
 )
 
 // SensorServiceClient is the client API for SensorService service.
@@ -66,6 +67,27 @@ type SensorServiceClient interface {
 	// episode capture adapter uses, so subscribing never takes a device away from
 	// capture (or from another app).
 	Subscribe(ctx context.Context, in *SensorSubscribeRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[SensorSample], error)
+	// SubscribeFrameIdentity streams the identity of each frame the agent wrote to
+	// a source's v4l2loopback node, carrying NO pixels.
+	//
+	// This is the control plane of the two-plane camera path. An app that wants to
+	// use ordinary tooling reads the pixels from the loopback node with ffmpeg or
+	// GStreamer (the data plane) and joins them to harness identity through this
+	// stream, instead of receiving frames over gRPC. Because the node is fed from
+	// the same producer hub that episode capture consumes, the frame the app
+	// scores is provably the frame the episode recorded, which is not true of an
+	// app that opens the camera device itself.
+	//
+	// The join key is loopback_sequence, which an app reads from the
+	// v4l2_buffer.sequence of the buffer it dequeued. See FrameIdentity for why
+	// that number is assigned by the kernel rather than chosen by the agent, and
+	// for what a consumer must do about dropped frames.
+	//
+	// This grants strictly less than Subscribe, which already carries every
+	// identity field below alongside the payload. It does NOT grant the loopback
+	// node itself: reading the node is a device-node grant and remains the
+	// separate camera entitlement. An app needs both to use the two-plane path.
+	SubscribeFrameIdentity(ctx context.Context, in *FrameIdentitySubscribeRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[FrameIdentity], error)
 }
 
 type sensorServiceClient struct {
@@ -105,6 +127,25 @@ func (c *sensorServiceClient) Subscribe(ctx context.Context, in *SensorSubscribe
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type SensorService_SubscribeClient = grpc.ServerStreamingClient[SensorSample]
 
+func (c *sensorServiceClient) SubscribeFrameIdentity(ctx context.Context, in *FrameIdentitySubscribeRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[FrameIdentity], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &SensorService_ServiceDesc.Streams[1], SensorService_SubscribeFrameIdentity_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[FrameIdentitySubscribeRequest, FrameIdentity]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type SensorService_SubscribeFrameIdentityClient = grpc.ServerStreamingClient[FrameIdentity]
+
 // SensorServiceServer is the server API for SensorService service.
 // All implementations must embed UnimplementedSensorServiceServer
 // for forward compatibility.
@@ -135,6 +176,27 @@ type SensorServiceServer interface {
 	// episode capture adapter uses, so subscribing never takes a device away from
 	// capture (or from another app).
 	Subscribe(*SensorSubscribeRequest, grpc.ServerStreamingServer[SensorSample]) error
+	// SubscribeFrameIdentity streams the identity of each frame the agent wrote to
+	// a source's v4l2loopback node, carrying NO pixels.
+	//
+	// This is the control plane of the two-plane camera path. An app that wants to
+	// use ordinary tooling reads the pixels from the loopback node with ffmpeg or
+	// GStreamer (the data plane) and joins them to harness identity through this
+	// stream, instead of receiving frames over gRPC. Because the node is fed from
+	// the same producer hub that episode capture consumes, the frame the app
+	// scores is provably the frame the episode recorded, which is not true of an
+	// app that opens the camera device itself.
+	//
+	// The join key is loopback_sequence, which an app reads from the
+	// v4l2_buffer.sequence of the buffer it dequeued. See FrameIdentity for why
+	// that number is assigned by the kernel rather than chosen by the agent, and
+	// for what a consumer must do about dropped frames.
+	//
+	// This grants strictly less than Subscribe, which already carries every
+	// identity field below alongside the payload. It does NOT grant the loopback
+	// node itself: reading the node is a device-node grant and remains the
+	// separate camera entitlement. An app needs both to use the two-plane path.
+	SubscribeFrameIdentity(*FrameIdentitySubscribeRequest, grpc.ServerStreamingServer[FrameIdentity]) error
 	mustEmbedUnimplementedSensorServiceServer()
 }
 
@@ -150,6 +212,9 @@ func (UnimplementedSensorServiceServer) Sources(context.Context, *SensorSourcesR
 }
 func (UnimplementedSensorServiceServer) Subscribe(*SensorSubscribeRequest, grpc.ServerStreamingServer[SensorSample]) error {
 	return status.Error(codes.Unimplemented, "method Subscribe not implemented")
+}
+func (UnimplementedSensorServiceServer) SubscribeFrameIdentity(*FrameIdentitySubscribeRequest, grpc.ServerStreamingServer[FrameIdentity]) error {
+	return status.Error(codes.Unimplemented, "method SubscribeFrameIdentity not implemented")
 }
 func (UnimplementedSensorServiceServer) mustEmbedUnimplementedSensorServiceServer() {}
 func (UnimplementedSensorServiceServer) testEmbeddedByValue()                       {}
@@ -201,6 +266,17 @@ func _SensorService_Subscribe_Handler(srv interface{}, stream grpc.ServerStream)
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type SensorService_SubscribeServer = grpc.ServerStreamingServer[SensorSample]
 
+func _SensorService_SubscribeFrameIdentity_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(FrameIdentitySubscribeRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(SensorServiceServer).SubscribeFrameIdentity(m, &grpc.GenericServerStream[FrameIdentitySubscribeRequest, FrameIdentity]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type SensorService_SubscribeFrameIdentityServer = grpc.ServerStreamingServer[FrameIdentity]
+
 // SensorService_ServiceDesc is the grpc.ServiceDesc for SensorService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -217,6 +293,11 @@ var SensorService_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "Subscribe",
 			Handler:       _SensorService_Subscribe_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "SubscribeFrameIdentity",
+			Handler:       _SensorService_SubscribeFrameIdentity_Handler,
 			ServerStreams: true,
 		},
 	},


### PR DESCRIPTION
## Problem

An application that wants to use ordinary tooling cannot use the Wendy Data Platform harness.

The `sensor-read` entitlement delivers frames only over Google Remote Procedure Call (gRPC) as `SensorService.Subscribe`, so ffmpeg, OpenCV or GStreamer each need a bespoke integration before they can see a frame. The `camera` entitlement avoids that by handing over a raw device node, but it makes the application an independent second reader of the camera. The frame the model scores is then not provably the frame the episode recorded, which destroys the input-to-outcome join the whole harness exists to provide.

## Cause

The two entitlements sit at opposite ends of a trade-off that nothing currently bridges. One gives identity without ordinary tooling; the other gives ordinary tooling without identity. There is no path that gives both, because there is no mechanism that lets a process reading pixels outside gRPC say which harness sample those pixels are.

## Solution

One producer, two planes.

**Data plane.** The agent feeds a `v4l2loopback` node from the same producer hub that episode capture and the gRPC subscribers already consume. The pump is one more subscriber of the existing hub (`joinHub`), never a second opener of the device, and it asserts no stream parameters, so it can never take a running stream away from a viewer or from capture. An application reads that node with any standard tool, unmodified.

**Control plane.** A new `SensorService.SubscribeFrameIdentity` streams identity only: source id, sample id, canonical `CLOCK_BOOTTIME` receipt, uncertainty, drop count, and the loopback sequence. No pixels travel over gRPC, so per-frame framing cost stays negligible.

### The binding, and why it is inverted from the obvious design

The brief proposed mapping `v4l2_buffer.sequence` to our `sample_id`. **That is not possible, and the reason is in the kernel module rather than in anything we control.** In v4l2loopback's `VIDIOC_QBUF` handler for `V4L2_BUF_TYPE_VIDEO_OUTPUT`:

```c
bufd->buffer.sequence = dev->write_position;
```

The sequence a writer supplies is overwritten unconditionally, in both the mmap and the `write()` paths. No module option, format flag or ioctl disables it. A design asserting "sequence is the sample id" would be claiming a guarantee the kernel actively prevents.

What makes the feature possible anyway is three lines further down, in the same handler:

```c
bufd->buffer.sequence = dev->write_position;
set_queued(bufd->buffer.flags);
*buf = bufd->buffer;          /* returned to the writer */
buffer_written(dev, bufd);    /* this is what does ++dev->write_position */
```

The ioctl copies the stamped buffer back to userspace *before* the counter advances. So the writer learns, from the call it just made, the exact sequence the kernel assigned to that frame.

The binding is therefore inverted: **the pump does not choose the sequence, it observes the one the kernel chose**, and publishes the mapping on the control plane. This needs no assumption that the counter starts at zero (it resets only at device creation, not per open) and no reliance on arrival order. An application reads `v4l2_buffer.sequence` off the buffer it dequeued and looks it up.

### Dropped frames: two losses, two different signals

This is the part most likely to be got wrong by a consumer, so it is stated in the proto, in code comments, and pinned by tests.

1. **The agent could not keep up feeding the node.** The hub drops for a slow subscriber, so those samples never reach the node. The loopback sequence stays **dense** across the loss and shows no gap at all. The loss is visible only on the control plane, as a jump in `sample_id`, counted exactly by `dropped_before`.

2. **The application could not keep up reading the node.** v4l2loopback fast-forwards an overrun reader rather than blocking it (`opener->read_position = dev->write_position - 1`), so the next dequeued buffer's sequence has **jumped**. This loss is invisible on the control plane, because the agent did write those frames. The application detects it by differencing sequences of consecutive dequeued buffers.

A `sample_id` jump means the agent fell behind; a `sequence` jump means the reader fell behind. Both can happen at once and they are additive. A frame the agent failed to write appears in neither plane: it consumes no sequence and produces no identity, so it is absent rather than reported as lost.

## What I could not make sound, and therefore did not build

Per the brief, the parts that cannot be made sound are refused rather than approximated.

- **Unaligned producers are refused.** `auAligned` is set only by the native V4L2 producer, which delivers one buffer per encoded frame. The GStreamer and network camera producers read a byte stream from a pipe, so their frames are arbitrary chunks that can begin or end mid-access-unit. A sequence counted over those names chunks, not pictures. The pump stops rather than publishing a node whose sequences mean nothing.

- **No decoder is inserted, so raw-pixel consumers are not served.** Feeding OpenCV's default V4L capture would mean decoding H.264 and writing raw frames. A decoder does not preserve the correspondence: B-frame reordering means the Nth frame in is not the Nth frame out, and decoders drop and emit frames on their own. Adding one would destroy the very guarantee this feature exists to make. The node advertises a compressed fourcc and serves tools that accept one (ffmpeg, GStreamer). **This is a real limitation of the feature, not a gap to be patched later by adding a decoder.**

- **Drop attribution can be off by up to the channel depth.** The hub's drop counter is read when the pump consumes a frame, not when the hub queued it. This is the identical accounting the existing gRPC sensor path uses (`cameraSensorSubscription.Next`). The running total is exact and no loss is ever unreported; only the frame a given loss is charged to can be off. Making it exact means stamping the count onto the frame at broadcast, which changes shared hub behaviour that episode capture and the sensor path would also absorb, so it is not done here.

- **Identity delivery is not teed into the model-input ledger.** Publishing an identity says the agent wrote a frame to the node; it does not say the application read it. Recording those as model inputs would make the episode assert a delivery that may not have happened. An application that wants its consumption recorded must report what it actually read, which it now can, because it has the `sample_id` per frame.

## Entitlement decision: both `sensor-read` and `camera`

**The two-plane path requires both. Neither alone is sufficient, and `sensor-read` is not widened.**

The path has two halves and they are grants of different kinds.

The **data plane is a device node** the application opens and reads. Device-node grants are what `camera` is. The `sensor-read` entitlement documents itself as granting "no device nodes; raw device access remains the separate camera entitlement". If holding `sensor-read` alone caused a readable `/dev/video*` to appear in the container, `sensor-read` would have silently become a device-access entitlement. So `sensor-read` alone creates no node, and does not here.

The **control plane widens nothing**. `SubscribeFrameIdentity` carries source id, sample id, canonical time, uncertainty and a sequence number. That is strictly less than `Subscribe` already gives an application holding `sensor-read`, which carries every one of those fields plus the pixels. It therefore belongs to `sensor-read` and needs no new grant.

`camera` alone is not enough either, and this is the more interesting half. An application holding only `camera` can already open the physical device today. What it cannot do is prove which frame it saw. Handing it a hub-fed node *without* the identity stream would give it better-looking pixels with the same unprovable join, which is exactly the defect being fixed. The identity stream is what makes the node worth having, and that stream is a `sensor-read` grant.

Requiring both is not defensive caution: each entitlement covers exactly one plane, and one plane alone does not deliver the property. An application holding one of the two keeps precisely the behaviour it has today, and nothing anyone already had is taken away. `twoPlaneConsumerNames` enforces this, and a test pins that its result is always a subset of `cameraConsumerNames`.

## Reuse rather than a second mechanism

The node and pump lifecycle extends the existing wiring rather than duplicating it. `camera_wiring.go` gains `SetTwoPlaneContainerConsumers` alongside `SetCameraContainerConsumers`, driven from the same truth-driven `SyncCameraLoopbacks` sweep, with the same wholesale-replacement and best-effort posture. `ipcam.Loopback` gains auxiliary-node support that reuses its existing module detection and create/remove primitives.

Node numbers are allocated from the **top** of the reserved band downward, while the camera registry allocates from the bottom upward, and any number held by a registered camera or an existing node is skipped. The kernel's `VIDEO_NUM_DEVICES` of 256 leaves no room for a separate band, so sharing with a skip check is the honest option; silently reusing a camera's number would point an application at the wrong camera's frames.

The V4L2 writer is hand-written rather than a GStreamer `v4l2sink` because the binding depends on the sequence `VIDIOC_QBUF` returns, and a GStreamer sink issues that ioctl internally and surfaces nothing.

## Verification

Everything below passes on this branch.

- `CC=/usr/bin/clang go build ./...`
- `gofmt -l go/` empty
- `go vet ./go/...` clean
- `CC=/usr/bin/clang go test ./go/internal/agent/services/... ./go/internal/agent/containerd/... ./go/internal/agent/data/...`, also green under `-race`
This branch was rebased onto the current `split/7-tools-and-example` tip, which renamed the `sensors` entitlement to `sensor-read` and split off `episode-write`; the change was updated accordingly and re-verified after the rebase.

- Full `go test ./go/...` green apart from `TestSampleGPUFallsBackToTegrastatsForOrin` in `hoststats`, which is a pre-existing load-sensitive flake: it passes reliably in isolation, this branch touches no file in that package, and it passes on a pristine checkout.

The sequence-to-sample-id mapping is unit-tested directly, including the dropped-frame cases: hub-side drops with a dense sequence, reader-side drops detected by sequence gap, the 32-bit sequence wrap, repeated buffers not counted as loss, write failures recording nothing, and a fake writer that deliberately starts its counter at a non-zero base so a pump that numbered frames itself could not pass.

## This change is UNVERIFIED ON HARDWARE

No part of the V4L2 OUTPUT path has been exercised against a live node on a device. The ioctl sequence, struct offsets and buffer strategy were derived from the kernel's `videodev2.h` and from v4l2loopback 0.15.4's own source, which is the module version the WendyOS recipe pins, but derivation is not verification. `hub_loopback_writer.go` is the file most likely to need adjustment and deliberately carries the least logic; everything that can be reasoned about without a kernel module lives in `hub_loopback_binding.go` and `hub_loopback_pump.go` and is covered by tests.

I did not run this on `wendyos-fernando.local`: it was recently used for a recording and a previous agent install crash-looped the model application on it, so installing an agent build to try this would risk that device.

### Hardware verification plan

Run on a Jetson or Raspberry Pi with a Universal Serial Bus (USB) camera that produces H.264, with an agent build from this branch and an application declaring both `sensor-read` and `camera`. Note that `sensor-read` requires a non-empty allowlist naming the source ids, so the application's `wendy.json` must list the camera source explicitly.

**1. Confirm the node appears only for an application holding both entitlements.**

```
v4l2-ctl --list-devices
ls -l /dev/video*
```
Expected: a node in the 200 to 255 band labelled `Wendy sensor <n>` while the two-entitlement container runs, and no such node when only one entitlement is declared. *Falsifies the entitlement gate if a node appears for a `sensor-read`-only application.*

**2. Confirm the node's advertised format.**

```
v4l2-ctl -d /dev/video<n> --all
v4l2-ctl -d /dev/video<n> --list-formats-ext
```
Expected: `H264` fourcc on the capture side. *Falsifies the writer's `VIDIOC_S_FMT` call if the format is unset or wrong.*

**3. Confirm ordinary tooling reads real frames.**

```
ffprobe -v verbose -f v4l2 -i /dev/video<n>
ffmpeg -f v4l2 -i /dev/video<n> -t 5 -c copy /tmp/out.mp4
ffprobe -show_streams -count_frames /tmp/out.mp4
```
Expected: a decodable stream with a plausible frame count for five seconds. *Falsifies the whole data plane if ffprobe sees no frames, or if frames are corrupt, which would point at buffer reuse or `bytesused`.*

**4. The core check: confirm the sequence binding.**

Read raw buffers and print the kernel sequence per frame:
```
v4l2-ctl -d /dev/video<n> --stream-mmap --stream-count=300 --stream-to=/dev/null --verbose
```
`--verbose` prints each dequeued buffer's `sequence`. Concurrently capture the control plane from inside the container:
```
grpcurl -plaintext -unix /run/wendy/sensors/sensors.sock \
  -d '{"source_ids":["v4l2:/dev/video0"]}' \
  wendy.agent.apps.v1.SensorService/SubscribeFrameIdentity > /tmp/identities.jsonl
```
Then join. Every sequence `v4l2-ctl` printed must appear exactly once in `identities.jsonl`, mapped to a strictly increasing `sample_id`.

**This is what falsifies the design.** If sequences printed by `v4l2-ctl` do not appear in the identity stream, or map to the wrong or duplicate sample ids, the read-back is not authoritative and the binding does not hold.

**5. Confirm behaviour under reader-side drops.** Re-run step 4 with a deliberately slow reader (for example `--stream-poll` with added sleep, or a heavily loaded machine). Expected: gaps in the sequences `v4l2-ctl` prints, with the identity stream still dense and `dropped_before` still zero, because the agent kept up while the reader did not. *Falsifies the drop model if the identity stream gaps instead, or if sequences stay dense while frames are visibly missing.*

**6. Confirm behaviour under agent-side drops.** Load the device so the hub drops for the pump. Expected: the identity stream reports non-zero `dropped_before` with a matching `sample_id` jump, while the sequences remain dense. *Falsifies the drop model if the sequence gaps here.*

**7. Confirm the episode join.** Record an episode while the application scores frames off the node, then check that a `sample_id` taken from the identity stream resolves in the episode's `cameras/<source>/index.jsonl` to a frame whose bytes match what the application read. This is the property the whole feature exists to provide.

Nothing in this change touches the ClickHouse database or the storage bucket.
