### PR TITLE
fix(agent): support live Go2 H.264 camera streams

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -376,9 +376,17 @@ wendy device camera list
 wendy device camera view --id 128
 ```
 
-Raw ROS images are converted to MJPEG; compressed JPEG feeds, including the
-Go2's 720p field, stay compressed on the way into the loopback device. Large
-DDS samples are reassembled from bounded RTPS DATA_FRAG sets in the agent.
+Raw ROS images are converted to MJPEG and compressed JPEG feeds stay
+compressed. Go2 firmware may publish either the SDK-declared JPEG fields or a
+resolution-tagged Annex-B H.264 access unit; both stay encoded on the way into
+the loopback device. Large DDS samples are reassembled from bounded RTPS
+DATA_FRAG sets in the agent.
+
+ROS 2 cameras require v4l2loopback 0.15.x's dynamic control API (the WendyOS
+recipe is pinned to 0.15.4). Ubuntu 22.04's `v4l2loopback-dkms` 0.12.7 package
+does not provide the compatible `/dev/v4l2loopback` interface. A previously
+failed availability check is retried, so loading the compatible module does
+not require restarting `wendy-agent`.
 
 ### Network cameras
 

--- a/Documentation/2026-08-28-pr-1827-go2-hardware-validation.md
+++ b/Documentation/2026-08-28-pr-1827-go2-hardware-validation.md
@@ -1,0 +1,144 @@
+# PR #1827 Go2 hardware validation
+
+- Original PR: https://github.com/wendylabsinc/WendyOS/pull/1827
+- Original head tested: `1a3b59df644b4b908f05829e05dd91dd7acdb9b3`
+- Device: Woof, an ARM64 Jetson Orin companion connected to a Unitree Go2
+- Safety boundary: perception only; no locomotion, actuator, DDS control, robot reset, or robot reboot commands
+
+## Original result
+
+PR #1827 discovered `/frontvideostream` as camera 128 and created
+`/dev/video128` after the compatible kernel module was loaded, but two
+unattended ten-second `camera view --id 128 --stdout` captures produced zero
+bytes. The agent reported `video360p: cdr: payload too short`.
+
+Passing CI, camera discovery, and loopback-node creation were therefore not
+evidence that the advertised Go2 path worked end to end.
+
+## Issues and required tweaks
+
+### 1. The tested companion image did not ship v4l2loopback
+
+`modinfo v4l2loopback` failed and neither `/dev/v4l2loopback` nor a video node
+was present. ROS 2 cameras use a loopback node for both CLI viewing and
+container access, so discovery alone could not produce a stream.
+
+### 2. Ubuntu 22.04's module is ABI-incompatible
+
+Ubuntu's `v4l2loopback-dkms` 0.12.7 package built and loaded against the active
+Tegra kernel, but did not provide the 0.15.x dynamic control interface the
+agent uses. Testing required v4l2loopback 0.15.4 at the commit already pinned
+by the WendyOS recipe. Installing the distro package is not a valid workaround.
+
+### 3. The missing-module message was transport-inaccurate
+
+The shared error said that `camera view` still worked. That is true for direct
+IP-camera streaming, but false for ROS 2 cameras because their CLI path also
+opens the loopback node. The error and documentation now state the compatible
+module requirement without making the IP-only promise globally.
+
+### 4. A failed module check was cached for the agent lifetime
+
+`Loopback.Available` used `sync.Once`, so loading a compatible module after the
+first failure still required an agent restart. Failed detection is now
+retryable while successful detection remains cached.
+
+### 5. The live Go2 layout and codec differed from the decoder
+
+A one-shot bounded payload diagnostic captured this sanitized prefix:
+
+```text
+payload_len=2728
+head_hex=000100019823e1030000000068010000930a00000000000141e0018003027fdb
+```
+
+It decodes as little-endian CDR, an eight-byte timestamp, resolution `360`, a
+2707-byte sequence, and an Annex-B H.264 NAL beginning `00 00 01 41`. The PR
+treated `360` as the byte count of a `video720p` JPEG field, then tried to read
+another sequence from the middle of the H.264 access unit. Correcting offsets
+alone was insufficient because the writer also advertised MJPEG unconditionally.
+
+The fix recognizes both this live H.264 layout and the SDK-declared three-JPEG
+layout, carries the codec with each decoded frame, and configures the loopback
+writer as H.264 or MJPEG without transcoding.
+
+### 6. The Go2 unit fixture did not represent hardware
+
+The original test generated a JPEG inside the SDK-declared struct. It could not
+catch the resolution-plus-H.264 layout. A regression fixture now mirrors the
+captured wire shape, including CDR padding, and asserts codec, dimensions, and
+exact access-unit preservation. The manager test also asserts that H.264 reaches
+the loopback writer unchanged as H.264.
+
+### 7. Restarting from an agent-hosted shell delayed recovery
+
+Restarting `wendy-agent` inside `wendy device shell` leaves that shell in the
+service cgroup while systemd is trying to stop it. The connection must close
+before the restart completes. This is a validation-workflow issue, not a camera
+crash: close the device shell before a restart, or use `wendy device push-agent`
+for binary replacement.
+
+### 8. The existing V4L2 capture struct was shifted by four bytes
+
+After the Go2 decoder and H.264 writer were corrected, `camera view` still
+fell back to GStreamer and failed negotiation. A bounded ioctl probe showed
+that the kernel's valid 640x360 H.264 format was read as width 0, height 640,
+and pixel format 360. The video service's `v4l2_format` declaration omitted the
+four bytes required to align the UAPI union at offset 8 on 64-bit Linux.
+
+The struct now matches the 208-byte UAPI layout used by the writer, with both a
+regression test and compile-time size/offset checks. Native H.264 capture then
+worked without the raw-video GStreamer fallback.
+
+### 9. Parameterless entitlement labels disappeared in containerd
+
+The first `camera`-entitled test app received the `/dev` mount and video-device
+permissions, but the ROS 2 manager never saw it as a consumer. Live container
+metadata showed no `sh.wendy/entitlement.camera` label. Parameterless
+entitlements were encoded with an empty label value, which did not survive
+containerd persistence, so the truth-driven consumer scan always returned an
+empty set.
+
+Parameterless entitlements now use the non-empty `enabled=true` sentinel. The
+existing parser ignores that field and reconstructs the entitlement from its
+key, preserving compatibility while keeping camera, GPU, and other
+parameterless entitlements visible to lifecycle reconciliation.
+
+## Final hardware result
+
+With all fixes applied and v4l2loopback 0.15.4 loaded:
+
+- The same agent PID recovered after an initial missing-module failure; no
+  agent restart was needed after loading the module.
+- The PR-built CLI captured a clean 373,223-byte Annex-B H.264 stream in ten
+  seconds, with the file growing on every one-second observation after startup.
+- The capture contained 104 non-IDR slices and four each of IDR, SPS, and PPS
+  NAL units, proving advancing and independently decodable stream structure.
+- A temporary `TEST-pr1827-go2-camera` Stagefile app with the `camera`
+  entitlement saw `/dev/video128` as 640x360 H.264 and captured 101,569 bytes
+  across 30 buffers at approximately 13.3 fps.
+- The temporary app and image were removed after the test.
+
+The loopback device is exclusive-caps: an app that opens it immediately at
+process start can briefly see `VIDIOC_G_FMT: Invalid argument` before the first
+producer frame configures the capture side. The test app used a bounded retry,
+then captured successfully.
+
+## Validation workflow notes
+
+- The installed host CLI was older than the PR and wrote its status banner into
+  redirected `--stdout` output. Final stream evidence used a CLI built from the
+  fixing branch, whose status line is on stderr and whose stdout begins with an
+  Annex-B start code.
+- The host Docker config referenced an unavailable
+  `docker-credential-desktop`. The temporary Stagefile build used an isolated
+  empty Docker config for anonymous pulls and the native Apple Container
+  builder; no workstation Docker configuration was changed.
+
+## Automated verification
+
+Focused race tests, related package tests, vet, ARM64 agent compilation, and a
+Linux/ARM64 ROS 2 camera test-binary compile pass. The broad `go test ./...`
+run also reached three unrelated, pre-existing Mac/environment failures: the
+tegrastats fallback test, a `/private/var` path-alias expectation, and a live
+address-resolution expectation. None is in a package changed by this fix.

--- a/go/internal/agent/containerd/helpers_test.go
+++ b/go/internal/agent/containerd/helpers_test.go
@@ -391,7 +391,7 @@ func TestWendyLabels_EntitlementsStoredAsKeyValue(t *testing.T) {
 		wantVal string
 	}{
 		{appconfig.EntitlementAnnotationKeyPrefix + appconfig.EntitlementNetwork, "mode=host"},
-		{appconfig.EntitlementAnnotationKeyPrefix + appconfig.EntitlementGPU, ""},
+		{appconfig.EntitlementAnnotationKeyPrefix + appconfig.EntitlementGPU, "enabled=true"},
 	}
 	for _, tc := range cases {
 		raw, ok := labels[tc.key]

--- a/go/internal/agent/ipcam/loopback.go
+++ b/go/internal/agent/ipcam/loopback.go
@@ -10,12 +10,12 @@ import (
 	"go.uber.org/zap"
 )
 
-// ErrLoopbackUnavailable is returned when the running build has no
+// ErrLoopbackUnavailable is returned when the running build has no compatible
 // v4l2loopback module. Its text is user-facing: EnsureNodes swallows it into
 // a one-time log so the rest of the agent degrades gracefully, but anything
 // that surfaces it to a person (a CLI command, a status field) should show
 // this text as-is rather than paraphrasing it.
-var ErrLoopbackUnavailable = errors.New("running WendyOS build lacks the v4l2loopback module; `camera view` still works")
+var ErrLoopbackUnavailable = errors.New("running build lacks compatible v4l2loopback 0.15.x support")
 
 // PumpFunc starts the in-process GStreamer helper that copies an RTSP
 // camera's stream into its v4l2loopback node. Per branch-C-preamble.md, this
@@ -172,8 +172,9 @@ type Loopback struct {
 	deps  loopbackDeps
 	clock clock
 
-	detectOnce sync.Once
-	detectErr  error
+	detectMu sync.Mutex
+	detected bool
+	warnOnce sync.Once
 
 	mu sync.Mutex
 	// containerOwners is the current set of running entitled container names,
@@ -224,22 +225,28 @@ func NewLoopback(ctx context.Context, logger *zap.Logger, reg *Registry, creds *
 }
 
 // Available reports whether the v4l2loopback module is usable, attempting to
-// load it — once, ever, for the life of this Loopback — if it is not already
-// present. A non-nil error always wraps ErrLoopbackUnavailable.
+// load it if it is not already present. Success is cached; failure is not, so
+// installing or loading the module can recover without restarting the agent.
+// A non-nil error always wraps ErrLoopbackUnavailable.
 func (l *Loopback) Available() error {
-	l.detectOnce.Do(func() {
-		l.detectErr = l.detect()
-	})
-	return l.detectErr
+	l.detectMu.Lock()
+	defer l.detectMu.Unlock()
+	if l.detected {
+		return nil
+	}
+	if err := l.detect(); err != nil {
+		return err
+	}
+	l.detected = true
+	return nil
 }
 
-// detect runs the module-detection policy exactly once, guarded by
-// detectOnce: stat the control device; if absent, try to load the module;
-// re-stat; if it is still absent, degrade for good and log that once. See
+// detect runs one module-detection attempt while detectMu is held: stat the
+// control device; if absent, try to load the module; re-stat; if it is still
+// absent, degrade for this attempt and log the condition once. See
 // loopback_linux.go's modprobe implementation for the params-then-plain
-// fallback retry — from here it is a single seam call, so a fake in tests can
-// prove modprobe is attempted at most once regardless of how many times
-// Available is called.
+// fallback retry. From here each detection attempt makes one seam call; a
+// later Available call may retry after the module has been installed.
 func (l *Loopback) detect() error {
 	if err := l.deps.statControl(); err == nil {
 		return nil
@@ -278,12 +285,13 @@ func (l *Loopback) sweepAutoCreatedNodes() {
 	}
 }
 
-// warnUnavailable logs the degradation. It is only ever called from inside
-// detectOnce, so — regardless of how many times Available or EnsureNodes are
-// called afterward — it fires exactly once for the life of this Loopback.
+// warnUnavailable logs the degradation once even though Available permits
+// later detection attempts after an operator installs or loads the module.
 func (l *Loopback) warnUnavailable(cause error) {
-	l.logger.Warn("v4l2loopback module unavailable; camera view still works, but container mirroring is disabled",
-		zap.Error(cause))
+	l.warnOnce.Do(func() {
+		l.logger.Warn("compatible v4l2loopback module unavailable; virtual camera streams are disabled",
+			zap.Error(cause))
+	})
 }
 
 // EnsureNodes creates a v4l2loopback node for every registered camera that

--- a/go/internal/agent/ipcam/loopback_test.go
+++ b/go/internal/agent/ipcam/loopback_test.go
@@ -143,25 +143,30 @@ func TestLoopback_AvailableWhenControlDeviceExists(t *testing.T) {
 	}
 }
 
-// When the module can't be loaded at all, Available must degrade to a wrapped
-// ErrLoopbackUnavailable — and detection, including the modprobe attempt,
-// must run at most once no matter how many times Available is called.
-func TestLoopback_AvailableAttemptsModprobeOnceThenDegrades(t *testing.T) {
+// A failed detection must not poison the Loopback for the life of the agent.
+// Operators can install or load the compatible module and retry without
+// restarting wendy-agent; a successful detection is cached afterward.
+func TestLoopback_AvailableRetriesAfterModuleBecomesAvailable(t *testing.T) {
 	h := newLoopbackHarness()
 	h.modprobeErr = errors.New("modprobe: FATAL: Module v4l2loopback not found")
 	l, _ := newTestLoopback(t, h)
 
 	err1 := l.Available()
-	err2 := l.Available()
-
 	if !errors.Is(err1, ErrLoopbackUnavailable) {
 		t.Fatalf("Available() #1 = %v, want an error wrapping ErrLoopbackUnavailable", err1)
 	}
-	if !errors.Is(err2, ErrLoopbackUnavailable) {
-		t.Fatalf("Available() #2 = %v, want an error wrapping ErrLoopbackUnavailable", err2)
+
+	h.mu.Lock()
+	h.modprobeErr = nil
+	h.mu.Unlock()
+	if err := l.Available(); err != nil {
+		t.Fatalf("Available() #2 = %v after module install, want nil", err)
 	}
-	if calls := h.modprobeCallCount(); calls != 1 {
-		t.Fatalf("modprobe called %d times across two Available() calls, want exactly 1", calls)
+	if err := l.Available(); err != nil {
+		t.Fatalf("Available() #3 = %v, want cached success", err)
+	}
+	if calls := h.modprobeCallCount(); calls != 2 {
+		t.Fatalf("modprobe called %d times, want one failed attempt and one successful retry", calls)
 	}
 }
 

--- a/go/internal/agent/ros2camera/frame.go
+++ b/go/internal/agent/ros2camera/frame.go
@@ -25,6 +25,23 @@ const (
 
 var ErrUnsupportedEncoding = errors.New("unsupported ROS 2 image encoding")
 
+// Codec is the compressed format written to the V4L2 loopback device.
+type Codec uint8
+
+const (
+	CodecMJPEG Codec = iota + 1
+	CodecH264
+)
+
+// Frame is one encoded camera frame and the format the loopback writer must
+// advertise. Keeping the codec with the bytes avoids transcoding the Go2's
+// native H.264 stream merely to fit the JPEG-oriented ROS message paths.
+type Frame struct {
+	Data          []byte
+	Width, Height int
+	Codec         Codec
+}
+
 // SupportsType reports whether typeName carries a video frame this package can
 // decode. DDS and ros2cli spellings are both accepted.
 func SupportsType(typeName string) bool {
@@ -46,6 +63,20 @@ func TopicName(topic string) string {
 		topic = "/" + topic
 	}
 	return topic
+}
+
+// DecodeFrame extracts one frame from a serialized ROS 2 sample. Standard ROS
+// image messages become MJPEG. Go2 firmware is seen in two wire layouts: the
+// SDK-declared three-JPEG form and a live single-resolution H.264 form.
+func DecodeFrame(typeName string, payload []byte) (Frame, error) {
+	if typeName == TypeGo2FrontVideo || typeName == "unitree_go/msg/Go2FrontVideoData" {
+		return decodeGo2Frame(payload)
+	}
+	data, width, height, err := DecodeJPEG(typeName, payload)
+	if err != nil {
+		return Frame{}, err
+	}
+	return Frame{Data: data, Width: width, Height: height, Codec: CodecMJPEG}, nil
 }
 
 // DecodeJPEG extracts a frame from a serialized ROS 2 sample and returns a
@@ -151,6 +182,67 @@ func decodeGo2FrontVideo(payload []byte) ([]byte, int, int, error) {
 		}
 	}
 	return nil, 0, 0, errors.New("Go2 front-video sample contains no image")
+}
+
+func decodeGo2Frame(payload []byte) (Frame, error) {
+	h264, matchedH264Layout, h264Err := decodeGo2H264Frame(payload)
+	if matchedH264Layout && h264Err == nil {
+		return h264, nil
+	}
+	jpegFrame, width, height, jpegErr := decodeGo2FrontVideo(payload)
+	if jpegErr == nil {
+		return Frame{Data: jpegFrame, Width: width, Height: height, Codec: CodecMJPEG}, nil
+	}
+	if matchedH264Layout {
+		return Frame{}, h264Err
+	}
+	return Frame{}, jpegErr
+}
+
+func decodeGo2H264Frame(payload []byte) (Frame, bool, error) {
+	d, err := cdr.NewDecoder(payload)
+	if err != nil {
+		return Frame{}, false, err
+	}
+	if _, err := d.Uint64(); err != nil {
+		return Frame{}, false, fmt.Errorf("time_frame: %w", err)
+	}
+	resolution, err := d.Uint32()
+	if err != nil {
+		return Frame{}, false, fmt.Errorf("resolution: %w", err)
+	}
+	width, height, ok := go2ResolutionDimensions(resolution)
+	if !ok {
+		return Frame{}, false, nil
+	}
+	data, err := d.Bytes()
+	if err != nil {
+		return Frame{}, true, fmt.Errorf("video: %w", err)
+	}
+	// XCDR may leave at most three bytes of alignment padding at the end of a
+	// top-level sample. Anything larger means this is not the observed layout.
+	if d.Remaining() > 3 {
+		return Frame{}, true, fmt.Errorf("video: %d unexpected trailing bytes", d.Remaining())
+	}
+	if !hasAnnexBStartCode(data) {
+		return Frame{}, true, fmt.Errorf("%w: Go2 frame is not Annex-B H.264", ErrUnsupportedEncoding)
+	}
+	return Frame{Data: data, Width: width, Height: height, Codec: CodecH264}, true, nil
+}
+
+func go2ResolutionDimensions(resolution uint32) (width, height int, ok bool) {
+	switch resolution {
+	case 180, 360, 720:
+		height = int(resolution)
+		return height * 16 / 9, height, true
+	default:
+		return 0, 0, false
+	}
+}
+
+func hasAnnexBStartCode(frame []byte) bool {
+	return len(frame) >= 4 && frame[0] == 0 && frame[1] == 0 &&
+		(frame[2] == 1 || (len(frame) >= 5 && frame[2] == 0 && frame[3] == 1))
 }
 
 func decodeRawImage(payload []byte) ([]byte, int, int, error) {

--- a/go/internal/agent/ros2camera/frame_test.go
+++ b/go/internal/agent/ros2camera/frame_test.go
@@ -130,6 +130,38 @@ func TestDecodeGo2FrontVideoPrefers720p(t *testing.T) {
 	}
 }
 
+func TestDecodeGo2FrontVideoH264FirmwareLayout(t *testing.T) {
+	// This is the minimal form of the payload observed from a physical Go2:
+	// time_frame, resolution height, one H.264 access unit. The encapsulation
+	// option records the single trailing CDR padding byte.
+	want := []byte{0x00, 0x00, 0x01, 0x41, 0xe0, 0x01, 0x80, 0x03, 0x02, 0x7f, 0xdb}
+	c := newCDRBuilder()
+	c.b[3] = 1
+	c.u64(0x00000003e12398)
+	c.u32(360)
+	c.bytes(want)
+	c.b = append(c.b, 0)
+
+	got, err := DecodeFrame(TypeGo2FrontVideo, c.b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Codec != CodecH264 || got.Width != 640 || got.Height != 360 || !bytes.Equal(got.Data, want) {
+		t.Fatalf("frame = %+v, want 640x360 H.264 with %d bytes", got, len(want))
+	}
+}
+
+func TestDecodeGo2FrontVideoH264LayoutRejectsNonAnnexBPayload(t *testing.T) {
+	c := newCDRBuilder()
+	c.u64(42)
+	c.u32(360)
+	c.bytes([]byte{1, 2, 3, 4})
+
+	if _, err := DecodeFrame(TypeGo2FrontVideo, c.b); !errors.Is(err, ErrUnsupportedEncoding) {
+		t.Fatalf("error = %v; want ErrUnsupportedEncoding", err)
+	}
+}
+
 func TestDecodeRawBGR8(t *testing.T) {
 	c := newCDRBuilder()
 	c.header()

--- a/go/internal/agent/ros2camera/manager.go
+++ b/go/internal/agent/ros2camera/manager.go
@@ -49,7 +49,7 @@ type Graph struct {
 type GraphSource func(context.Context) ([]Graph, error)
 
 type cameraWriter interface {
-	WriteJPEG(frame []byte, width, height int) error
+	WriteFrame(frame Frame) error
 	Close() error
 }
 
@@ -412,7 +412,7 @@ func (m *Manager) handleSample(sample rtps.Sample) {
 	}
 	cam.lastFrame = now
 	m.mu.Unlock()
-	frame, width, height, err := DecodeJPEG(typeName, sample.Payload)
+	frame, err := DecodeFrame(typeName, sample.Payload)
 	if err != nil {
 		m.logCameraErrorOnce(cam, "decoding ROS 2 camera frame failed", err)
 		return
@@ -423,7 +423,7 @@ func (m *Manager) handleSample(sample rtps.Sample) {
 	}
 	w := cam.writer
 	m.mu.Unlock()
-	if err := w.WriteJPEG(frame, width, height); err != nil {
+	if err := w.WriteFrame(frame); err != nil {
 		m.logCameraErrorOnce(cam, "writing ROS 2 camera loopback failed", err)
 		return
 	}

--- a/go/internal/agent/ros2camera/manager_test.go
+++ b/go/internal/agent/ros2camera/manager_test.go
@@ -37,11 +37,12 @@ type fakeWriter struct {
 	frames int
 	width  int
 	height int
+	codec  Codec
 }
 
-func (w *fakeWriter) WriteJPEG(_ []byte, width, height int) error {
+func (w *fakeWriter) WriteFrame(frame Frame) error {
 	w.frames++
-	w.width, w.height = width, height
+	w.width, w.height, w.codec = frame.Width, frame.Height, frame.Codec
 	return nil
 }
 func (*fakeWriter) Close() error { return nil }
@@ -91,7 +92,28 @@ func TestManagerPumpsCompressedImageToLoopback(t *testing.T) {
 	m.handleSample(rtps.Sample{Writer: guid, Payload: c.b})
 	m.handleSample(rtps.Sample{Writer: guid, Payload: c.b})
 
-	if writer.frames != 1 || writer.width != 5 || writer.height != 4 {
+	if writer.frames != 1 || writer.width != 5 || writer.height != 4 || writer.codec != CodecMJPEG {
+		t.Fatalf("writer = %+v", writer)
+	}
+}
+
+func TestManagerPreservesGo2H264ForLoopback(t *testing.T) {
+	loop := &fakeLoopback{}
+	m := NewManager(context.Background(), zap.NewNop(), loop, filepath.Join(t.TempDir(), "registry.json"), nil)
+	t.Cleanup(m.Shutdown)
+	writer := &fakeWriter{}
+	m.newWriter = func(string) cameraWriter { return writer }
+	m.containerUse = true
+	guid := rtps.GUID{EntityID: 8}
+	m.registerEndpoint(&participantState{iface: "eth0", domainID: 0}, rtps.Endpoint{Topic: "rt/frontvideostream", Type: TypeGo2FrontVideo, GUID: guid})
+
+	c := newCDRBuilder()
+	c.u64(42)
+	c.u32(360)
+	c.bytes([]byte{0, 0, 1, 0x41, 1, 2, 3})
+	m.handleSample(rtps.Sample{Writer: guid, Payload: c.b})
+
+	if writer.frames != 1 || writer.width != 640 || writer.height != 360 || writer.codec != CodecH264 {
 		t.Fatalf("writer = %+v", writer)
 	}
 }

--- a/go/internal/agent/ros2camera/writer_linux.go
+++ b/go/internal/agent/ros2camera/writer_linux.go
@@ -14,6 +14,7 @@ import (
 const (
 	v4l2BufTypeVideoOutput = 2
 	v4l2PixFmtMJPEG        = 0x47504a4d // MJPG
+	v4l2PixFmtH264         = 0x34363248 // H264
 	v4l2FieldNone          = 1
 	vidiocSFmt             = 0xc0d05605
 )
@@ -51,13 +52,19 @@ type frameWriter struct {
 	path          string
 	file          *os.File
 	width, height int
+	codec         Codec
 }
 
 func newFrameWriter(path string) cameraWriter { return &frameWriter{path: path} }
 
-func (w *frameWriter) WriteJPEG(frame []byte, width, height int) error {
+func (w *frameWriter) WriteFrame(frame Frame) error {
+	width, height := frame.Width, frame.Height
 	if width <= 0 || height <= 0 || width > 8192 || height > 8192 {
 		return fmt.Errorf("invalid frame dimensions %dx%d", width, height)
+	}
+	pixelFormat, err := v4l2PixelFormat(frame.Codec)
+	if err != nil {
+		return err
 	}
 	if w.file == nil {
 		fd, err := unix.Open(w.path, unix.O_WRONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
@@ -66,34 +73,50 @@ func (w *frameWriter) WriteJPEG(frame []byte, width, height int) error {
 		}
 		w.file = os.NewFile(uintptr(fd), w.path)
 	}
-	if w.width != width || w.height != height {
+	if w.width != width || w.height != height || w.codec != frame.Codec {
+		sizeImage := width * height * 3
+		if len(frame.Data) > sizeImage {
+			sizeImage = len(frame.Data)
+		}
 		format := v4l2Format{
 			Type:        v4l2BufTypeVideoOutput,
 			Width:       uint32(width),
 			Height:      uint32(height),
-			PixelFormat: v4l2PixFmtMJPEG,
+			PixelFormat: pixelFormat,
 			Field:       v4l2FieldNone,
 			// Compressed frame sizes vary with scene complexity. Reserve the
 			// uncompressed RGB bound rather than sizing the loopback buffer from
 			// the first (possibly unusually small) JPEG.
-			SizeImage: uint32(width * height * 3),
+			SizeImage: uint32(sizeImage),
 		}
 		if _, _, errno := unix.Syscall(unix.SYS_IOCTL, w.file.Fd(), vidiocSFmt, uintptr(unsafe.Pointer(&format))); errno != 0 {
 			return fmt.Errorf("configuring ROS 2 camera loopback %s: %w", w.path, errno)
 		}
-		w.width, w.height = width, height
+		w.width, w.height, w.codec = width, height, frame.Codec
 	}
-	for len(frame) > 0 {
-		n, err := w.file.Write(frame)
+	data := frame.Data
+	for len(data) > 0 {
+		n, err := w.file.Write(data)
 		if err != nil {
 			return fmt.Errorf("writing ROS 2 camera frame: %w", err)
 		}
 		if n == 0 {
 			return errors.New("writing ROS 2 camera frame made no progress")
 		}
-		frame = frame[n:]
+		data = data[n:]
 	}
 	return nil
+}
+
+func v4l2PixelFormat(codec Codec) (uint32, error) {
+	switch codec {
+	case CodecMJPEG:
+		return v4l2PixFmtMJPEG, nil
+	case CodecH264:
+		return v4l2PixFmtH264, nil
+	default:
+		return 0, fmt.Errorf("unsupported ROS 2 loopback codec %d", codec)
+	}
 }
 
 func (w *frameWriter) Close() error {

--- a/go/internal/agent/ros2camera/writer_other.go
+++ b/go/internal/agent/ros2camera/writer_other.go
@@ -7,7 +7,7 @@ import "errors"
 type unsupportedWriter struct{}
 
 func newFrameWriter(string) cameraWriter { return &unsupportedWriter{} }
-func (*unsupportedWriter) WriteJPEG([]byte, int, int) error {
+func (*unsupportedWriter) WriteFrame(Frame) error {
 	return errors.New("ROS 2 loopback cameras require Linux")
 }
 func (*unsupportedWriter) Close() error { return nil }

--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -87,6 +87,7 @@ const (
 // v4l2Format matches struct v4l2_format (208 bytes) for V4L2_BUF_TYPE_VIDEO_CAPTURE.
 type v4l2Format struct {
 	Type         uint32
+	_            [4]byte // align the v4l2_format union to 8 bytes on 64-bit Linux
 	Width        uint32
 	Height       uint32
 	PixelFormat  uint32
@@ -99,8 +100,18 @@ type v4l2Format struct {
 	Enc          uint32
 	Quantization uint32
 	XferFunc     uint32
-	_            [156]byte
+	_            [152]byte
 }
+
+// VIDIOC_S_FMT encodes a 208-byte argument, and the anonymous format union
+// starts at byte 8 on Linux's 64-bit UAPI. Keep both properties compile-time
+// checked because shifted fields make valid H.264 devices look unsupported.
+var (
+	_ [208 - unsafe.Sizeof(v4l2Format{})]byte
+	_ [unsafe.Sizeof(v4l2Format{}) - 208]byte
+	_ [8 - unsafe.Offsetof(v4l2Format{}.Width)]byte
+	_ [unsafe.Offsetof(v4l2Format{}.Width) - 8]byte
+)
 
 // v4l2FrmSizeEnum matches struct v4l2_frmsizeenum (44 bytes). Only the discrete
 // branch of the union is read; Union covers the larger stepwise variant so the

--- a/go/internal/agent/services/video_service_test.go
+++ b/go/internal/agent/services/video_service_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/wendylabsinc/wendy/go/internal/agent/camera"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
@@ -16,6 +17,16 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+func TestV4L2FormatMatches64BitUAPI(t *testing.T) {
+	var format v4l2Format
+	if got := unsafe.Sizeof(format); got != 208 {
+		t.Fatalf("sizeof(v4l2Format) = %d, want 208", got)
+	}
+	if got := unsafe.Offsetof(format.Width); got != 8 {
+		t.Fatalf("offsetof(v4l2Format.Width) = %d, want 8", got)
+	}
+}
 
 // mustBuildGStreamerArgs calls buildGStreamerArgs for the USB/v4l2src path and
 // fails the test if it returns an error. CSI-specific behaviour is covered by

--- a/go/internal/cli/assets/docs/device/entitlements.mdx
+++ b/go/internal/cli/assets/docs/device/entitlements.mdx
@@ -143,9 +143,9 @@ A `camera` entitlement can also carry `user`/`password` fields, but they are not
 </Callout>
 
 <Callout type="warning">
-  **Builds without the module**: container access to a network camera needs `v4l2loopback`. Without it, the agent logs this once and continues — direct `wendy device camera view` on the host is unaffected, only the in-container `/dev/video2xx` mirror is unavailable:
+  **Builds without the module**: container access to a network camera needs compatible v4l2loopback 0.15.x support. Without it, the agent logs this once and continues — direct IP-camera `wendy device camera view` on the host is unaffected, only the in-container `/dev/video2xx` mirror is unavailable:
 
-  > running WendyOS build lacks the v4l2loopback module; `camera view` still works
+  > running build lacks compatible v4l2loopback 0.15.x support
 </Callout>
 
 ### Audio Entitlement

--- a/go/internal/cli/assets/docs/hardware/camera.mdx
+++ b/go/internal/cli/assets/docs/hardware/camera.mdx
@@ -73,12 +73,20 @@ scope. Host/robot feeds on domain 0 are discovered on wired interfaces.
 
 Unitree Go2 robots receive special handling: the native
 `unitree_go/msg/Go2FrontVideoData` publisher on `/frontvideostream` appears as
-**Unitree Go2 front camera**. Wendy uses its 720p JPEG field when available and
-falls back to the lower-resolution fields on firmware that leaves it empty.
+**Unitree Go2 front camera**. Wendy accepts both the SDK-declared JPEG fields
+and the resolution-tagged Annex-B H.264 layout emitted by current Go2 firmware,
+preserving either codec through the loopback rather than transcoding it.
 
-ROS 2 camera mirroring requires the WendyOS `v4l2loopback` module. If the
-running image does not include it, the agent logs the missing-module error and
-the ROS 2 feed cannot be opened as a camera.
+ROS 2 camera mirroring requires v4l2loopback 0.15.x's dynamic control API; the
+WendyOS recipe is pinned to 0.15.4. Ubuntu 22.04's packaged 0.12.7 DKMS module
+is not compatible even if it loads successfully. If a compatible module is
+installed or loaded after an initial failure, retry the camera command; the
+agent rechecks availability without requiring a restart.
+
+The loopback uses exclusive capabilities. A container process that opens its
+device immediately at startup may briefly find it output-only while the first
+ROS 2 frame configures the capture format. Retry the initial format/open step
+for up to the agent's 15-second first-frame window.
 
 ## IP Cameras
 
@@ -127,11 +135,14 @@ Apps with the `camera` entitlement (see [Camera Entitlement](/docs/device/entitl
 </Callout>
 
 <Callout type="warning">
-  **Builds without the kernel module**: mirroring a camera into a container needs the `v4l2loopback` kernel module. On a WendyOS build that lacks it (or in local development), the agent logs this once and moves on:
+  **Builds without the kernel module**: mirroring a camera into a container needs compatible v4l2loopback 0.15.x support. On a WendyOS build that lacks it (or in local development), the agent logs this once and moves on:
 
-  > running WendyOS build lacks the v4l2loopback module; `camera view` still works
+  > running build lacks compatible v4l2loopback 0.15.x support
 
-  `wendy device camera view` and `wendy device camera test` are unaffected either way — only the in-container `/dev/video2xx` mirror is unavailable.
+  Direct IP-camera `wendy device camera view` and `camera test` are unaffected;
+  only the in-container `/dev/video2xx` mirror is unavailable. ROS 2 cameras
+  use a loopback node for both viewing and container access, so neither path is
+  available until the compatible module is present.
 </Callout>
 
 ## App Configuration

--- a/go/internal/shared/appconfig/annotation.go
+++ b/go/internal/shared/appconfig/annotation.go
@@ -174,7 +174,10 @@ func isAnnotationKey(s string) bool {
 // sh.wendy/entitlement.* keys to their encoded values, suitable for use as OCI
 // manifest annotations or containerd container labels. When multiple entitlements
 // share the same type a numeric suffix (.0, .1, …) is appended to disambiguate.
-// Entitlements with an empty type are skipped.
+// Entitlements with an empty type are skipped. Parameterless entitlements use
+// enabled=true instead of an empty value because containerd omits empty-valued
+// labels when it persists container metadata; the parser deliberately ignores
+// this sentinel and reconstructs the entitlement from the key.
 func BuildEntitlementAnnotations(entitlements []Entitlement) map[string]string {
 	typeCounts := make(map[string]int)
 	for _, e := range entitlements {
@@ -195,7 +198,11 @@ func BuildEntitlementAnnotations(entitlements []Entitlement) map[string]string {
 			key = EntitlementAnnotationKeyPrefix + e.Type + "." + strconv.Itoa(typeIndex[e.Type])
 			typeIndex[e.Type]++
 		}
-		out[key] = EntitlementAnnotationValue(e)
+		value := EntitlementAnnotationValue(e)
+		if value == "" {
+			value = "enabled=true"
+		}
+		out[key] = value
 	}
 	return out
 }

--- a/go/internal/shared/appconfig/annotation_test.go
+++ b/go/internal/shared/appconfig/annotation_test.go
@@ -198,6 +198,21 @@ func TestBuildEntitlementAnnotationsIndexesDistinctSerialDevices(t *testing.T) {
 	}
 }
 
+func TestBuildEntitlementAnnotationsKeepsParameterlessEntitlement(t *testing.T) {
+	key := EntitlementAnnotationKeyPrefix + EntitlementCamera
+	annotations := BuildEntitlementAnnotations([]Entitlement{{Type: EntitlementCamera}})
+	value, ok := annotations[key]
+	if !ok {
+		t.Fatalf("missing parameterless entitlement annotation %q", key)
+	}
+	if value == "" {
+		t.Fatal("parameterless entitlement annotation has an empty value, which containerd drops")
+	}
+	if got := ParseEntitlementAnnotation(EntitlementCamera, value); !reflect.DeepEqual(got, Entitlement{Type: EntitlementCamera}) {
+		t.Fatalf("round-trip = %+v, want camera entitlement", got)
+	}
+}
+
 func TestSplitAnnotationParams(t *testing.T) {
 	tests := []struct {
 		input string


### PR DESCRIPTION
## Relationship to #1827

This is a stacked fix PR targeting `codex/ros2-loopback-camera`, the head branch of #1827. It contains only the changes required to make that PR work end to end on the Go2 hardware tested below. It should be reviewed with #1827 and is intentionally left unmerged.

## What was broken

Live testing exposed issues that the original fixtures and CI did not cover:

1. Woof's current image did not ship `v4l2loopback`.
2. Ubuntu 22.04's packaged v4l2loopback 0.12.7 lacks the 0.15.x dynamic-control ABI used by the agent.
3. The missing-module error incorrectly implied every `camera view` path still worked; ROS 2 viewing also depends on the loopback.
4. A failed module check was cached for the lifetime of `wendy-agent`, forcing a restart after the module was loaded.
5. The live Go2 payload is `timestamp + resolution + Annex-B H.264`, not only the three-JPEG SDK layout handled by #1827.
6. The Go2 unit fixture modeled only the SDK-declared JPEG shape and could not catch the live layout.
7. Restarting the agent from an agent-hosted device shell delays service recovery until that shell closes.
8. The existing 64-bit `v4l2_format` declaration omitted the union-alignment padding, shifting width, height, and pixel-format reads by four bytes.
9. Parameterless entitlement labels used empty values, which did not survive containerd persistence; the ROS 2 manager therefore never observed a camera consumer.

The full reproduction notes and evidence are in `Documentation/2026-08-28-pr-1827-go2-hardware-validation.md`.

## Fix

- Decode both the observed resolution-tagged Annex-B H.264 layout and the SDK-declared Go2 JPEG layout.
- Carry codec metadata through the ROS 2 camera manager and configure V4L2 as H.264 or MJPEG without transcoding.
- Correct and compile-time-check the 208-byte, 64-bit V4L2 UAPI layout.
- Retry failed loopback availability checks while caching success.
- Use `enabled=true` for parameterless entitlement labels so containerd lifecycle reconciliation can see them.
- Add hardware-derived regression coverage and update the camera/entitlement docs.

## Go2 hardware validation

Tested perception-only on **Woof**, an ARM64 Jetson Orin companion connected to a Unitree Go2. No locomotion, actuator, DDS control, robot reset, or robot reboot commands were sent.

With v4l2loopback 0.15.4 loaded:

- The same agent PID recovered after an initial missing-module failure.
- The branch-built CLI captured **373,223 bytes** of clean Annex-B H.264 in 10 seconds, growing at every one-second observation after startup.
- The capture contained 104 non-IDR slices and four each of IDR, SPS, and PPS NAL units.
- A temporary Stagefile app with the `camera` entitlement saw `/dev/video128` as **640x360 H.264** and captured **101,569 bytes across 30 buffers at about 13.3 fps**.
- The test app/container, loopback module, temporary module build, and test agent were removed afterward. The running agent and `/usr/bin/wendy-agent` were restored to the original matching SHA-256.

## Automated verification

Passed:

```text
go test -race ./go/internal/rtps/... ./go/internal/agent/ros2camera ./go/internal/agent/services ./go/internal/agent/containerd ./go/internal/agent/ipcam ./go/internal/shared/appconfig
go vet ./go/internal/rtps/... ./go/internal/agent/ros2camera ./go/internal/agent/services ./go/internal/agent/containerd ./go/internal/agent/ipcam ./go/internal/shared/appconfig ./go/cmd/wendy-agent
GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build ./go/cmd/wendy-agent
GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go test -c ./go/internal/agent/ros2camera
go build ./go/cmd/wendy
git diff --check
```

A broad `go test ./...` also ran. It reached three unrelated existing Mac/environment-sensitive failures outside the changed packages: the tegrastats fallback fixture, a `/private/var` versus `/var` path expectation, and a live address-resolution expectation.

## Merge status

**Do not merge yet.** This PR is open for review and remains stacked on #1827.
