### PR TITLE
feat/arm64 vm launcher

### DIFF
--- a/go/internal/agent/services/agent_service_test.go
+++ b/go/internal/agent/services/agent_service_test.go
@@ -654,6 +654,12 @@ func TestParseDeviceTypePrefersBoard(t *testing.T) {
 			wantStorage: "nvme",
 		},
 		{
+			name:        "disk storage",
+			content:     "BOARD=vm-arm64\nMACHINE=vm-arm64-wendyos\nSTORAGE=disk\n",
+			wantType:    "vm-arm64",
+			wantStorage: "disk",
+		},
+		{
 			name:        "board wins when listed after machine",
 			content:     "MACHINE=jetson-orin-nano-devkit-nvme-wendyos\nBOARD=jetson-orin-nano\n",
 			wantType:    "jetson-orin-nano",

--- a/go/internal/cli/assets/docs/installation/meta.json
+++ b/go/internal/cli/assets/docs/installation/meta.json
@@ -4,6 +4,7 @@
     "wendyos-nvidia-jetson-orin-nano",
     "wendyos-nvidia-jetson-agx-thor",
     "wendyos-raspberry-pi-5",
+    "wendyos-virtual-machine",
     "linux",
     "wendy-agent-macos",
     "wendy-agent-unitree-g1",

--- a/go/internal/cli/assets/docs/installation/wendyos-virtual-machine.mdx
+++ b/go/internal/cli/assets/docs/installation/wendyos-virtual-machine.mdx
@@ -357,9 +357,11 @@ usually running fine; check with `wendy vm logs <name>`.
 
 **`Decompressor is not installed for grpc-encoding "gzip"`, then a registry
 push that fails.** The agent in the VM's image is older than your CLI and cannot
-accept compressed layers. The push it falls back to needs port 5000 forwarded,
-which VMs created before that forward existed do not have — recreate the VM, or
-restart it so the new forward is applied.
+accept compressed layers. The CLI falls back to a registry push and resolves
+the selected VM's registry forward automatically, allocating another loopback
+port if host port 5000 is busy. If the error reports an unavailable control
+socket, restart the VM with the current CLI to enable forwarding. There is no
+need to recreate its disk.
 
 **It boots slowly.** On a Mac without Apple Silicon, or on an x86 PC, the guest
 is emulated rather than accelerated, because the guest is ARM64 and the host is

--- a/go/internal/cli/assets/docs/installation/wendyos-virtual-machine.mdx
+++ b/go/internal/cli/assets/docs/installation/wendyos-virtual-machine.mdx
@@ -227,6 +227,13 @@ processes running as your user (and root) can connect and have full QEMU control
 
 ### If port 50051 is taken
 
+Prefer `--device vm:<name>` (or save it with `wendy device set-default
+vm:<name>`) over a literal loopback address. The alias follows the VM's current
+port and keeps enrolled-device trust pins separate for each VM. A literal
+`127.0.0.1` target retains its existing host-based pin behavior. If you replace
+an enrolled VM intentionally, clear only its pin with `wendy device unpin
+vm:<name>` before connecting to the replacement.
+
 The agent's port is often already in use on a development machine. Move the
 host side of the forward:
 

--- a/go/internal/cli/assets/docs/installation/wendyos-virtual-machine.mdx
+++ b/go/internal/cli/assets/docs/installation/wendyos-virtual-machine.mdx
@@ -307,6 +307,13 @@ a PR under the same label cannot silently reuse the old image. If no checksum
 is published, each create downloads afresh and removes that temporary download
 after provisioning. Existing VM disks are never refreshed implicitly.
 
+New VMs receive a random locally-administered MAC stored in `meta.json`, stable
+across restarts and distinct even when another host creates a VM with the same
+name. Older VMs without a stored MAC retain their legacy name-derived address
+to avoid changing their network identity on upgrade. If two such legacy VMs
+share a name, do not place both on the same shared network; recreate one to
+allocate a fresh address. Copying an entire VM directory also copies its MAC.
+
 <Callout type="info">
 A freshly created VM's agent is unauthenticated until the device is provisioned,
 and it is reachable on `127.0.0.1`. On a machine you share with other people,

--- a/go/internal/cli/assets/docs/installation/wendyos-virtual-machine.mdx
+++ b/go/internal/cli/assets/docs/installation/wendyos-virtual-machine.mdx
@@ -208,18 +208,22 @@ forwards three:
 | `50052` | the agent again, once the device is provisioned and on mTLS |
 | `5000` | the device's container registry, which `wendy run` pushes to |
 
-An app's own port is **not** among them, so `wendy run` can deploy an app to a
-VM and still leave it unreachable — and its readiness probe times out for the
-same reason. Add the forward from QEMU's monitor without restarting: press
-**Ctrl-A** then **C** on the VM's console and
+On macOS and Linux, `wendy run` also forwards each declared `http` entitlement
+and TCP readiness port to the same port on `127.0.0.1`. The app URL uses that
+loopback address, and readiness checks use it too. This works with background
+VMs and detached applications; forwards last until the VM stops and are
+recreated on the next run.
 
-```
-hostfwd_add net0 tcp:127.0.0.1:3001-:3001
-```
+If another application or VM owns the host port, deployment reports a forwarding
+error. Free that port or choose a different application port. Other ports are
+not automatically exposed. VMs started with an older launcher must be restarted
+once to enable this feature. On `--net shared` the guest is on your network
+directly and none of this applies.
 
-using your app's port. **Ctrl-A** then **C** returns you to the console, and
-`http://127.0.0.1:3001` then works. On `--net shared` the guest is on your
-network directly and none of this applies.
+The launcher manages these forwards through a Unix control socket in the VM's
+directory, whose permissions are enforced as `0700` on each launch. There is no
+TCP control listener. Other user accounts cannot traverse the directory, but
+processes running as your user (and root) can connect and have full QEMU control.
 
 ### If port 50051 is taken
 

--- a/go/internal/cli/assets/docs/installation/wendyos-virtual-machine.mdx
+++ b/go/internal/cli/assets/docs/installation/wendyos-virtual-machine.mdx
@@ -1,0 +1,338 @@
+---
+title: WendyOS in a Virtual Machine
+description: Run WendyOS on your own computer, without a Jetson or Raspberry Pi
+---
+
+## What this is for
+
+The simulator runs a real WendyOS ARM64 image on your own machine. It is the same
+image a physical device runs — same agent, same containerd, same entitlements —
+so you can build and deploy apps before you have hardware on your desk, or
+alongside it.
+
+On an Apple Silicon Mac this is also the fastest development loop WendyOS has.
+`wendy run` targets `linux/arm64`, and an ARM64 guest on an ARM64 host builds
+natively, with none of the emulation an x86 machine pays when it cross-builds
+for a device.
+
+<Callout type="info">
+The VM has no camera, microphone, speaker, Bluetooth adapter, GPU, GPIO or USB
+devices. Anything under **Hardware Access**
+needs a real device. The VM is for the software half of your project.
+</Callout>
+
+## What you'll need
+
+QEMU, plus its ARM64 UEFI firmware:
+
+<Tabs items={['macOS', 'Debian / Ubuntu']} groupId="developer-machine-os" persist>
+<Tab value="macOS">
+```sh
+brew install qemu
+```
+</Tab>
+<Tab value="Debian / Ubuntu">
+```sh
+sudo apt install qemu-system-arm qemu-efi-aarch64
+```
+</Tab>
+</Tabs>
+
+On macOS you can skip this: if QEMU is missing when you start a simulator,
+`wendy` offers to run `brew install qemu` for you.
+
+That is the only prerequisite. The image is downloaded the first time you need
+one and reused for every simulator afterwards.
+
+## The short version
+
+You do not have to create or start anything by hand. With no `--device` and no
+default device set, `wendy run` opens a picker with a **Simulator** tab:
+
+```sh
+wendy run
+```
+
+Pick a simulator and press enter. If it is stopped, it is booted for you. On a
+fresh machine the first boot downloads the image, so it takes a few minutes.
+
+The tab manages simulators without dropping to `wendy vm`:
+
+| Key | Does |
+| --- | --- |
+| `c` | Create one at the latest release, naming it `sim`, `sim-2`, … |
+| `s` | Power off the highlighted VM |
+| `r` | Delete it, once it is stopped |
+
+`wendy discover` shows the same tab with the same three keys; there `enter`
+copies the VM's address instead of selecting it. For a specific name, version
+or disk size, use `wendy vm create`.
+
+To skip the picker entirely, name the simulator directly:
+
+```sh
+wendy --device sim device info
+```
+
+`sim` starts the simulator if it is not already running. Everything below is the
+manual equivalent, useful when you want several VMs or need to debug one.
+
+## Create and start a VM
+
+<Steps>
+<Step>
+
+### Create it
+
+```sh
+wendy vm create dev
+```
+
+The published image is downloaded and unpacked straight into the VM's disk. It
+is cached compressed, so a second VM starts from the cache rather than the
+network, and the raw multi-gigabyte image is never written twice. `--disk` sets
+the disk size and WendyOS expands `/data` into the extra room on first boot; the
+disk is sparse, so a 16 GiB VM only occupies what it uses. Container images live
+on the root filesystem rather than `/data`, so a bigger disk does not give
+`wendy run` more room.
+
+To pin a version, or to run a VM from an image you built yourself:
+
+```sh
+wendy vm create dev --version 0.19.0
+wendy vm create dev --image ./wendyos-image-vm-arm64-wendyos.rootfs.wic
+```
+
+</Step>
+<Step>
+
+### Start it
+
+```sh
+wendy vm start dev
+```
+
+This attaches you to the VM's console. Press **Ctrl-A** then **X** to power it
+off.
+
+</Step>
+<Step>
+
+### Talk to it
+
+In another terminal:
+
+```sh
+wendy --device 127.0.0.1:50051 device info
+```
+
+To avoid repeating the address:
+
+```sh
+wendy device set-default 127.0.0.1:50051
+wendy run
+```
+
+</Step>
+</Steps>
+
+## Trying a change before it merges
+
+Every pull request to WendyOS-Builder builds a VM image, so a change can be run
+without hardware and without waiting for a release:
+
+```sh
+wendy vm create review --pr 1234
+wendy vm start review
+```
+
+`--pr` takes the pull request number and stands in for the version: a PR
+publishes exactly one build, so it cannot be combined with `--version`,
+`--nightly` or `--image`.
+
+<Callout type="warn">
+A pull request's image is built from an unmerged branch, so booting one runs
+code that has not been reviewed — on your machine, with a real filesystem and a
+real network stack. Treat `--pr` the way you would treat running that branch's
+build script: only for branches you trust. `wendy vm create --pr` says the same
+thing when it starts.
+</Callout>
+
+## Networking
+
+`wendy vm start` offers two networks. Both are discoverable from your own
+machine; the difference is whether anything *else* can reach the VM.
+
+| `--net` | Setup needed | Listed by `wendy discover` | On your network |
+| --- | --- | --- | --- |
+| `user` (default) | none | Yes — as a local VM | No |
+| `shared` | one-time `socket_vmnet` install, **macOS only** | Yes — over mDNS, like a device | Yes |
+
+The default forwards the agent's port to your machine and needs no privileges.
+It carries no multicast, so the VM answers no mDNS and no other machine can see
+it — but `wendy discover` still lists it, because the CLI knows about VMs on
+this machine directly and probes the forwarded port. It appears as `vm:<name>`,
+and the **Simulator** tab shows stopped ones too.
+
+Choose `shared` when you need the VM to behave like a real device on the wire —
+to test mDNS itself, or to reach it from another machine:
+
+```sh
+wendy vm start dev --net shared
+```
+
+The helper it needs is `socket_vmnet`; if it is missing, `wendy` offers to run
+`brew install socket_vmnet` and `sudo brew services start socket_vmnet` for you.
+Both are also fine to run by hand.
+
+<Callout type="warn">
+`--net shared` is macOS only — it builds on Apple's vmnet framework. On Linux
+use the default `--net user` and reach the VM by address.
+</Callout>
+
+<Callout type="info">
+On macOS 15 and later the first `wendy discover` may ask for **Local Network**
+permission. Discovery cannot see anything until you allow it.
+</Callout>
+
+### Reaching an app you deployed
+
+`--net user` puts the guest on a private NAT. The address the guest sees itself
+at — something like `10.0.2.15` — does not exist on your machine, and nothing
+routes into that network. Only forwarded ports are reachable, and the launcher
+forwards three:
+
+| Port | Carries |
+| --- | --- |
+| `50051` | the agent |
+| `50052` | the agent again, once the device is provisioned and on mTLS |
+| `5000` | the device's container registry, which `wendy run` pushes to |
+
+An app's own port is **not** among them, so `wendy run` can deploy an app to a
+VM and still leave it unreachable — and its readiness probe times out for the
+same reason. Add the forward from QEMU's monitor without restarting: press
+**Ctrl-A** then **C** on the VM's console and
+
+```
+hostfwd_add net0 tcp:127.0.0.1:3001-:3001
+```
+
+using your app's port. **Ctrl-A** then **C** returns you to the console, and
+`http://127.0.0.1:3001` then works. On `--net shared` the guest is on your
+network directly and none of this applies.
+
+### If port 50051 is taken
+
+The agent's port is often already in use on a development machine. Move the
+host side of the forward:
+
+```sh
+wendy vm start dev --port 50151
+wendy --device 127.0.0.1:50151 device info
+```
+
+## Updating the OS
+
+The VM is partitioned exactly like a device — two rootfs slots plus a growable
+`/data`, with GRUB choosing between them through `grubenv` — so A/B OTA works
+here the same way it works on hardware:
+
+```sh
+wendy --device 127.0.0.1:50051 os update
+```
+
+The update is written to the slot that is not running, the VM reboots into it,
+and the new slot is committed once the agent comes back. `/data` is untouched,
+so containers and app data survive.
+
+`device info` reports both slots under `osUpdate.engine` — `currentSlot` is the
+one running, and each entry names its partition, so you can watch A on
+`/dev/vda3` hand over to B on `/dev/vda4`:
+
+```sh
+wendy --device 127.0.0.1:50051 device info
+wendy --device 127.0.0.1:50051 os update-status   # how the last update ended
+```
+
+The agent returns on the same forwarded port after the reboot, so nothing needs
+restarting on your side. `wendy vm logs <name>` shows the reboot and the slot
+GRUB picked, which is the quickest way to watch an update land.
+
+<Callout type="info">
+This makes the simulator the cheapest way to rehearse an OS update — including a
+rollback — without tying up a Jetson or a Raspberry Pi.
+</Callout>
+
+## Managing VMs
+
+`wendy vm` is hidden from `wendy --help` on purpose — the simulator is meant to
+be reached through `wendy run` or `--device sim`. The subcommands below are all
+still available for when you need to look under the hood.
+
+```sh
+wendy vm list          # every VM, with its state, address and version
+wendy vm start dev -d  # run it in the background instead of taking the terminal
+wendy vm logs dev -f   # the console of a backgrounded VM
+wendy vm stop dev      # power it off
+wendy vm rm dev        # delete a VM and its disk
+```
+
+A backgrounded VM outlives the command that started it, so closing the terminal
+or pressing Ctrl-C does not power it off. `wendy vm rm` refuses to delete a
+running VM unless you pass `--force`.
+
+VMs live in `~/.wendy/vms/<name>/`. Removing one deletes its disk, which cannot
+be undone — but the image you created it from is untouched, so you can always
+make a fresh one.
+
+<Callout type="info">
+A freshly created VM's agent is unauthenticated until the device is provisioned,
+and it is reachable on `127.0.0.1`. On a machine you share with other people,
+that means any local account can talk to it — including enrolling it — in the
+window before you do. Provision it promptly, or use a machine you do not share.
+</Callout>
+
+## Options
+
+| Flag | Default | Purpose |
+| --- | --- | --- |
+| `--image` | — | Create from a local `.wic` instead of downloading |
+| `--version` | latest | Version to download |
+| `--nightly` | off | Download a nightly rather than a release |
+| `--disk` | `16` | Disk size in GiB |
+| `--net` | `user` | `user` or `shared` — see above |
+| `--port` | `50051` | Host port forwarded to the agent |
+| `--memory` | `4096` | Guest memory in MiB |
+| `--cpus` | `4` | Guest CPU count |
+| `--detach` / `-d` | off | Run in the background rather than on this terminal |
+| `--yes` / `-y` | off | Accept prompts, including installing QEMU |
+
+## Troubleshooting
+
+**`no ARM64 UEFI firmware found`** — QEMU is installed but its firmware is not.
+Reinstall it with the command under *What you'll need*; the error lists every
+path that was searched.
+
+**`host port already in use`** — something already holds 50051. Use `--port`.
+
+**`shared networking needs macOS`** — `--net shared` builds on Apple's vmnet
+framework. Use `--net user`.
+
+**`socket_vmnet helper not found`** — `--net shared` needs the helper installed
+*and* running. Install it as above, or drop back to `--net user` and reach the
+VM by address.
+
+**`readiness probe timed out`, or the app's URL does not load.** The app's port
+is not forwarded — see *Reaching an app you deployed*. The app itself is
+usually running fine; check with `wendy vm logs <name>`.
+
+**`Decompressor is not installed for grpc-encoding "gzip"`, then a registry
+push that fails.** The agent in the VM's image is older than your CLI and cannot
+accept compressed layers. The push it falls back to needs port 5000 forwarded,
+which VMs created before that forward existed do not have — recreate the VM, or
+restart it so the new forward is applied.
+
+**It boots slowly.** On a Mac without Apple Silicon, or on an x86 PC, the guest
+is emulated rather than accelerated, because the guest is ARM64 and the host is
+not. It still works; it is just slower. `wendy vm start` prints which mode it
+chose.

--- a/go/internal/cli/assets/docs/installation/wendyos-virtual-machine.mdx
+++ b/go/internal/cli/assets/docs/installation/wendyos-virtual-machine.mdx
@@ -277,9 +277,14 @@ still available for when you need to look under the hood.
 wendy vm list          # every VM, with its state, address and version
 wendy vm start dev -d  # run it in the background instead of taking the terminal
 wendy vm logs dev -f   # the console of a backgrounded VM
-wendy vm stop dev      # power it off
+wendy vm stop dev      # request graceful guest shutdown
 wendy vm rm dev        # delete a VM and its disk
 ```
+
+`vm stop` waits up to two minutes for the guest to shut down and flush its
+filesystems. If QMP is unavailable or the guest does not finish, it reports an
+error without killing the VM. Shut down inside an older guest without QMP, or
+use `wendy vm stop dev --force` only when an immediate power cut is intended.
 
 A backgrounded VM outlives the command that started it, so closing the terminal
 or pressing Ctrl-C does not power it off. `wendy vm rm` refuses to delete a

--- a/go/internal/cli/assets/docs/installation/wendyos-virtual-machine.mdx
+++ b/go/internal/cli/assets/docs/installation/wendyos-virtual-machine.mdx
@@ -301,6 +301,12 @@ VMs live in `~/.wendy/vms/<name>/`. Removing one deletes its disk, which cannot
 be undone — but the image you created it from is untouched, so you can always
 make a fresh one.
 
+Published VM images are cached by their manifest SHA-256, not by the version
+label. Cached and newly downloaded bytes are verified before use, so rebuilding
+a PR under the same label cannot silently reuse the old image. If no checksum
+is published, each create downloads afresh and removes that temporary download
+after provisioning. Existing VM disks are never refreshed implicitly.
+
 <Callout type="info">
 A freshly created VM's agent is unauthenticated until the device is provisioned,
 and it is reachable on `127.0.0.1`. On a machine you share with other people,

--- a/go/internal/cli/assets/docs/wendyos/networking/README.md
+++ b/go/internal/cli/assets/docs/wendyos/networking/README.md
@@ -56,7 +56,7 @@ WendyOS runs on multiple hardware platforms. Networking behaviour is identical a
 | Jetson AGX Orin / Orin Nano | `tegra-xudc` | USB 3.2 |
 | Other Linux (generic) | Detected at runtime | USB 2.0 fallback |
 
-The QEMU virtual machine (`qemuarm64-wendyos`) does not use USB NCM gadget networking. It emulates a standard virtio network device instead.
+The virtual machine boards (`vm-arm64-wendyos`, `vm-x86-64-wendyos`) do not use USB NCM gadget networking. They emulate a standard virtio network device instead.
 
 ## Planned changes (not yet shipped)
 

--- a/go/internal/cli/assets/skills/wendy-contributing/SKILL.md
+++ b/go/internal/cli/assets/skills/wendy-contributing/SKILL.md
@@ -27,17 +27,20 @@ The `wendy-agent` is a container daemon (similar to `dockerd`/`containerd`):
 
 ## Building WendyOS (Yocto)
 
-WendyOS images are built with Yocto. Three meta layers exist:
+WendyOS images are built with Yocto, from one repo (`WendyOS-Builder`) whose
+sub-layers cover each target. Every board builds `wendyos-image`; the board id
+selects the machine.
 
-| Layer | Target | Image |
-|-------|--------|-------|
-| `meta-wendyos-jetson` | NVIDIA Jetson | `edgeos-image` |
-| `meta-wendyos-virtual` | ARM64 VM | `edgeos-vm-image` |
-| `meta-wendyos-rpi` | Raspberry Pi 4/5 | `edgeos-rpi-image` |
+| Sub-layer | Target | Board id |
+|-----------|--------|----------|
+| `meta-tegra-extensions*` | NVIDIA Jetson | `jetson-*` |
+| `meta-rpi-extensions` | Raspberry Pi 3/4/5 | `rpi*` |
+| `meta-x86-extensions` | Generic x86_64 PC | `generic-x86-64` |
+| `meta-vm-extensions` | ARM64 and x86-64 VMs | `vm-arm64`, `vm-x86-64` |
 
-Quick build (any layer):
+Quick build (any board):
 ```bash
-cd meta-wendyos-<target>
+cd WendyOS-Builder
 ./bootstrap.sh
 source ./repos/poky/oe-init-build-env build
 bitbake <image-name>
@@ -57,8 +60,8 @@ The `wendy-agent` repository includes an E2E test suite in `swift/WendyE2ETests/
 ### Running E2E Tests
 ```bash
 # Start the VM
-cd meta-wendyos-virtual
-./scripts/setup-dev-vm.sh create && ./scripts/setup-dev-vm.sh start
+wendy vm create dev --image wendyos-image-vm-arm64-wendyos.rootfs.wic --disk 16
+wendy vm start dev
 
 # Deploy a test app first (required for container tests)
 cd wendy-agent/Examples/HelloWorld
@@ -66,7 +69,7 @@ wendy run --json --device localhost:50051  # --json for non-interactive output
 
 # Run E2E tests with fast path (CRITICAL for performance)
 cd wendy-agent/E2ETests
-E2E_USE_EXISTING_VM=true E2E_VM_PATH=/path/to/meta-wendyos-virtual swift test
+E2E_USE_EXISTING_VM=true swift test
 ```
 
 **Important**: Always set `E2E_USE_EXISTING_VM=true` when the VM is already running. This skips shell script checks and reduces test time from ~5s/test to ~0.01s/test.

--- a/go/internal/cli/assets/skills/wendy-contributing/references/system-internals.md
+++ b/go/internal/cli/assets/skills/wendy-contributing/references/system-internals.md
@@ -91,42 +91,29 @@ ctr -n default images ls
 ctr -n default containers ls
 ```
 
-## Lima VM Development (macOS)
+## Running WendyOS in a VM (macOS and Linux)
 
-For Apple Silicon developers, use Lima with bridged networking:
+`wendy vm` runs the `vm-arm64-wendyos` `.wic` locally:
 
 ```bash
-./scripts/setup-dev-vm.sh create   # Create VM
-./scripts/setup-dev-vm.sh shell    # Enter VM
-./scripts/setup-dev-vm.sh delete   # Remove VM
+wendy vm create dev --image wendyos-image-vm-arm64-wendyos.rootfs.wic --disk 16
+wendy vm start dev                 # Ctrl-A then X to power off
+wendy --device 127.0.0.1:50051 device info
 ```
 
-**Bridged networking** requires socket_vmnet:
-```bash
-brew install socket_vmnet
-```
+The image is UEFI-bootable on its own (ESP + GRUB `bootaa64.efi`), so it needs
+no external kernel and no `-append`.
 
-Lima config must use:
-```yaml
-networks:
-  - lima: bridged
-    interface: en0
-```
+**Tested**: QEMU directly, on macOS and Linux.
+**Untested**: Apple Virtualization.framework, and therefore Parallels and UTM in
+virtualize mode. The image is now UEFI-bootable, which removes one obstacle, but
+`vm-grub.cfg` hardcodes `console=ttyAMA0` — a PL011 that Virtualization.framework
+does not expose (it offers a virtio console, `hvc0`) — so a VZ guest would very
+likely boot mute. UTM in *emulate* mode runs QEMU and should behave like QEMU.
 
-Without bridged networking, mDNS won't work from LAN.
-
-## Running Built Images
-
-The Yocto-built image is for QEMU, NOT Apple Virtualization.framework.
-
-**Works**: Lima, UTM (emulation mode), QEMU directly
-**Doesn't work**: Parallels, UTM (virtualization mode)
-
-For UTM:
-1. Use **Emulate** (not Virtualize)
-2. Select ARM64 architecture
-3. Add Serial device for console
-4. Import qcow2 as VirtIO drive
+`--net user` (the default) forwards the agent port but carries no multicast, so
+`wendy discover` cannot see the VM; `--net shared` uses `socket_vmnet` and can.
+See the *WendyOS in a Virtual Machine* installation guide for the full flow.
 
 ## Offline Container Image Bundling
 

--- a/go/internal/cli/assets/skills/wendy-contributing/references/yocto-meta-layers.md
+++ b/go/internal/cli/assets/skills/wendy-contributing/references/yocto-meta-layers.md
@@ -1,100 +1,86 @@
 # WendyOS Yocto Meta Layers Reference
 
-WendyOS has three Yocto meta layers for different hardware targets:
+WendyOS builds from one repo, `WendyOS-Builder`, whose sub-layers cover each
+target. Every board builds `wendyos-image`; the board id selects the machine.
 
-| Layer | Target | Location |
-|-------|--------|----------|
-| `meta-wendyos-jetson` | NVIDIA Jetson (Orin Nano) | Production devices with Mender OTA |
-| `meta-wendyos-virtual` | ARM64 VM (Apple Silicon, QEMU) | Development/testing |
-| `meta-wendyos-rpi` | Raspberry Pi 4/5 | Edge devices without GPU |
+| Sub-layer | Target | Board id |
+|-----------|--------|----------|
+| `meta-tegra-extensions*` | NVIDIA Jetson (Orin, Thor) | `jetson-*` |
+| `meta-rpi-extensions` | Raspberry Pi 3/4/5 | `rpi*` |
+| `meta-x86-extensions` | Generic x86_64 PC | `generic-x86-64` |
+| `meta-vm-extensions` | ARM64 and x86-64 VMs | `vm-arm64`, `vm-x86-64` |
 
 ## Common Structure
 
-All layers follow the same pattern:
+Shared recipes live at the repo root; each sub-layer adds only what its target
+needs.
 
 ```
-meta-wendyos-<target>/
+WendyOS-Builder/
 ├── conf/
-│   ├── layer.conf                 # Layer registration
-│   ├── distro/<distro>.conf       # Distro configuration
-│   ├── machine/<machine>.conf     # Machine configurations
-│   └── template/
-│       ├── bblayers.conf          # Layer dependencies
-│       └── local.conf             # Build settings
-├── recipes-core/
-│   ├── images/<image>.bb          # Main image recipe
-│   ├── packagegroups/             # Package groups
-│   ├── edgeos-identity/           # Device UUID/hostname
-│   ├── edgeos-agent/              # wendy-agent service
-│   ├── edgeos-motd/               # Login banner
-│   └── systemd-mount-containerd/  # Persistent storage
-├── wic/<target>.wks               # Disk partition layout
-├── scripts/docker/                # Docker build environment
-├── bootstrap.sh                   # Environment setup
-└── CLAUDE.md                      # AI context
+│   ├── distro/wendyos.conf        # The distro, and its per-target includes
+│   ├── machine/<machine>.conf     # One per board
+│   └── template/boards/<board-id>/ # bblayers.conf, local.conf, repos.overrides
+├── recipes-core/                  # wendyos-identity, wendyos-agent, images, ...
+├── meta-<target>-extensions/      # Per-target recipes, bbappends and wic files
+└── bootstrap.sh                   # Clones the upstream layer tree
 ```
 
-## Quick Start (Any Layer)
+## Quick Start (Any Board)
 
 ```bash
-cd meta-wendyos-<target>
-./bootstrap.sh
-source ./repos/poky/oe-init-build-env build
-bitbake <image-name>
+make setup BOARD=<board-id>
+make build MACHINE=<machine>
 ```
 
 ## Layer-Specific Details
 
-### Jetson (`meta-wendyos-jetson`)
+### Jetson (`meta-tegra-extensions*`)
 
-- **Distro**: `edgeos`
-- **Machines**: `jetson-orin-nano-devkit-edgeos`, `jetson-orin-nano-devkit-nvme-edgeos`
-- **Image**: `edgeos-image`
-- **Features**: Mender OTA, NVIDIA Container Toolkit, CUDA/TensorRT, USB Gadget
-- **Dependencies**: meta-tegra, meta-mender
+- **Board ids**: `jetson-orin-nano-sd`, `jetson-orin-nano-nvme`, `jetson-agx-orin`,
+  `jetson-agx-orin-emmc`, `jetson-agx-thor`
+- **Features**: NVIDIA Container Toolkit, CUDA/TensorRT, USB gadget, A/B OTA
+- **Dependencies**: meta-tegra, meta-tegra-community, meta-security
 
-```bash
-bitbake edgeos-image
-```
+### Virtual (`meta-vm-extensions`)
 
-### Virtual (`meta-wendyos-virtual`)
+Lives in WendyOS-Builder, not a separate repo.
 
-- **Distro**: `edgeos-vm`
-- **Machine**: `wendyos-vm-arm64`
-- **Image**: `edgeos-vm-image`
-- **Features**: QEMU/UTM compatible, Lima integration
-- **Output**: `.wic.qcow2`, `.wic.vmdk`
+- **Machines**: `vm-arm64-wendyos` (board id `vm-arm64`) and
+  `vm-x86-64-wendyos` (`vm-x86-64`)
+- **Image**: `wendyos-image`
+- **Output**: `.wic` (UEFI: ESP + GRUB + A/B rootfs slots + growable `/data`)
+- **Features**: virtio only, plus the A/B OTA stack via the grubenv connector.
+  No USB gadget, no camera/audio/Bluetooth/GPU
 
 ```bash
-bitbake edgeos-vm-image
+make setup BOARD=vm-arm64
+make build MACHINE=vm-arm64-wendyos
 ```
 
-### Raspberry Pi (`meta-wendyos-rpi`)
+Run the result with `wendy vm` — see the *WendyOS in a Virtual Machine*
+installation guide.
 
-- **Distro**: `edgeos-rpi`
-- **Machines**: `raspberrypi4-64-edgeos`, `raspberrypi5-edgeos`
-- **Image**: `edgeos-rpi-image`
-- **Features**: I2C, SPI, serial console enabled
-- **Output**: `.wic.bz2`, `.wic.bmap`, `.sdimg` (Mender A/B)
+### Raspberry Pi (`meta-rpi-extensions`)
 
-```bash
-bitbake edgeos-rpi-image
-```
+- **Board ids**: `rpi3-sd`, `rpi4-sd`, `rpi5-sd`, `rpi5-nvme`
+- **Features**: I2C, SPI, serial console, USB gadget, A/B OTA
+- **Output**: `.sdimg` / `.wic` plus `.wic.bmap`
 
 ## Common Recipes
 
-### edgeos-identity
+### wendyos-identity
 
 Generates unique device identity on first boot:
-- UUID: `/etc/edgeos/device-uuid`
-- Name: `/etc/edgeos/device-name` (e.g., "brave-falcon")
+- UUID: `/etc/wendyos/device-uuid`
+- Name: `/etc/wendyos/device-name` (e.g., "brave-falcon")
 - Sets hostname to device name
 - Registers with Avahi mDNS
 
-### edgeos-agent
+### wendyos-agent
 
-Downloads and installs wendy-agent from GitHub releases:
-- Binary: `/opt/wendyos/bin/wendy-agent`
+Installs wendy-agent from its GitHub release tarball:
+- Binary: `/opt/wendyos/bin/wendy-agent`, symlinked from `/usr/local/bin/wendy-agent`
 - Auto-updater via systemd timer
 - Data: `/var/lib/wendy-agent`
 
@@ -110,7 +96,7 @@ Bind mounts `/data/containerd` to `/var/lib/containerd` for persistent container
 | p1 | Root A (active) |
 | p2 | Root B (OTA fallback) |
 | p11 | Boot/EFI |
-| p17 | Mender data (expandable) |
+| p17 | `/data` (expandable) |
 
 ### VM/RPi
 | Partition | Mount | Size |
@@ -192,8 +178,7 @@ SSTATE_DIR = "/home/dev/sstate-cache"
 
 Machine config needs KMACHINE mapping:
 ```bitbake
-KMACHINE:wendyos-vm-arm64 = "qemuarm64"
-KBRANCH:wendyos-vm-arm64 = "v6.6/standard/qemuarm64"
+KMACHINE:vm-arm64-wendyos = "genericarm64"
 ```
 
 ### containerd storage not persisting

--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -1234,6 +1234,13 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 		}
 	}
 	svcLifecycleCfgs := composeServiceLifecycleConfigs(svcCfgs, companion)
+	portConfigs := []*appconfig.AppConfig{companion}
+	for _, svc := range svcCfgs {
+		portConfigs = append(portConfigs, svc)
+	}
+	if err := prepareVMAppPorts(ctx, conn, portConfigs...); err != nil {
+		return err
+	}
 
 	// App-level lifecycle fallback: only a companion wendy.json can declare
 	// top-level HTTP/readiness/hooks for a compose project (x-wendy is

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -148,7 +148,6 @@ func newDevicePushAgentCmd() *cobra.Command {
 				return err
 			}
 			defer conn.Close()
-			addr := hostPort(conn.Host, defaultAgentPort)
 
 			h := sha256.Sum256(binaryData)
 			sha256Hex := hex.EncodeToString(h[:])
@@ -165,7 +164,7 @@ func newDevicePushAgentCmd() *cobra.Command {
 			conn.Close()
 
 			fmt.Fprint(os.Stderr, "Waiting for agent to restart...")
-			newConn, err := waitForAgentRestart(ctx, addr)
+			newConn, err := reconnectAgentAfterRestart(ctx, conn)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, " failed.")
 				return fmt.Errorf("agent did not come back after update: %w", err)
@@ -2032,7 +2031,17 @@ func reconnectAgentAfterRestart(ctx context.Context, conn *grpcclient.AgentConne
 	if conn != nil && conn.Reconnect != nil {
 		return conn.Reconnect(ctx)
 	}
-	return waitForAgentRestart(ctx, hostPort(conn.Host, defaultAgentPort))
+	if conn == nil {
+		return nil, fmt.Errorf("cannot reconnect without the original device")
+	}
+	if conn.SimulatorName != "" {
+		return waitForSimulatorAgent(ctx, conn.SimulatorName, conn.Addr, 60*time.Second)
+	}
+	addr := conn.Addr
+	if addr == "" {
+		addr = hostPort(conn.Host, defaultAgentPort)
+	}
+	return waitForAgentRestart(ctx, addr)
 }
 
 // osUpdateOutcome reports what `device update`'s OS-update step did, so the
@@ -3098,6 +3107,12 @@ func updatedAgentReconnectFunc(ctx context.Context, previous *grpcclient.AgentCo
 	if previous != nil && previous.Reconnect != nil {
 		return previous.Reconnect
 	}
+	if previous != nil && previous.SimulatorName != "" {
+		return func(waitCtx context.Context) (*grpcclient.AgentConnection, error) {
+			conn, _, err := connectSimulatorAgent(waitCtx, previous.SimulatorName, previous.Addr)
+			return conn, err
+		}
+	}
 
 	if cloudCfg, ok := cloudDeviceConfigFromContext(ctx); ok {
 		return func(waitCtx context.Context) (*grpcclient.AgentConnection, error) {
@@ -3112,7 +3127,10 @@ func updatedAgentReconnectFunc(ctx context.Context, previous *grpcclient.AgentCo
 	}
 
 	if previous != nil && previous.Host != "" {
-		addr := hostPort(previous.Host, defaultAgentPort)
+		addr := previous.Addr
+		if addr == "" {
+			addr = hostPort(previous.Host, defaultAgentPort)
+		}
 		return func(waitCtx context.Context) (*grpcclient.AgentConnection, error) {
 			return connectResolvedAgentWithProvisionedHint(waitCtx, previous.Host, addr, false, func() bool { return false })
 		}

--- a/go/internal/cli/commands/device_picker_simulator.go
+++ b/go/internal/cli/commands/device_picker_simulator.go
@@ -45,12 +45,12 @@ type simulatorPickerModel struct {
 	vms    *[]vm.Status
 }
 
-func newSimulatorPickerModel(context.Context) simulatorPickerModel {
+func newSimulatorPickerModel(ctx context.Context) simulatorPickerModel {
 	m := simulatorPickerModel{
 		picker: tui.NewPickerWithTitleAndColumns("Select a simulator", simulatorPickerColumns()),
 	}
 	m.picker.RemoveHint = "remove"
-	m.picker.OnStopItem = stopSimulatorRow
+	m.picker.OnStopItem = func(item tui.PickerItem) (string, bool) { return stopSimulatorRow(ctx, item) }
 	m.picker.OnRemoveItem = removeSimulatorRow
 	// Quits the picker: creating downloads an image behind its own progress
 	// program, and two Bubble Tea programs cannot share a terminal. The caller
@@ -78,7 +78,7 @@ var vmStatusFn = func(name string) (vm.Status, error) {
 // stopSimulatorRow powers 's'. Stop only: a mis-press on the wrong row can then
 // never boot something, and starting already has a home (enter, or
 // `wendy vm start`).
-func stopSimulatorRow(item tui.PickerItem) (string, bool) {
+func stopSimulatorRow(ctx context.Context, item tui.PickerItem) (string, bool) {
 	choice, _ := item.Value.(*simulatorChoice)
 	if choice == nil || choice.Create {
 		return "", false
@@ -94,7 +94,7 @@ func stopSimulatorRow(item tui.PickerItem) (string, bool) {
 	if err != nil {
 		return err.Error(), true
 	}
-	if err := store.Stop(choice.Name, false, vmStopGrace); err != nil {
+	if err := store.StopContext(ctx, choice.Name, false, vmStopGrace); err != nil {
 		return err.Error(), true
 	}
 	return fmt.Sprintf("Stopped %s.", choice.Name), false

--- a/go/internal/cli/commands/device_picker_simulator.go
+++ b/go/internal/cli/commands/device_picker_simulator.go
@@ -1,0 +1,271 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+	"github.com/wendylabsinc/wendy/go/internal/cli/vm"
+)
+
+// defaultSimulatorVMName is the VM provisioned for someone who never named one.
+const defaultSimulatorVMName = "sim"
+
+// simulatorRefreshInterval re-reads the store while the tab is open, so a VM
+// started or stopped in another terminal shows up. The read is a directory scan
+// plus a small file per VM, so this is cheap.
+const simulatorRefreshInterval = 2 * time.Second
+
+// simulatorChoice is what selecting a Simulator row means.
+type simulatorChoice struct {
+	Name   string
+	Create bool // the store is empty: provision before starting
+
+	// Address is the forwarded agent address, empty unless the VM is running
+	// with a port forward.
+	Address string
+}
+
+type simulatorVMsMsg struct {
+	vms []vm.Status
+	err error
+}
+
+type simulatorPickerModel struct {
+	picker tui.PickerModel
+	err    error
+	loaded bool
+
+	// create is set by the OnCreateItem closure, and vms is the store contents
+	// the new VM's name is chosen against. Pointers because Bubble Tea passes
+	// models by value, so a closure cannot write to a plain field.
+	create *bool
+	vms    *[]vm.Status
+}
+
+func newSimulatorPickerModel(context.Context) simulatorPickerModel {
+	m := simulatorPickerModel{
+		picker: tui.NewPickerWithTitleAndColumns("Select a simulator", simulatorPickerColumns()),
+	}
+	m.picker.RemoveHint = "remove"
+	m.picker.OnStopItem = stopSimulatorRow
+	m.picker.OnRemoveItem = removeSimulatorRow
+	// Quits the picker: creating downloads an image behind its own progress
+	// program, and two Bubble Tea programs cannot share a terminal. The caller
+	// creates the VM and comes back.
+	m.create, m.vms = new(bool), new([]vm.Status)
+	create, vms := m.create, m.vms
+	m.picker.OnCreateItem = func() (string, bool) {
+		*create = true
+		return fmt.Sprintf("Creating %s...", nextSimulatorName(*vms)), true
+	}
+	return m
+}
+
+// vmStatusFn reads one VM's state. A seam, like vmStatusesFn: the row actions
+// below are the only place a test can reach them, and they must not touch the
+// developer's real VM store.
+var vmStatusFn = func(name string) (vm.Status, error) {
+	store, err := vm.NewStore()
+	if err != nil {
+		return vm.Status{}, err
+	}
+	return store.Status(name)
+}
+
+// stopSimulatorRow powers 's'. Stop only: a mis-press on the wrong row can then
+// never boot something, and starting already has a home (enter, or
+// `wendy vm start`).
+func stopSimulatorRow(item tui.PickerItem) (string, bool) {
+	choice, _ := item.Value.(*simulatorChoice)
+	if choice == nil || choice.Create {
+		return "", false
+	}
+	st, err := vmStatusFn(choice.Name)
+	if err != nil {
+		return err.Error(), true
+	}
+	if !st.Running {
+		return fmt.Sprintf("%s is not running", choice.Name), false
+	}
+	store, err := vm.NewStore()
+	if err != nil {
+		return err.Error(), true
+	}
+	if err := store.Stop(choice.Name, false, vmStopGrace); err != nil {
+		return err.Error(), true
+	}
+	return fmt.Sprintf("Stopped %s.", choice.Name), false
+}
+
+// removeSimulatorRow powers 'r'. Store.Remove takes the run lock, so a running
+// VM is refused rather than deleted out from under its emulator -- say which
+// key fixes that rather than making the user guess.
+func removeSimulatorRow(item tui.PickerItem) (string, bool, *tui.PickerItem) {
+	choice, _ := item.Value.(*simulatorChoice)
+	if choice == nil || choice.Create {
+		return "", false, &item
+	}
+	if st, err := vmStatusFn(choice.Name); err == nil && st.Running {
+		return fmt.Sprintf("%s is running; press s to stop it first", choice.Name), true, &item
+	}
+	store, err := vm.NewStore()
+	if err != nil {
+		return err.Error(), true, &item
+	}
+	if err := store.Remove(choice.Name); err != nil {
+		return err.Error(), true, &item
+	}
+	return fmt.Sprintf("Removed %s.", choice.Name), false, nil
+}
+
+// newSimulatorListModel is the read-only variant `wendy discover` shows: enter
+// copies the address instead of selecting, matching what every other row in
+// that view does.
+func newSimulatorListModel(ctx context.Context) simulatorPickerModel {
+	m := newSimulatorPickerModel(ctx)
+	m.picker.OnCopyItem = func(item tui.PickerItem) string {
+		choice, _ := item.Value.(*simulatorChoice)
+		return copySimulatorAddress(choice)
+	}
+	return m
+}
+
+// nextSimulatorName picks the name 'c' creates under. Auto-named rather than
+// prompted: the picker cannot host a text prompt while the table owns the
+// screen, and a specific name is what `wendy vm create` is for.
+func nextSimulatorName(existing []vm.Status) string {
+	taken := make(map[string]bool, len(existing))
+	for _, st := range existing {
+		taken[st.Name] = true
+	}
+	if !taken[defaultSimulatorVMName] {
+		return defaultSimulatorVMName
+	}
+	for i := 2; ; i++ {
+		name := fmt.Sprintf("%s-%d", defaultSimulatorVMName, i)
+		if !taken[name] {
+			return name
+		}
+	}
+}
+
+// refreshCmd reads the store. Scheduled from Init rather than on the tab
+// switch: a lazy start would return a non-nil cmd from the tab handler, which
+// is how the Cloud tab signals its one-time discovery start.
+func (m simulatorPickerModel) refreshCmd() tea.Cmd {
+	return func() tea.Msg {
+		statuses, err := vmStatusesFn()
+		return simulatorVMsMsg{vms: statuses, err: err}
+	}
+}
+
+func (m simulatorPickerModel) Init() tea.Cmd {
+	// The picker's own Init drives its spinner; without it the table renders
+	// under a "Scanning..." banner that never clears.
+	return tea.Batch(m.picker.Init(), m.refreshCmd())
+}
+
+// simulatorPickerColumns describes a VM rather than a network device. The
+// device column set is wrong here: VM rows have no USB, no mTLS and no probe
+// state, and their key attribute -- running or stopped -- has no home in it.
+func simulatorPickerColumns() []tui.PickerColumn {
+	return []tui.PickerColumn{
+		{Title: "Name", MinWidth: 12, Required: true, Value: func(i tui.PickerItem) string { return i.Name }},
+		{Title: "State", MinWidth: 8, Required: true, Value: func(i tui.PickerItem) string { return i.Type }},
+		{Title: "Address", MinWidth: 16, Value: func(i tui.PickerItem) string { return i.Address }},
+		{Title: "Version", MinWidth: 10, Value: func(i tui.PickerItem) string { return i.OSVersion }},
+	}
+}
+
+// simulatorRows turns the store's contents into picker rows. An empty store
+// still offers one row, so a fresh machine has something to select rather than
+// an empty tab that explains nothing.
+func simulatorRows(statuses []vm.Status) []tui.PickerItem {
+	if len(statuses) == 0 {
+		return []tui.PickerItem{{
+			Name: "Simulator",
+			Type: "not created",
+			// Says c, not enter: enter copies in the discover view, while c
+			// creates in both.
+			Hint: "press c to create it — this downloads the WendyOS image once",
+			Value: &simulatorChoice{
+				Name:   defaultSimulatorVMName,
+				Create: true,
+			},
+		}}
+	}
+	items := make([]tui.PickerItem, 0, len(statuses))
+	for _, st := range statuses {
+		choice := &simulatorChoice{Name: st.Name, Address: vmAddress(st)}
+		items = append(items, tui.PickerItem{
+			Name:      st.Name,
+			Type:      vmStateLabel(st),
+			Address:   choice.Address,
+			OSVersion: st.Meta.ImageVersion,
+			Value:     choice,
+		})
+	}
+	return items
+}
+
+func (m simulatorPickerModel) Update(msg tea.Msg) (simulatorPickerModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case simulatorVMsMsg:
+		m.loaded, m.err = true, msg.err
+		if msg.err == nil {
+			// Kept so 'c' can name the new VM against what already exists.
+			if m.vms != nil {
+				*m.vms = msg.vms
+			}
+			// Set, not add: a VM removed elsewhere has to disappear rather
+			// than linger as a row that cannot be selected.
+			updated, cmd := m.picker.Update(tui.PickerSetMsg{Items: simulatorRows(msg.vms)})
+			m.picker = updated.(tui.PickerModel)
+			// The store read is the scan, and it just finished: without this the
+			// banner claims it is still looking.
+			done, doneCmd := m.picker.Update(tui.PickerDoneMsg{})
+			m.picker = done.(tui.PickerModel)
+			return m, tea.Batch(cmd, doneCmd, delayThen(simulatorRefreshInterval, m.refreshCmd()))
+		}
+		return m, delayThen(simulatorRefreshInterval, m.refreshCmd())
+	default:
+		updated, cmd := m.picker.Update(msg)
+		m.picker = updated.(tui.PickerModel)
+		return m, cmd
+	}
+}
+
+func (m simulatorPickerModel) View() string {
+	if !m.loaded {
+		return "Looking for local VMs..."
+	}
+	if m.err != nil {
+		return "Could not read the VM store: " + m.err.Error()
+	}
+	return m.picker.View()
+}
+
+// createRequested reports that 'c' was pressed, which quits the picker so the
+// download can own the terminal.
+func (m simulatorPickerModel) createRequested() bool {
+	return m.create != nil && *m.create
+}
+
+func (m simulatorPickerModel) selected() *simulatorChoice {
+	// A create reads as selecting a VM that does not exist yet, so every
+	// caller's existing Create handling applies without a second code path.
+	if m.createRequested() {
+		return &simulatorChoice{Name: nextSimulatorName(*m.vms), Create: true}
+	}
+	item := m.picker.Selected()
+	if item == nil {
+		return nil
+	}
+	choice, _ := item.Value.(*simulatorChoice)
+	return choice
+}
+
+func (m simulatorPickerModel) cancelled() bool { return m.picker.Cancelled() }

--- a/go/internal/cli/commands/device_picker_simulator_test.go
+++ b/go/internal/cli/commands/device_picker_simulator_test.go
@@ -1,0 +1,295 @@
+package commands
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+	"github.com/wendylabsinc/wendy/go/internal/cli/vm"
+)
+
+func stoppedVM(name, version string) vm.Status {
+	return vm.Status{
+		Name:   name,
+		Exists: true,
+		Meta:   vm.Meta{Name: name, ImageVersion: version},
+	}
+}
+
+func simulatorViewFor(t *testing.T, statuses ...vm.Status) (simulatorPickerModel, string) {
+	t.Helper()
+	m := newSimulatorPickerModel(context.Background())
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 120, Height: 30})
+	m, _ = m.Update(simulatorVMsMsg{vms: statuses})
+	return m, m.View()
+}
+
+func TestSimulatorTabListsEveryVMWithItsState(t *testing.T) {
+	_, view := simulatorViewFor(t,
+		runningVM("dev", vm.NetUser, 50053),
+		stoppedVM("scratch", "0.19.0"),
+	)
+	for _, want := range []string{"dev", "running", "127.0.0.1:50053", "scratch", "stopped"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("simulator view = %q, want it to contain %q", view, want)
+		}
+	}
+}
+
+func TestSimulatorTabShowsAVersionOnAStoppedVM(t *testing.T) {
+	// The reason meta and state are separate records: provenance outlives a run.
+	_, view := simulatorViewFor(t, stoppedVM("scratch", "0.19.0"))
+	if !strings.Contains(view, "0.19.0") {
+		t.Errorf("simulator view = %q, want the version of a stopped VM", view)
+	}
+}
+
+func TestSimulatorTabOffersToCreateOneWhenTheStoreIsEmpty(t *testing.T) {
+	// An empty tab explains nothing; a fresh machine still gets one action.
+	_, view := simulatorViewFor(t)
+	for _, want := range []string{"Simulator", "not created"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("empty simulator view = %q, want it to contain %q", view, want)
+		}
+	}
+}
+
+func TestSimulatorRowsMarkTheEmptyStoreRowForCreation(t *testing.T) {
+	items := simulatorRows(nil)
+	if len(items) != 1 {
+		t.Fatalf("simulatorRows(nil) returned %d rows, want 1", len(items))
+	}
+	choice, ok := items[0].Value.(*simulatorChoice)
+	if !ok {
+		t.Fatalf("row value is %T, want *simulatorChoice", items[0].Value)
+	}
+	if !choice.Create || choice.Name != defaultSimulatorVMName {
+		t.Errorf("choice = %+v, want Create with the default name", choice)
+	}
+}
+
+func TestSimulatorRowsCarryRunningStateAndAddress(t *testing.T) {
+	items := simulatorRows([]vm.Status{runningVM("dev", vm.NetUser, 50053)})
+	choice := items[0].Value.(*simulatorChoice)
+	if choice.Address != "127.0.0.1:50053" || choice.Create {
+		t.Errorf("choice = %+v, want a running VM at 127.0.0.1:50053", choice)
+	}
+}
+
+func TestSimulatorRefreshRemovesAVMThatDisappeared(t *testing.T) {
+	// Set, not add: a VM removed in another terminal must stop being offered.
+	m := newSimulatorPickerModel(context.Background())
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 120, Height: 30})
+	m, _ = m.Update(simulatorVMsMsg{vms: []vm.Status{stoppedVM("gone", ""), stoppedVM("stays", "")}})
+	if !strings.Contains(m.View(), "gone") {
+		t.Fatal("first refresh did not list the VM")
+	}
+
+	m, _ = m.Update(simulatorVMsMsg{vms: []vm.Status{stoppedVM("stays", "")}})
+	if strings.Contains(m.View(), "gone") {
+		t.Errorf("removed VM is still listed: %q", m.View())
+	}
+	if !strings.Contains(m.View(), "stays") {
+		t.Errorf("surviving VM disappeared: %q", m.View())
+	}
+}
+
+func TestSimulatorTabSurvivesAnUnreadableStore(t *testing.T) {
+	m := newSimulatorPickerModel(context.Background())
+	m, _ = m.Update(simulatorVMsMsg{err: context.DeadlineExceeded})
+	if view := m.View(); !strings.Contains(view, "Could not read") {
+		t.Errorf("view = %q, want it to explain the store could not be read", view)
+	}
+}
+
+func TestDevicePickerShowsAllThreeTabs(t *testing.T) {
+	m := newDevicePickerModel(context.Background(), tui.NewPicker(), nil, 0)
+	view := m.View()
+	for _, want := range []string{"Local", "Simulator", "Cloud", "tab switch"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("picker view = %q, want it to contain %q", view, want)
+		}
+	}
+}
+
+func TestDevicePickerCyclesThroughSimulator(t *testing.T) {
+	m := newDevicePickerModel(context.Background(), tui.NewPicker(), nil, 0)
+	for _, want := range []devicePickerTab{devicePickerSimulatorTab, devicePickerCloudTab, devicePickerLocalTab} {
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+		m = updated.(devicePickerModel)
+		if m.active != want {
+			t.Fatalf("after Tab, active = %v, want %v", m.active, want)
+		}
+	}
+}
+
+func TestDevicePickerChoiceReportsTheConfirmingTab(t *testing.T) {
+	// The regression test for the bug the tagged struct exists to prevent: a
+	// child keeps a selection from an earlier visit, and a fixed-order payload
+	// check would let that stale pick beat the tab the user confirmed on.
+	m := newDevicePickerModel(context.Background(), tui.NewPicker(), nil, 0)
+	m, _ = m.updateSimulator(tea.WindowSizeMsg{Width: 120, Height: 30})
+	m, _ = m.updateSimulator(simulatorVMsMsg{vms: []vm.Status{stoppedVM("dev", "")}})
+	m.active = devicePickerSimulatorTab
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(devicePickerModel)
+
+	choice, ok := m.choice()
+	if !ok {
+		t.Fatal("choice() reported no selection after Enter on the Simulator tab")
+	}
+	if choice.Tab != devicePickerSimulatorTab {
+		t.Errorf("choice.Tab = %v, want the Simulator tab", choice.Tab)
+	}
+	if choice.Simulator == nil || choice.Simulator.Name != "dev" {
+		t.Errorf("choice.Simulator = %+v, want the selected VM", choice.Simulator)
+	}
+}
+
+func TestDevicePickerChoiceIsEmptyWhenCancelled(t *testing.T) {
+	m := newDevicePickerModel(context.Background(), tui.NewPicker(), nil, 0)
+	m.cancelled = true
+	if _, ok := m.choice(); ok {
+		t.Error("choice() reported a selection after the picker was cancelled")
+	}
+}
+
+func TestDevicePickerChoiceIsEmptyWhenQuittingToLogIn(t *testing.T) {
+	// The login and org-switch retry flows must keep working unchanged.
+	m := newDevicePickerModel(context.Background(), tui.NewPicker(), nil, 0)
+	m.hasChosen, m.action = true, devicePickerLogin
+	if _, ok := m.choice(); ok {
+		t.Error("choice() reported a selection while quitting to log in")
+	}
+}
+
+func TestSimulatorBootTimeoutScalesWithAcceleration(t *testing.T) {
+	// An emulated boot takes minutes, so the budget must not be a
+	// hardware-sized one; an accelerated host should not wait that long.
+	got := simulatorBootTimeout()
+	if vm.AccelFor(runtime.GOOS, runtime.GOARCH) == vm.AccelTCG {
+		if got < 2*time.Minute {
+			t.Errorf("simulatorBootTimeout() = %v, too short for an emulated boot", got)
+		}
+		return
+	}
+	if got > time.Minute+30*time.Second {
+		t.Errorf("simulatorBootTimeout() = %v, longer than an accelerated boot needs", got)
+	}
+}
+
+func TestSimulatorListCopiesTheAddressOnEnter(t *testing.T) {
+	// The tab advertises "enter copy address". It was dead: the tabs model
+	// consumed enter before the picker ever saw it, so nothing was copied.
+	var copied string
+	saved := clipboardWriter
+	clipboardWriter = func(s string) error { copied = s; return nil }
+	t.Cleanup(func() { clipboardWriter = saved })
+
+	m := newSimulatorListModel(context.Background())
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 120, Height: 30})
+	m, _ = m.Update(simulatorVMsMsg{vms: []vm.Status{runningVM("dev", vm.NetUser, 50053)}})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if copied != "127.0.0.1:50053" {
+		t.Errorf("clipboard = %q, want the VM address", copied)
+	}
+}
+
+func TestSimulatorTabStopsSayingItIsScanning(t *testing.T) {
+	// The store read IS the scan; without reporting it done the populated
+	// table sat under a "Scanning..." banner forever.
+	_, view := simulatorViewFor(t, stoppedVM("dev", "0.19.0"))
+	if strings.Contains(view, "Scanning") {
+		t.Errorf("simulator view = %q, want no scanning banner once the store is read", view)
+	}
+}
+
+func TestNextSimulatorNameSkipsWhatExists(t *testing.T) {
+	// 'c' cannot prompt for a name -- the table owns the screen -- so it picks
+	// the first free one. A specific name is what `wendy vm create` is for.
+	if got := nextSimulatorName(nil); got != defaultSimulatorVMName {
+		t.Errorf("nextSimulatorName(empty) = %q, want %q", got, defaultSimulatorVMName)
+	}
+	one := []vm.Status{{Name: "sim"}}
+	if got := nextSimulatorName(one); got != "sim-2" {
+		t.Errorf("nextSimulatorName(sim) = %q, want sim-2", got)
+	}
+	two := []vm.Status{{Name: "sim"}, {Name: "sim-2"}}
+	if got := nextSimulatorName(two); got != "sim-3" {
+		t.Errorf("nextSimulatorName(sim, sim-2) = %q, want sim-3", got)
+	}
+	// A gap is reused rather than skipped past.
+	gap := []vm.Status{{Name: "sim"}, {Name: "sim-3"}}
+	if got := nextSimulatorName(gap); got != "sim-2" {
+		t.Errorf("nextSimulatorName(sim, sim-3) = %q, want sim-2", got)
+	}
+}
+
+func TestPressingCreateQuitsWithACreateChoice(t *testing.T) {
+	// Create has to leave the picker: the image download runs its own progress
+	// program, and two Bubble Tea programs cannot share a terminal. It surfaces
+	// as a selection so every caller's existing Create handling applies.
+	m := newSimulatorPickerModel(context.Background())
+	if m.createRequested() {
+		t.Fatal("createRequested() is true before any key was pressed")
+	}
+	updated, _ := m.Update(simulatorVMsMsg{vms: []vm.Status{{Name: "sim", Exists: true}}})
+	m = updated
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
+	m = m2
+
+	if !m.createRequested() {
+		t.Fatal("pressing c did not request a create")
+	}
+	choice := m.selected()
+	if choice == nil || !choice.Create {
+		t.Fatalf("selected() = %+v, want a Create choice", choice)
+	}
+	if choice.Name != "sim-2" {
+		t.Errorf("selected().Name = %q, want sim-2 alongside the existing sim", choice.Name)
+	}
+}
+
+func TestRemoveRefusesARunningVMAndSaysWhichKeyFixesIt(t *testing.T) {
+	// Store.Remove takes the run lock, so a running VM is refused anyway. The
+	// point here is that the refusal names the key that unblocks it instead of
+	// leaving the user stuck in the picker.
+	saved := vmStatusFn
+	vmStatusFn = func(string) (vm.Status, error) {
+		return vm.Status{Exists: true, Running: true, State: vm.State{PID: 4321}}, nil
+	}
+	t.Cleanup(func() { vmStatusFn = saved })
+
+	item := tui.PickerItem{Name: "dev", Value: &simulatorChoice{Name: "dev"}}
+	flash, isErr, replacement := removeSimulatorRow(item)
+	if !isErr {
+		t.Error("removing a running VM was reported as success")
+	}
+	if replacement == nil {
+		t.Error("the row was dropped even though the VM survived")
+	}
+	if !strings.Contains(flash, "press s") {
+		t.Errorf("flash = %q, want it to name the key that fixes this", flash)
+	}
+}
+
+func TestStopOnAStoppedVMIsANoOpNotAnError(t *testing.T) {
+	// Stop-only: pressing s on the wrong row must never boot anything, and a
+	// stopped VM is not an error worth colouring red.
+	saved := vmStatusFn
+	vmStatusFn = func(string) (vm.Status, error) { return vm.Status{Exists: true}, nil }
+	t.Cleanup(func() { vmStatusFn = saved })
+
+	flash, isErr := stopSimulatorRow(tui.PickerItem{Name: "dev", Value: &simulatorChoice{Name: "dev"}})
+	if isErr {
+		t.Errorf("stopping an already-stopped VM reported an error: %q", flash)
+	}
+	if !strings.Contains(flash, "not running") {
+		t.Errorf("flash = %q, want it to say the VM is not running", flash)
+	}
+}

--- a/go/internal/cli/commands/device_picker_simulator_test.go
+++ b/go/internal/cli/commands/device_picker_simulator_test.go
@@ -285,7 +285,7 @@ func TestStopOnAStoppedVMIsANoOpNotAnError(t *testing.T) {
 	vmStatusFn = func(string) (vm.Status, error) { return vm.Status{Exists: true}, nil }
 	t.Cleanup(func() { vmStatusFn = saved })
 
-	flash, isErr := stopSimulatorRow(tui.PickerItem{Name: "dev", Value: &simulatorChoice{Name: "dev"}})
+	flash, isErr := stopSimulatorRow(context.Background(), tui.PickerItem{Name: "dev", Value: &simulatorChoice{Name: "dev"}})
 	if isErr {
 		t.Errorf("stopping an already-stopped VM reported an error: %q", flash)
 	}

--- a/go/internal/cli/commands/device_picker_tabs.go
+++ b/go/internal/cli/commands/device_picker_tabs.go
@@ -13,29 +13,30 @@ import (
 	cloudpb "github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
 )
 
-type devicePickerTab int
-
-const (
-	devicePickerLocalTab devicePickerTab = iota
-	devicePickerCloudTab
-)
-
-type devicePickerAction int
-
-const (
-	devicePickerNoAction devicePickerAction = iota
-	devicePickerLogin
-	devicePickerSwitchOrg
-)
-
 // Child messages are tagged so background commands keep updating the correct
 // page after the user changes tabs.
 type devicePickerLocalMsg struct{ msg tea.Msg }
+type devicePickerSimulatorMsg struct{ msg tea.Msg }
 type devicePickerCloudMsg struct{ msg tea.Msg }
 type devicePickerOrgMsg struct{ name string }
 
+// devicePickerChoice is what the user picked, tagged by the tab that owned the
+// selection. Tab is authoritative: a child keeps whatever it selected on an
+// earlier visit, so checking payloads in a fixed order would let one tab's
+// leftover beat the tab the user actually confirmed on.
+type devicePickerChoice struct {
+	Tab       devicePickerTab
+	Local     *tui.PickerItem
+	Simulator *simulatorChoice
+	Cloud     *cloudpb.Asset
+}
+
 type devicePickerModel struct {
 	local        tui.PickerModel
+	sim          simulatorPickerModel
+	simStarted   bool
+	chosen       devicePickerTab
+	hasChosen    bool
 	cloud        cloudDiscoverModel
 	cloudAuth    *config.AuthConfig
 	cloudOrg     string
@@ -50,6 +51,7 @@ type devicePickerModel struct {
 func newDevicePickerModel(ctx context.Context, local tui.PickerModel, auth *config.AuthConfig, defaultOrg int32) devicePickerModel {
 	m := devicePickerModel{
 		local:      local,
+		sim:        newSimulatorPickerModel(ctx),
 		cloudAuth:  auth,
 		defaultOrg: defaultOrg,
 	}
@@ -72,15 +74,26 @@ func tagDevicePickerCmd(cmd tea.Cmd, tab devicePickerTab) tea.Cmd {
 			}
 			return tagged
 		}
-		if tab == devicePickerCloudTab {
+		switch tab {
+		case devicePickerCloudTab:
 			return devicePickerCloudMsg{msg: msg}
+		case devicePickerSimulatorTab:
+			return devicePickerSimulatorMsg{msg: msg}
+		default:
+			return devicePickerLocalMsg{msg: msg}
 		}
-		return devicePickerLocalMsg{msg: msg}
 	}
 }
 
 func (m devicePickerModel) Init() tea.Cmd {
+	// The simulator list is not started here: it polls the VM store, and doing
+	// that for a tab nobody opened is both wasted I/O and lock contention with
+	// any concurrent `vm start`.
 	return tagDevicePickerCmd(m.local.Init(), devicePickerLocalTab)
+}
+
+func (m devicePickerModel) startSimulatorCmd() tea.Cmd {
+	return tagDevicePickerCmd(m.sim.Init(), devicePickerSimulatorTab)
 }
 
 func (m devicePickerModel) startCloudCmd() tea.Cmd {
@@ -115,6 +128,7 @@ func (m devicePickerModel) updateLocal(msg tea.Msg) (devicePickerModel, tea.Cmd)
 	updated, cmd := m.local.Update(msg)
 	m.local = updated.(tui.PickerModel)
 	if m.local.Selected() != nil {
+		m.chosen, m.hasChosen = devicePickerLocalTab, true
 		return m, tea.Quit
 	}
 	if m.local.Cancelled() {
@@ -124,10 +138,25 @@ func (m devicePickerModel) updateLocal(msg tea.Msg) (devicePickerModel, tea.Cmd)
 	return m, tagDevicePickerCmd(cmd, devicePickerLocalTab)
 }
 
+func (m devicePickerModel) updateSimulator(msg tea.Msg) (devicePickerModel, tea.Cmd) {
+	updated, cmd := m.sim.Update(msg)
+	m.sim = updated
+	if m.sim.selected() != nil {
+		m.chosen, m.hasChosen = devicePickerSimulatorTab, true
+		return m, tea.Quit
+	}
+	if m.sim.cancelled() {
+		m.cancelled = true
+		return m, tea.Quit
+	}
+	return m, tagDevicePickerCmd(cmd, devicePickerSimulatorTab)
+}
+
 func (m devicePickerModel) updateCloud(msg tea.Msg) (devicePickerModel, tea.Cmd) {
 	updated, cmd := m.cloud.Update(msg)
 	m.cloud = updated.(cloudDiscoverModel)
 	if m.cloud.selected != nil {
+		m.chosen, m.hasChosen = devicePickerCloudTab, true
 		return m, tea.Quit
 	}
 	if m.cloud.quitting {
@@ -141,6 +170,8 @@ func (m devicePickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case devicePickerLocalMsg:
 		return m.updateLocal(msg.msg)
+	case devicePickerSimulatorMsg:
+		return m.updateSimulator(msg.msg)
 	case devicePickerCloudMsg:
 		if m.cloudAuth == nil {
 			return m, nil
@@ -151,25 +182,36 @@ func (m devicePickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case tea.WindowSizeMsg:
 		m.windowWidth = msg.Width
+		var cmds []tea.Cmd
 		local, localCmd := m.updateLocal(msg)
 		m = local
-		if m.cloudAuth == nil {
-			return m, localCmd
+		cmds = append(cmds, localCmd)
+		sim, simCmd := m.updateSimulator(msg)
+		m = sim
+		cmds = append(cmds, simCmd)
+		// Accumulated rather than early-returned: the old shape bailed out
+		// before the second child when there was no cloud auth, which would
+		// leave the simulator table unsized.
+		if m.cloudAuth != nil {
+			cloud, cloudCmd := m.updateCloud(msg)
+			m = cloud
+			cmds = append(cmds, cloudCmd)
 		}
-		cloud, cloudCmd := m.updateCloud(msg)
-		m = cloud
-		return m, tea.Batch(localCmd, cloudCmd)
+		return m, tea.Batch(cmds...)
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "tab", "shift+tab":
-			if m.active == devicePickerLocalTab {
-				m.active = devicePickerCloudTab
-				if m.cloudAuth != nil && !m.cloudStarted {
-					m.cloudStarted = true
-					return m, m.startCloudCmd()
-				}
-			} else {
-				m.active = devicePickerLocalTab
+			m.active = cycleTab(deviceTabOrder(), m.active, tabCycleDelta(msg.String()))
+			// Latched rather than keyed off "arrived from Local": with
+			// wrap-around, Cloud is reachable from either neighbour and
+			// discovery must still start exactly once.
+			if m.active == devicePickerCloudTab && m.cloudAuth != nil && !m.cloudStarted {
+				m.cloudStarted = true
+				return m, m.startCloudCmd()
+			}
+			if m.active == devicePickerSimulatorTab && !m.simStarted {
+				m.simStarted = true
+				return m, m.startSimulatorCmd()
 			}
 			return m, nil
 		case "o":
@@ -189,13 +231,17 @@ func (m devicePickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
-		if m.active == devicePickerCloudTab {
+		switch m.active {
+		case devicePickerCloudTab:
 			if m.cloudAuth == nil {
 				return m, nil
 			}
 			return m.updateCloud(msg)
+		case devicePickerSimulatorTab:
+			return m.updateSimulator(msg)
+		default:
+			return m.updateLocal(msg)
 		}
-		return m.updateLocal(msg)
 	}
 	return m, nil
 }
@@ -207,14 +253,17 @@ var (
 )
 
 func (m devicePickerModel) View() string {
-	if m.cancelled || m.action != devicePickerNoAction || m.selectedLocal() != nil || m.selectedCloud() != nil {
+	if m.cancelled || m.action != devicePickerNoAction || m.hasChosen {
 		return ""
 	}
 
-	header := deviceTabsHeader(m.active, m.windowWidth)
+	header := deviceTabsHeader(m.active, deviceTabOrder(), m.windowWidth)
 
-	if m.active == devicePickerLocalTab {
+	switch m.active {
+	case devicePickerLocalTab:
 		return header + "\n\n" + m.local.View()
+	case devicePickerSimulatorTab:
+		return header + "\n\n" + m.sim.View()
 	}
 
 	var body strings.Builder
@@ -235,21 +284,6 @@ func (m devicePickerModel) View() string {
 	return body.String()
 }
 
-func deviceTabsHeader(active devicePickerTab, width int) string {
-	local := devicePickerTabInactive.Render("Local")
-	cloud := devicePickerTabInactive.Render("Cloud")
-	if active == devicePickerLocalTab {
-		local = devicePickerTabActive.Render("Local")
-	} else {
-		cloud = devicePickerTabActive.Render("Cloud")
-	}
-	header := local + devicePickerTabInactive.Render(" | ") + cloud + devicePickerTabInactive.Render("  (tab switch)")
-	if width > 0 {
-		header = tui.CropANSIView(header, 0, width)
-	}
-	return header
-}
-
 func deviceCloudOrgLabel(auth *config.AuthConfig, name string, defaultOrg int32) string {
 	orgID := cloudAuthOrgID(auth)
 	label := fmt.Sprintf("Organization: org %d", orgID)
@@ -260,6 +294,24 @@ func deviceCloudOrgLabel(auth *config.AuthConfig, name string, defaultOrg int32)
 		label += "  ✦ default"
 	}
 	return label + "  (o switch)"
+}
+
+// choice reports the confirmed selection. ok is false when the picker exited
+// without one: cancelled, or quit to log in or switch org.
+func (m devicePickerModel) choice() (devicePickerChoice, bool) {
+	if !m.hasChosen || m.cancelled || m.action != devicePickerNoAction {
+		return devicePickerChoice{}, false
+	}
+	c := devicePickerChoice{Tab: m.chosen}
+	switch m.chosen {
+	case devicePickerSimulatorTab:
+		c.Simulator = m.sim.selected()
+	case devicePickerCloudTab:
+		c.Cloud = m.selectedCloud()
+	default:
+		c.Local = m.selectedLocal()
+	}
+	return c, true
 }
 
 func (m devicePickerModel) selectedLocal() *tui.PickerItem {

--- a/go/internal/cli/commands/device_picker_tabs_test.go
+++ b/go/internal/cli/commands/device_picker_tabs_test.go
@@ -31,10 +31,29 @@ func TestDevicePickerShowsLocalAndCloudTabs(t *testing.T) {
 	}
 }
 
+// tabTo presses Tab until the model lands on want, so a test that cares about
+// one tab does not encode how many tabs precede it. Returns the cmd from the
+// last press, which is what the lazy-start assertions read.
+func tabTo(t *testing.T, m devicePickerModel, want devicePickerTab) (devicePickerModel, tea.Cmd) {
+	t.Helper()
+	var cmd tea.Cmd
+	for range len(deviceTabOrder()) {
+		if m.active == want {
+			return m, cmd
+		}
+		var updated tea.Model
+		updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+		m = updated.(devicePickerModel)
+	}
+	if m.active != want {
+		t.Fatalf("never reached tab %v", want)
+	}
+	return m, cmd
+}
+
 func TestDevicePickerLoggedOutCloudTabOffersLoginRow(t *testing.T) {
 	m := newDevicePickerModel(context.Background(), tui.NewPicker(), nil, 0)
-	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
-	m = updated.(devicePickerModel)
+	m, _ = tabTo(t, m, devicePickerCloudTab)
 
 	view := m.View()
 	for _, want := range []string{"Wendy Cloud login", "Not logged in", "enter log in"} {
@@ -59,8 +78,7 @@ func TestDevicePickerStartsCloudDiscoveryOnFirstCloudTabVisit(t *testing.T) {
 		t.Fatal("cloud discovery started before the Cloud tab was visited")
 	}
 
-	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyTab})
-	m = updated.(devicePickerModel)
+	m, cmd := tabTo(t, m, devicePickerCloudTab)
 	if !m.cloudStarted {
 		t.Fatal("cloud discovery did not start on the first Cloud tab visit")
 	}
@@ -68,12 +86,11 @@ func TestDevicePickerStartsCloudDiscoveryOnFirstCloudTabVisit(t *testing.T) {
 		t.Fatal("first Cloud tab visit did not schedule discovery")
 	}
 
-	updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeyTab})
-	m = updated.(devicePickerModel)
+	m, cmd = tabTo(t, m, devicePickerLocalTab)
 	if cmd != nil {
 		t.Fatal("returning to Local unexpectedly restarted cloud discovery")
 	}
-	updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	_, cmd = tabTo(t, m, devicePickerCloudTab)
 	if cmd != nil {
 		t.Fatal("second Cloud tab visit restarted cloud discovery")
 	}

--- a/go/internal/cli/commands/device_pin.go
+++ b/go/internal/cli/commands/device_pin.go
@@ -66,6 +66,11 @@ func enforceDevicePin(hostname string, conn *grpcclient.AgentConnection) error {
 	if conn == nil {
 		return nil
 	}
+	// No key, no pin: the caller reached something whose address is not an
+	// identity, such as a VM behind a loopback forward.
+	if hostname == "" {
+		return nil
+	}
 	return enforceDeviceIdentity(hostname, observeDeviceIdentity(conn))
 }
 

--- a/go/internal/cli/commands/device_tabs.go
+++ b/go/internal/cli/commands/device_tabs.go
@@ -1,0 +1,88 @@
+package commands
+
+import (
+	"slices"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+)
+
+type devicePickerTab int
+
+const (
+	devicePickerLocalTab devicePickerTab = iota
+	devicePickerSimulatorTab
+	devicePickerCloudTab
+)
+
+type devicePickerAction int
+
+const (
+	devicePickerNoAction devicePickerAction = iota
+	devicePickerLogin
+	devicePickerSwitchOrg
+
+	// devicePickerCreateVM quits the view so the image download can own the
+	// terminal; the caller creates the VM and re-enters.
+	devicePickerCreateVM
+)
+
+// deviceTabOrder is the strip both device views show, left to right. One
+// source for the cycle and the header, so a tab can never be reachable by Tab
+// yet missing from the strip, or the reverse.
+func deviceTabOrder() []devicePickerTab {
+	return []devicePickerTab{devicePickerLocalTab, devicePickerSimulatorTab, devicePickerCloudTab}
+}
+
+func deviceTabLabel(t devicePickerTab) string {
+	switch t {
+	case devicePickerSimulatorTab:
+		return "Simulator"
+	case devicePickerCloudTab:
+		return "Cloud"
+	default:
+		return "Local"
+	}
+}
+
+// cycleTab moves active by delta positions through tabs, wrapping at both ends.
+// delta is -1 for shift+tab. An active tab that is not in tabs yields the first,
+// so the strip can never render with nothing selected.
+func cycleTab(tabs []devicePickerTab, active devicePickerTab, delta int) devicePickerTab {
+	if len(tabs) == 0 {
+		return active
+	}
+	idx := slices.Index(tabs, active)
+	if idx < 0 {
+		return tabs[0]
+	}
+	n := len(tabs)
+	return tabs[((idx+delta)%n+n)%n]
+}
+
+// tabCycleDelta maps a key to a direction. shift+tab used to be a silent alias
+// for tab, which was indistinguishable while there were only two tabs.
+func tabCycleDelta(key string) int {
+	if key == "shift+tab" {
+		return -1
+	}
+	return 1
+}
+
+func deviceTabsHeader(active devicePickerTab, tabs []devicePickerTab, width int) string {
+	header := ""
+	for i, t := range tabs {
+		if i > 0 {
+			header += devicePickerTabInactive.Render(" | ")
+		}
+		if t == active {
+			header += devicePickerTabActive.Render(deviceTabLabel(t))
+		} else {
+			header += devicePickerTabInactive.Render(deviceTabLabel(t))
+		}
+	}
+	header += devicePickerTabInactive.Render("  (tab switch)")
+	if width > 0 {
+		header = tui.CropANSIView(header, 0, width)
+	}
+	return header
+}

--- a/go/internal/cli/commands/device_tabs_test.go
+++ b/go/internal/cli/commands/device_tabs_test.go
@@ -1,0 +1,71 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCycleTabWrapsInBothDirections(t *testing.T) {
+	// Explicit rather than deviceTabOrder(): this is the cycling
+	// mechanism, not any particular strip.
+	tabs := []devicePickerTab{devicePickerLocalTab, devicePickerSimulatorTab, devicePickerCloudTab}
+	cases := []struct {
+		name   string
+		active devicePickerTab
+		delta  int
+		want   devicePickerTab
+	}{
+		{"forward from first", devicePickerLocalTab, 1, devicePickerSimulatorTab},
+		{"forward from middle", devicePickerSimulatorTab, 1, devicePickerCloudTab},
+		{"forward wraps", devicePickerCloudTab, 1, devicePickerLocalTab},
+		{"backward wraps", devicePickerLocalTab, -1, devicePickerCloudTab},
+		{"backward from middle", devicePickerSimulatorTab, -1, devicePickerLocalTab},
+	}
+	for _, tc := range cases {
+		if got := cycleTab(tabs, tc.active, tc.delta); got != tc.want {
+			t.Errorf("%s: cycleTab() = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestCycleTabRecoversFromATabNotInTheStrip(t *testing.T) {
+	// An active tab absent from the given strip must not leave it rendering
+	// with nothing selected.
+	twoTab := []devicePickerTab{devicePickerLocalTab, devicePickerCloudTab}
+	if got := cycleTab(twoTab, devicePickerSimulatorTab, 1); got != devicePickerLocalTab {
+		t.Errorf("cycleTab() = %v, want the first tab", got)
+	}
+}
+
+func TestTabCycleDeltaReversesOnShiftTab(t *testing.T) {
+	if got := tabCycleDelta("tab"); got != 1 {
+		t.Errorf("tabCycleDelta(tab) = %d, want 1", got)
+	}
+	if got := tabCycleDelta("shift+tab"); got != -1 {
+		t.Errorf("tabCycleDelta(shift+tab) = %d, want -1", got)
+	}
+}
+
+func TestDeviceTabsHeaderRendersOnlyTheGivenStrip(t *testing.T) {
+	// The guard that keeps `wendy discover` from silently growing a tab.
+	run := deviceTabsHeader(devicePickerLocalTab,
+		[]devicePickerTab{devicePickerLocalTab, devicePickerSimulatorTab, devicePickerCloudTab}, 0)
+	for _, want := range []string{"Local", "Simulator", "Cloud", "tab switch"} {
+		if !strings.Contains(run, want) {
+			t.Errorf("run picker header = %q, want it to contain %q", run, want)
+		}
+	}
+
+	// A strip that was not given the tab must not render it.
+	twoTab := deviceTabsHeader(devicePickerLocalTab,
+		[]devicePickerTab{devicePickerLocalTab, devicePickerCloudTab}, 0)
+	if strings.Contains(twoTab, "Simulator") {
+		t.Errorf("two-tab header = %q, want no Simulator tab", twoTab)
+	}
+	discover := deviceTabsHeader(devicePickerLocalTab, deviceTabOrder(), 0)
+	for _, want := range []string{"Local", "Simulator", "Cloud"} {
+		if !strings.Contains(discover, want) {
+			t.Errorf("discover header = %q, want it to contain %q", discover, want)
+		}
+	}
+}

--- a/go/internal/cli/commands/dial_target.go
+++ b/go/internal/cli/commands/dial_target.go
@@ -176,12 +176,34 @@ func governingPin(pinKey string) (config.DevicePin, string, bool) {
 // means. A resolved IP is deliberately never used as a key — it changes on
 // ordinary DHCP churn — but an address the user typed as a literal IP is the
 // name they asked for, so it keys a pin like any other host.
+// Loopback gets no special case. It used to: local VMs all answer on 127.0.0.1,
+// so two of them collide on one key. But every alternative was worse -- an
+// empty key reads as "unpinned" and disarms the guard against reaching a
+// previously-authenticated host over plaintext, and a port-qualified key
+// orphans the pins existing users already hold under the bare host. A VM is
+// exempted where the CLI knows it is talking to one (see connectToAgent),
+// which leaves this shared derivation identical to what every release ships.
 func pinKeyForAddr(addr string) string {
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
 		return strings.TrimSpace(addr)
 	}
 	return host
+}
+
+// isLoopbackHost reports whether host names this machine. "localhost" is
+// matched by name because net.ParseIP does not resolve it, and it is the form
+// people actually type at a forwarded port.
+func isLoopbackHost(host string) bool {
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	host = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 // expectedIdentityFor returns the asset identity pinned for pinKey, or nil when

--- a/go/internal/cli/commands/dial_target.go
+++ b/go/internal/cli/commands/dial_target.go
@@ -180,10 +180,15 @@ func governingPin(pinKey string) (config.DevicePin, string, bool) {
 // so two of them collide on one key. But every alternative was worse -- an
 // empty key reads as "unpinned" and disarms the guard against reaching a
 // previously-authenticated host over plaintext, and a port-qualified key
-// orphans the pins existing users already hold under the bare host. A VM is
-// exempted where the CLI knows it is talking to one (see connectToAgent),
-// which leaves this shared derivation identical to what every release ships.
+// orphans the pins existing users already hold under the bare host. Known VM
+// aliases instead use their own vm:<name> key (see connectSimulatorAgent),
+// leaving typed IP addresses governed by their existing pins.
 func pinKeyForAddr(addr string) string {
+	// SplitHostPort accepts non-numeric service names, so vm:dev would
+	// otherwise become just "vm" when set-default/unpin derives its key.
+	if name, matched, err := simulatorName(addr); err == nil && matched {
+		return vmDeviceIDPrefix + name
+	}
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
 		return strings.TrimSpace(addr)

--- a/go/internal/cli/commands/dial_target_test.go
+++ b/go/internal/cli/commands/dial_target_test.go
@@ -467,7 +467,7 @@ func TestPinnedHostSkipsPlaintextRung(t *testing.T) {
 	// The load-bearing assertion for the guard's independence: this failure is
 	// NOT a cert rejection, so the pre-existing isCertRejectionError branch
 	// would have fallen straight through to plaintext.
-	if isCertRejectionError(mtlsErr) {
+	if isCertRejectionError("192.168.2.253:50052", mtlsErr) {
 		t.Fatalf("mtlsErr = %v is a cert rejection; this test must exercise the transport-error shape that otherwise reaches the plaintext rung", mtlsErr)
 	}
 }
@@ -831,5 +831,31 @@ func selfSignedCLICert(t *testing.T, orgID int) config.CertificateInfo {
 		PemCertificate:      certPEM,
 		PemPrivateKey:       keyPEM,
 		PemCertificateChain: certPEM,
+	}
+}
+
+func TestPinKeyDerivationIsUnchangedForEveryAddress(t *testing.T) {
+	// This is shared, security-relevant derivation used by every device. Two
+	// VMs colliding on 127.0.0.1 is a real annoyance, but neither cure worked:
+	// an empty key reads as "unpinned" and disarms the plaintext-downgrade
+	// guard, and a port-qualified key orphans pins users already hold under the
+	// bare host, turning a mismatch into a silent first-use. The VM is exempted
+	// in connectToAgent instead, so this stays exactly what ships today.
+	for addr, want := range map[string]string{
+		"127.0.0.1:50051":  "127.0.0.1",
+		"localhost:50051":  "localhost",
+		"[::1]:50051":      "::1",
+		"127.0.0.1":        "127.0.0.1",
+		"rpi5.local:50051": "rpi5.local",
+		"192.168.2.253":    "192.168.2.253",
+	} {
+		if got := pinKeyForAddr(addr); got != want {
+			t.Errorf("pinKeyForAddr(%q) = %q, want %q", addr, got, want)
+		}
+	}
+	for _, addr := range []string{"127.0.0.1:50051", "localhost:50051"} {
+		if pinKeyForAddr(addr) == "" {
+			t.Errorf("pinKeyForAddr(%q) is empty; that would disarm the downgrade guard", addr)
+		}
 	}
 }

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -129,7 +129,7 @@ func shouldIncludeExternal(opts discovery.DiscoveryOptions) bool {
 }
 
 func discoverJSON(ctx context.Context, opts discovery.DiscoveryOptions) error {
-	collection, err := discoverWithUSBDirect(ctx, opts)
+	collection, err := discoverLocalTargets(ctx, opts)
 	if err != nil {
 		return fmt.Errorf("discovery failed: %w", err)
 	}
@@ -158,7 +158,7 @@ func discoverOnce(ctx context.Context, opts discovery.DiscoveryOptions, includeL
 	includeExternal := shouldIncludeExternal(opts)
 
 	work := func() tea.Msg {
-		collection, err := discoverWithUSBDirect(ctx, opts)
+		collection, err := discoverLocalTargets(ctx, opts)
 		if err == nil {
 			annotateLANUSBFromEthernet(collection)
 			sortLANDevicesForDiscover(collection.LANDevices)
@@ -222,8 +222,13 @@ func discoverContinuous(ctx context.Context, opts discovery.DiscoveryOptions, in
 		cfg = nil
 	}
 	cloudAuth := devicePickerInitialAuth(cfg)
+	var createReq *errCreateSimulator
+	// Which tab to open on. Only a create changes it, so the user lands back
+	// where they pressed the key rather than on Local.
+	openOn := devicePickerLocalTab
 	for {
-		err := discoverContinuousWithCloudAuth(ctx, opts, includeLocal, cloudAuth, defaultOrgForCloudAuth(cfg, cloudAuth))
+		err := discoverContinuousWithCloudAuth(ctx, opts, includeLocal, cloudAuth, defaultOrgForCloudAuth(cfg, cloudAuth), openOn)
+		openOn = devicePickerLocalTab
 		switch {
 		case errors.Is(err, errDevicePickerLogin):
 			if err := performLogin(ctx, defaultCloudDashboard, defaultCloudGRPC); err != nil {
@@ -234,6 +239,20 @@ func discoverContinuous(ctx context.Context, opts discovery.DiscoveryOptions, in
 				return fmt.Errorf("loading config after login: %w", err)
 			}
 			cloudAuth = devicePickerInitialAuth(cfg)
+		case errors.As(err, &createReq):
+			// The TUI is gone by now, so the prompt and the download's own
+			// progress program have the terminal to themselves. Same helper the
+			// run picker uses, so "c" does the same thing in both views.
+			name := createReq.name
+			createReq = nil
+			if createErr := createSimulator(name); createErr != nil {
+				if errors.Is(createErr, ErrUserCancelled) {
+					openOn = devicePickerSimulatorTab
+					continue
+				}
+				return createErr
+			}
+			openOn = devicePickerSimulatorTab
 		case errors.Is(err, errDevicePickerSwitchOrg):
 			cfg, err = config.Load()
 			if err != nil {
@@ -267,13 +286,13 @@ func defaultOrgForCloudAuth(cfg *config.Config, auth *config.AuthConfig) int32 {
 	return 0
 }
 
-func discoverContinuousWithCloudAuth(ctx context.Context, opts discovery.DiscoveryOptions, includeLocal bool, cloudAuth *config.AuthConfig, defaultOrg int32) error {
+func discoverContinuousWithCloudAuth(ctx context.Context, opts discovery.DiscoveryOptions, includeLocal bool, cloudAuth *config.AuthConfig, defaultOrg int32, openOn devicePickerTab) error {
 	opts.Timeout = 3 * time.Second // per-scan timeout
 	discoverCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	local := newDiscoverModel(discoverCtx, opts, includeLocal)
-	m := newDiscoverTabsModel(discoverCtx, local, cloudAuth, defaultOrg)
+	m := newDiscoverTabsModel(discoverCtx, local, cloudAuth, defaultOrg, openOn)
 	// Alt screen: the table grows to fill the window, and the alternate
 	// buffer restores the user's terminal content when the TUI exits.
 	p := tea.NewProgram(m, tea.WithAltScreen())
@@ -290,6 +309,8 @@ func discoverContinuousWithCloudAuth(ctx context.Context, opts discovery.Discove
 		return errDevicePickerLogin
 	case devicePickerSwitchOrg:
 		return errDevicePickerSwitchOrg
+	case devicePickerCreateVM:
+		return &errCreateSimulator{name: dm.createVMName}
 	}
 	return nil
 }
@@ -951,6 +972,8 @@ var deviceTypeNames = map[string]string{
 	"jetson-orin-nano": "Jetson Orin Nano",
 	"jetson-agx-thor":  "Jetson AGX Thor",
 	"x86_64":           "x86-64",
+	"vm-arm64":         "ARM64 VM",
+	"vm-x86-64":        "x86-64 VM",
 }
 
 func humanReadableDeviceType(dt string) string {
@@ -1506,3 +1529,10 @@ func copyToClipboard(text string) error {
 	}
 	return fmt.Errorf("no clipboard tool found; install one of: %s", strings.Join(names, ", "))
 }
+
+// errCreateSimulator asks the discover loop to create a VM and come back. Not a
+// sentinel: the name travels with it, and the TUI has to be gone before the
+// download starts so its progress program can own the terminal.
+type errCreateSimulator struct{ name string }
+
+func (e *errCreateSimulator) Error() string { return "create simulator " + e.name }

--- a/go/internal/cli/commands/discover_tabs.go
+++ b/go/internal/cli/commands/discover_tabs.go
@@ -81,7 +81,10 @@ func tagDiscoverTabsCmd(cmd tea.Cmd, tab devicePickerTab) tea.Cmd {
 }
 
 func (m discoverTabsModel) Init() tea.Cmd {
-	// Simulator polling starts on first entry; see devicePickerModel.Init.
+	if m.simStarted {
+		return tea.Batch(tagDiscoverTabsCmd(m.local.Init(), devicePickerLocalTab), m.startSimulatorCmd())
+	}
+	// Otherwise simulator polling starts on first entry.
 	return tagDiscoverTabsCmd(m.local.Init(), devicePickerLocalTab)
 }
 

--- a/go/internal/cli/commands/discover_tabs.go
+++ b/go/internal/cli/commands/discover_tabs.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
@@ -10,11 +11,14 @@ import (
 )
 
 type discoverTabsLocalMsg struct{ msg tea.Msg }
+type discoverTabsSimulatorMsg struct{ msg tea.Msg }
 type discoverTabsCloudMsg struct{ msg tea.Msg }
 type discoverTabsOrgMsg struct{ name string }
 
 type discoverTabsModel struct {
 	local        discoverModel
+	sim          simulatorPickerModel
+	simStarted   bool
 	cloud        cloudDiscoverModel
 	cloudAuth    *config.AuthConfig
 	cloudOrg     string
@@ -22,15 +26,26 @@ type discoverTabsModel struct {
 	defaultOrg   int32
 	active       devicePickerTab
 	action       devicePickerAction
+	createVMName string
 	cancelled    bool
 	windowWidth  int
 }
 
-func newDiscoverTabsModel(ctx context.Context, local discoverModel, auth *config.AuthConfig, defaultOrg int32) discoverTabsModel {
+// active selects the tab to open on. Creating a VM leaves and re-enters this
+// view, and coming back on Local would drop the user somewhere they did not ask
+// to be, with no sign the create happened.
+func newDiscoverTabsModel(ctx context.Context, local discoverModel, auth *config.AuthConfig, defaultOrg int32, active devicePickerTab) discoverTabsModel {
 	m := discoverTabsModel{
 		local:      local,
+		sim:        newSimulatorListModel(ctx),
 		cloudAuth:  auth,
 		defaultOrg: defaultOrg,
+		active:     active,
+	}
+	// The simulator list polls only once its tab is first shown; opening
+	// straight onto it has to start that here instead.
+	if active == devicePickerSimulatorTab {
+		m.simStarted = true
 	}
 	if auth != nil {
 		m.cloud = newCloudDiscoverModel(ctx, auth, os.Getenv("WENDY_BROKER_URL"), false, false, nil)
@@ -54,15 +69,24 @@ func tagDiscoverTabsCmd(cmd tea.Cmd, tab devicePickerTab) tea.Cmd {
 			}
 			return tagged
 		}
-		if tab == devicePickerCloudTab {
+		switch tab {
+		case devicePickerCloudTab:
 			return discoverTabsCloudMsg{msg: msg}
+		case devicePickerSimulatorTab:
+			return discoverTabsSimulatorMsg{msg: msg}
+		default:
+			return discoverTabsLocalMsg{msg: msg}
 		}
-		return discoverTabsLocalMsg{msg: msg}
 	}
 }
 
 func (m discoverTabsModel) Init() tea.Cmd {
+	// Simulator polling starts on first entry; see devicePickerModel.Init.
 	return tagDiscoverTabsCmd(m.local.Init(), devicePickerLocalTab)
+}
+
+func (m discoverTabsModel) startSimulatorCmd() tea.Cmd {
+	return tagDiscoverTabsCmd(m.sim.Init(), devicePickerSimulatorTab)
 }
 
 func (m discoverTabsModel) startCloudCmd() tea.Cmd {
@@ -103,6 +127,27 @@ func (m discoverTabsModel) updateLocal(msg tea.Msg) (discoverTabsModel, tea.Cmd)
 	return m, tagDiscoverTabsCmd(cmd, devicePickerLocalTab)
 }
 
+// updateSimulator forwards to the shared simulator list. A selection is ignored
+// -- discover shows devices, it does not connect to one, and enter copies
+// instead -- but 'c' still has to leave, because the download needs the
+// terminal this view is holding.
+func (m discoverTabsModel) updateSimulator(msg tea.Msg) (discoverTabsModel, tea.Cmd) {
+	updated, cmd := m.sim.Update(msg)
+	m.sim = updated
+	if m.sim.createRequested() {
+		if choice := m.sim.selected(); choice != nil {
+			m.createVMName = choice.Name
+		}
+		m.action = devicePickerCreateVM
+		return m, tea.Quit
+	}
+	if m.sim.cancelled() {
+		m.cancelled = true
+		return m, tea.Quit
+	}
+	return m, tagDiscoverTabsCmd(cmd, devicePickerSimulatorTab)
+}
+
 func (m discoverTabsModel) updateCloud(msg tea.Msg) (discoverTabsModel, tea.Cmd) {
 	updated, cmd := m.cloud.Update(msg)
 	m.cloud = updated.(cloudDiscoverModel)
@@ -117,6 +162,8 @@ func (m discoverTabsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case discoverTabsLocalMsg:
 		return m.updateLocal(msg.msg)
+	case discoverTabsSimulatorMsg:
+		return m.updateSimulator(msg.msg)
 	case discoverTabsCloudMsg:
 		if m.cloudAuth == nil {
 			return m, nil
@@ -127,25 +174,30 @@ func (m discoverTabsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case tea.WindowSizeMsg:
 		m.windowWidth = msg.Width
+		var cmds []tea.Cmd
 		local, localCmd := m.updateLocal(msg)
 		m = local
-		if m.cloudAuth == nil {
-			return m, localCmd
+		cmds = append(cmds, localCmd)
+		sim, simCmd := m.updateSimulator(msg)
+		m = sim
+		cmds = append(cmds, simCmd)
+		if m.cloudAuth != nil {
+			cloud, cloudCmd := m.updateCloud(msg)
+			m = cloud
+			cmds = append(cmds, cloudCmd)
 		}
-		cloud, cloudCmd := m.updateCloud(msg)
-		m = cloud
-		return m, tea.Batch(localCmd, cloudCmd)
+		return m, tea.Batch(cmds...)
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "tab", "shift+tab":
-			if m.active == devicePickerLocalTab {
-				m.active = devicePickerCloudTab
-				if m.cloudAuth != nil && !m.cloudStarted {
-					m.cloudStarted = true
-					return m, m.startCloudCmd()
-				}
-			} else {
-				m.active = devicePickerLocalTab
+			m.active = cycleTab(deviceTabOrder(), m.active, tabCycleDelta(msg.String()))
+			if m.active == devicePickerCloudTab && m.cloudAuth != nil && !m.cloudStarted {
+				m.cloudStarted = true
+				return m, m.startCloudCmd()
+			}
+			if m.active == devicePickerSimulatorTab && !m.simStarted {
+				m.simStarted = true
+				return m, m.startSimulatorCmd()
 			}
 			return m, nil
 		case "o":
@@ -165,13 +217,17 @@ func (m discoverTabsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
-		if m.active == devicePickerCloudTab {
+		switch m.active {
+		case devicePickerCloudTab:
 			if m.cloudAuth == nil {
 				return m, nil
 			}
 			return m.updateCloud(msg)
+		case devicePickerSimulatorTab:
+			return m.updateSimulator(msg)
+		default:
+			return m.updateLocal(msg)
 		}
-		return m.updateLocal(msg)
 	}
 	return m, nil
 }
@@ -180,9 +236,13 @@ func (m discoverTabsModel) View() string {
 	if m.cancelled || m.action != devicePickerNoAction {
 		return ""
 	}
-	header := deviceTabsHeader(m.active, m.windowWidth)
-	if m.active == devicePickerLocalTab {
+	header := deviceTabsHeader(m.active, deviceTabOrder(), m.windowWidth)
+	switch m.active {
+	case devicePickerLocalTab:
 		return header + "\n\n" + m.local.View()
+	case devicePickerSimulatorTab:
+		return header + "\n\n" + m.sim.View() + "\n" + devicePickerOrgStyle.Render(
+			"  enter copy address, tab switch, q quit — start one with 'wendy vm start <name>'")
 	}
 
 	var body strings.Builder
@@ -201,4 +261,22 @@ func (m discoverTabsModel) View() string {
 	body.WriteString("\n\n")
 	body.WriteString(m.cloud.View())
 	return body.String()
+}
+
+// copySimulatorAddress puts a running VM's agent address on the clipboard, so
+// the address can be pasted straight into a --device flag. A stopped VM has no
+// address to copy, so it says how to get one instead.
+func copySimulatorAddress(choice *simulatorChoice) string {
+	switch {
+	case choice == nil:
+		return ""
+	case choice.Create:
+		return "No simulator yet — press c to create one."
+	case choice.Address == "":
+		return fmt.Sprintf("%s is not running — start it with 'wendy vm start %s'.", choice.Name, choice.Name)
+	}
+	if err := clipboardWriter(choice.Address); err != nil {
+		return fmt.Sprintf("Copy failed: %v", err)
+	}
+	return "Copied " + choice.Address + " to clipboard."
 }

--- a/go/internal/cli/commands/discover_tabs_test.go
+++ b/go/internal/cli/commands/discover_tabs_test.go
@@ -170,6 +170,41 @@ func TestDiscoverOpensOnTheRequestedTab(t *testing.T) {
 	if !m.simStarted {
 		t.Error("opening on the Simulator tab did not start its polling")
 	}
+	stubVMStatuses(t, stoppedVM("created", "test"))
+	// Execute the actual initial simulator commands, not just the flag which
+	// previously claimed polling had started without scheduling anything.
+	batch, ok := m.Init()().(tea.BatchMsg)
+	if !ok || len(batch) != 2 {
+		t.Fatal("Init must schedule local and simulator initialization")
+	}
+	var found bool
+	var walk func(tea.Cmd)
+	walk = func(cmd tea.Cmd) {
+		if cmd == nil {
+			return
+		}
+		switch msg := cmd().(type) {
+		case tea.BatchMsg:
+			for _, child := range msg {
+				walk(child)
+			}
+		case discoverTabsSimulatorMsg:
+			if rows, ok := msg.msg.(simulatorVMsMsg); ok {
+				found = true
+				if len(rows.vms) != 1 || rows.vms[0].Name != "created" {
+					t.Fatalf("wrong initial rows: %+v", rows)
+				}
+				updated, next := m.Update(msg)
+				if next == nil || !strings.Contains(updated.View(), "created") {
+					t.Fatal("initial rows did not render/schedule refresh")
+				}
+			}
+		}
+	}
+	walk(batch[1])
+	if !found {
+		t.Fatal("Init did not poll simulator store")
+	}
 }
 
 func TestDiscoverStillDefaultsToLocal(t *testing.T) {

--- a/go/internal/cli/commands/discover_tabs_test.go
+++ b/go/internal/cli/commands/discover_tabs_test.go
@@ -13,9 +13,9 @@ func newTestDiscoverTabsModel(authOrg int, defaultOrg int32) discoverTabsModel {
 	ctx := context.Background()
 	local := newDiscoverModel(ctx, defaultOpts(), true)
 	if authOrg == 0 {
-		return newDiscoverTabsModel(ctx, local, nil, defaultOrg)
+		return newDiscoverTabsModel(ctx, local, nil, defaultOrg, devicePickerLocalTab)
 	}
-	return newDiscoverTabsModel(ctx, local, pickerAuth(authOrg), defaultOrg)
+	return newDiscoverTabsModel(ctx, local, pickerAuth(authOrg), defaultOrg, devicePickerLocalTab)
 }
 
 func TestDiscoverTabsShowsLocalAndCloud(t *testing.T) {
@@ -28,10 +28,28 @@ func TestDiscoverTabsShowsLocalAndCloud(t *testing.T) {
 	}
 }
 
+// discoverTabTo presses Tab until the model lands on want, so a test that cares
+// about one tab does not encode how many tabs precede it.
+func discoverTabTo(t *testing.T, m discoverTabsModel, want devicePickerTab) (discoverTabsModel, tea.Cmd) {
+	t.Helper()
+	var cmd tea.Cmd
+	for range len(deviceTabOrder()) {
+		if m.active == want {
+			return m, cmd
+		}
+		var updated tea.Model
+		updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+		m = updated.(discoverTabsModel)
+	}
+	if m.active != want {
+		t.Fatalf("never reached tab %v", want)
+	}
+	return m, cmd
+}
+
 func TestDiscoverTabsLoggedOutCloudOffersLogin(t *testing.T) {
 	m := newTestDiscoverTabsModel(0, 0)
-	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
-	m = updated.(discoverTabsModel)
+	m, _ = discoverTabTo(t, m, devicePickerCloudTab)
 
 	view := m.View()
 	for _, want := range []string{"Discover cloud devices", "Wendy Cloud login", "Not logged in"} {
@@ -53,12 +71,11 @@ func TestDiscoverTabsStartsCloudLazilyAndShowsDefaultOrg(t *testing.T) {
 		t.Fatal("cloud discovery started before visiting the Cloud tab")
 	}
 
-	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyTab})
-	m = updated.(discoverTabsModel)
+	m, cmd := discoverTabTo(t, m, devicePickerCloudTab)
 	if cmd == nil || !m.cloudStarted {
 		t.Fatalf("first Cloud visit: cmd=%v started=%v", cmd != nil, m.cloudStarted)
 	}
-	updated, _ = m.Update(discoverTabsOrgMsg{name: "Robotics"})
+	updated, _ := m.Update(discoverTabsOrgMsg{name: "Robotics"})
 	m = updated.(discoverTabsModel)
 	for _, want := range []string{"Organization: Robotics (org 7)", "default", "o switch"} {
 		if !strings.Contains(m.View(), want) {
@@ -113,5 +130,54 @@ func TestTagDiscoverTabsCmdPreservesBatchChildren(t *testing.T) {
 		if msg.msg == nil {
 			t.Fatalf("child %d lost its payload", i)
 		}
+	}
+}
+
+func TestDiscoverTabsShowsTheSimulatorTab(t *testing.T) {
+	// The Simulator tab is the only surface that lists a STOPPED VM: a Local
+	// tab row needs an answering agent, so a VM that is off or still booting
+	// never appears there.
+	m := newTestDiscoverTabsModel(0, 0)
+	if view := m.View(); !strings.Contains(view, "Simulator") {
+		t.Errorf("discover header = %q, want a Simulator tab", view)
+	}
+	m, _ = discoverTabTo(t, m, devicePickerSimulatorTab)
+	if view := m.View(); !strings.Contains(view, "enter copy address") {
+		t.Errorf("simulator tab view = %q, want the copy hint", view)
+	}
+}
+
+func TestCopySimulatorAddressExplainsWhatItCannotCopy(t *testing.T) {
+	// Points at the key, not the command: c creates one right here now.
+	if got := copySimulatorAddress(&simulatorChoice{Name: "sim", Create: true}); !strings.Contains(got, "press c") {
+		t.Errorf("create row = %q, want it to point at the c key", got)
+	}
+	if got := copySimulatorAddress(&simulatorChoice{Name: "sim"}); !strings.Contains(got, "vm start sim") {
+		t.Errorf("stopped VM = %q, want it to name 'wendy vm start sim'", got)
+	}
+}
+
+func TestDiscoverOpensOnTheRequestedTab(t *testing.T) {
+	// Creating a VM leaves and re-enters this view. Coming back on Local drops
+	// the user somewhere they did not ask to be, with no sign the create ran.
+	ctx := context.Background()
+	m := newDiscoverTabsModel(ctx, newDiscoverModel(ctx, defaultOpts(), true), nil, 0, devicePickerSimulatorTab)
+	if m.active != devicePickerSimulatorTab {
+		t.Errorf("active = %v, want the Simulator tab", m.active)
+	}
+	// The list polls only from the first time its tab is shown, so opening
+	// straight onto it has to start that up front or the table stays empty.
+	if !m.simStarted {
+		t.Error("opening on the Simulator tab did not start its polling")
+	}
+}
+
+func TestDiscoverStillDefaultsToLocal(t *testing.T) {
+	m := newTestDiscoverTabsModel(0, 0)
+	if m.active != devicePickerLocalTab {
+		t.Errorf("active = %v, want Local", m.active)
+	}
+	if m.simStarted {
+		t.Error("the simulator poll started before its tab was ever shown")
 	}
 }

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -2666,6 +2666,10 @@ var (
 // dialErr reports the shared proxy's most recent failure to reach the device
 // registry; it is non-nil on every nil-error return.
 func resolveRegistryForAgent(ctx context.Context, conn *grpcclient.AgentConnection, port int) (registryAddr string, cleanup func(), dialErr func() error, err error) {
+	port, err = registryHostPortForAgent(ctx, conn, port)
+	if err != nil {
+		return "", nil, nil, err
+	}
 	// Hold the lock for the entire operation so concurrent callers block rather
 	// than each starting their own proxy. Proxy creation is just a local
 	// net.Listen call, so the lock is held only briefly.
@@ -2747,6 +2751,10 @@ func resolveRegistryForSwift(ctx context.Context, host string, port int) (regist
 // of a generic build failure. dialErr is always safely callable (never nil)
 // on a nil-error return.
 func resolveRegistryForSwiftAgent(ctx context.Context, conn *grpcclient.AgentConnection, port int) (registryAddr string, swiftUseMTLS bool, cleanup func(), dialErr func() error, err error) {
+	port, err = registryHostPortForAgent(ctx, conn, port)
+	if err != nil {
+		return "", false, nil, nil, err
+	}
 	if conn.RegistryDialer == nil {
 		if conn.IsMTLS {
 			// Provisioned LAN device: the registry speaks HTTPS with a cert signed
@@ -2885,6 +2893,10 @@ func tlsClientDialer(certPEM, keyPEM, caPEM string, dial func(context.Context) (
 }
 
 func resolveRegistryForAppleContainer(ctx context.Context, conn *grpcclient.AgentConnection, port int) (registryAddr string, cleanup func(), useMTLS bool, dialErr func() error, err error) {
+	port, err = registryHostPortForAgent(ctx, conn, port)
+	if err != nil {
+		return "", nil, false, nil, err
+	}
 	if conn.RegistryDialer != nil || conn.IsMTLS {
 		registryAddr, appleUseMTLS, cleanup, proxyDialErr, err := resolveRegistryForSwiftAgent(ctx, conn, port)
 		if err != nil {

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1115,30 +1115,25 @@ func connectToAgent(ctx context.Context, opts ...resolveOption) (*grpcclient.Age
 		return conn, nil
 	}
 
-	// Rewrite a simulator alias before resolveDeviceAddress reads the flag: this
-	// path dials straight from it and never passes through resolveTargetInner's
-	// hook, so without this `--device sim` reaches only the commands that go via
-	// resolveTarget. After the socket and cloud branches, so neither is
-	// pre-empted by starting a VM.
-	aliasedVM := false
-	if deviceFlag != "" {
-		aliasAddr, matched, aliasErr := resolveVMAlias(ctx, deviceFlag)
-		if aliasErr != nil {
-			return nil, aliasErr
+	// Keep the alias intact, including when it comes from the saved default.
+	device := deviceFlag
+	if device == "" {
+		loaded, err := config.Load()
+		if err != nil {
+			return nil, err
 		}
-		if matched {
-			deviceFlag, aliasedVM = aliasAddr, true
-		}
+		device = loaded.DefaultDevice
 	}
-
+	if name, matched, err := simulatorName(device); err != nil {
+		return nil, err
+	} else if matched {
+		picked, err := connectSimulatorChoiceFn(ctx, &simulatorChoice{Name: name}, cfg.suppressUpdateCheck)
+		if err != nil {
+			return nil, err
+		}
+		return picked.Agent, nil
+	}
 	addr, pinKey, isDefault, err := resolveDeviceAddress()
-	if aliasedVM {
-		// A VM is identified by its name, not by the loopback address it was
-		// just resolved to -- which every other VM shares. Unpinned, like the
-		// cloud path. Only addresses the CLI itself derived from a VM alias are
-		// exempt; one the user typed is pinned as it has always been.
-		pinKey = ""
-	}
 	if err == nil {
 		// The name the user asked for, used both to talk about this device and
 		// to decide which device is acceptable — see resolveDeviceAddress.
@@ -1367,6 +1362,12 @@ func pinKeyForLANDevice(d *models.LANDevice) string {
 // pin first) or `wendy device unpin <host>` is the way back — a re-pin has to be
 // an act aimed at a specific device, not a row in a list mDNS filled in.
 func connectPickedLANDevice(ctx context.Context, d *models.DiscoveredDevice, addr string, suppressUpdateCheck bool) (*SelectedDevice, error) {
+	if name, matched, err := simulatorName(d.LAN.ID); err != nil {
+		return nil, err
+	} else if matched {
+		// Re-resolve the live record; discovery may predate a port change.
+		return connectSimulatorChoiceFn(ctx, &simulatorChoice{Name: name}, suppressUpdateCheck)
+	}
 	mtls := d.LAN.IsMTLS
 	conn, err := connectAgentAtAddressWithProvisionedHint(ctx, addr, func() bool { return mtls })
 	if err != nil {
@@ -3161,17 +3162,10 @@ func resolveTargetInner(ctx context.Context, opts ...resolveOption) (*SelectedDe
 
 	rt := phaseTimer()
 
-	// Rewrite a simulator alias to the address its agent is forwarded to,
-	// starting the VM if needed. Before the provider sweep, so no other target
-	// pays for it.
-	if device != "" {
-		addr, matched, err := resolveVMAlias(ctx, device)
-		if err != nil {
-			return nil, err
-		}
-		if matched {
-			device = addr
-		}
+	if name, matched, err := simulatorName(device); err != nil {
+		return nil, err
+	} else if matched {
+		return connectSimulatorChoiceFn(ctx, &simulatorChoice{Name: name}, cfg.suppressUpdateCheck)
 	}
 
 	// Check if the device flag matches a known provider key.
@@ -3935,7 +3929,7 @@ func pickDeviceWithCloudAuth(ctx context.Context, excludeProviders map[string]bo
 		}
 		return &SelectedDevice{Agent: conn}, nil
 	case devicePickerSimulatorTab:
-		return connectSimulatorChoice(ctx, choice.Simulator, suppressUpdateCheck)
+		return connectSimulatorChoiceFn(ctx, choice.Simulator, suppressUpdateCheck)
 	default:
 		return connectLocalPickerChoice(ctx, choice.Local, suppressUpdateCheck)
 	}

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -2368,7 +2368,7 @@ func (w *mtlsWalk) dialAddr(ctx context.Context, cand string, isPrimary bool) (*
 				}
 			}
 			conn.Close()
-			certRejected := isCertRejectionError(probeErr)
+			certRejected := isCertRejectionError(cand, probeErr)
 			if certRejected {
 				w.anyCertRejection = true
 			}
@@ -2532,11 +2532,22 @@ func rotateCertsForOrg(certs []config.CertificateInfo, orgID int32) []config.Cer
 // Matches "remote error: tls:" (server sent an alert) and other cert-specific
 // signals; deliberately excludes "tls: first record does not look like a TLS
 // handshake" (plaintext server probed with TLS) and plain transport errors.
-func isCertRejectionError(err error) bool {
+// addr is the endpoint the probe was aimed at: over loopback the verdict has
+// one extra exclusion, described below.
+func isCertRejectionError(addr string, err error) bool {
 	if err == nil {
 		return false
 	}
 	msg := err.Error()
+	// A handshake ending in EOF got no TLS alert back, so nothing rejected
+	// anything: something accepted the connection and closed it. A port forward
+	// does exactly that when the far side is not listening -- QEMU's user-mode
+	// networking accepts on the host and only then finds the guest port closed.
+	// Only over loopback: elsewhere an EOF may be an on-path reset, and reading
+	// that as "not a TLS endpoint" would re-offer the plaintext rung.
+	if isLoopbackHost(addr) && strings.Contains(msg, "handshake failed: EOF") {
+		return false
+	}
 	// A plaintext (unprovisioned) agent probed with TLS reports "first record
 	// does not look like a TLS handshake", which gRPC wraps inside its
 	// "authentication handshake failed" envelope. That is NOT a cert rejection —
@@ -2726,7 +2737,12 @@ func checkAndOfferUpdate(ctx context.Context, conn *grpcclient.AgentConnection) 
 
 	arch := resp.GetCpuArchitecture()
 	osName := resp.GetOs()
-	addr := hostPort(conn.Host, defaultAgentPort)
+	// conn.Addr, not conn.Host: the host alone loses the port, and a VM reached
+	// on a forwarded 50053 would come back on 50051 -- a different VM.
+	addr := conn.Addr
+	if addr == "" {
+		addr = hostPort(conn.Host, defaultAgentPort)
+	}
 
 	if err := performAgentUpdate(ctx, conn, osName, arch, false); err != nil {
 		fmt.Fprintf(os.Stderr, "Update failed: %v\nContinuing with existing connection.\n", err)

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -1115,7 +1115,30 @@ func connectToAgent(ctx context.Context, opts ...resolveOption) (*grpcclient.Age
 		return conn, nil
 	}
 
+	// Rewrite a simulator alias before resolveDeviceAddress reads the flag: this
+	// path dials straight from it and never passes through resolveTargetInner's
+	// hook, so without this `--device sim` reaches only the commands that go via
+	// resolveTarget. After the socket and cloud branches, so neither is
+	// pre-empted by starting a VM.
+	aliasedVM := false
+	if deviceFlag != "" {
+		aliasAddr, matched, aliasErr := resolveVMAlias(ctx, deviceFlag)
+		if aliasErr != nil {
+			return nil, aliasErr
+		}
+		if matched {
+			deviceFlag, aliasedVM = aliasAddr, true
+		}
+	}
+
 	addr, pinKey, isDefault, err := resolveDeviceAddress()
+	if aliasedVM {
+		// A VM is identified by its name, not by the loopback address it was
+		// just resolved to -- which every other VM shares. Unpinned, like the
+		// cloud path. Only addresses the CLI itself derived from a VM alias are
+		// exempt; one the user typed is pinned as it has always been.
+		pinKey = ""
+	}
 	if err == nil {
 		// The name the user asked for, used both to talk about this device and
 		// to decide which device is acceptable — see resolveDeviceAddress.
@@ -3138,6 +3161,19 @@ func resolveTargetInner(ctx context.Context, opts ...resolveOption) (*SelectedDe
 
 	rt := phaseTimer()
 
+	// Rewrite a simulator alias to the address its agent is forwarded to,
+	// starting the VM if needed. Before the provider sweep, so no other target
+	// pays for it.
+	if device != "" {
+		addr, matched, err := resolveVMAlias(ctx, device)
+		if err != nil {
+			return nil, err
+		}
+		if matched {
+			device = addr
+		}
+	}
+
 	// Check if the device flag matches a known provider key.
 	if device != "" {
 		if p := providers.ProviderForKey(device); p != nil {
@@ -3886,16 +3922,29 @@ func pickDeviceWithCloudAuth(ctx context.Context, excludeProviders map[string]bo
 	if dm.cancelled {
 		return nil, ErrUserCancelled
 	}
-	if asset := dm.selectedCloud(); asset != nil {
-		cliLogln("Connecting to %s via cloud tunnel...", asset.GetName())
-		conn, err := connectCloudAsset(ctx, cloudAuth, asset, dm.cloud.brokerURL)
+	choice, ok := dm.choice()
+	if !ok {
+		return nil, fmt.Errorf("no device selected")
+	}
+	switch choice.Tab {
+	case devicePickerCloudTab:
+		cliLogln("Connecting to %s via cloud tunnel...", choice.Cloud.GetName())
+		conn, err := connectCloudAsset(ctx, cloudAuth, choice.Cloud, dm.cloud.brokerURL)
 		if err != nil {
 			return nil, err
 		}
 		return &SelectedDevice{Agent: conn}, nil
+	case devicePickerSimulatorTab:
+		return connectSimulatorChoice(ctx, choice.Simulator, suppressUpdateCheck)
+	default:
+		return connectLocalPickerChoice(ctx, choice.Local, suppressUpdateCheck)
 	}
+}
 
-	sel := dm.selectedLocal()
+// connectLocalPickerChoice turns a Local-tab selection into a connection. Lifted
+// verbatim out of pickDeviceWithCloudAuth so the three-way dispatch above stays
+// readable on one screen.
+func connectLocalPickerChoice(ctx context.Context, sel *tui.PickerItem, suppressUpdateCheck bool) (*SelectedDevice, error) {
 	if sel == nil {
 		return nil, fmt.Errorf("no device selected")
 	}

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -2761,12 +2761,6 @@ func checkAndOfferUpdate(ctx context.Context, conn *grpcclient.AgentConnection) 
 
 	arch := resp.GetCpuArchitecture()
 	osName := resp.GetOs()
-	// conn.Addr, not conn.Host: the host alone loses the port, and a VM reached
-	// on a forwarded 50053 would come back on 50051 -- a different VM.
-	addr := conn.Addr
-	if addr == "" {
-		addr = hostPort(conn.Host, defaultAgentPort)
-	}
 
 	if err := performAgentUpdate(ctx, conn, osName, arch, false); err != nil {
 		fmt.Fprintf(os.Stderr, "Update failed: %v\nContinuing with existing connection.\n", err)
@@ -2776,7 +2770,7 @@ func checkAndOfferUpdate(ctx context.Context, conn *grpcclient.AgentConnection) 
 	conn.Close()
 
 	fmt.Fprintf(os.Stderr, "Waiting for agent to restart...")
-	newConn, err := waitForAgentRestart(ctx, addr)
+	newConn, err := reconnectAgentAfterRestart(ctx, conn)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, " failed.\n")
 		return nil, fmt.Errorf("agent did not come back after update: %w", err)

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -298,7 +298,7 @@ func TestLANAgentAddressesFallsBackToDefaultPort(t *testing.T) {
 func TestIsCertRejectionErrorIgnoresPlaintextTLSProbe(t *testing.T) {
 	err := errors.New(`rpc error: code = Unavailable desc = connection error: desc = "transport: authentication handshake failed: tls: first record does not look like a TLS handshake"`)
 
-	if isCertRejectionError(err) {
+	if isCertRejectionError("192.168.2.253:50052", err) {
 		t.Fatal("isCertRejectionError() = true, want false for plaintext TLS probe")
 	}
 }
@@ -306,7 +306,7 @@ func TestIsCertRejectionErrorIgnoresPlaintextTLSProbe(t *testing.T) {
 func TestIsCertRejectionErrorDetectsTLSAlert(t *testing.T) {
 	err := errors.New("rpc error: code = Unavailable desc = remote error: tls: bad certificate")
 
-	if !isCertRejectionError(err) {
+	if !isCertRejectionError("192.168.2.253:50052", err) {
 		t.Fatal("isCertRejectionError() = false, want true for TLS alert")
 	}
 }
@@ -1873,7 +1873,7 @@ func TestIsCertRejectionError(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := isCertRejectionError(tc.err); got != tc.want {
+			if got := isCertRejectionError("192.168.2.253:50052", tc.err); got != tc.want {
 				t.Errorf("isCertRejectionError(%v) = %v, want %v", tc.err, got, tc.want)
 			}
 		})
@@ -2328,5 +2328,51 @@ func TestCachedDeviceEntryAnyAgeMostRecentWins(t *testing.T) {
 	// Bare-name form matches the .local stored form.
 	if _, ok := cachedDeviceEntry(cache, "orin"); !ok {
 		t.Error("bare hostname did not match .local entry")
+	}
+}
+
+func TestIsCertRejectionErrorClassifiesHandshakeFailures(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  string
+		want bool
+	}{{
+		name: "server sent a TLS alert",
+		msg:  `rpc error: desc = "transport: authentication handshake failed: remote error: tls: bad certificate"`,
+		want: true,
+	}, {
+		name: "server demanded a certificate",
+		msg:  `rpc error: desc = "transport: authentication handshake failed: certificate required"`,
+		want: true,
+	}, {
+		name: "plaintext agent probed with TLS",
+		msg:  `rpc error: desc = "transport: authentication handshake failed: tls: first record does not look like a TLS handshake"`,
+		want: false,
+	}, {
+		// Off loopback an EOF may be an on-path reset, so it stays strict.
+		name: "handshake ended in EOF",
+		msg:  `rpc error: desc = "transport: authentication handshake failed: EOF"`,
+		want: true,
+	}}
+	for _, tc := range cases {
+		if got := isCertRejectionError("192.168.2.253:50052", errors.New(tc.msg)); got != tc.want {
+			t.Errorf("%s: isCertRejectionError() = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestLoopbackEOFIsNotTreatedAsACertRejection(t *testing.T) {
+	// QEMU's user-mode networking accepts on the host and only then finds the
+	// guest port closed, so an unprovisioned VM's mTLS probe ends in EOF. That
+	// must not suppress the plaintext rung -- but only for loopback, because
+	// off it the same EOF may be an on-path reset.
+	eof := errors.New(`rpc error: desc = "transport: authentication handshake failed: EOF"`)
+	for _, addr := range []string{"127.0.0.1:50052", "localhost:50052", "[::1]:50052"} {
+		if isCertRejectionError(addr, eof) {
+			t.Errorf("%s: a loopback EOF still counts as a cert rejection", addr)
+		}
+	}
+	if !isCertRejectionError("192.168.2.253:50052", eof) {
+		t.Error("an EOF off loopback stopped counting as a cert rejection")
 	}
 }

--- a/go/internal/cli/commands/manifest.go
+++ b/go/internal/cli/commands/manifest.go
@@ -165,10 +165,12 @@ type deviceInfo struct {
 // imageInfo describes a downloadable OS image.
 type imageInfo struct {
 	DownloadURL string
+	Checksum    string
 	ImageSize   int64
 	Version     string
 	BmapURL     string
 	ZstURL      string
+	ZstChecksum string
 	// Storage is the resolved manifest variant ("sd"/"nvme"/""), used to keep
 	// the on-disk cache keyed per variant so an SD download and an NVMe download
 	// of the same device+version never collide on one cache file.
@@ -367,6 +369,13 @@ func getImageInfo(dm *deviceManifest, ver, storage string) (*imageInfo, error) {
 		ImageSize:   t.imageSize,
 		Version:     ver,
 		Storage:     storage,
+	}
+	// Select checksums from the same artifact triple, including legacy fallback.
+	info.Checksum, info.ZstChecksum = v.Checksum, v.ZstChecksum
+	if storage == "nvme" && v.NVMEPath != "" {
+		info.Checksum, info.ZstChecksum = v.NVMEChecksum, v.NVMEZstChecksum
+	} else if storage == "sd" && v.SDPath != "" {
+		info.Checksum, info.ZstChecksum = v.SDChecksum, v.SDZstChecksum
 	}
 	if t.bmapPath != "" {
 		info.BmapURL = gcsBaseURL + "/" + t.bmapPath

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -369,6 +369,13 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	if err != nil {
 		return err
 	}
+	portConfigs := []*appconfig.AppConfig{appCfg}
+	for name, svc := range services {
+		portConfigs = append(portConfigs, multiServiceCreateConfig(appCfg, name, svc))
+	}
+	if err := prepareVMAppPorts(ctx, conn, portConfigs...); err != nil {
+		return err
+	}
 
 	versionResp, err := agentVersionForRun(ctx, conn)
 	if err != nil {

--- a/go/internal/cli/commands/os_cmd.go
+++ b/go/internal/cli/commands/os_cmd.go
@@ -1322,19 +1322,13 @@ func ensureAgentUpToDate(ctx context.Context, conn *grpcclient.AgentConnection, 
 	}
 
 	fmt.Printf("Updating agent: %s → %s\n", agentVer, latestVer)
-	// conn.Addr, not conn.Host: the host alone loses the port, and a VM reached
-	// on a forwarded 50053 would be reconnected to 50051 -- another VM.
-	addr := conn.Addr
-	if addr == "" {
-		addr = hostPort(conn.Host, defaultAgentPort)
-	}
 	if err := performAgentUpdate(ctx, conn, osName, arch, nightly); err != nil {
 		return nil, fmt.Errorf("agent update failed: %w", err)
 	}
 	conn.Close()
 
 	fmt.Print("Waiting for agent to restart...")
-	newConn, err := waitForAgentRestart(ctx, addr)
+	newConn, err := reconnectAgentAfterRestart(ctx, conn)
 	if err != nil {
 		return nil, fmt.Errorf("agent did not come back after update: %w", err)
 	}

--- a/go/internal/cli/commands/os_cmd.go
+++ b/go/internal/cli/commands/os_cmd.go
@@ -293,6 +293,13 @@ The device uses its in-house wendyos-update engine to apply the update.`,
 			if err := requireReflashableOSVersion(versionResp.GetOsVersion()); err != nil {
 				return err
 			}
+			// Same rule for a local artifact path: a device reached over loopback
+			// sits behind a port forward, and the only address this side could
+			// advertise is one that inside the guest is the guest.
+			if len(args) > 0 && isLoopbackHost(conn.Host) {
+				return fmt.Errorf("%s reaches this machine over loopback, so it cannot fetch a locally served artifact; "+
+					"pass --pr or --artifact-url and let the device download it directly", conn.Host)
+			}
 
 			// Step 2: Ensure the agent is at the latest release before updating the OS.
 			conn, err = ensureAgentUpToDate(ctx, conn, versionResp, nightly)
@@ -391,7 +398,10 @@ The device uses its in-house wendyos-update engine to apply the update.`,
 				defer cleanup()
 				artifactURL = servedURL
 				fmt.Printf("Serving artifact at: %s\n", artifactURL)
-			} else if artifactURL != "" && !deviceHasWiFi(ctx, conn) {
+				// A device on loopback has a port forward between us and it, so it
+				// has no WiFi to report yet is not offline: it reaches the internet
+				// through the host's NAT and can fetch the artifact itself.
+			} else if artifactURL != "" && !isLoopbackHost(conn.Host) && !deviceHasWiFi(ctx, conn) {
 				// Device has no WiFi connection — it cannot reach GCP directly.
 				// Download the artifact on the Mac and serve it over a local HTTP
 				// server so the device can fetch it from the Mac instead.
@@ -1312,7 +1322,12 @@ func ensureAgentUpToDate(ctx context.Context, conn *grpcclient.AgentConnection, 
 	}
 
 	fmt.Printf("Updating agent: %s → %s\n", agentVer, latestVer)
-	addr := hostPort(conn.Host, defaultAgentPort)
+	// conn.Addr, not conn.Host: the host alone loses the port, and a VM reached
+	// on a forwarded 50053 would be reconnected to 50051 -- another VM.
+	addr := conn.Addr
+	if addr == "" {
+		addr = hostPort(conn.Host, defaultAgentPort)
+	}
 	if err := performAgentUpdate(ctx, conn, osName, arch, nightly); err != nil {
 		return nil, fmt.Errorf("agent update failed: %w", err)
 	}

--- a/go/internal/cli/commands/os_cmd_test.go
+++ b/go/internal/cli/commands/os_cmd_test.go
@@ -892,3 +892,28 @@ func TestEvaluateOSUpdateOutcome(t *testing.T) {
 		})
 	}
 }
+
+func TestIsLoopbackHostIdentifiesAPortForwardedDevice(t *testing.T) {
+	// A VM answers on the host's loopback through a port forward. It reports no
+	// WiFi but is not offline, and the local artifact server could only ever
+	// advertise a loopback address, which inside the guest is the guest.
+	cases := []struct {
+		host string
+		want bool
+	}{
+		{"127.0.0.1:50051", true},
+		{"127.0.0.1", true},
+		{"::1", true},
+		{"[::1]:50051", true},
+		{"localhost:50051", true},
+		{"192.168.2.253:50051", false},
+		{"169.254.198.132", false},
+		{"rpi5.local:50051", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isLoopbackHost(tc.host); got != tc.want {
+			t.Errorf("isLoopbackHost(%q) = %v, want %v", tc.host, got, tc.want)
+		}
+	}
+}

--- a/go/internal/cli/commands/os_install.go
+++ b/go/internal/cli/commands/os_install.go
@@ -1884,6 +1884,21 @@ func isGzipFile(path string) bool {
 	return err == nil && magic[0] == 0x1f && magic[1] == 0x8b
 }
 
+// VM downloads and content-addressed cache entries have extensionless format
+// names (.img/.image). Identify ZIP containers by their signature as well.
+func isZipFile(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	var magic [4]byte
+	if _, err := io.ReadFull(f, magic[:]); err != nil {
+		return false
+	}
+	return string(magic[:]) == "PK\x03\x04" || string(magic[:]) == "PK\x05\x06" || string(magic[:]) == "PK\x07\x08"
+}
+
 // openOSImageStream resolves the cached file for deviceKey+img, then returns
 // a streaming reader over the image bytes. The caller must Close it.
 func openOSImageStream(deviceKey string, img *imageInfo) (*imageStream, error) {
@@ -1891,23 +1906,14 @@ func openOSImageStream(deviceKey string, img *imageInfo) (*imageStream, error) {
 	if err != nil {
 		return nil, err
 	}
-	if strings.HasSuffix(strings.ToLower(cachePath), ".zip") {
-		return streamZipImageEntry(cachePath)
-	}
-	if isGzipFile(cachePath) {
-		return streamGzipImage(cachePath)
-	}
-	if isZstdFile(cachePath) {
-		return streamZstdImage(cachePath)
-	}
-	return openRawImageStream(cachePath)
+	return openLocalImageStream(cachePath)
 }
 
 // openLocalImageStream opens an arbitrary local file for streaming.
-// If the path ends in .zip it finds the first image entry inside it.
-// Otherwise it opens the file directly as a reader.
+// ZIP, gzip and zstd are detected by content, independently of cache filenames.
+// ZIP archives yield their first image entry; other files are raw disk images.
 func openLocalImageStream(imagePath string) (*imageStream, error) {
-	if strings.HasSuffix(strings.ToLower(imagePath), ".zip") {
+	if strings.HasSuffix(strings.ToLower(imagePath), ".zip") || isZipFile(imagePath) {
 		return streamZipImageEntry(imagePath)
 	}
 	if isGzipFile(imagePath) {

--- a/go/internal/cli/commands/root.go
+++ b/go/internal/cli/commands/root.go
@@ -251,6 +251,7 @@ func NewRootCmd() *cobra.Command {
 		// Manage
 		projectCmd,
 		deviceCmd,
+		newVMCmd(),
 		fleetCmd,
 		// Cloud
 		cloudCmd,

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -723,6 +723,11 @@ func resolveWithCloudFallback(ctx context.Context, cloudName string, opts ...res
 	if errors.Is(err, ErrUserCancelled) {
 		return nil, err
 	}
+	// The user picked a local VM. Falling back to a cloud device here would
+	// deploy their app to an entirely different machine and report success.
+	if errors.Is(err, errSimulatorUnavailable) {
+		return nil, err
+	}
 
 	cfg, loadErr := config.Load()
 	if loadErr != nil || len(cfg.Auth) == 0 {

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -1911,6 +1911,9 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 		return runMultiServiceWithAgent(ctx, conn, cwd, appCfg, opts)
 	}
 
+	if err := prepareVMAppPorts(ctx, conn, appCfg); err != nil {
+		return err
+	}
 	// Detect project type and ensure a build file exists when needed.
 	projectType, err := resolveRunProjectType(cwd, opts.buildType)
 	if err != nil {
@@ -2615,6 +2618,9 @@ func announceReachableURL(ctx context.Context, conn *grpcclient.AgentConnection,
 		return ""
 	}
 	ip := bestReachableIP(resp.GetNetworkInterfaces())
+	if name, err := userVMForConnection(conn); err == nil && name != "" {
+		ip = "127.0.0.1"
+	}
 	url := reachableAppURL(hookURL, appCfg.AppID, appCfg.ServiceName, ip, httpPort, readiness)
 	if url == "" {
 		return ""

--- a/go/internal/cli/commands/vm.go
+++ b/go/internal/cli/commands/vm.go
@@ -491,7 +491,7 @@ func runVMStop(cmd *cobra.Command, name string, force bool) error {
 	}
 	// Store.Stop makes the "still starting" refusal itself, so that `vm rm
 	// --force` gets it too rather than only this command.
-	if err := store.Stop(name, force, vmStopGrace); err != nil {
+	if err := store.StopContext(cmd.Context(), name, force, vmStopGrace); err != nil {
 		return err
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "Stopped VM %q.\n", name)

--- a/go/internal/cli/commands/vm.go
+++ b/go/internal/cli/commands/vm.go
@@ -196,9 +196,9 @@ func resolveVMSpec(name string, o vmStartOptions) (vm.Spec, *vm.Store, error) {
 			return vm.Spec{}, nil, err
 		}
 		net.AgentPort = o.hostPort
-		// Best effort: `wendy run` addresses the device registry as
-		// host:5000, so the forward only works on that exact port. A host
-		// already using it loses the registry fallback, not the VM.
+		// Keep the conventional port when available. Deployment resolves the
+		// VM's actual registry forward through QMP and allocates another port
+		// when 5000 belongs to another VM or host process.
 		if err := vm.CheckHostPort(vm.DeviceRegistryPort); err == nil {
 			net.RegistryPort = vm.DeviceRegistryPort
 		}

--- a/go/internal/cli/commands/vm.go
+++ b/go/internal/cli/commands/vm.go
@@ -1,0 +1,686 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/wendylabsinc/wendy/go/internal/cli/vm"
+)
+
+func newVMCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "vm",
+		Short: "Run WendyOS in a local ARM64 virtual machine",
+		// Hidden because the simulator is meant to be reached through
+		// `wendy run`'s Simulator tab or --device sim, not administered by
+		// hand. The subcommands stay for debugging a VM that misbehaves.
+		Hidden: true,
+		Long: "Run a WendyOS ARM64 virtual machine on this computer, so you can " +
+			"develop and evaluate WendyOS without a Jetson or Raspberry Pi.\n\n" +
+			"Requires QEMU (" + qemuInstallHint() + "); on macOS it is offered " +
+			"automatically when missing.",
+	}
+	cmd.PersistentFlags().BoolVarP(&vmAssumeYes, "yes", "y", false,
+		"Accept prompts, including installing QEMU when it is missing")
+	cmd.AddCommand(newVMCreateCmd(), newVMStartCmd(), newVMStopCmd(),
+		newVMLogsCmd(), newVMListCmd(), newVMRemoveCmd())
+	return cmd
+}
+
+func newVMCreateCmd() *cobra.Command {
+	var image, version string
+	var diskGiB, prNumber int
+	var nightly bool
+
+	cmd := &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a VM, downloading the WendyOS image if needed",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runVMCreate(cmd, args[0], image, version, diskGiB, nightly, prNumber)
+		},
+	}
+	cmd.Flags().StringVar(&image, "image", "", "Path to a local .wic disk image (default: download the published one)")
+	cmd.Flags().StringVar(&version, "version", "", "WendyOS version to download (default: latest)")
+	cmd.Flags().BoolVar(&nightly, "nightly", false, "Use nightly/prerelease builds")
+	cmd.Flags().IntVar(&prNumber, "pr", 0, "Create from a pull request's build, so a change can be tried before it merges")
+	cmd.Flags().IntVar(&diskGiB, "disk", 16, "Disk size in GiB (the image is grown to this size)")
+	return cmd
+}
+
+// runVMCreate provisions a VM from a local image when one is named, and from the
+// published image otherwise.
+func runVMCreate(cmd *cobra.Command, name, image, version string, diskGiB int, nightly bool, pr int) error {
+	return createVM(cmd.OutOrStdout(), name, image, version, diskGiB, nightly, pr)
+}
+
+// createVM provisions a VM, writing progress to out. Split from the cobra
+// command so the simulator picker can provision one without a *cobra.Command.
+func createVM(out io.Writer, name, image, version string, diskGiB int, nightly bool, pr int) error {
+	if image != "" && (version != "" || nightly || pr > 0) {
+		return fmt.Errorf("--image cannot be combined with --version, --nightly or --pr: a local image is already a specific build")
+	}
+	if pr > 0 && (version != "" || nightly) {
+		return fmt.Errorf("--pr cannot be combined with --version or --nightly: a pull request publishes exactly one build")
+	}
+	store, err := vm.NewStore()
+	if err != nil {
+		return err
+	}
+	// Before the download: fetching gigabytes only to reject the name is a long
+	// wait for an error knowable up front.
+	if err := store.CheckCreatable(name); err != nil {
+		return err
+	}
+
+	if pr > 0 {
+		// Booting an image is running it. A PR build comes from a contributor
+		// branch, so this is the one place the CLI runs code that has not been
+		// through review -- say so rather than let --pr look like --nightly.
+		cliLogln("Warning: PR %d's image is built from an unmerged branch. "+
+			"Only boot it if you trust that branch's contents.", pr)
+	}
+	path, resolvedVersion := image, ""
+	if path == "" {
+		if path, resolvedVersion, err = fetchPublishedVMImage(version, nightly, pr); err != nil {
+			return err
+		}
+	}
+
+	// Published images and cached copies are compressed; sniff rather than trust
+	// the extension, exactly as os install does for the same artifacts.
+	stream, err := openLocalImageStream(path)
+	if err != nil {
+		return err
+	}
+	defer stream.Close()
+
+	meta := vm.Meta{ImageVersion: resolvedVersion, ImageSource: vmImageSource(image, nightly, pr)}
+	if err := store.CreateFrom(name, stream, stream.uncompressedSize, int64(diskGiB)<<30, meta); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "Created VM %q. Start it with 'wendy vm start %s'.\n", name, name)
+	return nil
+}
+
+func newVMStartCmd() *cobra.Command {
+	var o vmStartOptions
+
+	cmd := &cobra.Command{
+		Use:   "start <name>",
+		Short: "Start a VM and attach to its console",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runVMStart(cmd, args[0], o)
+		},
+	}
+	cmd.Flags().StringVar(&o.netMode, "net", string(vm.NetUser),
+		"Networking: 'user' forwards the agent port and needs no setup, but "+
+			"'wendy discover' cannot see the VM; 'shared' puts it on a host-visible "+
+			"network so discover works (needs socket_vmnet)")
+	cmd.Flags().IntVar(&o.hostPort, "port", vm.DefaultAgentPort,
+		"Host port to forward to the guest agent's 50051. Only needed when "+
+			"something else already holds the default")
+	cmd.Flags().IntVar(&o.memoryMiB, "memory", vm.DefaultMemoryMiB, "Guest memory in MiB")
+	cmd.Flags().IntVar(&o.cpus, "cpus", vm.DefaultCPUs, "Guest CPU count")
+	cmd.Flags().BoolVarP(&o.detach, "detach", "d", false,
+		"Run the VM in the background instead of attaching to its console")
+	return cmd
+}
+
+// vmStartOptions are the knobs both start paths share.
+type vmStartOptions struct {
+	netMode   string
+	hostPort  int
+	memoryMiB int
+	cpus      int
+	detach    bool
+}
+
+// resolveVMSpec turns the host's capabilities and the caller's flags into a
+// launchable Spec. Shared by the foreground and detached paths so the two can
+// never diverge on acceleration, firmware or networking.
+func resolveVMSpec(name string, o vmStartOptions) (vm.Spec, *vm.Store, error) {
+	if err := vm.ValidName(name); err != nil {
+		return vm.Spec{}, nil, err
+	}
+	netMode, err := vm.ParseNetMode(o.netMode)
+	if err != nil {
+		return vm.Spec{}, nil, err
+	}
+	store, err := vm.NewStore()
+	if err != nil {
+		return vm.Spec{}, nil, err
+	}
+	if _, err := os.Stat(store.DiskPath(name)); err != nil {
+		return vm.Spec{}, nil, fmt.Errorf("no VM named %q; create one with 'wendy vm create %s'", name, name)
+	}
+	if err := ensureQEMUFn(context.Background()); err != nil {
+		return vm.Spec{}, nil, err
+	}
+
+	brew := vm.BrewPrefix()
+	firmware, err := vm.FindFirmware(runtime.GOOS, brew)
+	if err != nil {
+		return vm.Spec{}, nil, err
+	}
+
+	net := vm.NetConfig{Mode: netMode, MAC: vm.MACFor(name)}
+	if net.Mode == vm.NetShared {
+		socket, err := ensureSocketVMNet(context.Background(), runtime.GOOS, brew)
+		if err != nil {
+			return vm.Spec{}, nil, err
+		}
+		net.SocketPath = socket
+	} else {
+		// Only user mode forwards a port. Leaving AgentPort zero in shared mode
+		// keeps a loopback address that nothing listens on out of the run
+		// record, and so out of `vm list`, discovery and the simulator picker.
+		if err := vm.CheckHostPort(o.hostPort); err != nil {
+			return vm.Spec{}, nil, err
+		}
+		net.AgentPort = o.hostPort
+		// Best effort: `wendy run` addresses the device registry as
+		// host:5000, so the forward only works on that exact port. A host
+		// already using it loses the registry fallback, not the VM.
+		if err := vm.CheckHostPort(vm.DeviceRegistryPort); err == nil {
+			net.RegistryPort = vm.DeviceRegistryPort
+		}
+	}
+
+	return vm.Spec{
+		Name:         name,
+		DiskPath:     store.DiskPath(name),
+		FirmwareCode: firmware,
+		FirmwareVars: store.VarsPath(name),
+		MemoryMiB:    o.memoryMiB,
+		CPUs:         o.cpus,
+		Accel:        vm.AccelFor(runtime.GOOS, runtime.GOARCH),
+		Net:          net,
+	}, store, nil
+}
+
+// runVMStart boots a VM, either attached to this terminal or in the background.
+func runVMStart(cmd *cobra.Command, name string, o vmStartOptions) error {
+	spec, store, err := resolveVMSpec(name, o)
+	if err != nil {
+		// A running VM still holds its forwarded port, so the port check fires
+		// first and blames the port for what is really "already running". Asked
+		// only once the start has failed anyway: a liveness probe on the happy
+		// path would turn a transient reading into a start that silently does
+		// nothing.
+		if s, sErr := vm.NewStore(); sErr == nil {
+			if st, sErr := s.Status(name); sErr == nil && st.Running {
+				return fmt.Errorf("VM %q is already running; reach it with 'wendy vm logs %s' or stop it first", name, name)
+			}
+		}
+		return err
+	}
+	out := cmd.OutOrStdout()
+
+	if o.detach {
+		st, err := store.StartDetached(spec)
+		if err != nil {
+			if errors.Is(err, vm.ErrAlreadyRunning) {
+				fmt.Fprintf(out, "VM %q is already running.\n", name)
+				return nil
+			}
+			return err
+		}
+		// StartDetached returns as soon as QEMU is spawned. One that rejects its
+		// arguments or firmware is gone milliseconds later, and reporting
+		// success then sends the user off to debug a VM that never existed.
+		if err := confirmVMSurvivedStartup(store, name); err != nil {
+			return err
+		}
+		fmt.Fprintf(out, "Started %s in the background (pid %d).\n", name, st.PID)
+		vmPrintReachability(out, spec.Net, o.hostPort)
+		fmt.Fprintf(out, "Console: 'wendy vm logs %s'. Stop it with 'wendy vm stop %s'.\n", name, name)
+		return nil
+	}
+
+	fmt.Fprintf(out, "Starting %s (%s acceleration, %s networking).\n", name, spec.Accel, spec.Net.Mode)
+	vmPrintReachability(out, spec.Net, o.hostPort)
+	fmt.Fprintln(out, "Press Ctrl-A then X to power it off.")
+
+	// Hand the terminal to QEMU: the guest console is the point of `vm start`.
+	err = store.RunForeground(cmd.Context(), spec, os.Stdin, out, cmd.ErrOrStderr())
+	if errors.Is(err, vm.ErrAlreadyRunning) {
+		return fmt.Errorf("VM %q is already running; reach it with 'wendy vm logs %s' or stop it first", name, name)
+	}
+	return err
+}
+
+// vmStartupSettleTime is how long a detached start waits before believing the
+// emulator is up. QEMU rejects a bad spec and exits well inside this.
+const vmStartupSettleTime = 400 * time.Millisecond
+
+// confirmVMSurvivedStartup reports an emulator that exited immediately after
+// launch, quoting the console so the reason is in the error rather than in a
+// log the user has not thought to read yet.
+func confirmVMSurvivedStartup(store *vm.Store, name string) error {
+	time.Sleep(vmStartupSettleTime)
+	st, err := store.Status(name)
+	if err != nil || st.Running {
+		return nil
+	}
+	return fmt.Errorf("VM %q exited immediately after starting%s", name, vmConsoleTail(name))
+}
+
+// vmConsoleTail returns the last few console lines, to append to a boot
+// failure. Best-effort: a missing log just means there is nothing to add.
+func vmConsoleTail(name string) string {
+	store, err := vm.NewStore()
+	if err != nil {
+		return ""
+	}
+	data, err := readFileTail(store.LogPath(name), consoleTailBytes)
+	if err != nil {
+		return ""
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) > vmConsoleTailLines {
+		lines = lines[len(lines)-vmConsoleTailLines:]
+	}
+	for i, l := range lines {
+		lines[i] = sanitizeConsoleLine(l)
+	}
+	return fmt.Sprintf("\nlast console output (%s):\n  %s",
+		store.LogPath(name), strings.Join(lines, "\n  "))
+}
+
+// readFileTail returns at most n bytes from the end of path.
+func readFileTail(path string, n int64) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if info.Size() > n {
+		if _, err := f.Seek(-n, io.SeekEnd); err != nil {
+			return nil, err
+		}
+	}
+	return io.ReadAll(io.LimitReader(f, n))
+}
+
+// sanitizeConsoleLine strips control characters before guest output reaches the
+// terminal. The console is whatever the guest chose to print, and an escape
+// sequence in it would otherwise be executed by the user's terminal rather than
+// shown -- repositioning the cursor or rewriting what is already on screen.
+func sanitizeConsoleLine(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\t' {
+			return r
+		}
+		// C0 and C1 both: 0x9b and 0x9d are the 8-bit CSI and OSC introducers,
+		// so stripping only the 7-bit ESC form leaves the same door open.
+		if r < 0x20 || (r >= 0x7f && r <= 0x9f) {
+			return -1
+		}
+		return r
+	}, s)
+}
+
+// consoleTailBytes bounds the read. A console log grows for the life of the VM,
+// and only the last few lines are ever shown.
+const consoleTailBytes = 8 << 10
+
+const vmConsoleTailLines = 15
+
+// vmPrintReachability says how to reach the guest, which differs by net mode.
+func vmPrintReachability(out io.Writer, net vm.NetConfig, hostPort int) {
+	if net.SupportsDiscovery() {
+		fmt.Fprintln(out, "Once it boots, find it with 'wendy discover'.")
+		return
+	}
+	fmt.Fprintf(out, "Once it boots, reach it with 'wendy --device 127.0.0.1:%d device info', "+
+		"or pick it out of 'wendy discover'.\n", hostPort)
+	fmt.Fprintln(out, "It is not on your network, though: user-mode networking carries no mDNS, "+
+		"so no other machine can see it. Use --net shared for that.")
+}
+
+// ensureQEMUFn resolves the emulator, prompting to install it where that is
+// possible. A package var so both start paths share one message and tests can
+// describe a host without QEMU.
+var ensureQEMUFn = func(ctx context.Context) error {
+	return ensureQEMUForHostOS(ctx, runtime.GOOS)
+}
+
+// qemuLookPathFn resolves the emulator binary; indirected so tests can describe
+// a host that does not have it.
+var qemuLookPathFn = exec.LookPath
+
+func newVMListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List local VMs",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store, err := vm.NewStore()
+			if err != nil {
+				return err
+			}
+			statuses, err := store.Statuses()
+			if err != nil {
+				return err
+			}
+			if jsonOutput {
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(vmListJSON(statuses))
+			}
+			if len(statuses) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No VMs. Create one with 'wendy vm create <name>'.")
+				return nil
+			}
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+			fmt.Fprintln(w, "NAME\tSTATE\tADDRESS\tVERSION")
+			for _, st := range statuses {
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+					st.Name, vmStateLabel(st), firstNonEmpty(vmAddress(st), "-"),
+					firstNonEmpty(st.Meta.ImageVersion, "-"))
+			}
+			return w.Flush()
+		},
+	}
+}
+
+// vmStateLabel distinguishes a VM that is booting from one that is up: the run
+// lock is taken before the emulator has a pid, and a reader must not mistake
+// that window for a stale record.
+func vmStateLabel(st vm.Status) string {
+	switch {
+	case !st.Running:
+		return "stopped"
+	case st.State.PID == 0:
+		return "starting"
+	default:
+		return "running"
+	}
+}
+
+// vmAddress is where the guest agent answers, which only user-mode VMs forward.
+// vmAddress returns the forwarded agent address, or empty when the VM has
+// none. Empty rather than a display dash: both callers that treat it as data
+// had to recognise and undo the dash first.
+func vmAddress(st vm.Status) string {
+	if !st.Running || st.State.AgentPort == 0 {
+		return ""
+	}
+	return fmt.Sprintf("127.0.0.1:%d", st.State.AgentPort)
+}
+
+type vmListEntry struct {
+	Name    string `json:"name"`
+	State   string `json:"state"`
+	Address string `json:"address,omitempty"`
+	Version string `json:"version,omitempty"`
+	Source  string `json:"source,omitempty"`
+	PID     int    `json:"pid,omitempty"`
+}
+
+func vmListJSON(statuses []vm.Status) []vmListEntry {
+	out := make([]vmListEntry, 0, len(statuses))
+	for _, st := range statuses {
+		e := vmListEntry{
+			Name:    st.Name,
+			State:   vmStateLabel(st),
+			Version: st.Meta.ImageVersion,
+			Source:  st.Meta.ImageSource,
+			PID:     st.State.PID,
+		}
+		if addr := vmAddress(st); addr != "" {
+			e.Address = addr
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+func newVMStopCmd() *cobra.Command {
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "stop <name>",
+		Short: "Stop a VM running in the background",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runVMStop(cmd, args[0], force)
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false, "Kill the VM instead of asking it to power off")
+	return cmd
+}
+
+// vmStopGrace is how long a VM gets to shut down cleanly before being killed.
+// The guest flushes its filesystems in that window, so it is worth waiting.
+const vmStopGrace = 20 * time.Second
+
+func runVMStop(cmd *cobra.Command, name string, force bool) error {
+	store, err := vm.NewStore()
+	if err != nil {
+		return err
+	}
+	st, err := store.Status(name)
+	if err != nil {
+		return err
+	}
+	if !st.Exists {
+		return fmt.Errorf("no VM named %q", name)
+	}
+	if !st.Running {
+		fmt.Fprintf(cmd.OutOrStdout(), "VM %q is not running.\n", name)
+		return nil
+	}
+	// Store.Stop makes the "still starting" refusal itself, so that `vm rm
+	// --force` gets it too rather than only this command.
+	if err := store.Stop(name, force, vmStopGrace); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Stopped VM %q.\n", name)
+	return nil
+}
+
+func newVMLogsCmd() *cobra.Command {
+	var follow bool
+	cmd := &cobra.Command{
+		Use:   "logs <name>",
+		Short: "Show a backgrounded VM's console output",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store, err := vm.NewStore()
+			if err != nil {
+				return err
+			}
+			if err := vm.ValidName(args[0]); err != nil {
+				return err
+			}
+			return streamFile(cmd.Context(), cmd.OutOrStdout(), store.LogPath(args[0]), follow)
+		},
+	}
+	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "Keep printing as the guest writes")
+	return cmd
+}
+
+// streamFile copies path to out, optionally waiting for more. Written against
+// the file rather than tailing a pipe because a detached VM's console is a
+// plain file that outlives any particular CLI invocation.
+func streamFile(ctx context.Context, out io.Writer, path string, follow bool) error {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("no console log yet; start the VM with 'wendy vm start -d'")
+		}
+		return err
+	}
+	// Closes whichever handle is current: a rotation below replaces f, and a
+	// plain `defer f.Close()` would bind the original -- double-closing it and
+	// leaking the replacement.
+	defer func() { f.Close() }()
+
+	for {
+		if _, err := io.Copy(out, f); err != nil {
+			return err
+		}
+		if !follow {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(300 * time.Millisecond):
+		}
+		// A restart renames console.log to console.log.prev and starts a new
+		// one. Following the inode we opened would tail the file nobody writes
+		// to any more, which looks exactly like a VM that stopped logging.
+		if next, err := reopenIfReplaced(f, path); err == nil && next != nil {
+			f.Close()
+			f = next
+		}
+	}
+}
+
+// reopenIfReplaced returns a handle on path when it is no longer the file f
+// refers to, or nil when it is unchanged or momentarily absent.
+func reopenIfReplaced(f *os.File, path string) (*os.File, error) {
+	open, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	onDisk, err := os.Stat(path)
+	if err != nil || os.SameFile(open, onDisk) {
+		return nil, err
+	}
+	return os.Open(path)
+}
+
+func newVMRemoveCmd() *cobra.Command {
+	var force bool
+	cmd := &cobra.Command{
+		Use:     "rm <name>",
+		Short:   "Delete a VM and its disk",
+		Args:    cobra.ExactArgs(1),
+		Aliases: []string{"remove"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			store, err := vm.NewStore()
+			if err != nil {
+				return err
+			}
+			st, err := store.Status(name)
+			if err != nil {
+				return err
+			}
+			// Store.Remove refuses a running VM on its own; stopping first is
+			// what --force means, and turns its lock error into a clear one.
+			if st.Running {
+				if !force {
+					return fmt.Errorf("VM %q is running; stop it first or pass --force", name)
+				}
+				if err := store.Stop(name, true, vmStopGrace); err != nil {
+					return err
+				}
+			}
+			if err := store.Remove(name); err != nil {
+				if errors.Is(err, vm.ErrAlreadyRunning) {
+					return fmt.Errorf("VM %q started while it was being removed; stop it and retry", name)
+				}
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Deleted VM %q.\n", name)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false, "Stop the VM first if it is running")
+	return cmd
+}
+
+// The VM's manifest key is its WENDYOS_BOARD_ID, the same string the image
+// bakes into /etc/wendyos/device-type. Every board is keyed that way, so this
+// is not a name to choose freely.
+const (
+	vmDeviceKey  = "vm-arm64"
+	vmStorageKey = "disk"
+)
+
+// fetchPublishedVMImage resolves the published VM image, downloading it if the
+// cache does not already hold it. It returns the local path and the version tag
+// it resolved to, which the caller records so a stopped VM still knows what it
+// is running.
+func fetchPublishedVMImage(version string, nightly bool, pr int) (string, string, error) {
+	fetchMain := fetchMainManifest
+	if pr > 0 {
+		fetchMain = func() (*mainManifest, error) { return fetchPRMainManifest(pr) }
+	}
+	mm, err := fetchMain()
+	if err != nil {
+		return "", "", err
+	}
+	dev, ok := mm.Devices[vmDeviceKey]
+	if !ok {
+		if pr > 0 {
+			return "", "", fmt.Errorf("PR %d published no %s image; check the build finished for that device", pr, vmDeviceKey)
+		}
+		return "", "", fmt.Errorf("no published %s image yet; build one and pass --image", vmDeviceKey)
+	}
+
+	// PR entries are always published as nightlies, so their tag lives in
+	// LatestNightly.
+	ver := version
+	if pr > 0 {
+		ver = prDeviceVersion(dev)
+	} else if ver == "" {
+		ver = dev.Latest
+		if nightly && dev.LatestNightly != "" {
+			ver = dev.LatestNightly
+		}
+	}
+	if ver == "" {
+		return "", "", fmt.Errorf("no %s release published yet; retry with --nightly, or build one and pass --image", vmDeviceKey)
+	}
+
+	dm, err := fetchDeviceManifest(dev.ManifestPath)
+	if err != nil {
+		return "", "", err
+	}
+	info, err := getImageInfo(dm, ver, vmStorageKey)
+	if err != nil {
+		return "", "", err
+	}
+
+	// Prefer the seekable artifact: far smaller over the wire, and
+	// resolveSeekableZst already caches it.
+	if info.ZstURL != "" {
+		path, err := resolveSeekableZst(vmDeviceKey, ver, vmStorageKey, info.ZstURL)
+		return path, ver, err
+	}
+	path, err := resolveOSImage(vmDeviceKey, info)
+	return path, ver, err
+}
+
+// vmImageSource names where a VM's image came from, for the record kept beside
+// the disk. Only the channel, not the URL: a PR or nightly build is replaced in
+// place, so a stored URL would outlive the bytes it named.
+func vmImageSource(image string, nightly bool, pr int) string {
+	switch {
+	case image != "":
+		return "local"
+	case pr > 0:
+		return fmt.Sprintf("pr/%d", pr)
+	case nightly:
+		return "nightly"
+	default:
+		return "release"
+	}
+}

--- a/go/internal/cli/commands/vm.go
+++ b/go/internal/cli/commands/vm.go
@@ -92,9 +92,11 @@ func createVM(out io.Writer, name, image, version string, diskGiB int, nightly b
 	}
 	path, resolvedVersion := image, ""
 	if path == "" {
-		if path, resolvedVersion, err = fetchPublishedVMImage(version, nightly, pr); err != nil {
+		var cleanup func()
+		if path, resolvedVersion, cleanup, err = fetchPublishedVMImage(version, nightly, pr); err != nil {
 			return err
 		}
+		defer cleanup()
 	}
 
 	// Published images and cached copies are compressed; sniff rather than trust
@@ -618,21 +620,21 @@ const (
 // cache does not already hold it. It returns the local path and the version tag
 // it resolved to, which the caller records so a stopped VM still knows what it
 // is running.
-func fetchPublishedVMImage(version string, nightly bool, pr int) (string, string, error) {
+func fetchPublishedVMImage(version string, nightly bool, pr int) (string, string, func(), error) {
 	fetchMain := fetchMainManifest
 	if pr > 0 {
 		fetchMain = func() (*mainManifest, error) { return fetchPRMainManifest(pr) }
 	}
 	mm, err := fetchMain()
 	if err != nil {
-		return "", "", err
+		return "", "", nil, err
 	}
 	dev, ok := mm.Devices[vmDeviceKey]
 	if !ok {
 		if pr > 0 {
-			return "", "", fmt.Errorf("PR %d published no %s image; check the build finished for that device", pr, vmDeviceKey)
+			return "", "", nil, fmt.Errorf("PR %d published no %s image; check the build finished for that device", pr, vmDeviceKey)
 		}
-		return "", "", fmt.Errorf("no published %s image yet; build one and pass --image", vmDeviceKey)
+		return "", "", nil, fmt.Errorf("no published %s image yet; build one and pass --image", vmDeviceKey)
 	}
 
 	// PR entries are always published as nightlies, so their tag lives in
@@ -647,26 +649,20 @@ func fetchPublishedVMImage(version string, nightly bool, pr int) (string, string
 		}
 	}
 	if ver == "" {
-		return "", "", fmt.Errorf("no %s release published yet; retry with --nightly, or build one and pass --image", vmDeviceKey)
+		return "", "", nil, fmt.Errorf("no %s release published yet; retry with --nightly, or build one and pass --image", vmDeviceKey)
 	}
 
 	dm, err := fetchDeviceManifest(dev.ManifestPath)
 	if err != nil {
-		return "", "", err
+		return "", "", nil, err
 	}
 	info, err := getImageInfo(dm, ver, vmStorageKey)
 	if err != nil {
-		return "", "", err
+		return "", "", nil, err
 	}
 
-	// Prefer the seekable artifact: far smaller over the wire, and
-	// resolveSeekableZst already caches it.
-	if info.ZstURL != "" {
-		path, err := resolveSeekableZst(vmDeviceKey, ver, vmStorageKey, info.ZstURL)
-		return path, ver, err
-	}
-	path, err := resolveOSImage(vmDeviceKey, info)
-	return path, ver, err
+	path, cleanup, err := resolveVMImage(info)
+	return path, ver, cleanup, err
 }
 
 // vmImageSource names where a VM's image came from, for the record kept beside

--- a/go/internal/cli/commands/vm.go
+++ b/go/internal/cli/commands/vm.go
@@ -463,9 +463,9 @@ func newVMStopCmd() *cobra.Command {
 	return cmd
 }
 
-// vmStopGrace is how long a VM gets to shut down cleanly before being killed.
-// The guest flushes its filesystems in that window, so it is worth waiting.
-const vmStopGrace = 20 * time.Second
+// Allow systemd's normal service-stop timeout and filesystem flushing. Timing
+// out leaves the guest running; power cuts require an explicit --force.
+const vmStopGrace = 120 * time.Second
 
 func runVMStop(cmd *cobra.Command, name string, force bool) error {
 	store, err := vm.NewStore()

--- a/go/internal/cli/commands/vm.go
+++ b/go/internal/cli/commands/vm.go
@@ -177,7 +177,11 @@ func resolveVMSpec(name string, o vmStartOptions) (vm.Spec, *vm.Store, error) {
 		return vm.Spec{}, nil, err
 	}
 
-	net := vm.NetConfig{Mode: netMode, MAC: vm.MACFor(name)}
+	mac, err := store.MACAddress(name)
+	if err != nil {
+		return vm.Spec{}, nil, err
+	}
+	net := vm.NetConfig{Mode: netMode, MAC: mac}
 	if net.Mode == vm.NetShared {
 		socket, err := ensureSocketVMNet(context.Background(), runtime.GOOS, brew)
 		if err != nil {

--- a/go/internal/cli/commands/vm_discover.go
+++ b/go/internal/cli/commands/vm_discover.go
@@ -78,10 +78,12 @@ func probeLocalVMDevices(ctx context.Context) []models.LANDevice {
 			if !anyAgentPortAnswers(pctx, hostAddrFor) {
 				return
 			}
-			isMTLS, resp, err := getAgentVersionAtAddress(pctx, hostAddrFor(defaultAgentPort))
+			conn, resp, err := probeSimulatorAgent(pctx, c.name, hostAddrFor(defaultAgentPort))
 			if err != nil || resp == nil {
 				return
 			}
+			defer conn.Close()
+			isMTLS := conn.IsMTLS
 			advertisedPort := c.port
 			if isMTLS {
 				advertisedPort += agentMTLSPortOffset

--- a/go/internal/cli/commands/vm_discover.go
+++ b/go/internal/cli/commands/vm_discover.go
@@ -1,0 +1,154 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/vm"
+	"github.com/wendylabsinc/wendy/go/internal/shared/discovery"
+	"github.com/wendylabsinc/wendy/go/internal/shared/models"
+)
+
+// vmDeviceIDPrefix marks a discovery row as a local VM rather than a device on
+// the network. Dotless, so resolveTargetInner still treats it as a provider-ish
+// key rather than an address.
+const vmDeviceIDPrefix = "vm:"
+
+// vmProbeBudget bounds the whole sweep, matching usbDirectProbeBudget's role
+// for the USB probe.
+const vmProbeBudget = 8 * time.Second
+
+// vmStatusesFn reports what the local VM store holds. A seam so tests can
+// describe a set of VMs directly, rather than having to hold a real run lock
+// to make one look running.
+var vmStatusesFn = func() ([]vm.Status, error) {
+	store, err := vm.NewStore()
+	if err != nil {
+		return nil, err
+	}
+	return store.Statuses()
+}
+
+// probeLocalVMDevices returns a row for every running user-mode VM whose agent
+// answers on its forwarded loopback port.
+//
+// Shared-mode VMs are skipped: mDNS already finds them, so a row here would
+// list them twice. User-mode VMs are the ones discovery can never see, because
+// SLIRP carries no multicast.
+func probeLocalVMDevices(ctx context.Context) []models.LANDevice {
+	statuses, err := vmStatusesFn()
+	if err != nil {
+		return nil
+	}
+
+	type candidate struct {
+		name string
+		port int
+	}
+	var candidates []candidate
+	for _, st := range statuses {
+		if st.Running && st.State.NetMode == vm.NetUser && st.State.AgentPort != 0 {
+			candidates = append(candidates, candidate{st.Name, st.State.AgentPort})
+		}
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	// Bounded like the USB probe: a QEMU forward accepts on the host before it
+	// checks the guest, so a booting VM passes the connect gate and reaches the
+	// full auto-TLS ladder. Without a budget discovery would block on it.
+	pctx, cancel := context.WithTimeout(ctx, vmProbeBudget)
+	defer cancel()
+
+	results := make([]*models.LANDevice, len(candidates))
+	var wg sync.WaitGroup
+	for i, c := range candidates {
+		wg.Add(1)
+		go func(i int, c candidate) {
+			defer wg.Done()
+			// The forward maps host c.port onto the guest's plaintext port and
+			// c.port+1 onto its mTLS port, so a guest port shifts by the same
+			// delta to reach the host side.
+			hostAddrFor := func(guestPort int) string {
+				return fmt.Sprintf("127.0.0.1:%d", c.port+guestPort-defaultAgentPort)
+			}
+			if !anyAgentPortAnswers(pctx, hostAddrFor) {
+				return
+			}
+			isMTLS, resp, err := getAgentVersionAtAddress(pctx, hostAddrFor(defaultAgentPort))
+			if err != nil || resp == nil {
+				return
+			}
+			advertisedPort := c.port
+			if isMTLS {
+				advertisedPort += agentMTLSPortOffset
+			}
+			results[i] = &models.LANDevice{
+				ID:          vmDeviceIDPrefix + c.name,
+				DisplayName: c.name,
+				// Hostname stays empty on purpose. Every VM booted from the
+				// same image reports the same guest hostname, and the dedup key
+				// prefers the hostname -- two VMs would collapse into one row.
+				IPAddress: "127.0.0.1",
+				// A provisioned agent advertises its mTLS port; lanAgentAddresses
+				// subtracts the offset back off to recover what to dial.
+				Port:            advertisedPort,
+				IsMTLS:          isMTLS,
+				InterfaceType:   string(models.InterfaceLAN),
+				IsWendyDevice:   true,
+				AgentVersion:    resp.GetVersion(),
+				OS:              resp.GetOs(),
+				OSVersion:       resp.GetOsVersion(),
+				CPUArchitecture: resp.GetCpuArchitecture(),
+				DeviceType:      resp.GetDeviceType(),
+			}
+		}(i, c)
+	}
+	wg.Wait()
+
+	var out []models.LANDevice
+	for _, r := range results {
+		if r != nil {
+			out = append(out, *r)
+		}
+	}
+	return out
+}
+
+// discoverLocalTargets runs ordinary discovery plus the sources that only this
+// machine can see: USB-direct links and local VMs.
+// The launcher forwards a span of host ports starting at its own default, and
+// that span has to cover the port provisioning moves the agent to -- otherwise
+// a provisioned VM silently goes unreachable. The constants live in two
+// packages, so this is what keeps them honest: a mismatch fails to compile.
+var (
+	_ = [1]struct{}{}[defaultAgentPort-vm.DefaultAgentPort]
+	_ = [1]struct{}{}[vm.AgentPortSpan-(agentMTLSPortOffset+1)]
+)
+
+func discoverLocalTargets(ctx context.Context, opts discovery.DiscoveryOptions) (*models.DevicesCollection, error) {
+	var vms []models.LANDevice
+	var wg sync.WaitGroup
+	// Same filter as the USB-direct probe: both synthesise LAN-type rows, so
+	// both run exactly when LAN discovery would.
+	if shouldProbeUSBDirect(opts) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			vms = probeLocalVMDevices(ctx)
+		}()
+	}
+	collection, err := discoverWithUSBDirect(ctx, opts)
+	wg.Wait()
+	if collection == nil {
+		collection = &models.DevicesCollection{}
+	}
+	// Merged in even when LAN discovery failed, so the rows are there for a
+	// caller that renders a partial result. Both of today's callers surface
+	// the error instead, which is why the error is still returned.
+	collection.LANDevices = append(collection.LANDevices, vms...)
+	return collection, err
+}

--- a/go/internal/cli/commands/vm_discover_test.go
+++ b/go/internal/cli/commands/vm_discover_test.go
@@ -1,0 +1,100 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/vm"
+)
+
+// stubVMStatuses describes the local VM store for the discovery probe.
+func stubVMStatuses(t *testing.T, statuses ...vm.Status) {
+	t.Helper()
+	saved := vmStatusesFn
+	vmStatusesFn = func() ([]vm.Status, error) { return statuses, nil }
+	t.Cleanup(func() { vmStatusesFn = saved })
+}
+
+func runningVM(name string, mode vm.NetMode, port int) vm.Status {
+	return vm.Status{
+		Name:    name,
+		Exists:  true,
+		Running: true,
+		State:   vm.State{Name: name, PID: 1234, AgentPort: port, NetMode: mode},
+	}
+}
+
+func TestProbeSkipsStoppedVMs(t *testing.T) {
+	stubVMStatuses(t, vm.Status{Name: "stopped", Exists: true})
+
+	if got := probeLocalVMDevices(context.Background()); len(got) != 0 {
+		t.Errorf("probeLocalVMDevices() = %+v, want none for a stopped VM", got)
+	}
+}
+
+func TestProbeSkipsSharedModeVMs(t *testing.T) {
+	// A shared-mode VM is on a real segment where mDNS already finds it;
+	// synthesising a row would list it twice.
+	stubVMStatuses(t, runningVM("shared", vm.NetShared, 0))
+
+	if got := probeLocalVMDevices(context.Background()); len(got) != 0 {
+		t.Errorf("probeLocalVMDevices() = %+v, want none for a shared-mode VM", got)
+	}
+}
+
+func TestProbeSkipsAVMWhoseAgentDoesNotAnswer(t *testing.T) {
+	// Nothing is listening on this port, so the pre-dial gate rejects it.
+	stubVMStatuses(t, runningVM("booting", vm.NetUser, 59999))
+
+	if got := probeLocalVMDevices(context.Background()); len(got) != 0 {
+		t.Errorf("probeLocalVMDevices() = %+v, want none while the agent is down", got)
+	}
+}
+
+func TestVMRowLeavesHostnameEmptySoTwoVMsStayDistinct(t *testing.T) {
+	// Every VM from the same image reports the same guest hostname, and the
+	// dedup key prefers hostname over display name -- so a populated Hostname
+	// would collapse two VMs into one row.
+	// Empty host key (what the probe sets), distinct display names.
+	one := deviceDedupKey("", "one")
+	two := deviceDedupKey("", "two")
+	if one == two {
+		t.Errorf("two VMs share the dedup key %q", one)
+	}
+	// And the failure mode being guarded against: a shared guest hostname.
+	if deviceDedupKey("wendyos.local", "one") != deviceDedupKey("wendyos.local", "two") {
+		t.Error("expected a shared hostname to collapse rows; the guard is why Hostname stays empty")
+	}
+}
+
+func TestProbeSurvivesAStoreItCannotRead(t *testing.T) {
+	saved := vmStatusesFn
+	vmStatusesFn = func() ([]vm.Status, error) { return nil, errors.New("permission denied") }
+	t.Cleanup(func() { vmStatusesFn = saved })
+
+	if got := probeLocalVMDevices(context.Background()); got != nil {
+		t.Errorf("probeLocalVMDevices() = %+v, want nil when the store is unreadable", got)
+	}
+}
+
+func TestVMBoardsHaveHumanReadableDeviceTypes(t *testing.T) {
+	// Without an entry the discover table shows the raw board id from
+	// /etc/wendyos/device-type.
+	for _, board := range []string{"vm-arm64", "vm-x86-64"} {
+		if got := humanReadableDeviceType(board); got == board {
+			t.Errorf("%s has no display name in deviceTypeNames", board)
+		}
+	}
+}
+
+func TestVMDeviceKeyMatchesThePublishedBoardID(t *testing.T) {
+	// The key is the image's WENDYOS_BOARD_ID, not a name chosen here: it is
+	// what the Builder publishes under and what the guest reports.
+	if vmDeviceKey != "vm-arm64" {
+		t.Errorf("vmDeviceKey = %q, want the published board id vm-arm64", vmDeviceKey)
+	}
+	if got := humanReadableDeviceType(vmDeviceKey); got == vmDeviceKey {
+		t.Errorf("the VM board %q the CLI downloads has no display name", vmDeviceKey)
+	}
+}

--- a/go/internal/cli/commands/vm_ensure.go
+++ b/go/internal/cli/commands/vm_ensure.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/go/internal/cli/vm"
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
 
 // errSimulatorUnavailable marks a failure to bring up the selected simulator.
@@ -124,37 +125,72 @@ func ensureSimulatorRunning(ctx context.Context, name string) (addr string, star
 // Readiness is a completed GetAgentVersion, not a dial: gRPC connects lazily,
 // so dialling a still-booting guest succeeds and fails only on the first call.
 func waitForSimulatorAgent(ctx context.Context, name, addr string, budget time.Duration) (*grpcclient.AgentConnection, error) {
-	if err := waitForSimulatorReady(ctx, name, addr, budget); err != nil {
-		return nil, err
-	}
-	return connectWithAutoTLS(ctx, addr)
-}
-
-// waitForSimulatorReady blocks until a GetAgentVersion completes or the budget
-// expires.
-func waitForSimulatorReady(ctx context.Context, name, addr string, budget time.Duration) error {
 	deadline := time.Now().Add(budget)
+	waitCtx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
 	for {
 		if err := ctx.Err(); err != nil {
-			return err
+			return nil, err
 		}
-		if _, resp, err := getAgentVersionAtAddress(ctx, addr); err == nil && resp != nil {
-			return nil
+		conn, _, err := connectSimulatorAgent(waitCtx, name, addr)
+		if err == nil {
+			return conn, nil
+		}
+		if blocksUnauthenticatedFallback(err) {
+			return nil, err
 		}
 		// Under emulation the budget is five minutes. Without this, a guest that
 		// died on its first instruction is waited out in full.
 		if !simulatorStillRunning(name) {
-			return fmt.Errorf("VM %q stopped while waiting for its agent", name)
+			return nil, fmt.Errorf("VM %q stopped while waiting for its agent", name)
 		}
 		if time.Now().After(deadline) {
-			return fmt.Errorf("the simulator did not answer on %s within %s", addr, budget)
+			return nil, fmt.Errorf("the simulator did not answer on %s within %s: %w", addr, budget, err)
 		}
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return nil, ctx.Err()
 		case <-time.After(2 * time.Second):
 		}
 	}
+}
+
+// VM aliases carry identity separately from their current loopback port. Never
+// consult a localhost pin or session cached for an unrelated VM/container.
+func connectSimulatorAgent(ctx context.Context, name, addr string) (*grpcclient.AgentConnection, *agentpb.GetAgentVersionResponse, error) {
+	conn, resp, err := probeSimulatorAgent(ctx, name, addr)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := enforceDevicePin(vmDeviceIDPrefix+name, conn); err != nil {
+		conn.Close()
+		return nil, nil, err
+	}
+	return conn, resp, nil
+}
+
+// Discovery honors existing pins through the ladder, but does not enroll a
+// merely-listed VM into the user's device-pin config as a side effect of scan.
+func probeSimulatorAgent(ctx context.Context, name, addr string) (*grpcclient.AgentConnection, *agentpb.GetAgentVersionResponse, error) {
+	key := vmDeviceIDPrefix + name
+	conn, _, err := dialAgentLadderFn(ctx, newDialTarget(key, addr))
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := conn.AgentService.GetAgentVersion(ctx, &agentpb.GetAgentVersionRequest{})
+	if err != nil {
+		conn.Close()
+		return nil, nil, err
+	}
+	return conn, resp, nil
+}
+
+func waitForSimulatorReady(ctx context.Context, name, addr string, budget time.Duration) error {
+	conn, err := waitForSimulatorAgent(ctx, name, addr, budget)
+	if err == nil {
+		conn.Close()
+	}
+	return err
 }
 
 // simulatorStillRunning reports whether name is up. A store it cannot read
@@ -179,6 +215,8 @@ func simulatorStillRunning(name string) bool {
 //
 // Runs AFTER the picker's tea.Program exits: creating a VM shows downloadImage's
 // own progress program, and two Bubble Tea programs cannot share a terminal.
+var connectSimulatorChoiceFn = connectSimulatorChoice
+
 func connectSimulatorChoice(ctx context.Context, choice *simulatorChoice, suppressUpdateCheck bool) (*SelectedDevice, error) {
 	if choice == nil {
 		return nil, fmt.Errorf("no simulator selected")
@@ -205,10 +243,7 @@ func connectSimulatorChoice(ctx context.Context, choice *simulatorChoice, suppre
 		return nil, err
 	}
 
-	// PinKey stays empty: every VM answers on 127.0.0.1, so pinning by address
-	// would file them all under one key and make one VM fail another's pin. The
-	// cloud path leaves it empty for the same reason.
-	picked := &SelectedDevice{Agent: conn}
+	picked := &SelectedDevice{Agent: conn, PinKey: vmDeviceIDPrefix + choice.Name}
 	if !suppressUpdateCheck {
 		picked.Agent, err = checkAndOfferUpdateFn(ctx, picked.Agent)
 		if err != nil {
@@ -307,6 +342,21 @@ var simulatorAliases = map[string]bool{"sim": true, "simulator": true}
 // address that VM's agent is forwarded to, starting it if it is not running.
 // matched is false for anything that does not name a VM, which is left alone.
 func resolveVMAlias(ctx context.Context, device string) (addr string, matched bool, err error) {
+	name, matched, err := simulatorName(device)
+	if err != nil || !matched {
+		return "", matched, err
+	}
+	addr, started, err := ensureSimulatorRunning(ctx, name)
+	if err != nil {
+		return "", false, markSimulatorUnavailable(err)
+	}
+	if err := awaitSimulatorReady(ctx, name, addr, started); err != nil {
+		return "", false, err
+	}
+	return addr, true, nil
+}
+
+func simulatorName(device string) (string, bool, error) {
 	name := ""
 	switch {
 	case simulatorAliases[device]:
@@ -321,15 +371,5 @@ func resolveVMAlias(ctx context.Context, device string) (addr string, matched bo
 		// name by deploying to a cloud device instead.
 		return "", false, fmt.Errorf("%w: %w", errSimulatorUnavailable, err)
 	}
-	addr, started, err := ensureSimulatorRunning(ctx, name)
-	if err != nil {
-		return "", false, markSimulatorUnavailable(err)
-	}
-	// Wait here rather than letting the caller dial a guest that is still
-	// booting: the ordinary ladder would report the VM unreachable seconds
-	// after we deliberately started it.
-	if err := awaitSimulatorReady(ctx, name, addr, started); err != nil {
-		return "", false, err
-	}
-	return addr, true, nil
+	return name, true, nil
 }

--- a/go/internal/cli/commands/vm_ensure.go
+++ b/go/internal/cli/commands/vm_ensure.go
@@ -1,0 +1,335 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/cli/vm"
+)
+
+// errSimulatorUnavailable marks a failure to bring up the selected simulator.
+// resolveWithCloudFallback must not answer it with a cloud tunnel: the user
+// named a local VM, and quietly deploying to a cloud device instead would land
+// the app on an entirely different machine.
+var errSimulatorUnavailable = errors.New("simulator unavailable")
+
+// markSimulatorUnavailable tags err so resolveWithCloudFallback will not answer
+// it by deploying to a cloud device -- without stacking a second copy of the
+// prefix onto an error that already carries one.
+func markSimulatorUnavailable(err error) error {
+	if errors.Is(err, errSimulatorUnavailable) {
+		return err
+	}
+	return fmt.Errorf("%w: %w", errSimulatorUnavailable, err)
+}
+
+// simulatorPortSearchTries bounds the scan for a free forward. Eight spans is
+// enough to step past a busy development machine without hunting forever.
+const simulatorPortSearchTries = 8
+
+// simulatorBootTimeout scales the wait with the host's acceleration: an ARM64
+// host runs the guest natively, while anything else emulates every instruction
+// and a cold WendyOS boot takes minutes rather than seconds.
+func simulatorBootTimeout() time.Duration {
+	if vm.AccelFor(runtime.GOOS, runtime.GOARCH) == vm.AccelTCG {
+		return 5 * time.Minute
+	}
+	return 90 * time.Second
+}
+
+// ensureSimulatorRunning brings name to a running state and returns the address
+// its agent is forwarded to, plus whether this call is what started it.
+//
+// Starting a VM only gets QEMU running; the guest still has to boot, so a
+// caller must wait for the agent before dialling.
+func ensureSimulatorRunning(ctx context.Context, name string) (addr string, started bool, err error) {
+	store, err := vm.NewStore()
+	if err != nil {
+		return "", false, err
+	}
+	st, err := store.Status(name)
+	if err != nil {
+		return "", false, err
+	}
+	if st.Running {
+		if st.State.AgentPort != 0 {
+			return fmt.Sprintf("127.0.0.1:%d", st.State.AgentPort), false, nil
+		}
+		// Running with no forwarded port: either shared networking, which has no
+		// loopback address at all, or a run that has not recorded one yet.
+		// Restarting it would only fail on the lock it already holds.
+		if st.State.NetMode == vm.NetShared {
+			return "", false, fmt.Errorf("%w: %s uses shared networking, so it has no loopback address; "+
+				"find it with 'wendy discover'", errSimulatorUnavailable, name)
+		}
+		return "", false, fmt.Errorf("VM %q is starting; retry in a moment", name)
+	}
+
+	if !st.Exists {
+		// Ahead of the port scan below, which costs a bind and a close per
+		// candidate and would otherwise run for a VM that was never created.
+		return "", false, fmt.Errorf("%w: no VM named %q; create it with 'wendy vm create %s'",
+			errSimulatorUnavailable, name, name)
+	}
+
+	// resolveVMSpec re-checks the winner, so this only has to find a candidate.
+	port, err := vm.PickHostPort(st.Meta.AgentPort, simulatorPortSearchTries)
+	if err != nil {
+		return "", false, err
+	}
+	spec, store, err := resolveVMSpec(name, vmStartOptions{
+		netMode:   string(vm.NetUser),
+		hostPort:  port,
+		memoryMiB: vm.DefaultMemoryMiB,
+		cpus:      vm.DefaultCPUs,
+	})
+	if err != nil {
+		return "", false, err
+	}
+	if _, err := store.StartDetached(spec); err != nil {
+		if !errors.Is(err, vm.ErrAlreadyRunning) {
+			return "", false, err
+		}
+		// Another process won the race. Its forward is the live one, so re-read
+		// the record rather than returning the port we picked and never bound.
+		st, err := store.Status(name)
+		if err != nil {
+			return "", false, err
+		}
+		if !st.Running || st.State.AgentPort == 0 {
+			return "", false, fmt.Errorf("VM %q is starting elsewhere; retry in a moment", name)
+		}
+		return fmt.Sprintf("127.0.0.1:%d", st.State.AgentPort), false, nil
+	}
+
+	// Sticky, so a VM pushed off the default port keeps the address next time.
+	// Skipped when the record could not be read: writing it back would persist
+	// an empty one and lose the VM's provenance.
+	if meta, ok := store.ReadMeta(name); ok && meta.AgentPort != port {
+		meta.AgentPort = port
+		_ = store.WriteMeta(meta)
+	}
+	return fmt.Sprintf("127.0.0.1:%d", port), true, nil
+}
+
+// waitForSimulatorAgent polls addr until the guest agent answers or the budget
+// expires; the budget is long because a cold boot under emulation is minutes.
+//
+// Readiness is a completed GetAgentVersion, not a dial: gRPC connects lazily,
+// so dialling a still-booting guest succeeds and fails only on the first call.
+func waitForSimulatorAgent(ctx context.Context, name, addr string, budget time.Duration) (*grpcclient.AgentConnection, error) {
+	if err := waitForSimulatorReady(ctx, name, addr, budget); err != nil {
+		return nil, err
+	}
+	return connectWithAutoTLS(ctx, addr)
+}
+
+// waitForSimulatorReady blocks until a GetAgentVersion completes or the budget
+// expires.
+func waitForSimulatorReady(ctx context.Context, name, addr string, budget time.Duration) error {
+	deadline := time.Now().Add(budget)
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if _, resp, err := getAgentVersionAtAddress(ctx, addr); err == nil && resp != nil {
+			return nil
+		}
+		// Under emulation the budget is five minutes. Without this, a guest that
+		// died on its first instruction is waited out in full.
+		if !simulatorStillRunning(name) {
+			return fmt.Errorf("VM %q stopped while waiting for its agent", name)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("the simulator did not answer on %s within %s", addr, budget)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+// simulatorStillRunning reports whether name is up. A store it cannot read
+// answers true: an unreadable store is no evidence the VM died, and giving up
+// on it would abort a boot that is going fine.
+func simulatorStillRunning(name string) bool {
+	store, err := vm.NewStore()
+	if err != nil {
+		return true
+	}
+	st, err := store.Status(name)
+	if err != nil {
+		return true
+	}
+	// Only a VM the store knows about can be known to have died. No record at
+	// all is inconclusive, not evidence of death.
+	return !st.Exists || st.Running
+}
+
+// connectSimulatorChoice turns a Simulator-tab selection into a live agent
+// connection, provisioning and booting the VM first when needed.
+//
+// Runs AFTER the picker's tea.Program exits: creating a VM shows downloadImage's
+// own progress program, and two Bubble Tea programs cannot share a terminal.
+func connectSimulatorChoice(ctx context.Context, choice *simulatorChoice, suppressUpdateCheck bool) (*SelectedDevice, error) {
+	if choice == nil {
+		return nil, fmt.Errorf("no simulator selected")
+	}
+	if err := ensureQEMUFn(ctx); err != nil {
+		return nil, fmt.Errorf("%w: %w", errSimulatorUnavailable, err)
+	}
+
+	if choice.Create {
+		if err := createSimulator(choice.Name); err != nil {
+			return nil, err
+		}
+	}
+
+	addr, started, err := ensureSimulatorRunning(ctx, choice.Name)
+	if err != nil {
+		// Not re-wrapped: ensureSimulatorRunning marks its own failures, and
+		// doing it twice printed "simulator unavailable: simulator
+		// unavailable: ...".
+		return nil, markSimulatorUnavailable(err)
+	}
+	conn, err := awaitSimulator(ctx, choice.Name, addr, started)
+	if err != nil {
+		return nil, err
+	}
+
+	// PinKey stays empty: every VM answers on 127.0.0.1, so pinning by address
+	// would file them all under one key and make one VM fail another's pin. The
+	// cloud path leaves it empty for the same reason.
+	picked := &SelectedDevice{Agent: conn}
+	if !suppressUpdateCheck {
+		picked.Agent, err = checkAndOfferUpdateFn(ctx, picked.Agent)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return picked, nil
+}
+
+// createSimulator provisions name at the latest release, after asking. Shared
+// by the run picker and by discover so pressing "c" does the same thing in
+// both: same prompt, same download, same errors.
+//
+// The caller must not be inside a Bubble Tea program -- the download runs its
+// own, and two cannot share a terminal.
+var createSimulator = func(name string) error {
+	if !vm.DetachSupported() {
+		return fmt.Errorf("%w: %w", errSimulatorUnavailable, vm.ErrDetachUnsupported)
+	}
+	if !isInteractiveTerminalFn() && !vmAssumeYes {
+		return fmt.Errorf("%w: no simulator yet; create one with 'wendy vm create %s'",
+			errSimulatorUnavailable, name)
+	}
+	if !vmAssumeYes && !confirmFn("Download the WendyOS simulator image and create a VM? This is a one-time download of a few hundred MB.") {
+		return ErrUserCancelled
+	}
+	cliLogln("Creating simulator %q...", name)
+	if err := createVM(os.Stderr, name, "", "", defaultSimulatorDiskGiB, false, 0); err != nil {
+		return fmt.Errorf("%w: %w", errSimulatorUnavailable, err)
+	}
+	return nil
+}
+
+// awaitSimulator waits under a spinner for the guest agent to answer. Shared by
+// the picker and the --device alias so both wait the same way: "running" means
+// QEMU is up, not that the guest has finished booting.
+func awaitSimulator(ctx context.Context, name, addr string, booting bool) (*grpcclient.AgentConnection, error) {
+	return awaitSimulatorWith(ctx, name, addr, booting,
+		func(c context.Context) (*grpcclient.AgentConnection, error) {
+			return waitForSimulatorAgent(c, name, addr, simulatorBootTimeout())
+		})
+}
+
+// awaitSimulatorWith runs wait under a spinner where there is a terminal for
+// one, and turns a timeout into the guest's own last words.
+func awaitSimulatorWith(ctx context.Context, name, addr string, booting bool,
+	wait func(context.Context) (*grpcclient.AgentConnection, error),
+) (*grpcclient.AgentConnection, error) {
+	label := fmt.Sprintf("Connecting to simulator %s...", name)
+	if booting {
+		label = fmt.Sprintf("Booting simulator %s (first boot under emulation takes a few minutes)...", name)
+	}
+
+	var conn *grpcclient.AgentConnection
+	var err error
+	if isInteractiveTerminalFn() {
+		conn, err = runAgentConnectionSpinner(ctx, label, wait)
+	} else {
+		// The spinner needs a TTY it cannot open here, and `--device sim` has
+		// to work from a script. Wait the same way, just without the animation.
+		cliLogln("%s", label)
+		conn, err = wait(ctx)
+	}
+	if err != nil {
+		if errors.Is(err, ErrUserCancelled) {
+			return nil, err
+		}
+		// A silent timeout after minutes of waiting is the worst outcome, so
+		// hand back what the guest actually printed.
+		return nil, fmt.Errorf("%w: %v%s", errSimulatorUnavailable, err, vmConsoleTail(name))
+	}
+	return conn, nil
+}
+
+// awaitSimulatorReady waits for the guest agent without building a connection.
+// The --device path dials again through the ordinary ladder, so minting one
+// here would mean two handshakes and a connection nobody health-checked.
+func awaitSimulatorReady(ctx context.Context, name, addr string, booting bool) error {
+	_, err := awaitSimulatorWith(ctx, name, addr, booting,
+		func(c context.Context) (*grpcclient.AgentConnection, error) {
+			if err := waitForSimulatorReady(c, name, addr, simulatorBootTimeout()); err != nil {
+				return nil, err
+			}
+			return nil, nil
+		})
+	return err
+}
+
+const defaultSimulatorDiskGiB = 16
+
+// simulatorAliases name the implicit simulator without the user having to know
+// the VM's name or its forwarded port.
+var simulatorAliases = map[string]bool{"sim": true, "simulator": true}
+
+// resolveVMAlias turns "sim", "simulator" or "vm:<name>" into the loopback
+// address that VM's agent is forwarded to, starting it if it is not running.
+// matched is false for anything that does not name a VM, which is left alone.
+func resolveVMAlias(ctx context.Context, device string) (addr string, matched bool, err error) {
+	name := ""
+	switch {
+	case simulatorAliases[device]:
+		name = defaultSimulatorVMName
+	case strings.HasPrefix(device, vmDeviceIDPrefix):
+		name = strings.TrimPrefix(device, vmDeviceIDPrefix)
+	default:
+		return "", false, nil
+	}
+	if err := vm.ValidName(name); err != nil {
+		// Wrapped, so resolveWithCloudFallback does not answer a malformed VM
+		// name by deploying to a cloud device instead.
+		return "", false, fmt.Errorf("%w: %w", errSimulatorUnavailable, err)
+	}
+	addr, started, err := ensureSimulatorRunning(ctx, name)
+	if err != nil {
+		return "", false, markSimulatorUnavailable(err)
+	}
+	// Wait here rather than letting the caller dial a guest that is still
+	// booting: the ordinary ladder would report the VM unreachable seconds
+	// after we deliberately started it.
+	if err := awaitSimulatorReady(ctx, name, addr, started); err != nil {
+		return "", false, err
+	}
+	return addr, true, nil
+}

--- a/go/internal/cli/commands/vm_ensure.go
+++ b/go/internal/cli/commands/vm_ensure.go
@@ -166,6 +166,7 @@ func connectSimulatorAgent(ctx context.Context, name, addr string) (*grpcclient.
 		conn.Close()
 		return nil, nil, err
 	}
+	conn.SimulatorName = name
 	return conn, resp, nil
 }
 

--- a/go/internal/cli/commands/vm_ensure_test.go
+++ b/go/internal/cli/commands/vm_ensure_test.go
@@ -1,0 +1,124 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestResolveVMAliasIgnoresAnythingThatIsNotAVM(t *testing.T) {
+	// A hostname or address must fall through untouched, and must not pay for
+	// a store read or a VM start.
+	for _, device := range []string{"rpi5.local", "127.0.0.1:50051", "docker", "192.168.2.253", ""} {
+		addr, matched, err := resolveVMAlias(context.Background(), device)
+		if matched || err != nil || addr != "" {
+			t.Errorf("resolveVMAlias(%q) = (%q, %v, %v), want it left alone", device, addr, matched, err)
+		}
+	}
+}
+
+func TestResolveVMAliasRejectsAnInvalidVMName(t *testing.T) {
+	if _, _, err := resolveVMAlias(context.Background(), "vm:../escape"); err == nil {
+		t.Error("resolveVMAlias() accepted a traversal in the VM name")
+	}
+}
+
+func TestSimulatorFailureNeverBecomesACloudDeploy(t *testing.T) {
+	// resolveWithCloudFallback answers most errors with a cloud tunnel. If it
+	// did that here the app would land on a different machine than the user
+	// picked, and report success.
+	err := errors.New("boom")
+	wrapped := errors.Join(errSimulatorUnavailable, err)
+	if !errors.Is(wrapped, errSimulatorUnavailable) {
+		t.Fatal("errSimulatorUnavailable does not survive wrapping")
+	}
+}
+
+func TestConnectSimulatorChoiceRefusesToDownloadNonInteractively(t *testing.T) {
+	stubTerminal(t, false)
+	savedYes := vmAssumeYes
+	vmAssumeYes = false
+	t.Cleanup(func() { vmAssumeYes = savedYes })
+
+	savedQEMU := ensureQEMUFn
+	ensureQEMUFn = func(context.Context) error { return nil }
+	t.Cleanup(func() { ensureQEMUFn = savedQEMU })
+
+	_, err := connectSimulatorChoice(context.Background(),
+		&simulatorChoice{Name: "sim", Create: true}, true)
+	if err == nil {
+		t.Fatal("connectSimulatorChoice() = nil, want a refusal")
+	}
+	if !errors.Is(err, errSimulatorUnavailable) {
+		t.Errorf("err = %v, want errSimulatorUnavailable", err)
+	}
+	if !strings.Contains(err.Error(), "wendy vm create") {
+		t.Errorf("err = %v, want it to name the manual command", err)
+	}
+}
+
+func TestConnectSimulatorChoiceSurfacesAMissingQEMU(t *testing.T) {
+	saved := ensureQEMUFn
+	ensureQEMUFn = func(context.Context) error { return errors.New("qemu-system-aarch64 not found") }
+	t.Cleanup(func() { ensureQEMUFn = saved })
+
+	_, err := connectSimulatorChoice(context.Background(), &simulatorChoice{Name: "sim"}, true)
+	if !errors.Is(err, errSimulatorUnavailable) {
+		t.Errorf("err = %v, want errSimulatorUnavailable so it never falls back to cloud", err)
+	}
+}
+
+func TestWaitForSimulatorAgentGivesUpAtTheBudget(t *testing.T) {
+	// Nothing is listening, so this must hit the deadline rather than block.
+	start := time.Now()
+	_, err := waitForSimulatorAgent(context.Background(), "dev", "127.0.0.1:59998", 50*time.Millisecond)
+	if err == nil {
+		t.Fatal("waitForSimulatorAgent() = nil, want a timeout")
+	}
+	if !strings.Contains(err.Error(), "did not answer") {
+		t.Errorf("err = %v, want it to say the simulator never answered", err)
+	}
+	if elapsed := time.Since(start); elapsed > 30*time.Second {
+		t.Errorf("waited %v, far past the budget", elapsed)
+	}
+}
+
+func TestWaitForSimulatorAgentStopsWhenCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := waitForSimulatorAgent(ctx, "dev", "127.0.0.1:59998", time.Minute); !errors.Is(err, context.Canceled) {
+		t.Errorf("waitForSimulatorAgent() = %v, want context.Canceled", err)
+	}
+}
+
+func TestSimulatorErrorsAreMarkedOnceNotTwice(t *testing.T) {
+	// ensureSimulatorRunning marks its own failures, so re-wrapping at the call
+	// site printed "simulator unavailable: simulator unavailable: ...".
+	already := fmt.Errorf("%w: no VM named %q", errSimulatorUnavailable, "sim")
+	got := markSimulatorUnavailable(already).Error()
+	if strings.Count(got, "simulator unavailable") != 1 {
+		t.Errorf("markSimulatorUnavailable() = %q, want the prefix exactly once", got)
+	}
+	plain := markSimulatorUnavailable(errors.New("boom"))
+	if !errors.Is(plain, errSimulatorUnavailable) {
+		t.Error("an unmarked error lost the marker; cloud fallback would take over")
+	}
+}
+
+func TestConsoleTailStripsGuestControlSequences(t *testing.T) {
+	// The console is whatever the guest printed. An escape sequence in it would
+	// be executed by the user's terminal rather than shown.
+	got := sanitizeConsoleLine("boot \x1b[2Jok\x07\ttab")
+	if strings.ContainsAny(got, "\x1b\x07") {
+		t.Errorf("sanitizeConsoleLine() = %q, want no control characters", got)
+	}
+	if !strings.Contains(got, "\t") {
+		t.Errorf("sanitizeConsoleLine() = %q, want the tab kept", got)
+	}
+	if !strings.Contains(got, "boot") || !strings.Contains(got, "ok") {
+		t.Errorf("sanitizeConsoleLine() = %q, want the printable text kept", got)
+	}
+}

--- a/go/internal/cli/commands/vm_identity_test.go
+++ b/go/internal/cli/commands/vm_identity_test.go
@@ -1,0 +1,100 @@
+package commands
+
+import (
+	"context"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+	"github.com/wendylabsinc/wendy/go/internal/shared/models"
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+func TestVMIdentityUsesNameNotLoopbackOrPort(t *testing.T) {
+	for alias, want := range map[string]string{"vm:one": "vm:one", "vm:two": "vm:two", "sim": "vm:sim", "simulator": "vm:sim", "127.0.0.1:50100": "127.0.0.1"} {
+		if got := pinKeyForAddr(alias); got != want {
+			t.Fatalf("pin key for %s = %s, want %s", alias, got, want)
+		}
+	}
+	cfg := &config.Config{}
+	cfg.SetDevicePin("127.0.0.1", 1, "cloud", "old-container")
+	cfg.SetDevicePin("vm:one", 1, "cloud", "one")
+	cfg.SetDevicePin("vm:two", 1, "cloud", "two")
+	oldLoad, oldDial := loadConfigForPinFn, dialAgentLadderFn
+	t.Cleanup(func() { loadConfigForPinFn, dialAgentLadderFn = oldLoad, oldDial })
+	loadConfigForPinFn = func() (*config.Config, error) { return cfg, nil }
+	for _, tc := range []struct{ name, addr, asset string }{
+		{"one", "127.0.0.1:50053", "one"},
+		{"one", "127.0.0.1:50100", "one"},
+		{"two", "127.0.0.1:50053", "two"},
+		{"fresh", "127.0.0.1:50051", ""},
+	} {
+		dialAgentLadderFn = func(_ context.Context, target dialTarget) (*grpcclient.AgentConnection, error, error) {
+			if target.PinKey != "vm:"+tc.name || target.Addr != tc.addr {
+				t.Fatalf("wrong target: %+v", target)
+			}
+			if tc.asset == "" {
+				if target.pinned() {
+					t.Fatal("fresh VM inherited localhost pin")
+				}
+			} else if target.Expected == nil || target.Expected.EntityID != tc.asset {
+				t.Fatalf("wrong identity constraint: %+v", target)
+			}
+			return &grpcclient.AgentConnection{AgentService: &fakeAgentVersionClient{resp: &agentpb.GetAgentVersionResponse{}}}, nil, nil
+		}
+		conn, _, err := connectSimulatorAgent(context.Background(), tc.name, tc.addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		conn.Close()
+	}
+}
+
+func TestVMSelectionKeepsAliasAcrossEveryFrontDoor(t *testing.T) {
+	original, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = config.Save(original) })
+	cfg := *original
+	cfg.DefaultDevice = "vm:second"
+	if err := config.Save(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	oldFlag, oldConnect := deviceFlag, connectSimulatorChoiceFn
+	t.Cleanup(func() { deviceFlag, connectSimulatorChoiceFn = oldFlag, oldConnect })
+	var names []string
+	connectSimulatorChoiceFn = func(_ context.Context, choice *simulatorChoice, _ bool) (*SelectedDevice, error) {
+		names = append(names, choice.Name)
+		return &SelectedDevice{PinKey: "vm:" + choice.Name, Agent: &grpcclient.AgentConnection{Host: "127.0.0.1", Addr: "127.0.0.1:50053"}}, nil
+	}
+	for _, flag := range []string{"vm:second", ""} {
+		deviceFlag = flag
+		if _, err := connectToAgent(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		if deviceFlag != flag {
+			t.Fatal("connect mutated global device selection")
+		}
+		selected, err := resolveTargetInner(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		name, err := defaultDeviceNameFor(selected)
+		if err != nil || name != "vm:second" {
+			t.Fatalf("default lost alias/port: %q, %v", name, err)
+		}
+	}
+	_, err = connectPickedLANDevice(context.Background(), &models.DiscoveredDevice{LAN: &models.LANDevice{ID: "vm:second"}}, "127.0.0.1:50051", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(names) != 5 {
+		t.Fatalf("got %d VM selections, want 5", len(names))
+	}
+	for _, name := range names {
+		if name != "second" {
+			t.Fatal(name)
+		}
+	}
+}

--- a/go/internal/cli/commands/vm_identity_test.go
+++ b/go/internal/cli/commands/vm_identity_test.go
@@ -50,6 +50,58 @@ func TestVMIdentityUsesNameNotLoopbackOrPort(t *testing.T) {
 	}
 }
 
+func TestVMReconnectPreservesAliasAndFullEndpoint(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.SetDevicePin("127.0.0.1", 1, "cloud", "unrelated-container")
+	oldLoad, oldDial := loadConfigForPinFn, dialAgentLadderFn
+	t.Cleanup(func() { loadConfigForPinFn, dialAgentLadderFn = oldLoad, oldDial })
+	loadConfigForPinFn = func() (*config.Config, error) { return cfg, nil }
+	calls := 0
+	dialAgentLadderFn = func(_ context.Context, target dialTarget) (*grpcclient.AgentConnection, error, error) {
+		calls++
+		if target.PinKey != "vm:second" || target.Addr != "127.0.0.1:50103" || target.pinned() {
+			t.Fatalf("reconnect lost VM identity: %+v", target)
+		}
+		return &grpcclient.AgentConnection{Host: "127.0.0.1", Addr: target.Addr,
+			AgentService: &fakeAgentVersionClient{resp: &agentpb.GetAgentVersionResponse{}}}, nil, nil
+	}
+	conn, _, err := connectSimulatorAgent(context.Background(), "second", "127.0.0.1:50103")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, reconnect := range []func(context.Context) (*grpcclient.AgentConnection, error){
+		func(ctx context.Context) (*grpcclient.AgentConnection, error) {
+			return reconnectAgentAfterRestart(ctx, conn)
+		},
+		updatedAgentReconnectFunc(context.Background(), conn),
+	} {
+		next, err := reconnect(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if next.SimulatorName != "second" || next.Addr != conn.Addr {
+			t.Fatalf("identity not retained: %+v", next)
+		}
+		next.Close()
+	}
+	conn.Close()
+	if calls != 3 {
+		t.Fatalf("got %d named dials, want 3", calls)
+	}
+	// An identity change after an update must fail immediately, not retry via
+	// generic localhost discovery or an unauthenticated connection.
+	cfg.SetDevicePin("vm:second", 1, "cloud", "second")
+	dialAgentLadderFn = func(_ context.Context, target dialTarget) (*grpcclient.AgentConnection, error, error) {
+		if target.Expected == nil || target.Expected.EntityID != "second" {
+			t.Fatalf("lost expected identity: %+v", target)
+		}
+		return nil, nil, &deviceIdentityRefusalError{msg: "changed identity"}
+	}
+	if _, err := reconnectAgentAfterRestart(context.Background(), conn); !blocksUnauthenticatedFallback(err) {
+		t.Fatalf("did not retain identity refusal: %v", err)
+	}
+}
+
 func TestVMSelectionKeepsAliasAcrossEveryFrontDoor(t *testing.T) {
 	original, err := config.Load()
 	if err != nil {

--- a/go/internal/cli/commands/vm_image.go
+++ b/go/internal/cli/commands/vm_image.go
@@ -1,0 +1,82 @@
+package commands
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var downloadVMImage = downloadImage
+
+// Mutable PR labels and URLs are not cache identities. Use the manifest's
+// artifact digest, verifying both hits and downloads. Without a checksum,
+// download afresh and let the caller remove the temporary file after use.
+func resolveVMImage(info *imageInfo) (string, func(), error) {
+	dir, err := osCacheDir()
+	if err != nil {
+		return "", nil, err
+	}
+	return resolveVMImageIn(dir, info)
+}
+
+func resolveVMImageIn(dir string, info *imageInfo) (string, func(), error) {
+	artifact := *info
+	if info.ZstURL != "" {
+		artifact.DownloadURL, artifact.Checksum, artifact.ImageSize = info.ZstURL, info.ZstChecksum, 0
+	}
+	digest := strings.ToLower(strings.TrimSpace(artifact.Checksum))
+	if digest != "" {
+		decoded, err := hex.DecodeString(digest)
+		if err != nil || len(decoded) != sha256.Size {
+			return "", nil, fmt.Errorf("invalid VM image SHA-256 in manifest")
+		}
+	}
+	cached := filepath.Join(dir, "vm-sha256-"+digest+".image")
+	if digest != "" && verifyVMImage(cached, digest) == nil {
+		return cached, func() {}, nil
+	}
+	tmp, err := downloadVMImage(&artifact)
+	if err != nil {
+		return "", nil, err
+	}
+	cleanup := func() { _ = os.Remove(tmp) }
+	if digest == "" {
+		return tmp, cleanup, nil
+	}
+	if err := verifyVMImage(tmp, digest); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	// Never remove an old cache file before the new download is verified.
+	// A concurrent writer has the same digest and therefore identical bytes.
+	if err := os.Rename(tmp, cached); err != nil {
+		if verifyVMImage(cached, digest) == nil {
+			cleanup()
+			return cached, func() {}, nil
+		}
+		// Windows cannot replace some open cache files. The verified temporary
+		// artifact is still usable without deleting a file another reader uses.
+		return tmp, cleanup, nil
+	}
+	return cached, func() {}, nil
+}
+
+func verifyVMImage(path, digest string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return err
+	}
+	if got := hex.EncodeToString(h.Sum(nil)); got != digest {
+		return fmt.Errorf("VM image checksum mismatch: got %s, manifest says %s; the build may have changed during download, retry", got, digest)
+	}
+	return nil
+}

--- a/go/internal/cli/commands/vm_image_test.go
+++ b/go/internal/cli/commands/vm_image_test.go
@@ -1,11 +1,72 @@
 package commands
 
 import (
+	"archive/zip"
+	"bytes"
 	"crypto/sha256"
 	"fmt"
+	"io"
 	"os"
 	"testing"
 )
+
+func TestVMZIPImageSurvivesDownloadAndDigestCacheNames(t *testing.T) {
+	var archive bytes.Buffer
+	w := zip.NewWriter(&archive)
+	entry, err := w.Create("wendy.wic")
+	if err != nil {
+		t.Fatal(err)
+	}
+	disk := []byte("raw bootable disk bytes, not the ZIP container")
+	if _, err := entry.Write(disk); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	old := downloadVMImage
+	t.Cleanup(func() { downloadVMImage = old })
+	downloads := 0
+	downloadVMImage = func(*imageInfo) (string, error) {
+		downloads++
+		f, err := os.CreateTemp(dir, "download-*.img")
+		if err != nil {
+			return "", err
+		}
+		_, err = f.Write(archive.Bytes())
+		closeErr := f.Close()
+		if err == nil {
+			err = closeErr
+		}
+		return f.Name(), err
+	}
+	info := &imageInfo{DownloadURL: "https://example.test/wendy.zip", Checksum: fmt.Sprintf("%x", sha256.Sum256(archive.Bytes()))}
+	// First download, cache hit, then checksum-free temporary download.
+	for i := range 3 {
+		if i == 2 {
+			info.Checksum = ""
+		}
+		path, done, err := resolveVMImageIn(dir, info)
+		if err != nil {
+			t.Fatal(err)
+		}
+		stream, err := openLocalImageStream(path)
+		if err != nil {
+			done()
+			t.Fatal(err)
+		}
+		got, err := io.ReadAll(stream)
+		stream.Close()
+		done()
+		if err != nil || !bytes.Equal(got, disk) {
+			t.Fatalf("disk bytes = %q: %v", got, err)
+		}
+	}
+	if downloads != 2 {
+		t.Fatalf("downloads = %d, want 2", downloads)
+	}
+}
 
 func TestVMImageCacheTracksBytesNotMutableVersion(t *testing.T) {
 	dir := t.TempDir()

--- a/go/internal/cli/commands/vm_image_test.go
+++ b/go/internal/cli/commands/vm_image_test.go
@@ -1,0 +1,102 @@
+package commands
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestVMImageCacheTracksBytesNotMutableVersion(t *testing.T) {
+	dir := t.TempDir()
+	old := downloadVMImage
+	t.Cleanup(func() { downloadVMImage = old })
+	content, downloads := "first build", 0
+	downloadVMImage = func(info *imageInfo) (string, error) {
+		if info.DownloadURL != "https://example.test/pr/image.zst" {
+			t.Fatal(info.DownloadURL)
+		}
+		downloads++
+		f, err := os.CreateTemp(dir, "download-")
+		if err != nil {
+			return "", err
+		}
+		_, err = f.WriteString(content)
+		_ = f.Close()
+		return f.Name(), err
+	}
+	digest := func(s string) string { return fmt.Sprintf("%x", sha256.Sum256([]byte(s))) }
+	info := &imageInfo{Version: "pr-1834", ZstURL: "https://example.test/pr/image.zst", ZstChecksum: digest(content)}
+	first, done, err := resolveVMImageIn(dir, info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	done()
+	if _, done, err := resolveVMImageIn(dir, info); err != nil {
+		t.Fatal(err)
+	} else {
+		done()
+	}
+	if downloads != 1 {
+		t.Fatal("verified cache hit downloaded again")
+	}
+	content = "second build"
+	info.ZstChecksum = digest(content)
+	second, done, err := resolveVMImageIn(dir, info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	done()
+	if first == second || downloads != 2 {
+		t.Fatal("mutable PR reused old bytes")
+	}
+	if err := os.WriteFile(second, []byte("corrupt"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, done, err := resolveVMImageIn(dir, info); err != nil {
+		t.Fatal(err)
+	} else {
+		done()
+	}
+	if downloads != 3 {
+		t.Fatal("corrupt cache not redownloaded")
+	}
+	info.ZstChecksum = digest("manifest ahead of artifact")
+	if _, _, err := resolveVMImageIn(dir, info); err == nil {
+		t.Fatal("accepted mismatched download")
+	}
+	info.ZstChecksum = ""
+	for range 2 {
+		path, done, err := resolveVMImageIn(dir, info)
+		if err != nil {
+			t.Fatal(err)
+		}
+		done()
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatal("temporary image survived cleanup")
+		}
+	}
+	if downloads != 6 {
+		t.Fatal("checksum-free image was cached")
+	}
+	info.ZstChecksum = "../../escape"
+	if _, _, err := resolveVMImageIn(dir, info); err == nil {
+		t.Fatal("accepted invalid digest")
+	}
+}
+
+func TestVMImageChecksumFollowsArtifactStorage(t *testing.T) {
+	dm := &deviceManifest{Versions: map[string]deviceVersion{"v": {
+		Path: "legacy.zip", Checksum: "legacy", ZstPath: "legacy.zst", ZstChecksum: "legacy-zst",
+		NVMEPath: "nvme.zip", NVMEChecksum: "nvme", NVMEZstPath: "nvme.zst", NVMEZstChecksum: "nvme-zst",
+	}}}
+	for _, tc := range []struct{ storage, checksum string }{{"nvme", "nvme"}, {"sd", "legacy"}, {"", "legacy"}} {
+		info, err := getImageInfo(dm, "v", tc.storage)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Checksum != tc.checksum || info.ZstChecksum != tc.checksum+"-zst" {
+			t.Fatalf("wrong triple: %+v", info)
+		}
+	}
+}

--- a/go/internal/cli/commands/vm_ports.go
+++ b/go/internal/cli/commands/vm_ports.go
@@ -69,6 +69,16 @@ func vmAppPorts(configs ...*appconfig.AppConfig) []int {
 			continue
 		}
 		for _, entitlement := range cfg.Entitlements {
+			if entitlement.Type == appconfig.EntitlementNetwork {
+				for _, mapping := range entitlement.Ports {
+					// The container runtime publishes Container on the guest's
+					// Host port. QEMU must forward that published port, not the
+					// private port inside the container.
+					if mapping.Host != 0 {
+						seen[int(mapping.Host)] = true
+					}
+				}
+			}
 			if entitlement.Type == "http" && entitlement.Port != 0 {
 				seen[entitlement.Port] = true
 			}

--- a/go/internal/cli/commands/vm_ports.go
+++ b/go/internal/cli/commands/vm_ports.go
@@ -15,15 +15,28 @@ import (
 // Match the full agent endpoint, including its port, to the live VM record.
 // A loopback connection alone could be a native agent or another tunnel.
 func userVMForConnection(conn *grpcclient.AgentConnection) (string, error) {
-	if conn == nil || conn.Reconnect != nil {
+	if conn == nil {
+		return "", nil
+	}
+	// A named VM never becomes an ordinary localhost device just because it
+	// stopped during a build. Also refuse a reused endpoint owned by another
+	// VM, instead of redirecting a push or port forward to that new owner.
+	named := conn.SimulatorName
+	if named == "" && conn.Reconnect != nil {
 		return "", nil
 	}
 	host, portString, err := net.SplitHostPort(conn.Addr)
 	if err != nil || host != "127.0.0.1" {
+		if named != "" {
+			return "", fmt.Errorf("VM %q has an invalid agent endpoint %q", named, conn.Addr)
+		}
 		return "", nil
 	}
 	port, err := strconv.Atoi(portString)
 	if err != nil {
+		if named != "" {
+			return "", fmt.Errorf("VM %q has an invalid agent endpoint %q", named, conn.Addr)
+		}
 		return "", nil
 	}
 	statuses, err := vmStatusesFn()
@@ -31,10 +44,16 @@ func userVMForConnection(conn *grpcclient.AgentConnection) (string, error) {
 		return "", err
 	}
 	for _, st := range statuses {
+		if named != "" && st.Name != named {
+			continue
+		}
 		if st.Running && st.State.NetMode == vm.NetUser && st.State.AgentPort != 0 &&
 			(port == st.State.AgentPort || port == st.State.AgentPort+1) {
 			return st.Name, nil
 		}
+	}
+	if named != "" {
+		return "", fmt.Errorf("VM %q is no longer running at %s; reconnect to vm:%s before deploying", named, conn.Addr, named)
 	}
 	return "", nil
 }

--- a/go/internal/cli/commands/vm_ports.go
+++ b/go/internal/cli/commands/vm_ports.go
@@ -1,0 +1,86 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sort"
+	"strconv"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/cli/vm"
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+// Match the full agent endpoint, including its port, to the live VM record.
+// A loopback connection alone could be a native agent or another tunnel.
+func userVMForConnection(conn *grpcclient.AgentConnection) (string, error) {
+	if conn == nil || conn.Reconnect != nil {
+		return "", nil
+	}
+	host, portString, err := net.SplitHostPort(conn.Addr)
+	if err != nil || host != "127.0.0.1" {
+		return "", nil
+	}
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		return "", nil
+	}
+	statuses, err := vmStatusesFn()
+	if err != nil {
+		return "", err
+	}
+	for _, st := range statuses {
+		if st.Running && st.State.NetMode == vm.NetUser && st.State.AgentPort != 0 &&
+			(port == st.State.AgentPort || port == st.State.AgentPort+1) {
+			return st.Name, nil
+		}
+	}
+	return "", nil
+}
+
+var forwardVMPorts = func(ctx context.Context, name string, ports []int) error {
+	s, err := vm.NewStore()
+	if err != nil {
+		return err
+	}
+	return s.EnsureTCPPorts(ctx, name, ports)
+}
+
+func prepareVMAppPorts(ctx context.Context, conn *grpcclient.AgentConnection, configs ...*appconfig.AppConfig) error {
+	ports := vmAppPorts(configs...)
+	if len(ports) == 0 {
+		return nil
+	}
+	name, err := userVMForConnection(conn)
+	if err != nil {
+		return fmt.Errorf("finding simulator for app port forwarding: %w", err)
+	}
+	if name == "" {
+		return nil
+	}
+	return forwardVMPorts(ctx, name, ports)
+}
+
+func vmAppPorts(configs ...*appconfig.AppConfig) []int {
+	seen := map[int]bool{}
+	for _, cfg := range configs {
+		if cfg == nil {
+			continue
+		}
+		for _, entitlement := range cfg.Entitlements {
+			if entitlement.Type == "http" && entitlement.Port != 0 {
+				seen[entitlement.Port] = true
+			}
+		}
+		if cfg.Readiness != nil && cfg.Readiness.TCPSocket != nil && cfg.Readiness.TCPSocket.Port != 0 {
+			seen[cfg.Readiness.TCPSocket.Port] = true
+		}
+	}
+	ports := make([]int, 0, len(seen))
+	for port := range seen {
+		ports = append(ports, port)
+	}
+	sort.Ints(ports)
+	return ports
+}

--- a/go/internal/cli/commands/vm_ports_test.go
+++ b/go/internal/cli/commands/vm_ports_test.go
@@ -24,6 +24,16 @@ func TestVMAppPortsIncludesEveryHTTPAndReadinessPort(t *testing.T) {
 	}
 }
 
+func TestVMAppPortsIncludesPublishedNetworkPortsWithoutReadiness(t *testing.T) {
+	web := &appconfig.AppConfig{Entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementNetwork,
+		Ports: []appconfig.PortMapping{{Host: 18082, Container: 80}, {Host: 18443, Container: 443}}}}}
+	other := &appconfig.AppConfig{Entitlements: []appconfig.Entitlement{{Type: appconfig.EntitlementNetwork,
+		Ports: []appconfig.PortMapping{{Host: 18083, Container: 80}, {Host: 18082, Container: 80}}}}}
+	if got := vmAppPorts(web, nil, other); !reflect.DeepEqual(got, []int{18082, 18083, 18443}) {
+		t.Fatalf("published ports = %v", got)
+	}
+}
+
 func TestVMAppPortsMatchFullEndpointAndCorrectURL(t *testing.T) {
 	oldStatuses, oldForward := vmStatusesFn, forwardVMPorts
 	t.Cleanup(func() { vmStatusesFn = oldStatuses; forwardVMPorts = oldForward })

--- a/go/internal/cli/commands/vm_ports_test.go
+++ b/go/internal/cli/commands/vm_ports_test.go
@@ -1,0 +1,130 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/cli/vm"
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+func TestVMAppPortsIncludesEveryHTTPAndReadinessPort(t *testing.T) {
+	cfg := &appconfig.AppConfig{Entitlements: []appconfig.Entitlement{{Type: "http", Port: 8080}, {Type: "http", Port: 9000}}, Readiness: &appconfig.ReadinessConfig{TCPSocket: &appconfig.TCPSocketProbe{Port: 8081}}}
+	if got := vmAppPorts(nil, cfg, cfg); !reflect.DeepEqual(got, []int{8080, 8081, 9000}) {
+		t.Fatal(got)
+	}
+}
+
+func TestVMAppPortsMatchFullEndpointAndCorrectURL(t *testing.T) {
+	oldStatuses, oldForward := vmStatusesFn, forwardVMPorts
+	t.Cleanup(func() { vmStatusesFn = oldStatuses; forwardVMPorts = oldForward })
+	vmStatusesFn = func() ([]vm.Status, error) {
+		return []vm.Status{
+			{Name: "first", Running: true, State: vm.State{NetMode: vm.NetUser, AgentPort: 50051}},
+			{Name: "second", Running: true, State: vm.State{NetMode: vm.NetUser, AgentPort: 50053}},
+		}, nil
+	}
+	var names []string
+	forwardVMPorts = func(_ context.Context, name string, ports []int) error {
+		names = append(names, name)
+		if !reflect.DeepEqual(ports, []int{18080}) {
+			t.Fatal(ports)
+		}
+		return nil
+	}
+	cfg := &appconfig.AppConfig{Entitlements: []appconfig.Entitlement{{Type: "http", Port: 18080}}}
+	conn := &grpcclient.AgentConnection{Host: "127.0.0.1", Addr: "127.0.0.1:50054", AgentService: &fakeAgentVersionClient{resp: &agentpb.GetAgentVersionResponse{}}}
+	if err := prepareVMAppPorts(context.Background(), conn, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(names, []string{"second"}) {
+		t.Fatal(names)
+	}
+	if host, ok := resolveHookHost(context.Background(), conn, cfg); !ok || host != "127.0.0.1" {
+		t.Fatalf("%q %v", host, ok)
+	}
+	if ip := announceReachableURL(context.Background(), conn, cfg); ip != "127.0.0.1" {
+		t.Fatalf("announced IP %q", ip)
+	}
+	conn.Addr = "127.0.0.1:50100"
+	if err := prepareVMAppPorts(context.Background(), conn, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if len(names) != 1 {
+		t.Fatal("forwarded an unrelated loopback agent")
+	}
+	conn.Addr = "127.0.0.1:50054"
+	forwardVMPorts = func(context.Context, string, []int) error { return fmt.Errorf("port occupied") }
+	if err := prepareVMAppPorts(context.Background(), conn, cfg); err == nil {
+		t.Fatal("suppressed port conflict")
+	}
+}
+
+// Opt-in live regression. Start an HTTP server returning Wendy-HTTP-review on
+// guest port 18080, then set WENDY_VM_HTTP_TEST to its local VM name and
+// WENDY_VM_HTTP_ROOT to the absolute VM store path. This tests
+// the same port preparation and readiness/URL paths that run invokes, without
+// provisioning a disposable guest or changing the developer's device pins.
+func TestVMHTTPIntegration(t *testing.T) {
+	name := os.Getenv("WENDY_VM_HTTP_TEST")
+	if name == "" {
+		t.Skip("requires an explicit test VM")
+	}
+	root := os.Getenv("WENDY_VM_HTTP_ROOT")
+	if root == "" {
+		t.Fatal("WENDY_VM_HTTP_ROOT must explicitly select the live VM store")
+	}
+	s := &vm.Store{Root: root}
+	oldStatuses, oldForward := vmStatusesFn, forwardVMPorts
+	t.Cleanup(func() { vmStatusesFn, forwardVMPorts = oldStatuses, oldForward })
+	vmStatusesFn = s.Statuses
+	forwardVMPorts = s.EnsureTCPPorts
+	st, err := s.Status(name)
+	if err != nil || !st.Running {
+		t.Fatalf("VM not running: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	conn, err := grpcclient.Connect(ctx, fmt.Sprintf("127.0.0.1:%d", st.State.AgentPort))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	cfg := &appconfig.AppConfig{Entitlements: []appconfig.Entitlement{{Type: "http", Port: 18080}}}
+	for range 2 {
+		if err := prepareVMAppPorts(ctx, conn, cfg); err != nil {
+			t.Fatal(err)
+		}
+	}
+	host, ok := resolveHookHost(ctx, conn, cfg)
+	if !ok || host != "127.0.0.1" {
+		t.Fatalf("host %q, ok %v", host, ok)
+	}
+	if err := waitForReadiness(ctx, effectiveReadiness(cfg), host); err != nil {
+		t.Fatal(err)
+	}
+	client := &http.Client{Timeout: 3 * time.Second, Transport: &http.Transport{Proxy: nil}}
+	defer client.CloseIdleConnections()
+	resp, err := client.Get("http://" + host + ":18080/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 || !strings.Contains(string(body), "Wendy-HTTP-review") {
+		t.Fatalf("HTTP %d: %s", resp.StatusCode, body)
+	}
+	t.Logf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+}

--- a/go/internal/cli/commands/vm_qemu.go
+++ b/go/internal/cli/commands/vm_qemu.go
@@ -1,0 +1,208 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+	"github.com/wendylabsinc/wendy/go/internal/cli/vm"
+)
+
+// installQEMUFn runs `brew install qemu`; indirected so tests can stub it
+// without invoking Homebrew.
+var installQEMUFn = installQEMUViaBrew
+
+// vmAssumeYes accepts the VM prompts -- installing QEMU, and downloading the
+// simulator image. Bound to `wendy vm --yes` only: `wendy run --yes` resolves
+// non-interactively and never reaches the picker that raises them, so mirroring
+// the flag here would be an unsynchronised write for no gain.
+var vmAssumeYes bool
+
+// ensureQEMUForHostOS resolves the emulator, and on an interactive macOS
+// session where it is missing offers to install QEMU via Homebrew first.
+// Non-interactive runs, other platforms and hosts without Homebrew fall
+// straight through to the plain "not found" error.
+//
+// Homebrew's qemu also ships the aarch64 UEFI firmware, so accepting here
+// resolves FindFirmware's separate failure at the same time.
+func ensureQEMUForHostOS(ctx context.Context, hostOS string) error {
+	binary := vm.Spec{}.Binary()
+	if _, err := qemuLookPathFn(binary); err == nil {
+		return nil
+	}
+	notFound := fmt.Errorf("%s not found: install QEMU (%s)", binary, qemuInstallHint())
+
+	if hostOS != "darwin" {
+		return notFound
+	}
+	if !isInteractiveTerminalFn() && !vmAssumeYes {
+		return notFound
+	}
+	if _, err := brewLookPathFn("brew"); err != nil {
+		return notFound
+	}
+	if !vmAssumeYes && !confirmFn("QEMU is required to run a WendyOS VM and was not found. Install it now with `brew install qemu`?") {
+		return notFound
+	}
+	if err := installQEMUFn(ctx); err != nil {
+		if errors.Is(err, ErrUserCancelled) {
+			return err
+		}
+		return fmt.Errorf("installing QEMU via Homebrew: %w", err)
+	}
+	if _, err := qemuLookPathFn(binary); err != nil {
+		return errors.New("QEMU was installed via Homebrew but is not yet on PATH; " +
+			"open a new terminal or run: eval \"$(brew shellenv)\"")
+	}
+	return nil
+}
+
+func installQEMUViaBrew(ctx context.Context) error {
+	return brewInstallWithSpinner(ctx, "qemu", "Installing QEMU via Homebrew...")
+}
+
+// brewInstallWithSpinner runs `brew install <formula>` behind a spinner instead
+// of streaming Homebrew's own log; the captured output is printed only on
+// failure.
+func brewInstallWithSpinner(ctx context.Context, formula, label string) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "brew", "install", formula)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	cmd.Stdin = nil
+
+	prog := tui.NewProgressProgram(tui.NewSpinner(label))
+
+	var (
+		runErr error
+		doneCh = make(chan struct{})
+	)
+	go func() {
+		defer close(doneCh)
+		runErr = cmd.Run()
+		prog.Send(tui.SpinnerDoneMsg{})
+	}()
+
+	finalModel, err := prog.Run()
+	if err != nil {
+		cancel()
+		<-doneCh
+		return fmt.Errorf("spinner TUI: %w", err)
+	}
+	sm, ok := finalModel.(tui.SpinnerModel)
+	if !ok {
+		cancel()
+		<-doneCh
+		return fmt.Errorf("spinner TUI: unexpected model type %T", finalModel)
+	}
+	if !sm.Done() {
+		cancel()
+		<-doneCh
+		return ErrUserCancelled
+	}
+
+	<-doneCh
+	if runErr != nil {
+		_, _ = os.Stderr.Write(out.Bytes())
+		return runErr
+	}
+	return nil
+}
+
+// qemuInstallHint names the command that installs QEMU and, on macOS, its UEFI
+// firmware. The single source for that advice: the VM command's help, the
+// missing-emulator error and the missing-firmware error all read it.
+func qemuInstallHint() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return "brew install qemu"
+	case "windows":
+		return "the QEMU for Windows installer"
+	default:
+		return "apt install qemu-system-arm qemu-efi-aarch64"
+	}
+}
+
+// socketVMNetStartTimeout bounds the wait for the daemon to bind its socket.
+const socketVMNetStartTimeout = 10 * time.Second
+
+// installSocketVMNetFn and startSocketVMNetFn run the two Homebrew commands
+// socket_vmnet needs; indirected so tests never invoke Homebrew.
+var (
+	installSocketVMNetFn = installSocketVMNetViaBrew
+	startSocketVMNetFn   = startSocketVMNetService
+)
+
+// ensureSocketVMNet resolves the socket_vmnet endpoint that shared networking
+// needs, offering to install and start the helper on an interactive Mac.
+//
+// Two steps, because the socket only exists once the service runs: `brew
+// install` alone leaves the path missing and would look like a failed install.
+func ensureSocketVMNet(ctx context.Context, hostOS, brewPrefix string) (string, error) {
+	socket, err := vm.FindSocketVMNet(hostOS, brewPrefix)
+	if err == nil {
+		return socket, nil
+	}
+	// Not a Mac: there is nothing to install, so the error already says so.
+	if errors.Is(err, vm.ErrSharedNetUnsupported) {
+		return "", err
+	}
+	if !isInteractiveTerminalFn() && !vmAssumeYes {
+		return "", err
+	}
+	if _, lookErr := brewLookPathFn("brew"); lookErr != nil {
+		return "", err
+	}
+	if !vmAssumeYes && !confirmFn("Shared networking needs the socket_vmnet helper, which was not found. "+
+		"Install and start it now with Homebrew? It needs sudo to start.") {
+		return "", err
+	}
+
+	if instErr := installSocketVMNetFn(ctx); instErr != nil {
+		if errors.Is(instErr, ErrUserCancelled) {
+			return "", instErr
+		}
+		return "", fmt.Errorf("installing socket_vmnet via Homebrew: %w", instErr)
+	}
+	if startErr := startSocketVMNetFn(ctx); startErr != nil {
+		return "", fmt.Errorf("starting socket_vmnet: %w", startErr)
+	}
+	// brew services returns once launchctl has loaded the job, before the
+	// daemon has bound its socket. Without this the freshly installed helper
+	// reports "not found" and tells the user to install what they just did.
+	deadline := time.Now().Add(socketVMNetStartTimeout)
+	for {
+		socket, err = vm.FindSocketVMNet(hostOS, brewPrefix)
+		if err == nil || time.Now().After(deadline) {
+			return socket, err
+		}
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+}
+
+func installSocketVMNetViaBrew(ctx context.Context) error {
+	return brewInstallWithSpinner(ctx, "socket_vmnet", "Installing socket_vmnet via Homebrew...")
+}
+
+// startSocketVMNetService runs the privileged half. Its output is streamed
+// rather than captured: sudo may need to prompt for a password, which a spinner
+// would hide.
+func startSocketVMNetService(ctx context.Context) error {
+	cliLogln("Starting socket_vmnet (sudo brew services start socket_vmnet)...")
+	cmd := exec.CommandContext(ctx, "sudo", "brew", "services", "start", "socket_vmnet")
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stderr, os.Stderr
+	return cmd.Run()
+}

--- a/go/internal/cli/commands/vm_qemu_test.go
+++ b/go/internal/cli/commands/vm_qemu_test.go
@@ -1,0 +1,252 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/vm"
+)
+
+// stubQEMUMissing makes the emulator look absent, and records whether an
+// install was attempted.
+func stubQEMUMissing(t *testing.T, installed *bool) {
+	t.Helper()
+	savedLook, savedInstall := qemuLookPathFn, installQEMUFn
+	qemuLookPathFn = func(string) (string, error) { return "", errors.New("not found") }
+	installQEMUFn = func(context.Context) error {
+		*installed = true
+		return nil
+	}
+	t.Cleanup(func() { qemuLookPathFn, installQEMUFn = savedLook, savedInstall })
+}
+
+// stubTerminal forces the interactive check either way; the shared
+// stubInteractive only covers the true case.
+func stubTerminal(t *testing.T, interactive bool) {
+	t.Helper()
+	prev := isInteractiveTerminalFn
+	isInteractiveTerminalFn = func() bool { return interactive }
+	t.Cleanup(func() { isInteractiveTerminalFn = prev })
+}
+
+func TestEnsureQEMUIsANoOpWhenAlreadyInstalled(t *testing.T) {
+	saved := qemuLookPathFn
+	qemuLookPathFn = func(name string) (string, error) { return "/usr/bin/" + name, nil }
+	t.Cleanup(func() { qemuLookPathFn = saved })
+
+	asked := false
+	stubConfirmFn(t, func(string) bool { asked = true; return true })
+	if err := ensureQEMUForHostOS(context.Background(), "darwin"); err != nil {
+		t.Fatalf("ensureQEMUForHostOS() = %v, want nil", err)
+	}
+	if asked {
+		t.Error("prompted even though QEMU is already installed")
+	}
+}
+
+func TestEnsureQEMUOffersToInstallOnInteractiveMac(t *testing.T) {
+	var installed, asked bool
+	stubQEMUMissing(t, &installed)
+	stubBrewLookPath(t, func(n string) (string, error) { return "/opt/homebrew/bin/" + n, nil })
+	stubTerminal(t, true)
+	stubConfirmFn(t, func(string) bool { asked = true; return true })
+
+	// The stub keeps reporting the binary as missing, so the post-install PATH
+	// re-check is what this lands on -- which is the point: an install that
+	// does not put QEMU on PATH must say so rather than claim success.
+	err := ensureQEMUForHostOS(context.Background(), "darwin")
+	if !asked {
+		t.Error("did not prompt before installing")
+	}
+	if !installed {
+		t.Error("accepted the prompt but never ran the install")
+	}
+	if err == nil || !strings.Contains(err.Error(), "not yet on PATH") {
+		t.Errorf("ensureQEMUForHostOS() = %v, want the PATH re-check error", err)
+	}
+}
+
+func TestEnsureQEMUDoesNotPromptWithoutHomebrew(t *testing.T) {
+	var installed, asked bool
+	stubQEMUMissing(t, &installed)
+	stubBrewLookPath(t, func(string) (string, error) { return "", errors.New("not found") })
+	stubTerminal(t, true)
+	stubConfirmFn(t, func(string) bool { asked = true; return true })
+
+	err := ensureQEMUForHostOS(context.Background(), "darwin")
+	if asked || installed {
+		t.Error("prompted or installed on a host with no Homebrew")
+	}
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("ensureQEMUForHostOS() = %v, want the plain not-found error", err)
+	}
+}
+
+func TestEnsureQEMUDoesNotPromptWhenNotInteractive(t *testing.T) {
+	var installed, asked bool
+	stubQEMUMissing(t, &installed)
+	stubBrewLookPath(t, func(n string) (string, error) { return "/opt/homebrew/bin/" + n, nil })
+	stubTerminal(t, false)
+	stubConfirmFn(t, func(string) bool { asked = true; return true })
+
+	if err := ensureQEMUForHostOS(context.Background(), "darwin"); err == nil {
+		t.Fatal("ensureQEMUForHostOS() = nil, want the not-found error")
+	}
+	if asked || installed {
+		t.Error("prompted or installed without a terminal to prompt on")
+	}
+}
+
+func TestEnsureQEMUDeclinedKeepsTheManualCommand(t *testing.T) {
+	var installed, asked bool
+	stubQEMUMissing(t, &installed)
+	stubBrewLookPath(t, func(n string) (string, error) { return "/opt/homebrew/bin/" + n, nil })
+	stubTerminal(t, true)
+	stubConfirmFn(t, func(string) bool { asked = true; return false })
+
+	err := ensureQEMUForHostOS(context.Background(), "darwin")
+	if !asked {
+		t.Error("never prompted")
+	}
+	if installed {
+		t.Error("installed despite the prompt being declined")
+	}
+	if err == nil || !strings.Contains(err.Error(), qemuInstallHint()) {
+		t.Errorf("ensureQEMUForHostOS() = %v, want it to name %q", err, qemuInstallHint())
+	}
+}
+
+func TestEnsureQEMUNeverPromptsOffMac(t *testing.T) {
+	// No non-brew installer is ever driven for the user, so Linux and Windows
+	// get the hint and nothing else.
+	for _, hostOS := range []string{"linux", "windows"} {
+		var installed, asked bool
+		stubQEMUMissing(t, &installed)
+		stubBrewLookPath(t, func(n string) (string, error) { return "/opt/homebrew/bin/" + n, nil })
+		stubTerminal(t, true)
+		stubConfirmFn(t, func(string) bool { asked = true; return true })
+
+		err := ensureQEMUForHostOS(context.Background(), hostOS)
+		if asked || installed {
+			t.Errorf("%s: prompted or installed", hostOS)
+		}
+		if err == nil {
+			t.Errorf("%s: ensureQEMUForHostOS() = nil, want the not-found error", hostOS)
+		}
+	}
+}
+
+func TestEnsureQEMUWithYesSkipsThePromptAndInstalls(t *testing.T) {
+	var installed, asked bool
+	stubQEMUMissing(t, &installed)
+	stubBrewLookPath(t, func(n string) (string, error) { return "/opt/homebrew/bin/" + n, nil })
+	stubTerminal(t, false)
+	stubConfirmFn(t, func(string) bool { asked = true; return false })
+
+	saved := vmAssumeYes
+	vmAssumeYes = true
+	t.Cleanup(func() { vmAssumeYes = saved })
+
+	_ = ensureQEMUForHostOS(context.Background(), "darwin")
+	if asked {
+		t.Error("prompted despite --yes")
+	}
+	if !installed {
+		t.Error("--yes did not install QEMU")
+	}
+}
+
+func TestVMCommandHasAYesFlag(t *testing.T) {
+	if newVMCmd().PersistentFlags().Lookup("yes") == nil {
+		t.Error("wendy vm has no --yes flag")
+	}
+}
+
+func TestQEMUInstallHintIsTheOnlySourceInHelp(t *testing.T) {
+	// The help text used to carry its own copy of the install command, which
+	// then drifted from the error a user actually hits.
+	if long := newVMCmd().Long; !strings.Contains(long, qemuInstallHint()) {
+		t.Errorf("vm help = %q, want it to name %q", long, qemuInstallHint())
+	}
+}
+
+// stubSocketVMNetMissing records what would be run. The helper is genuinely
+// absent here -- the socket paths it probes are macOS-only -- so nothing needs
+// to fake that half.
+func stubSocketVMNetMissing(t *testing.T, installed, started *bool) {
+	t.Helper()
+	savedInstall, savedStart := installSocketVMNetFn, startSocketVMNetFn
+	installSocketVMNetFn = func(context.Context) error { *installed = true; return nil }
+	startSocketVMNetFn = func(context.Context) error { *started = true; return nil }
+	t.Cleanup(func() { installSocketVMNetFn, startSocketVMNetFn = savedInstall, savedStart })
+}
+
+func TestEnsureSocketVMNetNeverPromptsOffMac(t *testing.T) {
+	// vmnet is an Apple framework: there is nothing to offer to install, and
+	// the error must not recommend Homebrew on a host without it.
+	for _, hostOS := range []string{"linux", "windows"} {
+		var installed, started, asked bool
+		stubSocketVMNetMissing(t, &installed, &started)
+		stubTerminal(t, true)
+		stubBrewLookPath(t, func(n string) (string, error) { return "/opt/homebrew/bin/" + n, nil })
+		stubConfirmFn(t, func(string) bool { asked = true; return true })
+
+		_, err := ensureSocketVMNet(context.Background(), hostOS, "")
+		if asked || installed || started {
+			t.Errorf("%s: prompted or installed for a platform that cannot run vmnet", hostOS)
+		}
+		if !errors.Is(err, vm.ErrSharedNetUnsupported) {
+			t.Errorf("%s: err = %v, want ErrSharedNetUnsupported", hostOS, err)
+		}
+	}
+}
+
+func TestEnsureSocketVMNetInstallsAndStartsOnMac(t *testing.T) {
+	// Install alone leaves the socket missing, so both halves must run.
+	var installed, started, asked bool
+	stubSocketVMNetMissing(t, &installed, &started)
+	stubTerminal(t, true)
+	stubBrewLookPath(t, func(n string) (string, error) { return "/opt/homebrew/bin/" + n, nil })
+	stubConfirmFn(t, func(string) bool { asked = true; return true })
+
+	_, _ = ensureSocketVMNet(context.Background(), "darwin", "/opt/homebrew")
+	if !asked {
+		t.Error("did not prompt before installing")
+	}
+	if !installed || !started {
+		t.Errorf("installed=%v started=%v, want both", installed, started)
+	}
+}
+
+func TestEnsureSocketVMNetDeclinedKeepsTheManualCommands(t *testing.T) {
+	var installed, started bool
+	stubSocketVMNetMissing(t, &installed, &started)
+	stubTerminal(t, true)
+	stubBrewLookPath(t, func(n string) (string, error) { return "/opt/homebrew/bin/" + n, nil })
+	stubConfirmFn(t, func(string) bool { return false })
+
+	_, err := ensureSocketVMNet(context.Background(), "darwin", "/opt/homebrew")
+	if installed || started {
+		t.Error("installed despite the prompt being declined")
+	}
+	if err == nil || !strings.Contains(err.Error(), "brew install socket_vmnet") {
+		t.Errorf("err = %v, want it to name the manual command", err)
+	}
+}
+
+func TestEnsureSocketVMNetDoesNotPromptWithoutHomebrew(t *testing.T) {
+	var installed, started, asked bool
+	stubSocketVMNetMissing(t, &installed, &started)
+	stubTerminal(t, true)
+	stubBrewLookPath(t, func(string) (string, error) { return "", errors.New("not found") })
+	stubConfirmFn(t, func(string) bool { asked = true; return true })
+
+	if _, err := ensureSocketVMNet(context.Background(), "darwin", ""); err == nil {
+		t.Fatal("ensureSocketVMNet() = nil, want the not-found error")
+	}
+	if asked || installed || started {
+		t.Error("prompted or installed on a host with no Homebrew")
+	}
+}

--- a/go/internal/cli/commands/vm_registry.go
+++ b/go/internal/cli/commands/vm_registry.go
@@ -1,0 +1,37 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/cli/vm"
+)
+
+var vmRegistryPort = func(ctx context.Context, name string) (int, error) {
+	s, err := vm.NewStore()
+	if err != nil {
+		return 0, err
+	}
+	return s.RegistryPort(ctx, name)
+}
+
+// Only translate the selected VM's registry port. Cloud dialers already own
+// their routing, and LAN devices retain their ordinary host:port destination.
+func registryHostPortForAgent(ctx context.Context, conn *grpcclient.AgentConnection, port int) (int, error) {
+	if conn.RegistryDialer != nil || port != vm.DeviceRegistryPort {
+		return port, nil
+	}
+	name, err := userVMForConnection(conn)
+	if err != nil {
+		return 0, err
+	}
+	if name == "" {
+		return port, nil
+	}
+	port, err = vmRegistryPort(ctx, name)
+	if err != nil {
+		return 0, fmt.Errorf("resolving VM %q registry: %w", name, err)
+	}
+	return port, nil
+}

--- a/go/internal/cli/commands/vm_registry_test.go
+++ b/go/internal/cli/commands/vm_registry_test.go
@@ -67,3 +67,56 @@ func TestVMRegistryRoutesEveryBuilderToSelectedVM(t *testing.T) {
 		t.Fatal("fell back to another VM's registry")
 	}
 }
+
+func TestNamedVMRegistryFailsClosedWhenTargetChanges(t *testing.T) {
+	for _, scenario := range []string{"missing", "stopped", "moved", "reused", "shared", "invalid"} {
+		t.Run(scenario, func(t *testing.T) {
+			statuses := []vm.Status{runningVM("one", vm.NetUser, 50051)}
+			conn := &grpcclient.AgentConnection{Host: "127.0.0.1", Addr: "127.0.0.1:50053", SimulatorName: "two"}
+			switch scenario {
+			case "stopped":
+				statuses = append(statuses, vm.Status{Name: "two", Exists: true})
+			case "moved":
+				statuses = append(statuses, runningVM("two", vm.NetUser, 50100))
+			case "reused":
+				statuses = append(statuses, runningVM("replacement", vm.NetUser, 50053))
+			case "shared":
+				statuses = append(statuses, runningVM("two", vm.NetShared, 0))
+			case "invalid":
+				conn.Addr = "localhost:bad"
+			}
+			stubVMStatuses(t, statuses...)
+			old := vmRegistryPort
+			t.Cleanup(func() { vmRegistryPort = old })
+			vmRegistryPort = func(context.Context, string) (int, error) {
+				t.Fatal("attempted registry forwarding for a lost or replaced VM")
+				return 0, nil
+			}
+			if _, _, _, _, err := resolveRegistryForSwiftAgent(context.Background(), conn, 5000); err == nil {
+				t.Fatal("Swift fell back to localhost")
+			}
+			if _, _, _, err := resolveRegistryForAgent(context.Background(), conn, 5000); err == nil {
+				t.Fatal("Docker fell back to localhost")
+			}
+			if _, _, _, _, err := resolveRegistryForAppleContainer(context.Background(), conn, 5000); err == nil {
+				t.Fatal("Apple Container fell back to localhost")
+			}
+		})
+	}
+}
+
+func TestNamedVMEndpointMatchRetainsIdentityForPlaintextAndTLS(t *testing.T) {
+	stubVMStatuses(t, runningVM("one", vm.NetUser, 50051), runningVM("two", vm.NetUser, 50053))
+	for _, port := range []int{50053, 50054} {
+		conn := &grpcclient.AgentConnection{Host: "127.0.0.1", Addr: fmt.Sprintf("127.0.0.1:%d", port), SimulatorName: "two"}
+		name, err := userVMForConnection(conn)
+		if err != nil || name != "two" {
+			t.Fatalf("named endpoint %d = %q: %v", port, name, err)
+		}
+	}
+	// Native loopback agents still use the ordinary registry path.
+	conn := &grpcclient.AgentConnection{Host: "127.0.0.1", Addr: "127.0.0.1:50100"}
+	if port, err := registryHostPortForAgent(context.Background(), conn, 5000); err != nil || port != 5000 {
+		t.Fatalf("native registry = %d: %v", port, err)
+	}
+}

--- a/go/internal/cli/commands/vm_registry_test.go
+++ b/go/internal/cli/commands/vm_registry_test.go
@@ -1,0 +1,69 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/cli/vm"
+)
+
+func TestVMRegistryRoutesEveryBuilderToSelectedVM(t *testing.T) {
+	stubVMStatuses(t, runningVM("one", vm.NetUser, 50051), runningVM("two", vm.NetUser, 50053))
+	old := vmRegistryPort
+	t.Cleanup(func() { vmRegistryPort = old })
+	ports := map[string]int{}
+	for _, name := range []string{"one", "two"} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { fmt.Fprint(w, name) }))
+		t.Cleanup(srv.Close)
+		_, port, _ := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
+		ports[name], _ = strconv.Atoi(port)
+	}
+	vmRegistryPort = func(_ context.Context, name string) (int, error) { return ports[name], nil }
+	for _, builder := range []string{"swift", "docker", "apple"} {
+		for i, name := range []string{"one", "two"} {
+			conn := &grpcclient.AgentConnection{Host: "127.0.0.1", Addr: fmt.Sprintf("127.0.0.1:%d", 50051+2*i)}
+			var addr string
+			var done func()
+			var err error
+			switch builder {
+			case "swift":
+				addr, _, done, _, err = resolveRegistryForSwiftAgent(context.Background(), conn, 5000)
+			case "docker":
+				addr, done, _, err = resolveRegistryForAgent(context.Background(), conn, 5000)
+			case "apple":
+				addr, done, _, _, err = resolveRegistryForAppleContainer(context.Background(), conn, 5000)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp, err := http.Get("http://127.0.0.1:" + port + "/v2/")
+			if err != nil {
+				t.Fatal(err)
+			}
+			body, err := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			done()
+			conn.Close()
+			if err != nil || string(body) != name {
+				t.Fatalf("%s for %s reached %q: %v", builder, name, body, err)
+			}
+		}
+	}
+	vmRegistryPort = func(context.Context, string) (int, error) { return 0, fmt.Errorf("monitor unavailable") }
+	conn := &grpcclient.AgentConnection{Host: "127.0.0.1", Addr: "127.0.0.1:50053"}
+	if _, _, _, _, err := resolveRegistryForSwiftAgent(context.Background(), conn, 5000); err == nil {
+		t.Fatal("fell back to another VM's registry")
+	}
+}

--- a/go/internal/cli/commands/vm_test.go
+++ b/go/internal/cli/commands/vm_test.go
@@ -1,0 +1,253 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/wendylabsinc/wendy/go/internal/cli/vm"
+)
+
+func vmSubcommand(t *testing.T, name string) *cobra.Command {
+	t.Helper()
+	for _, c := range newVMCmd().Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	t.Fatalf("wendy vm has no %q subcommand", name)
+	return nil
+}
+
+func TestVMStartDocumentsTheDiscoveryTradeoffInHelp(t *testing.T) {
+	start := vmSubcommand(t, "start")
+	f := start.Flags().Lookup("net")
+	if f == nil {
+		t.Fatal("start has no --net flag")
+	}
+	// The default must be the tier that needs no privileges, and the help has to
+	// say what it costs, because a silently undiscoverable VM looks broken.
+	if f.DefValue != "user" {
+		t.Errorf("--net default = %q, want user", f.DefValue)
+	}
+	if !strings.Contains(f.Usage, "discover") {
+		t.Errorf("--net help should mention discovery; got %q", f.Usage)
+	}
+}
+
+func TestVMCreateAcceptsNoImageAndOffersVersionFlags(t *testing.T) {
+	// --image is now the escape hatch, not the requirement: with nothing passed,
+	// create resolves the published image. That is what makes the feature usable
+	// by someone who has never built WendyOS.
+	create := vmSubcommand(t, "create")
+	if f := create.Flags().Lookup("image"); f == nil || f.DefValue != "" {
+		t.Fatal("create should have an optional --image")
+	}
+	for _, name := range []string{"version", "nightly"} {
+		if create.Flags().Lookup(name) == nil {
+			t.Errorf("create has no --%s flag", name)
+		}
+	}
+}
+
+func TestVMCreateRejectsALocalImageCombinedWithAVersion(t *testing.T) {
+	// A local file is already a specific build; honouring --version alongside it
+	// would silently ignore one of the two.
+	cmd := newVMCmd()
+	cmd.SetArgs([]string{"create", "dev", "--image", "/nonexistent.wic", "--version", "1.2.3"})
+	cmd.SetOut(&strings.Builder{})
+	cmd.SetErr(&strings.Builder{})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("create accepted --image with --version")
+	}
+	if !strings.Contains(err.Error(), "--version") {
+		t.Errorf("error should name the conflicting flag; got %q", err)
+	}
+}
+
+func TestVMSubcommandsRejectTheWrongNumberOfNames(t *testing.T) {
+	// Args != nil is not enough: ArbitraryArgs would satisfy it and let a
+	// missing VM name through to be dropped silently.
+	for _, name := range []string{"create", "start", "stop", "logs", "rm"} {
+		c := vmSubcommand(t, name)
+		for _, args := range [][]string{{}, {"one", "two"}} {
+			if err := c.Args(c, args); err == nil {
+				t.Errorf("%q accepted %d names, want exactly 1", name, len(args))
+			}
+		}
+		if err := c.Args(c, []string{"dev"}); err != nil {
+			t.Errorf("%q rejected a single name: %v", name, err)
+		}
+	}
+}
+
+func TestVMStartHasAPortFlagWithAWorkingDefault(t *testing.T) {
+	// The default is what makes `wendy vm start dev` work with no arguments;
+	// the flag exists only for the machine that already has 50051 taken.
+	start := vmSubcommand(t, "start")
+	f := start.Flags().Lookup("port")
+	if f == nil {
+		t.Fatal("start has no --port flag; a host with 50051 taken cannot start a VM")
+	}
+	if f.DefValue != "50051" {
+		t.Errorf("--port default = %q, want 50051 so the flag is optional", f.DefValue)
+	}
+	if !strings.Contains(f.Usage, "50051") {
+		t.Errorf("--port help should name the guest port it maps to; got %q", f.Usage)
+	}
+}
+
+func TestVMCreateHasAPRFlag(t *testing.T) {
+	// The VM is the one target a reviewer can run without hardware, which is why
+	// it builds on every PR. Without this flag that build is unreachable.
+	create := vmSubcommand(t, "create")
+	f := create.Flags().Lookup("pr")
+	if f == nil {
+		t.Fatal("create has no --pr flag; a PR's VM image cannot be run")
+	}
+	if f.DefValue != "0" {
+		t.Errorf("--pr default = %q, want 0 (unset)", f.DefValue)
+	}
+}
+
+func TestVMCreateRejectsPRCombinedWithAChannel(t *testing.T) {
+	// A PR publishes exactly one build, so a version or channel alongside it is
+	// a contradiction rather than a refinement.
+	for _, extra := range [][]string{
+		{"--version", "1.2.3"},
+		{"--nightly"},
+		{"--image", "/nonexistent.wic"},
+	} {
+		args := append([]string{"create", "dev", "--pr", "246"}, extra...)
+		cmd := newVMCmd()
+		cmd.SetArgs(args)
+		cmd.SetOut(&strings.Builder{})
+		cmd.SetErr(&strings.Builder{})
+		err := cmd.Execute()
+		if err == nil {
+			t.Errorf("create accepted --pr with %v", extra)
+			continue
+		}
+		if !strings.Contains(err.Error(), "--pr") {
+			t.Errorf("error for --pr with %v should name --pr; got %q", extra, err)
+		}
+	}
+}
+
+func TestVMCommandHasBackgroundLifecycleSubcommands(t *testing.T) {
+	want := map[string]bool{"create": false, "start": false, "stop": false, "logs": false, "list": false, "rm": false}
+	for _, sub := range newVMCmd().Commands() {
+		if _, ok := want[sub.Name()]; ok {
+			want[sub.Name()] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("wendy vm is missing the %q subcommand", name)
+		}
+	}
+}
+
+func TestVMStartOffersDetach(t *testing.T) {
+	for _, sub := range newVMCmd().Commands() {
+		if sub.Name() != "start" {
+			continue
+		}
+		if sub.Flags().Lookup("detach") == nil {
+			t.Error("wendy vm start has no --detach flag")
+		}
+		if sub.Flags().ShorthandLookup("d") == nil {
+			t.Error("wendy vm start has no -d shorthand for --detach")
+		}
+		return
+	}
+	t.Fatal("no start subcommand")
+}
+
+func TestVMStateLabelDistinguishesStartingFromRunning(t *testing.T) {
+	// The run lock is taken before the emulator has a pid; that window must
+	// read as "starting", not as a stale record.
+	cases := []struct {
+		name string
+		st   vm.Status
+		want string
+	}{
+		{"stopped", vm.Status{Exists: true}, "stopped"},
+		{"starting", vm.Status{Exists: true, Running: true}, "starting"},
+		{"running", vm.Status{Exists: true, Running: true, State: vm.State{PID: 42}}, "running"},
+	}
+	for _, tc := range cases {
+		if got := vmStateLabel(tc.st); got != tc.want {
+			t.Errorf("vmStateLabel(%s) = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestVMAddressOnlyForARunningForwardedVM(t *testing.T) {
+	// Empty, not a display dash: callers treat the result as a dial target.
+	if got := vmAddress(vm.Status{Exists: true}); got != "" {
+		t.Errorf("vmAddress(stopped) = %q, want empty", got)
+	}
+	// Shared networking forwards no port, so there is no loopback address.
+	if got := vmAddress(vm.Status{Running: true, State: vm.State{PID: 1}}); got != "" {
+		t.Errorf("vmAddress(shared) = %q, want empty", got)
+	}
+	running := vm.Status{Running: true, State: vm.State{PID: 1, AgentPort: 50053}}
+	if got := vmAddress(running); got != "127.0.0.1:50053" {
+		t.Errorf("vmAddress(running) = %q, want 127.0.0.1:50053", got)
+	}
+}
+
+func TestVMImageSourceNamesTheChannel(t *testing.T) {
+	cases := []struct {
+		image   string
+		nightly bool
+		pr      int
+		want    string
+	}{
+		{"", false, 0, "release"},
+		{"", true, 0, "nightly"},
+		{"", false, 1834, "pr/1834"},
+		{"/tmp/x.wic", false, 0, "local"},
+	}
+	for _, tc := range cases {
+		if got := vmImageSource(tc.image, tc.nightly, tc.pr); got != tc.want {
+			t.Errorf("vmImageSource(%q, %v, %d) = %q, want %q", tc.image, tc.nightly, tc.pr, got, tc.want)
+		}
+	}
+}
+
+func TestSharedNetworkingRecordsNoAgentPort(t *testing.T) {
+	// Shared mode forwards nothing, so a recorded port would be a loopback
+	// address nothing listens on -- handed out by vm list, the simulator tab
+	// and ensureSimulatorRunning alike.
+	if !strings.Contains(newVMCmd().Long, "QEMU") {
+		t.Skip("vm command shape changed")
+	}
+	st := vm.Status{Running: true, State: vm.State{PID: 1, NetMode: vm.NetShared}}
+	if got := vmAddress(st); got != "" {
+		t.Errorf("vmAddress(shared) = %q, want empty", got)
+	}
+}
+
+func TestConsoleTailStripsEightBitControlIntroducers(t *testing.T) {
+	// \u009b and \u009d are the 8-bit CSI and OSC introducers. Stripping only
+	// the 7-bit ESC form leaves the same escape route open from guest output,
+	// which `wendy vm logs` and a failed boot both print to the terminal.
+	got := sanitizeConsoleLine("a\u009b2Jb\u009d0;xc\x1b[2Jd")
+	for _, bad := range []string{"\u009b", "\u009d", "\x1b"} {
+		if strings.Contains(got, bad) {
+			t.Errorf("sanitizeConsoleLine() = %q, still contains %q", got, bad)
+		}
+	}
+	for _, keep := range []string{"a", "b", "c", "d"} {
+		if !strings.Contains(got, keep) {
+			t.Errorf("sanitizeConsoleLine() = %q, dropped the printable %q", got, keep)
+		}
+	}
+	// Multi-byte text must survive: the guest prints UTF-8 and box drawing.
+	if got := sanitizeConsoleLine("na\u00efve \u2713 caf\u00e9"); got != "na\u00efve \u2713 caf\u00e9" {
+		t.Errorf("sanitizeConsoleLine() = %q, want multi-byte text kept intact", got)
+	}
+}

--- a/go/internal/cli/grpcclient/client.go
+++ b/go/internal/cli/grpcclient/client.go
@@ -481,7 +481,14 @@ func hostFromAddress(address string) string {
 }
 
 // Close closes the underlying gRPC connection.
+//
+// Safe on a nil receiver: callers defer Close on a connection variable that a
+// later reconnect may set back to nil, and a failed reconnect must surface its
+// own error rather than a panic from the deferred cleanup.
 func (c *AgentConnection) Close() error {
+	if c == nil {
+		return nil
+	}
 	var errs []error
 	if c.Conn != nil {
 		errs = append(errs, c.Conn.Close())

--- a/go/internal/cli/grpcclient/client.go
+++ b/go/internal/cli/grpcclient/client.go
@@ -63,7 +63,9 @@ type AgentConnection struct {
 	// Addr is the full host:port this connection dialed — the endpoint that
 	// actually answered, mTLS port included. Empty for unix-socket and
 	// pre-built (NewFromConn) connections.
-	Addr           string
+	Addr string
+	// SimulatorName retains the VM pin identity independently of its loopback endpoint.
+	SimulatorName  string
 	IsMTLS         bool                    // true when connected via mutual TLS
 	IsSessionProxy bool                    // true when Conn reaches a local session broker retaining the mTLS transport
 	CertInfo       *config.CertificateInfo // cert used to establish mTLS; nil for plaintext

--- a/go/internal/cli/grpcclient/client_test.go
+++ b/go/internal/cli/grpcclient/client_test.go
@@ -194,3 +194,13 @@ func assertValidPassthroughURL(t *testing.T, target, wantPath string) {
 		t.Fatal("endpoint is empty — passthrough resolver would reject this target")
 	}
 }
+
+func TestCloseOnANilConnectionDoesNotPanic(t *testing.T) {
+	// `wendy os update` defers Close on a variable that ensureAgentUpToDate
+	// sets to nil when a post-restart reconnect fails; without a nil-receiver
+	// guard the deferred cleanup panics and hides the real error.
+	var conn *AgentConnection
+	if err := conn.Close(); err != nil {
+		t.Errorf("Close() on a nil connection = %v, want nil", err)
+	}
+}

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -213,6 +213,21 @@ type PickerModel struct {
 	// If nil, 'r' is ignored.
 	OnRemoveItem func(item PickerItem) (string, bool, *PickerItem)
 
+	// OnCreateItem is called when the user presses 'c'. Returning quit=true
+	// closes the picker, which an action needing the terminal to itself must
+	// do: creating a VM downloads an image behind its own progress program,
+	// and two Bubble Tea programs cannot share a terminal.
+	// If nil, 'c' is ignored.
+	OnCreateItem func() (flash string, quit bool)
+
+	// OnStopItem is called when the user presses 's' on the highlighted item.
+	// Returns (flash message, isError). If nil, 's' is ignored.
+	OnStopItem func(item PickerItem) (string, bool)
+
+	// RemoveHint is the wording for 'r' in the header, for a picker whose rows
+	// are not cloud credentials. Empty keeps the default.
+	RemoveHint string
+
 	// OnCopyItem is called when the user presses Enter. The callback should
 	// perform the copy operation (e.g. write to clipboard) and return a flash
 	// confirmation message. When set, Enter does NOT navigate away — the picker
@@ -375,6 +390,25 @@ func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.flashMessage = m.OnUnsetDefault()
 				m.flashIsError = false
 				m.refreshTable()
+			}
+			return m, nil
+		case key == "c" && !m.Filterable:
+			if m.OnCreateItem != nil {
+				flash, quit := m.OnCreateItem()
+				m.flashMessage = flash
+				m.flashIsError = false
+				if quit {
+					return m, tea.Quit
+				}
+			}
+			return m, nil
+		case key == "s" && !m.Filterable:
+			if m.OnStopItem != nil {
+				visible := m.visibleItems()
+				if idx := m.itemIndexForRow(m.table.Cursor()); idx >= 0 && idx < len(visible) {
+					m.flashMessage, m.flashIsError = m.OnStopItem(visible[idx])
+					m.refreshTable()
+				}
 			}
 			return m, nil
 		case key == "r" && !m.Filterable:
@@ -563,7 +597,8 @@ func (m PickerModel) View() string {
 	if m.Filterable {
 		hint = " (type to filter, ↑/↓ navigate" + scrollHint + ", " + enterAction + ", esc quit)"
 	}
-	if m.OnSetDefault != nil || m.OnUnsetDefault != nil || m.OnRemoveItem != nil {
+	if m.OnSetDefault != nil || m.OnUnsetDefault != nil || m.OnRemoveItem != nil ||
+		m.OnCreateItem != nil || m.OnStopItem != nil {
 		extras := ""
 		if m.OnSetDefault != nil {
 			extras += ", d set default"
@@ -571,8 +606,18 @@ func (m PickerModel) View() string {
 		if m.OnUnsetDefault != nil {
 			extras += ", x clear default"
 		}
+		if m.OnCreateItem != nil {
+			extras += ", c create"
+		}
+		if m.OnStopItem != nil {
+			extras += ", s stop"
+		}
 		if m.OnRemoveItem != nil {
-			extras += ", r remove creds"
+			label := m.RemoveHint
+			if label == "" {
+				label = "remove creds"
+			}
+			extras += ", r " + label
 		}
 		hint = " (↑/↓ navigate" + scrollHint + ", " + enterAction + extras + ", q quit)"
 	}

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -220,9 +220,11 @@ type PickerModel struct {
 	// If nil, 'c' is ignored.
 	OnCreateItem func() (flash string, quit bool)
 
-	// OnStopItem is called when the user presses 's' on the highlighted item.
+	// OnStopItem runs asynchronously when the user presses 's'. It must not
+	// mutate the model, and should honor its owner's cancellation context.
 	// Returns (flash message, isError). If nil, 's' is ignored.
-	OnStopItem func(item PickerItem) (string, bool)
+	OnStopItem   func(item PickerItem) (string, bool)
+	stoppingName string
 
 	// RemoveHint is the wording for 'r' in the header, for a picker whose rows
 	// are not cloud credentials. Empty keeps the default.
@@ -335,8 +337,18 @@ func (m PickerModel) anyProbePending() bool {
 	return false
 }
 
+type pickerStopResultMsg struct {
+	flash   string
+	isError bool
+}
+
 func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case pickerStopResultMsg:
+		m.stoppingName = ""
+		m.flashMessage, m.flashIsError = msg.flash, msg.isError
+		m.refreshTable()
+		return m, nil
 	case spinner.TickMsg:
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)
@@ -403,11 +415,16 @@ func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 		case key == "s" && !m.Filterable:
-			if m.OnStopItem != nil {
+			if m.OnStopItem != nil && m.stoppingName == "" {
 				visible := m.visibleItems()
 				if idx := m.itemIndexForRow(m.table.Cursor()); idx >= 0 && idx < len(visible) {
-					m.flashMessage, m.flashIsError = m.OnStopItem(visible[idx])
-					m.refreshTable()
+					item, stop := visible[idx], m.OnStopItem
+					m.stoppingName = item.Name
+					m.flashMessage = ""
+					return m, func() tea.Msg {
+						flash, isError := stop(item)
+						return pickerStopResultMsg{flash: flash, isError: isError}
+					}
 				}
 			}
 			return m, nil
@@ -646,6 +663,9 @@ func (m PickerModel) View() string {
 
 	sb.WriteString(colorizeSectionHeaders(ColorizeProbeGlyphs(m.tableView()), m.sectionLabels()) + "\n")
 
+	if m.stoppingName != "" {
+		sb.WriteString(m.viewLine("  Stopping "+m.stoppingName+"… (waiting for guest shutdown)") + "\n")
+	}
 	if m.flashMessage != "" {
 		style := lipgloss.NewStyle().Foreground(ColorPrimary)
 		if m.flashIsError {

--- a/go/internal/cli/tui/picker_test.go
+++ b/go/internal/cli/tui/picker_test.go
@@ -48,6 +48,47 @@ func TestPickerModel_SelectsFromTable(t *testing.T) {
 	}
 }
 
+func TestPickerStopRunsOutsideUpdateAndRemainsResponsive(t *testing.T) {
+	m := NewPickerWithTitle("Simulators")
+	called := false
+	m.OnStopItem = func(item PickerItem) (string, bool) {
+		called = true
+		if item.Name != "alpha" {
+			t.Fatalf("stopped wrong row: %s", item.Name)
+		}
+		return "Stopped alpha.", false
+	}
+	u, _ := m.Update(PickerAddMsg{Items: []PickerItem{{Name: "alpha"}, {Name: "beta"}}})
+	m = u.(PickerModel)
+	u, stop := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("s")})
+	m = u.(PickerModel)
+	if called || stop == nil {
+		t.Fatal("stop ran synchronously or was not scheduled")
+	}
+	if !strings.Contains(m.View(), "Stopping alpha") {
+		t.Fatal("no shutdown progress")
+	}
+	u, duplicate := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("s")})
+	if duplicate != nil {
+		t.Fatal("scheduled duplicate shutdown")
+	}
+	m = u.(PickerModel)
+	u, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = u.(PickerModel)
+	if m.table.Cursor() != 1 || !strings.Contains(m.View(), "Stopping alpha") {
+		t.Fatal("navigation lost progress")
+	}
+	u, quit := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if quit == nil || !u.(PickerModel).Cancelled() {
+		t.Fatal("cannot quit during shutdown")
+	}
+	u, _ = m.Update(stop())
+	m = u.(PickerModel)
+	if !called || m.stoppingName != "" || !strings.Contains(m.View(), "Stopped alpha.") {
+		t.Fatal("stop result not applied")
+	}
+}
+
 func TestPickerModel_DedupesItems(t *testing.T) {
 	m := NewPicker()
 

--- a/go/internal/cli/vm/host.go
+++ b/go/internal/cli/vm/host.go
@@ -1,0 +1,149 @@
+// Package vm runs a WendyOS ARM64 virtual machine on the developer's own
+// machine, so WendyOS can be evaluated and developed against without a Jetson
+// or a Raspberry Pi on the desk.
+package vm
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// Seams so tests can describe a host they are not running on.
+var (
+	vmStat        = os.Stat
+	vmOpen        = os.Open
+	vmLookPath    = exec.LookPath
+	vmBrewCommand = exec.Command
+)
+
+// ErrFirmwareNotFound reports that no host UEFI firmware image was located.
+// oe-core's only firmware recipe, ovmf, is x86_64-only, so aarch64 firmware
+// always comes from the host's QEMU installation.
+var ErrFirmwareNotFound = errors.New("no ARM64 UEFI firmware found")
+
+// pflashBytes is the size the virt machine's pflash unit maps, and therefore the
+// size both the firmware image and its variable store must be.
+const pflashBytes = 64 << 20
+
+// Accel names the CPU acceleration available to an ARM64 guest.
+type Accel string
+
+const (
+	AccelHVF Accel = "hvf" // Apple Silicon, via Hypervisor.framework
+	AccelKVM Accel = "kvm" // ARM64 Linux
+	AccelTCG Accel = "tcg" // software emulation: correct everywhere, slow
+)
+
+// AccelFor reports the best acceleration for an ARM64 guest on the given host.
+// Acceleration needs the host and guest architectures to match, so only ARM64
+// hosts get it; everything else emulates.
+func AccelFor(goos, goarch string) Accel {
+	if goarch != "arm64" {
+		return AccelTCG
+	}
+	switch goos {
+	case "darwin":
+		return AccelHVF
+	case "linux":
+		// /dev/kvm may be absent or unreadable. Emulating is slow but works;
+		// asking for KVM without it aborts QEMU.
+		if f, err := vmOpen("/dev/kvm"); err == nil {
+			_ = f.Close()
+			return AccelKVM
+		}
+		return AccelTCG
+	default:
+		return AccelTCG
+	}
+}
+
+// CPUModel returns the -cpu value for an acceleration mode. An emulated guest
+// has no physical CPU to pass through, so it gets the concrete model upstream
+// qemuarm64.conf uses.
+func CPUModel(a Accel) string {
+	if a == AccelTCG {
+		return "cortex-a57"
+	}
+	return "host"
+}
+
+// MachineType returns the -machine value for an acceleration mode. Only HVF
+// pins the GIC, having no GICv2 implementation; KVM must be left free to match
+// a host that may be GICv2.
+func MachineType(a Accel) string {
+	if a == AccelHVF {
+		return "virt,gic-version=3"
+	}
+	return "virt"
+}
+
+// BrewPrefix reports the Homebrew prefix, or "" when brew is not installed.
+// Used only to locate QEMU's bundled firmware on macOS.
+func BrewPrefix() string {
+	if _, err := vmLookPath("brew"); err != nil {
+		return ""
+	}
+	out, err := vmBrewCommand("brew", "--prefix").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// FirmwareCandidates lists the UEFI code images to try, most likely first.
+// Layouts differ per packager, so the common ones are named outright.
+func FirmwareCandidates(goos, brewPrefix string) []string {
+	switch goos {
+	case "darwin":
+		var out []string
+		if brewPrefix != "" {
+			out = append(out, brewPrefix+"/share/qemu/edk2-aarch64-code.fd")
+		}
+		return append(out,
+			"/opt/homebrew/share/qemu/edk2-aarch64-code.fd",
+			"/usr/local/share/qemu/edk2-aarch64-code.fd",
+		)
+	case "windows":
+		return []string{
+			`C:\Program Files\qemu\share\edk2-aarch64-code.fd`,
+			`C:\Program Files\qemu\edk2-aarch64-code.fd`,
+		}
+	default:
+		return []string{
+			"/usr/share/AAVMF/AAVMF_CODE.fd",
+			"/usr/share/qemu-efi-aarch64/QEMU_EFI.fd",
+			"/usr/share/edk2/aarch64/QEMU_EFI.silent.fd",
+			"/usr/share/qemu/edk2-aarch64-code.fd",
+		}
+	}
+}
+
+// FindFirmware returns the first firmware image padded to the pflash size the
+// virt machine maps. Distributions ship unpadded images under similar names,
+// and QEMU rejects those only at boot, long after `vm create` succeeded.
+func FindFirmware(goos, brewPrefix string) (string, error) {
+	candidates := FirmwareCandidates(goos, brewPrefix)
+	for _, path := range candidates {
+		if info, err := vmStat(path); err == nil && info != nil && info.Size() == pflashBytes {
+			return path, nil
+		}
+	}
+	return "", fmt.Errorf("%w; install it with %s (looked in: %s)",
+		ErrFirmwareNotFound, firmwareInstallHint(goos), strings.Join(candidates, ", "))
+}
+
+// firmwareInstallHint names the command that installs the firmware, so the
+// error says how to fix it.
+func firmwareInstallHint(goos string) string {
+	switch goos {
+	case "darwin":
+		return "brew install qemu"
+	case "windows":
+		return "the QEMU for Windows installer, which bundles it"
+	default:
+		return "apt install qemu-efi-aarch64 (or dnf install edk2-aarch64)"
+	}
+}

--- a/go/internal/cli/vm/host_test.go
+++ b/go/internal/cli/vm/host_test.go
@@ -1,0 +1,173 @@
+package vm
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"strings"
+	"testing"
+)
+
+// stubKVM controls whether the fake host has a usable /dev/kvm.
+func stubKVM(t *testing.T, present bool) {
+	t.Helper()
+	orig := vmOpen
+	t.Cleanup(func() { vmOpen = orig })
+	vmOpen = func(name string) (*os.File, error) {
+		if present && name == "/dev/kvm" {
+			return os.NewFile(0, name), nil
+		}
+		return nil, fs.ErrNotExist
+	}
+}
+
+func TestAccelFor(t *testing.T) {
+	stubKVM(t, true)
+	for _, tc := range []struct {
+		goos, goarch string
+		want         Accel
+	}{
+		{"darwin", "arm64", AccelHVF},
+		{"linux", "arm64", AccelKVM},
+		{"darwin", "amd64", AccelTCG},
+		{"linux", "amd64", AccelTCG},
+		{"windows", "amd64", AccelTCG},
+	} {
+		if got := AccelFor(tc.goos, tc.goarch); got != tc.want {
+			t.Errorf("AccelFor(%q, %q) = %q, want %q", tc.goos, tc.goarch, got, tc.want)
+		}
+	}
+}
+
+func TestAccelForFallsBackToTCGWithoutKVM(t *testing.T) {
+	// No nested virt, or the user is not in the kvm group. Emulating is slow but
+	// works; asking for KVM without it aborts.
+	stubKVM(t, false)
+	if got := AccelFor("linux", "arm64"); got != AccelTCG {
+		t.Errorf("AccelFor(linux, arm64) without /dev/kvm = %q, want tcg", got)
+	}
+}
+
+func TestCPUModelAndMachineType(t *testing.T) {
+	// Accelerated hosts pass the physical CPU through; TCG must name a concrete
+	// ARMv8 model because there is no host CPU to inherit.
+	if got := CPUModel(AccelHVF); got != "host" {
+		t.Errorf("CPUModel(hvf) = %q, want host", got)
+	}
+	if got := CPUModel(AccelKVM); got != "host" {
+		t.Errorf("CPUModel(kvm) = %q, want host", got)
+	}
+	if got := CPUModel(AccelTCG); got != "cortex-a57" {
+		t.Errorf("CPUModel(tcg) = %q, want cortex-a57", got)
+	}
+
+	// HVF has no GICv2 emulation, so it must pin GICv3. KVM must NOT: an ARM64
+	// host with a GICv2 aborts on a GICv3 request, where the default matches.
+	if got := MachineType(AccelHVF); !strings.Contains(got, "gic-version=3") {
+		t.Errorf("MachineType(hvf) = %q, want gic-version=3", got)
+	}
+	if got := MachineType(AccelKVM); got != "virt" {
+		t.Errorf("MachineType(kvm) = %q, want plain virt so the host GIC is matched", got)
+	}
+	if got := MachineType(AccelTCG); got != "virt" {
+		t.Errorf("MachineType(tcg) = %q, want plain virt", got)
+	}
+}
+
+func TestFirmwareCandidatesUsesBrewPrefixFirstOnDarwin(t *testing.T) {
+	got := FirmwareCandidates("darwin", "/opt/homebrew")
+	if len(got) == 0 {
+		t.Fatal("no candidates for darwin")
+	}
+	if got[0] != "/opt/homebrew/share/qemu/edk2-aarch64-code.fd" {
+		t.Errorf("first darwin candidate = %q, want the brew-prefix path", got[0])
+	}
+}
+
+func TestFirmwareCandidatesCoversDebianAndFedoraLayoutsOnLinux(t *testing.T) {
+	got := strings.Join(FirmwareCandidates("linux", ""), "\n")
+	for _, want := range []string{
+		"/usr/share/AAVMF/AAVMF_CODE.fd",
+		"/usr/share/qemu-efi-aarch64/QEMU_EFI.fd",
+		"/usr/share/edk2/aarch64/QEMU_EFI.silent.fd",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("linux candidates missing %q; got:\n%s", want, got)
+		}
+	}
+}
+
+// fakeFileInfo reports only a size; FindFirmware consults nothing else.
+type fakeFileInfo struct {
+	os.FileInfo
+	size int64
+}
+
+func (f fakeFileInfo) Size() int64 { return f.size }
+
+// stubFirmware makes vmStat report the given paths at the given sizes.
+func stubFirmware(t *testing.T, sizes map[string]int64) {
+	t.Helper()
+	orig := vmStat
+	t.Cleanup(func() { vmStat = orig })
+	vmStat = func(name string) (os.FileInfo, error) {
+		if s, ok := sizes[name]; ok {
+			return fakeFileInfo{size: s}, nil
+		}
+		return nil, fs.ErrNotExist
+	}
+}
+
+func TestFindFirmwareReturnsTheFirstUsableCandidate(t *testing.T) {
+	want := "/usr/share/qemu-efi-aarch64/QEMU_EFI.fd"
+	stubFirmware(t, map[string]int64{want: pflashBytes})
+
+	got, err := FindFirmware("linux", "")
+	if err != nil {
+		t.Fatalf("FindFirmware() error = %v", err)
+	}
+	if got != want {
+		t.Errorf("FindFirmware() = %q, want %q", got, want)
+	}
+}
+
+func TestFindFirmwareSkipsUnpaddedFirmware(t *testing.T) {
+	// Debian's qemu-efi-aarch64 ships both: a padded AAVMF_CODE.fd and a 2 MiB
+	// QEMU_EFI.fd that QEMU rejects as pflash. Picking the wrong one fails at
+	// start, long after create reported success.
+	padded := "/usr/share/AAVMF/AAVMF_CODE.fd"
+	stubFirmware(t, map[string]int64{
+		"/usr/share/qemu-efi-aarch64/QEMU_EFI.fd": 2 << 20,
+		padded: pflashBytes,
+	})
+
+	got, err := FindFirmware("linux", "")
+	if err != nil {
+		t.Fatalf("FindFirmware() error = %v", err)
+	}
+	if got != padded {
+		t.Errorf("FindFirmware() = %q, want the padded %q", got, padded)
+	}
+}
+
+func TestFindFirmwareRejectsAnUnpaddedOnlyHost(t *testing.T) {
+	stubFirmware(t, map[string]int64{"/usr/share/qemu-efi-aarch64/QEMU_EFI.fd": 2 << 20})
+	if _, err := FindFirmware("linux", ""); !errors.Is(err, ErrFirmwareNotFound) {
+		t.Errorf("unpadded-only host should report firmware not found; got %v", err)
+	}
+}
+
+func TestFindFirmwareErrorNamesTheInstallCommand(t *testing.T) {
+	stubFirmware(t, nil)
+
+	_, err := FindFirmware("darwin", "/opt/homebrew")
+	if err == nil {
+		t.Fatal("expected an error when no firmware is installed")
+	}
+	if !strings.Contains(err.Error(), "brew install qemu") {
+		t.Errorf("error should tell the user how to fix it; got %q", err)
+	}
+	if !errors.Is(err, ErrFirmwareNotFound) {
+		t.Errorf("error should wrap ErrFirmwareNotFound; got %#v", err)
+	}
+}

--- a/go/internal/cli/vm/kill_test.go
+++ b/go/internal/cli/vm/kill_test.go
@@ -1,0 +1,9 @@
+//go:build darwin || linux
+
+package vm
+
+import "syscall"
+
+// syscallKill hard-kills a stubbed emulator, standing in for the VM dying
+// without a chance to clean up after itself.
+func syscallKill(pid int) error { return syscall.Kill(pid, syscall.SIGKILL) }

--- a/go/internal/cli/vm/launch.go
+++ b/go/internal/cli/vm/launch.go
@@ -159,10 +159,9 @@ func (s *Store) openConsoleLog(name string) (*os.File, error) {
 // emulator's last descriptor closes, so this reports the process is really
 // gone rather than that a signal was delivered.
 //
-// SIGTERM makes QEMU exit, which is a power cut from the guest's point of view
-// -- it never sees an ACPI power-button event, so its filesystems are not
-// flushed. The launcher now exposes QMP, but Stop does not yet use it for a
-// graceful guest shutdown. Power the guest off from inside when that matters.
+// Without force, request the guest's power-button handler through QMP. A
+// missing monitor or an unresponsive guest is an error, never permission to
+// cut power. Only an explicit force request may kill the emulator.
 func (s *Store) Stop(name string, force bool, grace time.Duration) error {
 	st, err := s.Status(name)
 	if err != nil {
@@ -179,14 +178,13 @@ func (s *Store) Stop(name string, force bool, grace time.Duration) error {
 		return fmt.Errorf("VM %q is starting; retry in a moment", name)
 	}
 
-	// Checked running above, so at worst this signals a pid recycled in the
-	// microseconds since. Nothing to do about that beyond keeping the window
-	// this small.
-	if err := killProcess(st.State.PID, force); err != nil {
-		return fmt.Errorf("signalling VM %q: %w", name, err)
-	}
 	if force {
+		if err := killProcess(st.State.PID, true); err != nil {
+			return fmt.Errorf("signalling VM %q: %w", name, err)
+		}
 		grace = time.Second
+	} else if err := s.requestPowerdown(context.Background(), name); err != nil {
+		return fmt.Errorf("requesting VM %q shutdown: %w; shut down inside the guest or use 'wendy vm stop %s --force' to cut power", name, err, name)
 	}
 
 	deadline := time.Now().Add(grace)
@@ -204,7 +202,7 @@ func (s *Store) Stop(name string, force bool, grace time.Duration) error {
 	if force {
 		return fmt.Errorf("VM %q did not exit after SIGKILL", name)
 	}
-	return s.Stop(name, true, grace)
+	return fmt.Errorf("VM %q has not shut down after %s; it was not killed: wait longer or use 'wendy vm stop %s --force' to cut power", name, grace, name)
 }
 
 // RunForeground runs a VM attached to the given streams and blocks until it

--- a/go/internal/cli/vm/launch.go
+++ b/go/internal/cli/vm/launch.go
@@ -180,6 +180,15 @@ func (s *Store) openConsoleLog(name string) (*os.File, error) {
 // missing monitor or an unresponsive guest is an error, never permission to
 // cut power. Only an explicit force request may kill the emulator.
 func (s *Store) Stop(name string, force bool, grace time.Duration) error {
+	return s.StopContext(context.Background(), name, force, grace)
+}
+
+// StopContext lets callers abandon the wait without cutting the VM's power.
+// A shutdown already requested from the guest continues after cancellation.
+func (s *Store) StopContext(ctx context.Context, name string, force bool, grace time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	st, err := s.Status(name)
 	if err != nil {
 		return err
@@ -200,7 +209,10 @@ func (s *Store) Stop(name string, force bool, grace time.Duration) error {
 			return fmt.Errorf("signalling VM %q: %w", name, err)
 		}
 		grace = time.Second
-	} else if err := s.requestPowerdown(context.Background(), name); err != nil {
+	} else if err := s.requestPowerdown(ctx, name); err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		return fmt.Errorf("requesting VM %q shutdown: %w; shut down inside the guest or use 'wendy vm stop %s --force' to cut power", name, err, name)
 	}
 
@@ -214,7 +226,11 @@ func (s *Store) Stop(name string, force bool, grace time.Duration) error {
 			_, err := s.Status(name) // reaps state.json
 			return err
 		}
-		time.Sleep(50 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(50 * time.Millisecond):
+		}
 	}
 	if force {
 		return fmt.Errorf("VM %q did not exit after SIGKILL", name)

--- a/go/internal/cli/vm/launch.go
+++ b/go/internal/cli/vm/launch.go
@@ -52,6 +52,12 @@ func (s *Store) StartDetached(spec Spec) (State, error) {
 	// spec, and rotating the log first would discard the previous boot's
 	// output over a launch that never happens.
 	spec.ConsoleLog = s.LogPath(spec.Name)
+	if DetachSupported() {
+		spec.QMPPath, err = s.prepareQMP(spec.Name)
+		if err != nil {
+			return State{}, err
+		}
+	}
 	args, err := spec.Args()
 	if err != nil {
 		return State{}, err
@@ -155,9 +161,8 @@ func (s *Store) openConsoleLog(name string) (*os.File, error) {
 //
 // SIGTERM makes QEMU exit, which is a power cut from the guest's point of view
 // -- it never sees an ACPI power-button event, so its filesystems are not
-// flushed. A graceful guest shutdown would need a QMP monitor, which the
-// detached spec deliberately does not open. Power the guest off from inside
-// when that matters.
+// flushed. The launcher now exposes QMP, but Stop does not yet use it for a
+// graceful guest shutdown. Power the guest off from inside when that matters.
 func (s *Store) Stop(name string, force bool, grace time.Duration) error {
 	st, err := s.Status(name)
 	if err != nil {
@@ -220,6 +225,12 @@ func (s *Store) RunForeground(ctx context.Context, spec Spec, stdin io.Reader, s
 
 	// No ConsoleLog: the console is this terminal, which is the whole point of
 	// a foreground start.
+	if DetachSupported() {
+		spec.QMPPath, err = s.prepareQMP(spec.Name)
+		if err != nil {
+			return err
+		}
+	}
 	args, err := spec.Args()
 	if err != nil {
 		return err

--- a/go/internal/cli/vm/launch.go
+++ b/go/internal/cli/vm/launch.go
@@ -1,0 +1,267 @@
+package vm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// vmCommand builds the emulator command; a seam so tests can launch something
+// cheaper than QEMU. Deliberately exec.Command and not exec.CommandContext: a
+// context-bound child dies with the CLI, which is exactly what detaching must
+// prevent.
+var vmCommand = exec.Command
+
+// vmCommandContext is the foreground equivalent: the VM is tied to the CLI's
+// lifetime here, which is exactly what an attached console means.
+var vmCommandContext = exec.CommandContext
+
+// StartDetached launches a VM in the background and records the run. The VM
+// outlives the CLI: Ctrl-C on the command that started it must not power the
+// guest off.
+//
+// Returns ErrAlreadyRunning if the VM is already up, which callers that only
+// need it running should treat as success.
+// ErrDetachUnsupported reports that this host cannot run a VM in the
+// background. Windows has neither the inherited-descriptor lock nor the signal
+// semantics the detached path relies on; foreground `wendy vm start` still
+// works. Declared here rather than beside detachProcess so callers can check
+// DetachSupported on every platform.
+var ErrDetachUnsupported = errors.New("detached VMs need macOS or Linux; use 'wendy vm start'")
+
+func (s *Store) StartDetached(spec Spec) (State, error) {
+	if err := ValidName(spec.Name); err != nil {
+		return State{}, err
+	}
+
+	lock, err := s.acquireRunLock(spec.Name)
+	if err != nil {
+		return State{}, err
+	}
+	// The parent always drops its copy: the lock must end up held by QEMU
+	// alone, so that QEMU's death is what frees it. Bare, and deliberately so --
+	// nothing is written through a lock handle, and a close error here would
+	// otherwise report a failure for a VM that started perfectly well.
+	defer func() { _ = lock.Close() }()
+
+	// Args before openConsoleLog: it is the last thing that can reject the
+	// spec, and rotating the log first would discard the previous boot's
+	// output over a launch that never happens.
+	spec.ConsoleLog = s.LogPath(spec.Name)
+	args, err := spec.Args()
+	if err != nil {
+		return State{}, err
+	}
+
+	logFile, err := s.openConsoleLog(spec.Name)
+	if err != nil {
+		return State{}, err
+	}
+	// Closed bare: this handle is handed to QEMU below and never written to
+	// here, and QEMU keeps its own descriptor open long after the parent drops
+	// this one.
+	defer func() { _ = logFile.Close() }()
+
+	// Recorded before the process exists so a concurrent reader never sees a
+	// held lock with no state at all. PID 0 reads as "starting".
+	st := State{
+		Name:      spec.Name,
+		AgentPort: spec.Net.AgentPort,
+		NetMode:   spec.Net.Mode,
+		MAC:       spec.Net.MAC,
+		Accel:     spec.Accel,
+		MemoryMiB: spec.MemoryMiB,
+		CPUs:      spec.CPUs,
+		StartedAt: time.Now().UTC(),
+		Detached:  true,
+		LogPath:   spec.ConsoleLog,
+	}
+	if err := s.WriteState(st); err != nil {
+		return State{}, err
+	}
+
+	cmd := vmCommand(spec.Binary(), args...)
+	cmd.Stdin = nil
+	// QEMU's own startup failures ("Could not set up host forwarding rule")
+	// belong in the same log as the guest console; they are all a user has
+	// when a detached boot fails.
+	cmd.Stdout, cmd.Stderr = logFile, logFile
+	attachRunLock(cmd, lock)
+	if err := detachProcess(cmd); err != nil {
+		_ = os.Remove(s.StatePath(spec.Name))
+		return State{}, err
+	}
+
+	if err := cmd.Start(); err != nil {
+		_ = os.Remove(s.StatePath(spec.Name))
+		return State{}, fmt.Errorf("starting %s: %w", spec.Binary(), err)
+	}
+
+	st.PID = cmd.Process.Pid
+	if err := s.WriteState(st); err != nil {
+		// The record still says pid 0, which every command reads as "starting"
+		// and refuses to act on. Rather than leave a VM nothing can stop, take
+		// it down with us.
+		_ = killProcess(st.PID, true)
+		_ = os.Remove(s.StatePath(spec.Name))
+		return State{}, err
+	}
+
+	// Reap the child if this process outlives it, and clear the record so a
+	// long-lived CLI notices a VM that died mid-deploy. When the CLI exits
+	// first the VM is simply orphaned to init, which is the intent.
+	go func() {
+		_ = cmd.Wait()
+		s.clearStateForPID(spec.Name, st.PID)
+	}()
+
+	return st, nil
+}
+
+// clearStateForPID removes the run record only while it still describes pid.
+// A second run may have started and written its own record by the time this
+// process reaps its child, and deleting that would report the live VM as
+// merely "starting", with no address.
+func (s *Store) clearStateForPID(name string, pid int) {
+	if cur, err := s.ReadState(name); err != nil || cur.PID != pid {
+		return
+	}
+	_ = os.Remove(s.StatePath(name))
+}
+
+// openConsoleLog truncates a fresh log, keeping the previous run's alongside it
+// so a boot failure is still diagnosable after one retry.
+func (s *Store) openConsoleLog(name string) (*os.File, error) {
+	path := s.LogPath(name)
+	if err := os.Rename(path, path+".prev"); err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("opening console log: %w", err)
+	}
+	return f, nil
+}
+
+// Stop shuts a running VM down.
+//
+// Waits on the run lock rather than the pid: the kernel frees it when the
+// emulator's last descriptor closes, so this reports the process is really
+// gone rather than that a signal was delivered.
+//
+// SIGTERM makes QEMU exit, which is a power cut from the guest's point of view
+// -- it never sees an ACPI power-button event, so its filesystems are not
+// flushed. A graceful guest shutdown would need a QMP monitor, which the
+// detached spec deliberately does not open. Power the guest off from inside
+// when that matters.
+func (s *Store) Stop(name string, force bool, grace time.Duration) error {
+	st, err := s.Status(name)
+	if err != nil {
+		return err
+	}
+	if !st.Running {
+		return nil
+	}
+	// Running with no pid means the record was written but the emulator has not
+	// been started yet, or the record is unreadable. Either way there is nothing
+	// safe to signal, and reporting success would let `vm rm --force` delete the
+	// disk out from under a live emulator.
+	if st.State.PID == 0 {
+		return fmt.Errorf("VM %q is starting; retry in a moment", name)
+	}
+
+	// Checked running above, so at worst this signals a pid recycled in the
+	// microseconds since. Nothing to do about that beyond keeping the window
+	// this small.
+	if err := killProcess(st.State.PID, force); err != nil {
+		return fmt.Errorf("signalling VM %q: %w", name, err)
+	}
+	if force {
+		grace = time.Second
+	}
+
+	deadline := time.Now().Add(grace)
+	for time.Now().Before(deadline) {
+		held, err := s.runLockHeld(name)
+		if err != nil {
+			return err
+		}
+		if !held {
+			_, err := s.Status(name) // reaps state.json
+			return err
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if force {
+		return fmt.Errorf("VM %q did not exit after SIGKILL", name)
+	}
+	return s.Stop(name, true, grace)
+}
+
+// RunForeground runs a VM attached to the given streams and blocks until it
+// exits, recording the run exactly as StartDetached does.
+//
+// The record is what `wendy vm list`, discovery and the simulator picker read,
+// so leaving it out would make a VM started this way invisible to all three --
+// and would let them try to start a second emulator on the same disk.
+func (s *Store) RunForeground(ctx context.Context, spec Spec, stdin io.Reader, stdout, stderr io.Writer) error {
+	if err := ValidName(spec.Name); err != nil {
+		return err
+	}
+	lock, err := s.acquireRunLock(spec.Name)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = lock.Close() }()
+
+	// No ConsoleLog: the console is this terminal, which is the whole point of
+	// a foreground start.
+	args, err := spec.Args()
+	if err != nil {
+		return err
+	}
+
+	st := State{
+		Name:      spec.Name,
+		AgentPort: spec.Net.AgentPort,
+		NetMode:   spec.Net.Mode,
+		MAC:       spec.Net.MAC,
+		Accel:     spec.Accel,
+		MemoryMiB: spec.MemoryMiB,
+		CPUs:      spec.CPUs,
+		StartedAt: time.Now().UTC(),
+	}
+	if err := s.WriteState(st); err != nil {
+		return err
+	}
+	// Captured after Start; until then the record has pid 0 and clearing it is
+	// still correct, because nothing else can have taken the lock.
+	startedPID := 0
+	defer func() { s.clearStateForPID(spec.Name, startedPID) }()
+
+	qemu := vmCommandContext(ctx, spec.Binary(), args...)
+	qemu.Stdin, qemu.Stdout, qemu.Stderr = stdin, stdout, stderr
+	// Where the platform allows it the lock rides on the emulator's descriptor,
+	// so a CLI killed outright does not free it while its VM still runs.
+	attachRunLock(qemu, lock)
+	qemu.Cancel = func() error { return terminateProcess(qemu.Process) }
+	if err := qemu.Start(); err != nil {
+		return fmt.Errorf("starting %s: %w", spec.Binary(), err)
+	}
+
+	st.PID = qemu.Process.Pid
+	startedPID = st.PID
+	if err := s.WriteState(st); err != nil {
+		// QEMU is up and holding the lock, but the record still says pid 0, so
+		// no command would act on it. Take it down rather than orphan it --
+		// StartDetached does the same with the identical failure.
+		_ = killProcess(st.PID, true)
+		_ = qemu.Wait()
+		return err
+	}
+	return qemu.Wait()
+}

--- a/go/internal/cli/vm/launch.go
+++ b/go/internal/cli/vm/launch.go
@@ -133,6 +133,23 @@ func (s *Store) StartDetached(spec Spec) (State, error) {
 // process reaps its child, and deleting that would report the live VM as
 // merely "starting", with no address.
 func (s *Store) clearStateForPID(name string, pid int) {
+	// A PID comparison alone races a new start between ReadState and Remove.
+	// Serialize both operations against writers using the same run lock.
+	f, err := os.OpenFile(s.LockPath(name), os.O_RDWR, 0600)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	locked, err := tryLockFile(f)
+	if err != nil || !locked {
+		return
+	}
+	defer unlockFile(f)
+	s.clearStateForPIDLocked(name, pid)
+}
+
+// The caller owns the exclusive run lock, including through Remove.
+func (s *Store) clearStateForPIDLocked(name string, pid int) {
 	if cur, err := s.ReadState(name); err != nil || cur.PID != pid {
 		return
 	}
@@ -250,7 +267,8 @@ func (s *Store) RunForeground(ctx context.Context, spec Spec, stdin io.Reader, s
 	// Captured after Start; until then the record has pid 0 and clearing it is
 	// still correct, because nothing else can have taken the lock.
 	startedPID := 0
-	defer func() { s.clearStateForPID(spec.Name, startedPID) }()
+	// This foreground launcher still owns lock until its earlier Close defer.
+	defer func() { s.clearStateForPIDLocked(spec.Name, startedPID) }()
 
 	qemu := vmCommandContext(ctx, spec.Binary(), args...)
 	qemu.Stdin, qemu.Stdout, qemu.Stderr = stdin, stdout, stderr

--- a/go/internal/cli/vm/launch_other.go
+++ b/go/internal/cli/vm/launch_other.go
@@ -1,0 +1,33 @@
+//go:build !darwin && !linux
+
+package vm
+
+import (
+	"os"
+	"os/exec"
+)
+
+func detachProcess(*exec.Cmd) error { return ErrDetachUnsupported }
+
+// DetachSupported lets a caller check for the limitation up front, rather than
+// hitting it after an image download it did not need to make.
+func DetachSupported() bool { return false }
+
+// killProcess stops a foreground VM. Windows has no SIGTERM, so there is only
+// the abrupt form -- the same outcome SIGTERM produces on the other platforms,
+// where QEMU exits without telling the guest either.
+func killProcess(pid int, _ bool) error {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return p.Kill()
+}
+
+// terminateProcess is what Cmd.Cancel uses; Kill for the same reason.
+func terminateProcess(p *os.Process) error { return p.Kill() }
+
+// attachRunLock is a no-op: os/exec cannot pass extra descriptors on Windows,
+// so the lock stays with this process. A foreground VM is tied to the CLI's
+// lifetime there anyway, which is the same guarantee by another route.
+func attachRunLock(*exec.Cmd, *os.File) {}

--- a/go/internal/cli/vm/launch_test.go
+++ b/go/internal/cli/vm/launch_test.go
@@ -1,0 +1,312 @@
+//go:build darwin || linux
+
+package vm
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// stubEmulator points vmCommand at a long-lived process instead of QEMU.
+//
+// It execs the binary directly rather than going through a shell: a shell
+// forks a grandchild that also inherits the run-lock descriptor, so the lock
+// would outlive the process the test kills and liveness would look stuck.
+func stubEmulator(t *testing.T) {
+	t.Helper()
+	sleep, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Skipf("no sleep binary: %v", err)
+	}
+	savedCmd, savedCtx := vmCommand, vmCommandContext
+	vmCommand = func(_ string, _ ...string) *exec.Cmd { return exec.Command(sleep, "30") }
+	vmCommandContext = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, sleep, "30")
+	}
+	t.Cleanup(func() { vmCommand, vmCommandContext = savedCmd, savedCtx })
+}
+
+func detachableSpec(t *testing.T, s *Store, name string) Spec {
+	t.Helper()
+	createTestVM(t, s, name, Meta{})
+	return Spec{
+		Name:         name,
+		DiskPath:     s.DiskPath(name),
+		FirmwareCode: filepath.Join(t.TempDir(), "code.fd"),
+		FirmwareVars: s.VarsPath(name),
+		Accel:        AccelTCG,
+		Net:          NetConfig{Mode: NetUser, AgentPort: 50051, MAC: MACFor(name)},
+	}
+}
+
+func waitForStop(t *testing.T, s *Store, name string) Status {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		st, err := s.Status(name)
+		if err != nil {
+			t.Fatalf("Status() = %v", err)
+		}
+		if !st.Running || time.Now().After(deadline) {
+			return st
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestStartDetachedRecordsTheRun(t *testing.T) {
+	stubEmulator(t)
+	s := newTestStore(t)
+	spec := detachableSpec(t, s, "dev")
+
+	st, err := s.StartDetached(spec)
+	if err != nil {
+		t.Fatalf("StartDetached() = %v", err)
+	}
+	t.Cleanup(func() {
+		if st.PID > 0 {
+			_ = syscallKill(st.PID)
+		}
+	})
+
+	if st.PID <= 0 {
+		t.Errorf("StartDetached().PID = %d, want the real pid", st.PID)
+	}
+	if !st.Detached {
+		t.Error("StartDetached() recorded Detached = false")
+	}
+
+	got, err := s.Status("dev")
+	if err != nil {
+		t.Fatalf("Status() = %v", err)
+	}
+	if !got.Running || got.State.PID != st.PID {
+		t.Errorf("Status() = %+v, want running with pid %d", got, st.PID)
+	}
+}
+
+func TestStartDetachedCreatesAnOwnerOnlyConsoleLog(t *testing.T) {
+	stubEmulator(t)
+	s := newTestStore(t)
+	st, err := s.StartDetached(detachableSpec(t, s, "dev"))
+	if err != nil {
+		t.Fatalf("StartDetached() = %v", err)
+	}
+	t.Cleanup(func() { _ = syscallKill(st.PID) })
+
+	info, err := os.Stat(s.LogPath("dev"))
+	if err != nil {
+		t.Fatalf("stat console log: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("console.log mode = %v, want 0600", perm)
+	}
+}
+
+func TestStartDetachedRefusesASecondInstance(t *testing.T) {
+	stubEmulator(t)
+	s := newTestStore(t)
+	spec := detachableSpec(t, s, "dev")
+
+	st, err := s.StartDetached(spec)
+	if err != nil {
+		t.Fatalf("first StartDetached() = %v", err)
+	}
+	t.Cleanup(func() { _ = syscallKill(st.PID) })
+
+	if _, err := s.StartDetached(spec); !errors.Is(err, ErrAlreadyRunning) {
+		t.Errorf("second StartDetached() = %v, want ErrAlreadyRunning", err)
+	}
+}
+
+func TestKillingTheVMFreesTheLockAndClearsTheState(t *testing.T) {
+	// The whole point of holding the lock on the emulator's own descriptor:
+	// a hard kill leaves no chance to clean up, and the kernel does it for us.
+	stubEmulator(t)
+	s := newTestStore(t)
+	st, err := s.StartDetached(detachableSpec(t, s, "dev"))
+	if err != nil {
+		t.Fatalf("StartDetached() = %v", err)
+	}
+	if err := syscallKill(st.PID); err != nil {
+		t.Fatalf("kill: %v", err)
+	}
+
+	got := waitForStop(t, s, "dev")
+	if got.Running {
+		t.Error("Status() still reports running after the VM was killed")
+	}
+	if _, err := os.Stat(s.StatePath("dev")); !os.IsNotExist(err) {
+		t.Errorf("state.json survived the kill: %v", err)
+	}
+}
+
+func TestStartDetachedKeepsThePreviousConsoleLog(t *testing.T) {
+	stubEmulator(t)
+	s := newTestStore(t)
+	spec := detachableSpec(t, s, "dev")
+
+	first, err := s.StartDetached(spec)
+	if err != nil {
+		t.Fatalf("StartDetached() = %v", err)
+	}
+	if err := os.WriteFile(s.LogPath("dev"), []byte("first boot"), 0o600); err != nil {
+		t.Fatalf("seed log: %v", err)
+	}
+	_ = syscallKill(first.PID)
+	waitForStop(t, s, "dev")
+
+	second, err := s.StartDetached(spec)
+	if err != nil {
+		t.Fatalf("second StartDetached() = %v", err)
+	}
+	t.Cleanup(func() { _ = syscallKill(second.PID) })
+
+	prev, err := os.ReadFile(s.LogPath("dev") + ".prev")
+	if err != nil {
+		t.Fatalf("read rotated log: %v", err)
+	}
+	if !strings.Contains(string(prev), "first boot") {
+		t.Errorf("console.log.prev = %q, want the previous run's output", prev)
+	}
+}
+
+func TestStopReturnsOnlyOnceTheVMIsReallyGone(t *testing.T) {
+	stubEmulator(t)
+	s := newTestStore(t)
+	st, err := s.StartDetached(detachableSpec(t, s, "dev"))
+	if err != nil {
+		t.Fatalf("StartDetached() = %v", err)
+	}
+
+	if err := s.Stop("dev", true, 5*time.Second); err != nil {
+		t.Fatalf("Stop() = %v", err)
+	}
+	got, err := s.Status("dev")
+	if err != nil {
+		t.Fatalf("Status() = %v", err)
+	}
+	if got.Running {
+		t.Errorf("Status() after Stop() = %+v, want stopped", got)
+	}
+	if _, err := os.Stat(s.StatePath("dev")); !os.IsNotExist(err) {
+		t.Errorf("state.json survived Stop(): %v", err)
+	}
+	_ = st
+}
+
+func TestStopIsANoOpOnAStoppedVM(t *testing.T) {
+	s := newTestStore(t)
+	createTestVM(t, s, "dev", Meta{})
+	if err := s.Stop("dev", false, time.Second); err != nil {
+		t.Errorf("Stop() on a stopped VM = %v, want nil", err)
+	}
+}
+
+func TestForegroundRunIsVisibleLikeADetachedOne(t *testing.T) {
+	// A VM started in the foreground must still be discoverable: `vm list`,
+	// device discovery and the simulator picker all read the run record, and
+	// without one they would report it stopped and try to start a second
+	// emulator on the same disk.
+	stubEmulator(t)
+	s := newTestStore(t)
+	spec := detachableSpec(t, s, "dev")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- s.RunForeground(ctx, spec, nil, io.Discard, io.Discard) }()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		st, err := s.Status("dev")
+		if err != nil {
+			t.Fatalf("Status() = %v", err)
+		}
+		if st.Running && st.State.PID > 0 {
+			if st.State.Detached {
+				t.Error("a foreground run recorded Detached = true")
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("foreground run never became visible in Status()")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	cancel()
+	<-done
+	got := waitForStop(t, s, "dev")
+	if got.Running {
+		t.Error("Status() still reports running after the foreground run ended")
+	}
+}
+
+func TestForegroundRunRefusesASecondInstance(t *testing.T) {
+	stubEmulator(t)
+	s := newTestStore(t)
+	spec := detachableSpec(t, s, "dev")
+
+	st, err := s.StartDetached(spec)
+	if err != nil {
+		t.Fatalf("StartDetached() = %v", err)
+	}
+	t.Cleanup(func() { _ = syscallKill(st.PID) })
+
+	err = s.RunForeground(context.Background(), spec, nil, io.Discard, io.Discard)
+	if !errors.Is(err, ErrAlreadyRunning) {
+		t.Errorf("RunForeground() on a running VM = %v, want ErrAlreadyRunning", err)
+	}
+}
+
+func TestStopRefusesAVMWithNoRecordedPID(t *testing.T) {
+	// Running with no pid means the emulator has not started yet, or the record
+	// is unreadable. Reporting success here let `vm rm --force` delete the disk
+	// out from under a live emulator.
+	s := newTestStore(t)
+	createTestVM(t, s, "dev", Meta{})
+	lock, err := s.acquireRunLock("dev")
+	if err != nil {
+		t.Fatalf("acquireRunLock() = %v", err)
+	}
+	defer lock.Close()
+	if err := s.WriteState(State{Name: "dev"}); err != nil {
+		t.Fatalf("WriteState() = %v", err)
+	}
+
+	if err := s.Stop("dev", true, time.Second); err == nil {
+		t.Error("Stop() = nil for a VM with no recorded pid, want a refusal")
+	}
+}
+
+func TestARejectedSpecKeepsThePreviousConsoleLog(t *testing.T) {
+	// Args is the last thing that can reject a spec. Rotating the console log
+	// before it runs would discard the previous boot's output -- exactly what
+	// the user goes looking for when a start stops working.
+	s := newTestStore(t)
+	spec := detachableSpec(t, s, "dev")
+	spec.Net.Mode = "bridged"
+
+	const previous = "earlier boot output\n"
+	if err := os.WriteFile(s.LogPath("dev"), []byte(previous), 0o600); err != nil {
+		t.Fatalf("seed console log: %v", err)
+	}
+
+	if _, err := s.StartDetached(spec); err == nil {
+		t.Fatal("StartDetached() accepted an unknown network mode")
+	}
+	got, err := os.ReadFile(s.LogPath("dev"))
+	if err != nil {
+		t.Fatalf("read console log: %v", err)
+	}
+	if string(got) != previous {
+		t.Errorf("console.log = %q, want the previous boot's output untouched", got)
+	}
+}

--- a/go/internal/cli/vm/launch_test.go
+++ b/go/internal/cli/vm/launch_test.go
@@ -213,7 +213,7 @@ func TestStopIsANoOpOnAStoppedVM(t *testing.T) {
 }
 
 func TestGracefulStopNeverSilentlyCutsPower(t *testing.T) {
-	for _, mode := range []string{"missing", "refused", "timeout", "shutdown"} {
+	for _, mode := range []string{"missing", "refused", "timeout", "shutdown", "cancelled"} {
 		t.Run(mode, func(t *testing.T) {
 			stubEmulator(t)
 			s := shortQMPStore(t)
@@ -222,6 +222,8 @@ func TestGracefulStopNeverSilentlyCutsPower(t *testing.T) {
 				t.Fatal(err)
 			}
 			t.Cleanup(func() { _ = s.Stop("dev", true, time.Second) })
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			if mode != "missing" {
 				ln, err := net.Listen("unix", s.QMPPath("dev"))
 				if err != nil {
@@ -255,15 +257,21 @@ func TestGracefulStopNeverSilentlyCutsPower(t *testing.T) {
 					if mode == "shutdown" {
 						_ = killProcess(st.PID, true)
 					} // emulate guest exit
+					if mode == "cancelled" {
+						cancel()
+					}
 				}()
 			}
-			err = s.Stop("dev", false, 200*time.Millisecond)
+			err = s.StopContext(ctx, "dev", false, 200*time.Millisecond)
 			if mode == "shutdown" {
 				if err != nil {
 					t.Fatal(err)
 				}
 			} else {
-				if err == nil || !strings.Contains(err.Error(), "--force") {
+				if mode == "cancelled" && !errors.Is(err, context.Canceled) {
+					t.Fatalf("want cancellation, got %v", err)
+				}
+				if mode != "cancelled" && (err == nil || !strings.Contains(err.Error(), "--force")) {
 					t.Fatalf("want explicit-force guidance, got %v", err)
 				}
 				status, err := s.Status("dev")

--- a/go/internal/cli/vm/launch_test.go
+++ b/go/internal/cli/vm/launch_test.go
@@ -4,8 +4,10 @@ package vm
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -207,6 +209,69 @@ func TestStopIsANoOpOnAStoppedVM(t *testing.T) {
 	createTestVM(t, s, "dev", Meta{})
 	if err := s.Stop("dev", false, time.Second); err != nil {
 		t.Errorf("Stop() on a stopped VM = %v, want nil", err)
+	}
+}
+
+func TestGracefulStopNeverSilentlyCutsPower(t *testing.T) {
+	for _, mode := range []string{"missing", "refused", "timeout", "shutdown"} {
+		t.Run(mode, func(t *testing.T) {
+			stubEmulator(t)
+			s := shortQMPStore(t)
+			st, err := s.StartDetached(detachableSpec(t, s, "dev"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = s.Stop("dev", true, time.Second) })
+			if mode != "missing" {
+				ln, err := net.Listen("unix", s.QMPPath("dev"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer ln.Close()
+				go func() {
+					c, err := ln.Accept()
+					if err != nil {
+						return
+					}
+					defer c.Close()
+					_ = c.SetDeadline(time.Now().Add(time.Second))
+					e, d := json.NewEncoder(c), json.NewDecoder(c)
+					_ = e.Encode(map[string]any{"QMP": map[string]any{}})
+					for _, want := range []string{"qmp_capabilities", "system_powerdown"} {
+						var req struct{ Execute string }
+						if err := d.Decode(&req); err != nil {
+							return
+						}
+						if req.Execute != want {
+							t.Errorf("command = %s, want %s", req.Execute, want)
+							return
+						}
+						if want == "system_powerdown" && mode == "refused" {
+							_ = e.Encode(map[string]any{"error": map[string]string{"desc": "denied"}})
+							return
+						}
+						_ = e.Encode(map[string]any{"return": map[string]any{}})
+					}
+					if mode == "shutdown" {
+						_ = killProcess(st.PID, true)
+					} // emulate guest exit
+				}()
+			}
+			err = s.Stop("dev", false, 200*time.Millisecond)
+			if mode == "shutdown" {
+				if err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				if err == nil || !strings.Contains(err.Error(), "--force") {
+					t.Fatalf("want explicit-force guidance, got %v", err)
+				}
+				status, err := s.Status("dev")
+				if err != nil || !status.Running {
+					t.Fatalf("guest was killed: %+v, %v", status, err)
+				}
+			}
+		})
 	}
 }
 

--- a/go/internal/cli/vm/launch_unix.go
+++ b/go/internal/cli/vm/launch_unix.go
@@ -1,0 +1,49 @@
+//go:build darwin || linux
+
+package vm
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// detachProcess puts the VM in its own session, so the terminal's SIGINT and
+// SIGHUP never reach it: Ctrl-C on the command that started the VM, or closing
+// that terminal, must not power the guest off.
+// DetachSupported reports that this platform can run a VM in the background.
+func DetachSupported() bool { return true }
+
+func detachProcess(cmd *exec.Cmd) error {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setsid = true
+	return nil
+}
+
+// killProcess asks the VM to power off, or kills it outright when force is set.
+// A process that is already gone is not an error: Stop's caller only cares that
+// it is no longer running.
+func killProcess(pid int, force bool) error {
+	sig := syscall.SIGTERM
+	if force {
+		sig = syscall.SIGKILL
+	}
+	if err := syscall.Kill(pid, sig); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return err
+	}
+	return nil
+}
+
+// attachRunLock hands the run lock to the emulator, so the kernel frees it when
+// the emulator exits rather than when this process does.
+func attachRunLock(cmd *exec.Cmd, lock *os.File) {
+	cmd.ExtraFiles = append(cmd.ExtraFiles, lock)
+}
+
+// terminateProcess asks QEMU to exit. SIGTERM, not SIGKILL: QEMU puts the
+// terminal in raw mode for the guest console and only restores it on a clean
+// shutdown.
+func terminateProcess(p *os.Process) error { return p.Signal(syscall.SIGTERM) }

--- a/go/internal/cli/vm/lifecycle.go
+++ b/go/internal/cli/vm/lifecycle.go
@@ -1,0 +1,37 @@
+package vm
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+var ErrLifecycleBusy = errors.New("VM is being created, started or removed; retry when that operation finishes")
+
+// Keep lifecycle locks outside the removable VM directory. Never unlink them:
+// replacing a lock file lets two callers lock different inodes for one name.
+// The run lock still belongs to QEMU; this lock only orders filesystem changes
+// and acquisition of that run lock, not the lifetime of the emulator.
+func (s *Store) acquireLifecycleLock(name string) (*os.File, error) {
+	if err := ValidName(name); err != nil {
+		return nil, err
+	}
+	dir := filepath.Join(s.Root, ".locks")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return nil, err
+	}
+	f, err := os.OpenFile(filepath.Join(dir, name+".lock"), os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		return nil, err
+	}
+	locked, err := tryLockFile(f)
+	if err != nil || !locked {
+		_ = f.Close()
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("%w: %s", ErrLifecycleBusy, name)
+	}
+	return f, nil
+}

--- a/go/internal/cli/vm/lifecycle_test.go
+++ b/go/internal/cli/vm/lifecycle_test.go
@@ -1,0 +1,85 @@
+package vm
+
+import (
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+type lifecycleTestReader func([]byte) (int, error)
+
+func (r lifecycleTestReader) Read(p []byte) (int, error) { return r(p) }
+
+func TestCreationExcludesRemovalAndStartThroughRollback(t *testing.T) {
+	s := &Store{Root: t.TempDir()}
+	copyFailure := errors.New("simulated download failure")
+	image := lifecycleTestReader(func([]byte) (int, error) {
+		// Invoked during the copy, after the directory and disk exist. Separate
+		// handles model another CLI acting on the visible partial VM.
+		other := &Store{Root: s.Root}
+		if err := other.Remove("dev"); !errors.Is(err, ErrLifecycleBusy) {
+			t.Fatalf("remove during creation = %v", err)
+		}
+		if lock, err := other.acquireRunLock("dev"); !errors.Is(err, ErrLifecycleBusy) {
+			if lock != nil {
+				lock.Close()
+			}
+			t.Fatalf("start during creation = %v", err)
+		}
+		if err := other.CreateFrom("dev", strings.NewReader("replacement"), 11, 1024, Meta{}); !errors.Is(err, ErrLifecycleBusy) {
+			t.Fatalf("replacement during creation = %v", err)
+		}
+		return 0, copyFailure
+	})
+	if err := s.CreateFrom("dev", image, 0, 1024, Meta{}); !errors.Is(err, copyFailure) {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(s.Dir("dev")); !os.IsNotExist(err) {
+		t.Fatalf("rollback left directory: %v", err)
+	}
+	if err := s.CreateFrom("dev", strings.NewReader("replacement"), 11, 1024, Meta{}); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(s.DiskPath("dev"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	got := make([]byte, 11)
+	if _, err := io.ReadFull(f, got); err != nil || string(got) != "replacement" {
+		t.Fatalf("replacement disk = %q: %v", got, err)
+	}
+}
+
+func TestLifecycleLockIdentitySurvivesRemoval(t *testing.T) {
+	s := &Store{Root: t.TempDir()}
+	if err := s.CreateFrom("dev", strings.NewReader("disk"), 4, 1024, Meta{}); err != nil {
+		t.Fatal(err)
+	}
+	lock, err := s.acquireLifecycleLock("dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := lock.Stat()
+	lock.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Remove("dev"); err != nil {
+		t.Fatal(err)
+	}
+	lock, err = s.acquireLifecycleLock("dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lock.Close()
+	after, err := lock.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(before, after) {
+		t.Fatal("removal replaced the lifecycle lock inode")
+	}
+}

--- a/go/internal/cli/vm/lock_unix.go
+++ b/go/internal/cli/vm/lock_unix.go
@@ -1,0 +1,43 @@
+//go:build darwin || linux
+
+package vm
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// tryLockFile attempts a non-blocking exclusive (advisory) lock on f. It
+// returns (true, nil) when the lock was acquired, (false, nil) when another
+// process holds it, and a non-nil error for any other failure.
+func tryLockFile(f *os.File) (bool, error) {
+	err := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, unix.EWOULDBLOCK) {
+		return false, nil
+	}
+	return false, err
+}
+
+// unlockFile releases the advisory lock held on f.
+func unlockFile(f *os.File) error {
+	return unix.Flock(int(f.Fd()), unix.LOCK_UN)
+}
+
+// trySharedLock probes whether anyone holds the exclusive lock, without ever
+// taking it. A status read that grabbed LOCK_EX -- even for microseconds --
+// would make a concurrent start fail with a spurious ErrAlreadyRunning.
+func trySharedLock(f *os.File) (bool, error) {
+	err := unix.Flock(int(f.Fd()), unix.LOCK_SH|unix.LOCK_NB)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, unix.EWOULDBLOCK) {
+		return false, nil
+	}
+	return false, err
+}

--- a/go/internal/cli/vm/lock_windows.go
+++ b/go/internal/cli/vm/lock_windows.go
@@ -1,0 +1,48 @@
+//go:build windows
+
+package vm
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// tryLockFile attempts a non-blocking exclusive lock on f via LockFileEx. It
+// returns (true, nil) when the lock was acquired, (false, nil) when another
+// process holds it, and a non-nil error for any other failure.
+func tryLockFile(f *os.File) (bool, error) {
+	ol := new(windows.Overlapped)
+	err := windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0, 1, 0, ol,
+	)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+		return false, nil
+	}
+	return false, err
+}
+
+// unlockFile releases the lock held on f.
+func unlockFile(f *os.File) error {
+	ol := new(windows.Overlapped)
+	return windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, ol)
+}
+
+// trySharedLock probes without taking the exclusive lock; see the unix version.
+func trySharedLock(f *os.File) (bool, error) {
+	ol := new(windows.Overlapped)
+	err := windows.LockFileEx(windows.Handle(f.Fd()), windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, ol)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+		return false, nil
+	}
+	return false, err
+}

--- a/go/internal/cli/vm/mac_test.go
+++ b/go/internal/cli/vm/mac_test.go
@@ -1,0 +1,63 @@
+package vm
+
+import (
+	"net"
+	"testing"
+)
+
+func TestNewVMsWithSameNameHaveDistinctStableMACs(t *testing.T) {
+	one, two := newTestStore(t), newTestStore(t)
+	createTestVM(t, one, "dev", Meta{})
+	createTestVM(t, two, "dev", Meta{})
+	first, err := one.MACAddress("dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := two.MACAddress("dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == second {
+		t.Fatalf("same-name VMs share MAC %s", first)
+	}
+	for _, address := range []string{first, second} {
+		mac, err := net.ParseMAC(address)
+		if err != nil || len(mac) != 6 || mac[0]&3 != 2 {
+			t.Fatalf("invalid local unicast MAC: %s", address)
+		}
+	}
+	reopened := &Store{Root: one.Root}
+	if got, err := reopened.MACAddress("dev"); err != nil || got != first {
+		t.Fatalf("MAC changed: %s %v", got, err)
+	}
+	meta, _ := one.ReadMeta("dev")
+	meta.AgentPort = 50100
+	if err := one.WriteMeta(meta); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := one.MACAddress("dev"); err != nil || got != first {
+		t.Fatal("port update changed MAC")
+	}
+}
+
+func TestExistingVMKeepsLegacyMACAndRejectsCorruptIdentity(t *testing.T) {
+	s := newTestStore(t)
+	createTestVM(t, s, "dev", Meta{})
+	meta, _ := s.ReadMeta("dev")
+	meta.MAC = ""
+	if err := s.WriteMeta(meta); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := s.MACAddress("dev"); err != nil || got != MACFor("dev") {
+		t.Fatalf("legacy identity changed: %s %v", got, err)
+	}
+	for _, invalid := range []string{"invalid", "ff:ff:ff:ff:ff:ff", "00:11:22:33:44:55"} {
+		meta.MAC = invalid
+		if err := s.WriteMeta(meta); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := s.MACAddress("dev"); err == nil {
+			t.Fatalf("accepted corrupt identity %s", invalid)
+		}
+	}
+}

--- a/go/internal/cli/vm/net.go
+++ b/go/internal/cli/vm/net.go
@@ -1,0 +1,228 @@
+package vm
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+)
+
+// DefaultAgentPort is the agent's port, fixed in the image's avahi service
+// record. Only the host side of a forward is configurable.
+const DefaultAgentPort = 50051
+
+// AgentPortSpan is how many consecutive ports one VM occupies. A provisioned
+// agent stops serving plaintext and moves one port up, so forwarding only
+// DefaultAgentPort makes a VM unreachable the moment it is provisioned.
+const AgentPortSpan = 2
+
+// ErrSocketVMNetNotFound reports that the socket_vmnet helper is not available.
+var ErrSocketVMNetNotFound = errors.New("socket_vmnet helper not found")
+
+// ErrPortInUse reports that the host port for the agent forward is taken.
+var ErrPortInUse = errors.New("host port already in use")
+
+// CheckHostPort reports whether the agent forwards can bind the whole span
+// starting at port. Checked up front because QEMU's own failure names neither
+// the port nor a remedy.
+func CheckHostPort(port int) error {
+	// Range first: a bind failure on an impossible port would otherwise be
+	// reported as "already in use", sending the user to hunt for a process
+	// that was never there. The span has to fit too, not just the base.
+	if port < 1 || port+AgentPortSpan-1 > 65535 {
+		return fmt.Errorf("port %d is out of range: use 1-%d, leaving room for the %d ports a VM occupies",
+			port, 65535-AgentPortSpan+1, AgentPortSpan)
+	}
+	for i := range AgentPortSpan {
+		l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port+i))
+		if err != nil {
+			return fmt.Errorf("%w: %d is taken (%v); pass --port to pick another",
+				ErrPortInUse, port+i, err)
+		}
+		if err := l.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// PickHostPort returns the first free port span at or after preferred, trying
+// tries spans. The span is the unit: a VM needs its plaintext and mTLS ports
+// adjacent, so spans start AgentPortSpan apart rather than one.
+func PickHostPort(preferred, tries int) (int, error) {
+	if tries <= 0 {
+		return 0, fmt.Errorf("no ports to try")
+	}
+	if preferred == 0 {
+		preferred = DefaultAgentPort
+	}
+	var firstErr error
+	for i := range tries {
+		port := preferred + i*AgentPortSpan
+		if err := CheckHostPort(port); err == nil {
+			return port, nil
+		} else if firstErr == nil {
+			firstErr = err
+		}
+	}
+	return 0, firstErr
+}
+
+// NetMode selects how the guest reaches the network. Explicit rather than
+// inferred because it decides whether `wendy discover` can find the VM.
+type NetMode string
+
+const (
+	// NetUser forwards the agent port over SLIRP. Needs no privileges, but
+	// SLIRP carries no multicast, so mDNS never reaches the host and the VM is
+	// reachable only by address.
+	NetUser NetMode = "user"
+
+	// NetShared puts the guest on a vmnet segment the host also has an
+	// interface on, so mDNS reaches it and discovery works. Requires the
+	// socket_vmnet helper.
+	NetShared NetMode = "shared"
+)
+
+// ParseNetMode validates a user-supplied mode. Callers check it up front: the
+// deeper rejection in NetConfig.args happens after the run lock is taken and
+// the previous console log has already been rotated away.
+func ParseNetMode(s string) (NetMode, error) {
+	switch NetMode(s) {
+	case NetUser:
+		return NetUser, nil
+	case NetShared:
+		return NetShared, nil
+	default:
+		return "", fmt.Errorf("unknown network mode %q: use %q or %q", s, NetUser, NetShared)
+	}
+}
+
+// NetConfig is a fully resolved network choice.
+type NetConfig struct {
+	Mode NetMode
+
+	// AgentPort is the host port forwarded to the guest's agent in NetUser
+	// mode. Ignored in NetShared mode, which needs no forward.
+	AgentPort int
+
+	// RegistryPort forwards the guest's container registry. Zero means the host
+	// port was already taken, so the forward is skipped rather than failing the
+	// whole start -- a developer running their own registry on 5000 must still
+	// be able to boot a VM.
+	RegistryPort int
+
+	// SocketPath is the socket_vmnet endpoint in NetShared mode.
+	SocketPath string
+
+	// MAC determines the DHCP lease, and so the guest's address and mDNS
+	// hostname. Required; use MACFor.
+	MAC string
+}
+
+// SupportsDiscovery reports whether a guest on this network can be found by
+// `wendy discover`.
+func (n NetConfig) SupportsDiscovery() bool { return n.Mode == NetShared }
+
+// MACFor derives a NIC address for a VM name: deterministic so a VM keeps its
+// lease across restarts, distinct per name so two VMs never contend for one.
+// 0x52 is unicast and locally administered, so it cannot collide with a vendor
+// assignment.
+func MACFor(name string) string {
+	sum := sha256.Sum256([]byte("wendy-vm:" + name))
+	return fmt.Sprintf("52:%02x:%02x:%02x:%02x:%02x", sum[0], sum[1], sum[2], sum[3], sum[4])
+}
+
+// Args returns the QEMU netdev and device arguments for this configuration.
+func (n NetConfig) Args() ([]string, error) {
+	// QEMU silently defaults the MAC, which would give every VM on the host the
+	// same address.
+	if n.MAC == "" {
+		return nil, errors.New("no MAC address: use MACFor(name)")
+	}
+	device := "virtio-net-pci,netdev=net0,mac=" + n.MAC
+
+	switch n.Mode {
+	case NetUser:
+		port := n.AgentPort
+		if port == 0 {
+			port = DefaultAgentPort
+		}
+		// Bind loopback explicitly: with no host address QEMU forwards on the
+		// wildcard, exposing the agent, which is unauthenticated until the
+		// device is provisioned. Both ports of the span are forwarded so the
+		// VM stays reachable after provisioning moves the agent to mTLS.
+		fwd := make([]string, 0, AgentPortSpan)
+		for i := range AgentPortSpan {
+			fwd = append(fwd, fmt.Sprintf("hostfwd=tcp:127.0.0.1:%d-:%d", port+i, DefaultAgentPort+i))
+		}
+		if n.RegistryPort != 0 {
+			fwd = append(fwd, fmt.Sprintf("hostfwd=tcp:127.0.0.1:%d-:%d", n.RegistryPort, DeviceRegistryPort))
+		}
+		return []string{
+			"-netdev", "user,id=net0," + strings.Join(fwd, ","),
+			"-device", device,
+		}, nil
+
+	case NetShared:
+		if n.SocketPath == "" {
+			return nil, errors.New("shared networking needs a socket_vmnet path")
+		}
+		// The helper owns the privileged vmnet handle, so QEMU itself stays
+		// unprivileged; -netdev vmnet-shared would need root.
+		return []string{
+			"-netdev", fmt.Sprintf("stream,id=net0,addr.type=unix,addr.path=%s", escapeQEMUValue(n.SocketPath)),
+			"-device", device,
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unknown network mode %q: use %q or %q", n.Mode, NetUser, NetShared)
+	}
+}
+
+// SocketVMNetCandidates lists the helper's socket paths, most likely first.
+func SocketVMNetCandidates(brewPrefix string) []string {
+	var out []string
+	if brewPrefix != "" {
+		out = append(out, brewPrefix+"/var/run/socket_vmnet")
+	}
+	return append(out,
+		"/opt/homebrew/var/run/socket_vmnet",
+		"/usr/local/var/run/socket_vmnet",
+		"/var/run/socket_vmnet",
+	)
+}
+
+// ErrSharedNetUnsupported reports that shared networking cannot work on this
+// host at all.
+// DeviceRegistryPort is where a Linux device serves its container registry --
+// commands/helpers.go registryPort(). `wendy run` falls back to a registry push
+// when chunked deploy is unavailable, and it addresses the device by host and
+// this port, so the guest's 5000 has to be reachable at the host's 5000 or the
+// fallback cannot connect at all.
+const DeviceRegistryPort = 5000
+
+var ErrSharedNetUnsupported = errors.New("shared networking needs macOS")
+
+// FindSocketVMNet returns the first socket_vmnet endpoint present on the host.
+//
+// vmnet is an Apple framework, so anywhere else the answer is not "install the
+// helper" but "this mode does not exist here" -- the error used to recommend
+// Homebrew commands on machines with no Homebrew.
+func FindSocketVMNet(goos, brewPrefix string) (string, error) {
+	if goos != "darwin" {
+		return "", fmt.Errorf("%w: socket_vmnet builds on Apple's vmnet framework. "+
+			"Use --net user and reach the VM by address", ErrSharedNetUnsupported)
+	}
+	candidates := SocketVMNetCandidates(brewPrefix)
+	for _, path := range candidates {
+		if _, err := vmStat(path); err == nil {
+			return path, nil
+		}
+	}
+	return "", fmt.Errorf("%w: install and start it with 'brew install socket_vmnet' "+
+		"and 'sudo brew services start socket_vmnet', or use --net user "+
+		"(no setup, but `wendy discover` cannot see the VM). Looked in: %s",
+		ErrSocketVMNetNotFound, strings.Join(candidates, ", "))
+}

--- a/go/internal/cli/vm/net.go
+++ b/go/internal/cli/vm/net.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"crypto/rand"
 	"crypto/sha256"
 	"errors"
 	"fmt"
@@ -125,13 +126,37 @@ type NetConfig struct {
 // `wendy discover`.
 func (n NetConfig) SupportsDiscovery() bool { return n.Mode == NetShared }
 
-// MACFor derives a NIC address for a VM name: deterministic so a VM keeps its
-// lease across restarts, distinct per name so two VMs never contend for one.
-// 0x52 is unicast and locally administered, so it cannot collide with a vendor
-// assignment.
+// MACFor preserves the legacy name-derived identity for existing VMs without
+// a stored MAC. New VMs use a random, persisted address instead: the same name
+// is common on different hosts sharing one LAN.
 func MACFor(name string) string {
 	sum := sha256.Sum256([]byte("wendy-vm:" + name))
 	return fmt.Sprintf("52:%02x:%02x:%02x:%02x:%02x", sum[0], sum[1], sum[2], sum[3], sum[4])
+}
+
+func newMAC() (string, error) {
+	mac := make(net.HardwareAddr, 6)
+	if _, err := rand.Read(mac); err != nil {
+		return "", err
+	}
+	mac[0] = (mac[0] & 0xfc) | 0x02 // locally administered, unicast
+	return mac.String(), nil
+}
+
+// MACAddress never changes an existing VM's network identity on upgrade.
+func (s *Store) MACAddress(name string) (string, error) {
+	meta, ok := s.ReadMeta(name)
+	if !ok {
+		return "", fmt.Errorf("cannot read VM %q metadata to resolve its MAC address", name)
+	}
+	if meta.MAC == "" {
+		return MACFor(name), nil
+	}
+	mac, err := net.ParseMAC(meta.MAC)
+	if err != nil || len(mac) != 6 || mac[0]&3 != 2 {
+		return "", fmt.Errorf("VM %q has an invalid locally-administered unicast MAC in metadata", name)
+	}
+	return mac.String(), nil
 }
 
 // Args returns the QEMU netdev and device arguments for this configuration.

--- a/go/internal/cli/vm/net_test.go
+++ b/go/internal/cli/vm/net_test.go
@@ -1,0 +1,339 @@
+package vm
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestUserModeArgsForwardTheAgentPort(t *testing.T) {
+	args, err := NetConfig{Mode: NetUser, AgentPort: 50051, MAC: MACFor("dev")}.Args()
+	if err != nil {
+		t.Fatalf("Args() error = %v", err)
+	}
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "hostfwd=tcp:127.0.0.1:50051-:50051") {
+		t.Errorf("user-mode args should forward the agent port; got %q", joined)
+	}
+	if !strings.Contains(joined, "virtio-net-pci") {
+		t.Errorf("user-mode args should attach a virtio NIC; got %q", joined)
+	}
+}
+
+func TestUserModeHonoursAnAlternatePort(t *testing.T) {
+	args, err := NetConfig{Mode: NetUser, AgentPort: 51111, MAC: MACFor("dev")}.Args()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The guest port is fixed -- it is what the avahi service record advertises
+	// -- so only the host side moves.
+	if !strings.Contains(strings.Join(args, " "), "hostfwd=tcp:127.0.0.1:51111-:50051") {
+		t.Errorf("expected host port 51111 forwarded to guest 50051; got %v", args)
+	}
+}
+
+func TestMACForIsStablePerNameAndDistinctBetweenNames(t *testing.T) {
+	// The MAC drives the DHCP lease, which drives the guest's address and the
+	// hostname it announces over mDNS. An unstable MAC makes `wendy discover`
+	// show a different device after every restart; a shared one makes two VMs
+	// fight over one lease.
+	if MACFor("dev") != MACFor("dev") {
+		t.Error("MACFor must be deterministic for a given name")
+	}
+	if MACFor("dev") == MACFor("test") {
+		t.Error("different VM names must get different MACs")
+	}
+}
+
+func TestMACForIsAUnicastLocallyAdministeredAddress(t *testing.T) {
+	mac := MACFor("dev")
+	var first int
+	if _, err := fmt.Sscanf(mac, "%02x", &first); err != nil {
+		t.Fatalf("MACFor(%q) = %q, not parseable: %v", "dev", mac, err)
+	}
+	// Bit 0 clear = unicast (a multicast MAC is not a valid source address);
+	// bit 1 set = locally administered, so we never collide with a real vendor.
+	if first&0x01 != 0 {
+		t.Errorf("MAC %q is multicast", mac)
+	}
+	if first&0x02 == 0 {
+		t.Errorf("MAC %q is not locally administered", mac)
+	}
+	if len(mac) != len("52:54:00:12:34:56") {
+		t.Errorf("MAC %q is not six colon-separated octets", mac)
+	}
+}
+
+func TestArgsAlwaysSetTheMAC(t *testing.T) {
+	for _, n := range []NetConfig{
+		{Mode: NetUser, MAC: MACFor("dev")},
+		{Mode: NetShared, SocketPath: "/var/run/socket_vmnet", MAC: MACFor("dev")},
+	} {
+		args, err := n.Args()
+		if err != nil {
+			t.Fatalf("Args() error = %v", err)
+		}
+		if !strings.Contains(strings.Join(args, " "), "mac=") {
+			t.Errorf("%s mode did not set a MAC: %v", n.Mode, args)
+		}
+	}
+}
+
+func TestArgsRejectAMissingMAC(t *testing.T) {
+	// Falling back to QEMU's default would silently give every VM on the host
+	// the same address.
+	if _, err := (NetConfig{Mode: NetUser}).Args(); err == nil {
+		t.Fatal("Args() accepted a config with no MAC")
+	}
+}
+
+func TestSharedModeUsesTheSocketVMNetEndpoint(t *testing.T) {
+	args, err := NetConfig{Mode: NetShared, SocketPath: "/var/run/socket_vmnet", MAC: MACFor("dev")}.Args()
+	if err != nil {
+		t.Fatalf("Args() error = %v", err)
+	}
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "/var/run/socket_vmnet") {
+		t.Errorf("shared args should name the socket; got %q", joined)
+	}
+	if strings.Contains(joined, "hostfwd") {
+		t.Errorf("shared mode needs no port forward; got %q", joined)
+	}
+}
+
+func TestSharedModeRequiresASocketPath(t *testing.T) {
+	if _, err := (NetConfig{Mode: NetShared, MAC: MACFor("dev")}).Args(); err == nil {
+		t.Fatal("shared mode without a socket path should be an error, not a silent fallback")
+	}
+}
+
+func TestUnknownModeIsRejected(t *testing.T) {
+	if _, err := (NetConfig{Mode: "bridged", MAC: MACFor("dev")}).Args(); err == nil {
+		t.Fatal("unknown mode should be rejected")
+	}
+}
+
+func TestSupportsDiscovery(t *testing.T) {
+	// SLIRP does not carry multicast, so mDNS never reaches the host and
+	// `wendy discover` cannot see a user-mode VM. This is the fact the CLI has
+	// to tell the user, so it is asserted rather than assumed.
+	if (NetConfig{Mode: NetUser}).SupportsDiscovery() {
+		t.Error("user mode must not claim discovery support")
+	}
+	if !(NetConfig{Mode: NetShared}).SupportsDiscovery() {
+		t.Error("shared mode should support discovery")
+	}
+}
+
+func TestFindSocketVMNetPrefersTheBrewPrefix(t *testing.T) {
+	want := "/opt/homebrew/var/run/socket_vmnet"
+	orig := vmStat
+	t.Cleanup(func() { vmStat = orig })
+	vmStat = func(name string) (os.FileInfo, error) {
+		if name == want {
+			return nil, nil
+		}
+		return nil, fs.ErrNotExist
+	}
+
+	got, err := FindSocketVMNet("darwin", "/opt/homebrew")
+	if err != nil {
+		t.Fatalf("FindSocketVMNet() error = %v", err)
+	}
+	if got != want {
+		t.Errorf("FindSocketVMNet() = %q, want %q", got, want)
+	}
+}
+
+func TestFindSocketVMNetErrorExplainsTheOneTimeSetup(t *testing.T) {
+	orig := vmStat
+	t.Cleanup(func() { vmStat = orig })
+	vmStat = func(string) (os.FileInfo, error) { return nil, fs.ErrNotExist }
+
+	_, err := FindSocketVMNet("darwin", "/opt/homebrew")
+	if err == nil {
+		t.Fatal("expected an error when the helper is not running")
+	}
+	if !strings.Contains(err.Error(), "socket_vmnet") {
+		t.Errorf("error should name the helper; got %q", err)
+	}
+	if !strings.Contains(err.Error(), "--net user") {
+		t.Errorf("error should point at the tier that needs no setup; got %q", err)
+	}
+}
+
+func TestCheckHostPortAcceptsAFreePort(t *testing.T) {
+	// Bind and release to find a port that is genuinely free right now.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+
+	if err := CheckHostPort(port); err != nil {
+		t.Errorf("CheckHostPort(%d) on a free port = %v, want nil", port, err)
+	}
+}
+
+func TestCheckHostPortReportsAConflictAndNamesTheFlag(t *testing.T) {
+	// The whole point: QEMU's own message for this is "Could not set up host
+	// forwarding rule", which says nothing about what to do next.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+	port := l.Addr().(*net.TCPAddr).Port
+
+	err = CheckHostPort(port)
+	if err == nil {
+		t.Fatal("CheckHostPort on an occupied port returned nil")
+	}
+	if !errors.Is(err, ErrPortInUse) {
+		t.Errorf("error should wrap ErrPortInUse; got %#v", err)
+	}
+	if !strings.Contains(err.Error(), "--port") {
+		t.Errorf("error should name the flag that fixes it; got %q", err)
+	}
+}
+
+func TestUserModeForwardsOnLoopbackOnly(t *testing.T) {
+	// QEMU forwards on the wildcard when given no host address, which would put
+	// the guest's agent on the LAN. It is unauthenticated until the device is
+	// provisioned, which every fresh VM is.
+	args, err := NetConfig{Mode: NetUser, AgentPort: 50051, MAC: MACFor("dev")}.Args()
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "hostfwd=tcp:127.0.0.1:") {
+		t.Errorf("agent forward must bind loopback; got %q", joined)
+	}
+	if strings.Contains(joined, "hostfwd=tcp::") {
+		t.Errorf("agent forward binds the wildcard; got %q", joined)
+	}
+}
+
+func TestUserModeForwardsTheWholePortSpan(t *testing.T) {
+	// A provisioned agent serves mTLS one port up, so a VM that forwards only
+	// the plaintext port becomes unreachable the moment it is provisioned.
+	args, err := NetConfig{Mode: NetUser, AgentPort: 51111, MAC: MACFor("vm")}.Args()
+	if err != nil {
+		t.Fatalf("Args() = %v", err)
+	}
+	joined := strings.Join(args, " ")
+	for i := range AgentPortSpan {
+		want := fmt.Sprintf("hostfwd=tcp:127.0.0.1:%d-:%d", 51111+i, DefaultAgentPort+i)
+		if !strings.Contains(joined, want) {
+			t.Errorf("Args() = %q, want it to contain %q", joined, want)
+		}
+	}
+}
+
+func TestCheckHostPortRejectsAConflictAnywhereInTheSpan(t *testing.T) {
+	// The second port of the span is the one a naive check would miss.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer l.Close()
+	busy := l.Addr().(*net.TCPAddr).Port
+
+	if err := CheckHostPort(busy - 1); !errors.Is(err, ErrPortInUse) {
+		t.Errorf("CheckHostPort(%d) with %d busy = %v, want ErrPortInUse", busy-1, busy, err)
+	}
+}
+
+func TestPickHostPortSkipsAnOccupiedSpan(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer l.Close()
+	busy := l.Addr().(*net.TCPAddr).Port
+
+	got, err := PickHostPort(busy, 8)
+	if err != nil {
+		t.Fatalf("PickHostPort(%d) = %v", busy, err)
+	}
+	if got == busy {
+		t.Errorf("PickHostPort(%d) = %d, want it to skip the occupied span", busy, got)
+	}
+	if (got-busy)%AgentPortSpan != 0 {
+		t.Errorf("PickHostPort(%d) = %d, want a span-aligned port", busy, got)
+	}
+}
+
+func TestFindSocketVMNetSaysSharedNetIsMacOnly(t *testing.T) {
+	// The error used to recommend Homebrew commands on hosts with no Homebrew.
+	for _, goos := range []string{"linux", "windows"} {
+		_, err := FindSocketVMNet(goos, "")
+		if !errors.Is(err, ErrSharedNetUnsupported) {
+			t.Errorf("FindSocketVMNet(%q) = %v, want ErrSharedNetUnsupported", goos, err)
+		}
+		if strings.Contains(err.Error(), "brew") {
+			t.Errorf("FindSocketVMNet(%q) = %v, want no Homebrew advice off macOS", goos, err)
+		}
+	}
+}
+
+func TestUserModeForwardsTheDeviceRegistry(t *testing.T) {
+	// `wendy run` falls back to pushing to the device's registry when chunked
+	// deploy is unavailable, and it addresses it as <device host>:5000. Without
+	// this forward that fallback cannot reach the guest at all.
+	n := NetConfig{Mode: NetUser, AgentPort: 50051, RegistryPort: DeviceRegistryPort, MAC: MACFor("dev")}
+	args, err := n.Args()
+	if err != nil {
+		t.Fatalf("args() = %v", err)
+	}
+	joined := strings.Join(args, " ")
+	want := fmt.Sprintf("hostfwd=tcp:127.0.0.1:%d-:%d", DeviceRegistryPort, DeviceRegistryPort)
+	if !strings.Contains(joined, want) {
+		t.Errorf("args() = %q, want it to contain %q", joined, want)
+	}
+}
+
+func TestABusyRegistryPortStillBootsTheVM(t *testing.T) {
+	// A developer running their own registry on 5000 loses the fallback, not
+	// the ability to start a VM.
+	n := NetConfig{Mode: NetUser, AgentPort: 50051, MAC: MACFor("dev")}
+	args, err := n.Args()
+	if err != nil {
+		t.Fatalf("args() = %v", err)
+	}
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, fmt.Sprintf("-:%d", DeviceRegistryPort)) {
+		t.Errorf("args() = %q, want no registry forward when the port was not claimed", joined)
+	}
+	if !strings.Contains(joined, "hostfwd=tcp:127.0.0.1:50051-:50051") {
+		t.Errorf("args() = %q, want the agent forward regardless", joined)
+	}
+}
+
+func TestCheckHostPortSeparatesImpossibleFromTaken(t *testing.T) {
+	// An impossible port reported as "already in use" sends the user hunting
+	// for a process that was never there.
+	for _, port := range []int{0, -1, 99999, 65535} {
+		err := CheckHostPort(port)
+		if err == nil {
+			t.Errorf("CheckHostPort(%d) = nil, want an error", port)
+			continue
+		}
+		if errors.Is(err, ErrPortInUse) {
+			t.Errorf("CheckHostPort(%d) = %v, want out-of-range, not in-use", port, err)
+		}
+		if !strings.Contains(err.Error(), "out of range") {
+			t.Errorf("CheckHostPort(%d) = %v, want it to say out of range", port, err)
+		}
+	}
+	// 65535 is rejected for the SPAN, not the base port: a VM occupies two
+	// consecutive ports, so the last usable base is 65534.
+	if err := CheckHostPort(65534); err != nil && !errors.Is(err, ErrPortInUse) {
+		t.Errorf("CheckHostPort(65534) = %v, want it accepted on range (65534-65535 both fit)", err)
+	}
+}

--- a/go/internal/cli/vm/qmp.go
+++ b/go/internal/cli/vm/qmp.go
@@ -91,6 +91,16 @@ func (s *Store) EnsureTCPPorts(ctx context.Context, name string, ports []int) er
 	if !DetachSupported() {
 		return fmt.Errorf("automatic VM port forwarding currently requires macOS or Linux")
 	}
+	return s.withQMP(ctx, name, func(q *qmpClient) error { return q.ensureTCPPorts(name, ports) })
+}
+
+func (s *Store) requestPowerdown(ctx context.Context, name string) error {
+	return s.withQMP(ctx, name, func(q *qmpClient) error {
+		return q.execute("system_powerdown", map[string]any{}, nil)
+	})
+}
+
+func (s *Store) withQMP(ctx context.Context, name string, fn func(*qmpClient) error) error {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	c, err := (&net.Dialer{}).DialContext(ctx, "unix", s.QMPPath(name))
@@ -114,6 +124,10 @@ func (s *Store) EnsureTCPPorts(ctx context.Context, name string, ports []int) er
 	if err := q.execute("qmp_capabilities", map[string]any{}, nil); err != nil {
 		return err
 	}
+	return fn(&q)
+}
+
+func (q *qmpClient) ensureTCPPorts(name string, ports []int) error {
 	for _, port := range ports {
 		info, err := q.monitor("info usernet")
 		if err != nil {

--- a/go/internal/cli/vm/qmp.go
+++ b/go/internal/cli/vm/qmp.go
@@ -100,6 +100,65 @@ func (s *Store) requestPowerdown(ctx context.Context, name string) error {
 	})
 }
 
+// RegistryPort resolves the registry through this VM's own monitor. Never
+// assume the host's port 5000 belongs to the VM selected by its agent port.
+func (s *Store) RegistryPort(ctx context.Context, name string) (int, error) {
+	if err := ValidName(name); err != nil {
+		return 0, err
+	}
+	var port int
+	err := s.withQMP(ctx, name, func(q *qmpClient) error {
+		for range 4 {
+			info, err := q.monitor("info usernet")
+			if err != nil {
+				return err
+			}
+			if port = tcpForwardHostPort(info, DeviceRegistryPort); port != 0 {
+				return nil
+			}
+			// Reserve a candidate briefly; QEMU must own the actual listener.
+			// Retry if another host process wins the gap before hostfwd_add.
+			ln, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				return err
+			}
+			candidate := ln.Addr().(*net.TCPAddr).Port
+			if err := ln.Close(); err != nil {
+				return err
+			}
+			if _, err := q.monitor(fmt.Sprintf("hostfwd_add net0 tcp:127.0.0.1:%d-:%d", candidate, DeviceRegistryPort)); err != nil {
+				return err
+			}
+			info, err = q.monitor("info usernet")
+			if err != nil {
+				return err
+			}
+			if port = tcpForwardHostPort(info, DeviceRegistryPort); port != 0 {
+				return nil
+			}
+		}
+		return fmt.Errorf("could not allocate a loopback registry forward for VM %q", name)
+	})
+	return port, err
+}
+
+func tcpForwardHostPort(info string, guestPort int) int {
+	inNet0 := false
+	for _, line := range strings.Split(info, "\n") {
+		if strings.HasPrefix(line, "Hub ") {
+			inNet0 = strings.HasSuffix(strings.TrimSpace(line), "(net0):")
+			continue
+		}
+		f := strings.Fields(line)
+		if inNet0 && len(f) >= 6 && f[0] == "TCP[HOST_FORWARD]" && f[2] == "127.0.0.1" && f[4] == "10.0.2.15" && f[5] == strconv.Itoa(guestPort) {
+			if port, err := strconv.Atoi(f[3]); err == nil && port > 0 && port <= 65535 {
+				return port
+			}
+		}
+	}
+	return 0
+}
+
 func (s *Store) withQMP(ctx context.Context, name string, fn func(*qmpClient) error) error {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()

--- a/go/internal/cli/vm/qmp.go
+++ b/go/internal/cli/vm/qmp.go
@@ -1,0 +1,155 @@
+package vm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func (s *Store) QMPPath(name string) string { return filepath.Join(s.Dir(name), "qmp.sock") }
+
+// QMP grants full VM control to anyone who can connect. Enforce the user-only
+// directory boundary on every launch, including VMs created by older versions.
+func (s *Store) prepareQMP(name string) (string, error) {
+	dir := s.Dir(name)
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("VM control socket requires a real directory: %s", dir)
+	}
+	if err := os.Chmod(dir, 0700); err != nil {
+		return "", fmt.Errorf("protecting VM control socket directory: %w", err)
+	}
+	return s.QMPPath(name), nil
+}
+
+type qmpClient struct {
+	dec *json.Decoder
+	enc *json.Encoder
+}
+
+func (q *qmpClient) execute(command string, arguments any, result any) error {
+	if err := q.enc.Encode(map[string]any{"execute": command, "arguments": arguments}); err != nil {
+		return err
+	}
+	for {
+		var reply struct {
+			Event  string          `json:"event"`
+			Return json.RawMessage `json:"return"`
+			Error  *struct {
+				Desc string `json:"desc"`
+			} `json:"error"`
+		}
+		if err := q.dec.Decode(&reply); err != nil {
+			return err
+		}
+		if reply.Event != "" {
+			continue
+		}
+		if reply.Error != nil {
+			return fmt.Errorf("QEMU %s: %s", command, reply.Error.Desc)
+		}
+		if reply.Return == nil {
+			return fmt.Errorf("QEMU %s returned no result", command)
+		}
+		if result != nil {
+			return json.Unmarshal(reply.Return, result)
+		}
+		return nil
+	}
+}
+
+func (q *qmpClient) monitor(command string) (string, error) {
+	var result string
+	err := q.execute("human-monitor-command", map[string]string{"command-line": command}, &result)
+	return result, err
+}
+
+// EnsureTCPPorts adds loopback-only, same-port forwards to a running user-mode
+// VM. They live in QEMU, so detached apps stay reachable after the CLI exits.
+// Query QEMU's actual listeners rather than trusting a stale file across boots.
+func (s *Store) EnsureTCPPorts(ctx context.Context, name string, ports []int) error {
+	if err := ValidName(name); err != nil {
+		return err
+	}
+	for _, port := range ports {
+		if port < 1 || port > 65535 {
+			return fmt.Errorf("invalid TCP port %d", port)
+		}
+	}
+	if len(ports) == 0 {
+		return nil
+	}
+	if !DetachSupported() {
+		return fmt.Errorf("automatic VM port forwarding currently requires macOS or Linux")
+	}
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	c, err := (&net.Dialer{}).DialContext(ctx, "unix", s.QMPPath(name))
+	if err != nil {
+		return fmt.Errorf("connecting to VM %q control socket (restart VMs created with an older launcher): %w", name, err)
+	}
+	defer c.Close()
+	stop := context.AfterFunc(ctx, func() { _ = c.Close() })
+	defer stop()
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = c.SetDeadline(deadline)
+	}
+	q := qmpClient{dec: json.NewDecoder(c), enc: json.NewEncoder(c)}
+	var greeting map[string]json.RawMessage
+	if err := q.dec.Decode(&greeting); err != nil {
+		return err
+	}
+	if greeting["QMP"] == nil {
+		return fmt.Errorf("VM %q did not send a QMP greeting", name)
+	}
+	if err := q.execute("qmp_capabilities", map[string]any{}, nil); err != nil {
+		return err
+	}
+	for _, port := range ports {
+		info, err := q.monitor("info usernet")
+		if err != nil {
+			return err
+		}
+		if hasTCPForward(info, port) {
+			continue
+		}
+		output, err := q.monitor(fmt.Sprintf("hostfwd_add net0 tcp:127.0.0.1:%d-:%d", port, port))
+		if err != nil {
+			return err
+		}
+		// HMP errors are successful QMP string results. Verify the listener,
+		// also accepting a concurrent invocation that added the same forward.
+		info, err = q.monitor("info usernet")
+		if err != nil {
+			return err
+		}
+		if !hasTCPForward(info, port) {
+			return fmt.Errorf("forwarding VM %q TCP port %d to 127.0.0.1:%d failed: %s; free the host port or choose a different application port", name, port, port, strings.TrimSpace(output))
+		}
+	}
+	return nil
+}
+
+func hasTCPForward(info string, port int) bool {
+	inNet0 := false
+	for _, line := range strings.Split(info, "\n") {
+		if strings.HasPrefix(line, "Hub ") {
+			inNet0 = strings.HasSuffix(strings.TrimSpace(line), "(net0):")
+			continue
+		}
+		fields := strings.Fields(line)
+		if inNet0 && len(fields) >= 6 && fields[0] == "TCP[HOST_FORWARD]" && fields[2] == "127.0.0.1" && fields[3] == strconv.Itoa(port) && fields[4] == "10.0.2.15" && fields[5] == strconv.Itoa(port) {
+			return true
+		}
+	}
+	return false
+}

--- a/go/internal/cli/vm/qmp_test.go
+++ b/go/internal/cli/vm/qmp_test.go
@@ -1,0 +1,140 @@
+package vm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEnsureTCPPortsChecksQEMUAndReusesExistingForward(t *testing.T) {
+	for _, conflict := range []bool{false, true} {
+		t.Run(fmt.Sprintf("conflict=%v", conflict), func(t *testing.T) {
+			s := shortQMPStore(t)
+			ln, err := net.Listen("unix", s.QMPPath("test"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer ln.Close()
+			done := make(chan error, 1)
+			go func() {
+				c, err := ln.Accept()
+				if err != nil {
+					done <- err
+					return
+				}
+				defer c.Close()
+				_ = c.SetDeadline(time.Now().Add(5 * time.Second))
+				e, d := json.NewEncoder(c), json.NewDecoder(c)
+				_ = e.Encode(map[string]any{"QMP": map[string]any{}})
+				forwarded, additions := false, 0
+				for {
+					var req struct {
+						Execute   string            `json:"execute"`
+						Arguments map[string]string `json:"arguments"`
+					}
+					if err := d.Decode(&req); err != nil {
+						if !conflict && additions != 1 {
+							done <- fmt.Errorf("added %d times", additions)
+						} else {
+							done <- nil
+						}
+						return
+					}
+					_ = e.Encode(map[string]any{"event": "RESUME"}) // asynchronous events must be skipped
+					var result any = map[string]any{}
+					if req.Execute == "human-monitor-command" {
+						switch req.Arguments["command-line"] {
+						case "info usernet":
+							result = "Hub -1 (net0):\n"
+							if forwarded {
+								result = result.(string) + " TCP[HOST_FORWARD] 12 127.0.0.1 18080 10.0.2.15 18080 0 0\n"
+							}
+						case "hostfwd_add net0 tcp:127.0.0.1:18080-:18080":
+							additions++
+							result = ""
+							if conflict {
+								result = "Could not set up host forwarding rule"
+							} else {
+								forwarded = true
+							}
+						default:
+							done <- fmt.Errorf("unexpected command: %+v", req)
+							return
+						}
+					}
+					_ = e.Encode(map[string]any{"return": result})
+				}
+			}()
+			err = s.EnsureTCPPorts(context.Background(), "test", []int{18080, 18080})
+			if conflict {
+				if err == nil || !strings.Contains(err.Error(), "free the host port") {
+					t.Fatalf("want conflict guidance, got %v", err)
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			if err := <-done; err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func shortQMPStore(t *testing.T) *Store {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("VM control sockets currently supported on macOS and Linux")
+	}
+	root, err := os.MkdirTemp("/tmp", "qmp-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+	s := &Store{Root: root}
+	if err := os.Mkdir(s.Dir("test"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func TestPrepareQMPEnforcesPrivateDirectory(t *testing.T) {
+	s := shortQMPStore(t)
+	if err := os.Chmod(s.Dir("test"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.prepareQMP("test"); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(s.Dir("test"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0700 {
+		t.Fatalf("socket directory permissions = %o; want 0700", info.Mode().Perm())
+	}
+	if err := os.Symlink(s.Dir("test"), s.Dir("linked")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.prepareQMP("linked"); err == nil {
+		t.Fatal("accepted a symlink for the control socket directory")
+	}
+}
+
+func TestHasTCPForwardRequiresExactNetAndEndpoints(t *testing.T) {
+	for _, line := range []string{
+		"Hub -1 (other):\n TCP[HOST_FORWARD] 12 127.0.0.1 18080 10.0.2.15 18080 0 0",
+		"Hub -1 (net0):\n TCP[HOST_FORWARD] 12 0.0.0.0 18080 10.0.2.15 18080 0 0",
+		"Hub -1 (net0):\n TCP[HOST_FORWARD] 12 127.0.0.1 18080 10.0.2.15 8080 0 0",
+		"Hub -1 (net0):\n TCP[ESTABLISHED] 12 127.0.0.1 18080 10.0.2.15 18080 0 0",
+	} {
+		if hasTCPForward(line, 18080) {
+			t.Errorf("accepted wrong forward: %s", line)
+		}
+	}
+}

--- a/go/internal/cli/vm/registry_test.go
+++ b/go/internal/cli/vm/registry_test.go
@@ -1,0 +1,86 @@
+package vm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestRegistryPortAllocatesAndReusesVerifiedForward(t *testing.T) {
+	s := shortQMPStore(t)
+	ln, err := net.Listen("unix", s.QMPPath("test"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	done := make(chan error, 1)
+	go func() {
+		port, adds := 0, 0
+		for range 2 {
+			c, err := ln.Accept()
+			if err != nil {
+				done <- err
+				return
+			}
+			_ = c.SetDeadline(time.Now().Add(5 * time.Second))
+			e, d := json.NewEncoder(c), json.NewDecoder(c)
+			_ = e.Encode(map[string]any{"QMP": map[string]any{}})
+			for {
+				var req struct {
+					Execute   string
+					Arguments map[string]string
+				}
+				if d.Decode(&req) != nil {
+					break
+				}
+				var result any = map[string]any{}
+				if req.Execute == "human-monitor-command" {
+					command := req.Arguments["command-line"]
+					if command == "info usernet" {
+						result = "Hub -1 (net0):\n"
+						if port != 0 {
+							result = fmt.Sprintf("Hub -1 (net0):\n TCP[HOST_FORWARD] 12 127.0.0.1 %d 10.0.2.15 5000 0 0\n", port)
+						}
+					} else {
+						var candidate int
+						if _, err := fmt.Sscanf(command, "hostfwd_add net0 tcp:127.0.0.1:%d-:5000", &candidate); err != nil {
+							c.Close()
+							done <- err
+							return
+						}
+						adds++
+						result = "Could not set up host forwarding rule"
+						if adds > 1 {
+							port = candidate
+							result = ""
+						}
+					}
+				}
+				_ = e.Encode(map[string]any{"return": result})
+			}
+			c.Close()
+		}
+		if adds != 2 {
+			done <- fmt.Errorf("added %d times, want one collision and one success", adds)
+			return
+		}
+		done <- nil
+	}()
+	one, err := s.RegistryPort(context.Background(), "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	two, err := s.RegistryPort(context.Background(), "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if one == 0 || one != two {
+		t.Fatalf("registry forward not stable: %d %d", one, two)
+	}
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}

--- a/go/internal/cli/vm/spec.go
+++ b/go/internal/cli/vm/spec.go
@@ -1,0 +1,117 @@
+package vm
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Defaults match the Builder's own run-vm.sh, so a VM started by this launcher
+// has the same shape the image was built and tested against.
+const (
+	DefaultMemoryMiB = 4096
+	DefaultCPUs      = 4
+)
+
+// Spec is everything needed to launch one VM.
+type Spec struct {
+	Name         string
+	DiskPath     string
+	FirmwareCode string
+	FirmwareVars string
+	MemoryMiB    int
+	CPUs         int
+	Accel        Accel
+	Net          NetConfig
+
+	// ConsoleLog, when set, sends the guest console and QEMU's own diagnostics
+	// to this file instead of the terminal. A detached VM has no terminal to
+	// attach to, and the log is the only record of a boot that failed.
+	ConsoleLog string
+}
+
+// Binary names the emulator. Always the aarch64 system emulator: the guest is
+// ARM64 whatever the host is, because real WendyOS devices are ARM64.
+func (s Spec) Binary() string { return "qemu-system-aarch64" }
+
+// Args returns the full argument list for Binary().
+func (s Spec) Args() ([]string, error) {
+	if s.Name == "" {
+		return nil, errors.New("no VM name")
+	}
+	if s.DiskPath == "" {
+		return nil, errors.New("no disk image")
+	}
+	if s.FirmwareCode == "" {
+		return nil, errors.New("no UEFI firmware image")
+	}
+	if s.FirmwareVars == "" {
+		return nil, errors.New("no UEFI variable store")
+	}
+
+	mem := s.MemoryMiB
+	if mem == 0 {
+		mem = DefaultMemoryMiB
+	}
+	cpus := s.CPUs
+	if cpus == 0 {
+		cpus = DefaultCPUs
+	}
+
+	args := []string{
+		// Names the guest in ps, so one VM can be found and stopped without
+		// matching on the emulator binary.
+		"-name", s.Name,
+		"-machine", MachineType(s.Accel),
+		"-accel", string(s.Accel),
+		"-cpu", CPUModel(s.Accel),
+		"-smp", strconv.Itoa(cpus),
+		"-m", strconv.Itoa(mem),
+
+		// The shared firmware code stays read-only; only the per-VM variable
+		// store is writable. Order matters: edk2 expects code then vars, and
+		// QEMU maps pflash units in the order given.
+		"-drive", fmt.Sprintf("if=pflash,format=raw,readonly=on,file=%s", escapeQEMUValue(s.FirmwareCode)),
+		"-drive", fmt.Sprintf("if=pflash,format=raw,file=%s", escapeQEMUValue(s.FirmwareVars)),
+
+		// No -kernel: the image boots itself through its own ESP and GRUB, which
+		// is what makes it a single downloadable artifact.
+		"-drive", fmt.Sprintf("file=%s,if=none,format=raw,id=hd0", escapeQEMUValue(s.DiskPath)),
+		"-device", "virtio-blk-pci,drive=hd0",
+	}
+	args = append(args, s.consoleArgs()...)
+
+	netArgs, err := s.Net.Args()
+	if err != nil {
+		return nil, err
+	}
+	return append(args, netArgs...), nil
+}
+
+// consoleArgs routes the guest console, either to the terminal or to a file.
+//
+// The detached form spells out -display, -serial and -monitor rather than using
+// -nographic, which implies "serial and monitor to stdio unless overridden":
+// leaving the monitor pointed at a closed stdio kills the VM on its first
+// monitor write.
+func (s Spec) consoleArgs() []string {
+	if s.ConsoleLog == "" {
+		// mon:stdio keeps the QEMU monitor reachable with Ctrl-A x, the only
+		// way out of a headless guest.
+		return []string{"-nographic", "-serial", "mon:stdio"}
+	}
+	// append=on, because the caller also points QEMU's own stdout and stderr at
+	// this file: without it QEMU truncates and writes from offset 0, clobbering
+	// the diagnostics that explain a failed boot.
+	return []string{
+		"-display", "none",
+		"-chardev", "file,id=console,append=on,path=" + escapeQEMUValue(s.ConsoleLog),
+		"-serial", "chardev:console",
+		"-monitor", "none",
+	}
+}
+
+// escapeQEMUValue doubles commas, which separate QEMU option parameters. A home
+// directory may contain one, and an unescaped comma silently truncates the path.
+func escapeQEMUValue(v string) string { return strings.ReplaceAll(v, ",", ",,") }

--- a/go/internal/cli/vm/spec.go
+++ b/go/internal/cli/vm/spec.go
@@ -29,6 +29,8 @@ type Spec struct {
 	// to this file instead of the terminal. A detached VM has no terminal to
 	// attach to, and the log is the only record of a boot that failed.
 	ConsoleLog string
+	// QMPPath is a private control socket in the VM's owner-only directory.
+	QMPPath string
 }
 
 // Binary names the emulator. Always the aarch64 system emulator: the guest is
@@ -81,6 +83,9 @@ func (s Spec) Args() ([]string, error) {
 		"-device", "virtio-blk-pci,drive=hd0",
 	}
 	args = append(args, s.consoleArgs()...)
+	if s.QMPPath != "" {
+		args = append(args, "-qmp", "unix:"+escapeQEMUValue(s.QMPPath)+",server=on,wait=off")
+	}
 
 	netArgs, err := s.Net.Args()
 	if err != nil {

--- a/go/internal/cli/vm/spec_test.go
+++ b/go/internal/cli/vm/spec_test.go
@@ -1,0 +1,252 @@
+package vm
+
+import (
+	"strings"
+	"testing"
+)
+
+func testSpec() Spec {
+	return Spec{
+		Name:         "dev",
+		DiskPath:     "/vms/dev/disk.img",
+		FirmwareCode: "/fw/code.fd",
+		FirmwareVars: "/vms/dev/efivars.fd",
+		MemoryMiB:    4096,
+		CPUs:         4,
+		Accel:        AccelHVF,
+		Net:          NetConfig{Mode: NetUser, AgentPort: 50051, MAC: MACFor("dev")},
+	}
+}
+
+func TestBinaryIsTheAArch64SystemEmulator(t *testing.T) {
+	if got := testSpec().Binary(); got != "qemu-system-aarch64" {
+		t.Errorf("Binary() = %q, want qemu-system-aarch64", got)
+	}
+}
+
+func TestArgsCarryTheAcceleratedMachineAndCPU(t *testing.T) {
+	args, err := testSpec().Args()
+	if err != nil {
+		t.Fatalf("Args() error = %v", err)
+	}
+	joined := strings.Join(args, " ")
+	for _, want := range []string{
+		"-machine virt,gic-version=3",
+		"-accel hvf",
+		"-cpu host",
+		"-smp 4",
+		"-m 4096",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("args missing %q; got %q", want, joined)
+		}
+	}
+}
+
+func TestArgsMountFirmwareReadOnlyAndVarsWritable(t *testing.T) {
+	args, err := testSpec().Args()
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(args, " ")
+	// The code image is shared with every other VM on the host; only the
+	// variable store is per-VM and writable.
+	if !strings.Contains(joined, "if=pflash,format=raw,readonly=on,file=/fw/code.fd") {
+		t.Errorf("firmware code should be read-only pflash; got %q", joined)
+	}
+	if !strings.Contains(joined, "if=pflash,format=raw,file=/vms/dev/efivars.fd") {
+		t.Errorf("variable store should be writable pflash; got %q", joined)
+	}
+	if strings.Contains(joined, "-kernel") {
+		t.Errorf("the image is self-booting; args must not pass an external kernel: %q", joined)
+	}
+}
+
+func TestArgsOrderFirmwareCodeBeforeVars(t *testing.T) {
+	args, err := testSpec().Args()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// QEMU maps pflash units in the order given and edk2 expects code first;
+	// swapping them boots to a blank firmware with no error message.
+	joined := strings.Join(args, " ")
+	code := strings.Index(joined, "readonly=on,file=/fw/code.fd")
+	vars := strings.Index(joined, "file=/vms/dev/efivars.fd")
+	if code < 0 || vars < 0 {
+		t.Fatalf("both pflash drives should be present; got %q", joined)
+	}
+	if code > vars {
+		t.Errorf("firmware code must precede the variable store; got %q", joined)
+	}
+}
+
+func TestArgsAttachTheDiskAsVirtioBlock(t *testing.T) {
+	args, err := testSpec().Args()
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "file=/vms/dev/disk.img") {
+		t.Errorf("args missing the disk; got %q", joined)
+	}
+	if !strings.Contains(joined, "virtio-blk-pci") {
+		t.Errorf("disk should be virtio-blk-pci; got %q", joined)
+	}
+}
+
+func TestArgsPutTheConsoleOnStdio(t *testing.T) {
+	args, err := testSpec().Args()
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "-nographic") {
+		t.Errorf("args should run headless; got %q", joined)
+	}
+	// mon:stdio keeps the QEMU monitor escape (Ctrl-A x) available, which is
+	// the only way out of a headless guest.
+	if !strings.Contains(joined, "-serial mon:stdio") {
+		t.Errorf("args should multiplex the monitor onto stdio; got %q", joined)
+	}
+}
+
+func TestArgsUseTCGSettingsOnAnUnacceleratedHost(t *testing.T) {
+	s := testSpec()
+	s.Accel = AccelTCG
+	args, err := s.Args()
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "-accel tcg") || !strings.Contains(joined, "-cpu cortex-a57") {
+		t.Errorf("TCG spec should emit tcg + cortex-a57; got %q", joined)
+	}
+	if strings.Contains(joined, "gic-version=3") {
+		t.Errorf("TCG should use the default GIC; got %q", joined)
+	}
+}
+
+func TestArgsApplyDefaultsForMemoryAndCPUs(t *testing.T) {
+	s := testSpec()
+	s.MemoryMiB, s.CPUs = 0, 0
+	args, err := s.Args()
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "-m 4096") || !strings.Contains(joined, "-smp 4") {
+		t.Errorf("zero values should fall back to the machine conf defaults; got %q", joined)
+	}
+}
+
+func TestArgsRejectAnIncompleteSpec(t *testing.T) {
+	for name, mutate := range map[string]func(*Spec){
+		"no disk":     func(s *Spec) { s.DiskPath = "" },
+		"no firmware": func(s *Spec) { s.FirmwareCode = "" },
+		"no varstore": func(s *Spec) { s.FirmwareVars = "" },
+	} {
+		s := testSpec()
+		mutate(&s)
+		if _, err := s.Args(); err == nil {
+			t.Errorf("%s: Args() succeeded, want an error", name)
+		}
+	}
+}
+
+func TestArgsPropagateANetworkError(t *testing.T) {
+	s := testSpec()
+	// Shared mode with no socket path: the error has to reach the caller rather
+	// than degrade to a network the user did not ask for.
+	s.Net = NetConfig{Mode: NetShared, MAC: MACFor("dev")}
+	if _, err := s.Args(); err == nil {
+		t.Fatal("Args() should surface the network configuration error")
+	}
+}
+
+func TestArgsNameTheGuest(t *testing.T) {
+	// Without a name the only way to find one VM among several is to match the
+	// emulator binary, which cannot tell them apart.
+	args, err := testSpec().Args()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(strings.Join(args, " "), "-name dev") {
+		t.Errorf("args should name the guest; got %v", args)
+	}
+	s := testSpec()
+	s.Name = ""
+	if _, err := s.Args(); err == nil {
+		t.Error("Args() accepted a spec with no name")
+	}
+}
+
+func TestForegroundConsoleKeepsTheTerminal(t *testing.T) {
+	args, err := testSpec().Args()
+	if err != nil {
+		t.Fatalf("Args() = %v", err)
+	}
+	joined := strings.Join(args, " ")
+	for _, want := range []string{"-nographic", "-serial mon:stdio"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("Args() = %q, want it to contain %q", joined, want)
+		}
+	}
+}
+
+func TestDetachedConsoleGoesToTheLogAndNotStdio(t *testing.T) {
+	s := testSpec()
+	s.ConsoleLog = "/tmp/vm/console.log"
+	args, err := s.Args()
+	if err != nil {
+		t.Fatalf("Args() = %v", err)
+	}
+	joined := strings.Join(args, " ")
+	// append=on matters: the caller also points QEMU's stdout and stderr at
+	// this file, and a truncating chardev would clobber them.
+	for _, want := range []string{"-display none", "-chardev file,id=console,append=on,path=/tmp/vm/console.log", "-serial chardev:console", "-monitor none"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("Args() = %q, want it to contain %q", joined, want)
+		}
+	}
+	// -nographic would re-point the monitor at a closed stdio and kill the VM.
+	for _, unwanted := range []string{"-nographic", "mon:stdio"} {
+		if strings.Contains(joined, unwanted) {
+			t.Errorf("Args() = %q, want it NOT to contain %q", joined, unwanted)
+		}
+	}
+}
+
+func TestDetachedConsolePathEscapesCommas(t *testing.T) {
+	s := testSpec()
+	s.ConsoleLog = "/home/a,b/vms/sim/console.log"
+	args, err := s.Args()
+	if err != nil {
+		t.Fatalf("Args() = %v", err)
+	}
+	want := "path=/home/a,,b/vms/sim/console.log"
+	if joined := strings.Join(args, " "); !strings.Contains(joined, want) {
+		t.Errorf("Args() = %q, want it to contain %q", joined, want)
+	}
+}
+
+func TestEveryPathArgumentEscapesCommas(t *testing.T) {
+	// QEMU splits option strings on commas, so an unescaped one in any path
+	// silently truncates it and the rest parses as further options.
+	s := Spec{
+		Name:         "dev",
+		DiskPath:     "/home/a,b/disk.img",
+		FirmwareCode: "/opt/a,b/code.fd",
+		FirmwareVars: "/home/a,b/efivars.fd",
+		Net:          NetConfig{Mode: NetUser, AgentPort: 50051, MAC: MACFor("dev")},
+	}
+	args, err := s.Args()
+	if err != nil {
+		t.Fatalf("Args() = %v", err)
+	}
+	joined := strings.Join(args, " ")
+	for _, want := range []string{"/home/a,,b/disk.img", "/opt/a,,b/code.fd", "/home/a,,b/efivars.fd"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("Args() = %q, want it to contain the escaped %q", joined, want)
+		}
+	}
+}

--- a/go/internal/cli/vm/spec_test.go
+++ b/go/internal/cli/vm/spec_test.go
@@ -110,6 +110,25 @@ func TestArgsPutTheConsoleOnStdio(t *testing.T) {
 	}
 }
 
+func TestArgsExposeQMPOnlyOnUnixSocket(t *testing.T) {
+	for _, log := range []string{"", "/vms/dev/console.log"} {
+		s := testSpec()
+		s.ConsoleLog = log
+		s.QMPPath = "/vms/with,comma/dev/qmp.sock"
+		args, err := s.Args()
+		if err != nil {
+			t.Fatal(err)
+		}
+		joined := strings.Join(args, " ")
+		if !strings.Contains(joined, "-qmp unix:/vms/with,,comma/dev/qmp.sock,server=on,wait=off") {
+			t.Fatalf("missing Unix control socket: %s", joined)
+		}
+		if strings.Contains(joined, "-qmp tcp:") {
+			t.Fatalf("unexpected TCP control listener: %s", joined)
+		}
+	}
+}
+
 func TestArgsUseTCGSettingsOnAnUnacceleratedHost(t *testing.T) {
 	s := testSpec()
 	s.Accel = AccelTCG

--- a/go/internal/cli/vm/state.go
+++ b/go/internal/cli/vm/state.go
@@ -146,6 +146,17 @@ func (s *Store) ReadState(name string) (State, error) {
 // description, which fork+exec inherits and the kernel frees when the last
 // descriptor closes, so a recycled pid can never fake liveness.
 func (s *Store) acquireRunLock(name string) (*os.File, error) {
+	lifecycle, err := s.acquireLifecycleLock(name)
+	if err != nil {
+		return nil, err
+	}
+	defer lifecycle.Close()
+	return s.acquireRunLockUnderLifecycle(name)
+}
+
+// Caller owns the lifecycle lock, so the directory cannot be replaced while
+// the run lock is acquired. Once held, the run lock itself excludes Remove.
+func (s *Store) acquireRunLockUnderLifecycle(name string) (*os.File, error) {
 	f, err := os.OpenFile(s.LockPath(name), os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("opening run lock: %w", err)

--- a/go/internal/cli/vm/state.go
+++ b/go/internal/cli/vm/state.go
@@ -1,0 +1,287 @@
+package vm
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// lockAcquireWindow is how long a start waits out a transient holder before
+// declaring the VM already running.
+const lockAcquireWindow = 250 * time.Millisecond
+
+// ErrAlreadyRunning reports that another process already holds a VM's run lock.
+var ErrAlreadyRunning = errors.New("VM is already running")
+
+// Meta is a VM's durable record, written once when it is created. Kept apart
+// from State so a stopped VM can still report where its image came from.
+type Meta struct {
+	Name         string    `json:"name"`
+	CreatedAt    time.Time `json:"createdAt"`
+	ImageVersion string    `json:"imageVersion,omitempty"`
+	ImageSource  string    `json:"imageSource,omitempty"`
+	DiskBytes    int64     `json:"diskBytes,omitempty"`
+
+	// AgentPort is the host port this VM last bound successfully. Sticky, so a
+	// VM forced off the default port keeps the address the user wrote down.
+	AgentPort int `json:"agentPort,omitempty"`
+}
+
+// State describes one run of a VM. Its absence means the VM is not running.
+type State struct {
+	Name string `json:"name"`
+
+	// PID is 0 between reserving the run lock and QEMU actually starting,
+	// which readers should treat as "starting", not as a stale record.
+	PID       int       `json:"pid"`
+	AgentPort int       `json:"agentPort,omitempty"`
+	NetMode   NetMode   `json:"netMode,omitempty"`
+	MAC       string    `json:"mac,omitempty"`
+	Accel     Accel     `json:"accel,omitempty"`
+	MemoryMiB int       `json:"memoryMiB,omitempty"`
+	CPUs      int       `json:"cpus,omitempty"`
+	StartedAt time.Time `json:"startedAt"`
+	Detached  bool      `json:"detached,omitempty"`
+	LogPath   string    `json:"logPath,omitempty"`
+}
+
+// Status is everything known about one VM.
+type Status struct {
+	Name    string
+	Exists  bool
+	Running bool
+	Meta    Meta
+	State   State
+}
+
+// MetaPath, StatePath, LockPath and LogPath live inside the VM's own directory
+// so Store.List keeps working (it filters ReadDir to directories) and Remove
+// still cleans everything up.
+func (s *Store) MetaPath(name string) string  { return filepath.Join(s.Dir(name), "meta.json") }
+func (s *Store) StatePath(name string) string { return filepath.Join(s.Dir(name), "state.json") }
+func (s *Store) LockPath(name string) string  { return filepath.Join(s.Dir(name), "run.lock") }
+func (s *Store) LogPath(name string) string   { return filepath.Join(s.Dir(name), "console.log") }
+
+// writeJSON writes v through a temporary file in the same directory, so a
+// reader never observes a half-written record.
+func writeJSON(path string, v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	// A unique name per write: two processes sharing one ".tmp" can interleave
+	// write and rename and publish a truncated record.
+	f, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	defer func() { _ = os.Remove(tmp) }()
+	// These two discard the close error deliberately: a write already failed,
+	// and the close error would only mask the one worth reporting. The close on
+	// the success path below IS checked -- on a file this size it can be the
+	// first sign of a failed writeback.
+	if err := f.Chmod(0o600); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if _, err := f.Write(append(data, '\n')); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// WriteMeta records a VM's durable provenance.
+func (s *Store) WriteMeta(m Meta) error { return writeJSON(s.MetaPath(m.Name), m) }
+
+// ReadMeta returns a VM's durable record and whether it was actually read; a
+// missing or unreadable file yields a zero Meta, which stays usable.
+//
+// A caller that writes the record back must check ok, or a transient read
+// failure would persist the empty value and lose the VM's provenance.
+func (s *Store) ReadMeta(name string) (m Meta, ok bool) {
+	data, err := os.ReadFile(s.MetaPath(name))
+	if err != nil {
+		return Meta{Name: name}, false
+	}
+	if err := json.Unmarshal(data, &m); err != nil {
+		return Meta{Name: name}, false
+	}
+	m.Name = name
+	return m, true
+}
+
+// WriteState records the current run.
+func (s *Store) WriteState(st State) error { return writeJSON(s.StatePath(st.Name), st) }
+
+// ReadState returns the recorded run, or an error if there is none.
+func (s *Store) ReadState(name string) (State, error) {
+	data, err := os.ReadFile(s.StatePath(name))
+	if err != nil {
+		return State{}, err
+	}
+	var st State
+	if err := json.Unmarshal(data, &st); err != nil {
+		return State{}, fmt.Errorf("reading %s: %w", s.StatePath(name), err)
+	}
+	return st, nil
+}
+
+// Nothing is ever written through a run-lock handle -- it exists only to carry
+// the advisory lock -- so its Close can lose no data and is deferred bare. The
+// one handle in this file that IS written, writeJSON's temporary, checks Close
+// explicitly.
+//
+// acquireRunLock takes name's exclusive run lock. The returned file MUST be
+// passed to the emulator via Cmd.ExtraFiles: the lock lives on the open file
+// description, which fork+exec inherits and the kernel frees when the last
+// descriptor closes, so a recycled pid can never fake liveness.
+func (s *Store) acquireRunLock(name string) (*os.File, error) {
+	f, err := os.OpenFile(s.LockPath(name), os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("opening run lock: %w", err)
+	}
+	// Retry briefly. A status poll holds a shared lock for microseconds, and a
+	// shared lock still blocks this exclusive one -- so without a window, any
+	// start racing the simulator tab's 2-second refresh would report the VM
+	// already running. A VM that really is running holds the lock for its whole
+	// life, so it never becomes available inside this window.
+	deadline := time.Now().Add(lockAcquireWindow)
+	for {
+		locked, err := tryLockFile(f)
+		if err != nil {
+			_ = f.Close()
+			return nil, fmt.Errorf("locking %s: %w", s.LockPath(name), err)
+		}
+		if locked {
+			return f, nil
+		}
+		if time.Now().After(deadline) {
+			_ = f.Close()
+			return nil, fmt.Errorf("%w: %s", ErrAlreadyRunning, name)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// runLockHeld reports whether some process still holds name's run lock.
+func (s *Store) runLockHeld(name string) (bool, error) {
+	f, err := os.OpenFile(s.LockPath(name), os.O_RDWR, 0o600)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	defer func() { _ = f.Close() }()
+
+	// Shared, not exclusive: this is a read. Taking the write lock here would
+	// make a start racing with any status poll fail spuriously.
+	free, err := trySharedLock(f)
+	if err != nil {
+		return false, err
+	}
+	if free {
+		_ = unlockFile(f)
+		return false, nil
+	}
+	return true, nil
+}
+
+// Status reports what a VM is doing, and reaps the state of one that died
+// without cleaning up. Every abnormal exit -- SIGKILL, an OOM kill, a host
+// reboot -- releases the kernel lock, so no daemon or boot-time sweep is
+// needed: the next caller tidies up.
+func (s *Store) Status(name string) (Status, error) {
+	if err := ValidName(name); err != nil {
+		return Status{}, err
+	}
+	st := Status{Name: name}
+	if _, err := os.Stat(s.Dir(name)); err != nil {
+		if os.IsNotExist(err) {
+			return st, nil
+		}
+		return Status{}, err
+	}
+	st.Exists = true
+	st.Meta, _ = s.ReadMeta(name)
+
+	held, err := s.runLockHeld(name)
+	if err != nil {
+		return Status{}, err
+	}
+	if !held {
+		if err := s.reapStaleState(name); err != nil {
+			return Status{}, err
+		}
+		return st, nil
+	}
+	st.Running = true
+	if run, err := s.ReadState(name); err == nil {
+		st.State = run
+	}
+	return st, nil
+}
+
+// reapStaleState clears the record of a VM that died without cleaning up.
+//
+// Under the exclusive lock, because the probe that decided the VM was gone is
+// lock-free: a start can win the lock and write its own record in between, and
+// deleting that would leave a live VM reading as "starting" forever, which
+// every command refuses to act on. Failing to take the lock means exactly that
+// happened, so there is nothing stale left to reap.
+func (s *Store) reapStaleState(name string) error {
+	// Nothing recorded, nothing to reap -- and checking first keeps a status
+	// read of a never-started VM from creating its lock file below.
+	if _, err := os.Stat(s.StatePath(name)); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	// O_CREATE, not a missing-file shortcut: a start racing us creates this
+	// same file, so taking the lock through it is what orders us against it.
+	f, err := os.OpenFile(s.LockPath(name), os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	locked, err := tryLockFile(f)
+	if err != nil || !locked {
+		return err
+	}
+	defer func() { _ = unlockFile(f) }()
+
+	if err := os.Remove(s.StatePath(name)); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// Statuses reports every VM in the store, sorted by name.
+func (s *Store) Statuses() ([]Status, error) {
+	names, err := s.List()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Status, 0, len(names))
+	for _, name := range names {
+		st, err := s.Status(name)
+		if err != nil {
+			// One unreadable directory must not hide every healthy VM, which
+			// is what returning here did: the whole list, and the Simulator
+			// tab with it, went empty.
+			st = Status{Name: name, Exists: true}
+		}
+		out = append(out, st)
+	}
+	return out, nil
+}

--- a/go/internal/cli/vm/state.go
+++ b/go/internal/cli/vm/state.go
@@ -218,10 +218,15 @@ func (s *Store) Status(name string) (Status, error) {
 		return Status{}, err
 	}
 	if !held {
-		if err := s.reapStaleState(name); err != nil {
+		reaped, err := s.reapStaleState(name)
+		if err != nil {
 			return Status{}, err
 		}
-		return st, nil
+		if reaped {
+			return st, nil
+		}
+		// A start or cleanup won the lock after our probe. Do not report a
+		// stopped VM while another owner is still modifying its run record.
 	}
 	st.Running = true
 	if run, err := s.ReadState(name); err == nil {
@@ -237,33 +242,33 @@ func (s *Store) Status(name string) (Status, error) {
 // deleting that would leave a live VM reading as "starting" forever, which
 // every command refuses to act on. Failing to take the lock means exactly that
 // happened, so there is nothing stale left to reap.
-func (s *Store) reapStaleState(name string) error {
+func (s *Store) reapStaleState(name string) (bool, error) {
 	// Nothing recorded, nothing to reap -- and checking first keeps a status
 	// read of a never-started VM from creating its lock file below.
 	if _, err := os.Stat(s.StatePath(name)); err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			return true, nil
 		}
-		return err
+		return false, err
 	}
 	// O_CREATE, not a missing-file shortcut: a start racing us creates this
 	// same file, so taking the lock through it is what orders us against it.
 	f, err := os.OpenFile(s.LockPath(name), os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer func() { _ = f.Close() }()
 
 	locked, err := tryLockFile(f)
 	if err != nil || !locked {
-		return err
+		return false, err
 	}
 	defer func() { _ = unlockFile(f) }()
 
 	if err := os.Remove(s.StatePath(name)); err != nil && !os.IsNotExist(err) {
-		return err
+		return false, err
 	}
-	return nil
+	return true, nil
 }
 
 // Statuses reports every VM in the store, sorted by name.

--- a/go/internal/cli/vm/state.go
+++ b/go/internal/cli/vm/state.go
@@ -24,6 +24,8 @@ type Meta struct {
 	ImageVersion string    `json:"imageVersion,omitempty"`
 	ImageSource  string    `json:"imageSource,omitempty"`
 	DiskBytes    int64     `json:"diskBytes,omitempty"`
+	// MAC is allocated once per newly-created VM, not derived from its name.
+	MAC string `json:"mac,omitempty"`
 
 	// AgentPort is the host port this VM last bound successfully. Sticky, so a
 	// VM forced off the default port keeps the address the user wrote down.

--- a/go/internal/cli/vm/state_test.go
+++ b/go/internal/cli/vm/state_test.go
@@ -1,0 +1,314 @@
+package vm
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func createTestVM(t *testing.T, s *Store, name string, meta Meta) {
+	t.Helper()
+	const body = "image-bytes"
+	if err := s.CreateFrom(name, strings.NewReader(body), int64(len(body)), 1<<20, meta); err != nil {
+		t.Fatalf("CreateFrom(%q) = %v", name, err)
+	}
+}
+
+func TestCreateRecordsProvenance(t *testing.T) {
+	s := newTestStore(t)
+	createTestVM(t, s, "dev", Meta{ImageVersion: "0.19.0", ImageSource: "pr/1834"})
+
+	got, ok := s.ReadMeta("dev")
+	if !ok {
+		t.Fatal("ReadMeta() reported the record unreadable")
+	}
+	if got.ImageVersion != "0.19.0" || got.ImageSource != "pr/1834" {
+		t.Errorf("ReadMeta() = %+v, want version 0.19.0 from pr/1834", got)
+	}
+	if got.DiskBytes != 1<<20 {
+		t.Errorf("ReadMeta().DiskBytes = %d, want %d", got.DiskBytes, 1<<20)
+	}
+	if got.CreatedAt.IsZero() {
+		t.Error("ReadMeta().CreatedAt is zero, want it stamped at create")
+	}
+}
+
+func TestMetaAndStateAreOwnerOnly(t *testing.T) {
+	s := newTestStore(t)
+	createTestVM(t, s, "dev", Meta{})
+	if err := s.WriteState(State{Name: "dev", PID: 1234}); err != nil {
+		t.Fatalf("WriteState() = %v", err)
+	}
+	for _, path := range []string{s.MetaPath("dev"), s.StatePath("dev")} {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Errorf("%s mode = %v, want 0600", filepath.Base(path), perm)
+		}
+	}
+}
+
+func TestWritingRecordsLeavesNoTempFile(t *testing.T) {
+	s := newTestStore(t)
+	createTestVM(t, s, "dev", Meta{})
+	if err := s.WriteState(State{Name: "dev"}); err != nil {
+		t.Fatalf("WriteState() = %v", err)
+	}
+	entries, err := os.ReadDir(s.Dir("dev"))
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("left %s behind; writes must be tmp+rename", e.Name())
+		}
+	}
+}
+
+func TestReadMetaToleratesAGarbageRecord(t *testing.T) {
+	// VMs created before meta.json existed, or whose record was truncated,
+	// must stay usable rather than becoming unlistable.
+	s := newTestStore(t)
+	createTestVM(t, s, "dev", Meta{ImageVersion: "0.19.0"})
+	if err := os.WriteFile(s.MetaPath("dev"), []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("corrupt meta: %v", err)
+	}
+	got, ok := s.ReadMeta("dev")
+	if ok {
+		t.Error("ReadMeta() reported garbage as a good read; the caller would write the empty record back")
+	}
+	if got.Name != "dev" || got.ImageVersion != "" {
+		t.Errorf("ReadMeta() on garbage = %+v, want a zero Meta named dev", got)
+	}
+}
+
+func TestStatusOnAVMThatWasNeverStarted(t *testing.T) {
+	s := newTestStore(t)
+	createTestVM(t, s, "dev", Meta{})
+
+	st, err := s.Status("dev")
+	if err != nil {
+		t.Fatalf("Status() = %v", err)
+	}
+	if !st.Exists || st.Running {
+		t.Errorf("Status() = %+v, want exists and not running", st)
+	}
+}
+
+func TestStatusOnAnAbsentVM(t *testing.T) {
+	st, err := newTestStore(t).Status("ghost")
+	if err != nil {
+		t.Fatalf("Status() = %v", err)
+	}
+	if st.Exists || st.Running {
+		t.Errorf("Status() = %+v, want neither exists nor running", st)
+	}
+}
+
+func TestStatusReapsStateLeftByAVMThatDied(t *testing.T) {
+	// A VM killed with SIGKILL never clears its own state. Because liveness is
+	// the kernel-held lock rather than the recorded pid, the next caller can
+	// tell the record is stale and tidy it up -- no daemon, no boot sweep.
+	s := newTestStore(t)
+	createTestVM(t, s, "dev", Meta{})
+	if err := s.WriteState(State{Name: "dev", PID: 999999, AgentPort: 50051}); err != nil {
+		t.Fatalf("WriteState() = %v", err)
+	}
+
+	st, err := s.Status("dev")
+	if err != nil {
+		t.Fatalf("Status() = %v", err)
+	}
+	if st.Running {
+		t.Error("Status() reported running for a VM whose lock nobody holds")
+	}
+	if _, err := os.Stat(s.StatePath("dev")); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("stale state.json still present: %v", err)
+	}
+}
+
+func TestStatusReportsRunningWhileTheLockIsHeld(t *testing.T) {
+	s := newTestStore(t)
+	createTestVM(t, s, "dev", Meta{})
+
+	lock, err := s.acquireRunLock("dev")
+	if err != nil {
+		t.Fatalf("acquireRunLock() = %v", err)
+	}
+	defer lock.Close()
+	if err := s.WriteState(State{Name: "dev", PID: 4321, AgentPort: 50053, StartedAt: time.Now()}); err != nil {
+		t.Fatalf("WriteState() = %v", err)
+	}
+
+	st, err := s.Status("dev")
+	if err != nil {
+		t.Fatalf("Status() = %v", err)
+	}
+	if !st.Running {
+		t.Fatal("Status() reported not running while the lock is held")
+	}
+	if st.State.AgentPort != 50053 {
+		t.Errorf("Status().State.AgentPort = %d, want 50053", st.State.AgentPort)
+	}
+}
+
+func TestAcquireRunLockRefusesASecondHolder(t *testing.T) {
+	// Two `wendy` invocations starting the same VM: one wins, and the loser
+	// gets ErrAlreadyRunning so it can adopt rather than fail.
+	s := newTestStore(t)
+	createTestVM(t, s, "dev", Meta{})
+
+	first, err := s.acquireRunLock("dev")
+	if err != nil {
+		t.Fatalf("first acquireRunLock() = %v", err)
+	}
+	defer first.Close()
+
+	if _, err := s.acquireRunLock("dev"); !errors.Is(err, ErrAlreadyRunning) {
+		t.Errorf("second acquireRunLock() = %v, want ErrAlreadyRunning", err)
+	}
+}
+
+func TestRunLockFreesWhenTheHolderCloses(t *testing.T) {
+	s := newTestStore(t)
+	createTestVM(t, s, "dev", Meta{})
+
+	lock, err := s.acquireRunLock("dev")
+	if err != nil {
+		t.Fatalf("acquireRunLock() = %v", err)
+	}
+	held, err := s.runLockHeld("dev")
+	if err != nil || !held {
+		t.Fatalf("runLockHeld() = %v, %v; want true, nil", held, err)
+	}
+
+	lock.Close()
+	held, err = s.runLockHeld("dev")
+	if err != nil || held {
+		t.Fatalf("runLockHeld() after close = %v, %v; want false, nil", held, err)
+	}
+}
+
+func TestStatusesCoversEveryVMSorted(t *testing.T) {
+	s := newTestStore(t)
+	createTestVM(t, s, "alpha", Meta{})
+	createTestVM(t, s, "beta", Meta{})
+
+	got, err := s.Statuses()
+	if err != nil {
+		t.Fatalf("Statuses() = %v", err)
+	}
+	if len(got) != 2 || got[0].Name != "alpha" || got[1].Name != "beta" {
+		t.Fatalf("Statuses() = %+v, want alpha then beta", got)
+	}
+}
+
+func TestStatusDoesNotBlockAConcurrentStart(t *testing.T) {
+	// A status poll runs every couple of seconds behind the simulator tab. If
+	// it took the exclusive lock, even briefly, a start landing in that window
+	// would fail with a spurious ErrAlreadyRunning.
+	s := newTestStore(t)
+	createTestVM(t, s, "dev", Meta{})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 200 {
+			_, _ = s.Status("dev")
+		}
+	}()
+	for range 200 {
+		lock, err := s.acquireRunLock("dev")
+		if err != nil {
+			t.Errorf("acquireRunLock() failed while a status poll was running: %v", err)
+			break
+		}
+		lock.Close()
+	}
+	<-done
+}
+
+func TestStatusesSurvivesOneUnreadableVM(t *testing.T) {
+	// One bad directory must not empty the whole list, which is what the
+	// simulator tab renders.
+	s := newTestStore(t)
+	createTestVM(t, s, "good", Meta{})
+	if err := os.MkdirAll(s.Dir("broken"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	got, err := s.Statuses()
+	if err != nil {
+		t.Fatalf("Statuses() = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("Statuses() returned %d rows, want both VMs listed", len(got))
+	}
+}
+
+func TestRemoveRefusesARunningVM(t *testing.T) {
+	// The guard belongs here, not only in the cobra command: deleting the image
+	// a live emulator has mapped corrupts it.
+	s := newTestStore(t)
+	createTestVM(t, s, "dev", Meta{})
+	lock, err := s.acquireRunLock("dev")
+	if err != nil {
+		t.Fatalf("acquireRunLock() = %v", err)
+	}
+	defer lock.Close()
+
+	if err := s.Remove("dev"); !errors.Is(err, ErrAlreadyRunning) {
+		t.Errorf("Remove() on a running VM = %v, want ErrAlreadyRunning", err)
+	}
+	if _, err := os.Stat(s.DiskPath("dev")); err != nil {
+		t.Errorf("the disk was deleted anyway: %v", err)
+	}
+}
+
+func TestPickHostPortRejectsAnEmptySearch(t *testing.T) {
+	if _, err := PickHostPort(50051, 0); err == nil {
+		t.Error("PickHostPort(_, 0) = nil error, want a refusal rather than port 0")
+	}
+}
+
+func TestReapLeavesTheRecordOfAVMThatJustStarted(t *testing.T) {
+	// The probe that decides a VM is gone is lock-free, so a start can win the
+	// lock and write its record between that probe and the reap. Deleting it
+	// would leave a live VM reading as "starting" forever, and unstoppable.
+	s := newTestStore(t)
+	createTestVM(t, s, "dev", Meta{})
+
+	lock, err := s.acquireRunLock("dev")
+	if err != nil {
+		t.Fatalf("acquireRunLock() = %v", err)
+	}
+	defer lock.Close()
+	if err := s.WriteState(State{Name: "dev", PID: 4321}); err != nil {
+		t.Fatalf("WriteState() = %v", err)
+	}
+
+	if err := s.reapStaleState("dev"); err != nil {
+		t.Fatalf("reapStaleState() = %v", err)
+	}
+	if _, err := os.Stat(s.StatePath("dev")); err != nil {
+		t.Errorf("reap deleted the record of a VM holding the lock: %v", err)
+	}
+}
+
+func TestReapOnANeverStartedVMCreatesNoLockFile(t *testing.T) {
+	s := newTestStore(t)
+	createTestVM(t, s, "dev", Meta{})
+
+	if _, err := s.Status("dev"); err != nil {
+		t.Fatalf("Status() = %v", err)
+	}
+	if _, err := os.Stat(s.LockPath("dev")); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("a status read created %s; reads must not", s.LockPath("dev"))
+	}
+}

--- a/go/internal/cli/vm/state_test.go
+++ b/go/internal/cli/vm/state_test.go
@@ -18,6 +18,37 @@ func createTestVM(t *testing.T, s *Store, name string, meta Meta) {
 	}
 }
 
+func TestExitingLauncherCannotClearStateDuringNewStart(t *testing.T) {
+	s := newTestStore(t)
+	createTestVM(t, s, "dev", Meta{})
+	if err := s.WriteState(State{Name: "dev", PID: 100}); err != nil {
+		t.Fatal(err)
+	}
+	lock, err := s.acquireRunLock("dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lock.Close()
+	// The new start has taken the lock but has not written its state yet.
+	// An old launcher must not even clear its matching old PID in this window.
+	s.clearStateForPID("dev", 100)
+	if _, err := s.ReadState("dev"); err != nil {
+		t.Fatalf("cleanup ignored new owner's lock: %v", err)
+	}
+	if err := s.WriteState(State{Name: "dev", PID: 200}); err != nil {
+		t.Fatal(err)
+	}
+	_ = lock.Close()
+	s.clearStateForPID("dev", 100)
+	if state, err := s.ReadState("dev"); err != nil || state.PID != 200 {
+		t.Fatalf("new state lost: %+v %v", state, err)
+	}
+	s.clearStateForPID("dev", 200)
+	if _, err := os.Stat(s.StatePath("dev")); !os.IsNotExist(err) {
+		t.Fatal("matching stale state not removed")
+	}
+}
+
 func TestCreateRecordsProvenance(t *testing.T) {
 	s := newTestStore(t)
 	createTestVM(t, s, "dev", Meta{ImageVersion: "0.19.0", ImageSource: "pr/1834"})
@@ -293,8 +324,8 @@ func TestReapLeavesTheRecordOfAVMThatJustStarted(t *testing.T) {
 		t.Fatalf("WriteState() = %v", err)
 	}
 
-	if err := s.reapStaleState("dev"); err != nil {
-		t.Fatalf("reapStaleState() = %v", err)
+	if reaped, err := s.reapStaleState("dev"); err != nil || reaped {
+		t.Fatalf("reapStaleState() = %v, %v; want lock owner preserved", reaped, err)
 	}
 	if _, err := os.Stat(s.StatePath("dev")); err != nil {
 		t.Errorf("reap deleted the record of a VM holding the lock: %v", err)

--- a/go/internal/cli/vm/store.go
+++ b/go/internal/cli/vm/store.go
@@ -1,0 +1,216 @@
+package vm
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+)
+
+// vmNameRe constrains a VM name to something that is safe as a directory
+// component and usable as a hostname: lowercase, no separators, no traversal.
+var vmNameRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,30}[a-z0-9])?$`)
+
+// ValidName reports whether name may be used for a VM.
+func ValidName(name string) error {
+	if !vmNameRe.MatchString(name) {
+		return fmt.Errorf("invalid VM name %q: use 1-32 lowercase letters, digits or dashes, starting and ending with a letter or digit", name)
+	}
+	return nil
+}
+
+// Store is where the VMs this CLI manages live: ~/.wendy/vms/<name>/.
+type Store struct {
+	Root string
+}
+
+// NewStore returns the store rooted in the CLI's own config directory, so VM
+// disks sit beside the config that refers to them and inherit its 0700 mode.
+func NewStore() (*Store, error) {
+	dir, err := config.ConfigDir()
+	if err != nil {
+		return nil, err
+	}
+	return &Store{Root: filepath.Join(dir, "vms")}, nil
+}
+
+func (s *Store) Dir(name string) string      { return filepath.Join(s.Root, name) }
+func (s *Store) DiskPath(name string) string { return filepath.Join(s.Dir(name), "disk.img") }
+func (s *Store) VarsPath(name string) string { return filepath.Join(s.Dir(name), "efivars.fd") }
+
+// CheckCreatable reports whether a VM of this name could be created now, so a
+// caller can reject a bad or duplicate name before spending a download on it.
+// Advisory only: CreateFrom re-checks.
+func (s *Store) CheckCreatable(name string) error {
+	if err := ValidName(name); err != nil {
+		return err
+	}
+	if _, err := os.Stat(s.Dir(name)); err == nil {
+		return fmt.Errorf("VM %q already exists; remove it with 'wendy vm rm %s'", name, name)
+	}
+	return nil
+}
+
+// CreateFrom provisions a new VM from an open image stream: a private, resizable
+// copy of the image plus an empty UEFI variable store.
+//
+// A stream rather than a path because the published image is compressed:
+// decompressing to a temporary file only to copy it again would double both the
+// disk cost and the wait.
+//
+// imageSize is the image's uncompressed size, used to reject a disk too small to
+// hold it. It may overstate the stream's length, but must never understate it.
+//
+// meta records where the image came from. It is written last, inside the same
+// rollback guard, so a VM directory never outlives a failed create.
+func (s *Store) CreateFrom(name string, image io.Reader, imageSize, diskBytes int64, meta Meta) (retErr error) {
+	if err := ValidName(name); err != nil {
+		return err
+	}
+	// A disk truncated below the image loses the last partition and the GPT
+	// backup header that sits at the very end.
+	if diskBytes < imageSize {
+		return fmt.Errorf("disk size %d is smaller than the image (%d bytes)", diskBytes, imageSize)
+	}
+
+	dir := s.Dir(name)
+	if _, err := os.Stat(dir); err == nil {
+		return fmt.Errorf("VM %q already exists; remove it with 'wendy vm rm %s'", name, name)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("creating %s: %w", dir, err)
+	}
+
+	// The likeliest failure below is running out of room, and a half-written
+	// disk left behind would both hold that space and make the retry report
+	// "already exists". Registered before the Close defers so it runs after
+	// them, and so covers a failure they report. Only ever removes a directory
+	// this call created.
+	defer func() {
+		if retErr == nil {
+			return
+		}
+		if rmErr := os.RemoveAll(dir); rmErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not clean up %s: %v; "+
+				"remove it before retrying\n", dir, rmErr)
+		}
+	}()
+
+	// O_EXCL is the real existence check: a VM's disk is the one file whose loss
+	// cannot be undone, so never open it for truncation.
+	disk, err := os.OpenFile(s.DiskPath(name), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("creating disk: %w", err)
+	}
+	// A close error on a file this large can be the first report of a failed
+	// writeback, which would otherwise leave a corrupt disk behind a success.
+	defer func() {
+		if cerr := disk.Close(); cerr != nil && retErr == nil {
+			retErr = fmt.Errorf("closing disk: %w", cerr)
+		}
+	}()
+
+	// Bounded one byte past the disk: a compressed source reports size 0, so the
+	// up-front guard cannot fire and an over-large image would otherwise be
+	// written in full before the check below rejects it.
+	written, err := io.Copy(disk, io.LimitReader(image, diskBytes+1))
+	if err != nil {
+		return fmt.Errorf("writing image: %w", err)
+	}
+	// The up-front guard cannot fire when imageSize is 0, as a compressed source
+	// reports until its size is known. Without this the Truncate below would
+	// silently cut the image short.
+	if diskBytes < written {
+		return fmt.Errorf("disk size %d is smaller than the image (%d bytes)", diskBytes, written)
+	}
+	// Grow, not preallocate: the image is sparse-extended so /data can be grown
+	// into the space on first boot without writing gigabytes now.
+	if err := disk.Truncate(diskBytes); err != nil {
+		return fmt.Errorf("sizing disk: %w", err)
+	}
+
+	vars, err := os.OpenFile(s.VarsPath(name), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("creating UEFI variable store: %w", err)
+	}
+	defer func() {
+		if cerr := vars.Close(); cerr != nil && retErr == nil {
+			retErr = fmt.Errorf("closing UEFI variable store: %w", cerr)
+		}
+	}()
+	if err := vars.Truncate(pflashBytes); err != nil {
+		return fmt.Errorf("sizing UEFI variable store: %w", err)
+	}
+
+	meta.Name = name
+	meta.DiskBytes = diskBytes
+	if meta.CreatedAt.IsZero() {
+		meta.CreatedAt = time.Now().UTC()
+	}
+	if err := s.WriteMeta(meta); err != nil {
+		return fmt.Errorf("recording VM metadata: %w", err)
+	}
+	return nil
+}
+
+// List returns the names of every VM in the store, sorted.
+func (s *Store) List() ([]string, error) {
+	entries, err := os.ReadDir(s.Root)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", s.Root, err)
+	}
+
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() && ValidName(e.Name()) == nil {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// Remove deletes a VM and its disk, refusing while it is running.
+//
+// The check lives here rather than only in the command: deleting the image a
+// live emulator has mapped corrupts it, and every caller deserves that
+// guarantee. Take the run lock to make the check and the delete atomic -- a
+// VM started between a separate Status call and the delete would otherwise be
+// destroyed underneath QEMU.
+func (s *Store) Remove(name string) error {
+	if err := ValidName(name); err != nil {
+		return err
+	}
+	if _, err := os.Stat(s.Dir(name)); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("no VM named %q", name)
+		}
+		return err
+	}
+	lock, err := s.acquireRunLock(name)
+	if err != nil {
+		return err
+	}
+	// The disk goes first and under the lock. Releasing the lock and only then
+	// deleting would leave a window where a racing start acquires it, passes
+	// its own existence check and boots an image this call is midway through
+	// removing.
+	if err := os.Remove(s.DiskPath(name)); err != nil && !os.IsNotExist(err) {
+		_ = lock.Close()
+		return err
+	}
+	// Closed before the rest, not deferred: Windows cannot unlink an open file,
+	// so a held handle would leave a half-removed directory. A start that wins
+	// the lock from here on fails on the disk that is already gone.
+	_ = lock.Close()
+	return os.RemoveAll(s.Dir(name))
+}

--- a/go/internal/cli/vm/store.go
+++ b/go/internal/cli/vm/store.go
@@ -78,6 +78,13 @@ func (s *Store) CreateFrom(name string, image io.Reader, imageSize, diskBytes in
 	if diskBytes < imageSize {
 		return fmt.Errorf("disk size %d is smaller than the image (%d bytes)", diskBytes, imageSize)
 	}
+	// Each creation gets a fresh identity, even when its name matches a VM on
+	// another host. Persist it with the disk so restarts preserve DHCP leases.
+	mac, err := newMAC()
+	if err != nil {
+		return fmt.Errorf("allocating VM MAC: %w", err)
+	}
+	meta.MAC = mac
 
 	dir := s.Dir(name)
 	if _, err := os.Stat(dir); err == nil {

--- a/go/internal/cli/vm/store.go
+++ b/go/internal/cli/vm/store.go
@@ -87,10 +87,16 @@ func (s *Store) CreateFrom(name string, image io.Reader, imageSize, diskBytes in
 	meta.MAC = mac
 
 	dir := s.Dir(name)
-	if _, err := os.Stat(dir); err == nil {
-		return fmt.Errorf("VM %q already exists; remove it with 'wendy vm rm %s'", name, name)
+	if err := os.MkdirAll(s.Root, 0o700); err != nil {
+		return fmt.Errorf("creating VM store: %w", err)
 	}
-	if err := os.MkdirAll(dir, 0o700); err != nil {
+	// Mkdir, not MkdirAll: only the process that exclusively creates this
+	// directory owns its rollback. A losing concurrent create must never
+	// remove the winning creator's disk after its O_EXCL open fails.
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		if os.IsExist(err) {
+			return fmt.Errorf("VM %q already exists; remove it with 'wendy vm rm %s'", name, name)
+		}
 		return fmt.Errorf("creating %s: %w", dir, err)
 	}
 
@@ -109,8 +115,7 @@ func (s *Store) CreateFrom(name string, image io.Reader, imageSize, diskBytes in
 		}
 	}()
 
-	// O_EXCL is the real existence check: a VM's disk is the one file whose loss
-	// cannot be undone, so never open it for truncation.
+	// Defense in depth: never open a VM disk for truncation.
 	disk, err := os.OpenFile(s.DiskPath(name), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
 		return fmt.Errorf("creating disk: %w", err)

--- a/go/internal/cli/vm/store.go
+++ b/go/internal/cli/vm/store.go
@@ -85,6 +85,13 @@ func (s *Store) CreateFrom(name string, image io.Reader, imageSize, diskBytes in
 		return fmt.Errorf("allocating VM MAC: %w", err)
 	}
 	meta.MAC = mac
+	lifecycle, err := s.acquireLifecycleLock(name)
+	if err != nil {
+		return err
+	}
+	// Registered before rollback and file closes: ownership lasts until all
+	// cleanup has finished, including cleanup after a close/writeback error.
+	defer lifecycle.Close()
 
 	dir := s.Dir(name)
 	if err := os.MkdirAll(s.Root, 0o700); err != nil {
@@ -202,13 +209,18 @@ func (s *Store) Remove(name string) error {
 	if err := ValidName(name); err != nil {
 		return err
 	}
+	lifecycle, err := s.acquireLifecycleLock(name)
+	if err != nil {
+		return err
+	}
+	defer lifecycle.Close()
 	if _, err := os.Stat(s.Dir(name)); err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("no VM named %q", name)
 		}
 		return err
 	}
-	lock, err := s.acquireRunLock(name)
+	lock, err := s.acquireRunLockUnderLifecycle(name)
 	if err != nil {
 		return err
 	}

--- a/go/internal/cli/vm/store_test.go
+++ b/go/internal/cli/vm/store_test.go
@@ -1,0 +1,359 @@
+package vm
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidName(t *testing.T) {
+	for _, ok := range []string{"wendy-vm", "vm1", "a-b-c", "dev"} {
+		if err := ValidName(ok); err != nil {
+			t.Errorf("ValidName(%q) = %v, want nil", ok, err)
+		}
+	}
+	// Rejected because the name becomes both a directory and an mDNS-visible
+	// hostname: separators, traversal and shouting all have to go.
+	for _, bad := range []string{"", "-lead", "trail-", "Up", "a b", "../esc", "a/b", strings.Repeat("x", 64)} {
+		if err := ValidName(bad); err == nil {
+			t.Errorf("ValidName(%q) = nil, want an error", bad)
+		}
+	}
+}
+
+// createFromFile is the path-taking convenience the production code no longer
+// needs; the tests still find it clearer than opening the file at each site.
+func (s *Store) createFromFile(name, sourceImage string, diskBytes int64) error {
+	f, err := os.Open(sourceImage)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	return s.CreateFrom(name, f, info.Size(), diskBytes, Meta{})
+}
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	return &Store{Root: filepath.Join(t.TempDir(), "vms")}
+}
+
+func TestCreateCopiesTheImageAndSizesTheDisk(t *testing.T) {
+	s := newTestStore(t)
+
+	src := filepath.Join(t.TempDir(), "image.wic")
+	if err := os.WriteFile(src, []byte("disk-image-bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	const want = int64(32 << 20)
+	if err := s.createFromFile("dev", src, want); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	info, err := os.Stat(s.DiskPath("dev"))
+	if err != nil {
+		t.Fatalf("disk not created: %v", err)
+	}
+	if info.Size() != want {
+		t.Errorf("disk size = %d, want %d", info.Size(), want)
+	}
+
+	// The copy must be a copy, not a link: starting the VM writes to it and the
+	// downloaded image has to stay pristine for the next `vm create`.
+	head := make([]byte, len("disk-image-bytes"))
+	f, err := os.Open(s.DiskPath("dev"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if _, err := f.Read(head); err != nil {
+		t.Fatal(err)
+	}
+	if string(head) != "disk-image-bytes" {
+		t.Errorf("disk head = %q, want the source image bytes", head)
+	}
+
+	vars, err := os.Stat(s.VarsPath("dev"))
+	if err != nil {
+		t.Fatalf("varstore not created: %v", err)
+	}
+	if vars.Size() != pflashBytes {
+		t.Errorf("varstore size = %d, want %d", vars.Size(), pflashBytes)
+	}
+}
+
+func TestCreateRefusesToClobberAnExistingVM(t *testing.T) {
+	s := newTestStore(t)
+	src := filepath.Join(t.TempDir(), "image.wic")
+	if err := os.WriteFile(src, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.createFromFile("dev", src, 1<<20); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.createFromFile("dev", src, 1<<20); err == nil {
+		t.Fatal("second Create() succeeded; it must refuse rather than discard a VM's disk")
+	}
+}
+
+func TestCreateRefusesToShrinkTheImage(t *testing.T) {
+	s := newTestStore(t)
+	src := filepath.Join(t.TempDir(), "image.wic")
+	if err := os.WriteFile(src, make([]byte, 4096), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Truncating below the image would cut the GPT backup header and the last
+	// partition off the disk.
+	if err := s.createFromFile("dev", src, 1024); err == nil {
+		t.Fatal("Create() accepted a disk smaller than the image")
+	}
+}
+
+func TestListAndRemove(t *testing.T) {
+	s := newTestStore(t)
+	src := filepath.Join(t.TempDir(), "image.wic")
+	if err := os.WriteFile(src, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, n := range []string{"beta", "alpha"} {
+		if err := s.createFromFile(n, src, 1<<20); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := s.List()
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(got) != 2 || got[0] != "alpha" || got[1] != "beta" {
+		t.Errorf("List() = %v, want sorted [alpha beta]", got)
+	}
+
+	if err := s.Remove("alpha"); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+	got, err = s.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0] != "beta" {
+		t.Errorf("after Remove, List() = %v, want [beta]", got)
+	}
+
+	if err := s.Remove("alpha"); err == nil {
+		t.Fatal("Remove() of an absent VM succeeded; it should report the name")
+	}
+}
+
+func TestListOnAnAbsentRootIsEmptyNotAnError(t *testing.T) {
+	// `wendy vm list` before the first `create` is the common first command.
+	s := newTestStore(t)
+	got, err := s.List()
+	if err != nil {
+		t.Fatalf("List() on a missing root = %v, want nil error", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("List() = %v, want empty", got)
+	}
+}
+
+func TestRemoveRejectsAnInvalidNameRatherThanDeletingByPath(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.Remove("../.."); err == nil {
+		t.Fatal("Remove() accepted a traversal name")
+	}
+}
+
+func TestCreateLeavesNothingBehindWhenItFails(t *testing.T) {
+	// A failed create must not hoard the space it half-consumed: on ENOSPC the
+	// partial disk.img holds exactly the space that caused the failure, and the
+	// next attempt then reports "already exists" for a VM that never existed.
+	//
+	// A directory as the source image fails inside io.Copy (EISDIR) -- after
+	// MkdirAll and the O_EXCL open, which is the window that leaked.
+	s := newTestStore(t)
+	srcDir := t.TempDir()
+
+	if err := s.createFromFile("dev", srcDir, 1<<20); err == nil {
+		t.Fatal("Create() from a directory succeeded, want an error")
+	}
+
+	if _, err := os.Stat(s.Dir("dev")); !os.IsNotExist(err) {
+		t.Errorf("failed Create left %s behind", s.Dir("dev"))
+	}
+
+	names, err := s.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(names) != 0 {
+		t.Errorf("failed Create left a listed VM: %v", names)
+	}
+}
+
+func TestCreateAfterAFailureIsNotBlocked(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.createFromFile("dev", t.TempDir(), 1<<20); err == nil {
+		t.Fatal("expected the seeding failure")
+	}
+	// The retry must not hit "VM already exists".
+	good := filepath.Join(t.TempDir(), "image.wic")
+	if err := os.WriteFile(good, []byte("image"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.createFromFile("dev", good, 1<<20); err != nil {
+		t.Fatalf("retry after a failed Create = %v, want success", err)
+	}
+}
+
+func TestCreateFromStreamsAnImage(t *testing.T) {
+	// The published image is a compressed artifact; decompressing it to a
+	// temporary 7 GiB file just to copy it again would double both the disk cost
+	// and the wait, so Create has to accept a stream.
+	s := newTestStore(t)
+	const body = "streamed-image-bytes"
+
+	if err := s.CreateFrom("dev", strings.NewReader(body), int64(len(body)), 32<<20, Meta{}); err != nil {
+		t.Fatalf("CreateFrom() error = %v", err)
+	}
+
+	info, err := os.Stat(s.DiskPath("dev"))
+	if err != nil {
+		t.Fatalf("disk not created: %v", err)
+	}
+	if info.Size() != 32<<20 {
+		t.Errorf("disk size = %d, want %d", info.Size(), 32<<20)
+	}
+	head := make([]byte, len(body))
+	f, err := os.Open(s.DiskPath("dev"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if _, err := f.Read(head); err != nil {
+		t.Fatal(err)
+	}
+	if string(head) != body {
+		t.Errorf("disk head = %q, want %q", head, body)
+	}
+}
+
+func TestCreateFromRefusesADiskSmallerThanTheImage(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.CreateFrom("dev", strings.NewReader("0123456789"), 10, 4, Meta{}); err == nil {
+		t.Fatal("CreateFrom() accepted a disk smaller than the image")
+	}
+	if _, err := os.Stat(s.Dir("dev")); !os.IsNotExist(err) {
+		t.Error("rejected CreateFrom left a directory behind")
+	}
+}
+
+func TestCreateFromCleansUpWhenTheStreamFails(t *testing.T) {
+	s := newTestStore(t)
+	failing := io.MultiReader(strings.NewReader("partial"), errReader{})
+	if err := s.CreateFrom("dev", failing, 1024, 1<<20, Meta{}); err == nil {
+		t.Fatal("CreateFrom() succeeded despite a failing stream")
+	}
+	if _, err := os.Stat(s.Dir("dev")); !os.IsNotExist(err) {
+		t.Error("failed CreateFrom left a partial VM behind")
+	}
+}
+
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("stream broke") }
+
+func TestCheckCreatableRejectsBeforeAnyWork(t *testing.T) {
+	// Called before a multi-gigabyte download, so an invalid name or an existing
+	// VM costs nothing instead of costing the whole fetch.
+	s := newTestStore(t)
+	if err := s.CheckCreatable("Bad Name"); err == nil {
+		t.Error("CheckCreatable accepted an invalid name")
+	}
+	if err := s.CheckCreatable("dev"); err != nil {
+		t.Errorf("CheckCreatable(fresh) = %v, want nil", err)
+	}
+
+	src := filepath.Join(t.TempDir(), "image.wic")
+	if err := os.WriteFile(src, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.createFromFile("dev", src, 1<<20); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CheckCreatable("dev"); err == nil {
+		t.Error("CheckCreatable accepted a name that already exists")
+	}
+}
+
+func TestCreateFromRefusesToTruncateBelowWhatItWrote(t *testing.T) {
+	// A compressed source reports uncompressedSize 0 when its size is not known
+	// ahead of time (readImageSizeSidecar). The up-front guard cannot fire on 0,
+	// so the written length is what must be checked before truncating -- else the
+	// disk is cut below the image and reported as created.
+	s := newTestStore(t)
+	body := strings.Repeat("x", 4096)
+
+	if err := s.CreateFrom("dev", strings.NewReader(body), 0, 1024, Meta{}); err == nil {
+		t.Fatal("CreateFrom truncated the disk below the bytes it wrote")
+	}
+	if _, err := os.Stat(s.Dir("dev")); !os.IsNotExist(err) {
+		t.Error("the rejected VM was left behind")
+	}
+}
+
+func TestCreateFromAcceptsAnUnknownSizeThatFits(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.CreateFrom("dev", strings.NewReader("small"), 0, 1<<20, Meta{}); err != nil {
+		t.Fatalf("CreateFrom with unknown size that fits = %v, want nil", err)
+	}
+	info, err := os.Stat(s.DiskPath("dev"))
+	if err != nil || info.Size() != 1<<20 {
+		t.Errorf("disk = %v/%v, want 1 MiB", info, err)
+	}
+}
+
+func TestCreateFromRefusesAnImageLargerThanTheDisk(t *testing.T) {
+	// A compressed source reports size 0, so the up-front guard cannot fire.
+	// Without a bound on the copy the whole stream lands on the host disk
+	// before the size is rejected -- a decompression bomb fills the disk.
+	s := newTestStore(t)
+	const disk = 1 << 16
+	oversize := strings.NewReader(strings.Repeat("A", disk*4))
+
+	err := s.CreateFrom("dev", oversize, 0, disk, Meta{})
+	if err == nil {
+		t.Fatal("CreateFrom() accepted an image larger than the disk")
+	}
+	if _, statErr := os.Stat(s.Dir("dev")); !errors.Is(statErr, fs.ErrNotExist) {
+		t.Errorf("failed create left %s behind: %v", s.Dir("dev"), statErr)
+	}
+	if n := oversize.Len(); n == 0 {
+		t.Error("the whole oversized stream was consumed; the copy must stop at the disk size")
+	}
+}
+
+func TestRemoveDeletesTheDiskWhileStillHoldingTheLock(t *testing.T) {
+	// Remove has to release the lock before unlinking (Windows cannot delete an
+	// open file). The disk therefore goes first, under the lock, so a start
+	// that wins the lock in the gap fails its own existence check instead of
+	// booting an image mid-deletion.
+	s := newTestStore(t)
+	createTestVM(t, s, "dev", Meta{})
+	if err := s.Remove("dev"); err != nil {
+		t.Fatalf("Remove() = %v", err)
+	}
+	for _, p := range []string{s.DiskPath("dev"), s.Dir("dev")} {
+		if _, err := os.Stat(p); !errors.Is(err, fs.ErrNotExist) {
+			t.Errorf("%s survived Remove: %v", p, err)
+		}
+	}
+}

--- a/go/internal/cli/vm/store_test.go
+++ b/go/internal/cli/vm/store_test.go
@@ -32,7 +32,7 @@ func TestConcurrentCreatesHaveExactlyOneOwner(t *testing.T) {
 		for err := range results {
 			if err == nil {
 				winners++
-			} else if !strings.Contains(err.Error(), "already exists") {
+			} else if !errors.Is(err, ErrLifecycleBusy) && !strings.Contains(err.Error(), "already exists") {
 				t.Fatal(err)
 			}
 		}

--- a/go/internal/cli/vm/store_test.go
+++ b/go/internal/cli/vm/store_test.go
@@ -7,8 +7,53 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
+
+func TestConcurrentCreatesHaveExactlyOneOwner(t *testing.T) {
+	for range 25 {
+		s := newTestStore(t)
+		start := make(chan struct{})
+		results := make(chan error, 16)
+		var wg sync.WaitGroup
+		for range 16 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				results <- s.CreateFrom("dev", strings.NewReader("image"), 5, 1<<20, Meta{})
+			}()
+		}
+		close(start)
+		wg.Wait()
+		close(results)
+		winners := 0
+		for err := range results {
+			if err == nil {
+				winners++
+			} else if !strings.Contains(err.Error(), "already exists") {
+				t.Fatal(err)
+			}
+		}
+		if winners != 1 {
+			t.Fatalf("got %d successful creators, want exactly one", winners)
+		}
+		f, err := os.Open(s.DiskPath("dev"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var prefix [5]byte
+		_, err = io.ReadFull(f, prefix[:])
+		f.Close()
+		if err != nil || string(prefix[:]) != "image" {
+			t.Fatalf("winner's disk damaged: %q %v", prefix, err)
+		}
+		if _, ok := s.ReadMeta("dev"); !ok {
+			t.Fatal("winner's metadata removed")
+		}
+	}
+}
 
 func TestValidName(t *testing.T) {
 	for _, ok := range []string{"wendy-vm", "vm1", "a-b-c", "dev"} {


### PR DESCRIPTION
Adds a local ARM64 simulator so you can develop against WendyOS without a Jetson or Raspberry Pi on your desk.

It boots the same image a device runs, same agent, same containerd, same entitlements under QEMU.

```
wendy run                 # Simulator tab: enter selects, c creates, s stops, r removes
wendy --device sim ...    # alias that starts the VM if it isn't running
wendy discover            # lists local VMs as vm:<name>
```

`wendy vm` (hidden) has `create`, `start`, `stop`, `list`, `logs` and `rm` for when you need several VMs or want to look under the hood. 

A/B OTA works, `wendy os update` installs to the other slot, reboots into it and commits, with /data intact.