### PR TITLE
Fail closed on unsafe driver OTAs

### DIFF
--- a/go/internal/agent/services/driver_service.go
+++ b/go/internal/agent/services/driver_service.go
@@ -559,7 +559,11 @@ func (s *DriverService) snapshotDriver(kernel, name string) (*driverSnapshot, er
 // leaving a staged rebuild behind would resurrect the add-on at the next OTA.
 func (s *DriverService) snapshotDriverAllKernels(name string) (*driverSnapshot, error) {
 	var paths []string
-	for _, kernel := range s.storedKernels() {
+	kernels, err := s.storedKernels()
+	if err != nil {
+		return nil, err
+	}
+	for _, kernel := range kernels {
 		paths = append(paths, s.rawPath(kernel, name), s.confPath(kernel, name))
 	}
 	return s.snapshotPaths(paths...)
@@ -654,7 +658,11 @@ func (s *DriverService) RemoveDriver(req *agentpbv2.RemoveDriverRequest, stream 
 	if err := validateDriverName(name); err != nil {
 		return sendDriverFailure(stream, err.Error())
 	}
-	if !s.anyCopyInstalled(name) {
+	installed, err := s.anyCopyInstalled(name)
+	if err != nil {
+		return sendDriverFailure(stream, err.Error())
+	}
+	if !installed {
 		return sendDriverFailure(stream, fmt.Sprintf("driver %q is not installed", name))
 	}
 
@@ -696,6 +704,9 @@ func (s *DriverService) RemoveDriver(req *agentpbv2.RemoveDriverRequest, stream 
 
 // ListDrivers reports the installed (declared) drivers plus realized state.
 func (s *DriverService) ListDrivers(ctx context.Context, _ *agentpbv2.ListDriversRequest) (*agentpbv2.ListDriversResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	resp := &agentpbv2.ListDriversResponse{
 		BaseVersion:      osReleaseVersionID(),
 		KernelVersion:    s.unameR(),
@@ -710,7 +721,11 @@ func (s *DriverService) ListDrivers(ctx context.Context, _ *agentpbv2.ListDriver
 
 	// Every bucket, not just the running kernel's: an add-on left behind by an
 	// OTA must still be listed and flagged, rather than silently disappearing.
-	for _, c := range s.installedCopies() {
+	copies, err := s.installedCopies()
+	if err != nil {
+		return nil, err
+	}
+	for _, c := range copies {
 		// Self-describing add-on: the module list is baked into the .raw and
 		// surfaces at the merged path once systemd-sysext merges it. declaredModules
 		// mirrors wendyos-sysext-apply's precedence (/data override, then baked-in).
@@ -864,15 +879,22 @@ type installedCopy struct {
 // installedCopies returns every add-on in the store, deduped by name with the
 // running kernel's copy preferred so a staged name resolves to the one that can
 // load. Top-level entries are the flat layout, read until migration moves them.
-func (s *DriverService) installedCopies() []installedCopy {
+func (s *DriverService) installedCopies() ([]installedCopy, error) {
 	dirs := []string{filepath.Join(s.enabledDir, s.unameR()), filepath.Join(s.enabledDir, unpinnedKernelDir), s.enabledDir}
-	for _, kernel := range s.storedKernels() {
+	kernels, err := s.storedKernels()
+	if err != nil {
+		return nil, err
+	}
+	for _, kernel := range kernels {
 		dirs = append(dirs, filepath.Join(s.enabledDir, kernel))
 	}
 	seen := map[string]bool{}
 	var out []installedCopy
 	for _, dir := range dirs {
-		entries, _ := os.ReadDir(dir) //nolint:errcheck // absent bucket => nothing here
+		entries, err := readDriverDir(dir)
+		if err != nil {
+			return nil, err
+		}
 		for _, e := range entries {
 			if e.IsDir() || !strings.HasSuffix(e.Name(), ".raw") {
 				continue
@@ -885,29 +907,36 @@ func (s *DriverService) installedCopies() []installedCopy {
 			out = append(out, installedCopy{name: name, rawPath: filepath.Join(dir, e.Name())})
 		}
 	}
-	return out
+	return out, nil
 }
 
 // anyCopyInstalled reports whether the add-on exists under any kernel.
-func (s *DriverService) anyCopyInstalled(name string) bool {
-	for _, c := range s.installedCopies() {
+func (s *DriverService) anyCopyInstalled(name string) (bool, error) {
+	copies, err := s.installedCopies()
+	if err != nil {
+		return false, err
+	}
+	for _, c := range copies {
 		if c.name == name {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // storedKernels lists the buckets present in the store, running kernel first so
 // callers that dedupe by name prefer the copy that can actually load. The
 // unpinned bucket is always considered, even before it exists.
-func (s *DriverService) storedKernels() []string {
+func (s *DriverService) storedKernels() ([]string, error) {
 	seen := map[string]bool{}
 	out := []string{s.unameR(), unpinnedKernelDir}
 	for _, k := range out {
 		seen[k] = true
 	}
-	entries, _ := os.ReadDir(s.enabledDir) //nolint:errcheck // absent dir => no drivers
+	entries, err := readDriverDir(s.enabledDir)
+	if err != nil {
+		return nil, err
+	}
 	for _, e := range entries {
 		if !e.IsDir() || seen[e.Name()] || validateKernelDir(e.Name()) != nil {
 			continue
@@ -915,7 +944,21 @@ func (s *DriverService) storedKernels() []string {
 		seen[e.Name()] = true
 		out = append(out, e.Name())
 	}
-	return out
+	return out, nil
+}
+
+// readDriverDir distinguishes an absent store or bucket from one that exists but
+// cannot be inspected. The former means no drivers; the latter must fail closed
+// so an OTA cannot mistake an I/O, mount, or permission failure for an empty set.
+func readDriverDir(dir string) ([]os.DirEntry, error) {
+	entries, err := os.ReadDir(dir)
+	if err == nil {
+		return entries, nil
+	}
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	return nil, fmt.Errorf("reading driver store %s: %w", dir, err)
 }
 
 // validateKernelDir guards the one kernel string that is not ours: migration

--- a/go/internal/agent/services/driver_service_test.go
+++ b/go/internal/agent/services/driver_service_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -21,7 +22,7 @@ import (
 )
 
 // newTestDriverService wires a DriverService against a temp /data store, a fixed
-// kernel, an in-memory artifact fetcher, and /bin/true as the apply script so the
+// kernel, an in-memory artifact fetcher, and true as the apply script so the
 // verify/place/apply path runs without a device.
 // testKernel is what newTestDriverService reports from uname and what the
 // install-a/install-b fixtures declare, so an install lands in its bucket.
@@ -36,7 +37,7 @@ func newTestDriverService(t *testing.T, payload []byte) *DriverService {
 		enabledDir:      filepath.Join(tmp, "enabled"),
 		modulesDir:      filepath.Join(tmp, "modules-load.d"),
 		bakedModulesDir: filepath.Join(tmp, "baked-modules-load.d"),
-		applyScript:     "/bin/true",
+		applyScript:     testExecutable(t, "true"),
 		unameR:          func() string { return "6.6.0-test" },
 		// Nothing resident by default, so a test never inherits the host's modules.
 		loadedModules: func() []string { return nil },
@@ -44,6 +45,15 @@ func newTestDriverService(t *testing.T, payload []byte) *DriverService {
 			return io.NopCloser(bytes.NewReader(payload)), nil
 		},
 	}
+}
+
+func testExecutable(t *testing.T, name string) string {
+	t.Helper()
+	path, err := exec.LookPath(name)
+	if err != nil {
+		t.Fatalf("finding %s executable: %v", name, err)
+	}
+	return path
 }
 
 // driverImage returns a real add-on image. finalize reads the extension-release
@@ -342,7 +352,7 @@ func TestAllModulesLoaded(t *testing.T) {
 func TestInstallFromURL_ApplyFailureRollsBack(t *testing.T) {
 	payload := driverImage(t, "a")
 	svc := newTestDriverService(t, payload)
-	svc.applyScript = "/bin/false" // apply exits non-zero
+	svc.applyScript = testExecutable(t, "false") // apply exits non-zero
 
 	err := svc.InstallFromURL(context.Background(), DriverInstallSpec{
 		Name:          "wendyos-hello",
@@ -386,7 +396,7 @@ func TestInstallFromURL_ApplyFailureRestoresPreviousInstall(t *testing.T) {
 	svc.httpGet = func(_ context.Context, _ string) (io.ReadCloser, error) {
 		return io.NopCloser(bytes.NewReader(newPayload)), nil
 	}
-	svc.applyScript = "/bin/false"
+	svc.applyScript = testExecutable(t, "false")
 	if err := svc.InstallFromURL(context.Background(), DriverInstallSpec{
 		Name:          "wendyos-hello",
 		KernelVersion: "6.6.0-test",
@@ -429,7 +439,7 @@ func TestRemoveDriver_ApplyFailureRestoresInstall(t *testing.T) {
 		t.Fatalf("seeding the install: %v", err)
 	}
 
-	svc.applyScript = "/bin/false"
+	svc.applyScript = testExecutable(t, "false")
 	stream := &fakeRemoveStream{}
 	if err := svc.RemoveDriver(&agentpbv2.RemoveDriverRequest{Name: "wendyos-hello"}, stream); err != nil {
 		t.Fatalf("RemoveDriver returned a transport error: %v", err)
@@ -843,6 +853,24 @@ func TestSnapshotDriver_UnreadableStoreIsNotMistakenForEmpty(t *testing.T) {
 
 	if _, err := svc.snapshotDriver(testKernel, "acme"); err == nil {
 		t.Error("snapshotDriver = nil, want an error rather than an empty snapshot")
+	}
+}
+
+// ListDrivers gates an OTA, so an unreadable store must be an RPC failure rather
+// than a successful empty inventory. A regular file is a portable way to make
+// ReadDir fail on both Linux and macOS without relying on permission semantics.
+func TestListDrivers_UnreadableStoreIsNotMistakenForEmpty(t *testing.T) {
+	svc := newTestDriverService(t, nil)
+	if err := os.WriteFile(svc.enabledDir, []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := svc.ListDrivers(context.Background(), &agentpbv2.ListDriversRequest{})
+	if err == nil {
+		t.Fatalf("ListDrivers = %+v, nil; want a store read error", resp)
+	}
+	if !strings.Contains(err.Error(), "reading driver store") {
+		t.Errorf("ListDrivers error = %v, want driver-store context", err)
 	}
 }
 

--- a/go/internal/cli/commands/drivers_osupdate.go
+++ b/go/internal/cli/commands/drivers_osupdate.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
-	"slices"
+	"sort"
 	"strings"
 	"time"
 
@@ -49,20 +49,19 @@ func (p driverPreflight) blocking() bool {
 	return p.unreadable != "" || len(p.unstaged) > 0
 }
 
-// installedDriverAddons reads the device's add-ons. A nil response and a nil error
-// mean the device cannot have any — an unenrolled connection exposes no driver
-// service, an older agent answers Unimplemented — and blocking on those would
-// block the update that fixes them. Every other failure is returned: "could not
-// ask" and "has none" must not look alike to the caller.
+// installedDriverAddons reads the device's add-ons. Every inability to inspect
+// the store is an error: an unenrolled connection exposes no driver service, but
+// an unenrolled device may still retain add-ons installed before it was reset.
+// "Could not ask" and "has none" must never look alike to an OTA pre-flight.
 func installedDriverAddons(ctx context.Context, conn *grpcclient.AgentConnection) (*agentpbv2.ListDriversResponse, error) {
 	if conn == nil || conn.DriverService == nil {
-		return nil, nil
+		return nil, fmt.Errorf("the device's driver service is unavailable on this connection")
 	}
 	callCtx, cancel := context.WithTimeout(ctx, driverListTimeout)
 	defer cancel()
 	resp, err := conn.DriverService.ListDrivers(callCtx, &agentpbv2.ListDriversRequest{})
 	if status.Code(err) == codes.Unimplemented {
-		return nil, nil
+		return nil, fmt.Errorf("the device's driver service is unavailable; enrol the device or update its agent")
 	}
 	if err != nil {
 		return nil, err
@@ -100,87 +99,135 @@ func warnDriverAddonsBeforeUpdate(ctx context.Context, conn *grpcclient.AgentCon
 		}
 	}
 
-	// Files the operator supplied win over the registry: they are the answer for a
-	// network with no route to it. Reached even with nothing installed, so a fresh
-	// air-gapped device can be pre-loaded.
-	if driversDir != "" {
-		stageFromDir(ctx, conn, installed, driversDir, &pf)
-		return pf
-	}
-	if len(installed) == 0 {
+	atRisk := driversNeedingKernelCoverage(installed)
+	if len(atRisk) == 0 {
+		// Files the operator supplied are also how a fresh air-gapped device is
+		// pre-loaded, so stage them even though there is nothing installed to lose.
+		if driversDir != "" {
+			stageFromDir(ctx, conn, installed, driversDir, "", "", &pf)
+		}
 		return pf
 	}
 
-	// Without a resolved manifest nothing can be staged: a local artifact or
-	// --artifact-url names no version to look add-ons up against.
-	if deviceType == "" || targetVersion == "" {
+	// The release's add-on metadata is also the only pre-install statement of
+	// which kernel the OTA boots. A single pinned kernel is proof; no metadata or
+	// several kernels is ambiguous and must not be reported as safe.
+	targetKernel, exts, targetErr := releaseTargetKernel(deviceType, targetVersion, pr)
+
+	// Files the operator supplied win over registry downloads. When the release
+	// kernel is known, pass it to the agent so the image is checked against the OTA
+	// target rather than merely filed under whatever kernel it declares. When it
+	// is unknown, staging still helps an offline operator, but the verdict remains
+	// blocking until they explicitly accept that it could not be verified.
+	if driversDir != "" {
+		stageFromDir(ctx, conn, installed, driversDir, targetKernel, targetErr, &pf)
+		return pf
+	}
+
+	if targetErr != "" {
+		cliLogln("  target kernel could not be determined: %s", targetErr)
 		if stageDrivers {
-			for _, d := range installed {
-				pf.unstaged = append(pf.unstaged, unstagedAddon{d.GetName(),
-					"this update resolves no manifest, so no rebuild can be staged"})
+			for _, d := range atRisk {
+				pf.unstaged = append(pf.unstaged, unstagedAddon{d.GetName(), targetErr})
 			}
 		}
 		return pf
 	}
-	exts, err := driverExtensionsForFn(deviceType, targetVersion, pr)
-	if err != nil {
-		cliLogln("  could not read the add-ons published for %s: %v", targetVersion, err)
-		if stageDrivers {
-			for _, d := range installed {
-				pf.unstaged = append(pf.unstaged, unstagedAddon{d.GetName(),
-					fmt.Sprintf("could not read the published add-ons: %v", err)})
-			}
-		}
-		return pf
-	}
-	// The manifest publishes one entry per (name, kernel), so collect every
-	// kernel a name ships for rather than letting the last entry win.
-	published := map[string][]string{}
-	for _, e := range exts {
-		published[e.Name] = append(published[e.Name], e.KernelVersion)
-	}
+
 	byName := map[string][]extensionEntry{}
 	for _, e := range exts {
 		byName[e.Name] = append(byName[e.Name], e)
 	}
-	for _, d := range installed {
+	for _, d := range atRisk {
 		name := d.GetName()
-		kernels, ok := published[name]
 		switch {
-		case !ok:
+		case targetKernel == dl.GetKernelVersion():
+			cliLogln("  %s: unaffected — %s keeps kernel %s", name, targetVersion, targetKernel)
+		case !hasDriverForKernel(byName[name], targetKernel):
 			cliLogln("  %s: no rebuild published for %s", name, targetVersion)
 			if stageDrivers {
 				pf.unstaged = append(pf.unstaged, unstagedAddon{name, "no rebuild published for " + targetVersion})
 			}
-		case slices.Contains(kernels, dl.GetKernelVersion()):
-			cliLogln("  %s: unaffected — %s publishes it for this kernel", name, targetVersion)
 		case stageDrivers:
-			if reason := stageRebuild(ctx, conn, name, byName[name]); reason != "" {
+			if reason := stageRebuild(ctx, conn, name, targetKernel, byName[name]); reason != "" {
 				pf.unstaged = append(pf.unstaged, unstagedAddon{name, reason})
 			}
 		default:
 			// --no-drivers: the operator has already accepted this, so it is
 			// reported but never blocks.
-			cliLogln("  %s: rebuild published for kernel %s — reinstall after the update",
-				name, strings.Join(kernels, ", "))
+			cliLogln("  %s: rebuild published for kernel %s — reinstall after the update", name, targetKernel)
 		}
 	}
 	return pf
 }
 
+func driversNeedingKernelCoverage(installed []*agentpbv2.InstalledDriver) []*agentpbv2.InstalledDriver {
+	atRisk := make([]*agentpbv2.InstalledDriver, 0, len(installed))
+	for _, d := range installed {
+		if d.GetKernelVersion() != "" || d.GetUnreadable() {
+			atRisk = append(atRisk, d)
+		}
+	}
+	return atRisk
+}
+
+// releaseTargetKernel resolves the one kernel represented by a release's driver
+// metadata. The OS manifest does not yet carry a separate kernel field, so more
+// than one pinned kernel is not enough evidence to declare an OTA safe.
+func releaseTargetKernel(deviceType, targetVersion string, pr int) (string, []extensionEntry, string) {
+	if deviceType == "" || targetVersion == "" {
+		return "", nil, "this update resolves no manifest, so its target kernel cannot be verified"
+	}
+	exts, err := driverExtensionsForFn(deviceType, targetVersion, pr)
+	if err != nil {
+		return "", nil, fmt.Sprintf("could not read the published add-ons: %v", err)
+	}
+	set := map[string]bool{}
+	for _, e := range exts {
+		if e.KernelVersion != "" {
+			set[e.KernelVersion] = true
+		}
+	}
+	kernels := make([]string, 0, len(set))
+	for kernel := range set {
+		kernels = append(kernels, kernel)
+	}
+	sort.Strings(kernels)
+	switch len(kernels) {
+	case 0:
+		return "", exts, "the target release publishes no kernel metadata"
+	case 1:
+		return kernels[0], exts, ""
+	default:
+		return "", exts, fmt.Sprintf("the target release publishes several kernels (%s), so the one this update boots is ambiguous", strings.Join(kernels, ", "))
+	}
+}
+
+func hasDriverForKernel(entries []extensionEntry, kernel string) bool {
+	for _, e := range entries {
+		if e.KernelVersion == kernel {
+			return true
+		}
+	}
+	return false
+}
+
 // stageRebuild puts the published rebuild in place for the kernel the update is
 // about to boot into, so the add-on loads on the first boot of the new slot.
 // Returns "" on success, or why it could not be staged.
-func stageRebuild(ctx context.Context, conn *grpcclient.AgentConnection, name string, entries []extensionEntry) string {
-	// Every entry here targets a kernel other than the running one, so any of them
-	// is a candidate; more than one means the release ships several kernels and
-	// there is no way to tell from here which the update will boot.
-	if len(entries) != 1 {
-		reason := "published for several kernels, so the one this update boots is ambiguous"
+func stageRebuild(ctx context.Context, conn *grpcclient.AgentConnection, name, targetKernel string, entries []extensionEntry) string {
+	var matches []extensionEntry
+	for _, e := range entries {
+		if e.KernelVersion == targetKernel {
+			matches = append(matches, e)
+		}
+	}
+	if len(matches) != 1 {
+		reason := fmt.Sprintf("the manifest has %d rebuilds for target kernel %s", len(matches), targetKernel)
 		cliLogln("  %s: %s", name, reason)
 		return reason
 	}
-	e := entries[0]
+	e := matches[0]
 	if e.Path == "" {
 		reason := "the published rebuild has no artifact in the manifest"
 		cliLogln("  %s: %s", name, reason)
@@ -354,11 +401,11 @@ func driverRawsIn(dir string) ([]string, error) {
 }
 
 // stageFromDir stages every add-on image in dir, so an air-gapped update can put
-// the next kernel's drivers in place. Each image names its own kernel, so the
-// caller does not have to know the target. Staging one the device has not got is
-// how a fresh device is pre-loaded; an installed one with no image here is a
-// driver the device loses on reboot.
-func stageFromDir(ctx context.Context, conn *grpcclient.AgentConnection, installed []*agentpbv2.InstalledDriver, dir string, pf *driverPreflight) {
+// the next kernel's drivers in place. When targetKernel is known the agent checks
+// every pinned image against it. Otherwise images can still be pre-loaded into
+// their self-declared buckets, but an installed driver remains unverified and
+// blocks the OTA until the operator explicitly accepts the risk.
+func stageFromDir(ctx context.Context, conn *grpcclient.AgentConnection, installed []*agentpbv2.InstalledDriver, dir, targetKernel, targetErr string, pf *driverPreflight) {
 	files, err := driverRawsIn(dir)
 	if err != nil {
 		pf.unreadable = err.Error()
@@ -367,21 +414,40 @@ func stageFromDir(ctx context.Context, conn *grpcclient.AgentConnection, install
 	}
 	cliLogln("Staging driver add-ons from %s", tui.Path(dir))
 	present := make(map[string]bool, len(files))
+	staged := make(map[string]bool, len(files))
 	for _, path := range files {
 		name := strings.TrimSuffix(filepath.Base(path), ".raw")
 		present[name] = true
-		if err := stageLocalRebuild(ctx, conn, name, path); err != nil {
+		if err := stageLocalRebuild(ctx, conn, name, path, targetKernel); err != nil {
 			reason := fmt.Sprintf("staging failed: %v", err)
 			cliLogln("  %s: %s", name, reason)
 			pf.unstaged = append(pf.unstaged, unstagedAddon{name, reason})
 			continue
 		}
-		cliLogln("  %s: staged from %s", name, filepath.Base(path))
+		staged[name] = true
+		if targetKernel == "" {
+			cliLogln("  %s: staged from %s (OTA target kernel not verified)", name, filepath.Base(path))
+		} else {
+			cliLogln("  %s: staged from %s for target kernel %s", name, filepath.Base(path), targetKernel)
+		}
 	}
 	for _, d := range installed {
-		if name := d.GetName(); !present[name] {
+		name := d.GetName()
+		if !present[name] {
 			reason := fmt.Sprintf("no %s.raw in %s", name, dir)
 			cliLogln("  %s: %s", name, reason)
+			pf.unstaged = append(pf.unstaged, unstagedAddon{name, reason})
+			continue
+		}
+		if !staged[name] || (d.GetKernelVersion() == "" && !d.GetUnreadable()) {
+			continue // already failed above, or an unpinned add-on needs no kernel proof
+		}
+		if targetKernel == "" {
+			reason := targetErr
+			if reason == "" {
+				reason = "the OTA target kernel cannot be verified"
+			}
+			cliLogln("  %s: staged, but %s", name, reason)
 			pf.unstaged = append(pf.unstaged, unstagedAddon{name, reason})
 		}
 	}
@@ -390,7 +456,7 @@ func stageFromDir(ctx context.Context, conn *grpcclient.AgentConnection, install
 // stageLocalRebuild streams one local .raw to the agent for staging. The digest
 // is computed here so the agent can verify what it received, exactly as
 // `drivers install --file` does.
-func stageLocalRebuild(ctx context.Context, conn *grpcclient.AgentConnection, name, path string) error {
+func stageLocalRebuild(ctx context.Context, conn *grpcclient.AgentConnection, name, path, targetKernel string) error {
 	sum, err := sha256File(path)
 	if err != nil {
 		return err
@@ -401,13 +467,15 @@ func stageLocalRebuild(ctx context.Context, conn *grpcclient.AgentConnection, na
 	if err != nil {
 		return err
 	}
-	// No KernelVersion: the image declares the kernel it was built for, and the
-	// agent files it under that.
+	// KernelVersion binds the local image to the OTA target when release metadata
+	// made that target knowable. If it is empty the agent still files the image by
+	// its self-declared kernel, but the caller keeps the pre-flight blocking.
 	if err := stream.Send(&agentpbv2.InstallDriverRequest{
 		RequestType: &agentpbv2.InstallDriverRequest_Spec{Spec: &agentpbv2.DriverSpec{
-			Name:      name,
-			Sha256:    sum,
-			StageOnly: true,
+			Name:          name,
+			KernelVersion: targetKernel,
+			Sha256:        sum,
+			StageOnly:     true,
 		}},
 	}); err != nil {
 		return err

--- a/go/internal/cli/commands/drivers_osupdate_test.go
+++ b/go/internal/cli/commands/drivers_osupdate_test.go
@@ -92,15 +92,23 @@ func TestWarnDriverAddons_ListDriversFailureBlocks(t *testing.T) {
 	}
 }
 
-// An agent predating driver support answers Unimplemented. It has no add-ons to
-// lose, and blocking would block the very update that adds support.
-func TestWarnDriverAddons_UnimplementedDoesNotBlock(t *testing.T) {
+// Unimplemented does not prove the store is empty: the service is deliberately
+// absent on an unenrolled connection, while unprovisioning leaves /data add-ons
+// in place. An OTA must therefore require an explicit override.
+func TestWarnDriverAddons_UnimplementedBlocks(t *testing.T) {
 	conn := &grpcclient.AgentConnection{
 		DriverService: fakeDriverClient{listErr: status.Error(codes.Unimplemented, "unknown service")},
 	}
 	pf := warnDriverAddonsBeforeUpdate(context.Background(), conn, "raspberry-pi-5", "0.20.0", "", 0, true)
-	if pf.blocking() {
-		t.Error("an older agent blocked the update")
+	if !pf.blocking() || pf.unreadable == "" {
+		t.Error("an unavailable driver service did not block the update")
+	}
+}
+
+func TestWarnDriverAddons_MissingClientBlocks(t *testing.T) {
+	pf := warnDriverAddonsBeforeUpdate(context.Background(), &grpcclient.AgentConnection{}, "raspberry-pi-5", "0.20.0", "", 0, true)
+	if !pf.blocking() || pf.unreadable == "" {
+		t.Error("a connection with no driver client did not block the update")
 	}
 }
 
@@ -193,6 +201,50 @@ func TestWarnDriverAddons_UnaffectedAddonDoesNotBlock(t *testing.T) {
 	}
 }
 
+// A release that moves kernels must stage the exact matching rebuild and carry
+// that kernel through to the agent, where the image itself is cross-checked.
+func TestWarnDriverAddons_StagesRebuildForReleaseKernel(t *testing.T) {
+	stubDriverExtensionsFor(t, []extensionEntry{
+		{Name: "acme-nic", KernelVersion: "6.19.0", Path: "acme-nic.raw"},
+	}, nil)
+	var installs []*fakeInstallStream
+	conn := connWith(fakeDriverClient{installs: &installs}, "acme-nic")
+
+	pf := warnDriverAddonsBeforeUpdate(context.Background(), conn, "raspberry-pi-5", "0.20.0", "", 0, true)
+	if pf.blocking() {
+		t.Fatalf("verified rebuild blocked: %+v", pf.unstaged)
+	}
+	if len(installs) != 1 || len(installs[0].specs) != 1 {
+		t.Fatalf("installs = %+v, want one rebuild", installs)
+	}
+	if got := installs[0].specs[0].GetKernelVersion(); got != "6.19.0" {
+		t.Errorf("staged kernel = %q, want OTA target 6.19.0", got)
+	}
+}
+
+func TestWarnDriverAddons_AmbiguousReleaseKernelBlocks(t *testing.T) {
+	stubDriverExtensionsFor(t, []extensionEntry{
+		{Name: "acme-nic", KernelVersion: "6.19.0", Path: "a.raw"},
+		{Name: "acme-nic", KernelVersion: "6.20.0", Path: "b.raw"},
+	}, nil)
+
+	pf := warnDriverAddonsBeforeUpdate(context.Background(), connWithAddons("acme-nic"), "raspberry-pi-5", "0.20.0", "", 0, true)
+	if !pf.blocking() || len(pf.unstaged) != 1 || !strings.Contains(pf.unstaged[0].reason, "several kernels") {
+		t.Fatalf("unstaged = %+v, want ambiguous release to block", pf.unstaged)
+	}
+}
+
+func TestWarnDriverAddons_UnpinnedDriverNeedsNoKernelProof(t *testing.T) {
+	conn := &grpcclient.AgentConnection{DriverService: fakeDriverClient{list: &agentpbv2.ListDriversResponse{
+		KernelVersion: "6.18.33-v8-16k",
+		Installed:     []*agentpbv2.InstalledDriver{{Name: "acme-firmware", KernelVersion: ""}},
+	}}}
+	pf := warnDriverAddonsBeforeUpdate(context.Background(), conn, "", "", "", 0, true)
+	if pf.blocking() {
+		t.Fatalf("unpinned add-on blocked a kernel update: %+v", pf.unstaged)
+	}
+}
+
 // fakeInstallStream is one InstallDriver call: it records the spec the CLI sent
 // and answers with the verdict the test asked for.
 type fakeInstallStream struct {
@@ -250,6 +302,10 @@ func driversDirWith(t *testing.T, names ...string) string {
 // --drivers-dir stages the whole directory, including an add-on the device has
 // not got: that is how a fresh air-gapped device is pre-loaded.
 func TestWarnDriverAddons_DriversDirStagesEveryImage(t *testing.T) {
+	stubDriverExtensionsFor(t, []extensionEntry{
+		{Name: "acme-nic", KernelVersion: "6.19.0", Path: "nic.raw"},
+		{Name: "acme-npu", KernelVersion: "6.19.0", Path: "npu.raw"},
+	}, nil)
 	var installs []*fakeInstallStream
 	conn := connWith(fakeDriverClient{installs: &installs}, "acme-nic")
 	dir := driversDirWith(t, "acme-nic", "acme-npu")
@@ -266,9 +322,10 @@ func TestWarnDriverAddons_DriversDirStagesEveryImage(t *testing.T) {
 			t.Fatalf("stream sent %d specs, want 1", len(st.specs))
 		}
 		spec := st.specs[0]
-		// The image names its own kernel, so the CLI must not guess one.
-		if !spec.GetStageOnly() || spec.GetKernelVersion() != "" {
-			t.Errorf("spec = %+v, want StageOnly with no kernel version", spec)
+		// Binding the declared version makes the agent reject an image for any
+		// kernel other than the one represented by the OTA release.
+		if !spec.GetStageOnly() || spec.GetKernelVersion() != "6.19.0" {
+			t.Errorf("spec = %+v, want StageOnly for target kernel 6.19.0", spec)
 		}
 	}
 }
@@ -292,6 +349,9 @@ func TestWarnDriverAddons_DriversDirPreloadsAnEmptyDevice(t *testing.T) {
 // An installed add-on the directory has no image for is one the device loses on
 // reboot, so it must block and say which.
 func TestWarnDriverAddons_DriversDirMissingAnInstalledAddonBlocks(t *testing.T) {
+	stubDriverExtensionsFor(t, []extensionEntry{
+		{Name: "acme-nic", KernelVersion: "6.19.0", Path: "nic.raw"},
+	}, nil)
 	conn := connWith(fakeDriverClient{}, "acme-nic", "acme-npu")
 	dir := driversDirWith(t, "acme-nic")
 
@@ -307,6 +367,9 @@ func TestWarnDriverAddons_DriversDirMissingAnInstalledAddonBlocks(t *testing.T) 
 // A staging failure must be reported once, against the add-on whose image was
 // there — never a second time as a missing file.
 func TestWarnDriverAddons_DriversDirStagingFailureBlocksOnce(t *testing.T) {
+	stubDriverExtensionsFor(t, []extensionEntry{
+		{Name: "acme-nic", KernelVersion: "6.19.0", Path: "nic.raw"},
+	}, nil)
 	conn := connWith(fakeDriverClient{installFail: "signature verification failed"}, "acme-nic")
 	dir := driversDirWith(t, "acme-nic")
 
@@ -316,6 +379,42 @@ func TestWarnDriverAddons_DriversDirStagingFailureBlocksOnce(t *testing.T) {
 	}
 	if !strings.Contains(pf.unstaged[0].reason, "signature verification failed") {
 		t.Errorf("reason = %q, want the agent's cause", pf.unstaged[0].reason)
+	}
+}
+
+// A local or opaque artifact exposes no trustworthy target kernel. The images
+// are still staged for an offline workflow, but filename coverage alone must not
+// waive the OTA guard: the user has to explicitly accept the unverified match.
+func TestWarnDriverAddons_DriversDirUnknownTargetStillBlocks(t *testing.T) {
+	var installs []*fakeInstallStream
+	conn := connWith(fakeDriverClient{installs: &installs}, "acme-nic")
+	dir := driversDirWith(t, "acme-nic")
+
+	pf := warnDriverAddonsBeforeUpdate(context.Background(), conn, "raspberry-pi-5", "", dir, 0, true)
+	if !pf.blocking() || len(pf.unstaged) != 1 {
+		t.Fatalf("unstaged = %+v, want the unverified acme-nic to block", pf.unstaged)
+	}
+	if !strings.Contains(pf.unstaged[0].reason, "target kernel") {
+		t.Errorf("reason = %q, want the unknown target kernel named", pf.unstaged[0].reason)
+	}
+	if len(installs) != 1 || len(installs[0].specs) != 1 || installs[0].specs[0].GetKernelVersion() != "" {
+		t.Fatalf("offline staging specs = %+v, want one self-declared-kernel install", installs)
+	}
+}
+
+// Several kernels in the release metadata cannot identify which one this
+// device's OTA artifact boots. Staging remains possible, but it is not proof.
+func TestWarnDriverAddons_DriversDirAmbiguousTargetStillBlocks(t *testing.T) {
+	stubDriverExtensionsFor(t, []extensionEntry{
+		{Name: "acme-nic", KernelVersion: "6.19.0", Path: "a.raw"},
+		{Name: "acme-nic", KernelVersion: "6.20.0", Path: "b.raw"},
+	}, nil)
+	conn := connWith(fakeDriverClient{}, "acme-nic")
+	dir := driversDirWith(t, "acme-nic")
+
+	pf := warnDriverAddonsBeforeUpdate(context.Background(), conn, "raspberry-pi-5", "0.20.0", dir, 0, true)
+	if !pf.blocking() || len(pf.unstaged) != 1 || !strings.Contains(pf.unstaged[0].reason, "several kernels") {
+		t.Fatalf("unstaged = %+v, want an ambiguous-target blocker", pf.unstaged)
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1738, rolling up a few outstanding items found after that PR was merged:

- Bind locally staged driver images to the uniquely identified release kernel, rejecting images built for another kernel.
- Keep offline pre-staging useful for opaque or ambiguous OTA artifacts, but leave the preflight blocking until the operator explicitly accepts the unverified target.
- Fail closed when the installed driver inventory cannot be read, including unavailable or unimplemented driver RPCs and filesystem read errors.
- Serialize driver inventory reads with store mutations.
- Make the affected package tests portable on macOS by resolving `true` and `false` from `PATH` rather than assuming Linux paths.

Unpinned firmware and rules extensions remain exempt from kernel matching.

## Validation

- macOS: full affected agent-service and CLI-command packages, focused race tests, and `go vet`.
- Docker Linux/arm64: full affected packages, focused safety matrix, race tests, and `go vet`.
- Docker Linux/amd64 under emulation: focused affected suites.
- Raspberry Pi 4:
  - malformed driver store caused `ListDrivers` and OTA preflight to fail closed;
  - a future-kernel local image staged into its own bucket while an opaque OTA remained blocked;
  - explicit interactive confirmation permitted a controlled offline OTA from WendyOS 0.18.2 to 0.19.0;
  - the matching future-kernel image persisted across the OTA and was selected as non-stale after boot;
  - a wrong-kernel replacement was rejected without changing the existing stored image.

All hardware probe images were removed after validation.

## Remaining integration coverage

The published Pi4 images do not include the OS-side sysext apply script because WendyOS-Builder#236 enabled driver extensions only for Pi5. The Pi4 therefore validates the staging, persistence, rejection, and OTA-gating behavior in this PR, but actual merge/module activation still needs a Pi5 or a custom image with driver extensions enabled.