### PR TITLE
agent: ask the camera which controls it has, instead of a table

### DIFF
--- a/go/internal/agent/services/camera_controls.go
+++ b/go/internal/agent/services/camera_controls.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
 	"sync"
 	"unsafe"
 
@@ -40,6 +42,16 @@ const (
 	// controls. This is what v4l2-ctl uses.
 	v4l2CtrlWhichCurVal = 0x0
 
+	// V4L2_CTRL_FLAG_NEXT_CTRL: OR this into the id and QUERYCTRL returns the
+	// next control the DRIVER has, rather than the one asked for. Walking from
+	// 0 therefore enumerates a camera's whole control set without any list
+	// being written down here -- which is the point: a hardcoded table only
+	// ever covers the cameras somebody owned when they wrote it, and silently
+	// omits the rest (zoom, pan, tilt and focus were all missing that way).
+	v4l2CtrlFlagNextCtrl = 0x80000000
+	// V4L2_CTRL_TYPE_CTRL_CLASS: a heading in the enumeration, not a control.
+	v4l2CtrlTypeCtrlClass = 6
+
 	// v4l2_queryctrl flags we act on.
 	v4l2CtrlFlagDisabled = 0x0001
 	v4l2CtrlFlagReadOnly = 0x0004
@@ -53,6 +65,10 @@ const (
 // between the CLI and this API without a translation table. CIDs are the
 // standard V4L2_CID_* values from linux/videodev2.h: the USER class base is
 // 0x00980900, the CAMERA class base 0x009a0900.
+// tunableControls is no longer what this service supports --
+// enumerateV4L2Controls asks the camera. It survives only as the fallback probe
+// list for a driver that does not implement NEXT_CTRL, where the set has to be
+// guessed at.
 var tunableControls = []struct {
 	name string
 	cid  uint32
@@ -71,15 +87,6 @@ var tunableControls = []struct {
 	{"auto_exposure", 0x009a0901},          // V4L2_CID_EXPOSURE_AUTO
 	{"exposure_time_absolute", 0x009a0902}, // V4L2_CID_EXPOSURE_ABSOLUTE
 	{"exposure_dynamic_framerate", 0x009a0903},
-}
-
-func controlCID(name string) (uint32, bool) {
-	for _, c := range tunableControls {
-		if c.name == name {
-			return c.cid, true
-		}
-	}
-	return 0, false
 }
 
 // controlValue is a resolved control ready to write.
@@ -133,7 +140,33 @@ func getV4L2ExtControl(fd int, controlID uint32) (int32, unix.Errno) {
 // name[32]@8, minimum@40, maximum@44, step@48, default@52, flags@56, reserved@60.
 type v4l2QueryCtrl [68]byte
 
-func (q *v4l2QueryCtrl) setID(id uint32)   { *(*uint32)(unsafe.Pointer(&q[0])) = id }
+func (q *v4l2QueryCtrl) setID(id uint32)  { *(*uint32)(unsafe.Pointer(&q[0])) = id }
+func (q *v4l2QueryCtrl) id() uint32       { return *(*uint32)(unsafe.Pointer(&q[0])) }
+func (q *v4l2QueryCtrl) ctrlType() uint32 { return *(*uint32)(unsafe.Pointer(&q[4])) }
+
+// name is the driver's label, normalised to the spelling v4l2-ctl prints and
+// this API accepts: lower case, each run of non-alphanumerics becoming one
+// underscore. "White Balance, Automatic" -> "white_balance_automatic".
+func (q *v4l2QueryCtrl) name() string {
+	raw := q[8:40]
+	if i := bytes.IndexByte(raw, 0); i >= 0 {
+		raw = raw[:i]
+	}
+	var b strings.Builder
+	lastUnderscore := true // leading separators are dropped
+	for _, r := range strings.ToLower(string(raw)) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			lastUnderscore = false
+			continue
+		}
+		if !lastUnderscore {
+			b.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+	return strings.TrimSuffix(b.String(), "_")
+}
 func (q *v4l2QueryCtrl) minimum() int32    { return *(*int32)(unsafe.Pointer(&q[40])) }
 func (q *v4l2QueryCtrl) maximum() int32    { return *(*int32)(unsafe.Pointer(&q[44])) }
 func (q *v4l2QueryCtrl) step() int32       { return *(*int32)(unsafe.Pointer(&q[48])) }
@@ -147,6 +180,61 @@ func queryV4L2Control(fd int, controlID uint32) (q v4l2QueryCtrl, ok bool) {
 	q.setID(controlID)
 	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), vidiocQueryCtrl, uintptr(unsafe.Pointer(&q)))
 	return q, errno == 0
+}
+
+// enumerateV4L2Controls walks every control the driver exposes, in driver
+// order, skipping class headings and controls the driver reports as disabled.
+//
+// Falls back to the static tunableControls table when the driver does not
+// support NEXT_CTRL (pre-2.6.18 semantics, and a few odd drivers): the first
+// probe returning nothing is indistinguishable from "no controls", so a camera
+// that really has some would otherwise look empty.
+func enumerateV4L2Controls(fd int) []v4l2QueryCtrl {
+	var out []v4l2QueryCtrl
+	id := uint32(0)
+	for len(out) < 256 { // a driver looping would otherwise hang the agent
+		q, ok := queryV4L2Control(fd, id|v4l2CtrlFlagNextCtrl)
+		if !ok {
+			break
+		}
+		next := q.id()
+		if next == id { // driver ignored NEXT_CTRL; stop rather than spin
+			break
+		}
+		id = next
+		if q.ctrlType() == v4l2CtrlTypeCtrlClass || q.flags()&v4l2CtrlFlagDisabled != 0 {
+			continue
+		}
+		if q.name() == "" {
+			continue
+		}
+		out = append(out, q)
+	}
+	if len(out) == 0 {
+		for _, tc := range tunableControls {
+			if q, ok := queryV4L2Control(fd, tc.cid); ok {
+				out = append(out, q)
+			}
+		}
+	}
+	return out
+}
+
+// cameraControlIndex maps a camera's control names to their CIDs by asking the
+// camera, so a name is resolved against the device it is destined for rather
+// than against a table. Read-only open, same EBUSY reasoning as elsewhere.
+func cameraControlIndex(path string) (map[string]uint32, error) {
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NONBLOCK|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer unix.Close(fd) //nolint:errcheck
+
+	index := map[string]uint32{}
+	for _, q := range enumerateV4L2Controls(fd) {
+		index[q.name()] = q.id()
+	}
+	return index, nil
 }
 
 // applyCameraControlsV4L2 opens the node read-write and sets each control,
@@ -184,19 +272,16 @@ func queryCameraControlsV4L2(path string) ([]*agentpb.CameraControl, error) {
 	}
 	defer unix.Close(fd) //nolint:errcheck
 
-	out := make([]*agentpb.CameraControl, 0, len(tunableControls))
-	for _, tc := range tunableControls {
-		q, ok := queryV4L2Control(fd, tc.cid)
-		if !ok {
-			continue // this camera does not have it
-		}
-		val, errno := getV4L2ExtControl(fd, tc.cid)
+	discovered := enumerateV4L2Controls(fd)
+	out := make([]*agentpb.CameraControl, 0, len(discovered))
+	for _, q := range discovered {
+		val, errno := getV4L2ExtControl(fd, q.id())
 		if errno != 0 {
 			val = q.defaultVal() // report something rather than dropping the row
 		}
 		flags := q.flags()
 		out = append(out, &agentpb.CameraControl{
-			Name:         tc.name,
+			Name:         q.name(),
 			Value:        val,
 			Minimum:      q.minimum(),
 			Maximum:      q.maximum(),
@@ -330,15 +415,24 @@ func (s *VideoService) SetCameraControls(_ context.Context, req *agentpb.SetCame
 		return nil, status.Error(codes.InvalidArgument, "no controls given")
 	}
 
+	// Resolve names against THIS camera rather than a table, so any control the
+	// camera exposes is settable without a code change -- zoom, pan, tilt and
+	// focus were all unreachable while the table was the source of truth.
+	index, err := s.controlIndexFor(path)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "reading controls from %s: %v", path, err)
+	}
+
 	var resolved []controlValue
 	results := make([]*agentpb.CameraControlResult, 0, len(req.GetControls()))
 	unknown := map[string]bool{}
 	for _, c := range req.GetControls() {
-		cid, ok := controlCID(c.GetName())
+		cid, ok := index[c.GetName()]
 		if !ok {
 			unknown[c.GetName()] = true
 			results = append(results, &agentpb.CameraControlResult{
-				Name: c.GetName(), Applied: false, Detail: "unknown control",
+				Name: c.GetName(), Applied: false,
+				Detail: "this camera has no control by that name",
 			})
 			continue
 		}
@@ -387,9 +481,15 @@ func (s *VideoService) applyStoredCameraControls(path string) {
 	if len(stored) == 0 {
 		return
 	}
+	index, err := s.controlIndexFor(path)
+	if err != nil {
+		s.logger.Debug("re-applying stored camera controls: cannot read control list",
+			zap.String("device", path), zap.Error(err))
+		return
+	}
 	resolved := make([]controlValue, 0, len(stored))
 	for _, sc := range stored {
-		if cid, ok := controlCID(sc.Name); ok {
+		if cid, ok := index[sc.Name]; ok {
 			resolved = append(resolved, controlValue{name: sc.Name, cid: cid, value: sc.Value})
 		}
 	}

--- a/go/internal/agent/services/camera_controls_test.go
+++ b/go/internal/agent/services/camera_controls_test.go
@@ -12,12 +12,40 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func TestControlCID(t *testing.T) {
-	if cid, ok := controlCID("exposure_time_absolute"); !ok || cid != 0x009a0902 {
-		t.Fatalf("exposure_time_absolute: got (%#x, %v), want (0x009a0902, true)", cid, ok)
+// Control names now come from the driver, so the spelling this API accepts is
+// produced by normalising the driver's label. It must match what v4l2-ctl
+// prints, because that is what anyone reading a camera's docs will type.
+func TestQueryCtrlName_MatchesV4L2CtlSpelling(t *testing.T) {
+	cases := []struct{ raw, want string }{
+		{"Exposure Time, Absolute", "exposure_time_absolute"},
+		{"White Balance, Automatic", "white_balance_automatic"},
+		{"Zoom, Absolute", "zoom_absolute"},
+		{"Focus, Automatic Continuous", "focus_automatic_continuous"},
+		{"Backlight Compensation", "backlight_compensation"},
+		{"Gain", "gain"},
+		// trailing NUL padding, leading/trailing separators, and runs of
+		// punctuation must all collapse rather than leak into the name
+		{"Brightness   ", "brightness"},
+		{",,Hue,,", "hue"},
 	}
-	if _, ok := controlCID("not_a_control"); ok {
-		t.Fatalf("unknown control resolved to a CID")
+	for _, tc := range cases {
+		var q v4l2QueryCtrl
+		copy(q[8:40], tc.raw)
+		if got := q.name(); got != tc.want {
+			t.Errorf("name(%q) = %q, want %q", tc.raw, got, tc.want)
+		}
+	}
+}
+
+// A name longer than the 32-byte field, or one with no terminator, must not
+// read past the struct.
+func TestQueryCtrlName_UnterminatedFieldStaysInBounds(t *testing.T) {
+	var q v4l2QueryCtrl
+	for i := 8; i < 40; i++ {
+		q[i] = 'a'
+	}
+	if got := q.name(); len(got) != 32 {
+		t.Fatalf("want the full 32 bytes, got %d (%q)", len(got), got)
 	}
 }
 
@@ -90,6 +118,17 @@ func newControlsTestService(t *testing.T) (*VideoService, *[]controlValue) {
 	svc := NewVideoService(context.Background(), zap.NewNop())
 	svc.controls = newCameraControlStore(filepath.Join(t.TempDir(), "cc.json"))
 	captured := &[]controlValue{}
+	svc.controlIndexFor = func(string) (map[string]uint32, error) {
+		// stands in for asking the camera; the CIDs only need to be distinct
+		return map[string]uint32{
+			"auto_exposure":          0x009a0901,
+			"exposure_time_absolute": 0x009a0902,
+			"backlight_compensation": 0x0098091c,
+			"brightness":             0x00980900,
+			"gain":                   0x00980913,
+			"zoom_absolute":          0x009a090d,
+		}, nil
+	}
 	svc.applyLocalControls = func(_ string, ctrls []controlValue) ([]*agentpb.CameraControlResult, error) {
 		*captured = ctrls
 		res := make([]*agentpb.CameraControlResult, len(ctrls))
@@ -132,7 +171,11 @@ func TestSetCameraControls_UnknownControlReportedAndKnownApplied(t *testing.T) {
 	for _, r := range resp.GetResults() {
 		got[r.GetName()] = r
 	}
-	if r := got["totally_bogus"]; r == nil || r.GetApplied() || r.GetDetail() != "unknown control" {
+	// Names are resolved against the camera now, so the reason is not "nobody
+	// has heard of this control" but "this camera does not have it" -- the same
+	// answer a real camera gives for a control it lacks.
+	if r := got["totally_bogus"]; r == nil || r.GetApplied() ||
+		r.GetDetail() != "this camera has no control by that name" {
 		t.Fatalf("unknown control not reported correctly: %+v", got["totally_bogus"])
 	}
 	if r := got["auto_exposure"]; r == nil || !r.GetApplied() {
@@ -201,10 +244,16 @@ func TestApplyStoredCameraControls_ReAppliesResolved(t *testing.T) {
 	if len(*captured) != 2 {
 		t.Fatalf("want 2 controls re-applied, got %v", *captured)
 	}
-	// resolved with real CIDs
+	// Resolved against the camera, not a table: every control carries a CID the
+	// enumeration supplied, and two different names never share one.
+	seen := map[uint32]string{}
 	for _, c := range *captured {
-		if cid, ok := controlCID(c.name); !ok || cid != c.cid {
-			t.Fatalf("control %q resolved to wrong cid %#x", c.name, c.cid)
+		if c.cid == 0 {
+			t.Fatalf("control %q re-applied with no cid", c.name)
 		}
+		if prev, dup := seen[c.cid]; dup {
+			t.Fatalf("controls %q and %q share cid %#x", prev, c.name, c.cid)
+		}
+		seen[c.cid] = c.name
 	}
 }

--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -520,6 +520,10 @@ type VideoService struct {
 	controls           *cameraControlStore
 	applyLocalControls func(path string, ctrls []controlValue) ([]*agentpb.CameraControlResult, error)
 	queryLocalControls func(path string) ([]*agentpb.CameraControl, error)
+	// controlIndexFor resolves a control name to its CID by asking the camera.
+	// A seam for the same reason as the two above: the tests must not need a
+	// real /dev/videoN to exercise name resolution.
+	controlIndexFor func(path string) (map[string]uint32, error)
 
 	ctx    context.Context    // cancelled on Shutdown; hub contexts are derived from this
 	cancel context.CancelFunc // cancels ctx
@@ -581,6 +585,7 @@ func NewVideoService(ctx context.Context, logger *zap.Logger) *VideoService {
 	svc.controls = newCameraControlStore(cameraControlsPath)
 	svc.applyLocalControls = applyCameraControlsV4L2
 	svc.queryLocalControls = queryCameraControlsV4L2
+	svc.controlIndexFor = cameraControlIndex
 	if err := svc.controls.Load(); err != nil {
 		logger.Warn("loading camera controls failed", zap.Error(err))
 	}


### PR DESCRIPTION
Stacks on #1818 (base is `feat/camera-exposure-controls`), so it can be reviewed and merged with it. Independent of #1817.

## The problem

`tunableControls` is a hardcoded list of 14 CIDs, and a name outside it is refused as an "unknown control". That makes the feature only as good as the cameras somebody happened to own when the list was written.

On a Logitech C920 it covers **12 of the 17** controls the camera actually has. The five it misses are **zoom, pan, tilt, focus and auto-focus** — every geometry control. So the service can tune the picture but not aim it.

## Why that gap matters

Measured against the fire model on a wendy-console box, with a real candle:

| | frames with a detection | fire mean confidence |
|---|---|---|
| close, auto exposure | 98.4% | 0.629 |
| camera backed off | 52.4% | 0.506 |
| + manual exposure (**on** the list) | 51.8% | 0.601 |
| + 3× zoom (**not** on the list) | **86.3%** | 0.571 |

Manual exposure improved detection *quality* (+0.095 mean) and the hit rate not at all. Zoom recovered most of what distance cost. **The most useful control was the one that could not be set.**

## The change

Enumerate instead of listing. `V4L2_CTRL_FLAG_NEXT_CTRL` OR'd into the id makes `QUERYCTRL` return the next control the *driver* has, so walking from 0 yields the camera's whole set — vendor-private controls included.

The driver's label is normalised to the spelling `v4l2-ctl` prints (`"Zoom, Absolute"` → `zoom_absolute`), because that is what someone reading their camera's documentation will type. Names are then resolved **per camera**, so any camera attached to any device is tunable with no code change here.

## Verified on hardware, not only in tests

```
$ wendy cloud device camera controls 0 --device <box>
  17 controls (was 12) -- now including zoom_absolute, pan_absolute,
  tilt_absolute, focus_absolute, focus_automatic_continuous

$ wendy cloud device camera set-control 0 zoom_absolute=250
  camera 0: zoom_absolute applied          # previously: "unknown control"
$ wendy cloud device camera controls 0
  zoom_absolute = 250                      # read back

$ wendy cloud device camera set-control 0 iso_sensitivity=100
  camera 0: iso_sensitivity NOT applied (this camera has no control by that name)
```

## Details worth keeping

* **Falls back to the static table** when a driver does not implement `NEXT_CTRL`. A first probe returning nothing is indistinguishable from "this camera has no controls", so a real camera would otherwise enumerate empty.
* **Two loop guards**: stop after 256 controls, and stop if the driver returns the id it was given. A driver that ignores the flag would otherwise spin inside the agent forever.
* Class headings (`V4L2_CTRL_TYPE_CTRL_CLASS`) and driver-disabled controls are skipped; the 32-byte name field is read without assuming a terminator.
* The refusal text changes from `"unknown control"` to `"this camera has no control by that name"` — with enumeration the first is simply wrong, since the control may be perfectly well known and merely absent here.
* `controlIndexFor` joins `applyLocalControls`/`queryLocalControls` as a seam, so tests still need no real `/dev/videoN`.

`tunableControls` survives only as that fallback probe list, and says so.

## Tests

`TestControlCID` pinned a table that is no longer the source of truth, so it is replaced by normalisation cases against real driver spellings plus an unterminated-name bounds check. The re-apply test now asserts CIDs are non-zero and distinct — what "resolved against the camera" can actually promise — rather than matching the table.

Build, `go vet` and the full `internal/agent/services` package pass **on #1818's branch alone**, with no dependency on #1817.

## Two things this does NOT fix

Raising them rather than silently leaving them:

1. **No range validation before writing.** `QUERYCTRL` already returns min/max/step and `controls` reports them, but `set-control` writes the value straight through. Drivers commonly *clamp* rather than error, so a request can come back `applied: true` with a different value in force — asking for `exposure_time_absolute=30` on a C920 yields 19. A read-back-and-compare would make the result honest.
2. **Persistence is keyed by `/dev/videoN`.** Node numbering shuffles across replug and boot, so stored controls could re-apply to a different camera than the one they were set on. A by-id key would be stabler.
