### PR TITLE
cli+mcp: make camera controls discoverable, reversible, and usable by an agent

### DIFF
--- a/Proto/wendy/agent/services/v1/wendy_agent_v1_video_service.proto
+++ b/Proto/wendy/agent/services/v1/wendy_agent_v1_video_service.proto
@@ -120,6 +120,14 @@ message CameraControl {
     int32  step          = 5; // Get only
     int32  default_value = 6; // Get only
     bool   settable      = 7; // Get only: false when the driver reports it read-only or disabled right now
+    // Set only: put this control back to the driver's own default and stop
+    // persisting it, ignoring `value`. Without this a persisted control cannot
+    // be taken back -- the store only ever grows, and a setting that degrades a
+    // scene (a wrong exposure quietly costs a vision model its detections) is
+    // re-applied on every reopen with no way to undo it short of editing the
+    // store by hand. The default comes from the driver (QUERYCTRL), so it is
+    // the camera's answer rather than a value the caller has to know.
+    bool   reset         = 8;
 }
 
 message GetCameraControlsRequest {

--- a/go/internal/agent/services/camera_controls.go
+++ b/go/internal/agent/services/camera_controls.go
@@ -220,6 +220,29 @@ func enumerateV4L2Controls(fd int) []v4l2QueryCtrl {
 	return out
 }
 
+// cameraControlDefaults reads the driver's own default for each named control.
+// The default is the camera's answer, not something a caller has to know, which
+// is what makes "reset" meaningful for a control nobody documented.
+func cameraControlDefaults(path string, names []string) (map[string]int32, error) {
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NONBLOCK|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer unix.Close(fd) //nolint:errcheck
+
+	want := make(map[string]bool, len(names))
+	for _, n := range names {
+		want[n] = true
+	}
+	out := map[string]int32{}
+	for _, q := range enumerateV4L2Controls(fd) {
+		if want[q.name()] {
+			out[q.name()] = q.defaultVal()
+		}
+	}
+	return out, nil
+}
+
 // cameraControlIndex maps a camera's control names to their CIDs by asking the
 // camera, so a name is resolved against the device it is destined for rather
 // than against a table. Read-only open, same EBUSY reasoning as elsewhere.
@@ -373,6 +396,30 @@ func (c *cameraControlStore) save() error {
 	return os.Rename(tmp, c.path)
 }
 
+// remove drops controls from a camera's stored set, so a reset is not
+// re-applied on the next reopen. Without this the store only ever grows and a
+// persisted value cannot be taken back.
+func (c *cameraControlStore) remove(path string, names []string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	drop := make(map[string]bool, len(names))
+	for _, n := range names {
+		drop[n] = true
+	}
+	kept := c.byPath[path][:0:0]
+	for _, sc := range c.byPath[path] {
+		if !drop[sc.Name] {
+			kept = append(kept, sc)
+		}
+	}
+	if len(kept) == 0 {
+		delete(c.byPath, path)
+	} else {
+		c.byPath[path] = kept
+	}
+	return c.save()
+}
+
 func (c *cameraControlStore) get(path string) []storedControl {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -423,6 +470,23 @@ func (s *VideoService) SetCameraControls(_ context.Context, req *agentpb.SetCame
 		return nil, status.Errorf(codes.Internal, "reading controls from %s: %v", path, err)
 	}
 
+	// A control asked to reset takes the driver's default instead of the value
+	// in the request, and is dropped from the store afterwards so the reopen
+	// hook stops re-asserting it.
+	var resetNames []string
+	for _, c := range req.GetControls() {
+		if c.GetReset_() {
+			resetNames = append(resetNames, c.GetName())
+		}
+	}
+	defaults := map[string]int32{}
+	if len(resetNames) > 0 {
+		defaults, err = cameraControlDefaults(path, resetNames)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "reading defaults from %s: %v", path, err)
+		}
+	}
+
 	var resolved []controlValue
 	results := make([]*agentpb.CameraControlResult, 0, len(req.GetControls()))
 	unknown := map[string]bool{}
@@ -436,7 +500,19 @@ func (s *VideoService) SetCameraControls(_ context.Context, req *agentpb.SetCame
 			})
 			continue
 		}
-		resolved = append(resolved, controlValue{name: c.GetName(), cid: cid, value: c.GetValue()})
+		value := c.GetValue()
+		if c.GetReset_() {
+			def, known := defaults[c.GetName()]
+			if !known {
+				results = append(results, &agentpb.CameraControlResult{
+					Name: c.GetName(), Applied: false,
+					Detail: "this camera reports no default for that control",
+				})
+				continue
+			}
+			value = def
+		}
+		resolved = append(resolved, controlValue{name: c.GetName(), cid: cid, value: value})
 	}
 
 	if len(resolved) > 0 {
@@ -446,10 +522,35 @@ func (s *VideoService) SetCameraControls(_ context.Context, req *agentpb.SetCame
 		}
 		results = append(results, applied...)
 
+		// Forget what was reset before persisting the rest: a control that was
+		// both stored and reset must not survive in the store, or the next
+		// reopen puts the old value straight back.
+		if len(resetNames) > 0 && s.controls != nil {
+			// Forget UNCONDITIONALLY -- not only where the write succeeded.
+			// A control the driver reports inactive right now (exposure_time_
+			// absolute while auto_exposure is on) cannot be written, and if
+			// that also blocked forgetting it, the stored value would be
+			// re-asserted on every reopen with no way to clear it. Reset is
+			// two promises: stop persisting this, and put it back. The first
+			// must hold even when the second cannot.
+			if err := s.controls.remove(path, resetNames); err != nil {
+				s.logger.Warn("forgetting reset camera controls failed",
+					zap.String("device", path), zap.Error(err))
+			}
+		}
+
 		if req.GetPersist() && s.controls != nil {
+			// A reset must not be re-stored here: it was just removed above,
+			// and persisting the default would leave the control pinned to a
+			// value the driver would have chosen anyway -- and pinned is
+			// exactly what reset undoes.
+			isReset := make(map[string]bool, len(resetNames))
+			for _, n := range resetNames {
+				isReset[n] = true
+			}
 			var toStore []storedControl
 			for _, r := range applied {
-				if r.GetApplied() {
+				if r.GetApplied() && !isReset[r.GetName()] {
 					for _, rv := range resolved {
 						if rv.name == r.GetName() {
 							toStore = append(toStore, storedControl{Name: rv.name, Value: rv.value})

--- a/go/internal/cli/commands/camera_controls.go
+++ b/go/internal/cli/commands/camera_controls.go
@@ -94,6 +94,8 @@ func renderCameraControls(controls []*agentpb.CameraControl) error {
 // holds; --no-persist makes it a one-shot.
 func newCameraSetControlCmd() *cobra.Command {
 	var noPersist bool
+	var reset []string
+	var resetAll bool
 	cmd := &cobra.Command{
 		Use:   "set-control <id> name=value [name=value ...]",
 		Short: "Set tunable controls on a local camera",
@@ -109,7 +111,13 @@ manual exposure:
   wendy device camera set-control 0 auto_exposure=1 exposure_time_absolute=20 backlight_compensation=0
 
 Run "wendy device camera controls <id>" first to see the available controls and
-their ranges.`,
+their ranges.
+
+To undo: --reset puts named controls back to the driver's default and stops
+persisting them, and --reset-all does that for every settable control:
+
+  wendy device camera set-control 0 --reset auto_exposure,exposure_time_absolute
+  wendy device camera set-control 0 --reset-all`,
 		// Not MinimumNArgs(2): the two things a caller has to know are which
 		// camera and which control names, and an arity error tells them
 		// neither. Bare, we list the cameras; with an id and no pairs, we list
@@ -123,12 +131,16 @@ their ranges.`,
 			if err != nil {
 				return err
 			}
-			if len(args) == 1 {
+			if len(args) == 1 && len(reset) == 0 && !resetAll {
 				return listControlsForChoice(cmd, id)
 			}
-			controls, err := parseControlAssignments(args[1:])
-			if err != nil {
-				return err
+
+			var controls []*agentpb.CameraControl
+			if len(args) > 1 {
+				controls, err = parseControlAssignments(args[1:])
+				if err != nil {
+					return err
+				}
 			}
 			ctx := cmd.Context()
 			conn, err := connectToAgent(ctx)
@@ -136,6 +148,31 @@ their ranges.`,
 				return err
 			}
 			defer conn.Close()
+
+			// --reset-all asks the camera which controls it has rather than
+			// keeping a list here, so it covers whatever that hardware exposes.
+			if resetAll {
+				got, err := conn.VideoService.GetCameraControls(ctx,
+					&agentpb.GetCameraControlsRequest{DeviceId: id})
+				if err != nil {
+					return fmt.Errorf("getting camera controls: %w", err)
+				}
+				// Every control, not just the currently settable ones: a
+				// control gated inactive by a mode (exposure_time_absolute
+				// while auto_exposure is on) is exactly the one that would
+				// otherwise stay pinned in the store with no way to clear it.
+				for _, c := range got.GetControls() {
+					reset = append(reset, c.GetName())
+				}
+			}
+			for _, name := range reset {
+				controls = append(controls, &agentpb.CameraControl{
+					Name: strings.TrimSpace(name), Reset_: true,
+				})
+			}
+			if len(controls) == 0 {
+				return fmt.Errorf("nothing to do: give name=value pairs, --reset <name>, or --reset-all")
+			}
 
 			resp, err := conn.VideoService.SetCameraControls(ctx, &agentpb.SetCameraControlsRequest{
 				DeviceId: id,
@@ -150,6 +187,10 @@ their ranges.`,
 	}
 	cmd.Flags().BoolVar(&noPersist, "no-persist", false,
 		"Apply once now; do not re-apply on stream reconnect or reboot")
+	cmd.Flags().StringSliceVar(&reset, "reset", nil,
+		"Put these controls back to the driver's default and stop persisting them")
+	cmd.Flags().BoolVar(&resetAll, "reset-all", false,
+		"Put every settable control back to the driver's default and forget them all")
 	return cmd
 }
 

--- a/go/internal/cli/commands/camera_controls.go
+++ b/go/internal/cli/commands/camera_controls.go
@@ -20,8 +20,21 @@ func newCameraControlsCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "controls <id>",
 		Short: "Show a local camera's tunable controls (exposure, gain, white balance, ...)",
-		Args:  cobra.ExactArgs(1),
+		Long: `Show the tunable V4L2 controls a local (USB/CSI) camera exposes, with the
+current value and the range each accepts.
+
+The list comes from the camera itself, so it is whatever that hardware supports
+rather than a fixed set -- a webcam with zoom or focus shows those too.
+
+Run without an id to see which cameras this device has.`,
+		// Not ExactArgs(1): running this bare is how someone finds out what it
+		// wants, and "accepts 1 arg(s), received 0" does not tell them. With no
+		// id we list the cameras, which IS the missing argument.
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return listCamerasForChoice(cmd, "controls")
+			}
 			id, err := parseCameraID(args[0])
 			if err != nil {
 				return err
@@ -97,11 +110,21 @@ manual exposure:
 
 Run "wendy device camera controls <id>" first to see the available controls and
 their ranges.`,
-		Args: cobra.MinimumNArgs(2),
+		// Not MinimumNArgs(2): the two things a caller has to know are which
+		// camera and which control names, and an arity error tells them
+		// neither. Bare, we list the cameras; with an id and no pairs, we list
+		// that camera's settable controls and their ranges.
+		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return listCamerasForChoice(cmd, "set-control")
+			}
 			id, err := parseCameraID(args[0])
 			if err != nil {
 				return err
+			}
+			if len(args) == 1 {
+				return listControlsForChoice(cmd, id)
 			}
 			controls, err := parseControlAssignments(args[1:])
 			if err != nil {
@@ -170,5 +193,89 @@ func reportControlResults(out io.Writer, id uint32, results []*agentpb.CameraCon
 	if len(failed) > 0 {
 		return fmt.Errorf("camera %d: %d control(s) not applied: %s", id, len(failed), strings.Join(failed, ", "))
 	}
+	return nil
+}
+
+// listCamerasForChoice answers "which camera?" by showing the ones this device
+// has. It is what both commands do when run without an id: the answer to a
+// missing argument is the set of values it could take, not a count of how many
+// were expected.
+func listCamerasForChoice(cmd *cobra.Command, sub string) error {
+	ctx := cmd.Context()
+	conn, err := connectToAgent(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	resp, err := conn.VideoService.ListVideoDevices(ctx, &agentpb.ListVideoDevicesRequest{})
+	if err != nil {
+		return fmt.Errorf("listing cameras: %w", err)
+	}
+	devices := resp.GetDevices()
+	if len(devices) == 0 {
+		return fmt.Errorf("no cameras found on this device")
+	}
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "Which camera? This device has:\n\n")
+	headers := []string{"ID", "Name", "Path"}
+	var rows [][]string
+	for _, d := range devices {
+		rows = append(rows, []string{strconv.FormatUint(uint64(d.GetId()), 10), d.GetName(), d.GetPath()})
+	}
+	fmt.Fprint(out, tui.RenderTable(headers, rows))
+	if sub == "set-control" {
+		fmt.Fprintf(out, "\nThen: wendy device camera set-control <id> name=value [name=value ...]\n")
+		fmt.Fprintf(out, "Run   wendy device camera set-control <id>   to see that camera's controls.\n")
+	} else {
+		fmt.Fprintf(out, "\nThen: wendy device camera controls <id>\n")
+	}
+	return nil
+}
+
+// listControlsForChoice answers "which control?" for a camera whose id is
+// already known -- the second thing set-control needs and the second thing an
+// arity error will not say.
+func listControlsForChoice(cmd *cobra.Command, id uint32) error {
+	ctx := cmd.Context()
+	conn, err := connectToAgent(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	resp, err := conn.VideoService.GetCameraControls(ctx, &agentpb.GetCameraControlsRequest{DeviceId: id})
+	if err != nil {
+		return fmt.Errorf("getting camera controls: %w", err)
+	}
+	controls := resp.GetControls()
+
+	var settable []*agentpb.CameraControl
+	for _, c := range controls {
+		if c.GetSettable() {
+			settable = append(settable, c)
+		}
+	}
+	if len(settable) == 0 {
+		return fmt.Errorf("camera %d exposes no settable controls (is it a local USB/CSI camera?)", id)
+	}
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "Which control? Camera %d accepts:\n\n", id)
+	headers := []string{"Control", "Now", "Min", "Max"}
+	var rows [][]string
+	for _, c := range settable {
+		rows = append(rows, []string{
+			c.GetName(),
+			strconv.FormatInt(int64(c.GetValue()), 10),
+			strconv.FormatInt(int64(c.GetMinimum()), 10),
+			strconv.FormatInt(int64(c.GetMaximum()), 10),
+		})
+	}
+	fmt.Fprint(out, tui.RenderTable(headers, rows))
+	fmt.Fprintf(out, "\nThen: wendy device camera set-control %d name=value [name=value ...]\n", id)
+	fmt.Fprintf(out, "e.g.  wendy device camera set-control %d %s=%d\n",
+		id, settable[0].GetName(), settable[0].GetValue())
 	return nil
 }

--- a/go/internal/cli/mcp/server.go
+++ b/go/internal/cli/mcp/server.go
@@ -170,6 +170,7 @@ func (s *mcpServer) Start(ctx context.Context) error {
 	s.registerWiFiTools(srv)
 	s.registerBluetoothTools(srv)
 	s.registerHardwareTools(srv)
+	s.registerCameraTools(srv)
 	s.registerProvisioningTools(srv)
 	s.registerOSTools(srv)
 	s.registerCloudTools(srv)

--- a/go/internal/cli/mcp/server_test.go
+++ b/go/internal/cli/mcp/server_test.go
@@ -152,6 +152,7 @@ func TestDeadTools_NotRegistered(t *testing.T) {
 	s.registerWiFiTools(srv)
 	s.registerBluetoothTools(srv)
 	s.registerHardwareTools(srv)
+	s.registerCameraTools(srv)
 	s.registerProvisioningTools(srv)
 	s.registerOSTools(srv)
 	s.registerCloudTools(srv)

--- a/go/internal/cli/mcp/tools_camera.go
+++ b/go/internal/cli/mcp/tools_camera.go
@@ -1,0 +1,209 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+// Camera tools. The agent owns /dev/videoN -- StreamVideo multiplexes one
+// capture to every subscriber -- so it is the only writer whose control changes
+// survive a pipeline reopen. That makes these worth exposing to an agent: the
+// loop they enable is "look at the picture, notice the exposure is wrong, fix
+// it, put it back", and every step of it needs the device.
+//
+// Only local (USB/CSI) cameras have V4L2 controls; a network camera has none.
+func (s *mcpServer) registerCameraTools(srv *server.MCPServer) {
+	listOpts := []mcpgo.ToolOption{
+		mcpgo.WithDescription("List the cameras attached to the connected device, with the id each control tool takes"),
+	}
+	listOpts = append(listOpts, readOnly()...)
+	listOpts = append(listOpts, localOnly()...)
+	srv.AddTool(mcpgo.NewTool("camera_list", listOpts...), s.handleCameraList)
+
+	ctrlOpts := []mcpgo.ToolOption{
+		mcpgo.WithDescription("Show a local camera's tunable controls (exposure, gain, zoom, focus, ...) with the current value, range and driver default. The list comes from the camera, so it is whatever that hardware supports."),
+		mcpgo.WithNumber("device_id",
+			mcpgo.Description("Camera id from camera_list (the N in /dev/videoN)"),
+			mcpgo.Required(),
+		),
+	}
+	ctrlOpts = append(ctrlOpts, readOnly()...)
+	ctrlOpts = append(ctrlOpts, localOnly()...)
+	srv.AddTool(mcpgo.NewTool("camera_controls", ctrlOpts...), s.handleCameraControls)
+
+	setOpts := []mcpgo.ToolOption{
+		mcpgo.WithDescription("Set tunable controls on a local camera. Values persist across stream reconnects and reboots unless persist=false. Call camera_controls first for the names and ranges this camera accepts."),
+		mcpgo.WithNumber("device_id",
+			mcpgo.Description("Camera id from camera_list"),
+			mcpgo.Required(),
+		),
+		mcpgo.WithString("controls",
+			mcpgo.Description(`Comma-separated name=value pairs, e.g. "auto_exposure=1,exposure_time_absolute=20". A mode control is applied before the control it gates.`),
+		),
+		mcpgo.WithString("reset",
+			mcpgo.Description("Comma-separated control names to put back to the driver's default and stop persisting"),
+		),
+		mcpgo.WithBoolean("reset_all",
+			mcpgo.Description("Put every control back to the driver's default and forget them all"),
+		),
+		mcpgo.WithBoolean("persist",
+			mcpgo.Description("Re-apply on stream reconnect and reboot (default true)"),
+		),
+	}
+	// Mutating rather than destructive: it changes how the camera captures and
+	// that is durable, but nothing is removed and reset/reset_all undo it.
+	// Idempotent -- setting the same value twice lands the same camera state.
+	setOpts = append(setOpts, mutating()...)
+	setOpts = append(setOpts, idempotent()...)
+	setOpts = append(setOpts, localOnly()...)
+	srv.AddTool(mcpgo.NewTool("camera_set_control", setOpts...), s.handleCameraSetControl)
+}
+
+func (s *mcpServer) handleCameraList(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	conn := s.GetConn()
+	if conn == nil {
+		return errNotConnected(), nil
+	}
+	resp, err := conn.VideoService.ListVideoDevices(ctx, &agentpb.ListVideoDevicesRequest{})
+	if err != nil {
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
+	}
+	cams := make([]map[string]any, 0, len(resp.GetDevices()))
+	for _, d := range resp.GetDevices() {
+		cams = append(cams, map[string]any{
+			"device_id": d.GetId(),
+			"name":      d.GetName(),
+			"path":      d.GetPath(),
+			"driver":    d.GetDriver(),
+			"online":    d.GetOnline(),
+		})
+	}
+	return okResultBounded(map[string]any{"cameras": cams}, intParam(req, "max_bytes", 100000)), nil
+}
+
+func (s *mcpServer) handleCameraControls(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	conn := s.GetConn()
+	if conn == nil {
+		return errNotConnected(), nil
+	}
+	id, err := cameraDeviceID(req)
+	if err != nil {
+		return errResultf(errCodeInvalidArgument, "%v", err), nil
+	}
+	resp, err := conn.VideoService.GetCameraControls(ctx,
+		&agentpb.GetCameraControlsRequest{DeviceId: id})
+	if err != nil {
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
+	}
+	out := make([]map[string]any, 0, len(resp.GetControls()))
+	for _, c := range resp.GetControls() {
+		out = append(out, map[string]any{
+			"name":     c.GetName(),
+			"value":    c.GetValue(),
+			"minimum":  c.GetMinimum(),
+			"maximum":  c.GetMaximum(),
+			"step":     c.GetStep(),
+			"default":  c.GetDefaultValue(),
+			"settable": c.GetSettable(),
+		})
+	}
+	return okResultBounded(map[string]any{"device_id": id, "controls": out},
+		intParam(req, "max_bytes", 100000)), nil
+}
+
+func (s *mcpServer) handleCameraSetControl(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	conn := s.GetConn()
+	if conn == nil {
+		return errNotConnected(), nil
+	}
+	id, err := cameraDeviceID(req)
+	if err != nil {
+		return errResultf(errCodeInvalidArgument, "%v", err), nil
+	}
+
+	var controls []*agentpb.CameraControl
+	for _, pair := range splitList(stringParam(req, "controls")) {
+		name, val, ok := strings.Cut(pair, "=")
+		name = strings.TrimSpace(name)
+		if !ok || name == "" {
+			return errResultf(errCodeInvalidArgument, "expected name=value, got %q", pair), nil
+		}
+		n, convErr := strconv.ParseInt(strings.TrimSpace(val), 10, 32)
+		if convErr != nil {
+			return errResultf(errCodeInvalidArgument, "control %q: value %q is not an integer", name, val), nil
+		}
+		controls = append(controls, &agentpb.CameraControl{Name: name, Value: int32(n)})
+	}
+
+	resetNames := splitList(stringParam(req, "reset"))
+	if req.GetBool("reset_all", false) {
+		// Ask the camera what it has rather than keeping a list here, so this
+		// covers whatever the attached hardware exposes -- and every control,
+		// not only the currently settable ones: a control gated inactive by a
+		// mode is exactly the one that would otherwise stay pinned.
+		got, listErr := conn.VideoService.GetCameraControls(ctx,
+			&agentpb.GetCameraControlsRequest{DeviceId: id})
+		if listErr != nil {
+			return errResult(codeFromGRPC(listErr), grpcErrString(listErr)), nil
+		}
+		for _, c := range got.GetControls() {
+			resetNames = append(resetNames, c.GetName())
+		}
+	}
+	for _, name := range resetNames {
+		controls = append(controls, &agentpb.CameraControl{Name: name, Reset_: true})
+	}
+	if len(controls) == 0 {
+		return errResultf(errCodeInvalidArgument,
+			"nothing to do: give controls, reset, or reset_all"), nil
+	}
+
+	resp, err := conn.VideoService.SetCameraControls(ctx, &agentpb.SetCameraControlsRequest{
+		DeviceId: id,
+		Controls: controls,
+		Persist:  req.GetBool("persist", true),
+	})
+	if err != nil {
+		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
+	}
+	results := make([]map[string]any, 0, len(resp.GetResults()))
+	for _, r := range resp.GetResults() {
+		entry := map[string]any{"name": r.GetName(), "applied": r.GetApplied()}
+		// The reason a control did not apply is the useful half -- "this camera
+		// has no control by that name" is actionable, a bare false is not.
+		if d := r.GetDetail(); d != "" {
+			entry["detail"] = d
+		}
+		results = append(results, entry)
+	}
+	return okResultBounded(map[string]any{"device_id": id, "results": results},
+		intParam(req, "max_bytes", 100000)), nil
+}
+
+// cameraDeviceID reads the required device_id. Cameras are addressed by the N
+// in /dev/videoN, which camera_list reports.
+func cameraDeviceID(req mcpgo.CallToolRequest) (uint32, error) {
+	n := intParam(req, "device_id", -1)
+	if n < 0 {
+		return 0, fmt.Errorf("device_id is required (see camera_list)")
+	}
+	return uint32(n), nil
+}
+
+// splitList turns "a,b , c" into [a b c], dropping empties so a trailing comma
+// is not a control named "".
+func splitList(s string) []string {
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/go/proto/gen/agentpb/wendy_agent_v1_video_service.pb.go
+++ b/go/proto/gen/agentpb/wendy_agent_v1_video_service.pb.go
@@ -879,14 +879,22 @@ func (x *VideoFrame) GetCodec() VideoCodec {
 // -- a flame or lamp that blows out to white -- where forcing manual exposure
 // keeps the highlight from clipping.
 type CameraControl struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`                                      // stable slug, e.g. "auto_exposure", "exposure_time_absolute", "brightness", "gain", "backlight_compensation"
-	Value         int32                  `protobuf:"varint,2,opt,name=value,proto3" json:"value,omitempty"`                                   // current value (Get) or desired value (Set)
-	Minimum       int32                  `protobuf:"varint,3,opt,name=minimum,proto3" json:"minimum,omitempty"`                               // inclusive; Get only
-	Maximum       int32                  `protobuf:"varint,4,opt,name=maximum,proto3" json:"maximum,omitempty"`                               // inclusive; Get only
-	Step          int32                  `protobuf:"varint,5,opt,name=step,proto3" json:"step,omitempty"`                                     // Get only
-	DefaultValue  int32                  `protobuf:"varint,6,opt,name=default_value,json=defaultValue,proto3" json:"default_value,omitempty"` // Get only
-	Settable      bool                   `protobuf:"varint,7,opt,name=settable,proto3" json:"settable,omitempty"`                             // Get only: false when the driver reports it read-only or disabled right now
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	Name         string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`                                      // stable slug, e.g. "auto_exposure", "exposure_time_absolute", "brightness", "gain", "backlight_compensation"
+	Value        int32                  `protobuf:"varint,2,opt,name=value,proto3" json:"value,omitempty"`                                   // current value (Get) or desired value (Set)
+	Minimum      int32                  `protobuf:"varint,3,opt,name=minimum,proto3" json:"minimum,omitempty"`                               // inclusive; Get only
+	Maximum      int32                  `protobuf:"varint,4,opt,name=maximum,proto3" json:"maximum,omitempty"`                               // inclusive; Get only
+	Step         int32                  `protobuf:"varint,5,opt,name=step,proto3" json:"step,omitempty"`                                     // Get only
+	DefaultValue int32                  `protobuf:"varint,6,opt,name=default_value,json=defaultValue,proto3" json:"default_value,omitempty"` // Get only
+	Settable     bool                   `protobuf:"varint,7,opt,name=settable,proto3" json:"settable,omitempty"`                             // Get only: false when the driver reports it read-only or disabled right now
+	// Set only: put this control back to the driver's own default and stop
+	// persisting it, ignoring `value`. Without this a persisted control cannot
+	// be taken back -- the store only ever grows, and a setting that degrades a
+	// scene (a wrong exposure quietly costs a vision model its detections) is
+	// re-applied on every reopen with no way to undo it short of editing the
+	// store by hand. The default comes from the driver (QUERYCTRL), so it is
+	// the camera's answer rather than a value the caller has to know.
+	Reset_        bool `protobuf:"varint,8,opt,name=reset,proto3" json:"reset,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -966,6 +974,13 @@ func (x *CameraControl) GetDefaultValue() int32 {
 func (x *CameraControl) GetSettable() bool {
 	if x != nil {
 		return x.Settable
+	}
+	return false
+}
+
+func (x *CameraControl) GetReset_() bool {
+	if x != nil {
+		return x.Reset_
 	}
 	return false
 }
@@ -1277,7 +1292,7 @@ const file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDesc = 
 	"VideoFrame\x12\x12\n" +
 	"\x04data\x18\x01 \x01(\fR\x04data\x12!\n" +
 	"\ftimestamp_ns\x18\x02 \x01(\x04R\vtimestampNs\x129\n" +
-	"\x05codec\x18\x03 \x01(\x0e2#.wendy.agent.services.v1.VideoCodecR\x05codec\"\xc2\x01\n" +
+	"\x05codec\x18\x03 \x01(\x0e2#.wendy.agent.services.v1.VideoCodecR\x05codec\"\xd8\x01\n" +
 	"\rCameraControl\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\x05R\x05value\x12\x18\n" +
@@ -1285,7 +1300,8 @@ const file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDesc = 
 	"\amaximum\x18\x04 \x01(\x05R\amaximum\x12\x12\n" +
 	"\x04step\x18\x05 \x01(\x05R\x04step\x12#\n" +
 	"\rdefault_value\x18\x06 \x01(\x05R\fdefaultValue\x12\x1a\n" +
-	"\bsettable\x18\a \x01(\bR\bsettable\"7\n" +
+	"\bsettable\x18\a \x01(\bR\bsettable\x12\x14\n" +
+	"\x05reset\x18\b \x01(\bR\x05reset\"7\n" +
 	"\x18GetCameraControlsRequest\x12\x1b\n" +
 	"\tdevice_id\x18\x01 \x01(\rR\bdeviceId\"_\n" +
 	"\x19GetCameraControlsResponse\x12B\n" +


### PR DESCRIPTION
Stacks on #1818 (base `feat/camera-exposure-controls`), like #1837 did. Independent of #1817.

**This addresses @Joannis's review on #1818 directly** — the arguments are now discoverable, and anything you set can be taken back.

---

## 1. Answer "which camera / which control", instead of counting arguments

Running either command bare printed a cobra arity error and nothing else:

```
$ wendy device camera set-control
✗ requires at least 2 arg(s), only received 0
$ wendy device camera controls
✗ accepts 1 arg(s), received 0
```

That says how many arguments are missing and never what they are — so the only way forward is to guess.

Both arguments are things the tool can look up, so now it does:

* `controls` with no id, and `set-control` with no arguments, list the cameras this device has (id, name, path) — **the id is the missing argument**.
* `set-control <id>` with no pairs lists that camera's settable controls with current value and range, and prints an example using one of them.

Neither is a usage dump. The answer to a missing argument is the set of values it could take, read off the hardware in front of you.

```
$ wendy cloud device camera set-control 0 --device <box>
Which control? Camera 0 accepts:
╭────────────────────────────┬─────┬────────┬───────╮
│ Control                    │ Now │ Min    │ Max   │
├────────────────────────────┼─────┼────────┼───────┤
│ auto_exposure              │ 3   │ 0      │ 3     │
│ zoom_absolute              │ 100 │ 100    │ 500   │
│ pan_absolute               │ 0   │ -36000 │ 36000 │
│ …                                                 │
╰────────────────────────────┴─────┴────────┴───────╯
Then: wendy device camera set-control 0 name=value [name=value ...]
```

`Args` relaxes to `MaximumNArgs(1)` / `ArbitraryArgs`, because the bare invocation is now a legitimate way to ask what the command wants. Malformed pairs and non-numeric ids are still rejected — only the *empty* case changes, from a refusal into an answer.

## 2. Let a persisted control be put back

There was no way to undo one. `--no-persist` only declines to store the write in front of it; the store had `Load/merge/save/get` and **no remove**, so a persisted control was re-asserted on every reopen forever and the only way out was editing `/var/lib/wendy/camera-controls.json` by hand.

That is a trap rather than an inconvenience: a wrong camera setting does not fail loudly, it quietly costs a vision model its detections. Forcing a long exposure so a flame blows out to white is a durable, self-healing denial of detection that nothing in the CLI could reverse.

`CameraControl.reset` (field 8, Set only) means: put this control back to the driver's own default and stop persisting it. The default comes from `QUERYCTRL`, so it is the camera's answer — no caller has to know what "default" means for a control nobody documented.

```
wendy device camera set-control 0 --reset auto_exposure,exposure_time_absolute
wendy device camera set-control 0 --reset-all
```

**Two things this got wrong first, both found by running it against a C920:**

* **The persist block re-stored what reset had just removed**, because `applied` contains the reset controls too. Persisting now skips them — pinning a control to the default is still pinning, which is what reset undoes.
* **Forgetting has to be unconditional.** It was scoped to controls whose write succeeded, so `--reset-all` left `exposure_time_absolute` in the store: the driver reports it inactive while `auto_exposure` is on, the write fails, and the stale value would be re-applied on every reopen with no way to clear it. Reset makes two promises — stop persisting this, and put it back — and the first has to hold even when the second cannot. Same reason `--reset-all` covers every control the camera reports, not only the currently settable ones.

Verified end to end over the tunnel: `brightness=200` persisted and appeared in the store; `--reset brightness` returned it to 128 (the driver's default) and removed that entry while leaving the others; `--reset-all` then emptied the store, including the inactive control the first attempt had stripped.

Proto regeneration touched only the video service file — the generator bumps a `protoc` version header across all 69 generated files, so the rest were reverted and the header pinned, leaving a diff that is just the new field.

## 3. Expose it to MCP

The MCP server registers tools by hand, one file per area, and there was no camera file — the only camera mention anywhere in it was a description string in `hardware_capabilities`. So adding RPCs gave the CLI commands and gave an agent nothing.

* `camera_list` — read-only. The ids the other two take.
* `camera_controls` — read-only. Name, value, range, driver default, settable.
* `camera_set_control` — mutating, idempotent, **not** destructive: it changes how the camera captures and that is durable, but nothing is removed and `reset`/`reset_all` undo it.

This is the loop the tools exist for: look at the picture, notice the exposure is wrong for the scene, fix it, put it back. Every step needs the device, and until now an agent could do none of them.

Verified by running the server and listing tools: 37 total, the three present, `camera_set_control` annotated `readOnly=false destructive=false`, `device_id` required.

## Checks

`go build ./...`, `go vet` and `internal/agent/services` + `internal/cli/mcp` tests pass. One pre-existing failure in `internal/cli/commands` (`TestBuildCmd_MultiService_BuildsFromManifestOnly`) reproduces identically on the unmodified base and is unrelated.

## Not fixed here

`set-control` still does not validate against the reported min/max/step before writing. Drivers commonly **clamp** rather than error, so a request can come back `applied: true` with a different value in force — asking for `exposure_time_absolute=30` on a C920 yields 19. A read-back-and-compare would make the result honest. Left out to keep this reviewable; happy to add it.
