### PR TITLE
feat(data): make ROS 2 sources addressable per topic

### DIFF
--- a/go/internal/agent/data/campaign.go
+++ b/go/internal/agent/data/campaign.go
@@ -407,11 +407,12 @@ func (m *Manager) Campaigns() ([]Campaign, error) {
 }
 
 // ResolveCampaignSources maps semantic campaign selectors onto the current
-// device source inventory. ROS topic selectors intentionally select the local
-// ROS graph recorder, which preserves the requested topics in the manifest.
-// Camera capture policies are returned keyed by resolved source ID so the
-// capture adapter can honor them; ROS 2 and telemetry policies are not plumbed
-// because those adapters implement only continuous capture (deployment warns).
+// device source inventory. A ROS 2 topic selector resolves to that topic's own
+// source, so the episode records that topic and nothing else; the requested
+// topics are still preserved in the manifest. Camera capture policies are
+// returned keyed by resolved source ID so the capture adapter can honor them;
+// ROS 2 and telemetry policies are not plumbed because those adapters
+// implement only continuous capture (deployment warns).
 func (m *Manager) ResolveCampaignSources(campaign Campaign) ([]string, []string, map[string]*SourceCapture, error) {
 	all := m.Sources(context.Background())
 	selected := map[string]bool{"applications": true}
@@ -423,14 +424,12 @@ func (m *Manager) ResolveCampaignSources(campaign Campaign) ([]string, []string,
 			selected["telemetry"] = true
 		case requested.ROS2 != "":
 			topics = append(topics, requested.ROS2)
-			found := false
-			for _, source := range all {
-				if source.Kind == "ros2" && source.Healthy {
-					selected[source.ID], found = true, true
-				}
+			ids, err := resolveROS2Selector(all, requested.ROS2)
+			if err != nil {
+				return nil, nil, nil, err
 			}
-			if !found {
-				return nil, nil, nil, fmt.Errorf("no healthy ROS 2 graph is available for topic %s", requested.ROS2)
+			for _, id := range ids {
+				selected[id] = true
 			}
 		case requested.Camera != "":
 			id, err := resolveCameraSelector(all, requested.Camera)
@@ -459,6 +458,89 @@ func (m *Manager) ResolveCampaignSources(campaign Campaign) ([]string, []string,
 	sort.Strings(ids)
 	sort.Strings(topics)
 	return ids, topics, captures, nil
+}
+
+// resolveROS2Selector maps a campaign `ros2:` selector onto discovered source
+// identifiers. Three spellings resolve, and every one of them has to keep
+// working because campaign YAML is deployed to devices in the field.
+//
+//   - A topic name, "/lidar/points": the topic's own source on every healthy
+//     graph that publishes it. This is the spelling the documentation has
+//     always shown, and it is the one that used to silently select the whole
+//     DDS domain, so a plan asking for the lidar recorded every camera and
+//     every inertial measurement unit topic on the robot as well.
+//   - A full per-topic identifier, "ros2:rmw_cyclonedds_cpp:domain-42:/scan":
+//     that exact source, no graph search.
+//   - Anything else, which includes the domain-level identifier a plan written
+//     before per-topic sources existed names ("ros2:rmw_cyclonedds_cpp:domain-42",
+//     with or without the "ros2:" prefix): the whole domain, still recorded
+//     with `ros2 bag record -a`. An unrecognized selector selects every healthy
+//     domain, which is exactly what this function did for every selector before
+//     per-topic sources existed, so no deployed plan changes meaning except the
+//     topic selectors, which now mean what they say.
+//
+// A topic selector that names a topic no healthy graph publishes is an error
+// rather than a fallback to the whole domain. Falling back would resurrect the
+// bug this addresses, and the alternative failure, a sealed and uploaded
+// episode holding none of the data the plan asked for, is the one this package
+// already refuses for audio sources.
+func resolveROS2Selector(all []Source, selector string) ([]string, error) {
+	healthyROS2 := func(source Source) bool { return source.Kind == "ros2" && source.Healthy }
+
+	// A selector that parses as a source identifier names exactly one thing.
+	// Accept it with or without the "ros2:" prefix, because a person copying a
+	// domain out of `wendy data sources` may keep or drop it.
+	candidates := []string{selector, ROS2SourcePrefix + selector}
+	for _, candidate := range candidates {
+		wantDomain, wantTopic, ok := ParseROS2SourceID(candidate)
+		if !ok {
+			continue
+		}
+		var ids []string
+		for _, source := range all {
+			if !healthyROS2(source) {
+				continue
+			}
+			domainID, topic, parsed := ParseROS2SourceID(source.ID)
+			if parsed && domainID == wantDomain && topic == wantTopic {
+				ids = append(ids, source.ID)
+			}
+		}
+		if len(ids) == 0 {
+			return nil, fmt.Errorf("no healthy ROS 2 source %s is available", candidate)
+		}
+		return ids, nil
+	}
+
+	if strings.HasPrefix(selector, "/") {
+		var ids []string
+		for _, source := range all {
+			if !healthyROS2(source) {
+				continue
+			}
+			if _, topic, ok := ParseROS2SourceID(source.ID); ok && topic == selector {
+				ids = append(ids, source.ID)
+			}
+		}
+		if len(ids) == 0 {
+			return nil, fmt.Errorf("no healthy ROS 2 graph publishes topic %s", selector)
+		}
+		return ids, nil
+	}
+
+	var ids []string
+	for _, source := range all {
+		if !healthyROS2(source) {
+			continue
+		}
+		if _, topic, ok := ParseROS2SourceID(source.ID); ok && topic == "" {
+			ids = append(ids, source.ID)
+		}
+	}
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("no healthy ROS 2 graph is available for %s", selector)
+	}
+	return ids, nil
 }
 
 // checkDeployableAudioSources refuses a campaign whose audio selector does not

--- a/go/internal/agent/data/campaign_test.go
+++ b/go/internal/agent/data/campaign_test.go
@@ -3,6 +3,7 @@ package data
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -199,6 +200,9 @@ func TestCampaignPersistsAndResolvesSemanticSources(t *testing.T) {
 		return []Source{
 			{ID: "v4l2:/dev/video2", Kind: "camera", ClockDomain: "V4L2", Healthy: true, Detail: "Logitech Brio"},
 			{ID: "ros2:cyclone:domain-0", Kind: "ros2", ClockDomain: "ROS", Healthy: true},
+			{ID: "ros2:cyclone:domain-0:/lidar/points", Kind: "ros2", ClockDomain: "ROS", Healthy: true, Detail: "sensor_msgs/msg/PointCloud2"},
+			{ID: "ros2:cyclone:domain-0:/vehicle/odometry", Kind: "ros2", ClockDomain: "ROS", Healthy: true, Detail: "nav_msgs/msg/Odometry"},
+			{ID: "ros2:cyclone:domain-0:/camera/front/image_raw", Kind: "ros2", ClockDomain: "ROS", Healthy: true, Detail: "sensor_msgs/msg/Image"},
 		}
 	})
 	campaign, err := manager.DeployCampaign([]byte(exampleCampaignYAML))
@@ -221,8 +225,19 @@ func TestCampaignPersistsAndResolvesSemanticSources(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantSources := map[string]bool{"applications": true, "ros2:cyclone:domain-0": true, "v4l2:/dev/video2": true}
+	// The two ROS 2 topic selectors resolve to their own sources, not to the
+	// whole DDS domain: a plan asking for the lidar and the odometry must not
+	// drag /camera/front/image_raw into the episode with them.
+	wantSources := map[string]bool{
+		"applications":                            true,
+		"ros2:cyclone:domain-0:/lidar/points":     true,
+		"ros2:cyclone:domain-0:/vehicle/odometry": true,
+		"v4l2:/dev/video2":                        true,
+	}
 	for _, source := range sources {
+		if !wantSources[source] {
+			t.Errorf("campaign selected unrequested source %s", source)
+		}
 		delete(wantSources, source)
 	}
 	if len(wantSources) != 0 || len(topics) != 2 {
@@ -263,5 +278,97 @@ func TestDeployWarnsUnimplementedModesPerSourceKind(t *testing.T) {
 	}
 	if warnings := warned("camera: front\n    capture: {mode: threshold, trigger: \"model.uncertainty > 0.9\"}"); len(warnings) != 1 {
 		t.Fatalf("camera threshold mode must still deploy-warn: %v", warnings)
+	}
+}
+
+// TestResolveROS2SelectorSpellings covers every campaign spelling that has to
+// keep working, including the domain-level identifier deployed plans name.
+func TestResolveROS2SelectorSpellings(t *testing.T) {
+	all := []Source{
+		{ID: "applications", Kind: "application", Healthy: true},
+		{ID: "ros2:rmw_cyclonedds_cpp:domain-42", Kind: "ros2", Healthy: true},
+		{ID: "ros2:rmw_cyclonedds_cpp:domain-42:/chatter", Kind: "ros2", Healthy: true},
+		{ID: "ros2:rmw_cyclonedds_cpp:domain-42:/camera/left/image_raw", Kind: "ros2", Healthy: true},
+		{ID: "ros2:rmw_fastrtps_cpp:domain-42", Kind: "ros2", Healthy: true},
+		{ID: "ros2:rmw_fastrtps_cpp:domain-42:/chatter", Kind: "ros2", Healthy: true},
+	}
+	for _, tc := range []struct {
+		name     string
+		selector string
+		want     []string
+	}{
+		{
+			name:     "topic name selects that topic on every graph publishing it",
+			selector: "/chatter",
+			want:     []string{"ros2:rmw_cyclonedds_cpp:domain-42:/chatter", "ros2:rmw_fastrtps_cpp:domain-42:/chatter"},
+		},
+		{
+			name:     "nested topic name",
+			selector: "/camera/left/image_raw",
+			want:     []string{"ros2:rmw_cyclonedds_cpp:domain-42:/camera/left/image_raw"},
+		},
+		{
+			name:     "full per-topic identifier selects exactly one source",
+			selector: "ros2:rmw_cyclonedds_cpp:domain-42:/chatter",
+			want:     []string{"ros2:rmw_cyclonedds_cpp:domain-42:/chatter"},
+		},
+		{
+			name:     "domain-level identifier still selects the whole domain",
+			selector: "ros2:rmw_cyclonedds_cpp:domain-42",
+			want:     []string{"ros2:rmw_cyclonedds_cpp:domain-42"},
+		},
+		{
+			name:     "domain-level identifier without the ros2 prefix",
+			selector: "rmw_cyclonedds_cpp:domain-42",
+			want:     []string{"ros2:rmw_cyclonedds_cpp:domain-42"},
+		},
+		{
+			name:     "unrecognized selector keeps the pre-per-topic behavior",
+			selector: "everything",
+			want:     []string{"ros2:rmw_cyclonedds_cpp:domain-42", "ros2:rmw_fastrtps_cpp:domain-42"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ids, err := resolveROS2Selector(all, tc.selector)
+			if err != nil {
+				t.Fatal(err)
+			}
+			sort.Strings(ids)
+			want := append([]string(nil), tc.want...)
+			sort.Strings(want)
+			if strings.Join(ids, ",") != strings.Join(want, ",") {
+				t.Fatalf("resolveROS2Selector(%q) = %v, want %v", tc.selector, ids, want)
+			}
+		})
+	}
+}
+
+// TestResolveROS2SelectorRejectsAbsentTopic keeps a plan from sealing and
+// uploading an episode that holds none of the data it asked for. Falling back
+// to the whole domain would resurrect the bug per-topic sources exist to fix.
+func TestResolveROS2SelectorRejectsAbsentTopic(t *testing.T) {
+	all := []Source{
+		{ID: "ros2:rmw_cyclonedds_cpp:domain-42", Kind: "ros2", Healthy: true},
+		{ID: "ros2:rmw_cyclonedds_cpp:domain-42:/chatter", Kind: "ros2", Healthy: true},
+	}
+	if ids, err := resolveROS2Selector(all, "/lidar/points"); err == nil {
+		t.Fatalf("resolveROS2Selector returned %v for a topic no graph publishes", ids)
+	} else if !strings.Contains(err.Error(), "/lidar/points") {
+		t.Errorf("err = %v, want it to name the missing topic", err)
+	}
+}
+
+// TestResolveROS2SelectorSkipsUnhealthyGraphs keeps an unhealthy domain, which
+// is now derived from whether its topics could be enumerated at all, out of
+// every selection.
+func TestResolveROS2SelectorSkipsUnhealthyGraphs(t *testing.T) {
+	all := []Source{
+		{ID: "ros2:rmw_cyclonedds_cpp:domain-42", Kind: "ros2", Healthy: false, Detail: "listing topics failed"},
+	}
+	if _, err := resolveROS2Selector(all, "ros2:rmw_cyclonedds_cpp:domain-42"); err == nil {
+		t.Fatal("an unhealthy graph resolved")
+	}
+	if _, err := resolveROS2Selector(all, "everything"); err == nil {
+		t.Fatal("an unhealthy graph resolved through the fallback path")
 	}
 }

--- a/go/internal/agent/data/ros2_source_id.go
+++ b/go/internal/agent/data/ros2_source_id.go
@@ -1,0 +1,88 @@
+package data
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ROS 2 source identifiers.
+//
+// A ROS 2 graph is addressable at two granularities, and both are real:
+//
+//	ros2:<rmw>:domain-<n>            the whole DDS domain, recorded with -a
+//	ros2:<rmw>:domain-<n>:<topic>    one topic on that domain
+//
+// The per-topic form is deliberately the domain form with ":" and the topic
+// name appended, rather than a new shape such as "ros2:<domain>:<topic>". Two
+// reasons. First, one parser reads both, and the domain-level identifier that
+// deployed campaigns already name is literally the prefix of every topic
+// identifier on that domain, so backwards compatibility is a property of the
+// scheme instead of a special case in the resolver. Second, the RMW name has
+// to stay in the identifier: two RMW implementations can be live on the same
+// DDS domain number and they do not interoperate, so they are different
+// graphs, and dropping the RMW would let "/chatter" on one collide with
+// "/chatter" on the other. The domain-level identifier has always carried the
+// RMW; a per-topic identifier that dropped it would be a regression.
+//
+// <topic> is the ROS 2 topic name verbatim, leading slash included, and it is
+// always the last field. ROS 2 graph names admit only letters, digits,
+// underscores and slashes, so a ":" can never occur inside one: everything
+// after the third ":" is the topic, however many slashes it contains.
+// "ros2:rmw_cyclonedds_cpp:domain-42:/camera/left/image_raw" round-trips to
+// the domain identifier "ros2:rmw_cyclonedds_cpp:domain-42" and the topic
+// "/camera/left/image_raw".
+//
+// The grammar lives here, in the package that owns episode sources, because
+// two callers depend on it: the agent adapter that mints these identifiers and
+// the campaign resolver that matches campaign selectors against them. One
+// scheme, one parser.
+const ROS2SourcePrefix = "ros2:"
+
+// ROS2DomainSourceID builds the identifier for a whole DDS domain. An empty
+// RMW name is normalized to "default" so the identifier always has its three
+// fields.
+func ROS2DomainSourceID(rmw string, domainID int) string {
+	if rmw == "" {
+		rmw = "default"
+	}
+	return fmt.Sprintf("%s%s:domain-%d", ROS2SourcePrefix, safeName(rmw), domainID)
+}
+
+// ROS2TopicSourceID builds the identifier for one topic on a DDS domain.
+func ROS2TopicSourceID(rmw string, domainID int, topic string) string {
+	return ROS2DomainSourceID(rmw, domainID) + ":" + topic
+}
+
+// ParseROS2SourceID splits a ROS 2 source identifier into the domain-level
+// identifier it belongs to and the topic it names. topic is empty for a
+// domain-level identifier, which is what makes the pre-per-topic spelling
+// parse rather than needing a compatibility branch.
+func ParseROS2SourceID(id string) (domainID, topic string, ok bool) {
+	rest, found := strings.CutPrefix(id, ROS2SourcePrefix)
+	if !found {
+		return "", "", false
+	}
+	rmw, rest, found := strings.Cut(rest, ":")
+	if !found || rmw == "" {
+		return "", "", false
+	}
+	domainField, topic, hasTopic := strings.Cut(rest, ":")
+	digits, isDomain := strings.CutPrefix(domainField, "domain-")
+	if !isDomain {
+		return "", "", false
+	}
+	if _, err := strconv.Atoi(digits); err != nil {
+		return "", "", false
+	}
+	// A ROS 2 topic name is absolute, so the remainder must start with a
+	// slash. This rejects a truncated or hand-typed identifier instead of
+	// quietly recording a bag for a topic nobody named.
+	if hasTopic && !strings.HasPrefix(topic, "/") {
+		return "", "", false
+	}
+	if !hasTopic {
+		topic = ""
+	}
+	return ROS2SourcePrefix + rmw + ":" + domainField, topic, true
+}

--- a/go/internal/agent/data/ros2_source_id_test.go
+++ b/go/internal/agent/data/ros2_source_id_test.go
@@ -1,0 +1,70 @@
+package data
+
+import "testing"
+
+func TestROS2SourceIDRoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		rmw      string
+		domainID int
+		topic    string
+		wantID   string
+	}{
+		{name: "domain", rmw: "rmw_cyclonedds_cpp", domainID: 42, wantID: "ros2:rmw_cyclonedds_cpp:domain-42"},
+		{name: "topic", rmw: "rmw_cyclonedds_cpp", domainID: 42, topic: "/chatter", wantID: "ros2:rmw_cyclonedds_cpp:domain-42:/chatter"},
+		// The reason the topic is the last field: it carries slashes and the
+		// parser must not stop at the first one.
+		{name: "nested topic", rmw: "rmw_fastrtps_cpp", domainID: 0, topic: "/camera/left/image_raw", wantID: "ros2:rmw_fastrtps_cpp:domain-0:/camera/left/image_raw"},
+		{name: "deeply nested topic", rmw: "rmw_cyclonedds_cpp", domainID: 232, topic: "/a/b/c/d/e/f", wantID: "ros2:rmw_cyclonedds_cpp:domain-232:/a/b/c/d/e/f"},
+		{name: "hidden topic", rmw: "rmw_cyclonedds_cpp", domainID: 7, topic: "/_hidden/status", wantID: "ros2:rmw_cyclonedds_cpp:domain-7:/_hidden/status"},
+		{name: "empty rmw normalizes", rmw: "", domainID: 3, topic: "/scan", wantID: "ros2:default:domain-3:/scan"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			wantDomain := ROS2DomainSourceID(tc.rmw, tc.domainID)
+			id := wantDomain
+			if tc.topic != "" {
+				id = ROS2TopicSourceID(tc.rmw, tc.domainID, tc.topic)
+			}
+			if id != tc.wantID {
+				t.Fatalf("id = %q, want %q", id, tc.wantID)
+			}
+			domainID, topic, ok := ParseROS2SourceID(id)
+			if !ok {
+				t.Fatalf("ParseROS2SourceID(%q) did not parse", id)
+			}
+			if domainID != wantDomain || topic != tc.topic {
+				t.Fatalf("ParseROS2SourceID(%q) = (%q, %q), want (%q, %q)", id, domainID, topic, wantDomain, tc.topic)
+			}
+			// A topic identifier must resolve to the same domain identifier the
+			// pre-per-topic spelling used, or a deployed campaign naming that
+			// domain and a new campaign naming one of its topics would end up
+			// on different graphs.
+			if tc.topic != "" {
+				if parsedDomain, parsedTopic, ok := ParseROS2SourceID(domainID); !ok || parsedTopic != "" || parsedDomain != domainID {
+					t.Fatalf("domain prefix %q of %q does not parse as a domain identifier: (%q, %q, %v)", domainID, id, parsedDomain, parsedTopic, ok)
+				}
+			}
+		})
+	}
+}
+
+func TestParseROS2SourceIDRejectsMalformed(t *testing.T) {
+	for _, id := range []string{
+		"",
+		"v4l2:/dev/video0",
+		"ros2:",
+		"ros2:rmw_cyclonedds_cpp",
+		"ros2::domain-1",
+		"ros2:rmw_cyclonedds_cpp:domain-",
+		"ros2:rmw_cyclonedds_cpp:domain-abc",
+		"ros2:rmw_cyclonedds_cpp:dom-1",
+		// A topic must be absolute; a relative remainder is a truncated or
+		// hand-typed identifier, not a topic.
+		"ros2:rmw_cyclonedds_cpp:domain-1:chatter",
+		"ros2:rmw_cyclonedds_cpp:domain-1:",
+	} {
+		if domainID, topic, ok := ParseROS2SourceID(id); ok {
+			t.Errorf("ParseROS2SourceID(%q) = (%q, %q, true), want not ok", id, domainID, topic)
+		}
+	}
+}

--- a/go/internal/agent/services/data_ros2_adapter.go
+++ b/go/internal/agent/services/data_ros2_adapter.go
@@ -9,27 +9,130 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/wendylabsinc/wendy/go/internal/agent/data"
+	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
 	"golang.org/x/sys/unix"
 )
 
-type ros2DataAdapter struct{ service *ROS2Service }
+// ROS 2 source identifiers are defined by data.ParseROS2SourceID and its
+// siblings: "ros2:<rmw>:domain-<n>" for a whole DDS domain and
+// "ros2:<rmw>:domain-<n>:<topic>" for one topic on it. The grammar and the
+// reasoning behind it live in the data package because the campaign resolver
+// matches against the same identifiers.
 
-func newROS2DataAdapter(service *ROS2Service) dataCaptureAdapter {
-	return &ros2DataAdapter{service: service}
+// ros2ClockDomain is unchanged from what the domain-level source has always
+// reported: a per-topic source is a narrower selection of the same rosbag2
+// recording, not a different clock.
+const ros2ClockDomain = "ROSBAG2_STORAGE/ROS_MESSAGE_HEADER/SIM_TIME"
+
+// ros2DiscoveryTTL bounds how long one `ros2 topic list -t` result is reused.
+//
+// Measured against a live graph on hardware, that enumeration costs about 0.6
+// seconds beyond the bare `ros2` command-line baseline, and the cost does not
+// grow with the number of topics. Discover is not called once per user action:
+// rendering `wendy data sources` calls it, and a single campaign trigger calls
+// it twice more, once through ResolveCampaignSources and again through
+// Manager.Start. Uncached, that puts roughly 1.8 seconds of DDS discovery
+// between a trigger firing and the recorder starting, and the episode does not
+// capture what happened during it.
+//
+// Five seconds collapses each of those bursts into one enumeration while
+// keeping the listing fresh enough that a node started by hand appears in the
+// next `wendy data sources` a person types. The time to live is a bound on
+// staleness, not a substitute for correctness: the cache is keyed by sidecar
+// identity, so a sidecar restart, an RMW change or a domain override misses
+// immediately, and invalidateDiscovery drops every entry outright when the
+// adapter learns the graph moved under it.
+const ros2DiscoveryTTL = 5 * time.Second
+
+// ros2DiscoveryDetailLimit truncates an enumeration failure before it is put in
+// a source Detail, which the CLI renders in a table column.
+const ros2DiscoveryDetailLimit = 200
+
+type ros2DataAdapter struct {
+	service *ROS2Service
+	// now is time.Now, replaced by tests that need to step over the cache TTL
+	// without sleeping.
+	now func() time.Time
+
+	mu    sync.Mutex
+	cache map[string]ros2DiscoveryEntry
 }
 
-func ros2DataSource(sc ros2SC) data.Source {
-	rmw := sc.rmw
-	if rmw == "" {
-		rmw = "default"
+// ros2DiscoveryEntry is one sidecar's enumerated sources and their expiry.
+// Failures are cached too: a domain whose topic listing is failing tends to
+// keep failing, and re-running a slow failing exec on every Discover is how a
+// dead DDS domain turns `wendy data sources` into a hang.
+type ros2DiscoveryEntry struct {
+	sources []data.Source
+	expires time.Time
+}
+
+func newROS2DataAdapter(service *ROS2Service) dataCaptureAdapter {
+	return newROS2Adapter(service)
+}
+
+// newROS2Adapter returns the concrete adapter. Tests use it to step the clock
+// over the discovery TTL and to reach invalidateDiscovery.
+func newROS2Adapter(service *ROS2Service) *ros2DataAdapter {
+	return &ros2DataAdapter{service: service, now: time.Now, cache: map[string]ros2DiscoveryEntry{}}
+}
+
+// ros2SidecarKey identifies the graph an enumeration result belongs to. The
+// domain is part of the key because resolveSidecars applies a --domain
+// override to the same sidecar.
+func ros2SidecarKey(sc ros2SC) string {
+	return sc.name + "\x00" + sc.rmw + "\x00" + strconv.Itoa(sc.domainID)
+}
+
+// ros2DomainSourceID is the identifier for the whole DDS domain behind sc.
+func ros2DomainSourceID(sc ros2SC) string {
+	return data.ROS2DomainSourceID(sc.rmw, sc.domainID)
+}
+
+// ros2DomainSource describes the whole domain. Healthy is derived, never
+// asserted: see enumerate.
+func ros2DomainSource(sc ros2SC, healthy bool, detail string) data.Source {
+	return data.Source{
+		ID:          ros2DomainSourceID(sc),
+		Kind:        "ros2",
+		ClockDomain: ros2ClockDomain,
+		Healthy:     healthy,
+		Detail:      detail,
 	}
-	return data.Source{ID: fmt.Sprintf("ros2:%s:domain-%d", safeCaptureName(rmw), sc.domainID), Kind: "ros2", ClockDomain: "ROSBAG2_STORAGE/ROS_MESSAGE_HEADER/SIM_TIME", Healthy: true, Detail: fmt.Sprintf("%s DDS domain %d", rmw, sc.domainID)}
+}
+
+// ros2TopicSource describes one topic. Detail is the message type because that
+// is what `wendy data sources` prints in its DETAIL column, and the type is
+// the one fact that tells a person whether this is the topic they meant.
+//
+// Subscribable is not set here and must stay false: SensorService derives it
+// from whether a provider can multiplex the source to a model subscriber, and
+// ROS 2 has no producer hub, so a topic can be captured into an episode but
+// not streamed to an app. Making it true would advertise a stream that
+// Subscribe would then refuse.
+func ros2TopicSource(sc ros2SC, topic *agentpbv2.ROS2Topic) data.Source {
+	detail := strings.Join(topic.GetTypes(), ", ")
+	if detail == "" {
+		// `ros2 topic list -t` prints the type for every topic it lists, so an
+		// empty one means the line did not parse. Say so rather than printing
+		// an empty column that reads like "no type".
+		detail = "message type unreported by ros2 topic list"
+	}
+	return data.Source{
+		ID:          data.ROS2TopicSourceID(sc.rmw, sc.domainID, topic.GetName()),
+		Kind:        "ros2",
+		ClockDomain: ros2ClockDomain,
+		Healthy:     true,
+		Detail:      detail,
+	}
 }
 
 func (a *ros2DataAdapter) Discover(ctx context.Context) []data.Source {
@@ -37,18 +140,164 @@ func (a *ros2DataAdapter) Discover(ctx context.Context) []data.Source {
 	if err != nil {
 		return nil
 	}
-	out := make([]data.Source, 0, len(scs))
+	out := make([]data.Source, 0, len(scs)*8)
+	live := make(map[string]bool, len(scs))
 	for _, sc := range scs {
-		out = append(out, ros2DataSource(sc))
+		live[ros2SidecarKey(sc)] = true
+		out = append(out, a.discoverSidecar(ctx, sc)...)
 	}
+	a.evictAllBut(live)
 	return out
 }
 
+// discoverSidecar enumerates one graph, through the cache.
+func (a *ros2DataAdapter) discoverSidecar(ctx context.Context, sc ros2SC) []data.Source {
+	key := ros2SidecarKey(sc)
+	if cached, ok := a.cached(key); ok {
+		return cached
+	}
+	sources := a.enumerate(ctx, sc)
+	a.store(key, sources)
+	return sources
+}
+
+// enumerate runs the one command that answers the whole question. `ros2 topic
+// list -t` returns every topic name with its message type in a single exec, so
+// there is no second enumerator here.
+//
+// Publisher and subscriber counts are deliberately not fetched. That path runs
+// `ros2 topic info` once per topic, bounded at ros2TopicInfoConcurrency, and
+// measures at roughly 0.8 seconds per round, so it costs ten seconds or more
+// on a robot with a hundred topics and tells a person nothing they need in
+// order to choose what to record.
+func (a *ros2DataAdapter) enumerate(ctx context.Context, sc ros2SC) []data.Source {
+	out, err := a.service.runIn(ctx, sc, "topic", "list", "-t")
+	if err != nil {
+		// Healthy used to be hardcoded true, so a DDS domain that answered
+		// nothing still enumerated as healthy and a campaign naming it started
+		// a recorder that captured nothing. Enumeration is the signal: a graph
+		// that cannot list its own topics cannot be recorded from either, and
+		// the reason belongs in the Detail rather than in a log nobody reads.
+		return []data.Source{ros2DomainSource(sc, false, fmt.Sprintf(
+			"%s DDS domain %d: listing topics failed: %s",
+			a.rmwLabel(sc), sc.domainID, truncateROS2Detail(err.Error()),
+		))}
+	}
+	topics := parseROS2TopicList(out)
+	sources := make([]data.Source, 0, len(topics)+1)
+	// The domain-level source stays listed. It is the handle for "record
+	// everything on this graph", it is what a campaign written before per-topic
+	// sources existed names, and without it the default episode (no explicit
+	// source list) would start one rosbag2 process per topic instead of one.
+	sources = append(sources, ros2DomainSource(sc, true, fmt.Sprintf(
+		"%s DDS domain %d, %d topics", a.rmwLabel(sc), sc.domainID, len(topics),
+	)))
+	// `ros2 topic list -t` should not repeat a name, but a duplicate would mint
+	// two sources with the same id, and selectSources would then match one
+	// campaign entry against both.
+	seen := make(map[string]bool, len(topics))
+	for _, topic := range topics {
+		name := topic.GetName()
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		sources = append(sources, ros2TopicSource(sc, topic))
+	}
+	return sources
+}
+
+func (a *ros2DataAdapter) rmwLabel(sc ros2SC) string {
+	if sc.rmw == "" {
+		return "default"
+	}
+	return sc.rmw
+}
+
+func truncateROS2Detail(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= ros2DiscoveryDetailLimit {
+		return s
+	}
+	// Cut on a rune boundary: the Detail is serialized as JSON and a half
+	// rune would make the whole response invalid UTF-8.
+	cut := ros2DiscoveryDetailLimit
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + "..."
+}
+
+func (a *ros2DataAdapter) cached(key string) ([]data.Source, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	entry, ok := a.cache[key]
+	if !ok || !a.now().Before(entry.expires) {
+		return nil, false
+	}
+	return append([]data.Source(nil), entry.sources...), true
+}
+
+func (a *ros2DataAdapter) store(key string, sources []data.Source) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.cache[key] = ros2DiscoveryEntry{sources: append([]data.Source(nil), sources...), expires: a.now().Add(ros2DiscoveryTTL)}
+}
+
+// evictAllBut drops entries for sidecars that are no longer live so a device
+// that cycles through RMWs or domains does not grow the map forever.
+func (a *ros2DataAdapter) evictAllBut(live map[string]bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for key := range a.cache {
+		if !live[key] {
+			delete(a.cache, key)
+		}
+	}
+}
+
+// invalidateDiscovery is the explicit invalidation path for the TTL cache. It
+// is called when the adapter learns the graph is not what it enumerated, so
+// the next Discover re-runs `ros2 topic list -t` instead of serving a listing
+// that has already been shown to be wrong.
+func (a *ros2DataAdapter) invalidateDiscovery() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	clear(a.cache)
+}
+
+// ros2DomainSelection is the set of sources one episode selected on a single
+// DDS domain, reduced to one recorder invocation.
+type ros2DomainSelection struct {
+	// wholeDomain is set when the domain-level identifier was selected. It
+	// wins over any per-topic identifier on the same domain: `-a` already
+	// records those topics, and the alternative is two rosbag2 processes
+	// writing the same messages into two bags in one episode.
+	wholeDomain bool
+	sources     []data.Source
+	topics      []string
+}
+
 func (a *ros2DataAdapter) Start(ctx context.Context, session data.CaptureSession, selected []data.Source) (runningDataCapture, error) {
-	wanted := make(map[string]data.Source)
+	wanted := map[string]*ros2DomainSelection{}
 	for _, source := range selected {
-		if strings.HasPrefix(source.ID, "ros2:") {
-			wanted[source.ID] = source
+		if !strings.HasPrefix(source.ID, data.ROS2SourcePrefix) {
+			continue
+		}
+		domainID, topic, ok := data.ParseROS2SourceID(source.ID)
+		if !ok {
+			return nil, fmt.Errorf("unrecognized ROS 2 source id %q", source.ID)
+		}
+		selection := wanted[domainID]
+		if selection == nil {
+			selection = &ros2DomainSelection{}
+			wanted[domainID] = selection
+		}
+		selection.sources = append(selection.sources, source)
+		if topic == "" {
+			selection.wholeDomain = true
+		} else {
+			selection.topics = append(selection.topics, topic)
 		}
 	}
 	if len(wanted) == 0 {
@@ -60,29 +309,60 @@ func (a *ros2DataAdapter) Start(ctx context.Context, session data.CaptureSession
 	}
 	group := &ros2CaptureGroup{}
 	for _, sc := range scs {
-		source := ros2DataSource(sc)
-		if _, ok := wanted[source.ID]; !ok {
+		domainID := ros2DomainSourceID(sc)
+		selection, ok := wanted[domainID]
+		if !ok {
 			continue
 		}
-		capture, err := a.startOne(ctx, session, source, sc)
+		capture, err := a.startOne(ctx, session, sc, selection)
 		if err != nil {
 			_, _ = group.Stop(context.Background())
-			return nil, fmt.Errorf("%s: %w", source.ID, err)
+			return nil, fmt.Errorf("%s: %w", domainID, err)
 		}
 		group.captures = append(group.captures, capture)
-		delete(wanted, source.ID)
+		delete(wanted, domainID)
 	}
 	if len(wanted) != 0 {
 		_, _ = group.Stop(context.Background())
+		// The cached listing described a graph that is no longer there, so it
+		// must not be served to the next caller.
+		a.invalidateDiscovery()
 		return nil, errors.New("ROS 2 graph changed during recorder startup")
 	}
 	return group, nil
 }
 
-func (a *ros2DataAdapter) startOne(ctx context.Context, session data.CaptureSession, source data.Source, sc ros2SC) (*ros2Capture, error) {
-	name := safeCaptureName("wendy-" + session.ID + "-" + source.ID)
+// ros2RecordArgs builds the rosbag2 command line for one domain.
+//
+// One invocation records every selected topic on the domain rather than one
+// invocation per topic. Each rosbag2 process pays its own DDS discovery, opens
+// its own storage writer and produces its own bag directory, and this adapter
+// pairs each recorder with a clock sampler and one ClockMapping. Splitting a
+// domain across N recorders would therefore produce N bags and N independent
+// clock mappings for messages that share a single timeline, which is exactly
+// the alignment the episode exists to preserve.
+func ros2RecordArgs(staging string, selection *ros2DomainSelection) []string {
+	args := []string{"bag", "record", "-o", staging}
+	if selection.wholeDomain {
+		return append(args, "-a")
+	}
+	return append(args, sortedUniqueStrings(selection.topics)...)
+}
+
+func sortedUniqueStrings(in []string) []string {
+	out := append([]string(nil), in...)
+	slices.Sort(out)
+	return slices.Compact(out)
+}
+
+func (a *ros2DataAdapter) startOne(ctx context.Context, session data.CaptureSession, sc ros2SC, selection *ros2DomainSelection) (*ros2Capture, error) {
+	// Paths are keyed by the domain, not by any one selected source: a domain
+	// yields exactly one bag per episode, whether it was selected whole or by
+	// a list of topics, and a topic name is not a safe path component.
+	key := ros2DomainSourceID(sc)
+	name := safeCaptureName("wendy-" + session.ID + "-" + key)
 	staging := filepath.Join(a.service.bagDir, name)
-	destination := filepath.Join(session.Directory, "ros2", safeCaptureName(source.ID))
+	destination := filepath.Join(session.Directory, "ros2", safeCaptureName(key))
 	if _, err := os.Stat(staging); err == nil {
 		return nil, fmt.Errorf("staging bag %s already exists", name)
 	} else if !errors.Is(err, os.ErrNotExist) {
@@ -91,15 +371,16 @@ func (a *ros2DataAdapter) startOne(ctx context.Context, session data.CaptureSess
 	if err := os.MkdirAll(filepath.Dir(destination), 0o750); err != nil {
 		return nil, err
 	}
-	clockFile, err := os.OpenFile(filepath.Join(session.Directory, "ros2", safeCaptureName(source.ID)+"-clock_samples.jsonl"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o640)
+	clockFile, err := os.OpenFile(filepath.Join(session.Directory, "ros2", safeCaptureName(key)+"-clock_samples.jsonl"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o640)
 	if err != nil {
 		return nil, err
 	}
 	recordCtx, cancel := context.WithCancel(context.Background())
-	c := &ros2Capture{service: a.service, session: session, source: source, sc: sc, staging: staging, destination: destination, clockFile: clockFile, ctx: recordCtx, cancel: cancel, recordDone: make(chan ros2ExecResult, 1), samplerDone: make(chan struct{})}
+	c := &ros2Capture{service: a.service, session: session, sources: append([]data.Source(nil), selection.sources...), sc: sc, staging: staging, destination: destination, clockFile: clockFile, ctx: recordCtx, cancel: cancel, recordDone: make(chan ros2ExecResult, 1), samplerDone: make(chan struct{})}
+	args := ros2RecordArgs(staging, selection)
 	go func() {
 		var output bytes.Buffer
-		code, execErr := a.service.runtime.ExecROS2(recordCtx, ROS2ExecOptions{DomainID: sc.domainID, SidecarName: sc.name, Args: []string{"bag", "record", "-o", staging, "-a"}}, &output, &output)
+		code, execErr := a.service.runtime.ExecROS2(recordCtx, ROS2ExecOptions{DomainID: sc.domainID, SidecarName: sc.name, Args: args}, &output, &output)
 		c.recordDone <- ros2ExecResult{code: code, err: execErr, output: output.String()}
 	}()
 	go c.sampleClocks()
@@ -143,9 +424,12 @@ func (g *ros2CaptureGroup) Stop(ctx context.Context) ([]data.CaptureResult, erro
 }
 
 type ros2Capture struct {
-	service              *ROS2Service
-	session              data.CaptureSession
-	source               data.Source
+	service *ROS2Service
+	session data.CaptureSession
+	// sources are every episode source this one recorder covers: the
+	// domain-level source, one or more topic sources, or both. Each gets its
+	// own CaptureResult so the manifest accounts for what the campaign named.
+	sources              []data.Source
 	sc                   ros2SC
 	staging, destination string
 	clockFile            *os.File
@@ -286,7 +570,15 @@ func (c *ros2Capture) Stop(context.Context) ([]data.CaptureResult, error) {
 		if c.simClock {
 			mapping.Discontinuity = "ROS /clock retained as an independent, potentially resetting domain"
 		}
-		c.stopResult = []data.CaptureResult{{SourceID: c.source.ID, DropAccounting: "unavailable", Discontinuities: c.discontinuities, Mappings: []data.ClockMapping{mapping}}}
+		// One result per selected source, sharing this recorder's clock
+		// mapping. SourceDetail is left empty on purpose: it would overwrite
+		// the discovered Detail in the manifest, and for a topic source that
+		// Detail is the message type, which is worth more there than a note
+		// about which bag holds it.
+		c.stopResult = make([]data.CaptureResult, 0, len(c.sources))
+		for _, source := range c.sources {
+			c.stopResult = append(c.stopResult, data.CaptureResult{SourceID: source.ID, DropAccounting: "unavailable", Discontinuities: c.discontinuities, Mappings: []data.ClockMapping{mapping}})
+		}
 	})
 	return c.stopResult, c.stopErr
 }

--- a/go/internal/agent/services/data_ros2_adapter.go
+++ b/go/internal/agent/services/data_ros2_adapter.go
@@ -341,6 +341,13 @@ func (a *ros2DataAdapter) Start(ctx context.Context, session data.CaptureSession
 // domain across N recorders would therefore produce N bags and N independent
 // clock mappings for messages that share a single timeline, which is exactly
 // the alignment the episode exists to preserve.
+//
+// The topic names become argv elements of the rosbag2 exec, so they are an
+// argument-injection surface. They cannot be read as flags: every one of them
+// arrives through parseROS2TopicList, which keeps only lines beginning with
+// "/", and again through data.ParseROS2SourceID, which rejects an identifier
+// whose topic is not absolute (SOC2-CC6, ISO27001-A.8, NIST-SI-10). There is
+// no shell in the path either; ExecROS2 passes argv straight through.
 func ros2RecordArgs(staging string, selection *ros2DomainSelection) []string {
 	args := []string{"bag", "record", "-o", staging}
 	if selection.wholeDomain {

--- a/go/internal/agent/services/data_ros2_adapter_test.go
+++ b/go/internal/agent/services/data_ros2_adapter_test.go
@@ -2,53 +2,354 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/wendylabsinc/wendy/go/internal/agent/data"
 )
 
-func TestROS2AdapterRecordsAndMovesEachRMWBag(t *testing.T) {
-	bagRoot := t.TempDir()
-	episodeRoot := t.TempDir()
-	runtime := &fakeROS2Runtime{sidecar: ROS2Sidecar{Name: "sc-cyc", RMW: "rmw_cyclonedds_cpp", DomainID: 7}}
-	runtime.execFn = func(ctx context.Context, opts ROS2ExecOptions, stdout, _ io.Writer) (int, error) {
-		if strings.Join(opts.Args, " ") == "topic list" {
-			_, _ = io.WriteString(stdout, "/chatter\n")
-			return 0, nil
+const testROS2TopicList = "/camera/left/image_raw [sensor_msgs/msg/Image]\n" +
+	"/chatter [std_msgs/msg/String]\n" +
+	"/parameter_events [rcl_interfaces/msg/ParameterEvent]\n" +
+	"/rosout [rcl_interfaces/msg/Log]\n"
+
+// recordingROS2Runtime answers `topic list -t` and pretends to record a bag,
+// remembering the argument vectors so a test can assert what rosbag2 was told
+// to record.
+type recordingROS2Runtime struct {
+	*fakeROS2Runtime
+	mu         sync.Mutex
+	recordArgs [][]string
+	listCalls  int
+	listErr    bool
+}
+
+func newRecordingROS2Runtime(sidecars ...ROS2Sidecar) *recordingROS2Runtime {
+	r := &recordingROS2Runtime{fakeROS2Runtime: &fakeROS2Runtime{sidecars: sidecars}}
+	r.fakeROS2Runtime.execFn = r.exec
+	return r
+}
+
+func (r *recordingROS2Runtime) exec(ctx context.Context, opts ROS2ExecOptions, stdout, stderr io.Writer) (int, error) {
+	joined := strings.Join(opts.Args, " ")
+	switch {
+	case joined == "topic list -t":
+		r.mu.Lock()
+		r.listCalls++
+		failing := r.listErr
+		r.mu.Unlock()
+		if failing {
+			_, _ = io.WriteString(stderr, "failed to create node: rcl_init failed")
+			return 1, nil
 		}
-		if len(opts.Args) >= 5 && opts.Args[0] == "bag" && opts.Args[1] == "record" {
-			output := opts.Args[3]
-			if err := os.MkdirAll(output, 0o750); err != nil {
-				return 1, err
-			}
-			if err := os.WriteFile(filepath.Join(output, "metadata.yaml"), []byte("rosbag2_bagfile_information:\n"), 0o640); err != nil {
-				return 1, err
-			}
-			<-ctx.Done()
-			return 0, ctx.Err()
+		_, _ = io.WriteString(stdout, testROS2TopicList)
+		return 0, nil
+	case joined == "topic list":
+		// The clock sampler's /clock probe; no simulated time in these tests.
+		return 0, nil
+	case len(opts.Args) >= 5 && opts.Args[0] == "bag" && opts.Args[1] == "record":
+		r.mu.Lock()
+		r.recordArgs = append(r.recordArgs, append([]string(nil), opts.Args...))
+		r.mu.Unlock()
+		output := opts.Args[3]
+		if err := os.MkdirAll(output, 0o750); err != nil {
+			return 1, err
 		}
-		return 1, nil
+		if err := os.WriteFile(filepath.Join(output, "metadata.yaml"), []byte("rosbag2_bagfile_information:\n"), 0o640); err != nil {
+			return 1, err
+		}
+		<-ctx.Done()
+		return 0, ctx.Err()
 	}
-	service := NewROS2Service(nil, runtime, bagRoot)
-	adapter := newROS2DataAdapter(service)
-	source := ros2DataSource(ros2SC{name: "sc-cyc", rmw: "rmw_cyclonedds_cpp", domainID: 7})
-	capture, err := adapter.Start(context.Background(), data.CaptureSession{ID: "episode-test", Directory: episodeRoot}, []data.Source{source})
+	fmt.Fprintf(stderr, "unknown command: ros2 %s", joined)
+	return 1, nil
+}
+
+func (r *recordingROS2Runtime) recorded() [][]string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([][]string(nil), r.recordArgs...)
+}
+
+func (r *recordingROS2Runtime) enumerations() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.listCalls
+}
+
+func (r *recordingROS2Runtime) failListing(failing bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.listErr = failing
+}
+
+func testSidecar() ROS2Sidecar {
+	return ROS2Sidecar{Name: "sc-cyc", RMW: "rmw_cyclonedds_cpp", DomainID: 42}
+}
+
+func testAdapter(t *testing.T, runtime ROS2Runtime) *ros2DataAdapter {
+	t.Helper()
+	return newROS2Adapter(NewROS2Service(nil, runtime, t.TempDir()))
+}
+
+func sourceByID(sources []data.Source, id string) (data.Source, bool) {
+	for _, source := range sources {
+		if source.ID == id {
+			return source, true
+		}
+	}
+	return data.Source{}, false
+}
+
+// TestROS2DiscoverEmitsOneSourcePerTopic is the headline behavior: a robot's
+// ROS 2 graph is addressable topic by topic, and the DETAIL column carries the
+// message type so a person can tell which topic they meant.
+func TestROS2DiscoverEmitsOneSourcePerTopic(t *testing.T) {
+	runtime := newRecordingROS2Runtime(testSidecar())
+	sources := testAdapter(t, runtime).Discover(context.Background())
+
+	wantDetail := map[string]string{
+		"ros2:rmw_cyclonedds_cpp:domain-42:/camera/left/image_raw": "sensor_msgs/msg/Image",
+		"ros2:rmw_cyclonedds_cpp:domain-42:/chatter":               "std_msgs/msg/String",
+		"ros2:rmw_cyclonedds_cpp:domain-42:/parameter_events":      "rcl_interfaces/msg/ParameterEvent",
+		"ros2:rmw_cyclonedds_cpp:domain-42:/rosout":                "rcl_interfaces/msg/Log",
+	}
+	for id, detail := range wantDetail {
+		source, ok := sourceByID(sources, id)
+		if !ok {
+			t.Fatalf("topic source %s missing from %+v", id, sources)
+		}
+		if source.Detail != detail {
+			t.Errorf("%s detail = %q, want the message type %q", id, source.Detail, detail)
+		}
+		if source.Kind != "ros2" {
+			t.Errorf("%s kind = %q, want ros2", id, source.Kind)
+		}
+		if !source.Healthy {
+			t.Errorf("%s is not healthy but enumeration succeeded", id)
+		}
+		if source.ClockDomain != ros2ClockDomain {
+			t.Errorf("%s clock domain = %q, want %q", id, source.ClockDomain, ros2ClockDomain)
+		}
+	}
+	// The whole-domain handle stays listed: it is what a campaign written
+	// before per-topic sources existed names, and what "record everything"
+	// selects.
+	domain, ok := sourceByID(sources, "ros2:rmw_cyclonedds_cpp:domain-42")
+	if !ok {
+		t.Fatalf("domain-level source missing from %+v", sources)
+	}
+	if !strings.Contains(domain.Detail, "4 topics") {
+		t.Errorf("domain detail = %q, want it to report the topic count", domain.Detail)
+	}
+	if len(sources) != len(wantDetail)+1 {
+		t.Errorf("Discover returned %d sources, want %d", len(sources), len(wantDetail)+1)
+	}
+	// One `ros2 topic list -t` answers names and types together; nothing else
+	// may be run during discovery, and `ros2 topic info` in particular is a
+	// per-topic exec that would cost ten seconds on a hundred-topic robot.
+	for _, call := range runtime.fakeROS2Runtime.calls {
+		if joined := strings.Join(call.Args, " "); joined != "topic list -t" {
+			t.Errorf("Discover ran an unexpected command: ros2 %s", joined)
+		}
+	}
+}
+
+// TestROS2DiscoverDerivesHealthFromEnumeration pins the fix for a Healthy that
+// was hardcoded true, so a dead DDS domain enumerated as healthy.
+func TestROS2DiscoverDerivesHealthFromEnumeration(t *testing.T) {
+	runtime := newRecordingROS2Runtime(testSidecar())
+	runtime.failListing(true)
+	sources := testAdapter(t, runtime).Discover(context.Background())
+
+	if len(sources) != 1 {
+		t.Fatalf("failed enumeration yielded %d sources, want only the domain: %+v", len(sources), sources)
+	}
+	source := sources[0]
+	if source.ID != "ros2:rmw_cyclonedds_cpp:domain-42" {
+		t.Fatalf("source id = %q", source.ID)
+	}
+	if source.Healthy {
+		t.Fatal("a domain whose topic listing failed reported itself healthy")
+	}
+	if !strings.Contains(source.Detail, "listing topics failed") || !strings.Contains(source.Detail, "rcl_init failed") {
+		t.Errorf("detail = %q, want it to name the enumeration failure", source.Detail)
+	}
+}
+
+// TestROS2DiscoverCachesWithinTTL proves the cache actually prevents a second
+// enumeration, that the TTL expires it, and that invalidation is explicit.
+func TestROS2DiscoverCachesWithinTTL(t *testing.T) {
+	runtime := newRecordingROS2Runtime(testSidecar())
+	adapter := testAdapter(t, runtime)
+	now := time.Now()
+	adapter.now = func() time.Time { return now }
+
+	first := adapter.Discover(context.Background())
+	if got := runtime.enumerations(); got != 1 {
+		t.Fatalf("first Discover ran %d enumerations, want 1", got)
+	}
+	second := adapter.Discover(context.Background())
+	if got := runtime.enumerations(); got != 1 {
+		t.Fatalf("second Discover inside the TTL ran %d enumerations, want the cached 1", got)
+	}
+	if len(first) != len(second) {
+		t.Fatalf("cached listing differs: %d then %d sources", len(first), len(second))
+	}
+
+	now = now.Add(ros2DiscoveryTTL + time.Millisecond)
+	adapter.Discover(context.Background())
+	if got := runtime.enumerations(); got != 2 {
+		t.Fatalf("Discover past the TTL ran %d enumerations, want 2", got)
+	}
+
+	adapter.invalidateDiscovery()
+	adapter.Discover(context.Background())
+	if got := runtime.enumerations(); got != 3 {
+		t.Fatalf("Discover after explicit invalidation ran %d enumerations, want 3", got)
+	}
+
+	// A sidecar that changes identity must miss regardless of the TTL: the
+	// cached listing describes a graph that is no longer the one being asked
+	// about.
+	runtime.fakeROS2Runtime.sidecars = []ROS2Sidecar{{Name: "sc-cyc", RMW: "rmw_cyclonedds_cpp", DomainID: 7}}
+	adapter.Discover(context.Background())
+	if got := runtime.enumerations(); got != 4 {
+		t.Fatalf("Discover after a domain change ran %d enumerations, want 4", got)
+	}
+}
+
+func startROS2Capture(t *testing.T, adapter *ros2DataAdapter, selected []data.Source) ([]data.CaptureResult, string) {
+	t.Helper()
+	episodeRoot := t.TempDir()
+	capture, err := adapter.Start(context.Background(), data.CaptureSession{ID: "episode-test", Directory: episodeRoot}, selected)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if capture == nil {
+		t.Fatal("Start returned no capture for a selection that named ROS 2 sources")
 	}
 	results, err := capture.Stop(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(results) != 1 || results[0].SourceID != source.ID || results[0].DropAccounting != "unavailable" {
-		t.Fatalf("results = %+v", results)
+	return results, episodeRoot
+}
+
+// TestROS2CaptureRecordsOnlyTheNamedTopics is the point of the change: naming
+// two topics must not record the whole domain.
+func TestROS2CaptureRecordsOnlyTheNamedTopics(t *testing.T) {
+	runtime := newRecordingROS2Runtime(testSidecar())
+	adapter := testAdapter(t, runtime)
+	sources := adapter.Discover(context.Background())
+	chatter, _ := sourceByID(sources, "ros2:rmw_cyclonedds_cpp:domain-42:/chatter")
+	image, _ := sourceByID(sources, "ros2:rmw_cyclonedds_cpp:domain-42:/camera/left/image_raw")
+
+	results, episodeRoot := startROS2Capture(t, adapter, []data.Source{chatter, image})
+
+	recorded := runtime.recorded()
+	// One recorder for the domain, not one per topic: each rosbag2 process
+	// pays its own DDS discovery and produces its own bag and clock mapping.
+	if len(recorded) != 1 {
+		t.Fatalf("started %d recorders for two topics on one domain, want 1: %v", len(recorded), recorded)
 	}
-	metadata := filepath.Join(episodeRoot, "ros2", safeCaptureName(source.ID), "metadata.yaml")
+	args := recorded[0]
+	if got := strings.Join(args[4:], " "); got != "/camera/left/image_raw /chatter" {
+		t.Fatalf("recorder topics = %q, want the two named topics", got)
+	}
+	for _, arg := range args {
+		if arg == "-a" {
+			t.Fatalf("a per-topic selection recorded the whole domain: %v", args)
+		}
+	}
+	// Both named sources are accounted for in the manifest even though one
+	// recorder produced one bag.
+	if len(results) != 2 {
+		t.Fatalf("results = %+v, want one per selected source", results)
+	}
+	ids := map[string]bool{results[0].SourceID: true, results[1].SourceID: true}
+	if !ids[chatter.ID] || !ids[image.ID] {
+		t.Fatalf("results named %v, want %s and %s", ids, chatter.ID, image.ID)
+	}
+	// One bag per domain, named by the domain rather than by any one topic.
+	metadata := filepath.Join(episodeRoot, "ros2", safeCaptureName("ros2:rmw_cyclonedds_cpp:domain-42"), "metadata.yaml")
 	if _, err := os.Stat(metadata); err != nil {
 		t.Fatalf("moved bag missing: %v", err)
+	}
+}
+
+// TestROS2CaptureDomainIDStillRecordsEverything is the backwards-compatibility
+// case: campaign YAML deployed before per-topic sources existed names the
+// domain, and it must still get `ros2 bag record -a`.
+func TestROS2CaptureDomainIDStillRecordsEverything(t *testing.T) {
+	runtime := newRecordingROS2Runtime(testSidecar())
+	adapter := testAdapter(t, runtime)
+	sources := adapter.Discover(context.Background())
+	domain, ok := sourceByID(sources, "ros2:rmw_cyclonedds_cpp:domain-42")
+	if !ok {
+		t.Fatal("domain-level source is no longer discoverable, which breaks deployed campaigns")
+	}
+
+	results, episodeRoot := startROS2Capture(t, adapter, []data.Source{domain})
+
+	recorded := runtime.recorded()
+	if len(recorded) != 1 {
+		t.Fatalf("started %d recorders, want 1: %v", len(recorded), recorded)
+	}
+	if got := strings.Join(recorded[0][4:], " "); got != "-a" {
+		t.Fatalf("domain-level selection recorded %q, want -a", got)
+	}
+	if len(results) != 1 || results[0].SourceID != domain.ID || results[0].DropAccounting != "unavailable" {
+		t.Fatalf("results = %+v", results)
+	}
+	metadata := filepath.Join(episodeRoot, "ros2", safeCaptureName(domain.ID), "metadata.yaml")
+	if _, err := os.Stat(metadata); err != nil {
+		t.Fatalf("moved bag missing: %v", err)
+	}
+}
+
+// TestROS2CaptureDomainSelectionSubsumesTopics covers the default episode,
+// which selects every healthy source: the domain and all of its topics. That
+// must stay one `-a` recorder rather than one recorder for the domain plus one
+// per topic writing the same messages twice.
+func TestROS2CaptureDomainSelectionSubsumesTopics(t *testing.T) {
+	runtime := newRecordingROS2Runtime(testSidecar())
+	adapter := testAdapter(t, runtime)
+	sources := adapter.Discover(context.Background())
+
+	results, _ := startROS2Capture(t, adapter, sources)
+
+	recorded := runtime.recorded()
+	if len(recorded) != 1 {
+		t.Fatalf("started %d recorders, want 1: %v", len(recorded), recorded)
+	}
+	if got := strings.Join(recorded[0][4:], " "); got != "-a" {
+		t.Fatalf("recorded %q, want -a to subsume the per-topic sources", got)
+	}
+	if len(results) != len(sources) {
+		t.Fatalf("results = %d, want one per selected source (%d)", len(results), len(sources))
+	}
+}
+
+// TestROS2CaptureRejectsUnknownSourceID keeps an identifier this adapter does
+// not understand from silently recording nothing.
+func TestROS2CaptureRejectsUnknownSourceID(t *testing.T) {
+	adapter := testAdapter(t, newRecordingROS2Runtime(testSidecar()))
+	_, err := adapter.Start(context.Background(), data.CaptureSession{ID: "e", Directory: t.TempDir()}, []data.Source{{ID: "ros2:not-an-identifier", Kind: "ros2"}})
+	if err == nil || !strings.Contains(err.Error(), "unrecognized ROS 2 source id") {
+		t.Fatalf("err = %v, want an unrecognized source id error", err)
+	}
+}
+
+func TestROS2RecordArgsSortAndDeduplicateTopics(t *testing.T) {
+	args := ros2RecordArgs("/bags/x", &ros2DomainSelection{topics: []string{"/b", "/a", "/b"}})
+	if got := strings.Join(args, " "); got != "bag record -o /bags/x /a /b" {
+		t.Fatalf("args = %q", got)
 	}
 }

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
@@ -107,7 +107,7 @@ Each `sources` item selects exactly one source:
 | Source | Description |
 |---|---|
 | `camera: <selector>` | A stable source ID, `/dev/videoN` path, or unambiguous name fragment. `front` and `default` select the only healthy camera when exactly one exists. |
-| `ros2: <topic>` | Selects healthy local ROS graph recorders and retains the requested topic separately in the manifest. |
+| `ros2: <topic>` | A ROS 2 topic name such as `/lidar/points`. Selects that topic on every healthy ROS 2 graph publishing it, and the episode records that topic and nothing else. A topic no healthy graph publishes is an error. A full per-topic source ID such as `ros2:rmw_cyclonedds_cpp:domain-42:/lidar/points` selects that one source. A domain-level source ID such as `ros2:rmw_cyclonedds_cpp:domain-42`, or any other value, selects the whole DDS domain and records all of it. Requested topics are retained separately in the manifest either way. |
 | `telemetry: true` | Includes device telemetry. |
 
 An optional `calibration_revision` can accompany a source. Application records


### PR DESCRIPTION
## Problem

`wendy data sources` shows one opaque entry per ROS 2 Data Distribution Service (DDS) domain:

```
id:     ros2:rmw_cyclonedds_cpp:domain-42
detail: "rmw_cyclonedds_cpp DDS domain 42"
```

That is the only ROS 2 handle a person has, and it is the whole graph. Three consequences:

1. A campaign naming it records the entire domain, because the adapter always runs `ros2 bag record -a`. On a real robot that is every camera topic and every high-rate inertial measurement unit topic whether they were wanted or not. A user cannot express "record the lidar and the joint states, nothing else".
2. A user cannot see what the graph offers without leaving Wendy and running ROS 2 tooling by hand.
3. `Healthy` was hardcoded `true`, so a dead DDS domain enumerated as healthy and a campaign naming it started a recorder that captured nothing. This was already flagged in an audit.

Verified live against `wendyos-fernando.local`, which runs `Examples/ROS2` on domain 42. `wendy data sources` returns exactly one ROS 2 entry, while `wendy device ros2 topics` on the same device lists `/chatter`, `/parameter_events` and `/rosout` with their message types. Everything needed to address a topic was already reachable; nothing exposed it as a source.

## Cause

`ros2DataAdapter.Discover` emitted one `data.Source` per sidecar and stopped there, so the topic was never part of a source identity. Two places then had nothing finer to work with:

- `ros2DataAdapter.Start` had one source per domain and one recorder shape, `-a`.
- `Manager.ResolveCampaignSources` had documented `ros2: <topic>` in campaign YAML since the format existed, but with no per-topic source to resolve to it ignored the value entirely and selected every healthy ROS 2 source. The selector was decorative.

## Solution

### One source per topic

`Discover` now enumerates the graph and emits one source per topic, reusing the existing `ros2 topic list -t` path (`ROS2Service.ListTopics` / `parseROS2TopicList`), which returns names and their message types in a single exec. There is no second enumerator.

| Field | Value |
|---|---|
| `ID` | `ros2:<rmw>:domain-<n>:<topic>` |
| `Kind` | `ros2` |
| `Detail` | the message type, for example `std_msgs/msg/String` |
| `ClockDomain` | unchanged, `ROSBAG2_STORAGE/ROS_MESSAGE_HEADER/SIM_TIME` |
| `Subscribable` | false |

`Subscribable` is not a `data.Source` field: `SensorService.Sources` derives it from whether a provider can multiplex the source to a model subscriber, and ROS 2 has no producer hub, so it is already false and stays false. The reason is a comment on `ros2TopicSource` so nobody sets it later without adding the hub first.

The domain-level source stays listed. It is the "record everything on this graph" handle, it is what a deployed campaign names, and without it the default episode, which selects every healthy source, would start one rosbag2 process per topic instead of one.

On the Fernando device this turns one row into four:

```
ros2:rmw_cyclonedds_cpp:domain-42                     rmw_cyclonedds_cpp DDS domain 42, 3 topics
ros2:rmw_cyclonedds_cpp:domain-42:/chatter            std_msgs/msg/String
ros2:rmw_cyclonedds_cpp:domain-42:/parameter_events   rcl_interfaces/msg/ParameterEvent
ros2:rmw_cyclonedds_cpp:domain-42:/rosout             rcl_interfaces/msg/Log
```

### The identifier scheme, and why it is not `ros2:<domain>:<topic>`

The per-topic identifier is the domain identifier with `:` and the topic name appended. Two reasons for extending the existing shape rather than introducing a shorter one.

One parser reads both spellings. The domain identifier is literally the prefix of every topic identifier on that domain, so backwards compatibility is a property of the scheme instead of a compatibility branch in the resolver, and `ParseROS2SourceID` returns an empty topic for the old spelling rather than failing on it.

The Remote Middleware Interface (RMW) name has to stay in the identifier. Two RMW implementations can be live on the same DDS domain number and they do not interoperate, so they are different graphs; `resolveSidecars` returns one sidecar per RMW precisely because of that. Dropping the RMW would let `/chatter` on the Cyclone DDS graph and `/chatter` on the Fast DDS graph collide on one identifier. The domain-level identifier has always carried the RMW, and a per-topic identifier that dropped it would be a regression in identity, not a simplification.

Round-tripping a topic containing slashes is unambiguous because the topic is always the last field. ROS 2 graph names admit only letters, digits, underscores and slashes (see `ros2GraphNamePattern`), so a `:` can never occur inside one and everything after the third `:` is the topic:

```
ros2:rmw_cyclonedds_cpp:domain-42:/camera/left/image_raw
  -> domain "ros2:rmw_cyclonedds_cpp:domain-42", topic "/camera/left/image_raw"
```

A remainder that is not absolute is rejected, so a truncated or hand-typed identifier fails rather than quietly recording a bag for a topic nobody named.

The grammar lives in `go/internal/agent/data/ros2_source_id.go`, in the package that owns episode sources, because the agent adapter mints these identifiers and the campaign resolver matches against them. One scheme, one parser.

### Selection and backwards compatibility

`Start` groups the selected sources by the domain they name and runs one recorder per domain:

- the domain-level identifier selected: `ros2 bag record -o <staging> -a`, unchanged.
- topic identifiers only: `ros2 bag record -o <staging> <topic> [<topic>...]` for exactly the topics named, sorted and deduplicated.
- both, which is what the default episode selects: `-a` wins. It already records those topics, and the alternative is two rosbag2 processes writing the same messages into two bags in one episode.

One invocation per domain rather than one per topic. Each rosbag2 process pays its own DDS discovery, opens its own storage writer and produces its own bag directory, and this adapter pairs each recorder with a clock sampler and one `ClockMapping`. Splitting a domain across N recorders would produce N bags and N independent clock mappings for messages that share a single timeline, which is exactly the alignment the episode exists to preserve. Every selected source still gets its own `CaptureResult`, so the manifest accounts for what the campaign named even though one recorder produced one bag. `SourceDetail` is left empty on those results on purpose: `ApplyCaptureResults` would otherwise overwrite the discovered `Detail`, and for a topic source that `Detail` is the message type, which is worth more in the manifest than a note about which bag holds it.

Campaign YAML keeps working, three spellings:

| Selector | Resolves to |
|---|---|
| `ros2: /lidar/points` | that topic's source on every healthy graph publishing it; records that topic and nothing else |
| `ros2: ros2:rmw_cyclonedds_cpp:domain-42:/scan` | that one source |
| `ros2: ros2:rmw_cyclonedds_cpp:domain-42`, with or without the `ros2:` prefix, or any other value | the whole domain, still recorded with `-a` |

No deployed plan changes meaning except the topic selectors, which now mean what they say. That is the behaviour change this pull request exists to make, and it is worth naming explicitly for anyone with a plan in the field: a campaign spelling `ros2: /lidar/points` used to record the whole graph and now records the lidar.

One further behaviour change to flag. A topic selector naming a topic no healthy graph publishes is now an error rather than a fallback to the whole domain. Falling back would restore the bug, and the alternative failure is the one this package already refuses for audio selectors: a sealed, checksummed, uploaded episode holding none of the data the plan asked for.

### Derived health

`Healthy` is derived from whether the graph could enumerate its own topics. A failed enumeration yields the domain source alone, unhealthy, with the failure in its `Detail` (truncated on a rune boundary, since the Detail is serialized as JSON):

```
rmw_cyclonedds_cpp DDS domain 42: listing topics failed: ros2 topic list -t failed (exit 1): ...
```

A graph that cannot list its own topics cannot be recorded from either, and a status field that lies is worse than no status field.

### Cached discovery

Five second time to live, keyed by sidecar identity, with `invalidateDiscovery` as the explicit invalidation path.

The measurement behind it, taken on hardware against a live graph: `ros2 topic list -t` costs about 0.6 seconds beyond the bare `ros2` command-line baseline, and the cost does not grow with topic count. `Discover` is not called once per user action. Rendering `wendy data sources` calls it, and a single campaign trigger calls it twice more, once through `ResolveCampaignSources` and again through `Manager.Start`. Uncached, that is roughly 1.8 seconds of DDS discovery between a trigger firing and the recorder starting, and the episode does not capture what happened during it.

Five seconds collapses each of those bursts into one enumeration while keeping the listing fresh enough that a node started by hand appears in the next `wendy data sources` a person types. It is a bound on staleness rather than a substitute for correctness: the cache key includes the sidecar name, the RMW and the effective domain, so a sidecar restart, an RMW change or a `--domain` override misses immediately; entries for sidecars that are no longer live are evicted on every `Discover` so the map cannot grow without bound; and `Start` calls `invalidateDiscovery` when it finds the graph is not what was enumerated, so a listing already shown to be wrong is never served again. Failures are cached too, because re-running a slow failing exec on every `Discover` is how a dead DDS domain turns `wendy data sources` into a hang.

Publisher and subscriber counts are deliberately not fetched. That path runs `ros2 topic info` once per topic, bounded at `ros2TopicInfoConcurrency` (8), and measures at roughly 0.8 seconds per round, so it costs ten seconds or more on a robot with a hundred topics and answers no question involved in choosing what to record.

## Follow-up, deliberately not in this change

The `SensorSource` protobuf message gains no `topic` or `message_type` fields here. Typed fields would be better once ROS 2 becomes subscribable and an app needs to filter by type, but nothing consumes them today, and the proto lives in chunk 3, so adding them would force another propagation through the whole stack for no current consumer. The message type therefore travels in `Detail`, which is what `wendy data sources` prints anyway.

## Verification

Run:

- `CC=/usr/bin/clang go build ./...` clean.
- `gofmt -l go/` empty.
- `CC=/usr/bin/clang go vet ./go/...` clean.
- `CC=/usr/bin/clang go test ./go/internal/agent/services/... ./go/internal/agent/data/...` passing.
- `CC=/usr/bin/clang go test ./go/...`: one failure, `TestSampleGPUFallsBackToTegrastatsForOrin` in `go/internal/agent/hoststats`. It is a load-sensitive tegrastats test, it passes in isolation with `-count=3`, and it fails the same way on an unmodified worktree of `split/7-tools-and-example`. Pre-existing, unrelated.
- Live, read-only, against `wendyos-fernando.local`: `wendy device ros2 topics` returns the three topics with their types over one call, and `wendy data sources` returns the single opaque domain entry this change replaces.

New tests: per-topic enumeration with the message type in `Detail` and nothing but `topic list -t` executed; identifier round-trip including nested and hidden topic names, plus rejection of malformed identifiers; both campaign spellings, the full per-topic identifier, the unrecognized-selector fallback and the absent-topic error; unhealthy on enumeration failure; the cache preventing a second enumeration inside the time to live, expiring past it, dropping on explicit invalidation and missing on a sidecar identity change; `-a` for the domain identifier, the exact topic list for a topic selection, `-a` subsuming topics when both are selected, and one `CaptureResult` per selected source.

Not verified: the new listing on a device. Confirming it live would need an agent build installed on Fernando, which was out of bounds for this change, so the four-row output above is what the unit tests assert rather than something observed on hardware. The 0.6 second figure was measured on Fernando by difference against a device command that does no ROS 2 work, and it reproduces across two sessions with very different absolute latency:

| | session 1 | session 2 |
|---|---|---|
| `wendy device info` baseline | 1.84 s | 4.04 s |
| `wendy device ros2 topics` | 2.42 s | 4.77 s |
| difference | 0.58 s | 0.73 s |

Absolute latency is dominated by connection setup shared with every device command, and it roughly doubled between sessions once the ROS 2 containers were running, so only the difference is meaningful. The 0.8 second figure for the counts path (`--all`) was taken the same way against a three-topic graph, where all three `ros2 topic info` execs run inside the concurrency bound of 8, so it represents one round rather than three sequential fetches; on a graph large enough to need multiple rounds the cost scales with the number of rounds.

No ClickHouse or storage bucket access, no agent installed, no apps deployed or removed, and no episodes triggered.

## Relationship to #1829

Sibling of #1829 off the same base. No file overlap: this touches `data_ros2_adapter.go`, `campaign.go`, the new `ros2_source_id.go` and the campaign documentation, none of which #1829 changes.

