### PR TITLE
docs: embed USB-C, Wi-Fi, and cloud deployment video

### DIFF
--- a/go/internal/cli/assets/docs/device/discovering-devices.mdx
+++ b/go/internal/cli/assets/docs/device/discovering-devices.mdx
@@ -15,7 +15,7 @@ description: Find WendyOS devices on your network using the Wendy CLI
   allowFullScreen
 />
 
-This walkthrough deploys a YOLOv8 app with `wendy run` over USB-C, connects the device to Wi-Fi with `wendy device wifi connect` and keeps deploying over the LAN, then enrolls the device with `wendy cloud enroll device` to reach a Unitree Go2 from another location — the CLI picks the fastest available transport each time.
+This walkthrough deploys a YOLOv8 app with `wendy run` over USB-C, connects the device to Wi-Fi with `wendy device wifi connect` and keeps deploying over the LAN, then enrolls the device with `wendy cloud enroll-device` to reach a Unitree Go2 from another location — the CLI picks the fastest available transport each time.
 
 The Wendy CLI can automatically discover WendyOS devices connected to your development machine. This works over USB connections and over your Local Area Network (LAN).
 

--- a/go/internal/cli/assets/docs/device/discovering-devices.mdx
+++ b/go/internal/cli/assets/docs/device/discovering-devices.mdx
@@ -5,6 +5,18 @@ description: Find WendyOS devices on your network using the Wendy CLI
 
 ## Discovering WendyOS Devices
 
+<iframe
+  className="aspect-video w-full rounded-lg border-0"
+  src="https://www.youtube.com/embed/9vZIOcpbkl0"
+  title="Deploying to a WendyOS device over USB-C, Wi-Fi, and Wendy Cloud"
+  loading="lazy"
+  referrerPolicy="strict-origin-when-cross-origin"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  allowFullScreen
+/>
+
+This walkthrough deploys a YOLOv8 app with `wendy run` over USB-C, connects the device to Wi-Fi with `wendy device wifi connect` and keeps deploying over the LAN, then enrolls the device with `wendy cloud enroll device` to reach a Unitree Go2 from another location — the CLI picks the fastest available transport each time.
+
 The Wendy CLI can automatically discover WendyOS devices connected to your development machine. This works over USB connections and over your Local Area Network (LAN).
 
 ### Prerequisites


### PR DESCRIPTION
Embeds the walkthrough video on the Discovering Devices page, since it demonstrates deploying with `wendy run` over USB-C, then Wi-Fi/LAN, then Wendy Cloud — the transports that page documents.