### PR TITLE
feat(data): add optional notify block to the campaign schema

### DIFF
--- a/Examples/WendyDataCampaign/campaign.yaml
+++ b/Examples/WendyDataCampaign/campaign.yaml
@@ -51,3 +51,10 @@ retention:
 
 export:
   annotation: cvat
+
+notify:
+  # Optional. Device-inert notification intent: the block rides verbatim in
+  # each committed episode manifest and the cloud ingest service acts on it;
+  # the device itself never sends anything because of it. episode_committed
+  # is the only supported event.
+  on: episode_committed

--- a/go/internal/agent/data/campaign.go
+++ b/go/internal/agent/data/campaign.go
@@ -170,6 +170,54 @@ type CampaignPrivacy struct {
 	Revision string `json:"revision,omitempty" yaml:"revision,omitempty"`
 }
 
+// NotifyOnEpisodeCommitted is the only notification event campaign version 1
+// supports: fire when an episode this campaign captured is committed.
+const NotifyOnEpisodeCommitted = "episode_committed"
+
+// ErrUnsupportedNotifyOn marks a notify.on value this schema version does not
+// support, so callers can identify the rejection with errors.Is.
+var ErrUnsupportedNotifyOn = errors.New("notify.on must be " + NotifyOnEpisodeCommitted)
+
+// CampaignNotify is an optional, device-inert notification policy. The device
+// attaches no behavior to it: the block rides verbatim in the committed
+// episode manifest (and therefore in the manifest JSON the cloud ingest
+// service receives), and the cloud decides whether and whom to notify. No
+// device-side network activity ever results from this block.
+type CampaignNotify struct {
+	// On names the event to notify on. NotifyOnEpisodeCommitted is the only
+	// supported value.
+	On string `json:"on" yaml:"on"`
+	// UnknownKeys lists keys inside the notify block this schema version does
+	// not know. Unlike the rest of the campaign document, which rejects
+	// unknown fields, the notify block is read by the cloud rather than the
+	// device, so a newer cloud-side key must not brick deployment to an older
+	// device; DeployCampaign warns instead. The list is deploy-time state, not
+	// plan content: it is excluded from the stored plan and the revision hash.
+	UnknownKeys []string `json:"-" yaml:"-"`
+}
+
+// UnmarshalYAML decodes the notify block by hand so unknown keys inside it are
+// collected for a deploy-time warning instead of tripping the document-wide
+// KnownFields rejection. Comparing the raw key scalar also sidesteps YAML 1.1
+// resolving an unquoted "on" key as a boolean.
+func (n *CampaignNotify) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind != yaml.MappingNode {
+		return errors.New("notify must be a mapping such as {on: " + NotifyOnEpisodeCommitted + "}")
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := node.Content[i].Value
+		switch key {
+		case "on":
+			if err := node.Content[i+1].Decode(&n.On); err != nil {
+				return fmt.Errorf("notify.on: %w", err)
+			}
+		default:
+			n.UnknownKeys = append(n.UnknownKeys, key)
+		}
+	}
+	return nil
+}
+
 // Campaign is the durable, device-local collection plan. Deployment arms its
 // triggers; it does not require the configured sensors or network destination
 // to be online at deployment time.
@@ -184,6 +232,7 @@ type Campaign struct {
 	Export            CampaignExport    `json:"export" yaml:"export"`
 	Models            map[string]string `json:"models" yaml:"models,omitempty"`
 	Privacy           []CampaignPrivacy `json:"privacy" yaml:"privacy,omitempty"`
+	Notify            *CampaignNotify   `json:"notify,omitempty" yaml:"notify,omitempty"`
 	State             string            `json:"state" yaml:"-"`
 	Revision          string            `json:"revision" yaml:"-"`
 	DeployedUnixNanos int64             `json:"deployed_unix_nanos" yaml:"-"`
@@ -306,6 +355,9 @@ func (c Campaign) validate() error {
 			return fmt.Errorf("privacy[%d].name is required", i)
 		}
 	}
+	if c.Notify != nil && c.Notify.On != NotifyOnEpisodeCommitted {
+		return fmt.Errorf("notify.on %q is not supported: %w", c.Notify.On, ErrUnsupportedNotifyOn)
+	}
 	return nil
 }
 
@@ -349,6 +401,9 @@ func (m *Manager) DeployCampaign(contents []byte) (Campaign, error) {
 	}
 	if campaign.Retention.LocalQuota != "" {
 		campaign.Warnings = append(campaign.Warnings, "retention.local_quota is recorded with the plan, but this release enforces only the device-wide storage quota")
+	}
+	if campaign.Notify != nil && len(campaign.Notify.UnknownKeys) > 0 {
+		campaign.Warnings = append(campaign.Warnings, "notify has unknown keys this agent ignores: "+strings.Join(campaign.Notify.UnknownKeys, ", "))
 	}
 	dir := m.campaignDir()
 	if err := os.MkdirAll(dir, 0o750); err != nil {

--- a/go/internal/agent/data/campaign_notify_test.go
+++ b/go/internal/agent/data/campaign_notify_test.go
@@ -1,0 +1,127 @@
+package data
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// campaignWithNotify appends a top-level notify block to the minimal valid
+// campaign document.
+func campaignWithNotify(notify string) []byte {
+	return append(minimalCampaign(1, "telemetry: true", "wifi"), []byte(notify+"\n")...)
+}
+
+// TestNotifyBlockRoundTripsIntoManifestTrigger covers the whole device-side
+// life of the notify block: parsed from YAML, persisted with the deployed
+// plan, copied onto the episode trigger, and serialized into the manifest
+// JSON at trigger.notify.on, which is the path the cloud ingest service reads
+// out of attributes_json.
+func TestNotifyBlockRoundTripsIntoManifestTrigger(t *testing.T) {
+	campaign, err := ParseCampaign(campaignWithNotify("notify: {on: episode_committed}"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if campaign.Notify == nil || campaign.Notify.On != NotifyOnEpisodeCommitted {
+		t.Fatalf("notify block was not parsed: %+v", campaign.Notify)
+	}
+
+	manifest := Manifest{
+		Version: ManifestVersion,
+		ID:      "ep-1",
+		Trigger: EpisodeTrigger{
+			Reason:           "event:go",
+			CampaignName:     campaign.Name,
+			CampaignRevision: campaign.Revision,
+			Notify:           campaign.Notify,
+		},
+	}
+	raw, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `"notify":{"on":"episode_committed"}`) {
+		t.Fatalf("manifest JSON does not carry the notify block verbatim: %s", raw)
+	}
+	var decoded Manifest
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Trigger.Notify == nil || decoded.Trigger.Notify.On != NotifyOnEpisodeCommitted {
+		t.Fatalf("notify block did not survive the manifest round trip: %+v", decoded.Trigger.Notify)
+	}
+
+	// A campaign without notify must leave the manifest exactly as before:
+	// no notify key at all, not an empty one.
+	bare, err := json.Marshal(Manifest{Version: ManifestVersion, ID: "ep-2", Trigger: EpisodeTrigger{Reason: "manual"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(bare), `"notify"`) {
+		t.Fatalf("manifest without a notify block still mentions notify: %s", bare)
+	}
+}
+
+func TestNotifyRejectsUnsupportedOn(t *testing.T) {
+	if _, err := ParseCampaign(campaignWithNotify("notify: {on: episode_sealed}")); !errors.Is(err, ErrUnsupportedNotifyOn) {
+		t.Fatalf("unsupported notify.on accepted or misclassified: %v", err)
+	}
+	if _, err := ParseCampaign(campaignWithNotify("notify: {}")); !errors.Is(err, ErrUnsupportedNotifyOn) {
+		t.Fatalf("notify without on accepted or misclassified: %v", err)
+	}
+	if _, err := ParseCampaign(campaignWithNotify("notify: episode_committed")); err == nil || !strings.Contains(err.Error(), "mapping") {
+		t.Fatalf("non-mapping notify accepted or misdescribed: %v", err)
+	}
+}
+
+func TestDeployWarnsOnUnknownNotifyKeys(t *testing.T) {
+	manager, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	campaign, err := manager.DeployCampaign(campaignWithNotify("notify: {on: episode_committed, channel: slack}"))
+	if err != nil {
+		t.Fatalf("unknown notify key must warn, not fail deployment: %v", err)
+	}
+	found := false
+	for _, warning := range campaign.Warnings {
+		if strings.Contains(warning, "notify") && strings.Contains(warning, "channel") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no warning names the unknown notify key: %v", campaign.Warnings)
+	}
+	stored, err := manager.Campaign(campaign.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Notify == nil || stored.Notify.On != NotifyOnEpisodeCommitted {
+		t.Fatalf("notify block was not durably stored with the plan: %+v", stored.Notify)
+	}
+
+	clean, err := manager.DeployCampaign(campaignWithNotify("notify: {on: episode_committed}"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, warning := range clean.Warnings {
+		if strings.Contains(warning, "notify") {
+			t.Fatalf("a fully known notify block must not warn: %v", clean.Warnings)
+		}
+	}
+}
+
+func TestNotifyChangesRevisionHash(t *testing.T) {
+	base, err := ParseCampaign(minimalCampaign(1, "telemetry: true", "wifi"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	notified, err := ParseCampaign(campaignWithNotify("notify: {on: episode_committed}"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if base.Revision == notified.Revision {
+		t.Fatal("adding a notify block did not change the revision hash")
+	}
+}

--- a/go/internal/agent/data/model.go
+++ b/go/internal/agent/data/model.go
@@ -234,6 +234,11 @@ type EpisodeTrigger struct {
 	CampaignName     string `json:"campaign_name,omitempty"`
 	CampaignRevision string `json:"campaign_revision,omitempty"`
 	Expression       string `json:"expression,omitempty"`
+	// Notify carries the triggering campaign's notify block verbatim into the
+	// committed manifest, and from there into the manifest JSON the cloud
+	// ingest service receives. The device attaches no behavior to it; the
+	// cloud reads it to decide whether to notify.
+	Notify *CampaignNotify `json:"notify,omitempty"`
 }
 
 type PrivacyTransformation struct {

--- a/go/internal/agent/services/data_service.go
+++ b/go/internal/agent/services/data_service.go
@@ -346,7 +346,7 @@ func (s *DataService) triggerCampaign(ctx context.Context, campaign data.Campaig
 		Sources:              sources,
 		SourceCaptures:       captures,
 		PreRollDuration:      campaign.BufferDuration(),
-		Trigger:              data.EpisodeTrigger{Reason: reason, CampaignName: campaign.Name, CampaignRevision: campaign.Revision, Expression: expression},
+		Trigger:              data.EpisodeTrigger{Reason: reason, CampaignName: campaign.Name, CampaignRevision: campaign.Revision, Expression: expression, Notify: campaign.Notify},
 		CollectorVersion:     version.Version,
 		ModelVersions:        campaign.Models,
 		RequestedTopics:      topics,

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
@@ -87,7 +87,8 @@ A complete plan is in `Examples/WendyDataCampaign` in the WendyOS repository.
 ## Campaign YAML reference
 
 A campaign file contains exactly one YAML document. Unknown fields are
-rejected.
+rejected, with one exception: unknown keys inside the `notify` block warn at
+deployment instead (see the `notify` section below).
 
 | Top-level field | Required | Description |
 |---|---|---|
@@ -101,6 +102,7 @@ rejected.
 | `export` | yes | Annotation integration lifecycle intent. |
 | `models` | no | Map of model name to deployed version, copied into Episodes. |
 | `privacy` | no | List of declared transforms with optional revisions. |
+| `notify` | no | Optional cloud-side notification intent; see below. |
 
 Each `sources` item selects exactly one source:
 
@@ -157,6 +159,20 @@ The `upload` and `retention` blocks:
 | `upload.max_rate` | no | Upload bandwidth cap in bytes per second; plain integers and rates such as `5MB/s` are accepted. |
 | `retention.local_quota` | no | Declared on-device episode storage bound in bytes; plain integers and sizes such as `10GiB` are accepted. Stored with the plan; this release enforces only the device-wide quota and deployment prints a warning. |
 
+The optional `notify` block:
+
+| Field | Required | Description |
+|---|---|---|
+| `notify.on` | yes | The event to notify on. `episode_committed` is the only supported value; anything else is a deploy-time error. |
+
+The `notify` block is inert on the device. It rides verbatim in each committed
+episode manifest (under `trigger.notify`), and the cloud ingest service reads
+it there to decide whether to send a notification; devices never open a
+network connection because of it. Unlike the rest of the document, unknown
+keys inside `notify` do not fail deployment: the cloud side may understand
+keys an older agent does not, so deployment prints a warning naming each
+unrecognized key and ignores it.
+
 ```yaml
 version: 1
 name: forklift-failures
@@ -188,6 +204,9 @@ retention:
 
 export:
   annotation: cvat
+
+notify:
+  on: episode_committed
 ```
 
 ## Playing back camera capture


### PR DESCRIPTION
## Problem

Fleet operators want to be notified when a campaign episode is committed, but the campaign schema has no way for a plan author to declare that intent. Any notification mechanism must not add device-side network behavior: devices already upload the committed manifest, and the cloud is the right place to act.

## Context

The device manifest does not carry the campaign plan wholesale; it carries only `trigger.campaign_name` and `trigger.campaign_revision` through `EpisodeTrigger`. The uploader (`buildEpisodeManifest` in `go/internal/agent/services/data_transfer_worker.go`) marshals the full device manifest into the cloud `EpisodeManifest.attributes_json`, so anything on the manifest reaches the cloud verbatim, but a new plan block does not ride along on its own. It needs one field of plumbing from the plan onto the trigger.

## Solution

Campaign version 1 gains an optional `notify:` block:

```yaml
notify:
  on: episode_committed
```

- Schema and validation (`go/internal/agent/data/campaign.go`): `CampaignNotify` follows the same declaration pattern as the existing `upload:` and `export:` blocks. `episode_committed` is the only supported value for `on:`; anything else is rejected at deploy-time validation with the named sentinel error `ErrUnsupportedNotifyOn`, identifiable with `errors.Is`.
- Unknown keys inside `notify:` warn at deployment instead of failing it. The rest of the document rejects unknown fields via the YAML decoder's known-fields check, but this block is read by the cloud rather than the device, so a newer cloud-side key must not brick deployment to an older device. A custom `UnmarshalYAML` collects the unknown keys and `DeployCampaign` appends a warning naming each one.
- Manifest carriage (`go/internal/agent/data/model.go`, `go/internal/agent/services/data_service.go`): the block is copied verbatim from the plan onto `EpisodeTrigger.Notify` when a campaign triggers, and the trigger flows unchanged into the committed manifest. The cloud reads it at `attributes_json` -> `trigger` -> `notify` -> `{"on": "episode_committed"}`.
- The notify block is device-inert: it only rides in the committed manifest attributes, and the cloud ingest service acts on it (a companion cloud pull request exists). The device never opens a network connection because of it.
- The block feeds the campaign revision digest; plans without it keep their existing revisions (`omitempty` on a nil pointer).
- Docs: `docs/clients/wendy-cli/commands/data.md` documents the block, and the annotated `Examples/WendyDataCampaign/campaign.yaml` shows it with a comment.

## Tests

New unit tests in `go/internal/agent/data/campaign_notify_test.go` cover: the block round-tripping into the manifest JSON at `trigger.notify.on` (and staying absent when the plan has no notify block), rejection of unsupported `on:` values via `errors.Is(err, ErrUnsupportedNotifyOn)`, the deploy-time warning naming unknown keys, durable storage with the plan, and the revision hash changing when notify is added.

Verified with `CC=/usr/bin/clang go build ./go/...`, `go test ./go/internal/agent/data/... ./go/internal/agent/services/...` (all passing), `gofmt` and `go vet` clean on the changed packages.
