### PR TITLE
Seal episodes with a browser-playable MP4 per camera source

### DIFF
--- a/go/cmd/episode-playable/main.go
+++ b/go/cmd/episode-playable/main.go
@@ -85,6 +85,9 @@ The episode directory is never modified.
 		if r.SyncSamples == 0 {
 			fmt.Fprintf(os.Stderr, "episode-playable: warning: camera %s clip carries no random-access frame, so players cannot seek in it and many will not open it at all\n", r.Source)
 		}
+		if r.ParameterSetChanges > 0 {
+			fmt.Fprintf(os.Stderr, "episode-playable: warning: camera %s changes its SPS/PPS mid-stream (%d changed unit(s), a producer restart); the clip carries only the first decoder configuration, so frames after the change will misdecode\n", r.Source, r.ParameterSetChanges)
+		}
 		if r.BFrames {
 			fmt.Fprintf(os.Stderr, "episode-playable: warning: camera %s contains B slices, so its presentation order differs from the coded order index.jsonl records; the timing written for it is approximate\n", r.Source)
 		} else if r.UndecodedSliceHeaders > 0 {

--- a/go/cmd/episode-playable/main.go
+++ b/go/cmd/episode-playable/main.go
@@ -48,6 +48,20 @@ The episode directory is never modified.
 		dest = episode + "-playable"
 	}
 
+	// Episodes sealed since the agent learned to remux at seal time already
+	// carry cameras/<source>/playable.mp4, listed in their manifest. When
+	// every camera source has one there is nothing to convert; reconverting
+	// would only duplicate bytes the manifest already vouches for.
+	existing, _ := filepath.Glob(filepath.Join(episode, "cameras", "*", episodeexport.PlayableFileName))
+	indexes, _ := filepath.Glob(filepath.Join(episode, "cameras", "*", "index.jsonl"))
+	if len(existing) > 0 && len(existing) >= len(indexes) {
+		fmt.Println("episode already carries playable files written at seal time; nothing to convert:")
+		for _, p := range existing {
+			fmt.Printf("  %s\n", p)
+		}
+		return
+	}
+
 	results, errs := episodeexport.Convert(episode, dest)
 	for _, r := range results {
 		if r.Output == "" {

--- a/go/internal/agent/data/manager.go
+++ b/go/internal/agent/data/manager.go
@@ -928,6 +928,17 @@ func (m *Manager) finalizeLocked(a *activeEpisode, state, reason string) (Manife
 			return Manifest{}, err
 		}
 	}
+	// The playable remux runs before sealFiles so each derived
+	// cameras/<source>/playable.mp4 is checksummed, listed, uploaded and
+	// verified exactly like the capture it derives from. Sealing was already
+	// a synchronous pass over every episode byte (the checksums below), and
+	// the remux is a copy, not a transcode, so this keeps the seal's shape:
+	// one more read of the camera bytes, never a failure. A source that
+	// cannot be muxed honestly seals without its clip and the notes say why.
+	a.manifest.PlayableNotes = muxPlayableClips(a.dir)
+	for _, note := range a.manifest.PlayableNotes {
+		m.warnf("episode %s: %s", a.manifest.ID, note)
+	}
 	files, err := sealFiles(a.dir)
 	if err != nil {
 		return Manifest{}, err
@@ -1177,6 +1188,11 @@ func (m *Manager) recoverPartials() error {
 		if reconciled {
 			mf.RecoveryActions = append(mf.RecoveryActions, "recomputed model input/outcome counters from "+ModelInputLedgerFile+" and "+mf.ModelIO.OutcomeLog)
 		}
+		// Recovery is the other path that seals an episode, so it derives the
+		// same playable clips; the truncated index tails above were already
+		// cut, and the muxer counts a partial trailing line as unusable
+		// rather than guessing at it.
+		mf.PlayableNotes = muxPlayableClips(dir)
 		mf.Files, err = sealFiles(dir)
 		if err != nil {
 			return fmt.Errorf("recovering episode %s: %w", mf.ID, err)
@@ -1297,7 +1313,11 @@ func sealFiles(dir string) ([]File, error) {
 		}
 		rel = filepath.ToSlash(rel)
 		format, mediaType := payloadFormat(rel)
-		out = append(out, File{Path: rel, Size: n, SHA256: h, SourceID: sourceForPath(rel), Format: format, MediaType: mediaType})
+		entry := File{Path: rel, Size: n, SHA256: h, SourceID: sourceForPath(rel), Format: format, MediaType: mediaType}
+		if isDerivedPlayable(rel) {
+			entry.Role = FileRoleDerived
+		}
+		out = append(out, entry)
 		return nil
 	})
 	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })

--- a/go/internal/agent/data/model.go
+++ b/go/internal/agent/data/model.go
@@ -307,7 +307,7 @@ type Manifest struct {
 	// cameras/<source>/playable.mp4 or why the one it wrote omits frames.
 	// Absence of a note plus absence of the file means the episode captured
 	// no camera; a note is the seal's honest account of a mux it refused.
-	PlayableNotes     []string `json:"playable_notes,omitempty"`
+	PlayableNotes []string `json:"playable_notes,omitempty"`
 	// PreRollLost counts the application records that would have reached THIS
 	// episode's pre-roll window and did not, because the ring buffer hit its
 	// byte budget and dropped them while they were still inside their window.

--- a/go/internal/agent/data/model.go
+++ b/go/internal/agent/data/model.go
@@ -207,6 +207,15 @@ type MonotonicMappingSample struct {
 	OffsetUpperNanos int64 `json:"offset_upper_nanos"`
 }
 
+// FileRoleDerived marks a manifest file computed from capture payload at seal
+// time rather than recorded during capture. Today that is the per-source
+// cameras/<source>/playable.mp4 remux. A derived file is checksummed, uploaded
+// and verified exactly like every other listed file, but it is not capture
+// payload: model-input and payload-retention accounting resolve payload bytes
+// through cameras/<source>/index.jsonl into the raw segments and must never
+// count a derived file, and deleting one loses no recorded data.
+const FileRoleDerived = "derived"
+
 type File struct {
 	Path      string `json:"path"`
 	Size      int64  `json:"size"`
@@ -214,6 +223,10 @@ type File struct {
 	SourceID  string `json:"source_id,omitempty"`
 	Format    string `json:"format"`
 	MediaType string `json:"media_type"`
+	// Role distinguishes what a file is to the episode. Empty means capture
+	// payload or capture metadata written while recording; FileRoleDerived
+	// marks an artifact computed from that payload at seal time.
+	Role string `json:"role,omitempty"`
 }
 
 type Calibration struct {
@@ -285,9 +298,14 @@ type Manifest struct {
 	Upload            WorkflowState           `json:"upload"`
 	Labeling          WorkflowState           `json:"labeling"`
 	RecoveryActions   []string                `json:"recovery_actions,omitempty"`
-	PreRollLost       uint64                  `json:"pre_roll_lost"`
-	PreRollAccounting string                  `json:"pre_roll_accounting"`
-	ModelIO           ModelIO                 `json:"model_io"`
+	// PlayableNotes records, per camera source, why the seal wrote no
+	// cameras/<source>/playable.mp4 or why the one it wrote omits frames.
+	// Absence of a note plus absence of the file means the episode captured
+	// no camera; a note is the seal's honest account of a mux it refused.
+	PlayableNotes     []string `json:"playable_notes,omitempty"`
+	PreRollLost       uint64   `json:"pre_roll_lost"`
+	PreRollAccounting string   `json:"pre_roll_accounting"`
+	ModelIO           ModelIO  `json:"model_io"`
 }
 
 type StartOptions struct {

--- a/go/internal/agent/data/playable.go
+++ b/go/internal/agent/data/playable.go
@@ -1,0 +1,95 @@
+package data
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+
+	"github.com/wendylabsinc/wendy/go/internal/episodeexport"
+)
+
+// muxPlayableClips writes cameras/<source>/playable.mp4 for every camera
+// source of a finished episode. It runs while the episode is being sealed,
+// before sealFiles walks the directory, so the derived clip gets a size and
+// SHA-256 entry in the manifest and is uploaded and verified exactly like the
+// capture it derives from. The point is browser playback straight from the
+// bucket: browsers cannot play the raw H.264 elementary stream, and the remux
+// gives every frame the presentation time cameras/<source>/index.jsonl
+// recorded for it.
+//
+// It never fails or blocks the seal. The remux is a copy, not a transcode, so
+// its cost is one more pass over the camera bytes beside the checksum pass the
+// seal already makes, and the clip it leaves is roughly the size of the raw
+// stream it derives from; that size is counted against the episode by both
+// the manifest total and the disk-usage walk enforceQuota performs. A source
+// whose stream cannot become an honestly timed, seekable clip (B slices,
+// slice headers the muxer cannot parse, no random-access frame, or an
+// outright mux failure) seals without its playable.mp4, and the returned
+// notes, published as the manifest's playable_notes, name why. A clip that
+// was written but had to omit frames whose bytes were missing gets a note
+// too, so the manifest never presents a partial clip as a complete one.
+//
+// The raw capture is never touched: index.jsonl keeps addressing frames by
+// byte offset into the raw segments, so the correlation join between a frame
+// and the model input recorded against it is unaffected.
+func muxPlayableClips(dir string) []string {
+	indexes, err := filepath.Glob(filepath.Join(dir, "cameras", "*", "index.jsonl"))
+	if err != nil || len(indexes) == 0 {
+		return nil
+	}
+	sort.Strings(indexes)
+	var notes []string
+	for _, index := range indexes {
+		sourceDir := filepath.Dir(index)
+		rel := path.Join("cameras", filepath.Base(sourceDir), episodeexport.PlayableFileName)
+		result, err := episodeexport.ConvertSourceInPlace(dir, sourceDir)
+		if reason := playableSkipReason(result, err); reason != "" {
+			// ConvertSourceInPlace only leaves a file behind on success, but a
+			// clip refused by policy (B slices and the like) was written before
+			// the result could be judged, so it is removed rather than shipped
+			// with timing nobody can vouch for.
+			_ = os.Remove(filepath.Join(sourceDir, episodeexport.PlayableFileName))
+			notes = append(notes, fmt.Sprintf("%s not written: %s", rel, reason))
+			continue
+		}
+		if result.Skipped > 0 {
+			note := fmt.Sprintf("%s omits %d of %d indexed frame(s)", rel, result.Skipped, result.IndexLines)
+			if result.SkippedReason != "" {
+				note += ": " + result.SkippedReason
+			}
+			notes = append(notes, note)
+		}
+	}
+	return notes
+}
+
+// playableSkipReason decides whether a mux result is honest enough to publish
+// in the sealed episode, returning the reason to refuse it or "" to keep it.
+// The gates mirror the warnings the episode-playable command prints, but at
+// seal time they are hard: a clip whose timing or seekability the muxer
+// cannot vouch for is not listed in a manifest that vouches for everything it
+// lists.
+func playableSkipReason(r episodeexport.ClipResult, err error) string {
+	switch {
+	case err != nil:
+		return err.Error()
+	case r.Frames == 0:
+		return "no frame payload could be muxed"
+	case r.BFrames:
+		return "stream carries B slices, so its presentation order differs from the coded order index.jsonl records and the clip's timing would be wrong"
+	case r.UndecodedSliceHeaders > 0:
+		return fmt.Sprintf("%d slice header(s) could not be parsed, so whether the stream carries B slices is unknown and the clip's timing cannot be vouched for", r.UndecodedSliceHeaders)
+	case r.SyncSamples == 0:
+		return "clip would carry no random-access frame, so players cannot seek in it and many will not open it"
+	}
+	return ""
+}
+
+// isDerivedPlayable reports whether a manifest-relative path names a
+// seal-time derived camera remux, which sealFiles marks with FileRoleDerived.
+func isDerivedPlayable(rel string) bool {
+	dir, base := path.Split(rel)
+	return base == episodeexport.PlayableFileName && path.Dir(path.Clean(dir)) == "cameras"
+}

--- a/go/internal/agent/data/playable.go
+++ b/go/internal/agent/data/playable.go
@@ -81,6 +81,8 @@ func playableSkipReason(r episodeexport.ClipResult, err error) string {
 		return "stream carries B slices, so its presentation order differs from the coded order index.jsonl records and the clip's timing would be wrong"
 	case r.UndecodedSliceHeaders > 0:
 		return fmt.Sprintf("%d slice header(s) could not be parsed, so whether the stream carries B slices is unknown and the clip's timing cannot be vouched for", r.UndecodedSliceHeaders)
+	case r.ParameterSetChanges > 0:
+		return fmt.Sprintf("the stream's parameter sets change mid-episode (%d changed SPS/PPS unit(s), a producer restart), and the clip's single decoder configuration would misdecode every frame after the change", r.ParameterSetChanges)
 	case r.SyncSamples == 0:
 		return "clip would carry no random-access frame, so players cannot seek in it and many will not open it"
 	}

--- a/go/internal/agent/data/playable_test.go
+++ b/go/internal/agent/data/playable_test.go
@@ -1,0 +1,338 @@
+package data
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/episodeexport"
+)
+
+// The parameter sets are the ones a Jetson episode really carried, matching
+// the episodeexport package's own fixtures, so the seal-time mux is exercised
+// against the bitstream shape the device produces.
+const (
+	sealTestSPS = "6764001facb200a00b7602dc08081a94000003000400000300f23c60c920"
+	sealTestPPS = "68ebccb22c"
+)
+
+// Slice NAL units whose headers the muxer can and cannot parse. The seal only
+// keeps a clip whose timing it can vouch for, so the distinction is load
+// bearing: an IDR or P slice with a parseable header is publishable, a B
+// slice or an unparseable header is not.
+var (
+	parsedIDR     = append([]byte{0x65, 0x88}, make([]byte, 40)...) // slice_type 7 (I), parses
+	parsedPSlice  = append([]byte{0x41, 0xC0}, make([]byte, 30)...) // slice_type 0 (P), parses
+	parsedBSlice  = append([]byte{0x41, 0xA0}, make([]byte, 30)...) // slice_type 1 (B), parses
+	unparsedSlice = append([]byte{0x41}, make([]byte, 30)...)       // header is all zero bits, cannot parse
+)
+
+func annexB(nals ...[]byte) []byte {
+	var out []byte
+	for _, n := range nals {
+		out = append(out, 0, 0, 0, 1)
+		out = append(out, n...)
+	}
+	return out
+}
+
+// writeCameraSource lays one camera source into an active episode directory:
+// a single segment holding the given access units at irregular intervals, and
+// the index.jsonl that records where each frame's bytes landed.
+func writeCameraSource(t *testing.T, episodeDir, source string, accessUnits [][]byte) {
+	t.Helper()
+	sps, err := hex.DecodeString(sealTestSPS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pps, err := hex.DecodeString(sealTestPPS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(episodeDir, "cameras", source)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	segment := "cameras/" + source + "/segment-000001.h264"
+	// Irregular gaps on purpose: the remux must carry recorded timestamps,
+	// never a rate, and equal gaps could hide a muxer that assumed one.
+	gaps := []int64{0, 33_000_000, 95_000_000, 41_000_000, 62_000_000, 27_000_000}
+	var (
+		seg   []byte
+		index []byte
+		now   = int64(2_000_000_000)
+	)
+	for i, unit := range accessUnits {
+		payload := unit
+		if i == 0 {
+			payload = append(annexB(sps, pps), unit...)
+		}
+		now += gaps[i%len(gaps)]
+		line, err := json.Marshal(map[string]any{
+			"canonical_episode_nanos": now,
+			"segment":                 segment,
+			"byte_offset":             len(seg),
+			"byte_size":               len(payload),
+			"codec":                   "h264",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		seg = append(seg, payload...)
+		index = append(index, line...)
+		index = append(index, '\n')
+	}
+	if err := os.WriteFile(filepath.Join(dir, "segment-000001.h264"), seg, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "index.jsonl"), index, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func fileByPath(files []File, path string) (File, bool) {
+	for _, f := range files {
+		if f.Path == path {
+			return f, true
+		}
+	}
+	return File{}, false
+}
+
+func TestSealWritesPlayableClipListedInManifest(t *testing.T) {
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = m.Start(StartOptions{Sources: []string{"applications"}}); err != nil {
+		t.Fatal(err)
+	}
+	session, ok := m.ActiveSession(AdHocEpisodeKey)
+	if !ok {
+		t.Fatal("no active session")
+	}
+	writeCameraSource(t, session.Directory, "cam-front", [][]byte{
+		annexB(parsedIDR), annexB(parsedPSlice), annexB(parsedPSlice),
+	})
+	stopped, err := m.Stop(AdHocEpisodeKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stopped.State != "complete" {
+		t.Fatalf("state %q, want complete", stopped.State)
+	}
+	if len(stopped.PlayableNotes) != 0 {
+		t.Fatalf("clean mux left notes: %v", stopped.PlayableNotes)
+	}
+
+	rel := "cameras/cam-front/" + episodeexport.PlayableFileName
+	entry, ok := fileByPath(stopped.Files, rel)
+	if !ok {
+		t.Fatalf("manifest does not list %s: %+v", rel, stopped.Files)
+	}
+	if entry.Role != FileRoleDerived {
+		t.Errorf("derived clip role %q, want %q", entry.Role, FileRoleDerived)
+	}
+	if entry.Format != "mp4" || entry.MediaType != "video/mp4" {
+		t.Errorf("derived clip format %q media type %q, want mp4/video/mp4", entry.Format, entry.MediaType)
+	}
+	if entry.SourceID != "cam-front" {
+		t.Errorf("derived clip source %q, want cam-front", entry.SourceID)
+	}
+
+	// The listed size and SHA-256 must be the finished file's, so the
+	// transfer worker uploads it and commit-time verification covers it with
+	// no special casing.
+	onDisk := filepath.Join(m.root, stopped.ID, rel)
+	hash, size, err := checksum(onDisk)
+	if err != nil {
+		t.Fatalf("derived clip missing from sealed episode: %v", err)
+	}
+	if entry.SHA256 != hash || entry.Size != size {
+		t.Errorf("manifest entry (%d bytes, %s) does not match file (%d bytes, %s)", entry.Size, entry.SHA256, size, hash)
+	}
+	if size == 0 {
+		t.Error("derived clip is empty")
+	}
+
+	// The raw capture must still be listed, unmarked: only the remux is
+	// derived, and payload accounting keys on the raw files via the index.
+	for _, raw := range []string{"cameras/cam-front/segment-000001.h264", "cameras/cam-front/index.jsonl"} {
+		f, ok := fileByPath(stopped.Files, raw)
+		if !ok {
+			t.Fatalf("raw capture file %s missing from manifest", raw)
+		}
+		if f.Role != "" {
+			t.Errorf("raw capture file %s carries role %q, want none", raw, f.Role)
+		}
+	}
+
+	// Full verification passes with the derived file treated like any other
+	// listed file.
+	if _, failures, err := m.Inspect(stopped.ID, true); err != nil || len(failures) != 0 {
+		t.Fatalf("verification: err=%v failures=%v", err, failures)
+	}
+
+	// The derived clip counts against the episode's size, and so against the
+	// quota that size feeds.
+	infos, err := m.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var total int64
+	for _, f := range stopped.Files {
+		total += f.Size
+	}
+	if len(infos) != 1 || infos[0].SizeBytes != total {
+		t.Fatalf("episode size %d does not include every listed file (want %d)", infos[0].SizeBytes, total)
+	}
+	var withoutDerived int64
+	for _, f := range stopped.Files {
+		if f.Role != FileRoleDerived {
+			withoutDerived += f.Size
+		}
+	}
+	if withoutDerived >= total {
+		t.Error("derived clip contributed nothing to the episode size")
+	}
+}
+
+func TestSealRefusesClipItCannotVouchFor(t *testing.T) {
+	cases := []struct {
+		name       string
+		accessUnit []byte
+		wantNote   string
+	}{
+		{"b_slices", annexB(parsedBSlice), "B slices"},
+		{"unparsed_slice_header", annexB(unparsedSlice), "slice header"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := NewManager(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err = m.Start(StartOptions{Sources: []string{"applications"}}); err != nil {
+				t.Fatal(err)
+			}
+			session, ok := m.ActiveSession(AdHocEpisodeKey)
+			if !ok {
+				t.Fatal("no active session")
+			}
+			writeCameraSource(t, session.Directory, "cam-front", [][]byte{
+				annexB(parsedIDR), tc.accessUnit,
+			})
+			stopped, err := m.Stop(AdHocEpisodeKey)
+			if err != nil {
+				t.Fatalf("a refused mux must never fail the seal: %v", err)
+			}
+			if stopped.State != "complete" {
+				t.Fatalf("state %q, want complete", stopped.State)
+			}
+			rel := "cameras/cam-front/" + episodeexport.PlayableFileName
+			if _, ok := fileByPath(stopped.Files, rel); ok {
+				t.Errorf("manifest lists %s despite the refusal", rel)
+			}
+			if _, err := os.Stat(filepath.Join(m.root, stopped.ID, rel)); !os.IsNotExist(err) {
+				t.Errorf("refused clip left on disk (stat err %v)", err)
+			}
+			if len(stopped.PlayableNotes) != 1 || !strings.Contains(stopped.PlayableNotes[0], tc.wantNote) {
+				t.Errorf("notes %v do not name the refusal (%q)", stopped.PlayableNotes, tc.wantNote)
+			}
+			if !strings.Contains(stopped.PlayableNotes[0], rel+" not written") {
+				t.Errorf("note %q does not name the missing file", stopped.PlayableNotes[0])
+			}
+			if _, failures, err := m.Inspect(stopped.ID, true); err != nil || len(failures) != 0 {
+				t.Fatalf("verification: err=%v failures=%v", err, failures)
+			}
+		})
+	}
+}
+
+func TestSealRefusesClipWithoutRandomAccessFrame(t *testing.T) {
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = m.Start(StartOptions{Sources: []string{"applications"}}); err != nil {
+		t.Fatal(err)
+	}
+	session, ok := m.ActiveSession(AdHocEpisodeKey)
+	if !ok {
+		t.Fatal("no active session")
+	}
+	// Parameter sets but never an IDR: nothing a decoder can start on.
+	writeCameraSource(t, session.Directory, "cam-front", [][]byte{
+		annexB(parsedPSlice), annexB(parsedPSlice),
+	})
+	stopped, err := m.Stop(AdHocEpisodeKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rel := "cameras/cam-front/" + episodeexport.PlayableFileName
+	if _, ok := fileByPath(stopped.Files, rel); ok {
+		t.Errorf("manifest lists %s despite it having no sync sample", rel)
+	}
+	if len(stopped.PlayableNotes) != 1 || !strings.Contains(stopped.PlayableNotes[0], "random-access") {
+		t.Errorf("notes %v do not name the missing random-access frame", stopped.PlayableNotes)
+	}
+}
+
+func TestRecoverySealsPlayableClipToo(t *testing.T) {
+	root := t.TempDir()
+	m, err := NewManager(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := m.Start(StartOptions{Sources: []string{"applications"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeCameraSource(t, filepath.Join(root, started.ID+".partial"), "cam-front", [][]byte{
+		annexB(parsedIDR), annexB(parsedPSlice),
+	})
+	// A new manager over the same root recovers the abandoned partial.
+	m2, err := NewManager(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mf, failures, err := m2.Inspect(started.ID, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mf.State != "interrupted" {
+		t.Fatalf("state %q, want interrupted", mf.State)
+	}
+	if len(failures) != 0 {
+		t.Fatalf("verification failures: %v", failures)
+	}
+	rel := "cameras/cam-front/" + episodeexport.PlayableFileName
+	entry, ok := fileByPath(mf.Files, rel)
+	if !ok {
+		t.Fatalf("recovered manifest does not list %s", rel)
+	}
+	if entry.Role != FileRoleDerived {
+		t.Errorf("recovered clip role %q, want %q", entry.Role, FileRoleDerived)
+	}
+	if len(mf.PlayableNotes) != 0 {
+		t.Errorf("clean recovery mux left notes: %v", mf.PlayableNotes)
+	}
+}
+
+func TestIsDerivedPlayable(t *testing.T) {
+	for path, want := range map[string]bool{
+		"cameras/cam-front/playable.mp4":        true,
+		"cameras/cam-front/segment-000001.h264": false,
+		"playable.mp4":                          false,
+		"cameras/playable.mp4":                  false,
+		"audio/mic/playable.mp4":                false,
+		"cameras/cam/deeper/playable.mp4":       false,
+	} {
+		if got := isDerivedPlayable(path); got != want {
+			t.Errorf("isDerivedPlayable(%q) = %v, want %v", path, got, want)
+		}
+	}
+}

--- a/go/internal/agent/data/playable_test.go
+++ b/go/internal/agent/data/playable_test.go
@@ -252,6 +252,109 @@ func TestSealRefusesClipItCannotVouchFor(t *testing.T) {
 	}
 }
 
+// A producer restart mid-episode splices new SPS/PPS into the raw stream. The
+// derived clip carries exactly one decoder configuration, so such a stream
+// must seal without its playable.mp4 and say why; no other gate notices,
+// because every frame still copies cleanly.
+func TestSealRefusesClipAfterParameterSetChange(t *testing.T) {
+	// A second camera's parameter sets at 640x480, byte-different from the
+	// 1280x720 pair writeCameraSource lays down at the head of the stream.
+	sps2, err := hex.DecodeString("6742c01e8c8d40501e900f08846a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pps2, err := hex.DecodeString("68ce3c80")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = m.Start(StartOptions{Sources: []string{"applications"}}); err != nil {
+		t.Fatal(err)
+	}
+	session, ok := m.ActiveSession(AdHocEpisodeKey)
+	if !ok {
+		t.Fatal("no active session")
+	}
+	writeCameraSource(t, session.Directory, "cam-front", [][]byte{
+		annexB(parsedIDR), annexB(parsedPSlice),
+		annexB(sps2, pps2, parsedIDR), annexB(parsedPSlice),
+	})
+	stopped, err := m.Stop(AdHocEpisodeKey)
+	if err != nil {
+		t.Fatalf("a refused mux must never fail the seal: %v", err)
+	}
+	rel := "cameras/cam-front/" + episodeexport.PlayableFileName
+	if _, ok := fileByPath(stopped.Files, rel); ok {
+		t.Errorf("manifest lists %s despite the mid-episode parameter set change", rel)
+	}
+	if _, err := os.Stat(filepath.Join(m.root, stopped.ID, rel)); !os.IsNotExist(err) {
+		t.Errorf("refused clip left on disk (stat err %v)", err)
+	}
+	if len(stopped.PlayableNotes) != 1 || !strings.Contains(stopped.PlayableNotes[0], "parameter sets change") {
+		t.Errorf("notes %v do not name the parameter set change", stopped.PlayableNotes)
+	}
+}
+
+// The mux can fail on plain I/O (a full disk mid-write follows the same error
+// path: the write error surfaces, the .tmp is removed, and the seal goes on).
+// Provoke an open failure with an unwritable source directory and hold the
+// seal to its contract: the episode completes, the note says why, and nothing
+// half-written is listed or left behind.
+func TestSealSurvivesMuxWriteFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root, directory permissions do not deny writes")
+	}
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = m.Start(StartOptions{Sources: []string{"applications"}}); err != nil {
+		t.Fatal(err)
+	}
+	session, ok := m.ActiveSession(AdHocEpisodeKey)
+	if !ok {
+		t.Fatal("no active session")
+	}
+	writeCameraSource(t, session.Directory, "cam-front", [][]byte{
+		annexB(parsedIDR), annexB(parsedPSlice),
+	})
+	sourceDir := filepath.Join(session.Directory, "cameras", "cam-front")
+	if err := os.Chmod(sourceDir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(sourceDir, 0o755) })
+
+	stopped, err := m.Stop(AdHocEpisodeKey)
+	if err != nil {
+		t.Fatalf("a failed mux must never fail the seal: %v", err)
+	}
+	// The seal renamed the episode directory; restore write permission at its
+	// final location so the test's temporary tree can be removed.
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(m.root, stopped.ID, "cameras", "cam-front"), 0o755) })
+	if stopped.State != "complete" {
+		t.Fatalf("state %q, want complete", stopped.State)
+	}
+	rel := "cameras/cam-front/" + episodeexport.PlayableFileName
+	if _, ok := fileByPath(stopped.Files, rel); ok {
+		t.Errorf("manifest lists %s despite the mux failure", rel)
+	}
+	if len(stopped.PlayableNotes) != 1 || !strings.Contains(stopped.PlayableNotes[0], rel+" not written") {
+		t.Errorf("notes %v do not name the unwritten clip", stopped.PlayableNotes)
+	}
+	for _, f := range stopped.Files {
+		if strings.HasSuffix(f.Path, ".tmp") {
+			t.Errorf("manifest lists temporary file %s", f.Path)
+		}
+	}
+	// The raw capture sealed untouched and verifiable.
+	if _, failures, err := m.Inspect(stopped.ID, true); err != nil || len(failures) != 0 {
+		t.Fatalf("verification: err=%v failures=%v", err, failures)
+	}
+}
+
 func TestSealRefusesClipWithoutRandomAccessFrame(t *testing.T) {
 	m, err := NewManager(t.TempDir())
 	if err != nil {
@@ -319,6 +422,84 @@ func TestRecoverySealsPlayableClipToo(t *testing.T) {
 	}
 	if len(mf.PlayableNotes) != 0 {
 		t.Errorf("clean recovery mux left notes: %v", mf.PlayableNotes)
+	}
+}
+
+// A crash after the mux but before the manifest is written leaves a
+// playable.mp4 (and possibly its .tmp) in the partial directory whose frames
+// may postdate the index tail recovery truncates. Recovery must remux from
+// the truncated index, never reuse the stale clip, and clean up the .tmp.
+func TestRecoveryReplacesStaleClipAndTemporary(t *testing.T) {
+	root := t.TempDir()
+	m, err := NewManager(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := m.Start(StartOptions{Sources: []string{"applications"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	partial := filepath.Join(root, started.ID+".partial")
+	writeCameraSource(t, partial, "cam-front", [][]byte{
+		annexB(parsedIDR), annexB(parsedPSlice),
+	})
+	sourceDir := filepath.Join(partial, "cameras", "cam-front")
+	// The crash left a clip muxed from a longer index than the one recovery
+	// will keep, plus the temporary file of a mux cut off mid-write. Neither
+	// may survive as-is: the clip must be rebuilt from the truncated index,
+	// the temporary removed and never listed.
+	stale := []byte("stale clip muxed before the crash truncated the index")
+	if err := os.WriteFile(filepath.Join(sourceDir, episodeexport.PlayableFileName), stale, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, episodeexport.PlayableFileName+".tmp"), []byte("half a mux"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A partial trailing index line, the shape a crash leaves.
+	idx, err := os.OpenFile(filepath.Join(sourceDir, "index.jsonl"), os.O_WRONLY|os.O_APPEND, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := idx.WriteString(`{"canonical_episode_na`); err != nil {
+		t.Fatal(err)
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	m2, err := NewManager(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mf, failures, err := m2.Inspect(started.ID, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(failures) != 0 {
+		t.Fatalf("verification failures: %v", failures)
+	}
+	rel := "cameras/cam-front/" + episodeexport.PlayableFileName
+	entry, ok := fileByPath(mf.Files, rel)
+	if !ok {
+		t.Fatalf("recovered manifest does not list %s", rel)
+	}
+	onDisk, err := os.ReadFile(filepath.Join(root, started.ID, rel))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(onDisk) == string(stale) {
+		t.Error("recovery reused the stale pre-crash clip instead of remuxing")
+	}
+	if entry.Size == int64(len(stale)) {
+		t.Errorf("listed clip size %d matches the stale clip", entry.Size)
+	}
+	if _, err := os.Stat(filepath.Join(root, started.ID, rel+".tmp")); !os.IsNotExist(err) {
+		t.Errorf("stray mux temporary survived recovery (stat err %v)", err)
+	}
+	for _, f := range mf.Files {
+		if strings.HasSuffix(f.Path, ".tmp") {
+			t.Errorf("recovered manifest lists temporary file %s", f.Path)
+		}
 	}
 }
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
@@ -204,10 +204,37 @@ including the measured average, describes more than a fraction of the clip.
 The timing is already recorded. `cameras/<source>/index.jsonl` carries one line
 per kept frame with `canonical_episode_nanos`, the frame's position on the
 Episode's canonical `CLOCK_BOOTTIME` timeline, alongside the segment file, byte
-offset and `byte_size` of its payload. The `episode-playable` command remuxes
-those payload bytes into an MP4 that gives every frame the presentation time
-the index recorded for it, so the variable frame rate is represented honestly
-rather than averaged away:
+offset and `byte_size` of its payload. Remuxing those payload bytes into an MP4
+gives every frame the presentation time the index recorded for it, so the
+variable frame rate is represented honestly rather than averaged away.
+
+### Sealed Episodes already carry the MP4
+
+The agent runs that remux itself while sealing an Episode: each camera source
+gains a `cameras/<source>/playable.mp4` beside its raw capture, listed in the
+manifest with a size and SHA-256 like every other file and marked with
+`"role": "derived"`. Because it is listed, the transfer worker uploads it and
+commit-time verification covers it, so the bucket object plays directly in a
+browser (or after a plain download) with no conversion step. The derived file
+is never capture payload: model-input and payload-retention accounting
+resolve payloads through `index.jsonl` into the raw segments, and the raw
+files are kept byte-for-byte as before. The remux is a copy, not a transcode,
+so expect the clip to add roughly the size of the raw stream to the Episode;
+that overhead counts against the Episode's size for the local quota.
+
+Sealing never fails or waits on the remux. A source whose stream cannot become
+an honestly timed, seekable clip (B slices, slice headers the muxer cannot
+parse, no random-access frame) seals without its `playable.mp4`, and the
+manifest's `playable_notes` names the reason; a clip that had to omit frames
+whose bytes were missing gets a note too.
+
+### Converting older Episodes by hand
+
+The `episode-playable` command performs the same remux laptop-side, for
+Episodes sealed before the agent did it (or for a source whose seal-time mux
+was refused, where it will report the same warnings). When every camera source
+already carries a seal-time `playable.mp4` the command says so and converts
+nothing:
 
 ```sh
 # From the repository root.

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
@@ -224,7 +224,8 @@ that overhead counts against the Episode's size for the local quota.
 
 Sealing never fails or waits on the remux. A source whose stream cannot become
 an honestly timed, seekable clip (B slices, slice headers the muxer cannot
-parse, no random-access frame) seals without its `playable.mp4`, and the
+parse, parameter sets that change mid-stream after a producer restart, no
+random-access frame) seals without its `playable.mp4`, and the
 manifest's `playable_notes` names the reason; a clip that had to omit frames
 whose bytes were missing gets a note too.
 

--- a/go/internal/cli/assets/docs/wendy-data-platform-demo.md
+++ b/go/internal/cli/assets/docs/wendy-data-platform-demo.md
@@ -225,8 +225,13 @@ counts the predictions that named their inputs, and — per source — whether t
 episode retains payloads for all of the consumed samples or only the subset the
 capture policy kept.
 
-To watch the camera capture rather than join against it, convert the episode
-with `episode-playable`; the camera capture is a raw elementary stream with no
+To watch the camera capture rather than join against it, open the
+`cameras/<source>/playable.mp4` the episode already carries: the agent remuxes
+each camera source into a browser-playable MP4 while sealing, lists it in the
+manifest as a derived file, and uploads it with everything else. Only an
+episode sealed by an older agent (or a source whose seal-time remux was
+refused, see the manifest's `playable_notes`) still needs the laptop-side
+`episode-playable` conversion; the raw capture is an elementary stream with no
 container, so players otherwise invent a frame rate and the clip runs at the
 wrong speed. See "Playing back camera capture" in the `wendy data` command
 documentation.

--- a/go/internal/episodeexport/playable.go
+++ b/go/internal/episodeexport/playable.go
@@ -51,6 +51,7 @@
 package episodeexport
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -118,6 +119,16 @@ type ClipResult struct {
 	// pictures). A clip with none is not seekable and most players refuse it,
 	// so it must not be reported as a clean conversion on frame count alone.
 	SyncSamples int
+	// ParameterSetChanges counts in-band SPS or PPS units whose bytes differ
+	// from the first ones seen. Encoders repeat identical parameter sets
+	// before every IDR and those repeats are not counted; a change means the
+	// producer restarted mid-episode with new parameters (a different
+	// resolution, most likely). The MP4 written here carries exactly one
+	// decoder configuration, built from the first SPS/PPS, so every frame
+	// after a change would be decoded against the wrong parameters. A clip
+	// with this non-zero must not be presented as a faithful rendering of the
+	// capture.
+	ParameterSetChanges int
 	// MinInterval, MaxInterval and MeanInterval describe the spread of
 	// inter-frame intervals actually written. They differ from each other
 	// whenever the capture rate varied, which is the point.
@@ -204,6 +215,7 @@ func convertSource(episodeDir, sourceDir, indexPath, out string) (ClipResult, er
 	result.BFrames = stats.bFrames
 	result.UndecodedSliceHeaders = stats.undecodedSliceHeaders
 	result.SyncSamples = stats.syncSamples
+	result.ParameterSetChanges = stats.parameterSetChanges
 	result.MinInterval, result.MaxInterval, result.MeanInterval = stats.min, stats.max, stats.mean
 	if err := errors.Join(writeErr, closeErr); err != nil {
 		return result, err
@@ -283,6 +295,9 @@ type muxStats struct {
 	undecodedSliceHeaders int
 	// syncSamples counts written samples a decoder can start on.
 	syncSamples int
+	// parameterSetChanges counts SPS/PPS units that differ byte-wise from the
+	// first ones seen; identical repeats before each IDR are not counted.
+	parameterSetChanges int
 }
 
 // isBSlice reports whether a VCL NAL unit carries a B slice. It matters
@@ -378,11 +393,20 @@ func muxAnnexBToMP4(w *os.File, episodeDir string, frames []cameraIndexLine) (mu
 			case 7: // sequence parameter set, carried in avcC instead
 				if sps == nil {
 					sps = append([]byte(nil), nal...)
+				} else if !bytes.Equal(sps, nal) {
+					// The producer restarted with new parameters. avcC holds
+					// only the first SPS, so frames after this point would be
+					// decoded against the wrong configuration; count it so
+					// callers can refuse the clip instead of shipping one that
+					// silently misdecodes its tail.
+					stats.parameterSetChanges++
 				}
 				continue
 			case 8: // picture parameter set, carried in avcC instead
 				if pps == nil {
 					pps = append([]byte(nil), nal...)
+				} else if !bytes.Equal(pps, nal) {
+					stats.parameterSetChanges++
 				}
 				continue
 			case 9, 12: // access unit delimiter, filler

--- a/go/internal/episodeexport/playable.go
+++ b/go/internal/episodeexport/playable.go
@@ -36,11 +36,18 @@
 // external dependency to be missing: there is no ffmpeg, mkvmerge or PyAV in
 // the path from an episode to a playable file.
 //
-// The episode is read-only here. Output is written to a separate destination
+// The episode is read-only here. Convert writes into a separate destination
 // directory. The elementary stream and index are the checksummed archival
 // truth, and index.jsonl addresses frames by byte offset within the stream, so
 // rewriting it in place would break the join between a frame and the model
 // input recorded against it.
+//
+// ConvertSourceInPlace is the one sanctioned exception to that separation: the
+// agent calls it while sealing an episode, before the manifest's file list is
+// finalized, to add cameras/<source>/playable.mp4 beside the raw capture. The
+// raw segments and index are still only read; the derived clip is a new file
+// that the seal then checksums, lists and uploads like everything else, so a
+// browser can play the episode straight from the bucket.
 package episodeexport
 
 import (
@@ -62,6 +69,11 @@ import (
 // per-sample duration stays inside the 32-bit stts field for any gap short of
 // 71 minutes.
 const playableTimescale = 1_000_000
+
+// PlayableFileName is the derived MP4 written into a camera source directory
+// at seal time by ConvertSourceInPlace. The agent's manifest code and the
+// episode-playable command both key on this name.
+const PlayableFileName = "playable.mp4"
 
 // ClipResult reports what one camera source produced, in the numbers needed to
 // check the conversion without watching it.
@@ -148,6 +160,25 @@ func Convert(episodeDir, outDir string) ([]ClipResult, []error) {
 		results = append(results, result)
 	}
 	return results, errs
+}
+
+// ConvertSourceInPlace remuxes one camera source into
+// <sourceDir>/playable.mp4, reading timing from <sourceDir>/index.jsonl. It is
+// the seal-time variant of Convert: the caller is the agent finalizing an
+// episode, and the output lands inside the episode so the manifest can list
+// it. The raw segment files and the index are only ever read. The output is
+// written through a temporary file and renamed, so a crash mid-mux leaves no
+// half-written playable.mp4 behind (sealing ignores *.tmp files).
+//
+// A non-nil error means no playable.mp4 was left in place. A nil error means
+// the file exists, but the caller must still judge the ClipResult before
+// trusting it: BFrames, UndecodedSliceHeaders and SyncSamples report
+// conditions under which the clip's timing or seekability cannot be vouched
+// for, and Convert deliberately does not decide policy for its callers.
+func ConvertSourceInPlace(episodeDir, sourceDir string) (ClipResult, error) {
+	result, err := convertSource(episodeDir, sourceDir, filepath.Join(sourceDir, "index.jsonl"), filepath.Join(sourceDir, PlayableFileName))
+	result.Source = filepath.Base(sourceDir)
+	return result, err
 }
 
 func convertSource(episodeDir, sourceDir, indexPath, out string) (ClipResult, error) {

--- a/go/internal/episodeexport/playable_test.go
+++ b/go/internal/episodeexport/playable_test.go
@@ -285,6 +285,39 @@ func sum(b []byte) uint64 {
 	return h
 }
 
+func TestConvertSourceInPlaceWritesBesideRawCapture(t *testing.T) {
+	dir, _ := buildEpisode(t)
+	before := snapshot(t, dir)
+
+	result, err := ConvertSourceInPlace(dir, filepath.Join(dir, "cameras", "cam-a"))
+	if err != nil {
+		t.Fatalf("ConvertSourceInPlace: %v", err)
+	}
+	if result.Source != "cam-a" || result.Frames != 5 {
+		t.Errorf("got source %q with %d frames, want cam-a with 5", result.Source, result.Frames)
+	}
+	out := filepath.Join(dir, "cameras", "cam-a", PlayableFileName)
+	if result.Output != out {
+		t.Errorf("output %q, want %q", result.Output, out)
+	}
+	if _, err := os.Stat(out); err != nil {
+		t.Fatalf("no playable file in place: %v", err)
+	}
+	if _, err := os.Stat(out + ".tmp"); !os.IsNotExist(err) {
+		t.Errorf("temporary mux file left behind")
+	}
+
+	// Everything that existed before must be byte-identical: the raw stream
+	// and index are checksummed archival truth, and index.jsonl addresses
+	// frames by byte offset into the raw segments.
+	if err := os.Remove(out); err != nil {
+		t.Fatal(err)
+	}
+	if after := snapshot(t, dir); after != before {
+		t.Errorf("raw capture was modified:\nbefore %s\nafter  %s", before, after)
+	}
+}
+
 func TestConvertRejectsNonEpisodeDirectory(t *testing.T) {
 	_, errs := Convert(t.TempDir(), filepath.Join(t.TempDir(), "out"))
 	if len(errs) == 0 {

--- a/go/internal/episodeexport/playable_test.go
+++ b/go/internal/episodeexport/playable_test.go
@@ -184,6 +184,11 @@ func TestConvertRealShapes(t *testing.T) {
 	if a.MinInterval == a.MaxInterval {
 		t.Error("cam-a interval spread was flattened to a constant rate")
 	}
+	// Segment 2 re-inlines the same SPS/PPS before its keyframe, which is the
+	// normal encoder habit; identical repeats are not a parameter set change.
+	if a.ParameterSetChanges != 0 {
+		t.Errorf("cam-a reports %d parameter set changes for identical repeated SPS/PPS, want 0", a.ParameterSetChanges)
+	}
 
 	// A frame whose bytes are missing is reported and skipped, and a partial
 	// trailing line is counted as unusable, but the clip is still written.
@@ -315,6 +320,79 @@ func TestConvertSourceInPlaceWritesBesideRawCapture(t *testing.T) {
 	}
 	if after := snapshot(t, dir); after != before {
 		t.Errorf("raw capture was modified:\nbefore %s\nafter  %s", before, after)
+	}
+}
+
+// restartSPS and restartPPS are a second camera's parameter sets at 640x480,
+// the shape a producer restart splices into a running episode when it comes
+// back at a different resolution.
+const (
+	restartSPS = "6742c01e8c8d40501e900f08846a"
+	restartPPS = "68ce3c80"
+)
+
+// A producer restart mid-episode splices new parameter sets into the stream.
+// The MP4 written here carries exactly one decoder configuration (the first
+// SPS/PPS), so every frame after the change would decode against the wrong
+// parameters; the result must say so, because nothing else about the mux
+// fails: the frames all copy cleanly, slice headers parse, and sync samples
+// exist.
+func TestConvertSourceInPlaceFlagsParameterSetChange(t *testing.T) {
+	dir := t.TempDir()
+	sps1, pps1 := mustHex(t, realSPS), mustHex(t, realPPS)
+	sps2, pps2 := mustHex(t, restartSPS), mustHex(t, restartPPS)
+	if w, h, err := spsDimensions(sps2); err != nil || (w == 1280 && h == 720) {
+		t.Fatalf("restart SPS fixture must parse to a different resolution, got %dx%d err=%v", w, h, err)
+	}
+	idr := append([]byte{0x65, 0x88}, make([]byte, 40)...)
+	p := append([]byte{0x41, 0xC0}, make([]byte, 30)...)
+
+	cam := filepath.Join(dir, "cameras", "cam-a")
+	if err := os.MkdirAll(cam, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	type entry struct {
+		CanonicalEpisodeNanos int64  `json:"canonical_episode_nanos"`
+		Segment               string `json:"segment"`
+		ByteOffset            int64  `json:"byte_offset"`
+		ByteSize              int    `json:"byte_size"`
+		Codec                 string `json:"codec"`
+	}
+	units := [][]byte{
+		annexB(sps1, pps1, idr), annexB(p),
+		annexB(sps2, pps2, idr), annexB(p), // the producer came back at 640x480
+	}
+	var seg, index []byte
+	now := int64(1_000_000_000)
+	for _, u := range units {
+		line, err := json.Marshal(entry{now, "cameras/cam-a/segment-000001.h264", int64(len(seg)), len(u), "h264"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		index = append(index, line...)
+		index = append(index, '\n')
+		seg = append(seg, u...)
+		now += 33_000_000
+	}
+	if err := os.WriteFile(filepath.Join(cam, "segment-000001.h264"), seg, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cam, "index.jsonl"), index, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := ConvertSourceInPlace(dir, cam)
+	if err != nil {
+		t.Fatalf("ConvertSourceInPlace: %v", err)
+	}
+	if r.ParameterSetChanges != 2 {
+		t.Errorf("ParameterSetChanges = %d, want 2 (one changed SPS, one changed PPS)", r.ParameterSetChanges)
+	}
+	// The other gates must stay quiet: this failure mode is invisible to them,
+	// which is exactly why it needs its own counter.
+	if r.Frames != 4 || r.Skipped != 0 || r.BFrames || r.UndecodedSliceHeaders != 0 || r.SyncSamples == 0 {
+		t.Errorf("unexpected companion signals: frames %d skipped %d bframes %v undecoded %d sync %d",
+			r.Frames, r.Skipped, r.BFrames, r.UndecodedSliceHeaders, r.SyncSamples)
 	}
 }
 


### PR DESCRIPTION
## Problem

The Wendy Business Intelligence (BI) episodes browser will play episode video in a browser via signed Uniform Resource Locators (URLs) straight from the bucket. Browsers cannot play what episodes carry today: camera capture is a raw H.264 Annex-B elementary stream (`cameras/<source>/segment-NNNNNN.h264`) with no container and therefore no timing. An earlier decision kept the conversion laptop-side (`episode-playable`) for the demo; the browser-playback requirement reverses that decision deliberately.

## Cause

Nothing in the seal path produced a playable container, so the only playable form of an episode lived outside the episode, unlisted, unchecksummed, and never uploaded. The exact muxer needed already exists on the read side: `go/internal/episodeexport` remuxes the raw stream into a fragmentless MP4 whose per-sample durations come from `index.jsonl` `canonical_episode_nanos` (verified on hardware: 173/173 frames, 174 ns span error, plays in VLC and AVFoundation).

## Solution

Sealing an episode now runs that same remux per camera source, writing `cameras/<source>/playable.mp4` beside the raw capture before `sealFiles` walks the directory. Because it lands before the file list is sealed, the clip gets a size and SHA-256 manifest entry and the rest of the pipeline needs no change at all: `DataTransferWorker` uploads it because it is listed, cloud commit-time verification covers it for the same reason, `wendy data download` and `inspect` verify it like any other listed file, and the bucket object plays in a browser after a plain download.

- **Derived marking**: the entry carries `"role": "derived"` (`File.Role`, `FileRoleDerived`). A derived file is never capture payload; model-input and payload-retention accounting resolve payload bytes through `index.jsonl` into the raw segments, which stay byte-for-byte untouched, so the correlation join is unaffected. The manifest also gains `playable_notes`.
- **Failure honesty**: sealing never fails or waits on the mux. A source whose stream cannot become an honestly timed, seekable clip (B slices, slice headers the muxer cannot parse, no random-access frame, or an outright mux failure) seals without its `playable.mp4`, and `playable_notes` names the reason. A clip that omitted frames whose bytes were missing gets a note too. The gates are the hardened form of the warnings `episode-playable` prints (`BFrames`, `UndecodedSliceHeaders`, `SyncSamples`, `SkippedReason`).
- **Latency shape preserved**: sealing was already a synchronous pass over every episode byte (the checksum walk). The remux is a copy, not a transcode, so the seal gains one more read of the camera bytes, no external dependency, and no new failure mode.
- **Cost bound**: the clip is roughly the size of the raw stream it derives from (verbatim coded pictures plus container overhead). That counts against the episode's size through both the manifest total and the disk-usage walk `enforceQuota` performs.
- **Recovery**: interrupted `.partial` episodes derive the same clips when recovery seals them, after the truncated Javascript Object Notation Lines (JSONL) tails are cut.
- **CLI touch**: `episode-playable` detects an episode whose sources all carry a seal-time `playable.mp4`, says so, and converts nothing. It remains the path for episodes sealed by older agents.
- **Docs**: `docs/clients/wendy-cli/commands/data.md` and the data platform demo runbook now describe the sealed clip and demote the laptop-side conversion to older episodes.

## Verification

- `CC=/usr/bin/clang go build ./go/...` clean; `gofmt -l go/` empty; `go vet` clean on all touched packages.
- `go test ./go/internal/agent/data/... ./go/internal/episodeexport/... ./go/internal/agent/services/... ./go/internal/cli/commands/...` all pass.
- New unit tests: seal produces the MP4 with a matching manifest SHA-256, format `mp4`, role `derived`, source association, and full `Inspect(verify)` passing; B-slice, unparseable-header and no-sync-sample streams seal cleanly with no MP4 on disk, no manifest entry, and a note naming why; raw files stay unmarked and listed; the episode size (and therefore quota) includes the clip; recovery seals the clip too; `ConvertSourceInPlace` leaves the raw capture byte-identical and no `.tmp` behind.

### Hardware verification plan (no device installs done here)

1. Deploy the agent to a camera-bearing device and trigger a campaign episode (or `wendy data start`/`stop`).
2. `wendy data inspect <id>` on the device: expect `cameras/<source>/playable.mp4` listed with `"role": "derived"` and empty `playable_notes`.
3. Let the transfer worker upload, then confirm the cloud commit verified the episode (upload state `uploaded`).
4. Download the bucket object for `cameras/<source>/playable.mp4` with a plain HTTP GET (signed URL) and open it directly in a browser tab; confirm it plays and seeks, and that duration matches the episode span.
5. `wendy data download <id>` on a laptop: verification must pass, and `episode-playable` must report the episode already carries playable files.
