### PR TITLE
Campaign capture parameters win over a defaulted camera hub

### DIFF
--- a/go/internal/agent/services/data_camera_adapter.go
+++ b/go/internal/agent/services/data_camera_adapter.go
@@ -82,13 +82,27 @@ func (a *cameraDataAdapter) Start(ctx context.Context, session data.CaptureSessi
 			continue
 		}
 		capture, err := a.startOne(ctx, session, source, devID)
+		if errors.Is(err, errCameraHeldExplicitly) {
+			// Another consumer holds this camera at explicitly requested
+			// parameters that conflict with the campaign's. Refusing this one
+			// source, with the named error in its manifest entry, is the
+			// honest outcome: the episode continues with its other sources and
+			// the manifest says exactly who holds the camera and at what
+			// parameters, instead of recording a capture the campaign did not
+			// ask for.
+			group.refused = append(group.refused, data.CaptureResult{
+				SourceID:     source.ID,
+				SourceDetail: strings.TrimSpace(source.Detail + " (not captured: " + err.Error() + ")"),
+			})
+			continue
+		}
 		if err != nil {
 			_, _ = group.Stop(context.Background())
 			return nil, fmt.Errorf("%s: %w", source.ID, err)
 		}
 		group.captures = append(group.captures, capture)
 	}
-	if len(group.captures) == 0 {
+	if len(group.captures) == 0 && len(group.refused) == 0 {
 		return nil, nil
 	}
 	return group, nil
@@ -135,11 +149,15 @@ func (a *cameraDataAdapter) startOne(ctx context.Context, session data.CaptureSe
 		index.Close()
 		return nil, err
 	}
-	hub, subID, frames, achievedW, achievedH, achievedFPS, err := a.subscribeHub(ctx, src.key, req)
+	hub, subID, frames, achievedW, achievedH, achievedFPS, restarted, err := a.subscribeHub(ctx, src.key, req)
 	if err != nil {
 		index.Close()
 		mappings.Close()
 		return nil, err
+	}
+	if restarted {
+		notes = append(notes, fmt.Sprintf("campaign capture parameters took over the camera: restarted the producer, previously running at producer-default parameters for parameter-less subscribers, at the requested %s; those subscribers reattached to the new stream",
+			describeStreamParams(achievedW, achievedH, achievedFPS)))
 	}
 	if achievedW != req.GetWidth() || achievedH != req.GetHeight() || achievedFPS != req.GetFramerate() {
 		notes = append(notes, fmt.Sprintf("stream already active with different parameters; requested %s, capturing at %s",
@@ -147,7 +165,10 @@ func (a *cameraDataAdapter) startOne(ctx context.Context, session data.CaptureSe
 			describeStreamParams(achievedW, achievedH, achievedFPS)))
 	}
 	captureCtx, cancel := context.WithCancel(context.Background())
-	c := &cameraCapture{source: source, session: session, dir: dir, hub: hub, subID: subID, frames: frames, index: index, mappingFile: mappings, ctx: captureCtx, cancel: cancel, done: make(chan struct{}), ready: make(chan error, 1), mode: mode, interval: interval.Nanoseconds(), rateCap: rateCap, notes: notes, lastSnapshotIdx: -1}
+	rejoin := func(ctx context.Context) (*deviceHub, int, chan *videoFrame, error) {
+		return a.video.joinHub(ctx, src.key, &agentpb.StreamVideoRequest{DeviceId: devID})
+	}
+	c := &cameraCapture{source: source, session: session, dir: dir, hub: hub, subID: subID, frames: frames, rejoin: rejoin, index: index, mappingFile: mappings, ctx: captureCtx, cancel: cancel, done: make(chan struct{}), ready: make(chan error, 1), mode: mode, interval: interval.Nanoseconds(), rateCap: rateCap, notes: notes, lastSnapshotIdx: -1}
 	go c.run()
 	select {
 	case err := <-c.ready:
@@ -226,20 +247,27 @@ func describeStreamParams(w, h, fps uint32) string {
 	return size + " at default rate"
 }
 
-// subscribeHub joins the device's frame hub. When the hub already runs with
-// different stream parameters (for example a live dashboard viewer or a model
-// subscriber), the episode must not fail: fall back to subscribing at the
-// existing parameters and let the capture reconcile adapter-side, reporting
-// requested-vs-achieved. The retry-and-fall-back logic is shared with the model
-// subscribe path, which needs exactly the same behavior.
-func (a *cameraDataAdapter) subscribeHub(ctx context.Context, key string, req *agentpb.StreamVideoRequest) (*deviceHub, int, chan *videoFrame, uint32, uint32, uint32, error) {
-	return a.video.joinHubReportingParams(ctx, key, req)
+// subscribeHub joins the device's frame hub with episode capture's parameter
+// priority (see joinHubForCapture): explicit campaign parameters win over a
+// hub running at defaults for parameter-less subscribers (the producer is
+// restarted, reported via the restarted return), an explicit conflict with
+// another explicit-parameter consumer is a named error rather than a silent
+// downgrade, and a capture that asserts no parameters joins whatever runs and
+// reports requested-vs-achieved.
+func (a *cameraDataAdapter) subscribeHub(ctx context.Context, key string, req *agentpb.StreamVideoRequest) (*deviceHub, int, chan *videoFrame, uint32, uint32, uint32, bool, error) {
+	return a.video.joinHubForCapture(ctx, key, req)
 }
 
-type cameraCaptureGroup struct{ captures []*cameraCapture }
+type cameraCaptureGroup struct {
+	captures []*cameraCapture
+	// refused carries the manifest entries of sources this episode did not
+	// capture because another consumer held the camera at conflicting explicit
+	// parameters. Delivered at Stop like every other capture result.
+	refused []data.CaptureResult
+}
 
 func (g *cameraCaptureGroup) Stop(ctx context.Context) ([]data.CaptureResult, error) {
-	var results []data.CaptureResult
+	results := append([]data.CaptureResult(nil), g.refused...)
 	var errs []error
 	for i := len(g.captures) - 1; i >= 0; i-- {
 		r, err := g.captures[i].Stop(ctx)
@@ -252,12 +280,23 @@ func (g *cameraCaptureGroup) Stop(ctx context.Context) ([]data.CaptureResult, er
 }
 
 type cameraCapture struct {
-	source             data.Source
-	session            data.CaptureSession
-	dir                string
-	hub                *deviceHub
-	subID              int
-	frames             chan *videoFrame
+	source  data.Source
+	session data.CaptureSession
+	dir     string
+	hub     *deviceHub
+	subID   int
+	frames  chan *videoFrame
+	// rejoin resubscribes to the device's hub, asserting no parameters. A
+	// capture that itself asserted none is a parameter-less subscriber, so
+	// when a concurrent episode's explicit campaign parameters restart the
+	// producer (takeOverDefaultedHub) this capture reattaches to the restarted
+	// stream instead of ending. A capture with explicit parameters never
+	// observes such a restart: its own explicit subscription refuses the
+	// takeover. Nil only in unit tests that drive a bare hub.
+	rejoin func(ctx context.Context) (*deviceHub, int, chan *videoFrame, error)
+	// carriedDrops accumulates subscriber-channel drops from hub
+	// subscriptions this capture already left when reattaching.
+	carriedDrops       uint64
 	index, mappingFile *os.File
 	segment            *os.File
 	segmentRel         string
@@ -356,7 +395,7 @@ func (c *cameraCapture) run() {
 			c.result.ClockDomain = "GSTREAMER_PIPE/AGENT_RECEIPT"
 			c.notes = append([]string{"pipeline PTS unavailable; canonical time uses bounded agent receipt"}, c.notes...)
 		}
-		subscriberDrops := c.hub.unsubscribe(c.subID)
+		subscriberDrops := c.hub.unsubscribe(c.subID) + c.carriedDrops
 		end := int64(0)
 		if _, receipt, _, err := c.receiptNow(); err == nil {
 			end = receipt
@@ -398,10 +437,20 @@ func (c *cameraCapture) run() {
 			return
 		case frame, ok := <-c.frames:
 			if !ok {
-				c.runErr = c.hub.terminalErr()
-				if c.runErr == nil {
-					c.runErr = errors.New("camera producer stopped")
+				if err := c.hub.terminalErr(); err != nil {
+					c.runErr = err
+					c.signalReady(err)
+					return
 				}
+				if c.rejoin != nil && c.hub.wasRestarted() {
+					if err := c.reattachAfterRestart(); err != nil {
+						c.runErr = err
+						c.signalReady(err)
+						return
+					}
+					continue
+				}
+				c.runErr = errors.New("camera producer stopped")
 				c.signalReady(c.runErr)
 				return
 			}
@@ -415,6 +464,37 @@ func (c *cameraCapture) run() {
 			c.signalReady(nil)
 		}
 	}
+}
+
+// reattachAfterRestart rejoins the device's hub after an explicit-parameter
+// capture takeover replaced the producer this parameter-less capture was
+// consuming. The old stream has ended; the new one must not be spliced into
+// the current segment, because a segment holds one sequence parameter set and
+// downstream reads it as one timeline. Closing the segment forces the next
+// write through ensureSegment's random-access gate
+// (errAwaitCameraRandomAccess), so the new stream starts a fresh,
+// independently decodable segment. Driver sequence numbers and access-unit
+// alignment are properties of the producer, so both classifications reset.
+func (c *cameraCapture) reattachAfterRestart() error {
+	c.carriedDrops += c.hub.unsubscribe(c.subID)
+	hub, subID, frames, err := c.rejoin(c.ctx)
+	if err != nil {
+		return err
+	}
+	c.hub, c.subID, c.frames = hub, subID, frames
+	if c.segment != nil {
+		if err := c.segment.Sync(); err != nil {
+			return err
+		}
+		if err := c.segment.Close(); err != nil {
+			return err
+		}
+		c.segment = nil
+	}
+	c.haveSequence = false
+	c.alignmentKnown = false
+	c.notes = append(c.notes, "camera producer was restarted at another episode's explicit capture parameters; this parameter-less capture reattached and continues in a new segment on the new stream")
+	return nil
 }
 
 // handleFrame dispatches one hub frame to the active capture mode.

--- a/go/internal/agent/services/data_camera_adapter_test.go
+++ b/go/internal/agent/services/data_camera_adapter_test.go
@@ -383,21 +383,34 @@ func TestSnapshotSkipsTruncatedFrameOnAlignedTransport(t *testing.T) {
 	}
 }
 
-func TestHubCollisionFallsBackToExistingParameters(t *testing.T) {
-	video := NewVideoService(context.Background(), zap.NewNop())
+// newExplicitlyHeldHub builds a hub as a dashboard viewer's explicit
+// 1920x1080@30 StreamVideo request would, registered under /dev/video0.
+func newExplicitlyHeldHub(t *testing.T, video *VideoService) (hub *deviceHub, viewerID int, cancel context.CancelFunc) {
+	t.Helper()
 	hctx, hcancel := context.WithCancel(context.Background())
-	existing := &deviceHub{subs: make(map[int]chan *videoFrame), subDrops: make(map[int]uint64), ctx: hctx, cancel: hcancel, done: make(chan struct{}), width: 1920, height: 1080, framerate: 30}
-	viewerID, _, err := existing.subscribe()
+	hub = &deviceHub{subs: make(map[int]chan *videoFrame), subDrops: make(map[int]uint64), ctx: hctx, cancel: hcancel, done: make(chan struct{}), width: 1920, height: 1080, framerate: 30}
+	viewerID, _, err := hub.subscribeAs(hubHolderStreamClient)
 	if err != nil {
 		t.Fatal(err)
 	}
-	video.hubs["/dev/video0"] = existing
+	video.hubs["/dev/video0"] = hub
+	return hub, viewerID, hcancel
+}
+
+// A capture that asserts no parameters keeps the old fallback: it joins the
+// running hub at whatever parameters it has and reports them as achieved.
+func TestParameterlessCaptureFallsBackToExistingParameters(t *testing.T) {
+	video := NewVideoService(context.Background(), zap.NewNop())
+	existing, viewerID, _ := newExplicitlyHeldHub(t, video)
 	adapter := &cameraDataAdapter{video: video}
 
-	req := &agentpb.StreamVideoRequest{DeviceId: 0, Width: 1280, Height: 720, Framerate: 15}
-	hub, id, ch, w, h, fps, err := adapter.subscribeHub(context.Background(), "/dev/video0", req)
+	req := &agentpb.StreamVideoRequest{DeviceId: 0}
+	hub, id, ch, w, h, fps, restarted, err := adapter.subscribeHub(context.Background(), "/dev/video0", req)
 	if err != nil {
 		t.Fatalf("collision failed the episode: %v", err)
+	}
+	if restarted {
+		t.Fatal("a parameter-less capture must never restart a running producer")
 	}
 	if hub != existing || ch == nil {
 		t.Fatal("did not join the existing hub")
@@ -409,16 +422,37 @@ func TestHubCollisionFallsBackToExistingParameters(t *testing.T) {
 	existing.unsubscribe(viewerID)
 }
 
+// A capture with explicit campaign parameters conflicting with a hub held at
+// another consumer's explicit parameters is refused by name, never downgraded.
+func TestExplicitCaptureRefusedAgainstExplicitlyHeldHub(t *testing.T) {
+	video := NewVideoService(context.Background(), zap.NewNop())
+	existing, viewerID, _ := newExplicitlyHeldHub(t, video)
+	defer existing.unsubscribe(viewerID)
+	adapter := &cameraDataAdapter{video: video}
+
+	req := &agentpb.StreamVideoRequest{DeviceId: 0, Width: 1280, Height: 720, Framerate: 15}
+	_, _, _, _, _, _, _, err := adapter.subscribeHub(context.Background(), "/dev/video0", req)
+	if !errors.Is(err, errCameraHeldExplicitly) {
+		t.Fatalf("expected errCameraHeldExplicitly, got %v", err)
+	}
+	for _, want := range []string{hubHolderStreamClient, "1920x1080 at 30 fps", "1280x720 at 15 fps"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal %q does not name %q", err.Error(), want)
+		}
+	}
+	if existing.wasRestarted() {
+		t.Fatal("refused takeover must not restart the held hub")
+	}
+}
+
+// A parameter-less capture joining a hub at someone else's parameters still
+// records requested-versus-achieved in the manifest. The rate cap here (10 Hz)
+// is deliberately below the smallest source framerate, so the request asserts
+// nothing at the source and the cap is enforced adapter-side.
 func TestStartOneRecordsRequestedVersusAchievedOnCollision(t *testing.T) {
 	video := NewVideoService(context.Background(), zap.NewNop())
-	hctx, hcancel := context.WithCancel(context.Background())
-	existing := &deviceHub{subs: make(map[int]chan *videoFrame), subDrops: make(map[int]uint64), ctx: hctx, cancel: hcancel, done: make(chan struct{}), width: 1920, height: 1080, framerate: 30}
-	viewerID, _, err := existing.subscribe()
-	if err != nil {
-		t.Fatal(err)
-	}
+	existing, viewerID, _ := newExplicitlyHeldHub(t, video)
 	defer existing.unsubscribe(viewerID)
-	video.hubs["/dev/video0"] = existing
 	adapter := &cameraDataAdapter{video: video}
 
 	stop := make(chan struct{})
@@ -439,7 +473,7 @@ func TestStartOneRecordsRequestedVersusAchievedOnCollision(t *testing.T) {
 		t.Fatal(err)
 	}
 	session := data.CaptureSession{Directory: t.TempDir(), RequestBootNanos: origin}
-	source := data.Source{ID: "v4l2:/dev/video0", Kind: "camera", Capture: &data.SourceCapture{Rate: 15, MaxResolution: "1280x720"}}
+	source := data.Source{ID: "v4l2:/dev/video0", Kind: "camera", Capture: &data.SourceCapture{Rate: 10}}
 	capture, err := adapter.startOne(context.Background(), session, source, 0)
 	if err != nil {
 		t.Fatal(err)
@@ -455,11 +489,51 @@ func TestStartOneRecordsRequestedVersusAchievedOnCollision(t *testing.T) {
 	if !strings.Contains(detail, "capturing at 1920x1080 at 30 fps") || !strings.Contains(detail, "requested") {
 		t.Fatalf("requested-vs-achieved resolution not recorded: %q", detail)
 	}
-	if !strings.Contains(detail, "rate cap 15 Hz") {
+	if !strings.Contains(detail, "rate cap 10 Hz") {
 		t.Fatalf("rate cap note not recorded: %q", detail)
 	}
 	if results[0].Count == 0 {
 		t.Fatal("no frames captured through the existing hub")
+	}
+}
+
+// A refused camera source must not fail the episode: Start continues, and the
+// refusal is delivered at Stop as that source's manifest entry, naming who
+// holds the camera and at what parameters.
+func TestStartRecordsRefusalAndContinuesEpisode(t *testing.T) {
+	video := NewVideoService(context.Background(), zap.NewNop())
+	existing, viewerID, _ := newExplicitlyHeldHub(t, video)
+	defer existing.unsubscribe(viewerID)
+	adapter := &cameraDataAdapter{video: video}
+
+	_, origin, _, err := data.CaptureReceipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	session := data.CaptureSession{Directory: t.TempDir(), RequestBootNanos: origin}
+	source := data.Source{ID: "v4l2:/dev/video0", Kind: "camera", Detail: "USB Cam", Capture: &data.SourceCapture{Rate: 15, MaxResolution: "1280x720"}}
+	capture, err := adapter.Start(context.Background(), session, []data.Source{source})
+	if err != nil {
+		t.Fatalf("a refused camera source failed the whole episode: %v", err)
+	}
+	if capture == nil {
+		t.Fatal("refusal produced no capture group, so the manifest would never see the refusal note")
+	}
+	results, err := capture.Stop(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].SourceID != "v4l2:/dev/video0" {
+		t.Fatalf("results = %+v", results)
+	}
+	detail := results[0].SourceDetail
+	for _, want := range []string{"not captured", hubHolderStreamClient, "1920x1080 at 30 fps", "1280x720 at 15 fps"} {
+		if !strings.Contains(detail, want) {
+			t.Errorf("refusal detail %q does not name %q", detail, want)
+		}
+	}
+	if results[0].Count != 0 {
+		t.Fatalf("refused source claims %d captured frames", results[0].Count)
 	}
 }
 

--- a/go/internal/agent/services/hub_loopback_pump.go
+++ b/go/internal/agent/services/hub_loopback_pump.go
@@ -165,12 +165,17 @@ func (p *hubLoopbackPump) Run(ctx context.Context, svc *VideoService, src videoS
 	}()
 
 	awaitRandomAccess := false
+	// carried accumulates losses the previous subscription could not report on
+	// a binding of its own: frames the hub dropped after the last written
+	// frame, plus frames the starting gate skipped. The first binding on the
+	// replacement hub reports them, so the restart leaves no loss unreported.
+	var carried uint64
 	for {
 		hub, subID, frames, err := svc.joinHub(ctx, src.key, &agentpb.StreamVideoRequest{DeviceId: devID})
 		if err != nil {
 			return fmt.Errorf("joining producer hub for %s: %w", p.sourceID, err)
 		}
-		err = p.pumpFrom(ctx, hub, subID, frames, writer, awaitRandomAccess)
+		carried, err = p.pumpFrom(ctx, hub, subID, frames, writer, awaitRandomAccess, carried)
 		hub.unsubscribe(subID)
 		if errors.Is(err, errLoopbackHubRestarted) {
 			p.logger.Info("two-plane: producer restarted by episode capture; rejoining the replacement hub",
@@ -185,15 +190,21 @@ func (p *hubLoopbackPump) Run(ctx context.Context, svc *VideoService, src videoS
 // pump is the frame loop, split out from Run so tests can drive it with a fake
 // hub subscription and a fake writer without any device or kernel module.
 func (p *hubLoopbackPump) pump(ctx context.Context, hub *deviceHub, subID int, frames <-chan *videoFrame, writer loopbackFrameWriter) error {
-	return p.pumpFrom(ctx, hub, subID, frames, writer, false)
+	_, err := p.pumpFrom(ctx, hub, subID, frames, writer, false, 0)
+	return err
 }
 
-// pumpFrom is pump with an explicit starting gate: after a capture takeover
-// the rejoined stream must begin on a random-access unit, so the node's new
-// stream starts decodable. Frames skipped by the gate never reach the node and
-// record no binding; the next written frame's HubDropsBefore carries them, the
-// same way it carries hub-side drops, so no loss goes unreported.
-func (p *hubLoopbackPump) pumpFrom(ctx context.Context, hub *deviceHub, subID int, frames <-chan *videoFrame, writer loopbackFrameWriter, awaitRandomAccess bool) error {
+// pumpFrom is pump with an explicit starting gate and a carried loss count.
+// After a capture takeover the rejoined stream must begin on a random-access
+// unit, so the node's new stream starts decodable. Frames skipped by the gate
+// never reach the node and record no binding; the next written frame's
+// HubDropsBefore carries them, the same way it carries hub-side drops, so no
+// loss goes unreported. carried seeds that count with losses inherited from a
+// subscription the pump already left (see Run); the value returned alongside
+// errLoopbackHubRestarted hands the still-unreported total back for the next
+// subscription, including hub drops that accrued after the last written frame.
+// On every other return the count is meaningless and returned as zero.
+func (p *hubLoopbackPump) pumpFrom(ctx context.Context, hub *deviceHub, subID int, frames <-chan *videoFrame, writer loopbackFrameWriter, awaitRandomAccess bool, carried uint64) (uint64, error) {
 	// lastDrops is the hub's running drop total for this subscriber as of the
 	// previously WRITTEN frame, so each binding reports the drops since it. This
 	// is drop case 1 from hub_loopback_binding.go: those samples never reach the
@@ -214,23 +225,28 @@ func (p *hubLoopbackPump) pumpFrom(ctx context.Context, hub *deviceHub, subID in
 	// the frame at broadcast, which is a change to shared hub behaviour that the
 	// gRPC sensor path and episode capture would also have to absorb.
 	var lastDrops uint64
-	// gatedSkips counts frames the starting gate skipped after a rejoin. They
-	// never reached the node, so like hub-side drops they are reported on the
-	// next frame that did.
-	var gatedSkips uint64
+	// unreported counts losses no binding has reported yet: the count carried
+	// in from a previous subscription, plus frames the starting gate skipped
+	// after a rejoin. None of them reached the node, so like hub-side drops
+	// they are reported on the next frame that did.
+	unreported := carried
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return 0, ctx.Err()
 		case frame, ok := <-frames:
 			if !ok {
 				if err := hub.terminalErr(); err != nil {
-					return err
+					return 0, err
 				}
 				if hub.wasRestarted() {
-					return errLoopbackHubRestarted
+					// Hand back everything still unreported, including hub
+					// drops since the last written frame: this subscription
+					// will never write another binding, so they must ride on
+					// the replacement's first one.
+					return unreported + hub.drops(subID) - lastDrops, errLoopbackHubRestarted
 				}
-				return nil
+				return 0, nil
 			}
 			if bindable, reason := frameBindableToLoopback(frame); !bindable {
 				// Fail closed rather than writing something the sequence cannot
@@ -241,7 +257,7 @@ func (p *hubLoopbackPump) pumpFrom(ctx context.Context, hub *deviceHub, subID in
 					zap.String("source", p.sourceID),
 					zap.String("node", p.nodePath),
 					zap.String("reason", reason))
-				return fmt.Errorf("source %s: %s", p.sourceID, reason)
+				return 0, fmt.Errorf("source %s: %s", p.sourceID, reason)
 			}
 
 			if awaitRandomAccess {
@@ -249,14 +265,14 @@ func (p *hubLoopbackPump) pumpFrom(ctx context.Context, hub *deviceHub, subID in
 				// already guaranteed a whole H.264 access unit, so this only asks
 				// whether it is a random-access one.
 				if _, randomAccess := frameRandomAccess(frame); !randomAccess {
-					gatedSkips++
+					unreported++
 					continue
 				}
 				awaitRandomAccess = false
 			}
 
 			drops := hub.drops(subID)
-			delta := drops - lastDrops + gatedSkips
+			delta := drops - lastDrops + unreported
 
 			seq, err := writer.WriteFrame(frame.data)
 			if err != nil {
@@ -272,7 +288,7 @@ func (p *hubLoopbackPump) pumpFrom(ctx context.Context, hub *deviceHub, subID in
 				continue
 			}
 			lastDrops = drops
-			gatedSkips = 0
+			unreported = 0
 
 			binding := loopbackBinding{
 				LoopbackSequence: seq,

--- a/go/internal/agent/services/hub_loopback_pump.go
+++ b/go/internal/agent/services/hub_loopback_pump.go
@@ -130,6 +130,11 @@ func (p *hubLoopbackPump) publishIdentity(b loopbackBinding) {
 // sequence, and so tests can assert what was recorded.
 func (p *hubLoopbackPump) Bindings() *loopbackBindingTable { return p.bindings }
 
+// errLoopbackHubRestarted is pump's internal signal that the hub it was
+// consuming was torn down by an episode-capture takeover, so Run should rejoin
+// the replacement hub rather than stop the data plane.
+var errLoopbackHubRestarted = errors.New("producer hub restarted by episode capture")
+
 // Run joins the hub for src and pumps frames to the node until ctx is done or
 // the producer stops.
 //
@@ -138,6 +143,15 @@ func (p *hubLoopbackPump) Bindings() *loopbackBindingTable { return p.bindings }
 // running stream away from a viewer or from episode capture. An empty request
 // also matches the parameters episode capture uses by default, so the common
 // case joins the one existing hub rather than forcing a second producer.
+//
+// The reverse direction is allowed: episode capture with explicit campaign
+// parameters may restart a producer this pump joined at defaults. The pump is
+// a parameter-less subscriber like any other, so it survives the restart by
+// rejoining the replacement hub: the stream it was writing to the node ends
+// and a new one begins on a random-access unit, never a mid-stream splice of
+// different sequence parameter sets into one timeline. The node itself carries
+// its picture size in the bitstream's own parameter sets (see
+// hub_loopback_writer.go), so the writer stays open across the restart.
 func (p *hubLoopbackPump) Run(ctx context.Context, svc *VideoService, src videoSource, devID uint32) error {
 	writer, err := openLoopbackFrameWriter(p.nodePath)
 	if err != nil {
@@ -150,18 +164,36 @@ func (p *hubLoopbackPump) Run(ctx context.Context, svc *VideoService, src videoS
 		}
 	}()
 
-	hub, subID, frames, err := svc.joinHub(ctx, src.key, &agentpb.StreamVideoRequest{DeviceId: devID})
-	if err != nil {
-		return fmt.Errorf("joining producer hub for %s: %w", p.sourceID, err)
+	awaitRandomAccess := false
+	for {
+		hub, subID, frames, err := svc.joinHub(ctx, src.key, &agentpb.StreamVideoRequest{DeviceId: devID})
+		if err != nil {
+			return fmt.Errorf("joining producer hub for %s: %w", p.sourceID, err)
+		}
+		err = p.pumpFrom(ctx, hub, subID, frames, writer, awaitRandomAccess)
+		hub.unsubscribe(subID)
+		if errors.Is(err, errLoopbackHubRestarted) {
+			p.logger.Info("two-plane: producer restarted by episode capture; rejoining the replacement hub",
+				zap.String("source", p.sourceID), zap.String("node", p.nodePath))
+			awaitRandomAccess = true
+			continue
+		}
+		return err
 	}
-	defer hub.unsubscribe(subID)
-
-	return p.pump(ctx, hub, subID, frames, writer)
 }
 
 // pump is the frame loop, split out from Run so tests can drive it with a fake
 // hub subscription and a fake writer without any device or kernel module.
 func (p *hubLoopbackPump) pump(ctx context.Context, hub *deviceHub, subID int, frames <-chan *videoFrame, writer loopbackFrameWriter) error {
+	return p.pumpFrom(ctx, hub, subID, frames, writer, false)
+}
+
+// pumpFrom is pump with an explicit starting gate: after a capture takeover
+// the rejoined stream must begin on a random-access unit, so the node's new
+// stream starts decodable. Frames skipped by the gate never reach the node and
+// record no binding; the next written frame's HubDropsBefore carries them, the
+// same way it carries hub-side drops, so no loss goes unreported.
+func (p *hubLoopbackPump) pumpFrom(ctx context.Context, hub *deviceHub, subID int, frames <-chan *videoFrame, writer loopbackFrameWriter, awaitRandomAccess bool) error {
 	// lastDrops is the hub's running drop total for this subscriber as of the
 	// previously WRITTEN frame, so each binding reports the drops since it. This
 	// is drop case 1 from hub_loopback_binding.go: those samples never reach the
@@ -182,6 +214,10 @@ func (p *hubLoopbackPump) pump(ctx context.Context, hub *deviceHub, subID int, f
 	// the frame at broadcast, which is a change to shared hub behaviour that the
 	// gRPC sensor path and episode capture would also have to absorb.
 	var lastDrops uint64
+	// gatedSkips counts frames the starting gate skipped after a rejoin. They
+	// never reached the node, so like hub-side drops they are reported on the
+	// next frame that did.
+	var gatedSkips uint64
 	for {
 		select {
 		case <-ctx.Done():
@@ -190,6 +226,9 @@ func (p *hubLoopbackPump) pump(ctx context.Context, hub *deviceHub, subID int, f
 			if !ok {
 				if err := hub.terminalErr(); err != nil {
 					return err
+				}
+				if hub.wasRestarted() {
+					return errLoopbackHubRestarted
 				}
 				return nil
 			}
@@ -205,8 +244,19 @@ func (p *hubLoopbackPump) pump(ctx context.Context, hub *deviceHub, subID int, f
 				return fmt.Errorf("source %s: %s", p.sourceID, reason)
 			}
 
+			if awaitRandomAccess {
+				// The rejoined stream must begin decodable. frameBindableToLoopback
+				// already guaranteed a whole H.264 access unit, so this only asks
+				// whether it is a random-access one.
+				if _, randomAccess := frameRandomAccess(frame); !randomAccess {
+					gatedSkips++
+					continue
+				}
+				awaitRandomAccess = false
+			}
+
 			drops := hub.drops(subID)
-			delta := drops - lastDrops
+			delta := drops - lastDrops + gatedSkips
 
 			seq, err := writer.WriteFrame(frame.data)
 			if err != nil {
@@ -222,6 +272,7 @@ func (p *hubLoopbackPump) pump(ctx context.Context, hub *deviceHub, subID int, f
 				continue
 			}
 			lastDrops = drops
+			gatedSkips = 0
 
 			binding := loopbackBinding{
 				LoopbackSequence: seq,

--- a/go/internal/agent/services/hub_loopback_pump_test.go
+++ b/go/internal/agent/services/hub_loopback_pump_test.go
@@ -373,7 +373,7 @@ func TestPumpGatesRejoinedStreamToRandomAccess(t *testing.T) {
 	frames <- rau
 	close(frames)
 
-	if err := pump.pumpFrom(context.Background(), hub, subID, frames, writer, true); err != nil {
+	if _, err := pump.pumpFrom(context.Background(), hub, subID, frames, writer, true, 0); err != nil {
 		t.Fatalf("pumpFrom: %v", err)
 	}
 	if len(writer.writes) != 1 {
@@ -457,5 +457,52 @@ func mustRAUVideoFrame(_ uint64) *videoFrame {
 		data:      append([]byte(nil), testRAUFrame...),
 		codec:     agentpb.VideoCodec_VIDEO_CODEC_H264,
 		auAligned: true,
+	}
+}
+
+// TestPumpReturnsUnreportedLossesOnRestart: when the hub is torn down by a
+// capture takeover, this subscription will never write another binding, so
+// everything still unreported (the carried count plus hub drops since the last
+// written frame) must be handed back for the replacement subscription's first
+// binding.
+func TestPumpReturnsUnreportedLossesOnRestart(t *testing.T) {
+	hub, subID, frames := newPumpTestHub(t)
+	writer := newFakeLoopbackWriter(0)
+	pump := newHubLoopbackPump(zap.NewNop(), "v4l2:/dev/video0", "/dev/video200")
+
+	hub.mu.Lock()
+	hub.subDrops[subID] = 3
+	hub.restarted = true
+	hub.mu.Unlock()
+	close(frames)
+
+	carried, err := pump.pumpFrom(context.Background(), hub, subID, frames, writer, false, 2)
+	if !errors.Is(err, errLoopbackHubRestarted) {
+		t.Fatalf("pumpFrom returned %v, want errLoopbackHubRestarted", err)
+	}
+	if carried != 5 {
+		t.Fatalf("carried = %d, want 5 (2 carried in + 3 hub drops never reported)", carried)
+	}
+}
+
+// TestPumpReportsCarriedLossesOnFirstBinding: losses inherited from a previous
+// subscription ride on the first binding the new subscription writes.
+func TestPumpReportsCarriedLossesOnFirstBinding(t *testing.T) {
+	hub, subID, frames := newPumpTestHub(t)
+	writer := newFakeLoopbackWriter(50)
+	pump := newHubLoopbackPump(zap.NewNop(), "v4l2:/dev/video0", "/dev/video200")
+
+	frames <- bindableFrame(9, 900, 5)
+	close(frames)
+
+	if _, err := pump.pumpFrom(context.Background(), hub, subID, frames, writer, false, 4); err != nil {
+		t.Fatalf("pumpFrom: %v", err)
+	}
+	binding, ok := pump.Bindings().Lookup(50)
+	if !ok {
+		t.Fatal("no binding recorded")
+	}
+	if binding.HubDropsBefore != 4 {
+		t.Fatalf("HubDropsBefore = %d, want the 4 carried losses", binding.HubDropsBefore)
 	}
 }

--- a/go/internal/agent/services/hub_loopback_pump_test.go
+++ b/go/internal/agent/services/hub_loopback_pump_test.go
@@ -330,3 +330,132 @@ func TestPumpWritesFramePayloadVerbatim(t *testing.T) {
 		t.Errorf("wrote %v, want %v (payload must reach the node unaltered)", writer.writes[0], want)
 	}
 }
+
+// TestPumpSignalsRejoinAfterCaptureTakeover: a hub torn down by an episode
+// capture takeover must not end the data plane. The pump reports the restart
+// so Run rejoins the replacement hub instead of stopping.
+func TestPumpSignalsRejoinAfterCaptureTakeover(t *testing.T) {
+	hub, subID, frames := newPumpTestHub(t)
+	writer := newFakeLoopbackWriter(0)
+	pump := newHubLoopbackPump(zap.NewNop(), "v4l2:/dev/video0", "/dev/video200")
+
+	// Simulate takeOverDefaultedHub plus the old producer's teardown: mark the
+	// hub restarted, then close the subscriber channel as runProducer does.
+	hub.mu.Lock()
+	hub.restarted = true
+	hub.mu.Unlock()
+	close(frames)
+
+	err := pump.pump(context.Background(), hub, subID, frames, writer)
+	if !errors.Is(err, errLoopbackHubRestarted) {
+		t.Fatalf("pump returned %v, want errLoopbackHubRestarted", err)
+	}
+}
+
+// TestPumpGatesRejoinedStreamToRandomAccess: after a rejoin the node's new
+// stream must begin on a random-access unit, and the frames the gate skipped
+// are reported on the next binding like hub-side drops, never lost silently.
+func TestPumpGatesRejoinedStreamToRandomAccess(t *testing.T) {
+	hub, subID, frames := newPumpTestHub(t)
+	writer := newFakeLoopbackWriter(100)
+	pump := newHubLoopbackPump(zap.NewNop(), "v4l2:/dev/video0", "/dev/video200")
+
+	// A bare IDR without SPS/PPS is a whole access unit but not a
+	// random-access one; the gate must skip it.
+	frames <- bindableFrame(7, 700, 5)
+	rau := &videoFrame{
+		data:             append([]byte(nil), testRAUFrame...),
+		codec:            agentpb.VideoCodec_VIDEO_CODEC_H264,
+		auAligned:        true,
+		sampleID:         8,
+		receiptBootNanos: 800,
+	}
+	frames <- rau
+	close(frames)
+
+	if err := pump.pumpFrom(context.Background(), hub, subID, frames, writer, true); err != nil {
+		t.Fatalf("pumpFrom: %v", err)
+	}
+	if len(writer.writes) != 1 {
+		t.Fatalf("wrote %d frames, want only the random-access unit", len(writer.writes))
+	}
+	binding, ok := pump.Bindings().Lookup(100)
+	if !ok {
+		t.Fatal("no binding recorded for the written frame")
+	}
+	if binding.SampleID != 8 {
+		t.Fatalf("binding sample id = %d, want 8", binding.SampleID)
+	}
+	if binding.HubDropsBefore != 1 {
+		t.Fatalf("HubDropsBefore = %d, want 1: the gated frame never reached the node and must be reported", binding.HubDropsBefore)
+	}
+}
+
+// TestPumpRunRejoinsReplacementHub drives Run across a capture takeover: the
+// pump must survive the restart as one more parameter-less subscriber, keep
+// the same writer, and continue recording bindings from the replacement hub.
+func TestPumpRunRejoinsReplacementHub(t *testing.T) {
+	svc := newTestVideoService(nil, nil)
+	fp := installFakeProducers(svc)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	writer := newFakeLoopbackWriter(400)
+	restore := openLoopbackFrameWriter
+	openLoopbackFrameWriter = func(string) (loopbackFrameWriter, error) { return writer, nil }
+	defer func() { openLoopbackFrameWriter = restore }()
+
+	pump := newHubLoopbackPump(zap.NewNop(), "v4l2:/dev/video0", "/dev/video200")
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- pump.Run(ctx, svc, videoSource{kind: sourceV4L2, key: "/dev/video0", path: "/dev/video0"}, 0)
+	}()
+
+	// Wait for the pump's parameter-less join to create the defaulted hub.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && fp.count() == 0 {
+		time.Sleep(time.Millisecond)
+	}
+	if fp.count() == 0 {
+		t.Fatal("pump never created a hub")
+	}
+	fp.hub(0).broadcast(mustRAUVideoFrame(1))
+	waitForBindings(t, pump, 1)
+
+	// A campaign takes the camera over at explicit parameters.
+	req := &agentpb.StreamVideoRequest{DeviceId: 0, Width: 640, Height: 480, Framerate: 15}
+	newHub, captureID, _, _, _, _, restarted, err := svc.joinHubForCapture(ctx, "/dev/video0", req)
+	if err != nil || !restarted {
+		t.Fatalf("takeover failed: restarted=%v err=%v", restarted, err)
+	}
+	defer newHub.unsubscribe(captureID)
+
+	// The pump rejoins the replacement hub and keeps binding frames. Keep
+	// broadcasting until its binding lands: the rejoin is asynchronous.
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && pump.Bindings().Len() < 2 {
+		newHub.broadcast(mustRAUVideoFrame(0))
+		time.Sleep(2 * time.Millisecond)
+	}
+	if pump.Bindings().Len() < 2 {
+		t.Fatal("pump recorded no binding from the replacement hub")
+	}
+
+	cancel()
+	if err := <-runDone; !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run returned %v, want context.Canceled", err)
+	}
+	if !writer.closed {
+		t.Fatal("writer not closed on Run exit")
+	}
+}
+
+// mustRAUVideoFrame builds an access-unit-aligned SPS/PPS/IDR frame the hub
+// stamps with its own sample identity at broadcast.
+func mustRAUVideoFrame(_ uint64) *videoFrame {
+	return &videoFrame{
+		data:      append([]byte(nil), testRAUFrame...),
+		codec:     agentpb.VideoCodec_VIDEO_CODEC_H264,
+		auAligned: true,
+	}
+}

--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -383,6 +384,21 @@ type deviceHub struct {
 	// Storing scalars (not a proto pointer) prevents data races if the caller's
 	// proto message is ever mutated by middleware after the hub is created.
 	width, height, framerate uint32
+	// subExplicit records, per subscriber id, the label of the consumer kind
+	// that joined with EXPLICITLY asserted stream parameters; subscribers that
+	// asserted none (a model app on the sensor socket, the two-plane loopback
+	// pump) have no entry. This is the bit the parameter-priority rules pivot
+	// on, tracked as hub state at subscribe time rather than inferred later
+	// from the parameter values: the hub's parameters count as explicitly held
+	// only while at least one such subscriber remains, so a camera whose
+	// explicit consumer has left degrades back to a defaulted hub that episode
+	// capture may restart. Protected by h.mu.
+	subExplicit map[int]string
+	// restarted marks that this hub's producer was torn down by an episode
+	// capture takeover (takeOverDefaultedHub) rather than by a fault or a
+	// normal last-unsubscribe. Parameter-less subscribers use it to reattach
+	// to the replacement hub after their channel closes. Protected by h.mu.
+	restarted bool
 	// sampleSeq is the per-device sample counter, shared with every hub that
 	// has served the same device key. It outlives the hub so sample identities
 	// stay monotonic across producer restarts within one episode.
@@ -399,6 +415,14 @@ const maxSubscribersPerHub = 16
 // (checked atomically under h.mu so no subscriber can be added to a dying hub),
 // or codes.ResourceExhausted if the hub already has maxSubscribersPerHub active subscribers.
 func (h *deviceHub) subscribe() (int, chan *videoFrame, error) {
+	return h.subscribeAs("")
+}
+
+// subscribeAs is subscribe, additionally recording that this subscriber's join
+// asserted the hub's stream parameters explicitly when explicitHolder is
+// non-empty. The label names the kind of consumer (see the hubHolder
+// constants) so a refused campaign can be told exactly who holds the camera.
+func (h *deviceHub) subscribeAs(explicitHolder string) (int, chan *videoFrame, error) {
 	ch := make(chan *videoFrame, 4)
 	h.mu.Lock()
 	if h.ctx.Err() != nil {
@@ -416,6 +440,12 @@ func (h *deviceHub) subscribe() (int, chan *videoFrame, error) {
 		h.subDrops = make(map[int]uint64)
 	}
 	h.subDrops[id] = 0
+	if explicitHolder != "" {
+		if h.subExplicit == nil {
+			h.subExplicit = make(map[int]string)
+		}
+		h.subExplicit[id] = explicitHolder
+	}
 	h.mu.Unlock()
 	return id, ch, nil
 }
@@ -428,11 +458,39 @@ func (h *deviceHub) unsubscribe(id int) uint64 {
 	drops := h.subDrops[id]
 	delete(h.subs, id)
 	delete(h.subDrops, id)
+	delete(h.subExplicit, id)
 	if len(h.subs) == 0 {
 		h.cancel()
 	}
 	h.mu.Unlock()
 	return drops
+}
+
+// heldExplicitly reports whether any current subscriber asserted this hub's
+// stream parameters explicitly, and the label of one such holder (the one
+// with the lowest subscriber id, for determinism). A hub whose explicit
+// consumers have all left is held only by parameter-less subscribers, so its
+// parameters are defaulted again no matter what values the producer runs at.
+func (h *deviceHub) heldExplicitly() (holder string, held bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	lowest := -1
+	for id, label := range h.subExplicit {
+		if lowest == -1 || id < lowest {
+			lowest, holder = id, label
+		}
+	}
+	return holder, lowest != -1
+}
+
+// wasRestarted reports whether this hub's producer was torn down by an
+// episode-capture takeover. Subscribers that observe their channel closed
+// check it to distinguish "the stream is being restarted at the campaign's
+// parameters, reattach" from "the producer stopped, give up".
+func (h *deviceHub) wasRestarted() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.restarted
 }
 
 // drops reports how many frames the hub has dropped for one subscriber so far.
@@ -603,6 +661,14 @@ type VideoService struct {
 	readTegraRelease func() ([]byte, error)
 	dumpBootSlots    func(context.Context) ([]byte, error)
 
+	// startProducer launches the capture loop that feeds a hub. It is the
+	// injection seam for hub lifecycle tests (creation, capture takeover): the
+	// default forks runProducer, and a test substitutes a producer that
+	// broadcasts frames without opening a device. Any substitute must perform
+	// runProducer's teardown duties when its context ends: evict the hub from
+	// s.hubs, close the subscriber channels, and close h.done.
+	startProducer func(ctx context.Context, h *deviceHub, path string, req *agentpb.StreamVideoRequest)
+
 	ctx    context.Context    // cancelled on Shutdown; hub contexts are derived from this
 	cancel context.CancelFunc // cancels ctx
 	wg     sync.WaitGroup     // tracks active runProducer goroutines
@@ -670,6 +736,10 @@ func NewVideoService(ctx context.Context, logger *zap.Logger) *VideoService {
 	svc.runGStreamer = svc.gstreamerFrames
 	svc.cameraReachable = ipcam.Reachable
 	svc.probeCamera = ipcam.ProbeCredentials
+	svc.startProducer = func(ctx context.Context, h *deviceHub, path string, req *agentpb.StreamVideoRequest) {
+		svc.wg.Add(1)
+		go svc.runProducer(ctx, h, path, req)
+	}
 	// The pump closure reads svc.runGStreamer through the receiver at call
 	// time, not the value assigned above at construction: a test that swaps
 	// s.runGStreamer after NewVideoService returns (the usual pattern; see
@@ -1047,10 +1117,33 @@ const (
 	hubTeardownTimeout = 500 * time.Millisecond
 )
 
+// hubHolder labels name the kind of consumer whose join asserted a hub's
+// stream parameters, so a refused campaign capture can be told exactly who
+// holds the camera. They appear verbatim in manifest notes.
+const (
+	hubHolderStreamClient   = "a video stream client"
+	hubHolderEpisodeCapture = "episode capture"
+)
+
+// streamRequestAssertsParams reports whether a stream request asserts any
+// stream parameter explicitly. A request with no width, height, or framerate
+// is the parameter-less join used by consumers that must never take a running
+// stream away from anyone (the sensor socket, the loopback pump).
+func streamRequestAssertsParams(req *agentpb.StreamVideoRequest) bool {
+	return req.GetWidth() != 0 || req.GetHeight() != 0 || req.GetFramerate() != 0
+}
+
 // getOrCreateHub returns the existing hub for path, or starts a new producer and hub.
 // The caller receives a hub with at least one subscriber already registered (the returned id/ch).
 // Returns an error if a hub already exists with different stream parameters.
-func (s *VideoService) getOrCreateHub(ctx context.Context, path string, req *agentpb.StreamVideoRequest) (h *deviceHub, id int, ch chan *videoFrame, err error) {
+// origin labels the kind of consumer joining (see the hubHolder constants); it
+// is recorded against the subscription only when req asserts parameters
+// explicitly.
+func (s *VideoService) getOrCreateHub(ctx context.Context, path string, req *agentpb.StreamVideoRequest, origin string) (h *deviceHub, id int, ch chan *videoFrame, err error) {
+	explicitHolder := ""
+	if streamRequestAssertsParams(req) {
+		explicitHolder = origin
+	}
 	for retries := 0; ; retries++ {
 		if retries >= maxHubRetries {
 			s.logger.Warn("hub retry limit exceeded", zap.String("device", path), zap.Int("retries", retries))
@@ -1069,7 +1162,7 @@ func (s *VideoService) getOrCreateHub(ctx context.Context, path string, req *age
 					zap.Uint32("existing_fps", h.framerate))
 				return nil, 0, nil, status.Errorf(codes.InvalidArgument, "device already in use with different stream parameters")
 			}
-			id, ch, err = h.subscribe()
+			id, ch, err = h.subscribeAs(explicitHolder)
 			s.mu.Unlock()
 			if err != nil {
 				if st, _ := status.FromError(err); st.Code() == codes.Unavailable {
@@ -1137,12 +1230,11 @@ func (s *VideoService) getOrCreateHub(ctx context.Context, path string, req *age
 		sampleSeq: s.sampleSeqLocked(path),
 	}
 	// New hub: the first subscriber is always within the cap.
-	id, ch, _ = h.subscribe()
+	id, ch, _ = h.subscribeAs(explicitHolder)
 	s.hubs[path] = h
 	s.mu.Unlock()
 
-	s.wg.Add(1)
-	go s.runProducer(hctx, h, path, req)
+	s.startProducer(hctx, h, path, req)
 	return h, id, ch, nil
 }
 
@@ -1161,7 +1253,7 @@ func (s *VideoService) joinHub(ctx context.Context, key string, req *agentpb.Str
 // parameters the subscription actually runs at.
 func (s *VideoService) joinHubReportingParams(ctx context.Context, key string, req *agentpb.StreamVideoRequest) (*deviceHub, int, chan *videoFrame, uint32, uint32, uint32, error) {
 	for attempt := 0; attempt < maxHubRetries; attempt++ {
-		hub, id, ch, err := s.getOrCreateHub(ctx, key, req)
+		hub, id, ch, err := s.getOrCreateHub(ctx, key, req, hubHolderStreamClient)
 		if err == nil {
 			return hub, id, ch, req.GetWidth(), req.GetHeight(), req.GetFramerate(), nil
 		}
@@ -1178,6 +1270,164 @@ func (s *VideoService) joinHubReportingParams(ctx context.Context, key string, r
 		// The conflicting hub disappeared between the two calls; retry.
 	}
 	return nil, 0, nil, 0, 0, 0, status.Error(codes.Unavailable, "video device hub churned during subscription")
+}
+
+// errCameraHeldExplicitly is the named refusal for a campaign whose explicit
+// capture parameters conflict with a hub that another consumer holds at
+// explicitly requested parameters. It is recorded in the episode manifest
+// (CaptureResult source detail) instead of silently downgrading the capture;
+// the wrapped message names the holder and both parameter sets.
+var errCameraHeldExplicitly = errors.New("camera is held at explicitly requested stream parameters")
+
+// joinHubForCapture is the episode-capture join. It implements the parameter
+// priority the capture policy promises:
+//
+//   - A capture that asserts no parameters joins whatever runs, exactly like
+//     any other parameter-less subscriber (joinHubReportingParams).
+//   - A capture with EXPLICIT parameters wins over a hub whose parameters were
+//     chosen by default because every current subscriber asserted none: the
+//     producer is restarted at the campaign's parameters and the
+//     parameter-less subscribers reattach to the restarted stream
+//     (takeOverDefaultedHub). restarted reports that this happened so the
+//     capture can note it in the manifest.
+//   - A capture with explicit parameters that conflict with a hub held at
+//     parameters ANOTHER consumer asserted explicitly is refused with
+//     errCameraHeldExplicitly, never silently downgraded.
+func (s *VideoService) joinHubForCapture(ctx context.Context, key string, req *agentpb.StreamVideoRequest) (hub *deviceHub, id int, ch chan *videoFrame, width, height, framerate uint32, restarted bool, err error) {
+	if !streamRequestAssertsParams(req) {
+		hub, id, ch, width, height, framerate, err = s.joinHubReportingParams(ctx, key, req)
+		return hub, id, ch, width, height, framerate, false, err
+	}
+	for attempt := 0; attempt < maxHubRetries; attempt++ {
+		hub, id, ch, err := s.getOrCreateHub(ctx, key, req, hubHolderEpisodeCapture)
+		if err == nil {
+			return hub, id, ch, req.GetWidth(), req.GetHeight(), req.GetFramerate(), false, nil
+		}
+		if status.Code(err) != codes.InvalidArgument {
+			return nil, 0, nil, 0, 0, 0, false, err
+		}
+		hub, id, ch, retry, err := s.takeOverDefaultedHub(ctx, key, req)
+		if err != nil {
+			return nil, 0, nil, 0, 0, 0, false, err
+		}
+		if retry {
+			// The conflicting hub disappeared, or its parameters changed,
+			// between the two calls; re-evaluate from the top.
+			continue
+		}
+		return hub, id, ch, req.GetWidth(), req.GetHeight(), req.GetFramerate(), true, nil
+	}
+	return nil, 0, nil, 0, 0, 0, false, status.Error(codes.Unavailable, "video device hub churned during subscription")
+}
+
+// takeOverDefaultedHub replaces a hub running at defaulted parameters with one
+// running at the campaign's explicit parameters. Returns retry=true (and no
+// hub) when the observed hub is gone or no longer conflicts, in which case the
+// caller should retry getOrCreateHub; returns errCameraHeldExplicitly when a
+// current subscriber holds the hub's parameters explicitly.
+//
+// Splice semantics, deliberately NOT a mid-stream splice: each existing
+// subscriber's stream ends (its channel closes exactly as if the producer had
+// stopped) and a new stream begins on the replacement hub. A parameter-less
+// subscriber that reattaches gets a fresh decodable start on the new stream,
+// beginning on a random-access unit; nothing ever splices two different
+// sequence parameter sets into what a downstream decoder reads as one
+// timeline. gRPC StreamVideo subscribers get a terminal error telling them to
+// reconnect (see pumpFrames).
+//
+// The replacement hub is installed in s.hubs BEFORE the old producer is
+// cancelled, so every reattaching subscriber lands on it rather than racing
+// this takeover to create a competing defaulted hub.
+func (s *VideoService) takeOverDefaultedHub(ctx context.Context, key string, req *agentpb.StreamVideoRequest) (h *deviceHub, id int, ch chan *videoFrame, retry bool, err error) {
+	s.mu.Lock()
+	old, exists := s.hubs[key]
+	if !exists || old.ctx.Err() != nil {
+		s.mu.Unlock()
+		return nil, 0, nil, true, nil
+	}
+	if old.width == req.GetWidth() && old.height == req.GetHeight() && old.framerate == req.GetFramerate() {
+		// No conflict any more; the plain subscribe path handles it.
+		s.mu.Unlock()
+		return nil, 0, nil, true, nil
+	}
+	if holder, held := old.heldExplicitly(); held {
+		w, hgt, fps := old.width, old.height, old.framerate
+		s.mu.Unlock()
+		return nil, 0, nil, false, fmt.Errorf(
+			"%w: %s holds this camera at %s; the campaign requested %s; refusing to capture at parameters the campaign did not ask for",
+			errCameraHeldExplicitly, holder,
+			describeStreamParams(w, hgt, fps),
+			describeStreamParams(req.GetWidth(), req.GetHeight(), req.GetFramerate()))
+	}
+
+	hctx, cancel := context.WithCancel(s.ctx)
+	h = &deviceHub{
+		subs:      make(map[int]chan *videoFrame),
+		subDrops:  make(map[int]uint64),
+		ctx:       hctx,
+		cancel:    cancel,
+		done:      make(chan struct{}),
+		width:     req.GetWidth(),
+		height:    req.GetHeight(),
+		framerate: req.GetFramerate(),
+		sampleSeq: s.sampleSeqLocked(key),
+	}
+	id, ch, _ = h.subscribeAs(hubHolderEpisodeCapture)
+	s.hubs[key] = h
+	old.mu.Lock()
+	old.restarted = true
+	old.mu.Unlock()
+	old.cancel()
+	s.mu.Unlock()
+
+	s.logger.Info("episode capture restarting camera producer at campaign parameters",
+		zap.String("device", key),
+		zap.Uint32("width", req.GetWidth()), zap.Uint32("height", req.GetHeight()),
+		zap.Uint32("framerate", req.GetFramerate()))
+
+	// abort dismantles the replacement hub when the caller's context ends
+	// before its producer was started. No runProducer exists for it yet, so
+	// the cleanup runProducer would normally perform (evict from the map,
+	// close subscriber channels, close done) must happen here; otherwise a
+	// subscriber that reattached in the interim would wait forever on a
+	// channel nothing will ever close.
+	abort := func() {
+		s.mu.Lock()
+		if s.hubs[key] == h {
+			delete(s.hubs, key)
+		}
+		s.mu.Unlock()
+		cancel()
+		h.mu.Lock()
+		for _, sub := range h.subs {
+			close(sub)
+		}
+		h.mu.Unlock()
+		close(h.done)
+	}
+
+	// Wait for the old producer to release the device fd before starting the
+	// replacement, exactly like getOrCreateHub's teardown wait; otherwise
+	// VIDIOC_S_FMT returns EBUSY while the old streaming session is active.
+	waitCtx, waitCancel := context.WithTimeout(ctx, hubTeardownTimeout)
+	select {
+	case <-old.done:
+	case <-ctx.Done():
+		waitCancel()
+		abort()
+		return nil, 0, nil, false, ctx.Err()
+	case <-waitCtx.Done():
+		if ctx.Err() != nil {
+			waitCancel()
+			abort()
+			return nil, 0, nil, false, ctx.Err()
+		}
+		s.logger.Warn("timed out waiting for hub teardown before capture takeover", zap.String("device", key))
+	}
+	waitCancel()
+
+	s.startProducer(hctx, h, key, req)
+	return h, id, ch, false, nil
 }
 
 // sampleSeqLocked returns the sample counter for a device key, creating it on
@@ -1528,7 +1778,7 @@ func (s *VideoService) StreamVideo(req *agentpb.StreamVideoRequest, stream grpc.
 	// use for streaming, so capability verification and streaming happen atomically
 	// on a single fd rather than across separate opens.
 
-	h, id, ch, err := s.getOrCreateHub(ctx, path, req)
+	h, id, ch, err := s.getOrCreateHub(ctx, path, req, hubHolderStreamClient)
 	if err != nil {
 		return err
 	}
@@ -1551,6 +1801,13 @@ func (s *VideoService) pumpFrames(stream grpc.ServerStreamingServer[agentpb.Vide
 				// Producer exited. Return the original error if one was recorded.
 				if err := h.terminalErr(); err != nil {
 					return err
+				}
+				// A capture takeover ends this stream rather than splicing new
+				// sequence parameter sets into it mid-timeline; the client
+				// reconnects and joins the restarted producer as a new stream.
+				if h.wasRestarted() {
+					return status.Errorf(codes.Unavailable,
+						"video stream ended: episode capture restarted the camera producer at the campaign's requested parameters; reconnect to join the new stream")
 				}
 				// If the hub context was cancelled (e.g. service shutdown), propagate that.
 				if err := h.ctx.Err(); err != nil {
@@ -1594,7 +1851,7 @@ func (s *VideoService) streamIPCamera(stream grpc.ServerStreamingServer[agentpb.
 		defer s.loopback.AcquireView(src.camera.ID)()
 	}
 
-	h, id, ch, err := s.getOrCreateHub(stream.Context(), src.key, req)
+	h, id, ch, err := s.getOrCreateHub(stream.Context(), src.key, req, hubHolderStreamClient)
 	if err != nil {
 		return err
 	}

--- a/go/internal/agent/services/video_service_sensor.go
+++ b/go/internal/agent/services/video_service_sensor.go
@@ -167,9 +167,12 @@ func (c *cameraSensorSubscription) Next(ctx context.Context) (SensorSample, erro
 // reattach joins the replacement hub after a capture takeover, again asserting
 // no parameters. The hub-side drop counter starts at zero on the new
 // subscription, and delivery is gated to a random-access unit so the app's new
-// stream starts decodable.
+// stream starts decodable. Drops the old subscription accrued after the last
+// delivered sample can no longer ride on a sample of their own, so they are
+// carried into gatedSkips and reported on the first sample the new
+// subscription delivers; the restart leaves no loss unreported.
 func (c *cameraSensorSubscription) reattach(ctx context.Context) error {
-	c.hub.unsubscribe(c.subID)
+	c.gatedSkips += c.hub.unsubscribe(c.subID) - c.lastDrops
 	hub, subID, frames, err := c.video.joinHub(ctx, c.key, &agentpb.StreamVideoRequest{DeviceId: c.devID})
 	if err != nil {
 		return err

--- a/go/internal/agent/services/video_service_sensor.go
+++ b/go/internal/agent/services/video_service_sensor.go
@@ -61,7 +61,12 @@ func (s *VideoService) SupportsSensorSource(sourceID string) bool {
 // episode capture adapter can both consume the same camera. Nothing here opens
 // a device — if no producer is running, one is started and shared; if one is
 // running with different stream parameters, this joins it at the parameters it
-// has rather than failing or restarting it.
+// has rather than failing or restarting it. Subscribing never takes a device
+// away from anyone. The reverse does not hold: episode capture with explicit
+// campaign parameters may restart a producer this subscriber started at
+// defaults (see takeOverDefaultedHub), in which case the subscription
+// reattaches to the restarted stream — a restart initiated by capture is not
+// the subscriber taking anything.
 func (s *VideoService) SubscribeSensor(ctx context.Context, sourceID string) (sensorSubscription, error) {
 	src, err := s.resolveSensorSource(sourceID)
 	if err != nil {
@@ -81,44 +86,98 @@ func (s *VideoService) SubscribeSensor(ctx context.Context, sourceID string) (se
 	if err != nil {
 		return nil, err
 	}
-	return &cameraSensorSubscription{hub: hub, subID: subID, frames: frames}, nil
+	return &cameraSensorSubscription{video: s, key: src.key, devID: devID, hub: hub, subID: subID, frames: frames}, nil
 }
 
 // cameraSensorSubscription adapts one hub subscription to the sensor contract.
 type cameraSensorSubscription struct {
+	// video, key and devID are what reattaching after a capture takeover
+	// needs: the subscription asserted no parameters, so when episode capture
+	// restarts the producer at the campaign's parameters this subscriber
+	// simply rejoins and gets what the producer now provides. video is nil in
+	// unit tests that drive a bare hub; those never see a restarted hub.
+	video  *VideoService
+	key    string
+	devID  uint32
 	hub    *deviceHub
 	subID  int
 	frames chan *videoFrame
 	// lastDrops is the hub's drop counter for this subscriber as of the
 	// previously delivered sample, so each sample reports the drops since it.
 	lastDrops uint64
-	closed    bool
+	// awaitRandomAccess gates delivery after a reattach: the subscriber's old
+	// stream ended with the restarted producer, and the new one must begin on
+	// a random-access unit so the app decodes from a clean start rather than
+	// from the middle of a group of pictures. This is the subscriber-side
+	// counterpart of the rule episode capture enforces with
+	// errAwaitCameraRandomAccess. Frames skipped by the gate are reported in
+	// gatedSkips so the sample_id gap they leave stays explained.
+	awaitRandomAccess bool
+	gatedSkips        uint64
+	closed            bool
 }
 
 func (c *cameraSensorSubscription) Next(ctx context.Context) (SensorSample, error) {
-	select {
-	case <-ctx.Done():
-		return SensorSample{}, ctx.Err()
-	case frame, ok := <-c.frames:
-		if !ok {
-			if err := c.hub.terminalErr(); err != nil {
-				return SensorSample{}, err
+	for {
+		select {
+		case <-ctx.Done():
+			return SensorSample{}, ctx.Err()
+		case frame, ok := <-c.frames:
+			if !ok {
+				if err := c.hub.terminalErr(); err != nil {
+					return SensorSample{}, err
+				}
+				// Episode capture restarted the producer at the campaign's
+				// parameters. This subscription asserted none, so it reattaches
+				// to the restarted stream: its old stream has ended and a new
+				// one begins, never a mid-stream splice of different sequence
+				// parameter sets into one timeline.
+				if c.video != nil && c.hub.wasRestarted() {
+					if err := c.reattach(ctx); err != nil {
+						return SensorSample{}, err
+					}
+					continue
+				}
+				return SensorSample{}, errSensorProducerStopped
 			}
-			return SensorSample{}, errSensorProducerStopped
+			if c.awaitRandomAccess && frame.auAligned {
+				if _, randomAccess := frameRandomAccess(frame); !randomAccess {
+					c.gatedSkips++
+					continue
+				}
+			}
+			c.awaitRandomAccess = false
+			drops := c.hub.drops(c.subID)
+			delta := drops - c.lastDrops + c.gatedSkips
+			c.lastDrops = drops
+			c.gatedSkips = 0
+			return SensorSample{
+				SampleID:         frame.sampleID,
+				BootNanos:        frame.receiptBootNanos,
+				UncertaintyNanos: frame.receiptUncertaintyNanos,
+				Payload:          frame.data,
+				Encoding:         codecEncodingName(frame.codec),
+				SelfContained:    frame.auAligned,
+				DroppedBefore:    delta,
+			}, nil
 		}
-		drops := c.hub.drops(c.subID)
-		delta := drops - c.lastDrops
-		c.lastDrops = drops
-		return SensorSample{
-			SampleID:         frame.sampleID,
-			BootNanos:        frame.receiptBootNanos,
-			UncertaintyNanos: frame.receiptUncertaintyNanos,
-			Payload:          frame.data,
-			Encoding:         codecEncodingName(frame.codec),
-			SelfContained:    frame.auAligned,
-			DroppedBefore:    delta,
-		}, nil
 	}
+}
+
+// reattach joins the replacement hub after a capture takeover, again asserting
+// no parameters. The hub-side drop counter starts at zero on the new
+// subscription, and delivery is gated to a random-access unit so the app's new
+// stream starts decodable.
+func (c *cameraSensorSubscription) reattach(ctx context.Context) error {
+	c.hub.unsubscribe(c.subID)
+	hub, subID, frames, err := c.video.joinHub(ctx, c.key, &agentpb.StreamVideoRequest{DeviceId: c.devID})
+	if err != nil {
+		return err
+	}
+	c.hub, c.subID, c.frames = hub, subID, frames
+	c.lastDrops = 0
+	c.awaitRandomAccess = true
+	return nil
 }
 
 func (c *cameraSensorSubscription) Close() {

--- a/go/internal/agent/services/video_service_sensor_test.go
+++ b/go/internal/agent/services/video_service_sensor_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
@@ -310,5 +311,119 @@ func TestCaptureAndModelSubscriberShareOneProducer(t *testing.T) {
 	subscription.Close()
 	if !hub.broadcast(&videoFrame{data: []byte{1}, codec: agentpb.VideoCodec_VIDEO_CODEC_H264}) {
 		t.Fatal("the producer stopped when the model unsubscribed, starving the episode capture")
+	}
+}
+
+// TestSensorReattachGateSkipsToRandomAccess pins the reattach gate's
+// accounting deterministically: after a reattach the subscription delivers
+// nothing until a random-access unit arrives, and the skipped frames are
+// reported on that first delivered sample so its sample_id gap stays
+// explained.
+func TestSensorReattachGateSkipsToRandomAccess(t *testing.T) {
+	hub, cancel := newSampleHub(new(atomic.Uint64))
+	defer cancel()
+	subID, frames, err := hub.subscribe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	subscription := &cameraSensorSubscription{hub: hub, subID: subID, frames: frames, awaitRandomAccess: true}
+
+	// A whole access unit that is not random access (no SPS/PPS) is gated.
+	hub.broadcast(&videoFrame{data: []byte{0, 0, 0, 1, 0x41, 1}, codec: agentpb.VideoCodec_VIDEO_CODEC_H264, auAligned: true})
+	rau := []byte{0, 0, 0, 1, 0x67, 1, 0, 0, 0, 1, 0x68, 2, 0, 0, 0, 1, 0x65, 3}
+	hub.broadcast(&videoFrame{data: rau, codec: agentpb.VideoCodec_VIDEO_CODEC_H264, auAligned: true})
+
+	sample, err := subscription.Next(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sample.SampleID != 2 || !sample.SelfContained {
+		t.Fatalf("delivered sample = id %d selfContained %v, want the random-access unit (id 2)", sample.SampleID, sample.SelfContained)
+	}
+	if sample.DroppedBefore != 1 {
+		t.Fatalf("DroppedBefore = %d, want 1: the gated frame must be reported, not silently absent", sample.DroppedBefore)
+	}
+}
+
+// TestSensorSubscriptionReattachesAfterCaptureTakeover: the sensor socket's
+// guarantee is that subscribing never takes a device away, and its
+// counterpart is that a subscription survives episode capture taking the
+// producer over. The subscription reattaches to the replacement hub and the
+// app's new stream starts on a random-access unit.
+func TestSensorSubscriptionReattachesAfterCaptureTakeover(t *testing.T) {
+	svc := NewVideoService(context.Background(), zap.NewNop())
+	defer svc.Shutdown()
+	fp := installFakeProducers(svc)
+	ctx := context.Background()
+
+	subscription, err := svc.SubscribeSensor(ctx, "v4l2:/dev/video0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer subscription.Close()
+	if fp.count() != 1 {
+		t.Fatalf("started %d producers, want 1", fp.count())
+	}
+	rau := &videoFrame{
+		data:      []byte{0, 0, 0, 1, 0x67, 1, 0, 0, 0, 1, 0x68, 2, 0, 0, 0, 1, 0x65, 3},
+		codec:     agentpb.VideoCodec_VIDEO_CODEC_H264,
+		auAligned: true,
+	}
+	fp.hub(0).broadcast(rau)
+	first, err := subscription.Next(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Episode capture takes the camera over at explicit campaign parameters.
+	req := &agentpb.StreamVideoRequest{DeviceId: 0, Width: 640, Height: 480, Framerate: 15}
+	newHub, captureID, _, _, _, _, restarted, err := svc.joinHubForCapture(ctx, "/dev/video0", req)
+	if err != nil || !restarted {
+		t.Fatalf("takeover failed: restarted=%v err=%v", restarted, err)
+	}
+	defer newHub.unsubscribe(captureID)
+
+	// Next reattaches to the replacement hub and delivers its frames. The
+	// reattach is asynchronous relative to this test, so keep broadcasting
+	// random-access units until one lands.
+	type result struct {
+		sample SensorSample
+		err    error
+	}
+	got := make(chan result, 1)
+	go func() {
+		s, err := subscription.Next(ctx)
+		got <- result{s, err}
+	}()
+	var second SensorSample
+	deadline := time.After(5 * time.Second)
+	for {
+		bcast := &videoFrame{
+			data:      append([]byte(nil), rau.data...),
+			codec:     agentpb.VideoCodec_VIDEO_CODEC_H264,
+			auAligned: true,
+		}
+		newHub.broadcast(bcast)
+		select {
+		case r := <-got:
+			if r.err != nil {
+				t.Fatalf("Next after takeover: %v", r.err)
+			}
+			second = r.sample
+		case <-time.After(2 * time.Millisecond):
+			continue
+		case <-deadline:
+			t.Fatal("subscription never delivered a frame from the replacement hub")
+		}
+		break
+	}
+	if !second.SelfContained {
+		t.Fatal("first sample after reattach is not a self-contained random-access unit")
+	}
+	if second.SampleID <= first.SampleID {
+		t.Fatalf("sample id did not advance across the restart: %d then %d", first.SampleID, second.SampleID)
+	}
+	if cs, ok := subscription.(*cameraSensorSubscription); !ok || cs.hub != newHub {
+		t.Fatal("subscription did not reattach to the replacement hub")
 	}
 }

--- a/go/internal/agent/services/video_service_sensor_test.go
+++ b/go/internal/agent/services/video_service_sensor_test.go
@@ -427,3 +427,43 @@ func TestSensorSubscriptionReattachesAfterCaptureTakeover(t *testing.T) {
 		t.Fatal("subscription did not reattach to the replacement hub")
 	}
 }
+
+// TestSensorReattachCarriesTailDrops: drops the old subscription accrued after
+// the last delivered sample can no longer ride on a sample of their own once
+// the producer is taken over, so reattach must carry them into the first
+// sample the new subscription delivers.
+func TestSensorReattachCarriesTailDrops(t *testing.T) {
+	svc := newTestVideoService(nil, nil)
+	_ = installFakeProducers(svc)
+	ctx := context.Background()
+
+	hub, subID, frames, err := svc.joinHub(ctx, "/dev/video0", &agentpb.StreamVideoRequest{DeviceId: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	subscription := &cameraSensorSubscription{video: svc, key: "/dev/video0", hub: hub, subID: subID, frames: frames, lastDrops: 1}
+	hub.mu.Lock()
+	hub.subDrops[subID] = 4
+	hub.mu.Unlock()
+
+	req := &agentpb.StreamVideoRequest{DeviceId: 0, Width: 640, Height: 480, Framerate: 15}
+	newHub, captureID, _, _, _, _, restarted, err := svc.joinHubForCapture(ctx, "/dev/video0", req)
+	if err != nil || !restarted {
+		t.Fatalf("takeover failed: restarted=%v err=%v", restarted, err)
+	}
+	defer newHub.unsubscribe(captureID)
+
+	if err := subscription.reattach(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer subscription.Close()
+	if subscription.hub != newHub {
+		t.Fatal("reattach did not land on the replacement hub")
+	}
+	if subscription.gatedSkips != 3 {
+		t.Fatalf("gatedSkips = %d, want 3 (4 total drops minus 1 already reported)", subscription.gatedSkips)
+	}
+	if subscription.lastDrops != 0 || !subscription.awaitRandomAccess {
+		t.Fatalf("reattach state: lastDrops=%d awaitRandomAccess=%v, want 0/true", subscription.lastDrops, subscription.awaitRandomAccess)
+	}
+}

--- a/go/internal/agent/services/video_service_takeover_test.go
+++ b/go/internal/agent/services/video_service_takeover_test.go
@@ -1,0 +1,343 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/data"
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+// fakeProducers records every producer the service started and performs
+// runProducer's teardown duties when a producer's context ends, without
+// opening any device. Tests broadcast frames on the recorded hubs by hand.
+type fakeProducers struct {
+	mu      sync.Mutex
+	started []*agentpb.StreamVideoRequest
+	hubs    []*deviceHub
+}
+
+func installFakeProducers(svc *VideoService) *fakeProducers {
+	fp := &fakeProducers{}
+	svc.startProducer = func(ctx context.Context, h *deviceHub, path string, req *agentpb.StreamVideoRequest) {
+		fp.mu.Lock()
+		fp.started = append(fp.started, req)
+		fp.hubs = append(fp.hubs, h)
+		fp.mu.Unlock()
+		go func() {
+			<-ctx.Done()
+			svc.mu.Lock()
+			if svc.hubs[path] == h {
+				delete(svc.hubs, path)
+			}
+			svc.mu.Unlock()
+			h.mu.Lock()
+			for _, sub := range h.subs {
+				close(sub)
+			}
+			h.mu.Unlock()
+			close(h.done)
+		}()
+	}
+	return fp
+}
+
+func (fp *fakeProducers) count() int {
+	fp.mu.Lock()
+	defer fp.mu.Unlock()
+	return len(fp.hubs)
+}
+
+func (fp *fakeProducers) hub(i int) *deviceHub {
+	fp.mu.Lock()
+	defer fp.mu.Unlock()
+	return fp.hubs[i]
+}
+
+func (fp *fakeProducers) request(i int) *agentpb.StreamVideoRequest {
+	fp.mu.Lock()
+	defer fp.mu.Unlock()
+	return fp.started[i]
+}
+
+// Episode capture with explicit campaign parameters takes over a hub running
+// at defaults for parameter-less subscribers: the producer is restarted at the
+// campaign's parameters and the old subscriber's stream ends, marked as a
+// restart so the subscriber reattaches rather than giving up.
+func TestCaptureTakesOverDefaultedHub(t *testing.T) {
+	svc := newTestVideoService(nil, nil)
+	fp := installFakeProducers(svc)
+	ctx := context.Background()
+
+	// A parameter-less subscriber (a model app on the sensor socket) opens the
+	// camera first; the producer runs at its defaults.
+	oldHub, sensorID, sensorCh, err := svc.joinHub(ctx, "/dev/video0", &agentpb.StreamVideoRequest{DeviceId: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer oldHub.unsubscribe(sensorID)
+
+	req := &agentpb.StreamVideoRequest{DeviceId: 0, Width: 640, Height: 480, Framerate: 15}
+	newHub, captureID, _, w, h, fps, restarted, err := svc.joinHubForCapture(ctx, "/dev/video0", req)
+	if err != nil {
+		t.Fatalf("takeover failed: %v", err)
+	}
+	defer newHub.unsubscribe(captureID)
+	if !restarted {
+		t.Fatal("takeover not reported as a restart")
+	}
+	if w != 640 || h != 480 || fps != 15 {
+		t.Fatalf("achieved parameters = %dx%d@%d, want the campaign's 640x480@15", w, h, fps)
+	}
+	if newHub == oldHub {
+		t.Fatal("takeover reused the defaulted hub instead of replacing it")
+	}
+	if fp.count() != 2 {
+		t.Fatalf("started %d producers, want 2 (default, then campaign)", fp.count())
+	}
+	got := fp.request(1)
+	if got.GetWidth() != 640 || got.GetHeight() != 480 || got.GetFramerate() != 15 {
+		t.Fatalf("replacement producer started with %dx%d@%d, want 640x480@15", got.GetWidth(), got.GetHeight(), got.GetFramerate())
+	}
+
+	// The old subscriber's stream ends (no mid-stream splice) and the hub says
+	// why, so a parameter-less subscriber knows to reattach.
+	select {
+	case _, ok := <-sensorCh:
+		if ok {
+			t.Fatal("old subscriber received a frame after the takeover")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("old subscriber channel not closed by the takeover")
+	}
+	if !oldHub.wasRestarted() {
+		t.Fatal("old hub not marked restarted")
+	}
+	if err := oldHub.terminalErr(); err != nil {
+		t.Fatalf("takeover recorded a terminal error on the old hub: %v", err)
+	}
+
+	// A reattaching parameter-less subscriber lands on the replacement hub.
+	rejoined, rejoinedID, _, err := svc.joinHub(ctx, "/dev/video0", &agentpb.StreamVideoRequest{DeviceId: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rejoined.unsubscribe(rejoinedID)
+	if rejoined != newHub {
+		t.Fatal("reattaching subscriber did not join the replacement hub")
+	}
+}
+
+// A hub whose parameters a consumer asserted explicitly is never restarted:
+// the campaign is refused with the named error, and the holder keeps its
+// stream.
+func TestCaptureRefusedWhenHubHeldExplicitly(t *testing.T) {
+	svc := newTestVideoService(nil, nil)
+	_ = installFakeProducers(svc)
+	ctx := context.Background()
+
+	viewerReq := &agentpb.StreamVideoRequest{DeviceId: 0, Width: 1280, Height: 720, Framerate: 30}
+	viewerHub, viewerID, viewerCh, err := svc.getOrCreateHub(ctx, "/dev/video0", viewerReq, hubHolderStreamClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer viewerHub.unsubscribe(viewerID)
+
+	req := &agentpb.StreamVideoRequest{DeviceId: 0, Width: 640, Height: 480, Framerate: 15}
+	_, _, _, _, _, _, _, err = svc.joinHubForCapture(ctx, "/dev/video0", req)
+	if !errors.Is(err, errCameraHeldExplicitly) {
+		t.Fatalf("expected errCameraHeldExplicitly, got %v", err)
+	}
+	for _, want := range []string{hubHolderStreamClient, "1280x720 at 30 fps", "640x480 at 15 fps"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal %q does not name %q", err.Error(), want)
+		}
+	}
+	if viewerHub.wasRestarted() {
+		t.Fatal("refusal restarted the held hub")
+	}
+	select {
+	case _, ok := <-viewerCh:
+		if !ok {
+			t.Fatal("holder's stream was closed by the refused takeover")
+		}
+	default:
+	}
+}
+
+// Explicit possession follows the subscribers, not the hub's history: once the
+// explicit consumer leaves and only parameter-less subscribers remain, the
+// hub's parameters are defaulted again and a campaign may take it over.
+func TestTakeoverAllowedAfterExplicitHolderLeaves(t *testing.T) {
+	svc := newTestVideoService(nil, nil)
+	_ = installFakeProducers(svc)
+	ctx := context.Background()
+
+	viewerReq := &agentpb.StreamVideoRequest{DeviceId: 0, Width: 1280, Height: 720, Framerate: 30}
+	viewerHub, viewerID, _, err := svc.getOrCreateHub(ctx, "/dev/video0", viewerReq, hubHolderStreamClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A parameter-less subscriber joins the viewer's hub and keeps it alive.
+	sensorHub, sensorID, _, err := svc.joinHub(ctx, "/dev/video0", &agentpb.StreamVideoRequest{DeviceId: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sensorHub.unsubscribe(sensorID)
+	if sensorHub != viewerHub {
+		t.Fatal("parameter-less subscriber did not share the viewer's hub")
+	}
+	viewerHub.unsubscribe(viewerID)
+
+	req := &agentpb.StreamVideoRequest{DeviceId: 0, Width: 640, Height: 480, Framerate: 15}
+	newHub, captureID, _, _, _, _, restarted, err := svc.joinHubForCapture(ctx, "/dev/video0", req)
+	if err != nil {
+		t.Fatalf("takeover after the explicit holder left failed: %v", err)
+	}
+	defer newHub.unsubscribe(captureID)
+	if !restarted {
+		t.Fatal("takeover not reported as a restart")
+	}
+}
+
+// A capture takeover through the adapter records the takeover note in the
+// manifest alongside the parameters it achieved.
+func TestStartOneNotesTakeoverOfDefaultedHub(t *testing.T) {
+	svc := newTestVideoService(
+		func() ([]string, error) { return []string{"/dev/video0"}, nil },
+		func(string) (string, error) { return "USB Cam", nil },
+	)
+	fp := installFakeProducers(svc)
+	ctx := context.Background()
+
+	// The defaulted hub a model app would have created.
+	oldHub, sensorID, _, err := svc.joinHub(ctx, "/dev/video0", &agentpb.StreamVideoRequest{DeviceId: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer oldHub.unsubscribe(sensorID)
+
+	// Feed whatever producer is newest so the capture sees its first frame.
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			case <-time.After(2 * time.Millisecond):
+				fp.hub(fp.count() - 1).broadcast(testH264Frame(testRAUFrame))
+			}
+		}
+	}()
+
+	adapter := &cameraDataAdapter{video: svc}
+	_, origin, _, err := data.CaptureReceipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	session := data.CaptureSession{Directory: t.TempDir(), RequestBootNanos: origin}
+	source := data.Source{ID: "v4l2:/dev/video0", Kind: "camera", Detail: "USB Cam", Capture: &data.SourceCapture{Rate: 15, MaxResolution: "640x480"}}
+	capture, err := adapter.startOne(ctx, session, source, 0)
+	if err != nil {
+		t.Fatalf("takeover through the adapter failed: %v", err)
+	}
+	results, err := capture.Stop(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results = %d", len(results))
+	}
+	detail := results[0].SourceDetail
+	if !strings.Contains(detail, "took over the camera") || !strings.Contains(detail, "640x480 at 15 fps") {
+		t.Fatalf("takeover note not recorded: %q", detail)
+	}
+	if results[0].Count == 0 {
+		t.Fatal("no frames captured after the takeover")
+	}
+	if got := fp.request(fp.count() - 1); got.GetWidth() != 640 || got.GetHeight() != 480 || got.GetFramerate() != 15 {
+		t.Fatalf("campaign producer started with %dx%d@%d, want 640x480@15", got.GetWidth(), got.GetHeight(), got.GetFramerate())
+	}
+}
+
+// A parameter-less episode capture whose hub is taken over by a concurrent
+// campaign reattaches and keeps recording, starting a fresh segment rather
+// than splicing the new stream into the old one.
+func TestParameterlessCaptureReattachesAcrossTakeover(t *testing.T) {
+	svc := newTestVideoService(
+		func() ([]string, error) { return []string{"/dev/video0"}, nil },
+		func(string) (string, error) { return "USB Cam", nil },
+	)
+	fp := installFakeProducers(svc)
+	ctx := context.Background()
+
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			case <-time.After(2 * time.Millisecond):
+				if fp.count() > 0 {
+					fp.hub(fp.count() - 1).broadcast(testH264Frame(testRAUFrame))
+				}
+			}
+		}
+	}()
+
+	adapter := &cameraDataAdapter{video: svc}
+	_, origin, _, err := data.CaptureReceipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	session := data.CaptureSession{Directory: t.TempDir(), RequestBootNanos: origin}
+	source := data.Source{ID: "v4l2:/dev/video0", Kind: "camera", Detail: "USB Cam"}
+	capture, err := adapter.startOne(ctx, session, source, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A concurrent campaign takes the camera over at explicit parameters.
+	req := &agentpb.StreamVideoRequest{DeviceId: 0, Width: 640, Height: 480, Framerate: 15}
+	newHub, captureID, _, _, _, _, restarted, err := svc.joinHubForCapture(ctx, "/dev/video0", req)
+	if err != nil || !restarted {
+		t.Fatalf("takeover failed: restarted=%v err=%v", restarted, err)
+	}
+	defer newHub.unsubscribe(captureID)
+
+	// The capture reattaches as one more subscriber of the replacement hub
+	// (alongside the campaign subscription made above).
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) && hubSubscriberCount(newHub) < 2 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if hubSubscriberCount(newHub) < 2 {
+		t.Fatal("capture never reattached to the replacement hub")
+	}
+
+	results, err := capture.Stop(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results = %d", len(results))
+	}
+	if !strings.Contains(results[0].SourceDetail, "reattached") {
+		t.Fatalf("reattach note not recorded: %q", results[0].SourceDetail)
+	}
+	if results[0].Count == 0 {
+		t.Fatal("no frames captured")
+	}
+}
+
+func hubSubscriberCount(h *deviceHub) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.subs)
+}

--- a/go/internal/agent/services/video_service_test.go
+++ b/go/internal/agent/services/video_service_test.go
@@ -809,13 +809,13 @@ func TestDeviceHub_GetOrCreateHub_RejectsParamMismatch(t *testing.T) {
 	req1 := &agentpb.StreamVideoRequest{Width: 1280, Height: 720, Framerate: 30}
 	req2 := &agentpb.StreamVideoRequest{Width: 640, Height: 480, Framerate: 30}
 
-	h, id, _, err := svc.getOrCreateHub(ctx, "/dev/video0", req1)
+	h, id, _, err := svc.getOrCreateHub(ctx, "/dev/video0", req1, hubHolderStreamClient)
 	if err != nil {
 		t.Fatalf("first getOrCreateHub failed: %v", err)
 	}
 	defer h.unsubscribe(id)
 
-	_, _, _, err = svc.getOrCreateHub(ctx, "/dev/video0", req2)
+	_, _, _, err = svc.getOrCreateHub(ctx, "/dev/video0", req2, hubHolderStreamClient)
 	if err == nil {
 		t.Fatal("expected error for mismatched params, got nil")
 	}


### PR DESCRIPTION
## Problem

The camera producer hub gives the stream to whoever opens it first. A model application subscribing through the sensor socket deliberately asserts no stream parameters, so a subscriber can never steal a running stream. But the consequence ran the other way too: when the parameter-less app opened the camera first, the producer started at its defaults, and a campaign that later started an episode with explicit `max_resolution` and `rate` joined that running stream and recorded only "stream already active with different parameters; requested 640x480, capturing at default resolution" in the manifest. Measured on hardware during the demo: a 640x480 campaign captured at 1280x720. The campaign's explicit request was silently ignored, which violates the rule that a recorded status must not lie about intent, and it means an operator cannot actually control capture cost.

## Cause

`getOrCreateHub` refuses a mismatched join with an error, and the episode-capture join (`joinHubReportingParams`) treated every such refusal identically: fall back to `subscribeExistingHub` and record requested-versus-achieved. The hub had no notion of whether its current parameters were asserted by anyone or merely defaulted because every subscriber asserted none, so capture could not distinguish "a dashboard viewer explicitly requested this size" from "nobody asked for anything and the producer picked a default". Both cases downgraded the campaign silently.

## Solution

Campaign capture parameters win over parameter-less subscribers; explicit conflicts become errors instead of silent downgrades.

The pivot bit is now hub state: `deviceHub.subExplicit` records, per subscriber, the label of the consumer kind whose join asserted the stream parameters explicitly (`subscribeAs`). The hub counts as explicitly held only while at least one such subscriber remains, so a camera whose explicit consumer has left degrades back to a defaulted hub. The bit is recorded at subscribe time, never inferred later from the parameter values.

Episode capture joins through the new `joinHubForCapture`:

1. Explicit campaign parameters against a hub held only by parameter-less subscribers: `takeOverDefaultedHub` replaces the producer at the campaign's parameters. The replacement hub is installed before the old producer is cancelled, so every reattaching subscriber lands on it rather than racing to create a competing hub. The manifest records the takeover note, and the sample-identity counter is shared across the restart, so identities stay monotonic.
2. Explicit campaign parameters against a hub another consumer holds at explicit parameters (for example a dashboard viewer that requested a size): the source is refused with the named error `errCameraHeldExplicitly`. The refusal does not fail the episode; the adapter records a `CaptureResult` for that source whose detail names exactly who holds the camera and at what parameters, alongside what the campaign requested, and the episode continues with its other sources.
3. Requested-versus-achieved stays recorded in the existing manifest fields in all cases, including the unchanged fallback for a capture that asserts no parameters.
4. The sensor-socket path keeps asserting no parameters, and "subscribing never takes a device away" remains true; a restart initiated by capture is not the subscriber taking anything.

Splice semantics, documented at each site: a restart is never a mid-stream splice of different Sequence Parameter Sets (SPS) into one timeline. Each existing subscriber's stream ends (its channel closes) and a new one begins. Parameter-less consumers reattach and get a fresh decodable start:

* Sensor subscriptions rejoin the replacement hub and gate delivery until a random-access unit, the subscriber-side counterpart of the capture rule enforced by `errAwaitCameraRandomAccess`; gated frames, plus any drops the old subscription accrued after its last delivered sample, are reported in `DroppedBefore` on the first sample the new subscription delivers, so the sample-identity gap stays explained and the restart leaves no loss unreported.
* The two-plane loopback pump (#1829) survives the restart: `pump` reports the restart, `Run` rejoins the replacement hub with the same writer (the node's picture size is metadata; a decoder takes the real size from the bitstream's own parameter sets) and gates the rejoined stream to a random-access unit, carrying gated skips and the old subscription's unreported tail drops into the next binding's `HubDropsBefore`.
* A parameter-less episode capture whose hub is taken over by a concurrent campaign reattaches and forces a new segment, so the new stream never lands mid-segment; driver-sequence and access-unit-alignment classifications reset with the producer.
* `StreamVideo` clients get a clear terminal error telling them to reconnect to the new stream.

The delivered-frame guard in `captureLocalCamera` is untouched: it governs source fallback inside one producer, while a takeover replaces the producer entirely with all subscriber channels closed at the boundary.

## Verification

* `CC=/usr/bin/clang go build ./go/...` clean, `gofmt -l go/` empty, `go vet ./go/...` clean.
* `CC=/usr/bin/clang go test ./go/internal/agent/services/... ./go/internal/agent/data/...` passes, including with `-race`; the new timing-sensitive tests pass five consecutive race-detector runs.
* New unit tests: takeover of a defaulted hub (replacement producer started at campaign parameters, old subscribers see stream end plus restart marker, reattach lands on the replacement); refusal against an explicitly held hub with the named error, holder, and both parameter sets in the capture result; takeover allowed again after the explicit holder leaves; requested-versus-achieved recorded in fallback and takeover paths; sensor subscription reattach with random-access gating and drop accounting; loopback pump restart signal, rejoin through `Run`, and gated-skip accounting; carried-loss accounting across the reattach on both the pump path (unreported losses handed back on restart, carried losses reported on the first binding) and the sensor path (tail drops folded into the first delivered sample).

Hardware verification is pending. To verify on a device: deploy a model application that holds the camera through the sensor socket, then start a campaign episode with an explicit `max_resolution` (for example 640x480) on the same camera:

```
wendy data campaign deploy <campaign-with-max_resolution-640x480>
wendy data episodes show <episode-id>
```

The manifest source detail should carry the takeover note and the recorded segments should be 640x480; with a dashboard viewer holding the camera at an explicit size instead, the manifest should carry the named refusal and the episode's other sources should be unaffected.

