### PR TITLE
Camera pre-roll via an Arm lifecycle phase

### DIFF
--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -325,6 +325,10 @@ func main() {
 	// per-app sensor socket must be built with that provider already registered.
 	videoSvc := services.NewVideoService(ctx, logger)
 	dataSvc.SetVideoService(videoSvc)
+	// Arm pre-roll for campaigns deployed in a previous agent lifetime so their
+	// next trigger opens BEFORE the trigger instant, not only campaigns deployed
+	// during this run.
+	dataSvc.ReconcileArming(ctx)
 	defer videoSvc.Shutdown()
 
 	notificationSender := services.NewCloudNotificationSender(logger, provisioningSvc)

--- a/go/internal/agent/data/campaign.go
+++ b/go/internal/agent/data/campaign.go
@@ -319,6 +319,48 @@ func (c Campaign) AfterTriggerDuration() time.Duration {
 	return d
 }
 
+// preRollParameterConflicts names the camera sources whose explicit stream
+// parameters this campaign's pre-roll will not honor, so deployment can warn
+// while the operator can still change the plan.
+//
+// A camera source that is armed for pre-roll subscribes to the producer WITHOUT
+// asserting stream parameters, because arming must never take a running camera
+// away from a viewer, and because asserting them at the trigger would change the
+// sequence parameter set mid-clip, which costs the episode its browser-playable
+// rendering. The consequence is that an armed source records at whatever the
+// producer is already running, so an explicit max_resolution or rate on that
+// same source is requested but not achieved.
+//
+// Only sources that are actually armed conflict. Snapshot-mode camera sources
+// are never armed (snapshot capture writes sparse independent stills, not a
+// continuous ring), so their explicit parameters are still honored through the
+// normal capture join and they are deliberately not named here.
+func preRollParameterConflicts(c Campaign) []string {
+	if c.BufferDuration() <= 0 {
+		return nil
+	}
+	var conflicts []string
+	for i, source := range c.Sources {
+		if source.Camera == "" || source.Capture == nil {
+			continue
+		}
+		if source.Capture.EffectiveMode() != "continuous" {
+			continue
+		}
+		var explicit []string
+		if source.Capture.MaxResolution != "" {
+			explicit = append(explicit, "max_resolution "+source.Capture.MaxResolution)
+		}
+		if source.Capture.Rate > 0 {
+			explicit = append(explicit, fmt.Sprintf("rate %g", source.Capture.Rate))
+		}
+		if len(explicit) > 0 {
+			conflicts = append(conflicts, fmt.Sprintf("sources[%d] (%s, %s)", i, source.describe(), strings.Join(explicit, " and ")))
+		}
+	}
+	return conflicts
+}
+
 func (m *Manager) campaignDir() string { return filepath.Join(filepath.Dir(m.root), "campaigns") }
 
 func (m *Manager) DeployCampaign(contents []byte) (Campaign, error) {
@@ -346,6 +388,9 @@ func (m *Manager) DeployCampaign(contents []byte) (Campaign, error) {
 	}
 	if len(pendingModes) > 0 {
 		campaign.Warnings = append(campaign.Warnings, "these capture modes are not implemented yet for their source kind; the sources record continuously for now: "+strings.Join(pendingModes, ", "))
+	}
+	if conflicts := preRollParameterConflicts(campaign); len(conflicts) > 0 {
+		campaign.Warnings = append(campaign.Warnings, "pre-roll and explicit camera stream parameters are mutually exclusive in this release; a buffered camera arms a standby subscription that asserts no stream parameters, so both the pre-roll and the live tail record at the producer's running parameters and the explicit max_resolution or rate is reported as requested but not achieved in the episode manifest: "+strings.Join(conflicts, ", "))
 	}
 	if campaign.Retention.LocalQuota != "" {
 		campaign.Warnings = append(campaign.Warnings, "retention.local_quota is recorded with the plan, but this release enforces only the device-wide storage quota")

--- a/go/internal/agent/data/campaign.go
+++ b/go/internal/agent/data/campaign.go
@@ -332,8 +332,8 @@ func (m *Manager) DeployCampaign(contents []byte) (Campaign, error) {
 	campaign.DeployedUnixNanos = time.Now().UnixNano()
 	if campaign.BufferDuration() > 0 {
 		for _, source := range campaign.Sources {
-			if source.Camera != "" || source.Audio != "" || source.ROS2 != "" {
-				campaign.Warnings = append(campaign.Warnings, "pre-trigger buffering is currently exact for application records; sensor streams start at the trigger and report their achieved offset")
+			if source.Audio != "" || source.ROS2 != "" {
+				campaign.Warnings = append(campaign.Warnings, "pre-trigger buffering is exact for application records and camera streams; audio and ROS 2 streams start at the trigger and report their achieved offset")
 				break
 			}
 		}

--- a/go/internal/agent/data/campaign_preroll_test.go
+++ b/go/internal/agent/data/campaign_preroll_test.go
@@ -1,0 +1,75 @@
+package data
+
+import (
+	"strings"
+	"testing"
+)
+
+// A camera source no longer deploy-warns that its pre-roll starts at the
+// trigger: camera pre-roll is honored. Audio and ROS 2 sources still do.
+func TestBufferWarningExcludesCameraButNotROS2(t *testing.T) {
+	manager, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cameraOnly := []byte(`version: 1
+name: camera-only
+fleet: lab
+sources:
+  - camera: front
+capture:
+  buffer: 10s
+  after_trigger: 20s
+  triggers:
+    - event: emergency_stop
+upload:
+  when: wifi
+  destination: episodes
+export:
+  annotation: cvat
+`)
+	campaign, err := manager.DeployCampaign(cameraOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, warning := range campaign.Warnings {
+		if strings.Contains(warning, "start at the trigger") {
+			t.Fatalf("camera-only campaign still warns that its stream starts at the trigger: %q", warning)
+		}
+	}
+
+	withROS2 := []byte(`version: 1
+name: with-ros2
+fleet: lab
+sources:
+  - camera: front
+  - ros2: /lidar/points
+capture:
+  buffer: 10s
+  after_trigger: 20s
+  triggers:
+    - event: emergency_stop
+upload:
+  when: wifi
+  destination: episodes
+export:
+  annotation: cvat
+`)
+	campaign, err = manager.DeployCampaign(withROS2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var warned bool
+	for _, warning := range campaign.Warnings {
+		if strings.Contains(warning, "audio and ROS 2 streams start at the trigger") {
+			warned = true
+			if strings.Contains(warning, "camera streams start at the trigger") {
+				t.Fatalf("warning wrongly claims camera starts at the trigger: %q", warning)
+			}
+		}
+	}
+	if !warned {
+		t.Fatalf("a buffered campaign with a ROS 2 source did not warn about trigger-start streams: %v", campaign.Warnings)
+	}
+}

--- a/go/internal/agent/data/campaign_preroll_test.go
+++ b/go/internal/agent/data/campaign_preroll_test.go
@@ -73,3 +73,102 @@ export:
 		t.Fatalf("a buffered campaign with a ROS 2 source did not warn about trigger-start streams: %v", campaign.Warnings)
 	}
 }
+
+// bufferedCameraCampaign builds a deployable campaign whose camera source
+// carries the given capture policy body (empty for none) and the given buffer.
+func bufferedCameraCampaign(name, buffer, capture string) []byte {
+	source := "  - camera: front\n"
+	if capture != "" {
+		source += "    capture: {" + capture + "}\n"
+	}
+	// capture.buffer is a required field, so "no pre-roll" is spelled 0s.
+	if buffer == "" {
+		buffer = "0s"
+	}
+	plan := "version: 1\nname: " + name + "\nfleet: lab\nsources:\n" + source +
+		"capture:\n  buffer: " + buffer + "\n"
+	return []byte(plan + `  after_trigger: 20s
+  triggers:
+    - event: emergency_stop
+upload:
+  when: wifi
+  destination: episodes
+export:
+  annotation: cvat
+`)
+}
+
+func hasPreRollParameterWarning(warnings []string) bool {
+	for _, warning := range warnings {
+		if strings.Contains(warning, "mutually exclusive in this release") {
+			return true
+		}
+	}
+	return false
+}
+
+// Pre-roll subscribes without asserting stream parameters, so a camera source
+// that sets BOTH a buffer and an explicit max_resolution or rate does not get
+// those parameters. The operator must learn that at deploy time, not by reading
+// the manifest after the episode.
+func TestDeployWarnsWhenPreRollMeetsExplicitCameraParameters(t *testing.T) {
+	manager, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	deploy := func(t *testing.T, plan []byte) Campaign {
+		t.Helper()
+		campaign, err := manager.DeployCampaign(plan)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return campaign
+	}
+
+	t.Run("buffer with max_resolution warns", func(t *testing.T) {
+		campaign := deploy(t, bufferedCameraCampaign("res-conflict", "10s", "max_resolution: 1280x720"))
+		if !hasPreRollParameterWarning(campaign.Warnings) {
+			t.Fatalf("no mutual-exclusivity warning: %v", campaign.Warnings)
+		}
+		for _, warning := range campaign.Warnings {
+			if !strings.Contains(warning, "mutually exclusive in this release") {
+				continue
+			}
+			for _, want := range []string{"sources[0]", "camera:front", "max_resolution 1280x720", "producer's running parameters", "requested but not achieved"} {
+				if !strings.Contains(warning, want) {
+					t.Errorf("warning %q does not name %q", warning, want)
+				}
+			}
+		}
+	})
+
+	t.Run("buffer with rate warns", func(t *testing.T) {
+		campaign := deploy(t, bufferedCameraCampaign("rate-conflict", "10s", "rate: 5"))
+		if !hasPreRollParameterWarning(campaign.Warnings) {
+			t.Fatalf("no mutual-exclusivity warning for an explicit rate: %v", campaign.Warnings)
+		}
+	})
+
+	t.Run("buffer alone does not warn", func(t *testing.T) {
+		campaign := deploy(t, bufferedCameraCampaign("buffer-only", "10s", ""))
+		if hasPreRollParameterWarning(campaign.Warnings) {
+			t.Fatalf("buffer-only campaign warned about parameters it never set: %v", campaign.Warnings)
+		}
+	})
+
+	t.Run("explicit parameters alone do not warn", func(t *testing.T) {
+		campaign := deploy(t, bufferedCameraCampaign("params-only", "", "max_resolution: 1280x720, rate: 5"))
+		if hasPreRollParameterWarning(campaign.Warnings) {
+			t.Fatalf("unbuffered campaign warned though its explicit parameters are honored: %v", campaign.Warnings)
+		}
+	})
+
+	// A snapshot-mode source is never armed, so its explicit parameters are still
+	// honored through the normal capture join and must not be warned about.
+	t.Run("snapshot mode with buffer does not warn", func(t *testing.T) {
+		campaign := deploy(t, bufferedCameraCampaign("snapshot-buffered", "10s", "mode: snapshot, interval: 2s, max_resolution: 1280x720"))
+		if hasPreRollParameterWarning(campaign.Warnings) {
+			t.Fatalf("snapshot source warned though it is never armed: %v", campaign.Warnings)
+		}
+	})
+}

--- a/go/internal/agent/data/manager.go
+++ b/go/internal/agent/data/manager.go
@@ -506,7 +506,7 @@ func (m *Manager) ActiveSession(key string) (CaptureSession, bool) {
 	if a == nil {
 		return CaptureSession{}, false
 	}
-	return CaptureSession{ID: a.manifest.ID, Directory: a.dir, RequestBootNanos: a.manifest.RequestBootNanos, BootID: a.manifest.BootID}, true
+	return CaptureSession{ID: a.manifest.ID, Directory: a.dir, RequestBootNanos: a.manifest.RequestBootNanos, BootID: a.manifest.BootID, CampaignKey: a.key}, true
 }
 
 // ActiveEpisodeKeys returns the sorted concurrency keys of active episodes.

--- a/go/internal/agent/data/model.go
+++ b/go/internal/agent/data/model.go
@@ -181,6 +181,12 @@ type CaptureSession struct {
 	Directory        string
 	RequestBootNanos int64
 	BootID           string
+	// CampaignKey is the concurrency key of the episode's campaign
+	// (AdHocEpisodeKey for campaign-less episodes). Capture adapters use it to
+	// find the standby pre-roll ring a campaign armed for its camera sources, so
+	// the trigger flushes that ring into the opening frames on the same
+	// subscription that then continues live (see the camera adapter's Arm).
+	CampaignKey string
 }
 
 // CaptureResult is reported by an adapter before the episode is sealed.

--- a/go/internal/agent/services/data_camera_adapter.go
+++ b/go/internal/agent/services/data_camera_adapter.go
@@ -25,7 +25,14 @@ const captureModeSnapshot = "snapshot"
 
 var errAwaitCameraRandomAccess = errors.New("waiting for a decodable random-access unit")
 
-type cameraDataAdapter struct{ video *VideoService }
+type cameraDataAdapter struct {
+	video *VideoService
+	// armed holds the standby pre-roll rings a campaign armed for its camera
+	// sources, keyed by campaign concurrency key then by source ID. It is
+	// populated by Arm and consumed by Start when the campaign triggers.
+	armedMu sync.Mutex
+	armed   map[string]map[string]*armedCameraSource
+}
 
 func newCameraDataAdapter(video *VideoService) dataCaptureAdapter {
 	if video == nil {
@@ -76,9 +83,36 @@ func cameraDeviceID(sourceID string) (uint32, bool) {
 
 func (a *cameraDataAdapter) Start(ctx context.Context, session data.CaptureSession, selected []data.Source) (runningDataCapture, error) {
 	group := &cameraCaptureGroup{}
+	armed := a.takeArmed(session.CampaignKey)
 	for _, source := range selected {
 		devID, ok := cameraDeviceID(source.ID)
 		if !ok {
+			continue
+		}
+		// A campaign that armed this camera for pre-roll flushes its standby ring
+		// into the opening frames and continues live on the same subscription.
+		if pre := armed[source.ID]; pre != nil {
+			delete(armed, source.ID)
+			capture, _, err := pre.activate(session)
+			if err != nil {
+				// Pre-roll activation failed (for example the camera faulted mid
+				// arm). Fall back to a fresh live capture so the episode still
+				// records this camera from the trigger rather than losing it.
+				capture, err = a.startOne(ctx, session, source, devID)
+			}
+			if errors.Is(err, errCameraHeldExplicitly) {
+				group.refused = append(group.refused, data.CaptureResult{
+					SourceID:     source.ID,
+					SourceDetail: strings.TrimSpace(source.Detail + " (not captured: " + err.Error() + ")"),
+				})
+				continue
+			}
+			if err != nil {
+				_, _ = group.Stop(context.Background())
+				a.disarmAll(armed)
+				return nil, fmt.Errorf("%s: %w", source.ID, err)
+			}
+			group.captures = append(group.captures, capture)
 			continue
 		}
 		capture, err := a.startOne(ctx, session, source, devID)
@@ -102,10 +136,102 @@ func (a *cameraDataAdapter) Start(ctx context.Context, session data.CaptureSessi
 		}
 		group.captures = append(group.captures, capture)
 	}
+	// Any armed ring for this campaign whose source was not among the episode's
+	// selected sources is released rather than left subscribed.
+	a.disarmAll(armed)
 	if len(group.captures) == 0 && len(group.refused) == 0 {
 		return nil, nil
 	}
 	return group, nil
+}
+
+// Arm puts each continuous-mode camera source into standby for a campaign that
+// requested a buffer: it subscribes to the source's hub as a non-owning
+// consumer and keeps a keyframe-aligned ring of `buffer` seconds of encoded
+// frames without writing an episode. Snapshot-mode sources are not armed:
+// snapshot capture writes sparse independent stills, not a continuous ring.
+// Arm is idempotent per campaign key when paired with Disarm; a source that
+// cannot be resolved or subscribed is skipped so the campaign still arms its
+// other cameras.
+func (a *cameraDataAdapter) Arm(campaignKey string, buffer time.Duration, selected []data.Source) {
+	if a.video == nil || buffer <= 0 {
+		return
+	}
+	for _, source := range selected {
+		devID, ok := cameraDeviceID(source.ID)
+		if !ok {
+			continue
+		}
+		if source.Capture != nil && source.Capture.EffectiveMode() == captureModeSnapshot {
+			continue
+		}
+		src, err := a.video.resolveSource(devID)
+		if err != nil {
+			continue
+		}
+		if src.kind == sourceIP {
+			if err := a.video.preflightIPCamera(src.camera); err != nil {
+				continue
+			}
+		}
+		// A parameter-less request: arming must never take a running stream from
+		// a viewer, and must never register an explicit holder that would let it
+		// force the parameter-precedence takeover.
+		hub, subID, frames, err := a.video.joinHub(context.Background(), src.key, &agentpb.StreamVideoRequest{DeviceId: devID})
+		if err != nil {
+			continue
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		as := &armedCameraSource{
+			video: a.video, source: source, key: src.key, devID: devID, buffer: buffer,
+			hub: hub, subID: subID, frames: frames, alive: true,
+			ring:   &cameraPreRollRing{buffer: buffer, limitBytes: preRollCameraLimitBytes},
+			cancel: cancel, done: make(chan struct{}),
+		}
+		go as.fill(ctx)
+		a.store(campaignKey, source.ID, as)
+	}
+}
+
+// Disarm stops and releases every armed source for a campaign key.
+func (a *cameraDataAdapter) Disarm(campaignKey string) {
+	a.disarmAll(a.takeArmed(campaignKey))
+}
+
+func (a *cameraDataAdapter) store(campaignKey, sourceID string, as *armedCameraSource) {
+	a.armedMu.Lock()
+	if a.armed == nil {
+		a.armed = make(map[string]map[string]*armedCameraSource)
+	}
+	byKey := a.armed[campaignKey]
+	if byKey == nil {
+		byKey = make(map[string]*armedCameraSource)
+		a.armed[campaignKey] = byKey
+	}
+	old := byKey[sourceID]
+	byKey[sourceID] = as
+	a.armedMu.Unlock()
+	// Replace any stale armed source for the same key+source (re-arm), disarming
+	// the old one so its subscription is not leaked. Done outside the lock: disarm
+	// waits for the old fill goroutine to stop.
+	if old != nil {
+		old.disarm()
+	}
+}
+
+// takeArmed removes and returns the armed sources for a campaign key.
+func (a *cameraDataAdapter) takeArmed(campaignKey string) map[string]*armedCameraSource {
+	a.armedMu.Lock()
+	defer a.armedMu.Unlock()
+	byKey := a.armed[campaignKey]
+	delete(a.armed, campaignKey)
+	return byKey
+}
+
+func (a *cameraDataAdapter) disarmAll(sources map[string]*armedCameraSource) {
+	for _, as := range sources {
+		as.disarm()
+	}
 }
 
 func (a *cameraDataAdapter) startOne(ctx context.Context, session data.CaptureSession, source data.Source, devID uint32) (*cameraCapture, error) {
@@ -341,10 +467,24 @@ type cameraCapture struct {
 	snapshotNumber  int
 	missedIntervals uint64
 	// Rate-cap state: receipts of the first and last written frames, and
-	// whether the current group of pictures is being skipped.
-	rateStart int64
-	rateLast  int64
-	skipGOP   bool
+	// whether the current group of pictures is being skipped. rateWritten counts
+	// only frames the live loop wrote (not flushed pre-roll), so a campaign that
+	// both pre-rolls and rate-caps enforces the cap over the live capture rather
+	// than being thrown off by the pre-roll frames already on disk.
+	rateStart     int64
+	rateLast      int64
+	rateWritten   uint64
+	haveRateStart bool
+	skipGOP       bool
+	// preRoll holds the standby ring an armed campaign accumulated before the
+	// trigger. run() replays it first, writing each buffered frame at its real
+	// (negative-offset) capture time, before the live loop continues on the same
+	// hub subscription. Empty for captures that were not armed.
+	preRoll []bufferedCameraFrame
+	// armed marks a capture activated from a standby ring: it is already
+	// subscribed and producing, so run() reports ready once its pre-roll is
+	// flushed rather than waiting for a first live frame.
+	armed bool
 }
 
 func (c *cameraCapture) receiptNow() (int64, int64, int64, error) {
@@ -429,6 +569,29 @@ func (c *cameraCapture) run() {
 		_ = c.index.Close()
 		_ = c.mappingFile.Close()
 	}()
+
+	// Flush the armed pre-roll ring first: these frames were captured BEFORE the
+	// trigger, so they open the episode with real negative-offset canonical
+	// times before the live loop takes over on the same subscription. An
+	// undecodable leading frame (should not happen: the ring only retains from a
+	// keyframe) is skipped rather than failing the episode.
+	for i := range c.preRoll {
+		if err := c.writeBufferedFrame(c.preRoll[i]); errors.Is(err, errAwaitCameraRandomAccess) {
+			continue
+		} else if err != nil {
+			c.runErr = err
+			c.signalReady(err)
+			return
+		}
+	}
+	c.preRoll = nil
+	// The armed subscription was already producing while the ring filled, so the
+	// capture is ready as soon as its pre-roll is on disk; the live loop then
+	// continues. A never-armed capture leaves preRoll empty and signals ready on
+	// its first live frame below, exactly as before.
+	if c.armed {
+		c.signalReady(nil)
+	}
 
 	for {
 		select {
@@ -596,12 +759,14 @@ func frameRandomAccess(frame *videoFrame) (int, bool) {
 // its parsed prefix does not prove a GOP boundary.
 func (c *cameraCapture) gateGOP(frame *videoFrame, receipt int64) (skip bool) {
 	if _, randomAccess := frameRandomAccess(frame); randomAccess && frame.auAligned {
-		if c.result.Count == 0 {
-			// Always admit the first GOP so the capture starts promptly.
+		if c.rateWritten == 0 {
+			// Always admit the first live GOP so the capture starts promptly.
+			// Pre-roll frames already on disk are counted separately and never
+			// gate the live cap.
 			c.skipGOP = false
 		} else {
 			elapsed := float64(receipt-c.rateStart) / float64(time.Second)
-			c.skipGOP = elapsed <= 0 || float64(c.result.Count) > c.rateCap*elapsed
+			c.skipGOP = elapsed <= 0 || float64(c.rateWritten) > c.rateCap*elapsed
 		}
 	}
 	return c.skipGOP
@@ -614,6 +779,57 @@ func (c *cameraCapture) writeFrame(frame *videoFrame) error {
 	}
 	if c.rateCap > 0 && c.gateGOP(frame, receipt) {
 		return nil
+	}
+	if err := c.writeEncodedFrame(frame, canonical, uncertainty, mappingID, receipt, false); err != nil {
+		return err
+	}
+	if !c.haveRateStart {
+		c.rateStart, c.haveRateStart = receipt, true
+	}
+	c.rateWritten++
+	c.rateLast = receipt
+	return nil
+}
+
+// writeBufferedFrame replays one frame from an armed campaign's standby ring.
+// Unlike a live frame it is stamped with the bracketed CLOCK_BOOTTIME receipt
+// the hub took when it broadcast the frame (frame.receiptBootNanos), not a
+// fresh receipt: the frame was captured seconds before this replay, so its real
+// capture time is the only honest canonical time, and it lands at a negative
+// episode offset. The native-monotonic refinement live capture applies is not
+// available retroactively, so the receipt bracket is the canonical mapping,
+// exactly as the sensor path reports the same frames to a model. The rate cap
+// never applies to pre-roll: the ring's byte and window bounds already bound it.
+func (c *cameraCapture) writeBufferedFrame(bf bufferedCameraFrame) error {
+	frame := bf.frame
+	if c.observedDomains == nil {
+		c.observedDomains = make(map[string]bool)
+	}
+	c.observedDomains[frame.nativeClock] = true
+	uncertainty := frame.receiptUncertaintyNanos
+	if uncertainty > c.maxCanonicalError {
+		c.maxCanonicalError = uncertainty
+	}
+	return c.writeEncodedFrame(frame, frame.receiptBootNanos, uncertainty, "receipt-bracket-v1", frame.receiptBootNanos, bf.resetSegment)
+}
+
+// writeEncodedFrame is the shared write core for both live capture and pre-roll
+// replay: it rotates the segment on random-access boundaries, appends the
+// payload, records the auditable index entry that ties the harness sample_id to
+// its byte range, and accounts the frame as captured. canonical is the frame's
+// CLOCK_BOOTTIME episode time (negative for pre-roll); newStream forces a fresh
+// segment before the write so a producer restart never splices two sequence
+// parameter sets into one file.
+func (c *cameraCapture) writeEncodedFrame(frame *videoFrame, canonical, uncertainty int64, mappingID string, receipt int64, newStream bool) error {
+	if newStream && c.segment != nil {
+		if err := c.segment.Sync(); err != nil {
+			return err
+		}
+		if err := c.segment.Close(); err != nil {
+			return err
+		}
+		c.segment = nil
+		c.haveSequence = false
 	}
 	trim, err := c.ensureSegment(frame.codec, canonical, frame.data)
 	if err != nil {
@@ -648,10 +864,6 @@ func (c *cameraCapture) writeFrame(frame *videoFrame) error {
 		return err
 	}
 	c.result.Count++
-	if c.result.Count == 1 {
-		c.rateStart = receipt
-	}
-	c.rateLast = receipt
 	if c.result.ActualOffset == nil {
 		actual := canonical - c.session.RequestBootNanos
 		c.result.ActualOffset = &actual
@@ -779,8 +991,8 @@ func (c *cameraCapture) finishResultDetail(end int64) {
 			// No end receipt: fall back to the written-frame span.
 			span = c.rateLast - c.rateStart
 		}
-		if c.result.Count > 0 && span > 0 {
-			note += fmt.Sprintf("; achieved %.3g Hz", float64(c.result.Count)/(float64(span)/float64(time.Second)))
+		if c.rateWritten > 0 && span > 0 {
+			note += fmt.Sprintf("; achieved %.3g Hz", float64(c.rateWritten)/(float64(span)/float64(time.Second)))
 		}
 		c.notes = append(c.notes, note)
 	}

--- a/go/internal/agent/services/data_camera_preroll.go
+++ b/go/internal/agent/services/data_camera_preroll.go
@@ -1,0 +1,380 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/data"
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+// preRollCameraLimitBytes bounds one armed camera ring's retained encoded
+// payload. The ring keeps the smaller of `buffer` seconds and this many bytes,
+// so a high-bitrate stream cannot let a long buffer exhaust device memory; when
+// the byte bound bites first, the achieved pre-roll is honestly shorter than
+// the requested buffer and the manifest says so. It is the camera analogue of
+// the application ring's fixed byte ceiling in the data manager (preRollLimit),
+// counted per armed source against the device's memory.
+const preRollCameraLimitBytes = 64 << 20
+
+// bufferedCameraFrame is one encoded frame held in an armed campaign's standby
+// ring. The frame pointer is retained, not copied: hub frames are immutable
+// from the moment they are broadcast (identity, receipt, and payload never
+// change once a subscriber can see them), so the ring shares them exactly the
+// way the sensor path shares frame.data with a model subscriber.
+type bufferedCameraFrame struct {
+	frame        *videoFrame
+	randomAccess bool
+	// resetSegment marks the first frame of a new producer stream, either the
+	// clip's opening frame or the first frame after a mid-arm producer restart
+	// (an unrelated explicit-parameter capture took the camera over). Replaying
+	// it forces a fresh segment so two sequence parameter sets never land in one
+	// file, mirroring reattachAfterRestart on the live path.
+	resetSegment bool
+}
+
+// cameraPreRollRing is a keyframe-aligned, byte- and window-bounded ring of
+// encoded frames. It is the camera analogue of the data manager's application
+// pre-roll ring (manager.preRoll / evictPreRoll): the same eviction discipline
+// of dropping the oldest until the ring is within its time window and its byte
+// cap, specialised in two ways the application ring does not need. It only ever
+// begins on a random-access unit, and it only evicts whole groups of pictures,
+// because a flushed clip that does not start on a keyframe will not decode.
+//
+// The ring is not internally synchronised: it is owned by the fill goroutine
+// while arming and read only after that goroutine has stopped (activate waits
+// on it), so there is never concurrent access.
+type cameraPreRollRing struct {
+	buffer     time.Duration
+	limitBytes int
+	frames     []bufferedCameraFrame
+	bytes      int
+	// droppedForBytes records that the byte cap evicted frames the time window
+	// would otherwise have kept, so even at steady state the ring reaches back
+	// less than the requested buffer. Reported as an honesty note at flush.
+	droppedForBytes bool
+	// nextResetSegment marks the ring so the next keyframe it retains opens a new
+	// stream (set after a mid-arm producer restart).
+	nextResetSegment bool
+}
+
+// add appends one broadcast frame, then evicts. A ring must begin on a
+// decodable unit, so leading inter frames are dropped until the first keyframe;
+// likewise, after a restart the reset boundary attaches to the next keyframe.
+func (r *cameraPreRollRing) add(frame *videoFrame) {
+	_, ra := frameRandomAccess(frame)
+	if len(r.frames) == 0 && !ra {
+		return
+	}
+	if r.nextResetSegment && !ra {
+		return
+	}
+	reset := false
+	if r.nextResetSegment && ra {
+		reset, r.nextResetSegment = true, false
+	}
+	r.frames = append(r.frames, bufferedCameraFrame{frame: frame, randomAccess: ra, resetSegment: reset})
+	r.bytes += len(frame.data)
+	r.evict()
+}
+
+// markStreamReset makes the next retained keyframe open a new stream.
+func (r *cameraPreRollRing) markStreamReset() { r.nextResetSegment = true }
+
+func (r *cameraPreRollRing) evict() {
+	if len(r.frames) == 0 {
+		return
+	}
+	newest := r.frames[len(r.frames)-1].frame.receiptBootNanos
+	cutoff := newest - r.buffer.Nanoseconds()
+	keep := r.lastKeyframeAtOrBefore(cutoff)
+	for r.bytesFrom(keep) > r.limitBytes {
+		next := r.nextKeyframeAfter(keep)
+		if next < 0 {
+			// One group of pictures left: cannot shrink further without leaving
+			// the ring undecodable. Keep it and let the byte total ride; the flush
+			// reports the shortened reach.
+			break
+		}
+		keep = next
+		r.droppedForBytes = true
+	}
+	if keep <= 0 {
+		return
+	}
+	for i := 0; i < keep; i++ {
+		r.bytes -= len(r.frames[i].frame.data)
+	}
+	n := copy(r.frames, r.frames[keep:])
+	for i := n; i < len(r.frames); i++ {
+		r.frames[i] = bufferedCameraFrame{}
+	}
+	r.frames = r.frames[:n]
+}
+
+// lastKeyframeAtOrBefore returns the index of the newest retained keyframe whose
+// receipt is at or before cutoff, or 0 when none is (frames[0] is always a
+// keyframe, so 0 is a safe, decodable floor).
+func (r *cameraPreRollRing) lastKeyframeAtOrBefore(cutoff int64) int {
+	keep := 0
+	for i, bf := range r.frames {
+		if bf.randomAccess && bf.frame.receiptBootNanos <= cutoff {
+			keep = i
+		}
+	}
+	return keep
+}
+
+func (r *cameraPreRollRing) nextKeyframeAfter(idx int) int {
+	for j := idx + 1; j < len(r.frames); j++ {
+		if r.frames[j].randomAccess {
+			return j
+		}
+	}
+	return -1
+}
+
+func (r *cameraPreRollRing) bytesFrom(idx int) int {
+	total := 0
+	for i := idx; i < len(r.frames); i++ {
+		total += len(r.frames[i].frame.data)
+	}
+	return total
+}
+
+// flush selects the frames that open an episode triggered at triggerBoot: from
+// the last keyframe at or before (triggerBoot - buffer) through the newest
+// retained frame. It returns a copy (the ring is left intact), the achieved
+// pre-roll offset (the opening frame's episode-relative time, negative at steady
+// state), and whether the ring reached a full buffer back. The opening frame is
+// marked to start a fresh segment.
+func (r *cameraPreRollRing) flush(triggerBoot int64) (frames []bufferedCameraFrame, achievedOffset int64, reachedFull bool) {
+	if len(r.frames) == 0 {
+		return nil, 0, false
+	}
+	windowStart := triggerBoot - r.buffer.Nanoseconds()
+	start := r.lastKeyframeAtOrBefore(windowStart)
+	frames = make([]bufferedCameraFrame, len(r.frames)-start)
+	copy(frames, r.frames[start:])
+	frames[0].resetSegment = true
+	earliest := frames[0].frame.receiptBootNanos
+	return frames, earliest - triggerBoot, earliest <= windowStart
+}
+
+// armedCameraSource is one camera source's standby state for a campaign that
+// requested a buffer. It subscribes to the device hub as a NON-owning consumer
+// (asserting no stream parameters, exactly like the sensor path), so it never
+// takes a running stream away from a viewer and never forces the
+// parameter-precedence takeover: an empty StreamVideoRequest registers no
+// explicit holder in the hub, so subExplicit stays empty and takeOverDefaultedHub
+// is never reached. A background goroutine copies broadcast frames into the ring
+// until the campaign triggers (activate) or the source is disarmed.
+type armedCameraSource struct {
+	video  *VideoService
+	source data.Source
+	key    string // device hub key
+	devID  uint32
+	buffer time.Duration
+
+	// hub, subID and frames are the current subscription. They are owned by the
+	// fill goroutine (which reassigns them on reattach) and read elsewhere only
+	// after that goroutine has stopped.
+	hub    *deviceHub
+	subID  int
+	frames chan *videoFrame
+	ring   *cameraPreRollRing
+	// lastDrops tracks the hub's drop counter for this subscription so a reattach
+	// carries the unaccounted drops forward as a ring stream reset rather than
+	// losing them silently.
+	lastDrops uint64
+	// alive reports that the subscription is still delivering. The fill goroutine
+	// clears it if the producer stops or a reattach fails, so activate knows to
+	// re-subscribe for the live tail instead of handing capture a dead channel.
+	alive bool
+
+	cancel context.CancelFunc
+	done   chan struct{}
+
+	mu       sync.Mutex
+	consumed bool
+	disarmed bool
+}
+
+// fill copies broadcast frames into the ring until the source is activated or
+// disarmed (context cancelled). It mirrors the sensor path's reattach: if an
+// explicit-parameter capture restarts the producer, this non-owning subscriber
+// rejoins the replacement stream and marks a ring stream reset so the flush
+// rotates a segment at the boundary.
+func (a *armedCameraSource) fill(ctx context.Context) {
+	defer close(a.done)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case frame, ok := <-a.frames:
+			if !ok {
+				if err := a.hub.terminalErr(); err != nil {
+					a.alive = false
+					return
+				}
+				if a.hub.wasRestarted() {
+					if err := a.reattach(ctx); err != nil {
+						a.alive = false
+						return
+					}
+					continue
+				}
+				a.alive = false
+				return
+			}
+			a.ring.add(frame)
+		}
+	}
+}
+
+func (a *armedCameraSource) reattach(ctx context.Context) error {
+	a.lastDrops += a.hub.unsubscribe(a.subID)
+	hub, subID, frames, err := a.video.joinHub(ctx, a.key, &agentpb.StreamVideoRequest{DeviceId: a.devID})
+	if err != nil {
+		return err
+	}
+	a.hub, a.subID, a.frames = hub, subID, frames
+	a.lastDrops = 0
+	a.ring.markStreamReset()
+	return nil
+}
+
+// activate stops the fill goroutine (without unsubscribing) and turns this
+// armed source into a running cameraCapture bound to the episode. The standby
+// ring is flushed as the capture's pre-roll and the SAME hub subscription
+// continues delivering live frames, so there is no gap and no duplicate: frames
+// already copied into the ring are not re-read from the channel, and frames
+// still queued on the channel are consumed by the live loop. Returns the
+// running capture, whether the achieved pre-roll fell short of the request, and
+// an error only when neither the retained ring nor a fresh live subscription
+// could open.
+func (a *armedCameraSource) activate(session data.CaptureSession) (*cameraCapture, bool, error) {
+	a.cancel()
+	<-a.done
+
+	a.mu.Lock()
+	if a.disarmed {
+		a.mu.Unlock()
+		return nil, false, errors.New("camera pre-roll source was disarmed before the trigger")
+	}
+	a.consumed = true
+	a.mu.Unlock()
+
+	preRoll, achievedOffset, reachedFull := a.ring.flush(session.RequestBootNanos)
+	shortfall := !reachedFull && len(preRoll) > 0
+
+	dir := filepath.Join(session.Directory, "cameras", safeCaptureName(a.source.ID))
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return nil, false, err
+	}
+	index, err := os.OpenFile(filepath.Join(dir, "index.jsonl"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o640)
+	if err != nil {
+		return nil, false, err
+	}
+	mappings, err := os.OpenFile(filepath.Join(dir, "clock_samples.jsonl"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o640)
+	if err != nil {
+		index.Close()
+		return nil, false, err
+	}
+
+	// If arming lost its producer (the camera faulted or stopped mid-arm), the
+	// retained ring still opens the episode, but the live tail needs a fresh
+	// subscription rather than the dead channel.
+	if !a.alive || a.hub == nil {
+		hub, subID, frames, joinErr := a.video.joinHub(context.Background(), a.key, &agentpb.StreamVideoRequest{DeviceId: a.devID})
+		if joinErr != nil {
+			if len(preRoll) == 0 {
+				index.Close()
+				mappings.Close()
+				return nil, false, joinErr
+			}
+		} else {
+			a.hub, a.subID, a.frames = hub, subID, frames
+		}
+	}
+
+	var rateCap float64
+	if a.source.Capture != nil && a.source.Capture.Rate > 0 {
+		rateCap = a.source.Capture.Rate
+	}
+	notes := a.preRollNotes(preRoll, achievedOffset, shortfall)
+
+	captureCtx, cancel := context.WithCancel(context.Background())
+	devID := a.devID
+	rejoin := func(ctx context.Context) (*deviceHub, int, chan *videoFrame, error) {
+		return a.video.joinHub(ctx, a.key, &agentpb.StreamVideoRequest{DeviceId: devID})
+	}
+	c := &cameraCapture{
+		source: a.source, session: session, dir: dir, hub: a.hub, subID: a.subID, frames: a.frames,
+		rejoin: rejoin, index: index, mappingFile: mappings, ctx: captureCtx, cancel: cancel,
+		done: make(chan struct{}), ready: make(chan error, 1), mode: "continuous", rateCap: rateCap,
+		notes: notes, lastSnapshotIdx: -1, preRoll: preRoll, armed: true,
+	}
+	go c.run()
+	select {
+	case err := <-c.ready:
+		if err != nil {
+			cancel()
+			<-c.done
+			return nil, false, err
+		}
+		return c, shortfall, nil
+	case <-time.After(20 * time.Second):
+		cancel()
+		<-c.done
+		return nil, false, errors.New("timed out flushing camera pre-roll")
+	}
+}
+
+// preRollNotes builds the honesty notes folded into the capture's manifest
+// detail: what pre-roll was achieved against what was requested, and the fact
+// that a request for an explicit resolution cannot be honoured by a pre-roll
+// subscription (which asserts no parameters so it never takes the camera over).
+func (a *armedCameraSource) preRollNotes(preRoll []bufferedCameraFrame, achievedOffset int64, shortfall bool) []string {
+	var notes []string
+	if len(preRoll) == 0 {
+		notes = append(notes, fmt.Sprintf("camera pre-roll: requested %s buffer, but no decodable frame was buffered before the trigger; the episode opens at the trigger", a.buffer))
+	} else {
+		note := fmt.Sprintf("camera pre-roll: requested %s buffer, flushed %d frame(s) reaching %s before the trigger", a.buffer, len(preRoll), time.Duration(-achievedOffset))
+		if shortfall {
+			note += "; armed less than the buffer before the trigger, so achieved pre-roll is shorter than requested"
+		}
+		if a.ring.droppedForBytes {
+			note += fmt.Sprintf("; the %d MiB pre-roll ring cap bounded the retained window below the requested buffer", preRollCameraLimitBytes>>20)
+		}
+		notes = append(notes, note)
+	}
+	if a.source.Capture != nil {
+		if _, _, ok := a.source.Capture.MaxResolutionPixels(); ok {
+			notes = append(notes, "pre-roll subscribes without asserting stream parameters so it never takes the camera over; recorded at the producer's running parameters rather than the requested max_resolution")
+		}
+	}
+	return notes
+}
+
+// disarm stops arming and releases the subscription. It is a no-op once the
+// source has been consumed by activate, which then owns the subscription.
+func (a *armedCameraSource) disarm() {
+	a.mu.Lock()
+	if a.consumed || a.disarmed {
+		a.mu.Unlock()
+		return
+	}
+	a.disarmed = true
+	a.mu.Unlock()
+	a.cancel()
+	<-a.done
+	if a.hub != nil {
+		a.hub.unsubscribe(a.subID)
+	}
+}

--- a/go/internal/agent/services/data_camera_preroll_test.go
+++ b/go/internal/agent/services/data_camera_preroll_test.go
@@ -1,0 +1,269 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/data"
+	"go.uber.org/zap"
+)
+
+const ms = int64(time.Millisecond)
+
+// preRollFrame builds a broadcast-style frame carrying its own hub receipt and
+// sample identity, the two things the pre-roll ring relies on.
+func preRollFrame(receipt int64, sampleID uint64, key bool) *videoFrame {
+	payload := testInterFrame
+	if key {
+		payload = testRAUFrame
+	}
+	f := testH264Frame(payload)
+	f.receiptBootNanos = receipt
+	f.receiptUncertaintyNanos = 1000
+	f.sampleID = sampleID
+	return f
+}
+
+func fillRing(r *cameraPreRollRing, frames ...*videoFrame) {
+	for _, f := range frames {
+		r.add(f)
+	}
+}
+
+// The ring retains only from a keyframe that covers the window start, evicting
+// older groups of pictures, so a flushed clip begins on a decodable unit.
+func TestPreRollRingRetainsFromKeyframeCoveringWindow(t *testing.T) {
+	r := &cameraPreRollRing{buffer: time.Second, limitBytes: preRollCameraLimitBytes}
+	fillRing(r,
+		preRollFrame(0, 1, true), // GOP 0
+		preRollFrame(100*ms, 2, false),
+		preRollFrame(500*ms, 3, true), // GOP 1
+		preRollFrame(600*ms, 4, false),
+		preRollFrame(1000*ms, 5, true), // GOP 2 (== window start for newest 2000ms)
+		preRollFrame(1500*ms, 6, true), // GOP 3
+		preRollFrame(2000*ms, 7, true), // GOP 4, newest
+	)
+	// newest = 2000ms, cutoff = 1000ms: the last keyframe at or before 1000ms is
+	// the one at 1000ms, so GOPs 0 and 1 are evicted.
+	if len(r.frames) == 0 || !r.frames[0].randomAccess {
+		t.Fatalf("ring does not begin on a keyframe: %+v", r.frames)
+	}
+	if got := r.frames[0].frame.receiptBootNanos; got != 1000*ms {
+		t.Fatalf("earliest retained frame = %dms, want the keyframe at 1000ms", got/ms)
+	}
+	if got := r.frames[0].frame.sampleID; got != 5 {
+		t.Fatalf("earliest retained sample_id = %d, want 5", got)
+	}
+}
+
+// When armed less than a buffer before the trigger, the ring cannot reach a full
+// buffer back; flush reports the shorter reach honestly instead of fabricating.
+func TestPreRollFlushReportsShortReachWhenArmedRecently(t *testing.T) {
+	r := &cameraPreRollRing{buffer: time.Second, limitBytes: preRollCameraLimitBytes}
+	fillRing(r,
+		preRollFrame(0, 1, true),
+		preRollFrame(100*ms, 2, false),
+		preRollFrame(200*ms, 3, true),
+		preRollFrame(300*ms, 4, false),
+	)
+	trigger := int64(300 * ms)
+	frames, achieved, reachedFull := r.flush(trigger)
+	if len(frames) == 0 {
+		t.Fatal("flush returned no frames")
+	}
+	if reachedFull {
+		t.Fatal("reachedFull true, but the ring holds only 300ms against a 1s buffer")
+	}
+	if achieved != -300*ms {
+		t.Fatalf("achieved offset = %dms, want -300ms (the earliest keyframe)", achieved/ms)
+	}
+	if !frames[0].resetSegment {
+		t.Fatal("first flushed frame must open a fresh segment")
+	}
+}
+
+// Replaying a flushed ring writes the pre-roll frames as real captured payload:
+// negative episode offsets from their broadcast receipts, their real sample ids
+// in the index, and the receipt-bracket mapping, all counted as captured.
+func TestPreRollReplayWritesNegativeOffsetsAndRealSampleIDs(t *testing.T) {
+	trigger := int64(10 * time.Second)
+	c := newTestCameraCapture(t, &fakeReceipt{})
+	c.session = data.CaptureSession{RequestBootNanos: trigger}
+	c.armed = true
+
+	pre := []bufferedCameraFrame{
+		{frame: preRollFrame(trigger-800*ms, 11, true), randomAccess: true, resetSegment: true},
+		{frame: preRollFrame(trigger-700*ms, 12, false), randomAccess: false},
+		{frame: preRollFrame(trigger-100*ms, 13, false), randomAccess: false},
+	}
+	for _, bf := range pre {
+		if err := c.writeBufferedFrame(bf); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := c.segment.Sync(); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.index.Sync(); err != nil {
+		t.Fatal(err)
+	}
+
+	if c.result.Count != 3 {
+		t.Fatalf("captured count = %d, want the 3 pre-roll frames", c.result.Count)
+	}
+	if c.result.ActualOffset == nil || *c.result.ActualOffset != -800*ms {
+		t.Fatalf("actual offset = %v, want -800ms (the opening keyframe)", c.result.ActualOffset)
+	}
+
+	contents, err := os.ReadFile(filepath.Join(c.dir, "index.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := bytes.Split(bytes.TrimSpace(contents), []byte("\n"))
+	if len(lines) != 3 {
+		t.Fatalf("index lines = %d, want 3", len(lines))
+	}
+	wantOffsets := []int64{-800 * ms, -700 * ms, -100 * ms}
+	wantSamples := []uint64{11, 12, 13}
+	for i, line := range lines {
+		var rec cameraIndexRecord
+		if err := json.Unmarshal(line, &rec); err != nil {
+			t.Fatal(err)
+		}
+		if rec.CanonicalEpisodeNanos != wantOffsets[i] {
+			t.Fatalf("record %d canonical = %dms, want %dms (BEFORE the trigger)", i, rec.CanonicalEpisodeNanos/ms, wantOffsets[i]/ms)
+		}
+		if rec.SampleID != wantSamples[i] {
+			t.Fatalf("record %d sample_id = %d, want %d (the real broadcast identity)", i, rec.SampleID, wantSamples[i])
+		}
+		if rec.MappingSegment != "receipt-bracket-v1" {
+			t.Fatalf("record %d mapping = %q, want receipt-bracket-v1", i, rec.MappingSegment)
+		}
+	}
+	// The opening keyframe's payload landed in the first segment file.
+	media, err := os.ReadFile(filepath.Join(c.dir, "segment-000001.h264"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(media, testRAUFrame) {
+		t.Fatalf("segment missing the opening keyframe payload: %x", media)
+	}
+}
+
+// newDefaultHub registers a producer hub running at defaulted parameters, held
+// only by a parameter-less subscriber (as the sensor path or a defaulted viewer
+// would hold it). This is the hub state arming must join without taking over.
+func newDefaultHub(t *testing.T, video *VideoService, path string) (*deviceHub, int) {
+	t.Helper()
+	hctx, hcancel := context.WithCancel(context.Background())
+	hub := &deviceHub{subs: make(map[int]chan *videoFrame), subDrops: make(map[int]uint64), ctx: hctx, cancel: hcancel, done: make(chan struct{}), sampleSeq: video.sampleSeqLocked(path)}
+	t.Cleanup(hcancel)
+	id, _, err := hub.subscribe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	video.hubs[path] = hub
+	return hub, id
+}
+
+// Arming subscribes as a non-owning consumer: it joins the running hub, adds no
+// explicit-parameter holder, and never restarts the producer, so it plays
+// correctly with the parameter-precedence hub-state model.
+func TestArmingIsNonOwningAndDoesNotForceTakeover(t *testing.T) {
+	video := NewVideoService(context.Background(), zap.NewNop())
+	hub, viewerID := newDefaultHub(t, video, "/dev/video0")
+	adapter := &cameraDataAdapter{video: video}
+
+	adapter.Arm("cam", time.Second, []data.Source{{ID: "v4l2:/dev/video0", Kind: "camera"}})
+	defer adapter.Disarm("cam")
+
+	if hub.wasRestarted() {
+		t.Fatal("arming restarted a running producer; it must never take the camera over")
+	}
+	if _, held := hub.heldExplicitly(); held {
+		t.Fatal("arming registered an explicit-parameter holder; it must assert none")
+	}
+	if video.hubs["/dev/video0"] != hub {
+		t.Fatal("arming replaced the existing hub instead of joining it")
+	}
+	hub.mu.Lock()
+	n := len(hub.subs)
+	hub.mu.Unlock()
+	if n != 2 {
+		t.Fatalf("hub subscribers = %d, want the viewer plus the armed ring", n)
+	}
+	_ = viewerID
+}
+
+// End to end on a bare hub: a campaign arms, frames are broadcast before the
+// trigger, and the triggered episode opens with those frames at negative
+// offsets on the same subscription that then continues live.
+func TestArmedCampaignFlushesPreRollOnTrigger(t *testing.T) {
+	video := NewVideoService(context.Background(), zap.NewNop())
+	hub, _ := newDefaultHub(t, video, "/dev/video0")
+	adapter := &cameraDataAdapter{video: video}
+
+	adapter.Arm("cam", 5*time.Second, []data.Source{{ID: "v4l2:/dev/video0", Kind: "camera"}})
+
+	// Broadcast a handful of GOPs before the trigger, paced so the 4-deep
+	// subscriber channel never overflows and the fill goroutine keeps up.
+	for i := 0; i < 6; i++ {
+		hub.broadcast(testH264Frame(testRAUFrame))
+		time.Sleep(2 * time.Millisecond)
+		hub.broadcast(testH264Frame(testInterFrame))
+		time.Sleep(2 * time.Millisecond)
+	}
+	time.Sleep(30 * time.Millisecond)
+
+	_, origin, _, err := data.CaptureReceipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	session := data.CaptureSession{Directory: t.TempDir(), RequestBootNanos: origin, CampaignKey: "cam"}
+	capture, err := adapter.Start(context.Background(), session, []data.Source{{ID: "v4l2:/dev/video0", Kind: "camera"}})
+	if err != nil {
+		t.Fatalf("triggering the armed campaign failed: %v", err)
+	}
+	if capture == nil {
+		t.Fatal("armed campaign produced no capture")
+	}
+	results, err := capture.Stop(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want 1", len(results))
+	}
+	res := results[0]
+	if res.Count == 0 {
+		t.Fatal("episode opened with no pre-roll frames")
+	}
+	if res.ActualOffset == nil || *res.ActualOffset >= 0 {
+		t.Fatalf("actual offset = %v, want a negative (before-trigger) offset", res.ActualOffset)
+	}
+	if got := filepath.Join(session.Directory, "cameras", safeCaptureName("v4l2:/dev/video0"), "index.jsonl"); got == "" {
+		t.Fatal("no index path")
+	}
+	contents, err := os.ReadFile(filepath.Join(session.Directory, "cameras", safeCaptureName("v4l2:/dev/video0"), "index.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sawNegative bool
+	for _, line := range bytes.Split(bytes.TrimSpace(contents), []byte("\n")) {
+		var rec cameraIndexRecord
+		if err := json.Unmarshal(line, &rec); err != nil {
+			t.Fatal(err)
+		}
+		if rec.CanonicalEpisodeNanos < 0 && rec.SampleID != 0 {
+			sawNegative = true
+		}
+	}
+	if !sawNegative {
+		t.Fatal("no index entry carries a before-trigger canonical time with a real sample id")
+	}
+}

--- a/go/internal/agent/services/data_service.go
+++ b/go/internal/agent/services/data_service.go
@@ -63,11 +63,30 @@ type DataService struct {
 	// campaign-less episode started through the Start RPC.
 	activeCaptures map[string][]runningDataCapture
 	autoStopCancel map[string]context.CancelFunc
+	// armingAdapter is the capture adapter that supports pre-roll (the camera
+	// adapter). It is kept as a typed handle so the deploy, reconcile, and
+	// post-episode paths can arm and disarm campaigns; nil until a video service
+	// is registered.
+	armingAdapter dataArmingAdapter
 }
 
 type dataCaptureAdapter interface {
 	Discover(context.Context) []data.Source
 	Start(context.Context, data.CaptureSession, []data.Source) (runningDataCapture, error)
+}
+
+// dataArmingAdapter is the optional pre-roll extension of the capture-adapter
+// contract. An adapter that implements it can be Armed for a campaign that
+// requests a buffer: it subscribes to its producer as a non-owning consumer and
+// keeps a standby ring of the last `buffer` of encoded payload WITHOUT writing
+// an episode, so that when the campaign triggers the episode opens BEFORE the
+// trigger instant. The armed ring is consumed by the adapter's own Start, which
+// finds it by the episode's CaptureSession.CampaignKey. Only the camera adapter
+// implements it this round; audio and ROS 2 still begin at the trigger and
+// report their achieved offset honestly.
+type dataArmingAdapter interface {
+	Arm(campaignKey string, buffer time.Duration, selected []data.Source)
+	Disarm(campaignKey string)
 }
 
 type runningDataCapture interface {
@@ -90,9 +109,17 @@ func (s *DataService) addAdapter(adapter dataCaptureAdapter) {
 	s.adapterMu.Unlock()
 }
 
-// SetVideoService enables local V4L2/CSI and registered IP-camera capture.
+// SetVideoService enables local V4L2/CSI and registered IP-camera capture,
+// including camera pre-roll (the camera adapter can be armed for campaigns that
+// request a buffer).
 func (s *DataService) SetVideoService(video *VideoService) {
-	s.addAdapter(newCameraDataAdapter(video))
+	adapter := newCameraDataAdapter(video)
+	s.addAdapter(adapter)
+	if arming, ok := adapter.(dataArmingAdapter); ok {
+		s.adapterMu.Lock()
+		s.armingAdapter = arming
+		s.adapterMu.Unlock()
+	}
 }
 
 // SetAudioService enables microphone capture, including level-threshold
@@ -118,6 +145,79 @@ func (s *DataService) discoverAdapterSources(ctx context.Context) []data.Source 
 	var out []data.Source
 	for _, adapter := range s.adapterSnapshot() {
 		out = append(out, adapter.Discover(ctx)...)
+	}
+	return out
+}
+
+func (s *DataService) arming() dataArmingAdapter {
+	s.adapterMu.RLock()
+	defer s.adapterMu.RUnlock()
+	return s.armingAdapter
+}
+
+// ReconcileArming arms every deployed campaign that requests a buffer and names
+// at least one camera source. It is called once at startup, after the video
+// service is registered, so campaigns deployed in a previous agent lifetime
+// have their pre-roll rings running again before the first trigger.
+func (s *DataService) ReconcileArming(context.Context) {
+	if s.arming() == nil {
+		return
+	}
+	campaigns, err := s.manager.Campaigns()
+	if err != nil {
+		s.manager.Warnf("reconciling camera pre-roll arming: reading campaigns failed; armed campaigns will not pre-roll until redeployed: %v", err)
+		return
+	}
+	for _, campaign := range campaigns {
+		s.armCampaign(campaign)
+	}
+}
+
+// armCampaign (re)arms one campaign's camera sources for pre-roll. It is safe to
+// call repeatedly: the adapter disarms any prior ring for the same campaign key
+// before installing a fresh one. Campaigns without a buffer or without a camera
+// source are left untouched.
+func (s *DataService) armCampaign(campaign data.Campaign) {
+	arming := s.arming()
+	if arming == nil || campaign.State != "armed" || campaign.BufferDuration() <= 0 {
+		return
+	}
+	cameras := s.cameraSourcesFor(campaign)
+	if len(cameras) == 0 {
+		return
+	}
+	arming.Disarm(campaign.Name)
+	arming.Arm(campaign.Name, campaign.BufferDuration(), cameras)
+}
+
+// rearmByName re-arms the campaign with the given name after its episode has
+// finalized, so the next trigger again opens with pre-roll. A missing or
+// non-armed campaign simply leaves nothing armed.
+func (s *DataService) rearmByName(name string) {
+	if name == data.AdHocEpisodeKey || s.arming() == nil {
+		return
+	}
+	campaign, err := s.manager.Campaign(name)
+	if err != nil {
+		return
+	}
+	s.armCampaign(campaign)
+}
+
+// cameraSourcesFor resolves a campaign's camera sources to the source objects
+// the arming adapter needs (id plus capture policy), dropping non-camera and
+// unresolvable sources.
+func (s *DataService) cameraSourcesFor(campaign data.Campaign) []data.Source {
+	sources, _, captures, err := s.manager.ResolveCampaignSources(campaign)
+	if err != nil {
+		return nil
+	}
+	var out []data.Source
+	for _, id := range sources {
+		if _, ok := cameraDeviceID(id); !ok {
+			continue
+		}
+		out = append(out, data.Source{ID: id, Kind: "camera", Capture: captures[id]})
 	}
 	return out
 }
@@ -255,6 +355,12 @@ func (s *DataService) stopCaptureLocked(ctx context.Context, key string) (*agent
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
+	// The episode's camera pre-roll ring (if any) was consumed at trigger. Re-arm
+	// the campaign so its next trigger opens with pre-roll again. Arming
+	// subscribes to camera hubs, so it runs off the finalize path.
+	if key != data.AdHocEpisodeKey {
+		go s.rearmByName(key)
+	}
 	return manifestEpisode(m), nil
 }
 
@@ -275,6 +381,10 @@ func (s *DataService) CampaignDeploy(_ context.Context, req *agentpbv2.DataCampa
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
+	// Arm the campaign's camera sources for pre-roll so the very first trigger
+	// opens BEFORE the trigger instant. Arming subscribes to camera hubs, so it
+	// runs off the request path.
+	go s.armCampaign(campaign)
 	return message, nil
 }
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
@@ -136,7 +136,17 @@ deploys, and deployment prints a warning naming each source whose requested
 mode is not implemented for its kind; those sources record continuously for
 now.
 
-`capture.buffer` must be a Go-style duration from `0s` through `5m`.
+`capture.buffer` must be a Go-style duration from `0s` through `5m`. On a camera
+source, a buffer and explicit stream parameters are mutually exclusive in this
+release: a buffered camera is armed into a standby subscription that asserts no
+stream parameters, so it never takes a running camera away from a viewer and
+never changes the stream parameters part way through a clip. A source that sets
+both a buffer and an explicit `max_resolution` or `rate` therefore records both
+its pre-roll and its live tail at whatever parameters the producer is already
+running, and the explicit values are reported as requested but not achieved in
+the episode manifest. Deployment prints a warning naming each source in that
+position. Set one or the other: a buffer for pre-roll, or explicit parameters
+for a clip that must be captured at a specific resolution or rate.
 `capture.after_trigger` must be greater than `0s` and no more than `24h`. At
 least one trigger is required, and each trigger selects exactly one condition:
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
@@ -263,11 +263,16 @@ command becomes a verb on the CLI rather than a separate binary.
 ## Pre-trigger behavior
 
 Application pre-roll is exact, device-wide, and bounded by the campaign buffer
-(with a five-minute/50 MiB global ceiling). Camera and ROS 2 adapters currently
-start at the trigger. Their manifest entries preserve both the requested offset
-and the achieved offset; campaign deployment prints a warning when sensor
-pre-roll was requested. Unknown drop counts are displayed as unknown, never as
-zero.
+(with a five-minute/50 MiB global ceiling). Camera pre-roll is also honored: a
+campaign that requests a buffer arms its camera sources into a standby ring of
+keyframe-aligned encoded frames, so the episode opens BEFORE the trigger. The
+camera source's manifest entry reports the achieved offset, which is at least
+the requested buffer at steady state but may be shorter when the campaign was
+armed less than a buffer before the trigger fired. Audio and ROS 2 adapters
+still start at the trigger. Every source's manifest entry preserves both the
+requested offset and the achieved offset; campaign deployment prints a warning
+when audio or ROS 2 pre-roll was requested. Unknown drop counts are displayed
+as unknown, never as zero.
 
 ## Concurrency and retention
 


### PR DESCRIPTION
## Problem

A campaign that sets `buffer: 10s` promises a clip that runs from ten seconds
before the trigger to `after_trigger` past it. Today that promise holds only for
application records: the data manager keeps a continuously maintained pre-roll
ring, but it walks `storedApplicationRecord` only. Camera capture begins AT the
trigger, so the frame that caused the episode is never recorded. In the demo the
subject was already in frame rather than walking in. The design's Arm lifecycle
phase for exactly this was never built and is recorded in the debt register as
"No fragment pre-roll (Arm lifecycle unimplemented)".

## Cause

The camera capture adapter had no standby state. It joined the producer hub and
opened its episode files (segments, `index.jsonl`, `clock_samples.jsonl`) only
when the campaign triggered, so there was no keyframe-aligned buffer of the
seconds before the trigger to flush into the episode.

## Solution

Add an Arm (standby) phase to the capture-adapter contract, camera only this
round.

- **Where the phase lives.** `dataArmingAdapter` in
  `go/internal/agent/services/data_service.go` is the optional pre-roll
  extension of the existing capture-adapter contract (`Arm`/`Disarm`). The
  camera adapter implements it; audio and ROS 2 do not. The episode's campaign
  key is threaded to the adapter through a new
  `data.CaptureSession.CampaignKey`, so the adapter's own `Start` finds and
  consumes the ring the campaign armed.

- **Arming is non-owning.** A parameter-less `StreamVideoRequest` joins the
  device hub exactly like the sensor path, so arming never takes a running
  stream from a viewer and registers no explicit-parameter holder. That is the
  bit the parameter-precedence work this branch stacks on pivots the takeover
  on, so arming can never force the takeover, and if an unrelated
  explicit-parameter capture restarts the producer, the armed subscriber
  reattaches (like the sensor path) and marks a segment boundary in the ring.

- **The ring reuses existing mechanisms.** `cameraPreRollRing`
  (`data_camera_preroll.go`) mirrors the application ring's byte-eviction
  discipline (`preRollBytes`/`evictPreRoll`): drop the oldest until within the
  window and the byte cap. It is specialised so it only ever begins on a
  random-access unit and only evicts whole groups of pictures, reusing the
  adapter's `frameRandomAccess` keyframe logic, because a flushed clip that does
  not start on a keyframe will not decode. One ring per campaign source, bounded
  by `buffer` seconds and by a fixed byte ceiling, whichever is tighter.

- **Real capture times and identities.** On trigger the ring is flushed into the
  opening frames on the same subscription, which then continues live. Each
  buffered frame carries the bracketed `CLOCK_BOOTTIME` receipt the hub stamped
  at broadcast (`receiptBootNanos`) and its real `sample_id`, so `index.jsonl`
  gets true negative-offset `canonical_episode_nanos` and payload-retention
  accounting and the sample-id/model-input correlation treat them as captured
  frames with their real ids and offsets.

- **Pre-roll and explicit stream parameters are mutually exclusive, and
  deployment says so.** Because arming asserts no parameters, a camera source
  that sets both a `buffer` and an explicit `max_resolution` or `rate` records
  both its pre-roll and its live tail at the producer's running parameters. The
  manifest reports those values as requested but not achieved, and
  `wendy data campaign deploy` now warns at deploy time, naming each offending
  source, so the operator learns while they can still change the plan rather
  than after an episode was recorded at the wrong parameters. Snapshot-mode
  camera sources are never armed, so their explicit parameters are still
  honored and they are not warned about.

- **Achieved versus requested, honestly.** The manifest source entry keeps the
  requested offset (`-buffer`) and reports the achieved offset from how far back
  the ring actually reached: at steady state at least the buffer, but shorter
  right after arming. If the ring cannot reach a keyframe at or before
  `X - buffer`, it flushes from the earliest keyframe it has and records
  achieved < requested. It never fabricates frames and never fails the episode.
  Audio and ROS 2 still start at the trigger and report their achieved offset;
  the deployment warning is updated to say so.

Campaigns are armed on deploy, re-armed after each episode finalizes, and
reconciled at agent startup for campaigns deployed in a previous lifetime.

## Tests

`CC=/usr/bin/clang go test -race ./go/internal/agent/data/... ./go/internal/agent/services/...`
is green, along with `go build ./go/...`, empty `gofmt -l go/`, and clean
`go vet`. New unit tests:

- the armed ring retains keyframe-aligned frames and evicts whole older groups
  of pictures;
- a trigger flushes the pre-roll with correct negative canonical offsets and the
  real broadcast sample ids, counted as captured payload;
- achieved < requested is reported when armed less than a buffer before the
  trigger;
- arming joins a defaulted hub without restarting it and without registering an
  explicit-parameter holder (it never forces the takeover), plus an end-to-end
  arm/broadcast/trigger flush on a bare hub;
- a buffered camera-only campaign no longer deploy-warns that its stream starts
  at the trigger, while a ROS 2 source still does;
- the mutual-exclusivity warning fires for buffer plus `max_resolution` and for
  buffer plus `rate`, and does not fire for a buffer alone, for explicit
  parameters alone, or for an unarmed snapshot-mode source.

## Hardware verification plan

No device installs were performed. On a device:

1. Deploy a campaign with `buffer: 10s` and a camera source carrying no explicit
   `max_resolution` or `rate`, and confirm deployment no longer warns that the
   camera starts at the trigger and does not print the mutual-exclusivity
   warning. Deploy a second campaign that sets both a buffer and an explicit
   `max_resolution` and confirm the mutual-exclusivity warning does print.
2. Wait past the buffer, then walk into frame to fire the trigger.
3. Download the sealed clip and open the camera source's `index.jsonl`.
4. Confirm index entries exist whose `canonical_episode_nanos` is negative
   (BEFORE the trigger instant), each carrying a real `sample_id`, and that
   their `byte_offset`/`segment` resolve to decodable payload in the segment
   files. Join those sample ids against the model-input ledger to confirm frames
   a model consumed before the trigger resolve to retained payload.
5. Confirm the manifest's camera source entry reports an achieved offset at or
   below `-10s` once armed for at least the buffer, and a shorter (honest)
   achieved offset when triggered shortly after arming.

Do not squash merge. Do not merge without review.

