### PR TITLE
Send the per-file role on episode upload

### DIFF
--- a/Proto/cloud/data_ingest.proto
+++ b/Proto/cloud/data_ingest.proto
@@ -22,9 +22,11 @@ package wendycloud.data.v1;
 //
 // Authentication:
 //   - Begin/Upload/Commit require a device asset identity (mTLS client
-//     certificate SAN). Uploads are scoped to the asserted org and asset; a
-//     manifest whose org_id or asset_id differs from the certificate
-//     identity is rejected with PERMISSION_DENIED.
+//     certificate SAN). The owning organization and asset are read from that
+//     certificate and attested by the cloud; they are not carried on the
+//     request. Every catalog row and every storage object name is written
+//     from the certificate identity, so an upload cannot name a tenant it
+//     does not hold a certificate for.
 //   - QueryEpisodes/GetEpisode are read RPCs for users and services; the
 //     serving implementation defines the accepted credential.
 service DataIngestService {
@@ -79,11 +81,28 @@ enum EpisodeFileRole {
 message EpisodeManifest {
   string episode_id = 1;
 
-  // Must match the certificate identity of the uploading device.
-  uint64 org_id = 2;
-  uint64 asset_id = 3;
+  // 2 and 3 were org_id and asset_id, which the device asserted and the cloud
+  // only ever compared against the uploading certificate before discarding.
+  // The certificate is the sole source of both, so the wire no longer offers
+  // a place to claim otherwise. Numbers stay reserved: never reuse them.
+  reserved 2, 3;
+  reserved "org_id", "asset_id";
 
+  // Campaign name: the `name:` field of the campaign file that armed this
+  // capture, a human-authored slug such as "forklift-failures". It is not an
+  // identifier minted by the cloud, and it is not unique over time; the
+  // (campaign, campaign_revision) pair is what identifies an exact plan.
   string campaign = 4;
+  // Lowercase hex SHA-256 of the canonical campaign plan, so always exactly
+  // 64 characters. The device computes it in WendyOS at
+  // go/internal/agent/data/campaign.go:219, as
+  // hex(sha256(json(campaign.planOnly()))), where planOnly() strips deployment
+  // state so only author-declared plan fields feed the digest.
+  //
+  // String, not an integer: 256 bits of digest do not fit in a uint64, and no
+  // truncation of a hash preserves it as an identifier. It is a content
+  // digest rather than a sequence number, so it identifies the exact plan
+  // that produced this episode but does not order two revisions.
   string campaign_revision = 5;
   // Trigger reason (e.g. "manual", "campaign-trigger", or the fired
   // expression such as "model.uncertainty > 0.65").
@@ -102,11 +121,21 @@ message EpisodeManifest {
   int64 utc_offset_upper_nanos = 11;
   string system_clock_status = 12;
 
-  repeated EpisodeFileManifest files = 13;
-
   // The complete device manifest JSON (manifest v2), stored verbatim in the
   // catalog attributes column.
+  //
+  // Deliberately bytes rather than map<string, string> or google.protobuf.
+  // Struct. This is not a flat key-value bag: it is a nested document (a
+  // files array, a per-file clock-mapping object, a trigger object, a device
+  // identity object), which a string map cannot hold at all. Struct could
+  // hold the shape but not the bytes, and byte fidelity is the point of the
+  // field: it is the artifact the device sealed, kept as sent so the catalog
+  // can be audited against the device rather than against our re-encoding of
+  // it. The typed fields above are what the catalog indexes on.
   bytes attributes_json = 14;
+
+  // Declared last by convention; field number 13 is unchanged.
+  repeated EpisodeFileManifest files = 13;
 }
 
 // One file of an episode, as declared by the device manifest.
@@ -139,7 +168,7 @@ message FileUploadState {
   string path = 1;
   // Bytes durably stored in object storage for this file: 0 (not stored or
   // partially stored; restart from 0) or the full file size (stored; skip).
-  int64 committed_offset = 2;
+  uint64 committed_offset = 2;
 }
 
 message BeginEpisodeUploadResponse {
@@ -152,8 +181,20 @@ message EpisodeChunk {
   string path = 2;
   // Byte offset of this chunk within the file; must equal the number of
   // bytes already sent for the file (sequential, no gaps).
-  int64 offset = 3;
-  // At most 1 MiB per chunk.
+  uint64 offset = 3;
+  // At most 1 MiB of payload per chunk.
+  //
+  // Why 1 MiB: gRPC's default maximum received message size is 4 MiB, and
+  // that budget covers the whole encoded EpisodeChunk, not just this field.
+  // 1 MiB leaves room for path, offset and framing while staying well inside
+  // the default on every runtime, so neither end has to raise its limit to
+  // speak this protocol. It also bounds what one failed chunk costs to send
+  // again, which is what makes a retry cheap on a slow uplink. It is the
+  // device transfer worker's buffer size too, so cap and sender agree by
+  // construction rather than by luck.
+  //
+  // The cloud enforces this: an oversized chunk is INVALID_ARGUMENT naming
+  // the limit and the size received. The cap is a rule, not a request.
   bytes data = 4;
   // True on the last chunk of the file; the server then persists the file
   // to object storage.
@@ -163,11 +204,11 @@ message EpisodeChunk {
 message EpisodeChunkAck {
   string path = 1;
   // Contiguous bytes received (spooled server-side, not yet durable).
-  int64 received_offset = 2;
+  uint64 received_offset = 2;
   // Bytes durably stored in object storage. Stays 0 until the eof chunk is
   // persisted, then equals the file size. Never claims durability that
   // does not exist.
-  int64 committed_offset = 3;
+  uint64 committed_offset = 3;
 }
 
 message CommitEpisodeRequest {
@@ -181,6 +222,10 @@ message FileVerification {
   string expected_sha256 = 3;
   string actual_sha256 = 4;
   // Human-readable detail on failure (missing object, size mismatch, ...).
+  // Plain string rather than optional: `ok` is the discriminator, and the
+  // server sets detail on every failure and never on success, so empty and
+  // absent would mean the same thing. Presence here would add a has-check to
+  // every consumer without letting any of them decide anything new.
   string detail = 5;
 }
 
@@ -219,13 +264,27 @@ message GetEpisodeRequest {
 // A catalog row plus its files.
 message Episode {
   string episode_id = 1;
+  // Owning tenant, as attested by the cloud. Unlike the upload manifest, this
+  // is server output, not a client claim: it reports the identity the episode
+  // was actually stored under. It stays on the response because a query with
+  // no asset filter spans assets, and a reader that cannot tell the rows
+  // apart would have to reach into attributes_json to do it.
   uint64 org_id = 2;
   uint64 asset_id = 3;
+  // Campaign name and its trigger, as recorded at capture time.
   string campaign = 4;
   string trigger = 5;
   int64 started_unix_nanos = 6;
   int64 ended_unix_nanos = 7;
   EpisodeState state = 8;
+  // Total bytes the episode occupies in object storage: the sum of every
+  // file's size, derived files included. It is deliberately NOT capture-only.
+  // This number answers "what does this episode cost to store", which is what
+  // retention and quota act on, and it stays equal to the sum of the file
+  // sizes so the two can be checked against each other. A total that silently
+  // omitted some of its own parts would match neither storage nor the file
+  // list. Capture-only bytes are a filter over the per-file roles, e.g.
+  // summing size_bytes where role is CAPTURED or UNSPECIFIED.
   uint64 size_bytes = 9;
   // Clock correlation summary JSON (UTC offset bounds, clock status).
   bytes clock_correlation_json = 10;

--- a/Proto/cloud/data_ingest.proto
+++ b/Proto/cloud/data_ingest.proto
@@ -54,6 +54,25 @@ enum EpisodeState {
   EPISODE_STATE_FAILED = 3;
 }
 
+// What a file is to the episode it belongs to. Mirrors the device manifest's
+// per-file `role`, one word for one thing across device, wire and catalog.
+//
+// UNSPECIFIED means CAPTURED. Devices built before this field existed never
+// set it and upload nothing but capture payload and capture metadata, so an
+// absent role has exactly the meaning it always had; readers must treat
+// UNSPECIFIED and CAPTURED identically and must never report "unknown role".
+enum EpisodeFileRole {
+  EPISODE_FILE_ROLE_UNSPECIFIED = 0;
+  // Capture payload, or capture metadata written while recording.
+  EPISODE_FILE_ROLE_CAPTURED = 1;
+  // Computed from capture payload at seal time rather than recorded during
+  // capture, e.g. the per-source cameras/<source>/playable.mp4 remux. A
+  // derived file is checksummed, uploaded and verified like any other file,
+  // but it is not capture payload: deleting one loses no recorded data, and
+  // per-source payload accounting must never count its bytes as capture.
+  EPISODE_FILE_ROLE_DERIVED = 2;
+}
+
 // Compact typed projection of the device episode manifest (manifest v2).
 // The full manifest JSON rides in attributes_json for fidelity; the typed
 // fields are what the catalog indexes on.
@@ -107,6 +126,9 @@ message EpisodeFileManifest {
   int64 time_range_end_nanos = 8;
   // Source-clock to canonical-clock mapping summary JSON, when present.
   bytes clock_mapping_json = 9;
+  // What this file is to the episode. Unset (UNSPECIFIED) means CAPTURED, so
+  // devices predating this field keep their existing meaning unchanged.
+  EpisodeFileRole role = 10;
 }
 
 message BeginEpisodeUploadRequest {
@@ -222,4 +244,7 @@ message EpisodeFileInfo {
   // Short-lived retrieval URL for the stored object (signed in production,
   // direct in local development).
   string retrieval_url = 6;
+  // What this file is to the episode, as recorded in the catalog. Unset
+  // (UNSPECIFIED) means CAPTURED, as on the upload manifest.
+  EpisodeFileRole role = 7;
 }

--- a/Proto/cloud/data_ingest.proto
+++ b/Proto/cloud/data_ingest.proto
@@ -15,7 +15,10 @@ package wendycloud.data.v1;
 //   2. UploadEpisodeChunk streams file chunks (at most 1 MiB of data per
 //      chunk, sequential offsets per file, eof on the last chunk). Each
 //      chunk is acknowledged with the received (spooled) offset and the
-//      committed (durably stored in object storage) offset.
+//      committed (durably stored in object storage) offset. An ack names the
+//      (episode_id, path) it belongs to and must be matched on that pair,
+//      because one stream may carry chunks for more than one episode and a
+//      path is unique only within an episode.
 //   3. CommitEpisode verifies the SHA-256 of every stored object against
 //      the manifest and flips the catalog state to `complete`, or `failed`
 //      with per-file detail on any mismatch.
@@ -28,7 +31,13 @@ package wendycloud.data.v1;
 //     from the certificate identity, so an upload cannot name a tenant it
 //     does not hold a certificate for.
 //   - QueryEpisodes/GetEpisode are read RPCs for users and services; the
-//     serving implementation defines the accepted credential.
+//     serving implementation defines the accepted credential. Both carry an
+//     org_id whose membership the server does not verify today, and the read
+//     credential in use is a single shared token scoped to no organization.
+//     GetEpisode returns signed object URLs, so that combination is a
+//     cross-organization data-egress path, not just a catalog read. Read the
+//     org_id documentation on QueryEpisodesRequest and GetEpisodeRequest
+//     before exposing either RPC beyond a trusted internal caller.
 service DataIngestService {
   // Registers (or re-registers) an episode upload. Idempotent.
   rpc BeginEpisodeUpload(BeginEpisodeUploadRequest) returns (BeginEpisodeUploadResponse);
@@ -59,10 +68,25 @@ enum EpisodeState {
 // What a file is to the episode it belongs to. Mirrors the device manifest's
 // per-file `role`, one word for one thing across device, wire and catalog.
 //
-// UNSPECIFIED means CAPTURED. Devices built before this field existed never
-// set it and upload nothing but capture payload and capture metadata, so an
-// absent role has exactly the meaning it always had; readers must treat
-// UNSPECIFIED and CAPTURED identically and must never report "unknown role".
+// UNSPECIFIED carries exactly one meaning: the sender predates this field and
+// said nothing about roles. A file with no role is accounted as CAPTURED,
+// which is the meaning it carried before the field existed.
+//
+// That default is a best reading of a silent sender, not a proof about what
+// such senders produced. Derived files, including the playable remux, existed
+// on the device before the wire role did, so a manifest sealed in that window
+// can legitimately contain a derived file with no role on it.
+//
+// A sender that HAS a role but cannot express it on this enum MUST NOT send
+// UNSPECIFIED. Doing so books the file as capture payload, corrupts
+// capture-only accounting, and leaves no signal that anything was lost. Add
+// the role to this enum and send it.
+//
+// A reader that receives a role number it does not know must retain the
+// number as received, must not coerce it to CAPTURED, and must not fail the
+// episode. Carry it through storage, count its bytes in size totals, and
+// leave them out of capture-only sums. An unknown role means a newer peer,
+// not a corrupt one.
 enum EpisodeFileRole {
   EPISODE_FILE_ROLE_UNSPECIFIED = 0;
   // Capture payload, or capture metadata written while recording.
@@ -85,6 +109,24 @@ message EpisodeManifest {
   // only ever compared against the uploading certificate before discarding.
   // The certificate is the sole source of both, so the wire no longer offers
   // a place to claim otherwise. Numbers stay reserved: never reuse them.
+  //
+  // DEPLOYMENT ORDER, load-bearing: deploy the cloud BEFORE the devices.
+  // A new device omits 2 and 3. An old cloud decodes the absent fields as
+  // zero, compares zero against the certificate identity, and rejects, so
+  // every upload from a new device to an old cloud fails with
+  // PERMISSION_DENIED. The reverse pairing is safe: an old device still sends
+  // both, and a new cloud parks them in unknown fields and ignores them.
+  //
+  // The same asymmetry makes a cloud ROLLBACK a fleet-wide outage once
+  // devices have shipped. It does not degrade a subset of uploads; every
+  // upload from every migrated device returns PERMISSION_DENIED until the
+  // cloud is rolled forward again. Treat the cloud side of this change as a
+  // one-way door and stage it accordingly.
+  //
+  // With the fields gone there is also no wire signal that distinguishes an
+  // old device from a new one, so migration progress cannot be measured from
+  // the manifest. Measure it from agent version reporting instead, and do not
+  // plan a rollout that depends on counting manifests.
   reserved 2, 3;
   reserved "org_id", "asset_id";
 
@@ -92,12 +134,29 @@ message EpisodeManifest {
   // capture, a human-authored slug such as "forklift-failures". It is not an
   // identifier minted by the cloud, and it is not unique over time; the
   // (campaign, campaign_revision) pair is what identifies an exact plan.
+  //
+  // EMPTY when the episode has no campaign. A manual or otherwise ad-hoc
+  // capture is armed by an operator, not by a campaign file, so there is no
+  // campaign name to report; such an episode carries "manual" as its trigger
+  // reason and leaves both campaign fields empty together. This is ordinary
+  // traffic, not an edge case, so consumers must accept the empty value
+  // rather than reject or substitute it.
   string campaign = 4;
-  // Lowercase hex SHA-256 of the canonical campaign plan, so always exactly
-  // 64 characters. The device computes it in WendyOS at
-  // go/internal/agent/data/campaign.go:219, as
-  // hex(sha256(json(campaign.planOnly()))), where planOnly() strips deployment
-  // state so only author-declared plan fields feed the digest.
+  // Revision digest of the campaign plan that armed this capture.
+  //
+  // EMPTY when the episode has no campaign, for the same reason `campaign` is
+  // empty: a manual or ad-hoc capture never had a plan to digest. Otherwise
+  // it is a lowercase hex SHA-256 and therefore exactly 64 characters. A
+  // consumer that validates 64 hex characters unconditionally will reject
+  // legitimate and common data; check the length only after finding the value
+  // non-empty.
+  //
+  // Derivation: the device serialises the campaign to canonical JSON with
+  // deployment state stripped, so that only author-declared plan fields feed
+  // the digest, and takes the lowercase hex SHA-256 of those bytes. Two
+  // devices running the same plan report the same revision. Described rather
+  // than cited by file and line: the implementation lives in another
+  // repository and any line number given here is stale on its next edit.
   //
   // String, not an integer: 256 bits of digest do not fit in a uint64, and no
   // truncation of a hash preserves it as an identifier. It is a content
@@ -155,8 +214,10 @@ message EpisodeFileManifest {
   int64 time_range_end_nanos = 8;
   // Source-clock to canonical-clock mapping summary JSON, when present.
   bytes clock_mapping_json = 9;
-  // What this file is to the episode. Unset (UNSPECIFIED) means CAPTURED, so
-  // devices predating this field keep their existing meaning unchanged.
+  // What this file is to the episode. Unset (UNSPECIFIED) means the sender
+  // predates this field, and is accounted as CAPTURED. See EpisodeFileRole
+  // for what a sender must do with a role it cannot express, and what a
+  // reader must do with a role number it does not know.
   EpisodeFileRole role = 10;
 }
 
@@ -209,6 +270,23 @@ message EpisodeChunkAck {
   // persisted, then equals the file size. Never claims durability that
   // does not exist.
   uint64 committed_offset = 3;
+  // The episode the acknowledged path belongs to; echoes the `episode_id` of
+  // the chunk being acknowledged.
+  //
+  // A client MUST match an ack on the (episode_id, path) pair, never on path
+  // alone. EpisodeChunk carries episode_id per chunk, so one stream may carry
+  // chunks for more than one episode, and the server keys its assembler on
+  // the same pair. A path is unique only within an episode: two episodes on
+  // one stream that both contain "manifest.json" produce acks that path alone
+  // cannot tell apart, and a client matching on path credits one episode's
+  // committed offset to the other, then skips a file it never uploaded. That
+  // is silent data loss, not a retry.
+  //
+  // Added after `path`, so a server built before this field leaves it empty.
+  // A client that finds it empty cannot match safely on a multi-episode
+  // stream, and must keep to one stream per episode until the server carries
+  // the field.
+  string episode_id = 4;
 }
 
 message CommitEpisodeRequest {
@@ -235,10 +313,20 @@ message CommitEpisodeResponse {
 }
 
 message QueryEpisodesRequest {
-  // Organization scope. With certificate-identity credentials this must
-  // match the caller's organization; with the PoC static read token it
-  // selects the organization to read (chosen debt until user auth carries
-  // org membership).
+  // Organization to read. This is a filter the caller supplies, not an
+  // identity the server verifies. With certificate-identity credentials it
+  // must match the organization on the certificate.
+  //
+  // AUTHORIZATION GAP, unresolved: the read credential today is a single
+  // shared bearer token that is scoped to no organization, and the server
+  // does NOT check that the caller is a member of the organization named
+  // here. Possession of that token therefore grants catalog read across every
+  // organization, obtained by passing a different number in this field. The
+  // field is not the defect and must not be removed, because a filter is the
+  // right shape once membership is enforced. A server-side membership check,
+  // against the caller's own credential rather than against this value, is
+  // REQUIRED before this RPC is exposed to anything but a trusted internal
+  // caller.
   uint64 org_id = 1;
 
   // Optional filters; zero values mean "no filter".
@@ -257,6 +345,23 @@ message QueryEpisodesResponse {
 }
 
 message GetEpisodeRequest {
+  // Organization the named episode belongs to. Same caller-supplied filter as
+  // QueryEpisodesRequest.org_id, unverified in the same way, under the same
+  // shared read token.
+  //
+  // AUTHORIZATION GAP, sharper here than on the query: this RPC returns
+  // per-file retrieval URLs, short-lived signed object-storage URLs that read
+  // the stored bytes. Absent a membership check, the shared read token is not
+  // merely a cross-organization catalog read; it is a cross-organization
+  // data-egress capability. Name another organization's identifier here with
+  // one of its episode identifiers and the response hands back signed URLs to
+  // that organization's captured data. Those URLs are bearer capabilities in
+  // their own right: they work for anyone they are passed to, and revoking
+  // the read token afterwards does not revoke URLs already issued.
+  //
+  // The fix is authorization, not schema; the field stays. A server-side
+  // membership check is REQUIRED before this RPC is exposed to anything but a
+  // trusted internal caller.
   uint64 org_id = 1;
   string episode_id = 2;
 }
@@ -304,6 +409,8 @@ message EpisodeFileInfo {
   // direct in local development).
   string retrieval_url = 6;
   // What this file is to the episode, as recorded in the catalog. Unset
-  // (UNSPECIFIED) means CAPTURED, as on the upload manifest.
+  // (UNSPECIFIED) means the uploading sender predated the field, as on the
+  // upload manifest. A role the catalog did not recognise at write time is
+  // reported here as the number it arrived as, never rewritten to CAPTURED.
   EpisodeFileRole role = 7;
 }

--- a/go/cmd/episode-playable/main.go
+++ b/go/cmd/episode-playable/main.go
@@ -85,6 +85,9 @@ The episode directory is never modified.
 		if r.SyncSamples == 0 {
 			fmt.Fprintf(os.Stderr, "episode-playable: warning: camera %s clip carries no random-access frame, so players cannot seek in it and many will not open it at all\n", r.Source)
 		}
+		if r.ParameterSetChanges > 0 {
+			fmt.Fprintf(os.Stderr, "episode-playable: warning: camera %s changes its SPS/PPS mid-stream (%d changed unit(s), a producer restart); the clip carries only the first decoder configuration, so frames after the change will misdecode\n", r.Source, r.ParameterSetChanges)
+		}
 		if r.BFrames {
 			fmt.Fprintf(os.Stderr, "episode-playable: warning: camera %s contains B slices, so its presentation order differs from the coded order index.jsonl records; the timing written for it is approximate\n", r.Source)
 		} else if r.UndecodedSliceHeaders > 0 {

--- a/go/cmd/episode-playable/main.go
+++ b/go/cmd/episode-playable/main.go
@@ -48,6 +48,20 @@ The episode directory is never modified.
 		dest = episode + "-playable"
 	}
 
+	// Episodes sealed since the agent learned to remux at seal time already
+	// carry cameras/<source>/playable.mp4, listed in their manifest. When
+	// every camera source has one there is nothing to convert; reconverting
+	// would only duplicate bytes the manifest already vouches for.
+	existing, _ := filepath.Glob(filepath.Join(episode, "cameras", "*", episodeexport.PlayableFileName))
+	indexes, _ := filepath.Glob(filepath.Join(episode, "cameras", "*", "index.jsonl"))
+	if len(existing) > 0 && len(existing) >= len(indexes) {
+		fmt.Println("episode already carries playable files written at seal time; nothing to convert:")
+		for _, p := range existing {
+			fmt.Printf("  %s\n", p)
+		}
+		return
+	}
+
 	results, errs := episodeexport.Convert(episode, dest)
 	for _, r := range results {
 		if r.Output == "" {

--- a/go/internal/agent/data/manager.go
+++ b/go/internal/agent/data/manager.go
@@ -928,6 +928,17 @@ func (m *Manager) finalizeLocked(a *activeEpisode, state, reason string) (Manife
 			return Manifest{}, err
 		}
 	}
+	// The playable remux runs before sealFiles so each derived
+	// cameras/<source>/playable.mp4 is checksummed, listed, uploaded and
+	// verified exactly like the capture it derives from. Sealing was already
+	// a synchronous pass over every episode byte (the checksums below), and
+	// the remux is a copy, not a transcode, so this keeps the seal's shape:
+	// one more read of the camera bytes, never a failure. A source that
+	// cannot be muxed honestly seals without its clip and the notes say why.
+	a.manifest.PlayableNotes = muxPlayableClips(a.dir)
+	for _, note := range a.manifest.PlayableNotes {
+		m.warnf("episode %s: %s", a.manifest.ID, note)
+	}
 	files, err := sealFiles(a.dir)
 	if err != nil {
 		return Manifest{}, err
@@ -1177,6 +1188,11 @@ func (m *Manager) recoverPartials() error {
 		if reconciled {
 			mf.RecoveryActions = append(mf.RecoveryActions, "recomputed model input/outcome counters from "+ModelInputLedgerFile+" and "+mf.ModelIO.OutcomeLog)
 		}
+		// Recovery is the other path that seals an episode, so it derives the
+		// same playable clips; the truncated index tails above were already
+		// cut, and the muxer counts a partial trailing line as unusable
+		// rather than guessing at it.
+		mf.PlayableNotes = muxPlayableClips(dir)
 		mf.Files, err = sealFiles(dir)
 		if err != nil {
 			return fmt.Errorf("recovering episode %s: %w", mf.ID, err)
@@ -1297,7 +1313,11 @@ func sealFiles(dir string) ([]File, error) {
 		}
 		rel = filepath.ToSlash(rel)
 		format, mediaType := payloadFormat(rel)
-		out = append(out, File{Path: rel, Size: n, SHA256: h, SourceID: sourceForPath(rel), Format: format, MediaType: mediaType})
+		entry := File{Path: rel, Size: n, SHA256: h, SourceID: sourceForPath(rel), Format: format, MediaType: mediaType}
+		if isDerivedPlayable(rel) {
+			entry.Role = FileRoleDerived
+		}
+		out = append(out, entry)
 		return nil
 	})
 	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })

--- a/go/internal/agent/data/model.go
+++ b/go/internal/agent/data/model.go
@@ -207,6 +207,15 @@ type MonotonicMappingSample struct {
 	OffsetUpperNanos int64 `json:"offset_upper_nanos"`
 }
 
+// FileRoleDerived marks a manifest file computed from capture payload at seal
+// time rather than recorded during capture. Today that is the per-source
+// cameras/<source>/playable.mp4 remux. A derived file is checksummed, uploaded
+// and verified exactly like every other listed file, but it is not capture
+// payload: model-input and payload-retention accounting resolve payload bytes
+// through cameras/<source>/index.jsonl into the raw segments and must never
+// count a derived file, and deleting one loses no recorded data.
+const FileRoleDerived = "derived"
+
 type File struct {
 	Path      string `json:"path"`
 	Size      int64  `json:"size"`
@@ -214,6 +223,10 @@ type File struct {
 	SourceID  string `json:"source_id,omitempty"`
 	Format    string `json:"format"`
 	MediaType string `json:"media_type"`
+	// Role distinguishes what a file is to the episode. Empty means capture
+	// payload or capture metadata written while recording; FileRoleDerived
+	// marks an artifact computed from that payload at seal time.
+	Role string `json:"role,omitempty"`
 }
 
 type Calibration struct {
@@ -285,9 +298,14 @@ type Manifest struct {
 	Upload            WorkflowState           `json:"upload"`
 	Labeling          WorkflowState           `json:"labeling"`
 	RecoveryActions   []string                `json:"recovery_actions,omitempty"`
-	PreRollLost       uint64                  `json:"pre_roll_lost"`
-	PreRollAccounting string                  `json:"pre_roll_accounting"`
-	ModelIO           ModelIO                 `json:"model_io"`
+	// PlayableNotes records, per camera source, why the seal wrote no
+	// cameras/<source>/playable.mp4 or why the one it wrote omits frames.
+	// Absence of a note plus absence of the file means the episode captured
+	// no camera; a note is the seal's honest account of a mux it refused.
+	PlayableNotes     []string `json:"playable_notes,omitempty"`
+	PreRollLost       uint64   `json:"pre_roll_lost"`
+	PreRollAccounting string   `json:"pre_roll_accounting"`
+	ModelIO           ModelIO  `json:"model_io"`
 }
 
 type StartOptions struct {

--- a/go/internal/agent/data/playable.go
+++ b/go/internal/agent/data/playable.go
@@ -1,0 +1,95 @@
+package data
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+
+	"github.com/wendylabsinc/wendy/go/internal/episodeexport"
+)
+
+// muxPlayableClips writes cameras/<source>/playable.mp4 for every camera
+// source of a finished episode. It runs while the episode is being sealed,
+// before sealFiles walks the directory, so the derived clip gets a size and
+// SHA-256 entry in the manifest and is uploaded and verified exactly like the
+// capture it derives from. The point is browser playback straight from the
+// bucket: browsers cannot play the raw H.264 elementary stream, and the remux
+// gives every frame the presentation time cameras/<source>/index.jsonl
+// recorded for it.
+//
+// It never fails or blocks the seal. The remux is a copy, not a transcode, so
+// its cost is one more pass over the camera bytes beside the checksum pass the
+// seal already makes, and the clip it leaves is roughly the size of the raw
+// stream it derives from; that size is counted against the episode by both
+// the manifest total and the disk-usage walk enforceQuota performs. A source
+// whose stream cannot become an honestly timed, seekable clip (B slices,
+// slice headers the muxer cannot parse, no random-access frame, or an
+// outright mux failure) seals without its playable.mp4, and the returned
+// notes, published as the manifest's playable_notes, name why. A clip that
+// was written but had to omit frames whose bytes were missing gets a note
+// too, so the manifest never presents a partial clip as a complete one.
+//
+// The raw capture is never touched: index.jsonl keeps addressing frames by
+// byte offset into the raw segments, so the correlation join between a frame
+// and the model input recorded against it is unaffected.
+func muxPlayableClips(dir string) []string {
+	indexes, err := filepath.Glob(filepath.Join(dir, "cameras", "*", "index.jsonl"))
+	if err != nil || len(indexes) == 0 {
+		return nil
+	}
+	sort.Strings(indexes)
+	var notes []string
+	for _, index := range indexes {
+		sourceDir := filepath.Dir(index)
+		rel := path.Join("cameras", filepath.Base(sourceDir), episodeexport.PlayableFileName)
+		result, err := episodeexport.ConvertSourceInPlace(dir, sourceDir)
+		if reason := playableSkipReason(result, err); reason != "" {
+			// ConvertSourceInPlace only leaves a file behind on success, but a
+			// clip refused by policy (B slices and the like) was written before
+			// the result could be judged, so it is removed rather than shipped
+			// with timing nobody can vouch for.
+			_ = os.Remove(filepath.Join(sourceDir, episodeexport.PlayableFileName))
+			notes = append(notes, fmt.Sprintf("%s not written: %s", rel, reason))
+			continue
+		}
+		if result.Skipped > 0 {
+			note := fmt.Sprintf("%s omits %d of %d indexed frame(s)", rel, result.Skipped, result.IndexLines)
+			if result.SkippedReason != "" {
+				note += ": " + result.SkippedReason
+			}
+			notes = append(notes, note)
+		}
+	}
+	return notes
+}
+
+// playableSkipReason decides whether a mux result is honest enough to publish
+// in the sealed episode, returning the reason to refuse it or "" to keep it.
+// The gates mirror the warnings the episode-playable command prints, but at
+// seal time they are hard: a clip whose timing or seekability the muxer
+// cannot vouch for is not listed in a manifest that vouches for everything it
+// lists.
+func playableSkipReason(r episodeexport.ClipResult, err error) string {
+	switch {
+	case err != nil:
+		return err.Error()
+	case r.Frames == 0:
+		return "no frame payload could be muxed"
+	case r.BFrames:
+		return "stream carries B slices, so its presentation order differs from the coded order index.jsonl records and the clip's timing would be wrong"
+	case r.UndecodedSliceHeaders > 0:
+		return fmt.Sprintf("%d slice header(s) could not be parsed, so whether the stream carries B slices is unknown and the clip's timing cannot be vouched for", r.UndecodedSliceHeaders)
+	case r.SyncSamples == 0:
+		return "clip would carry no random-access frame, so players cannot seek in it and many will not open it"
+	}
+	return ""
+}
+
+// isDerivedPlayable reports whether a manifest-relative path names a
+// seal-time derived camera remux, which sealFiles marks with FileRoleDerived.
+func isDerivedPlayable(rel string) bool {
+	dir, base := path.Split(rel)
+	return base == episodeexport.PlayableFileName && path.Dir(path.Clean(dir)) == "cameras"
+}

--- a/go/internal/agent/data/playable.go
+++ b/go/internal/agent/data/playable.go
@@ -81,6 +81,8 @@ func playableSkipReason(r episodeexport.ClipResult, err error) string {
 		return "stream carries B slices, so its presentation order differs from the coded order index.jsonl records and the clip's timing would be wrong"
 	case r.UndecodedSliceHeaders > 0:
 		return fmt.Sprintf("%d slice header(s) could not be parsed, so whether the stream carries B slices is unknown and the clip's timing cannot be vouched for", r.UndecodedSliceHeaders)
+	case r.ParameterSetChanges > 0:
+		return fmt.Sprintf("the stream's parameter sets change mid-episode (%d changed SPS/PPS unit(s), a producer restart), and the clip's single decoder configuration would misdecode every frame after the change", r.ParameterSetChanges)
 	case r.SyncSamples == 0:
 		return "clip would carry no random-access frame, so players cannot seek in it and many will not open it"
 	}

--- a/go/internal/agent/data/playable_test.go
+++ b/go/internal/agent/data/playable_test.go
@@ -1,0 +1,338 @@
+package data
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/episodeexport"
+)
+
+// The parameter sets are the ones a Jetson episode really carried, matching
+// the episodeexport package's own fixtures, so the seal-time mux is exercised
+// against the bitstream shape the device produces.
+const (
+	sealTestSPS = "6764001facb200a00b7602dc08081a94000003000400000300f23c60c920"
+	sealTestPPS = "68ebccb22c"
+)
+
+// Slice NAL units whose headers the muxer can and cannot parse. The seal only
+// keeps a clip whose timing it can vouch for, so the distinction is load
+// bearing: an IDR or P slice with a parseable header is publishable, a B
+// slice or an unparseable header is not.
+var (
+	parsedIDR     = append([]byte{0x65, 0x88}, make([]byte, 40)...) // slice_type 7 (I), parses
+	parsedPSlice  = append([]byte{0x41, 0xC0}, make([]byte, 30)...) // slice_type 0 (P), parses
+	parsedBSlice  = append([]byte{0x41, 0xA0}, make([]byte, 30)...) // slice_type 1 (B), parses
+	unparsedSlice = append([]byte{0x41}, make([]byte, 30)...)       // header is all zero bits, cannot parse
+)
+
+func annexB(nals ...[]byte) []byte {
+	var out []byte
+	for _, n := range nals {
+		out = append(out, 0, 0, 0, 1)
+		out = append(out, n...)
+	}
+	return out
+}
+
+// writeCameraSource lays one camera source into an active episode directory:
+// a single segment holding the given access units at irregular intervals, and
+// the index.jsonl that records where each frame's bytes landed.
+func writeCameraSource(t *testing.T, episodeDir, source string, accessUnits [][]byte) {
+	t.Helper()
+	sps, err := hex.DecodeString(sealTestSPS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pps, err := hex.DecodeString(sealTestPPS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(episodeDir, "cameras", source)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	segment := "cameras/" + source + "/segment-000001.h264"
+	// Irregular gaps on purpose: the remux must carry recorded timestamps,
+	// never a rate, and equal gaps could hide a muxer that assumed one.
+	gaps := []int64{0, 33_000_000, 95_000_000, 41_000_000, 62_000_000, 27_000_000}
+	var (
+		seg   []byte
+		index []byte
+		now   = int64(2_000_000_000)
+	)
+	for i, unit := range accessUnits {
+		payload := unit
+		if i == 0 {
+			payload = append(annexB(sps, pps), unit...)
+		}
+		now += gaps[i%len(gaps)]
+		line, err := json.Marshal(map[string]any{
+			"canonical_episode_nanos": now,
+			"segment":                 segment,
+			"byte_offset":             len(seg),
+			"byte_size":               len(payload),
+			"codec":                   "h264",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		seg = append(seg, payload...)
+		index = append(index, line...)
+		index = append(index, '\n')
+	}
+	if err := os.WriteFile(filepath.Join(dir, "segment-000001.h264"), seg, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "index.jsonl"), index, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func fileByPath(files []File, path string) (File, bool) {
+	for _, f := range files {
+		if f.Path == path {
+			return f, true
+		}
+	}
+	return File{}, false
+}
+
+func TestSealWritesPlayableClipListedInManifest(t *testing.T) {
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = m.Start(StartOptions{Sources: []string{"applications"}}); err != nil {
+		t.Fatal(err)
+	}
+	session, ok := m.ActiveSession(AdHocEpisodeKey)
+	if !ok {
+		t.Fatal("no active session")
+	}
+	writeCameraSource(t, session.Directory, "cam-front", [][]byte{
+		annexB(parsedIDR), annexB(parsedPSlice), annexB(parsedPSlice),
+	})
+	stopped, err := m.Stop(AdHocEpisodeKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stopped.State != "complete" {
+		t.Fatalf("state %q, want complete", stopped.State)
+	}
+	if len(stopped.PlayableNotes) != 0 {
+		t.Fatalf("clean mux left notes: %v", stopped.PlayableNotes)
+	}
+
+	rel := "cameras/cam-front/" + episodeexport.PlayableFileName
+	entry, ok := fileByPath(stopped.Files, rel)
+	if !ok {
+		t.Fatalf("manifest does not list %s: %+v", rel, stopped.Files)
+	}
+	if entry.Role != FileRoleDerived {
+		t.Errorf("derived clip role %q, want %q", entry.Role, FileRoleDerived)
+	}
+	if entry.Format != "mp4" || entry.MediaType != "video/mp4" {
+		t.Errorf("derived clip format %q media type %q, want mp4/video/mp4", entry.Format, entry.MediaType)
+	}
+	if entry.SourceID != "cam-front" {
+		t.Errorf("derived clip source %q, want cam-front", entry.SourceID)
+	}
+
+	// The listed size and SHA-256 must be the finished file's, so the
+	// transfer worker uploads it and commit-time verification covers it with
+	// no special casing.
+	onDisk := filepath.Join(m.root, stopped.ID, rel)
+	hash, size, err := checksum(onDisk)
+	if err != nil {
+		t.Fatalf("derived clip missing from sealed episode: %v", err)
+	}
+	if entry.SHA256 != hash || entry.Size != size {
+		t.Errorf("manifest entry (%d bytes, %s) does not match file (%d bytes, %s)", entry.Size, entry.SHA256, size, hash)
+	}
+	if size == 0 {
+		t.Error("derived clip is empty")
+	}
+
+	// The raw capture must still be listed, unmarked: only the remux is
+	// derived, and payload accounting keys on the raw files via the index.
+	for _, raw := range []string{"cameras/cam-front/segment-000001.h264", "cameras/cam-front/index.jsonl"} {
+		f, ok := fileByPath(stopped.Files, raw)
+		if !ok {
+			t.Fatalf("raw capture file %s missing from manifest", raw)
+		}
+		if f.Role != "" {
+			t.Errorf("raw capture file %s carries role %q, want none", raw, f.Role)
+		}
+	}
+
+	// Full verification passes with the derived file treated like any other
+	// listed file.
+	if _, failures, err := m.Inspect(stopped.ID, true); err != nil || len(failures) != 0 {
+		t.Fatalf("verification: err=%v failures=%v", err, failures)
+	}
+
+	// The derived clip counts against the episode's size, and so against the
+	// quota that size feeds.
+	infos, err := m.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var total int64
+	for _, f := range stopped.Files {
+		total += f.Size
+	}
+	if len(infos) != 1 || infos[0].SizeBytes != total {
+		t.Fatalf("episode size %d does not include every listed file (want %d)", infos[0].SizeBytes, total)
+	}
+	var withoutDerived int64
+	for _, f := range stopped.Files {
+		if f.Role != FileRoleDerived {
+			withoutDerived += f.Size
+		}
+	}
+	if withoutDerived >= total {
+		t.Error("derived clip contributed nothing to the episode size")
+	}
+}
+
+func TestSealRefusesClipItCannotVouchFor(t *testing.T) {
+	cases := []struct {
+		name       string
+		accessUnit []byte
+		wantNote   string
+	}{
+		{"b_slices", annexB(parsedBSlice), "B slices"},
+		{"unparsed_slice_header", annexB(unparsedSlice), "slice header"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := NewManager(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err = m.Start(StartOptions{Sources: []string{"applications"}}); err != nil {
+				t.Fatal(err)
+			}
+			session, ok := m.ActiveSession(AdHocEpisodeKey)
+			if !ok {
+				t.Fatal("no active session")
+			}
+			writeCameraSource(t, session.Directory, "cam-front", [][]byte{
+				annexB(parsedIDR), tc.accessUnit,
+			})
+			stopped, err := m.Stop(AdHocEpisodeKey)
+			if err != nil {
+				t.Fatalf("a refused mux must never fail the seal: %v", err)
+			}
+			if stopped.State != "complete" {
+				t.Fatalf("state %q, want complete", stopped.State)
+			}
+			rel := "cameras/cam-front/" + episodeexport.PlayableFileName
+			if _, ok := fileByPath(stopped.Files, rel); ok {
+				t.Errorf("manifest lists %s despite the refusal", rel)
+			}
+			if _, err := os.Stat(filepath.Join(m.root, stopped.ID, rel)); !os.IsNotExist(err) {
+				t.Errorf("refused clip left on disk (stat err %v)", err)
+			}
+			if len(stopped.PlayableNotes) != 1 || !strings.Contains(stopped.PlayableNotes[0], tc.wantNote) {
+				t.Errorf("notes %v do not name the refusal (%q)", stopped.PlayableNotes, tc.wantNote)
+			}
+			if !strings.Contains(stopped.PlayableNotes[0], rel+" not written") {
+				t.Errorf("note %q does not name the missing file", stopped.PlayableNotes[0])
+			}
+			if _, failures, err := m.Inspect(stopped.ID, true); err != nil || len(failures) != 0 {
+				t.Fatalf("verification: err=%v failures=%v", err, failures)
+			}
+		})
+	}
+}
+
+func TestSealRefusesClipWithoutRandomAccessFrame(t *testing.T) {
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = m.Start(StartOptions{Sources: []string{"applications"}}); err != nil {
+		t.Fatal(err)
+	}
+	session, ok := m.ActiveSession(AdHocEpisodeKey)
+	if !ok {
+		t.Fatal("no active session")
+	}
+	// Parameter sets but never an IDR: nothing a decoder can start on.
+	writeCameraSource(t, session.Directory, "cam-front", [][]byte{
+		annexB(parsedPSlice), annexB(parsedPSlice),
+	})
+	stopped, err := m.Stop(AdHocEpisodeKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rel := "cameras/cam-front/" + episodeexport.PlayableFileName
+	if _, ok := fileByPath(stopped.Files, rel); ok {
+		t.Errorf("manifest lists %s despite it having no sync sample", rel)
+	}
+	if len(stopped.PlayableNotes) != 1 || !strings.Contains(stopped.PlayableNotes[0], "random-access") {
+		t.Errorf("notes %v do not name the missing random-access frame", stopped.PlayableNotes)
+	}
+}
+
+func TestRecoverySealsPlayableClipToo(t *testing.T) {
+	root := t.TempDir()
+	m, err := NewManager(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := m.Start(StartOptions{Sources: []string{"applications"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeCameraSource(t, filepath.Join(root, started.ID+".partial"), "cam-front", [][]byte{
+		annexB(parsedIDR), annexB(parsedPSlice),
+	})
+	// A new manager over the same root recovers the abandoned partial.
+	m2, err := NewManager(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mf, failures, err := m2.Inspect(started.ID, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mf.State != "interrupted" {
+		t.Fatalf("state %q, want interrupted", mf.State)
+	}
+	if len(failures) != 0 {
+		t.Fatalf("verification failures: %v", failures)
+	}
+	rel := "cameras/cam-front/" + episodeexport.PlayableFileName
+	entry, ok := fileByPath(mf.Files, rel)
+	if !ok {
+		t.Fatalf("recovered manifest does not list %s", rel)
+	}
+	if entry.Role != FileRoleDerived {
+		t.Errorf("recovered clip role %q, want %q", entry.Role, FileRoleDerived)
+	}
+	if len(mf.PlayableNotes) != 0 {
+		t.Errorf("clean recovery mux left notes: %v", mf.PlayableNotes)
+	}
+}
+
+func TestIsDerivedPlayable(t *testing.T) {
+	for path, want := range map[string]bool{
+		"cameras/cam-front/playable.mp4":        true,
+		"cameras/cam-front/segment-000001.h264": false,
+		"playable.mp4":                          false,
+		"cameras/playable.mp4":                  false,
+		"audio/mic/playable.mp4":                false,
+		"cameras/cam/deeper/playable.mp4":       false,
+	} {
+		if got := isDerivedPlayable(path); got != want {
+			t.Errorf("isDerivedPlayable(%q) = %v, want %v", path, got, want)
+		}
+	}
+}

--- a/go/internal/agent/data/playable_test.go
+++ b/go/internal/agent/data/playable_test.go
@@ -252,6 +252,109 @@ func TestSealRefusesClipItCannotVouchFor(t *testing.T) {
 	}
 }
 
+// A producer restart mid-episode splices new SPS/PPS into the raw stream. The
+// derived clip carries exactly one decoder configuration, so such a stream
+// must seal without its playable.mp4 and say why; no other gate notices,
+// because every frame still copies cleanly.
+func TestSealRefusesClipAfterParameterSetChange(t *testing.T) {
+	// A second camera's parameter sets at 640x480, byte-different from the
+	// 1280x720 pair writeCameraSource lays down at the head of the stream.
+	sps2, err := hex.DecodeString("6742c01e8c8d40501e900f08846a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pps2, err := hex.DecodeString("68ce3c80")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = m.Start(StartOptions{Sources: []string{"applications"}}); err != nil {
+		t.Fatal(err)
+	}
+	session, ok := m.ActiveSession(AdHocEpisodeKey)
+	if !ok {
+		t.Fatal("no active session")
+	}
+	writeCameraSource(t, session.Directory, "cam-front", [][]byte{
+		annexB(parsedIDR), annexB(parsedPSlice),
+		annexB(sps2, pps2, parsedIDR), annexB(parsedPSlice),
+	})
+	stopped, err := m.Stop(AdHocEpisodeKey)
+	if err != nil {
+		t.Fatalf("a refused mux must never fail the seal: %v", err)
+	}
+	rel := "cameras/cam-front/" + episodeexport.PlayableFileName
+	if _, ok := fileByPath(stopped.Files, rel); ok {
+		t.Errorf("manifest lists %s despite the mid-episode parameter set change", rel)
+	}
+	if _, err := os.Stat(filepath.Join(m.root, stopped.ID, rel)); !os.IsNotExist(err) {
+		t.Errorf("refused clip left on disk (stat err %v)", err)
+	}
+	if len(stopped.PlayableNotes) != 1 || !strings.Contains(stopped.PlayableNotes[0], "parameter sets change") {
+		t.Errorf("notes %v do not name the parameter set change", stopped.PlayableNotes)
+	}
+}
+
+// The mux can fail on plain I/O (a full disk mid-write follows the same error
+// path: the write error surfaces, the .tmp is removed, and the seal goes on).
+// Provoke an open failure with an unwritable source directory and hold the
+// seal to its contract: the episode completes, the note says why, and nothing
+// half-written is listed or left behind.
+func TestSealSurvivesMuxWriteFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root, directory permissions do not deny writes")
+	}
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = m.Start(StartOptions{Sources: []string{"applications"}}); err != nil {
+		t.Fatal(err)
+	}
+	session, ok := m.ActiveSession(AdHocEpisodeKey)
+	if !ok {
+		t.Fatal("no active session")
+	}
+	writeCameraSource(t, session.Directory, "cam-front", [][]byte{
+		annexB(parsedIDR), annexB(parsedPSlice),
+	})
+	sourceDir := filepath.Join(session.Directory, "cameras", "cam-front")
+	if err := os.Chmod(sourceDir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(sourceDir, 0o755) })
+
+	stopped, err := m.Stop(AdHocEpisodeKey)
+	if err != nil {
+		t.Fatalf("a failed mux must never fail the seal: %v", err)
+	}
+	// The seal renamed the episode directory; restore write permission at its
+	// final location so the test's temporary tree can be removed.
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(m.root, stopped.ID, "cameras", "cam-front"), 0o755) })
+	if stopped.State != "complete" {
+		t.Fatalf("state %q, want complete", stopped.State)
+	}
+	rel := "cameras/cam-front/" + episodeexport.PlayableFileName
+	if _, ok := fileByPath(stopped.Files, rel); ok {
+		t.Errorf("manifest lists %s despite the mux failure", rel)
+	}
+	if len(stopped.PlayableNotes) != 1 || !strings.Contains(stopped.PlayableNotes[0], rel+" not written") {
+		t.Errorf("notes %v do not name the unwritten clip", stopped.PlayableNotes)
+	}
+	for _, f := range stopped.Files {
+		if strings.HasSuffix(f.Path, ".tmp") {
+			t.Errorf("manifest lists temporary file %s", f.Path)
+		}
+	}
+	// The raw capture sealed untouched and verifiable.
+	if _, failures, err := m.Inspect(stopped.ID, true); err != nil || len(failures) != 0 {
+		t.Fatalf("verification: err=%v failures=%v", err, failures)
+	}
+}
+
 func TestSealRefusesClipWithoutRandomAccessFrame(t *testing.T) {
 	m, err := NewManager(t.TempDir())
 	if err != nil {
@@ -319,6 +422,84 @@ func TestRecoverySealsPlayableClipToo(t *testing.T) {
 	}
 	if len(mf.PlayableNotes) != 0 {
 		t.Errorf("clean recovery mux left notes: %v", mf.PlayableNotes)
+	}
+}
+
+// A crash after the mux but before the manifest is written leaves a
+// playable.mp4 (and possibly its .tmp) in the partial directory whose frames
+// may postdate the index tail recovery truncates. Recovery must remux from
+// the truncated index, never reuse the stale clip, and clean up the .tmp.
+func TestRecoveryReplacesStaleClipAndTemporary(t *testing.T) {
+	root := t.TempDir()
+	m, err := NewManager(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := m.Start(StartOptions{Sources: []string{"applications"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	partial := filepath.Join(root, started.ID+".partial")
+	writeCameraSource(t, partial, "cam-front", [][]byte{
+		annexB(parsedIDR), annexB(parsedPSlice),
+	})
+	sourceDir := filepath.Join(partial, "cameras", "cam-front")
+	// The crash left a clip muxed from a longer index than the one recovery
+	// will keep, plus the temporary file of a mux cut off mid-write. Neither
+	// may survive as-is: the clip must be rebuilt from the truncated index,
+	// the temporary removed and never listed.
+	stale := []byte("stale clip muxed before the crash truncated the index")
+	if err := os.WriteFile(filepath.Join(sourceDir, episodeexport.PlayableFileName), stale, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, episodeexport.PlayableFileName+".tmp"), []byte("half a mux"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A partial trailing index line, the shape a crash leaves.
+	idx, err := os.OpenFile(filepath.Join(sourceDir, "index.jsonl"), os.O_WRONLY|os.O_APPEND, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := idx.WriteString(`{"canonical_episode_na`); err != nil {
+		t.Fatal(err)
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	m2, err := NewManager(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mf, failures, err := m2.Inspect(started.ID, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(failures) != 0 {
+		t.Fatalf("verification failures: %v", failures)
+	}
+	rel := "cameras/cam-front/" + episodeexport.PlayableFileName
+	entry, ok := fileByPath(mf.Files, rel)
+	if !ok {
+		t.Fatalf("recovered manifest does not list %s", rel)
+	}
+	onDisk, err := os.ReadFile(filepath.Join(root, started.ID, rel))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(onDisk) == string(stale) {
+		t.Error("recovery reused the stale pre-crash clip instead of remuxing")
+	}
+	if entry.Size == int64(len(stale)) {
+		t.Errorf("listed clip size %d matches the stale clip", entry.Size)
+	}
+	if _, err := os.Stat(filepath.Join(root, started.ID, rel+".tmp")); !os.IsNotExist(err) {
+		t.Errorf("stray mux temporary survived recovery (stat err %v)", err)
+	}
+	for _, f := range mf.Files {
+		if strings.HasSuffix(f.Path, ".tmp") {
+			t.Errorf("recovered manifest lists temporary file %s", f.Path)
+		}
 	}
 }
 

--- a/go/internal/agent/services/data_transfer_worker.go
+++ b/go/internal/agent/services/data_transfer_worker.go
@@ -621,6 +621,7 @@ func buildEpisodeManifest(mf data.Manifest, orgID, assetID uint64) (*cloudpb.Epi
 			MediaType: f.MediaType,
 			Format:    f.Format,
 			SourceId:  f.SourceID,
+			Role:      episodeFileRole(f.Role),
 		})
 	}
 	var lower, upper int64
@@ -648,6 +649,31 @@ func buildEpisodeManifest(mf data.Manifest, orgID, assetID uint64) (*cloudpb.Epi
 		Files:                files,
 		AttributesJson:       raw,
 	}, nil
+}
+
+// episodeFileRole maps the device manifest's per-file role onto the wire enum.
+//
+// The manifest omits the role for capture payload and capture metadata, so an
+// empty role means captured. This sends CAPTURED explicitly rather than
+// leaving the field at its default, so a manifest that went through this
+// mapper is distinguishable on the wire from one written by an agent built
+// before the field existed.
+//
+// Any other string maps to UNSPECIFIED, which the wire contract defines as
+// captured. The enum has no "unknown" member and inventing one would force
+// every reader to handle a state it cannot act on, so an unrecognised role
+// degrades to the pre-existing meaning instead. That only arises when an
+// older agent resumes an upload for an episode a newer build sealed; adding a
+// role to data.File must add it here in the same change.
+func episodeFileRole(role string) cloudpb.EpisodeFileRole {
+	switch role {
+	case "":
+		return cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_CAPTURED
+	case data.FileRoleDerived:
+		return cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_DERIVED
+	default:
+		return cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_UNSPECIFIED
+	}
 }
 
 // byteRateLimiter paces a byte stream to at most ratePerSec bytes per second by

--- a/go/internal/agent/services/data_transfer_worker.go
+++ b/go/internal/agent/services/data_transfer_worker.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"strings"
 	"time"
 
@@ -52,7 +53,7 @@ const (
 // worker can populate the manifest the server cross-checks against the cert),
 // plus a closeFn the caller must invoke when the pass is done. Production dials
 // the cloud over mTLS; tests inject an in-process client.
-type ingestClientFactory func(ctx context.Context) (client cloudpb.DataIngestServiceClient, orgID, assetID uint64, closeFn func(), err error)
+type ingestClientFactory func(ctx context.Context) (client cloudpb.DataIngestServiceClient, closeFn func(), err error)
 
 // DataTransferWorker uploads sealed episodes to the cloud DataIngestService. It
 // consumes Manifest.Upload as a durable queue: episodes marked "pending" (and,
@@ -194,10 +195,10 @@ func contextSleeper(ctx context.Context) func(time.Duration) {
 
 // dialFactory is the production ingestClientFactory: it waits for provisioning,
 // dials the cloud over mTLS, and returns a DataIngestService client.
-func (w *DataTransferWorker) dialFactory(ctx context.Context) (cloudpb.DataIngestServiceClient, uint64, uint64, func(), error) {
+func (w *DataTransferWorker) dialFactory(ctx context.Context) (cloudpb.DataIngestServiceClient, func(), error) {
 	cloudHost, orgID, assetID, enrolled := w.provisioningSvc.ProvisioningInfo()
 	if !enrolled {
-		return nil, 0, 0, nil, errors.New("data transfer worker: not provisioned")
+		return nil, nil, errors.New("data transfer worker: not provisioned")
 	}
 	certPEM, chainPEM, keyData := w.provisioningSvc.ProvisioningCerts()
 	// The identity sent, when one is sent at all, is the one the enrolled asset
@@ -209,9 +210,9 @@ func (w *DataTransferWorker) dialFactory(ctx context.Context) (cloudpb.DataInges
 		return dialCloudMTLS(w.ingestDialHost(cloudHost), certPEM, chainPEM, keyData, extraOpts...)
 	}()
 	if err != nil {
-		return nil, 0, 0, nil, err
+		return nil, nil, err
 	}
-	return cloudpb.NewDataIngestServiceClient(conn), uint64(orgID), uint64(assetID), func() { _ = conn.Close() }, nil
+	return cloudpb.NewDataIngestServiceClient(conn), func() { _ = conn.Close() }, nil
 }
 
 // Run drives the transfer worker until ctx is cancelled. It waits for the agent
@@ -278,7 +279,7 @@ func (w *DataTransferWorker) backoff(ctx context.Context, attempt int) {
 // backoff); a failure uploading one episode is recorded on that episode's
 // manifest and does not abort the pass.
 func (w *DataTransferWorker) runPass(ctx context.Context) error {
-	client, orgID, assetID, closeFn, err := w.factory(ctx)
+	client, closeFn, err := w.factory(ctx)
 	if err != nil {
 		return fmt.Errorf("acquire ingest client: %w", err)
 	}
@@ -298,7 +299,7 @@ func (w *DataTransferWorker) runPass(ctx context.Context) error {
 		if mf.Upload.State == uploadStatePending && mf.Upload.NextAttemptUnixNanos > now.UnixNano() {
 			continue
 		}
-		w.processEpisode(ctx, client, orgID, assetID, mf)
+		w.processEpisode(ctx, client, mf)
 	}
 	return nil
 }
@@ -356,7 +357,7 @@ func (w *DataTransferWorker) uploadRate(mf data.Manifest) int64 {
 // manifest; transient failures move the episode back to "pending" with a
 // backoff (or to "failed" once the retry ceiling is hit), verification failures
 // move it straight to "failed", and success marks it "uploaded".
-func (w *DataTransferWorker) processEpisode(ctx context.Context, client cloudpb.DataIngestServiceClient, orgID, assetID uint64, mf data.Manifest) {
+func (w *DataTransferWorker) processEpisode(ctx context.Context, client cloudpb.DataIngestServiceClient, mf data.Manifest) {
 	if ok, reason := w.resolveShouldUpload(mf); !ok {
 		w.logger.Debug("data transfer worker: skipping episode", zap.String("episode", mf.ID), zap.String("reason", reason))
 		return
@@ -373,7 +374,7 @@ func (w *DataTransferWorker) processEpisode(ctx context.Context, client cloudpb.
 	w.logger.Info("data transfer worker: uploading episode", zap.String("episode", mf.ID),
 		zap.Int("files", len(mf.Files)), zap.String("campaign", mf.Trigger.CampaignName))
 
-	verifyErr, retryErr := w.uploadEpisode(ctx, client, orgID, assetID, mf)
+	verifyErr, retryErr := w.uploadEpisode(ctx, client, mf)
 	switch {
 	case verifyErr != nil:
 		// Server-side verification failed: the stored bytes do not match the
@@ -448,8 +449,8 @@ func (w *DataTransferWorker) markFailed(id, detail string) {
 // episode. It returns (verifyErr, retryErr): verifyErr is a terminal
 // verification/corruption failure, retryErr is a retryable transport failure.
 // At most one is non-nil; both nil means success.
-func (w *DataTransferWorker) uploadEpisode(ctx context.Context, client cloudpb.DataIngestServiceClient, orgID, assetID uint64, mf data.Manifest) (verifyErr, retryErr error) {
-	manifest, err := buildEpisodeManifest(mf, orgID, assetID)
+func (w *DataTransferWorker) uploadEpisode(ctx context.Context, client cloudpb.DataIngestServiceClient, mf data.Manifest) (verifyErr, retryErr error) {
+	manifest, err := buildEpisodeManifest(mf)
 	if err != nil {
 		// A manifest we cannot even serialize is corrupt local state; do not
 		// spin on it.
@@ -470,7 +471,13 @@ func (w *DataTransferWorker) uploadEpisode(ctx context.Context, client cloudpb.D
 	// resume is a server-side follow-up.
 	committed := make(map[string]int64, len(begin.GetFiles()))
 	for _, f := range begin.GetFiles() {
-		committed[f.GetPath()] = f.GetCommittedOffset()
+		// Offsets are unsigned on the wire and signed here, because that is
+		// what the file APIs use. Any value a correct server can report fits;
+		// one that does not is treated as "nothing committed" so the file
+		// restarts from 0 rather than wrapping to a negative offset.
+		if v := f.GetCommittedOffset(); v <= math.MaxInt64 {
+			committed[f.GetPath()] = int64(v)
+		}
 	}
 
 	rate := w.uploadRate(mf)
@@ -577,7 +584,7 @@ func (w *DataTransferWorker) streamOneFile(ctx context.Context, stream grpc.Bidi
 			if err := stream.Send(&cloudpb.EpisodeChunk{
 				EpisodeId: episodeID,
 				Path:      file.Path,
-				Offset:    offset,
+				Offset:    uint64(offset),
 				Data:      buf[:n],
 				Eof:       eof,
 			}); err != nil {
@@ -604,10 +611,12 @@ func (w *DataTransferWorker) streamOneFile(ctx context.Context, stream grpc.Bidi
 
 // buildEpisodeManifest projects the device manifest onto the cloud
 // EpisodeManifest. The full device manifest JSON rides in attributes_json for
-// fidelity; the typed fields are what the catalog indexes on. org_id/asset_id
-// come from the asserted asset identity and the server cross-checks them
-// against the client certificate.
-func buildEpisodeManifest(mf data.Manifest, orgID, assetID uint64) (*cloudpb.EpisodeManifest, error) {
+// fidelity; the typed fields are what the catalog indexes on.
+//
+// The manifest carries no org or asset. The cloud reads both from the client
+// certificate presented on the connection, so there is nothing here for the
+// device to assert and nothing for the server to cross-check.
+func buildEpisodeManifest(mf data.Manifest) (*cloudpb.EpisodeManifest, error) {
 	raw, err := json.Marshal(mf)
 	if err != nil {
 		return nil, fmt.Errorf("marshal manifest: %w", err)
@@ -635,8 +644,6 @@ func buildEpisodeManifest(mf data.Manifest, orgID, assetID uint64) (*cloudpb.Epi
 	}
 	return &cloudpb.EpisodeManifest{
 		EpisodeId:            mf.ID,
-		OrgId:                orgID,
-		AssetId:              assetID,
 		Campaign:             mf.Trigger.CampaignName,
 		CampaignRevision:     mf.Trigger.CampaignRevision,
 		Trigger:              trigger,

--- a/go/internal/agent/services/data_transfer_worker.go
+++ b/go/internal/agent/services/data_transfer_worker.go
@@ -490,6 +490,32 @@ func (w *DataTransferWorker) uploadEpisode(ctx context.Context, client cloudpb.D
 	}
 
 	// Drain acks concurrently so large uploads do not deadlock on flow control.
+	//
+	// The acks are read and discarded, not matched. That is deliberate, and it
+	// is why the (episode_id, path) matching rule the wire contract states for
+	// EpisodeChunkAck does not apply to this client today.
+	//
+	// Nothing here is keyed on an ack. Resume offsets come from
+	// BeginEpisodeUpload's per-file FileUploadState, above, which is scoped to
+	// one episode by construction; the acks contribute no state. Draining them
+	// serves two other purposes: gRPC flow control stalls a large upload if the
+	// receive side is never read, and a server-side stream error arrives here
+	// rather than being lost.
+	//
+	// The contract's hazard is a client that matches acks on `path` alone while
+	// one stream carries chunks for several episodes, which credits one
+	// episode's committed offset to another. This client cannot hit it from
+	// either direction: it matches on nothing, and it opens exactly one
+	// UploadEpisodeChunk stream per episode, here inside uploadEpisode, which
+	// processEpisode calls once per manifest. That is precisely the "keep to one
+	// stream per episode" fallback the contract requires of a client that cannot
+	// rely on the new episode_id field, and a server built before that field
+	// leaves it empty anyway.
+	//
+	// TestUploadStreamCarriesOneEpisode pins the one-stream-per-episode
+	// invariant. Batching several episodes onto a single stream, or using ack
+	// offsets to drive resume, means matching on the (episode_id, path) pair
+	// first; do not do one without the other.
 	ackErrCh := make(chan error, 1)
 	go func() {
 		for {
@@ -623,6 +649,10 @@ func buildEpisodeManifest(mf data.Manifest) (*cloudpb.EpisodeManifest, error) {
 	}
 	files := make([]*cloudpb.EpisodeFileManifest, 0, len(mf.Files))
 	for _, f := range mf.Files {
+		role, err := episodeFileRole(f.Role)
+		if err != nil {
+			return nil, fmt.Errorf("file %s: %w", f.Path, err)
+		}
 		files = append(files, &cloudpb.EpisodeFileManifest{
 			Path:      f.Path,
 			SizeBytes: uint64(f.Size),
@@ -630,7 +660,7 @@ func buildEpisodeManifest(mf data.Manifest) (*cloudpb.EpisodeManifest, error) {
 			MediaType: f.MediaType,
 			Format:    f.Format,
 			SourceId:  f.SourceID,
-			Role:      episodeFileRole(f.Role),
+			Role:      role,
 		})
 	}
 	var lower, upper int64
@@ -666,20 +696,33 @@ func buildEpisodeManifest(mf data.Manifest) (*cloudpb.EpisodeManifest, error) {
 // mapper is distinguishable on the wire from one written by an agent built
 // before the field existed.
 //
-// Any other string maps to UNSPECIFIED, which the wire contract defines as
-// captured. The enum has no "unknown" member and inventing one would force
-// every reader to handle a state it cannot act on, so an unrecognised role
-// degrades to the pre-existing meaning instead. That only arises when an
-// older agent resumes an upload for an episode a newer build sealed; adding a
-// role to data.File must add it here in the same change.
-func episodeFileRole(role string) cloudpb.EpisodeFileRole {
+// Any other string is a hard error rather than a value on the wire. The wire
+// contract gives UNSPECIFIED exactly one meaning, "the sender predates this
+// field", and states that a sender holding a role it cannot express MUST NOT
+// send UNSPECIFIED: doing so books the file as capture payload, corrupts
+// capture-only accounting, and tells the reader nothing was lost, so no
+// reader can flag it. The enum has no "unknown" member to fall back to, and
+// inventing one is not ours to do.
+//
+// Failing is the honest option because the role string is produced by this
+// same repository. Every value comes from a data.FileRole constant that seal
+// wrote, so a role this mapper does not know is a programming error on our
+// own side: someone added a role to the manifest and did not extend this
+// switch or the wire enum. It is deterministic, so a retry re-sends the same
+// manifest and fails identically. buildEpisodeManifest's error reaches
+// processEpisode as verifyErr, which marks the episode failed with the
+// offending role recorded and does not spin on it. The gap then surfaces on
+// the first episode that carries the new role, which is the whole point;
+// silently mis-accounting every such file forever is the alternative.
+func episodeFileRole(role string) (cloudpb.EpisodeFileRole, error) {
 	switch role {
 	case "":
-		return cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_CAPTURED
+		return cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_CAPTURED, nil
 	case data.FileRoleDerived:
-		return cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_DERIVED
+		return cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_DERIVED, nil
 	default:
-		return cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_UNSPECIFIED
+		return cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_UNSPECIFIED,
+			fmt.Errorf("unmappable manifest file role %q: add it to the EpisodeFileRole wire enum and to episodeFileRole", role)
 	}
 }
 

--- a/go/internal/agent/services/data_transfer_worker_e2e_test.go
+++ b/go/internal/agent/services/data_transfer_worker_e2e_test.go
@@ -133,8 +133,8 @@ func newRealWorker(mgr *data.Manager, client cloudpb.DataIngestServiceClient) *D
 		now:         time.Now,
 		newSleeper:  contextSleeper,
 	}
-	w.factory = func(context.Context) (cloudpb.DataIngestServiceClient, uint64, uint64, func(), error) {
-		return client, e2eOrgID, e2eAssetID, func() {}, nil
+	w.factory = func(context.Context) (cloudpb.DataIngestServiceClient, func(), error) {
+		return client, func() {}, nil
 	}
 	return w
 }

--- a/go/internal/agent/services/data_transfer_worker_test.go
+++ b/go/internal/agent/services/data_transfer_worker_test.go
@@ -587,3 +587,56 @@ func TestIngestIdentityHeaderWithOverride(t *testing.T) {
 		t.Errorf("streaming call: x-wendy-client-cert = %q, want exactly [%q]", stream, want)
 	}
 }
+
+// TestBuildEpisodeManifestCarriesFileRole pins the derived-artifact contract on
+// the upload wire. The device marks the seal-time playable.mp4 remux as derived
+// and everything else as capture payload; before the manifest carried a role,
+// the catalog saw the remux as a second capture on the camera's source id and
+// double-counted its bytes.
+func TestBuildEpisodeManifestCarriesFileRole(t *testing.T) {
+	mf := data.Manifest{
+		ID: "ep-role",
+		Files: []data.File{
+			{Path: "cameras/front/index.jsonl", SourceID: "front", MediaType: "application/jsonl"},
+			{Path: "cameras/front/000001.h264", SourceID: "front", MediaType: "video/h264"},
+			{Path: "cameras/front/playable.mp4", SourceID: "front", MediaType: "video/mp4", Role: data.FileRoleDerived},
+		},
+	}
+	got, err := buildEpisodeManifest(mf, 7, 9)
+	if err != nil {
+		t.Fatalf("buildEpisodeManifest: %v", err)
+	}
+	want := map[string]cloudpb.EpisodeFileRole{
+		"cameras/front/index.jsonl":  cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_CAPTURED,
+		"cameras/front/000001.h264":  cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_CAPTURED,
+		"cameras/front/playable.mp4": cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_DERIVED,
+	}
+	if len(got.Files) != len(want) {
+		t.Fatalf("sent %d files, want %d", len(got.Files), len(want))
+	}
+	for _, f := range got.Files {
+		expected, ok := want[f.Path]
+		if !ok {
+			t.Fatalf("unexpected file %q on the wire", f.Path)
+		}
+		if f.Role != expected {
+			t.Errorf("file %q role = %v, want %v", f.Path, f.Role, expected)
+		}
+	}
+}
+
+// TestEpisodeFileRoleUnknownDegradesToUnspecified documents that a role string
+// this build does not know is sent as UNSPECIFIED, which the wire contract
+// defines as captured. The enum has no "unknown" member on purpose, so the only
+// honest option is the pre-existing meaning rather than a fabricated one.
+func TestEpisodeFileRoleUnknownDegradesToUnspecified(t *testing.T) {
+	if got := episodeFileRole("some-future-role"); got != cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_UNSPECIFIED {
+		t.Errorf("unknown role = %v, want UNSPECIFIED", got)
+	}
+	if got := episodeFileRole(""); got != cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_CAPTURED {
+		t.Errorf("empty role = %v, want CAPTURED", got)
+	}
+	if got := episodeFileRole(data.FileRoleDerived); got != cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_DERIVED {
+		t.Errorf("derived role = %v, want DERIVED", got)
+	}
+}

--- a/go/internal/agent/services/data_transfer_worker_test.go
+++ b/go/internal/agent/services/data_transfer_worker_test.go
@@ -92,7 +92,7 @@ func (s *fakeIngestServer) BeginEpisodeUpload(_ context.Context, req *cloudpb.Be
 		if off > 0 {
 			s.committed[f.GetPath()] = off
 		}
-		files = append(files, &cloudpb.FileUploadState{Path: f.GetPath(), CommittedOffset: off})
+		files = append(files, &cloudpb.FileUploadState{Path: f.GetPath(), CommittedOffset: uint64(off)})
 	}
 	return &cloudpb.BeginEpisodeUploadResponse{State: s.beginState, Files: files}, nil
 }
@@ -115,7 +115,7 @@ func (s *fakeIngestServer) UploadEpisodeChunk(stream grpc.BidiStreamingServer[cl
 			committed = recv
 		}
 		s.mu.Unlock()
-		if err := stream.Send(&cloudpb.EpisodeChunkAck{Path: chunk.GetPath(), ReceivedOffset: recv, CommittedOffset: committed}); err != nil {
+		if err := stream.Send(&cloudpb.EpisodeChunkAck{Path: chunk.GetPath(), ReceivedOffset: uint64(recv), CommittedOffset: uint64(committed)}); err != nil {
 			return err
 		}
 	}
@@ -205,8 +205,8 @@ func newTestWorker(mgr *data.Manager, client cloudpb.DataIngestServiceClient) *D
 		now:         time.Now,
 		newSleeper:  contextSleeper,
 	}
-	w.factory = func(context.Context) (cloudpb.DataIngestServiceClient, uint64, uint64, func(), error) {
-		return client, 7, 42, func() {}, nil
+	w.factory = func(context.Context) (cloudpb.DataIngestServiceClient, func(), error) {
+		return client, func() {}, nil
 	}
 	return w
 }
@@ -536,8 +536,8 @@ func runIdentityHeaderPass(t *testing.T, override string, orgID, assetID int32) 
 	// The client is dialed with exactly the options dialFactory would pass, so
 	// the production interceptors (when there are any) run for real.
 	client := startFakeIngest(t, srv, w.ingestDialOptions(orgID, assetID)...)
-	w.factory = func(context.Context) (cloudpb.DataIngestServiceClient, uint64, uint64, func(), error) {
-		return client, uint64(orgID), uint64(assetID), func() {}, nil
+	w.factory = func(context.Context) (cloudpb.DataIngestServiceClient, func(), error) {
+		return client, func() {}, nil
 	}
 
 	if err := w.runPass(context.Background()); err != nil {
@@ -602,7 +602,7 @@ func TestBuildEpisodeManifestCarriesFileRole(t *testing.T) {
 			{Path: "cameras/front/playable.mp4", SourceID: "front", MediaType: "video/mp4", Role: data.FileRoleDerived},
 		},
 	}
-	got, err := buildEpisodeManifest(mf, 7, 9)
+	got, err := buildEpisodeManifest(mf)
 	if err != nil {
 		t.Fatalf("buildEpisodeManifest: %v", err)
 	}

--- a/go/internal/agent/services/data_transfer_worker_test.go
+++ b/go/internal/agent/services/data_transfer_worker_test.go
@@ -9,6 +9,8 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -42,6 +44,11 @@ type fakeIngestServer struct {
 
 	beginCalls  int
 	commitCalls int
+
+	// Distinct episode ids seen on each UploadEpisodeChunk stream, one entry
+	// per stream opened. The client must keep to one episode per stream while
+	// it does not match acks on the (episode_id, path) pair.
+	streamEpisodes []map[string]bool
 
 	// Incoming request metadata recorded by startFakeIngest, per call kind, so
 	// tests can assert on what the client actually put on the wire.
@@ -98,6 +105,10 @@ func (s *fakeIngestServer) BeginEpisodeUpload(_ context.Context, req *cloudpb.Be
 }
 
 func (s *fakeIngestServer) UploadEpisodeChunk(stream grpc.BidiStreamingServer[cloudpb.EpisodeChunk, cloudpb.EpisodeChunkAck]) error {
+	seen := map[string]bool{}
+	s.mu.Lock()
+	s.streamEpisodes = append(s.streamEpisodes, seen)
+	s.mu.Unlock()
 	for {
 		chunk, err := stream.Recv()
 		if err == io.EOF {
@@ -107,6 +118,7 @@ func (s *fakeIngestServer) UploadEpisodeChunk(stream grpc.BidiStreamingServer[cl
 			return err
 		}
 		s.mu.Lock()
+		seen[chunk.GetEpisodeId()] = true
 		s.received[chunk.GetPath()] = append(s.received[chunk.GetPath()], chunk.GetData()...)
 		recv := int64(len(s.received[chunk.GetPath()]))
 		var committed int64
@@ -115,7 +127,14 @@ func (s *fakeIngestServer) UploadEpisodeChunk(stream grpc.BidiStreamingServer[cl
 			committed = recv
 		}
 		s.mu.Unlock()
-		if err := stream.Send(&cloudpb.EpisodeChunkAck{Path: chunk.GetPath(), ReceivedOffset: uint64(recv), CommittedOffset: uint64(committed)}); err != nil {
+		// A server that carries the field echoes the chunk's episode_id, so the
+		// ack names the (episode_id, path) pair the contract matches on.
+		if err := stream.Send(&cloudpb.EpisodeChunkAck{
+			EpisodeId:       chunk.GetEpisodeId(),
+			Path:            chunk.GetPath(),
+			ReceivedOffset:  uint64(recv),
+			CommittedOffset: uint64(committed),
+		}); err != nil {
 			return err
 		}
 	}
@@ -625,18 +644,125 @@ func TestBuildEpisodeManifestCarriesFileRole(t *testing.T) {
 	}
 }
 
-// TestEpisodeFileRoleUnknownDegradesToUnspecified documents that a role string
-// this build does not know is sent as UNSPECIFIED, which the wire contract
-// defines as captured. The enum has no "unknown" member on purpose, so the only
-// honest option is the pre-existing meaning rather than a fabricated one.
-func TestEpisodeFileRoleUnknownDegradesToUnspecified(t *testing.T) {
-	if got := episodeFileRole("some-future-role"); got != cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_UNSPECIFIED {
-		t.Errorf("unknown role = %v, want UNSPECIFIED", got)
+// TestEpisodeFileRoleUnmappableFails pins the wire contract's rule that a
+// sender holding a role it cannot express MUST NOT send UNSPECIFIED, because
+// UNSPECIFIED means only "the sender predates this field" and is accounted as
+// capture payload. A role string this build does not know is a programming
+// error in this repository, so the mapper refuses it instead of quietly
+// booking the file as capture.
+//
+// The error assertions are what stop the old degrade-to-UNSPECIFIED default
+// from coming back: restoring it makes episodeFileRole return a nil error, and
+// both the mapper case and the buildEpisodeManifest case below fail.
+func TestEpisodeFileRoleUnmappableFails(t *testing.T) {
+	got, err := episodeFileRole("some-future-role")
+	if err == nil {
+		t.Errorf("unknown role returned %v and no error, want an error refusing to map it", got)
 	}
-	if got := episodeFileRole(""); got != cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_CAPTURED {
-		t.Errorf("empty role = %v, want CAPTURED", got)
+	if err != nil && !strings.Contains(err.Error(), "some-future-role") {
+		t.Errorf("error %q does not name the offending role", err)
 	}
-	if got := episodeFileRole(data.FileRoleDerived); got != cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_DERIVED {
-		t.Errorf("derived role = %v, want DERIVED", got)
+	if got != cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_UNSPECIFIED {
+		// The zero value is the only thing a failed mapping may return; what
+		// matters is that it never reaches the wire.
+		t.Errorf("unknown role value = %v, want the zero value alongside the error", got)
+	}
+
+	if got, err := episodeFileRole(""); err != nil || got != cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_CAPTURED {
+		t.Errorf("empty role = %v (err %v), want CAPTURED and no error", got, err)
+	}
+	if got, err := episodeFileRole(data.FileRoleDerived); err != nil || got != cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_DERIVED {
+		t.Errorf("derived role = %v (err %v), want DERIVED and no error", got, err)
+	}
+}
+
+// TestBuildEpisodeManifestRejectsUnmappableRole proves the refusal is not
+// confined to the mapper: a manifest carrying an unknown role produces no
+// EpisodeManifest at all, so nothing is uploaded under a wrong role. The
+// caller must propagate the error rather than drop it.
+func TestBuildEpisodeManifestRejectsUnmappableRole(t *testing.T) {
+	mf := data.Manifest{
+		ID: "ep-unmappable",
+		Files: []data.File{
+			{Path: "cameras/front/000001.h264", Size: 1, SHA256: "a"},
+			{Path: "cameras/front/thumbnail.jpg", Size: 1, SHA256: "b", Role: "some-future-role"},
+		},
+	}
+	got, err := buildEpisodeManifest(mf)
+	if err == nil {
+		t.Fatalf("buildEpisodeManifest accepted an unmappable role and returned %v, want an error", got)
+	}
+	if got != nil {
+		t.Errorf("buildEpisodeManifest returned a manifest alongside the error: %v", got)
+	}
+	if !strings.Contains(err.Error(), "some-future-role") {
+		t.Errorf("error %q does not name the offending role", err)
+	}
+	if !strings.Contains(err.Error(), "cameras/front/thumbnail.jpg") {
+		t.Errorf("error %q does not name the offending file", err)
+	}
+}
+
+// TestUploadStreamCarriesOneEpisode pins the invariant that lets the upload
+// loop read acks without matching them.
+//
+// The wire contract requires an ack to be matched on the (episode_id, path)
+// pair, because one stream may carry chunks for several episodes and a path is
+// unique only within an episode. This client matches on nothing: it drains acks
+// for flow control and error surfacing, and takes resume offsets from
+// BeginEpisodeUpload instead. The contract's fallback for a client that cannot
+// match is to keep to one stream per episode, which is what uploadEpisode does
+// by opening its stream per manifest.
+//
+// So this test guards the assumption rather than the ack handling. Two pending
+// episodes in one pass must produce two streams, each carrying exactly one
+// episode id. If someone batches episodes onto a shared stream, this fails, and
+// the ack matching has to be built before it can pass again.
+func TestUploadStreamCarriesOneEpisode(t *testing.T) {
+	mgr, root := newTestManager(t)
+	writeFixtureEpisode(t, root, "ep-one", "", "pending", map[string][]byte{
+		"video/000001.jpg": []byte("first episode payload"),
+	})
+	writeFixtureEpisode(t, root, "ep-two", "", "pending", map[string][]byte{
+		"video/000002.jpg": []byte("second episode payload"),
+	})
+
+	srv := newFakeIngestServer()
+	client := startFakeIngest(t, srv)
+	w := newTestWorker(mgr, client)
+
+	if err := w.runPass(context.Background()); err != nil {
+		t.Fatalf("runPass: %v", err)
+	}
+
+	for _, id := range []string{"ep-one", "ep-two"} {
+		if got := uploadState(t, mgr, id).State; got != uploadStateUploaded {
+			t.Fatalf("episode %s state = %q, want uploaded", id, got)
+		}
+	}
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+
+	if len(srv.streamEpisodes) != 2 {
+		t.Fatalf("opened %d upload streams for 2 episodes, want 2", len(srv.streamEpisodes))
+	}
+	all := map[string]bool{}
+	for i, seen := range srv.streamEpisodes {
+		if len(seen) != 1 {
+			ids := make([]string, 0, len(seen))
+			for id := range seen {
+				ids = append(ids, id)
+			}
+			sort.Strings(ids)
+			t.Errorf("stream %d carried %d episodes (%v), want exactly 1; "+
+				"a multi-episode stream requires matching acks on (episode_id, path)", i, len(seen), ids)
+		}
+		for id := range seen {
+			all[id] = true
+		}
+	}
+	if !all["ep-one"] || !all["ep-two"] {
+		t.Errorf("streams carried %v, want both ep-one and ep-two", all)
 	}
 }

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
@@ -204,10 +204,37 @@ including the measured average, describes more than a fraction of the clip.
 The timing is already recorded. `cameras/<source>/index.jsonl` carries one line
 per kept frame with `canonical_episode_nanos`, the frame's position on the
 Episode's canonical `CLOCK_BOOTTIME` timeline, alongside the segment file, byte
-offset and `byte_size` of its payload. The `episode-playable` command remuxes
-those payload bytes into an MP4 that gives every frame the presentation time
-the index recorded for it, so the variable frame rate is represented honestly
-rather than averaged away:
+offset and `byte_size` of its payload. Remuxing those payload bytes into an MP4
+gives every frame the presentation time the index recorded for it, so the
+variable frame rate is represented honestly rather than averaged away.
+
+### Sealed Episodes already carry the MP4
+
+The agent runs that remux itself while sealing an Episode: each camera source
+gains a `cameras/<source>/playable.mp4` beside its raw capture, listed in the
+manifest with a size and SHA-256 like every other file and marked with
+`"role": "derived"`. Because it is listed, the transfer worker uploads it and
+commit-time verification covers it, so the bucket object plays directly in a
+browser (or after a plain download) with no conversion step. The derived file
+is never capture payload: model-input and payload-retention accounting
+resolve payloads through `index.jsonl` into the raw segments, and the raw
+files are kept byte-for-byte as before. The remux is a copy, not a transcode,
+so expect the clip to add roughly the size of the raw stream to the Episode;
+that overhead counts against the Episode's size for the local quota.
+
+Sealing never fails or waits on the remux. A source whose stream cannot become
+an honestly timed, seekable clip (B slices, slice headers the muxer cannot
+parse, no random-access frame) seals without its `playable.mp4`, and the
+manifest's `playable_notes` names the reason; a clip that had to omit frames
+whose bytes were missing gets a note too.
+
+### Converting older Episodes by hand
+
+The `episode-playable` command performs the same remux laptop-side, for
+Episodes sealed before the agent did it (or for a source whose seal-time mux
+was refused, where it will report the same warnings). When every camera source
+already carries a seal-time `playable.mp4` the command says so and converts
+nothing:
 
 ```sh
 # From the repository root.

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
@@ -224,7 +224,8 @@ that overhead counts against the Episode's size for the local quota.
 
 Sealing never fails or waits on the remux. A source whose stream cannot become
 an honestly timed, seekable clip (B slices, slice headers the muxer cannot
-parse, no random-access frame) seals without its `playable.mp4`, and the
+parse, parameter sets that change mid-stream after a producer restart, no
+random-access frame) seals without its `playable.mp4`, and the
 manifest's `playable_notes` names the reason; a clip that had to omit frames
 whose bytes were missing gets a note too.
 

--- a/go/internal/cli/assets/docs/wendy-data-platform-demo.md
+++ b/go/internal/cli/assets/docs/wendy-data-platform-demo.md
@@ -225,8 +225,13 @@ counts the predictions that named their inputs, and — per source — whether t
 episode retains payloads for all of the consumed samples or only the subset the
 capture policy kept.
 
-To watch the camera capture rather than join against it, convert the episode
-with `episode-playable`; the camera capture is a raw elementary stream with no
+To watch the camera capture rather than join against it, open the
+`cameras/<source>/playable.mp4` the episode already carries: the agent remuxes
+each camera source into a browser-playable MP4 while sealing, lists it in the
+manifest as a derived file, and uploads it with everything else. Only an
+episode sealed by an older agent (or a source whose seal-time remux was
+refused, see the manifest's `playable_notes`) still needs the laptop-side
+`episode-playable` conversion; the raw capture is an elementary stream with no
 container, so players otherwise invent a frame rate and the clip runs at the
 wrong speed. See "Playing back camera capture" in the `wendy data` command
 documentation.

--- a/go/internal/episodeexport/playable.go
+++ b/go/internal/episodeexport/playable.go
@@ -51,6 +51,7 @@
 package episodeexport
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -118,6 +119,16 @@ type ClipResult struct {
 	// pictures). A clip with none is not seekable and most players refuse it,
 	// so it must not be reported as a clean conversion on frame count alone.
 	SyncSamples int
+	// ParameterSetChanges counts in-band SPS or PPS units whose bytes differ
+	// from the first ones seen. Encoders repeat identical parameter sets
+	// before every IDR and those repeats are not counted; a change means the
+	// producer restarted mid-episode with new parameters (a different
+	// resolution, most likely). The MP4 written here carries exactly one
+	// decoder configuration, built from the first SPS/PPS, so every frame
+	// after a change would be decoded against the wrong parameters. A clip
+	// with this non-zero must not be presented as a faithful rendering of the
+	// capture.
+	ParameterSetChanges int
 	// MinInterval, MaxInterval and MeanInterval describe the spread of
 	// inter-frame intervals actually written. They differ from each other
 	// whenever the capture rate varied, which is the point.
@@ -204,6 +215,7 @@ func convertSource(episodeDir, sourceDir, indexPath, out string) (ClipResult, er
 	result.BFrames = stats.bFrames
 	result.UndecodedSliceHeaders = stats.undecodedSliceHeaders
 	result.SyncSamples = stats.syncSamples
+	result.ParameterSetChanges = stats.parameterSetChanges
 	result.MinInterval, result.MaxInterval, result.MeanInterval = stats.min, stats.max, stats.mean
 	if err := errors.Join(writeErr, closeErr); err != nil {
 		return result, err
@@ -283,6 +295,9 @@ type muxStats struct {
 	undecodedSliceHeaders int
 	// syncSamples counts written samples a decoder can start on.
 	syncSamples int
+	// parameterSetChanges counts SPS/PPS units that differ byte-wise from the
+	// first ones seen; identical repeats before each IDR are not counted.
+	parameterSetChanges int
 }
 
 // isBSlice reports whether a VCL NAL unit carries a B slice. It matters
@@ -378,11 +393,20 @@ func muxAnnexBToMP4(w *os.File, episodeDir string, frames []cameraIndexLine) (mu
 			case 7: // sequence parameter set, carried in avcC instead
 				if sps == nil {
 					sps = append([]byte(nil), nal...)
+				} else if !bytes.Equal(sps, nal) {
+					// The producer restarted with new parameters. avcC holds
+					// only the first SPS, so frames after this point would be
+					// decoded against the wrong configuration; count it so
+					// callers can refuse the clip instead of shipping one that
+					// silently misdecodes its tail.
+					stats.parameterSetChanges++
 				}
 				continue
 			case 8: // picture parameter set, carried in avcC instead
 				if pps == nil {
 					pps = append([]byte(nil), nal...)
+				} else if !bytes.Equal(pps, nal) {
+					stats.parameterSetChanges++
 				}
 				continue
 			case 9, 12: // access unit delimiter, filler

--- a/go/internal/episodeexport/playable.go
+++ b/go/internal/episodeexport/playable.go
@@ -36,11 +36,18 @@
 // external dependency to be missing: there is no ffmpeg, mkvmerge or PyAV in
 // the path from an episode to a playable file.
 //
-// The episode is read-only here. Output is written to a separate destination
+// The episode is read-only here. Convert writes into a separate destination
 // directory. The elementary stream and index are the checksummed archival
 // truth, and index.jsonl addresses frames by byte offset within the stream, so
 // rewriting it in place would break the join between a frame and the model
 // input recorded against it.
+//
+// ConvertSourceInPlace is the one sanctioned exception to that separation: the
+// agent calls it while sealing an episode, before the manifest's file list is
+// finalized, to add cameras/<source>/playable.mp4 beside the raw capture. The
+// raw segments and index are still only read; the derived clip is a new file
+// that the seal then checksums, lists and uploads like everything else, so a
+// browser can play the episode straight from the bucket.
 package episodeexport
 
 import (
@@ -62,6 +69,11 @@ import (
 // per-sample duration stays inside the 32-bit stts field for any gap short of
 // 71 minutes.
 const playableTimescale = 1_000_000
+
+// PlayableFileName is the derived MP4 written into a camera source directory
+// at seal time by ConvertSourceInPlace. The agent's manifest code and the
+// episode-playable command both key on this name.
+const PlayableFileName = "playable.mp4"
 
 // ClipResult reports what one camera source produced, in the numbers needed to
 // check the conversion without watching it.
@@ -148,6 +160,25 @@ func Convert(episodeDir, outDir string) ([]ClipResult, []error) {
 		results = append(results, result)
 	}
 	return results, errs
+}
+
+// ConvertSourceInPlace remuxes one camera source into
+// <sourceDir>/playable.mp4, reading timing from <sourceDir>/index.jsonl. It is
+// the seal-time variant of Convert: the caller is the agent finalizing an
+// episode, and the output lands inside the episode so the manifest can list
+// it. The raw segment files and the index are only ever read. The output is
+// written through a temporary file and renamed, so a crash mid-mux leaves no
+// half-written playable.mp4 behind (sealing ignores *.tmp files).
+//
+// A non-nil error means no playable.mp4 was left in place. A nil error means
+// the file exists, but the caller must still judge the ClipResult before
+// trusting it: BFrames, UndecodedSliceHeaders and SyncSamples report
+// conditions under which the clip's timing or seekability cannot be vouched
+// for, and Convert deliberately does not decide policy for its callers.
+func ConvertSourceInPlace(episodeDir, sourceDir string) (ClipResult, error) {
+	result, err := convertSource(episodeDir, sourceDir, filepath.Join(sourceDir, "index.jsonl"), filepath.Join(sourceDir, PlayableFileName))
+	result.Source = filepath.Base(sourceDir)
+	return result, err
 }
 
 func convertSource(episodeDir, sourceDir, indexPath, out string) (ClipResult, error) {

--- a/go/internal/episodeexport/playable_test.go
+++ b/go/internal/episodeexport/playable_test.go
@@ -285,6 +285,39 @@ func sum(b []byte) uint64 {
 	return h
 }
 
+func TestConvertSourceInPlaceWritesBesideRawCapture(t *testing.T) {
+	dir, _ := buildEpisode(t)
+	before := snapshot(t, dir)
+
+	result, err := ConvertSourceInPlace(dir, filepath.Join(dir, "cameras", "cam-a"))
+	if err != nil {
+		t.Fatalf("ConvertSourceInPlace: %v", err)
+	}
+	if result.Source != "cam-a" || result.Frames != 5 {
+		t.Errorf("got source %q with %d frames, want cam-a with 5", result.Source, result.Frames)
+	}
+	out := filepath.Join(dir, "cameras", "cam-a", PlayableFileName)
+	if result.Output != out {
+		t.Errorf("output %q, want %q", result.Output, out)
+	}
+	if _, err := os.Stat(out); err != nil {
+		t.Fatalf("no playable file in place: %v", err)
+	}
+	if _, err := os.Stat(out + ".tmp"); !os.IsNotExist(err) {
+		t.Errorf("temporary mux file left behind")
+	}
+
+	// Everything that existed before must be byte-identical: the raw stream
+	// and index are checksummed archival truth, and index.jsonl addresses
+	// frames by byte offset into the raw segments.
+	if err := os.Remove(out); err != nil {
+		t.Fatal(err)
+	}
+	if after := snapshot(t, dir); after != before {
+		t.Errorf("raw capture was modified:\nbefore %s\nafter  %s", before, after)
+	}
+}
+
 func TestConvertRejectsNonEpisodeDirectory(t *testing.T) {
 	_, errs := Convert(t.TempDir(), filepath.Join(t.TempDir(), "out"))
 	if len(errs) == 0 {

--- a/go/internal/episodeexport/playable_test.go
+++ b/go/internal/episodeexport/playable_test.go
@@ -184,6 +184,11 @@ func TestConvertRealShapes(t *testing.T) {
 	if a.MinInterval == a.MaxInterval {
 		t.Error("cam-a interval spread was flattened to a constant rate")
 	}
+	// Segment 2 re-inlines the same SPS/PPS before its keyframe, which is the
+	// normal encoder habit; identical repeats are not a parameter set change.
+	if a.ParameterSetChanges != 0 {
+		t.Errorf("cam-a reports %d parameter set changes for identical repeated SPS/PPS, want 0", a.ParameterSetChanges)
+	}
 
 	// A frame whose bytes are missing is reported and skipped, and a partial
 	// trailing line is counted as unusable, but the clip is still written.
@@ -315,6 +320,79 @@ func TestConvertSourceInPlaceWritesBesideRawCapture(t *testing.T) {
 	}
 	if after := snapshot(t, dir); after != before {
 		t.Errorf("raw capture was modified:\nbefore %s\nafter  %s", before, after)
+	}
+}
+
+// restartSPS and restartPPS are a second camera's parameter sets at 640x480,
+// the shape a producer restart splices into a running episode when it comes
+// back at a different resolution.
+const (
+	restartSPS = "6742c01e8c8d40501e900f08846a"
+	restartPPS = "68ce3c80"
+)
+
+// A producer restart mid-episode splices new parameter sets into the stream.
+// The MP4 written here carries exactly one decoder configuration (the first
+// SPS/PPS), so every frame after the change would decode against the wrong
+// parameters; the result must say so, because nothing else about the mux
+// fails: the frames all copy cleanly, slice headers parse, and sync samples
+// exist.
+func TestConvertSourceInPlaceFlagsParameterSetChange(t *testing.T) {
+	dir := t.TempDir()
+	sps1, pps1 := mustHex(t, realSPS), mustHex(t, realPPS)
+	sps2, pps2 := mustHex(t, restartSPS), mustHex(t, restartPPS)
+	if w, h, err := spsDimensions(sps2); err != nil || (w == 1280 && h == 720) {
+		t.Fatalf("restart SPS fixture must parse to a different resolution, got %dx%d err=%v", w, h, err)
+	}
+	idr := append([]byte{0x65, 0x88}, make([]byte, 40)...)
+	p := append([]byte{0x41, 0xC0}, make([]byte, 30)...)
+
+	cam := filepath.Join(dir, "cameras", "cam-a")
+	if err := os.MkdirAll(cam, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	type entry struct {
+		CanonicalEpisodeNanos int64  `json:"canonical_episode_nanos"`
+		Segment               string `json:"segment"`
+		ByteOffset            int64  `json:"byte_offset"`
+		ByteSize              int    `json:"byte_size"`
+		Codec                 string `json:"codec"`
+	}
+	units := [][]byte{
+		annexB(sps1, pps1, idr), annexB(p),
+		annexB(sps2, pps2, idr), annexB(p), // the producer came back at 640x480
+	}
+	var seg, index []byte
+	now := int64(1_000_000_000)
+	for _, u := range units {
+		line, err := json.Marshal(entry{now, "cameras/cam-a/segment-000001.h264", int64(len(seg)), len(u), "h264"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		index = append(index, line...)
+		index = append(index, '\n')
+		seg = append(seg, u...)
+		now += 33_000_000
+	}
+	if err := os.WriteFile(filepath.Join(cam, "segment-000001.h264"), seg, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cam, "index.jsonl"), index, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := ConvertSourceInPlace(dir, cam)
+	if err != nil {
+		t.Fatalf("ConvertSourceInPlace: %v", err)
+	}
+	if r.ParameterSetChanges != 2 {
+		t.Errorf("ParameterSetChanges = %d, want 2 (one changed SPS, one changed PPS)", r.ParameterSetChanges)
+	}
+	// The other gates must stay quiet: this failure mode is invisible to them,
+	// which is exactly why it needs its own counter.
+	if r.Frames != 4 || r.Skipped != 0 || r.BFrames || r.UndecodedSliceHeaders != 0 || r.SyncSamples == 0 {
+		t.Errorf("unexpected companion signals: frames %d skipped %d bframes %v undecoded %d sync %d",
+			r.Frames, r.Skipped, r.BFrames, r.UndecodedSliceHeaders, r.SyncSamples)
 	}
 }
 

--- a/go/proto/gen/cloudpb/data_ingest.pb.go
+++ b/go/proto/gen/cloudpb/data_ingest.pb.go
@@ -74,6 +74,68 @@ func (EpisodeState) EnumDescriptor() ([]byte, []int) {
 	return file_cloud_data_ingest_proto_rawDescGZIP(), []int{0}
 }
 
+// What a file is to the episode it belongs to. Mirrors the device manifest's
+// per-file `role`, one word for one thing across device, wire and catalog.
+//
+// UNSPECIFIED means CAPTURED. Devices built before this field existed never
+// set it and upload nothing but capture payload and capture metadata, so an
+// absent role has exactly the meaning it always had; readers must treat
+// UNSPECIFIED and CAPTURED identically and must never report "unknown role".
+type EpisodeFileRole int32
+
+const (
+	EpisodeFileRole_EPISODE_FILE_ROLE_UNSPECIFIED EpisodeFileRole = 0
+	// Capture payload, or capture metadata written while recording.
+	EpisodeFileRole_EPISODE_FILE_ROLE_CAPTURED EpisodeFileRole = 1
+	// Computed from capture payload at seal time rather than recorded during
+	// capture, e.g. the per-source cameras/<source>/playable.mp4 remux. A
+	// derived file is checksummed, uploaded and verified like any other file,
+	// but it is not capture payload: deleting one loses no recorded data, and
+	// per-source payload accounting must never count its bytes as capture.
+	EpisodeFileRole_EPISODE_FILE_ROLE_DERIVED EpisodeFileRole = 2
+)
+
+// Enum value maps for EpisodeFileRole.
+var (
+	EpisodeFileRole_name = map[int32]string{
+		0: "EPISODE_FILE_ROLE_UNSPECIFIED",
+		1: "EPISODE_FILE_ROLE_CAPTURED",
+		2: "EPISODE_FILE_ROLE_DERIVED",
+	}
+	EpisodeFileRole_value = map[string]int32{
+		"EPISODE_FILE_ROLE_UNSPECIFIED": 0,
+		"EPISODE_FILE_ROLE_CAPTURED":    1,
+		"EPISODE_FILE_ROLE_DERIVED":     2,
+	}
+)
+
+func (x EpisodeFileRole) Enum() *EpisodeFileRole {
+	p := new(EpisodeFileRole)
+	*p = x
+	return p
+}
+
+func (x EpisodeFileRole) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (EpisodeFileRole) Descriptor() protoreflect.EnumDescriptor {
+	return file_cloud_data_ingest_proto_enumTypes[1].Descriptor()
+}
+
+func (EpisodeFileRole) Type() protoreflect.EnumType {
+	return &file_cloud_data_ingest_proto_enumTypes[1]
+}
+
+func (x EpisodeFileRole) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use EpisodeFileRole.Descriptor instead.
+func (EpisodeFileRole) EnumDescriptor() ([]byte, []int) {
+	return file_cloud_data_ingest_proto_rawDescGZIP(), []int{1}
+}
+
 // Compact typed projection of the device episode manifest (manifest v2).
 // The full manifest JSON rides in attributes_json for fidelity; the typed
 // fields are what the catalog indexes on.
@@ -253,8 +315,11 @@ type EpisodeFileManifest struct {
 	TimeRangeEndNanos   int64 `protobuf:"varint,8,opt,name=time_range_end_nanos,json=timeRangeEndNanos,proto3" json:"time_range_end_nanos,omitempty"`
 	// Source-clock to canonical-clock mapping summary JSON, when present.
 	ClockMappingJson []byte `protobuf:"bytes,9,opt,name=clock_mapping_json,json=clockMappingJson,proto3" json:"clock_mapping_json,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// What this file is to the episode. Unset (UNSPECIFIED) means CAPTURED, so
+	// devices predating this field keep their existing meaning unchanged.
+	Role          EpisodeFileRole `protobuf:"varint,10,opt,name=role,proto3,enum=wendycloud.data.v1.EpisodeFileRole" json:"role,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *EpisodeFileManifest) Reset() {
@@ -348,6 +413,13 @@ func (x *EpisodeFileManifest) GetClockMappingJson() []byte {
 		return x.ClockMappingJson
 	}
 	return nil
+}
+
+func (x *EpisodeFileManifest) GetRole() EpisodeFileRole {
+	if x != nil {
+		return x.Role
+	}
+	return EpisodeFileRole_EPISODE_FILE_ROLE_UNSPECIFIED
 }
 
 type BeginEpisodeUploadRequest struct {
@@ -1165,7 +1237,10 @@ type EpisodeFileInfo struct {
 	Sha256    string                 `protobuf:"bytes,5,opt,name=sha256,proto3" json:"sha256,omitempty"`
 	// Short-lived retrieval URL for the stored object (signed in production,
 	// direct in local development).
-	RetrievalUrl  string `protobuf:"bytes,6,opt,name=retrieval_url,json=retrievalUrl,proto3" json:"retrieval_url,omitempty"`
+	RetrievalUrl string `protobuf:"bytes,6,opt,name=retrieval_url,json=retrievalUrl,proto3" json:"retrieval_url,omitempty"`
+	// What this file is to the episode, as recorded in the catalog. Unset
+	// (UNSPECIFIED) means CAPTURED, as on the upload manifest.
+	Role          EpisodeFileRole `protobuf:"varint,7,opt,name=role,proto3,enum=wendycloud.data.v1.EpisodeFileRole" json:"role,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1242,6 +1317,13 @@ func (x *EpisodeFileInfo) GetRetrievalUrl() string {
 	return ""
 }
 
+func (x *EpisodeFileInfo) GetRole() EpisodeFileRole {
+	if x != nil {
+		return x.Role
+	}
+	return EpisodeFileRole_EPISODE_FILE_ROLE_UNSPECIFIED
+}
+
 var File_cloud_data_ingest_proto protoreflect.FileDescriptor
 
 const file_cloud_data_ingest_proto_rawDesc = "" +
@@ -1263,7 +1345,7 @@ const file_cloud_data_ingest_proto_rawDesc = "" +
 	"\x16utc_offset_upper_nanos\x18\v \x01(\x03R\x13utcOffsetUpperNanos\x12.\n" +
 	"\x13system_clock_status\x18\f \x01(\tR\x11systemClockStatus\x12=\n" +
 	"\x05files\x18\r \x03(\v2'.wendycloud.data.v1.EpisodeFileManifestR\x05files\x12'\n" +
-	"\x0fattributes_json\x18\x0e \x01(\fR\x0eattributesJson\"\xc8\x02\n" +
+	"\x0fattributes_json\x18\x0e \x01(\fR\x0eattributesJson\"\x81\x03\n" +
 	"\x13EpisodeFileManifest\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12\x1d\n" +
 	"\n" +
@@ -1275,7 +1357,9 @@ const file_cloud_data_ingest_proto_rawDesc = "" +
 	"\tsource_id\x18\x06 \x01(\tR\bsourceId\x123\n" +
 	"\x16time_range_start_nanos\x18\a \x01(\x03R\x13timeRangeStartNanos\x12/\n" +
 	"\x14time_range_end_nanos\x18\b \x01(\x03R\x11timeRangeEndNanos\x12,\n" +
-	"\x12clock_mapping_json\x18\t \x01(\fR\x10clockMappingJson\"\\\n" +
+	"\x12clock_mapping_json\x18\t \x01(\fR\x10clockMappingJson\x127\n" +
+	"\x04role\x18\n" +
+	" \x01(\x0e2#.wendycloud.data.v1.EpisodeFileRoleR\x04role\"\\\n" +
 	"\x19BeginEpisodeUploadRequest\x12?\n" +
 	"\bmanifest\x18\x01 \x01(\v2#.wendycloud.data.v1.EpisodeManifestR\bmanifest\"P\n" +
 	"\x0fFileUploadState\x12\x12\n" +
@@ -1337,7 +1421,7 @@ const file_cloud_data_ingest_proto_rawDesc = "" +
 	" \x01(\fR\x14clockCorrelationJson\x12'\n" +
 	"\x0fattributes_json\x18\v \x01(\fR\x0eattributesJson\x12,\n" +
 	"\x12updated_unix_nanos\x18\f \x01(\x03R\x10updatedUnixNanos\x129\n" +
-	"\x05files\x18\r \x03(\v2#.wendycloud.data.v1.EpisodeFileInfoR\x05files\"\xbd\x01\n" +
+	"\x05files\x18\r \x03(\v2#.wendycloud.data.v1.EpisodeFileInfoR\x05files\"\xf6\x01\n" +
 	"\x0fEpisodeFileInfo\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12\x1b\n" +
 	"\tsource_id\x18\x02 \x01(\tR\bsourceId\x12\x1d\n" +
@@ -1346,12 +1430,17 @@ const file_cloud_data_ingest_proto_rawDesc = "" +
 	"\n" +
 	"size_bytes\x18\x04 \x01(\x04R\tsizeBytes\x12\x16\n" +
 	"\x06sha256\x18\x05 \x01(\tR\x06sha256\x12#\n" +
-	"\rretrieval_url\x18\x06 \x01(\tR\fretrievalUrl*\x80\x01\n" +
+	"\rretrieval_url\x18\x06 \x01(\tR\fretrievalUrl\x127\n" +
+	"\x04role\x18\a \x01(\x0e2#.wendycloud.data.v1.EpisodeFileRoleR\x04role*\x80\x01\n" +
 	"\fEpisodeState\x12\x1d\n" +
 	"\x19EPISODE_STATE_UNSPECIFIED\x10\x00\x12\x1b\n" +
 	"\x17EPISODE_STATE_UPLOADING\x10\x01\x12\x1a\n" +
 	"\x16EPISODE_STATE_COMPLETE\x10\x02\x12\x18\n" +
-	"\x14EPISODE_STATE_FAILED\x10\x032\x87\x04\n" +
+	"\x14EPISODE_STATE_FAILED\x10\x03*s\n" +
+	"\x0fEpisodeFileRole\x12!\n" +
+	"\x1dEPISODE_FILE_ROLE_UNSPECIFIED\x10\x00\x12\x1e\n" +
+	"\x1aEPISODE_FILE_ROLE_CAPTURED\x10\x01\x12\x1d\n" +
+	"\x19EPISODE_FILE_ROLE_DERIVED\x10\x022\x87\x04\n" +
 	"\x11DataIngestService\x12s\n" +
 	"\x12BeginEpisodeUpload\x12-.wendycloud.data.v1.BeginEpisodeUploadRequest\x1a..wendycloud.data.v1.BeginEpisodeUploadResponse\x12_\n" +
 	"\x12UploadEpisodeChunk\x12 .wendycloud.data.v1.EpisodeChunk\x1a#.wendycloud.data.v1.EpisodeChunkAck(\x010\x01\x12d\n" +
@@ -1372,52 +1461,55 @@ func file_cloud_data_ingest_proto_rawDescGZIP() []byte {
 	return file_cloud_data_ingest_proto_rawDescData
 }
 
-var file_cloud_data_ingest_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_cloud_data_ingest_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
 var file_cloud_data_ingest_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_cloud_data_ingest_proto_goTypes = []any{
 	(EpisodeState)(0),                  // 0: wendycloud.data.v1.EpisodeState
-	(*EpisodeManifest)(nil),            // 1: wendycloud.data.v1.EpisodeManifest
-	(*EpisodeFileManifest)(nil),        // 2: wendycloud.data.v1.EpisodeFileManifest
-	(*BeginEpisodeUploadRequest)(nil),  // 3: wendycloud.data.v1.BeginEpisodeUploadRequest
-	(*FileUploadState)(nil),            // 4: wendycloud.data.v1.FileUploadState
-	(*BeginEpisodeUploadResponse)(nil), // 5: wendycloud.data.v1.BeginEpisodeUploadResponse
-	(*EpisodeChunk)(nil),               // 6: wendycloud.data.v1.EpisodeChunk
-	(*EpisodeChunkAck)(nil),            // 7: wendycloud.data.v1.EpisodeChunkAck
-	(*CommitEpisodeRequest)(nil),       // 8: wendycloud.data.v1.CommitEpisodeRequest
-	(*FileVerification)(nil),           // 9: wendycloud.data.v1.FileVerification
-	(*CommitEpisodeResponse)(nil),      // 10: wendycloud.data.v1.CommitEpisodeResponse
-	(*QueryEpisodesRequest)(nil),       // 11: wendycloud.data.v1.QueryEpisodesRequest
-	(*QueryEpisodesResponse)(nil),      // 12: wendycloud.data.v1.QueryEpisodesResponse
-	(*GetEpisodeRequest)(nil),          // 13: wendycloud.data.v1.GetEpisodeRequest
-	(*Episode)(nil),                    // 14: wendycloud.data.v1.Episode
-	(*EpisodeFileInfo)(nil),            // 15: wendycloud.data.v1.EpisodeFileInfo
+	(EpisodeFileRole)(0),               // 1: wendycloud.data.v1.EpisodeFileRole
+	(*EpisodeManifest)(nil),            // 2: wendycloud.data.v1.EpisodeManifest
+	(*EpisodeFileManifest)(nil),        // 3: wendycloud.data.v1.EpisodeFileManifest
+	(*BeginEpisodeUploadRequest)(nil),  // 4: wendycloud.data.v1.BeginEpisodeUploadRequest
+	(*FileUploadState)(nil),            // 5: wendycloud.data.v1.FileUploadState
+	(*BeginEpisodeUploadResponse)(nil), // 6: wendycloud.data.v1.BeginEpisodeUploadResponse
+	(*EpisodeChunk)(nil),               // 7: wendycloud.data.v1.EpisodeChunk
+	(*EpisodeChunkAck)(nil),            // 8: wendycloud.data.v1.EpisodeChunkAck
+	(*CommitEpisodeRequest)(nil),       // 9: wendycloud.data.v1.CommitEpisodeRequest
+	(*FileVerification)(nil),           // 10: wendycloud.data.v1.FileVerification
+	(*CommitEpisodeResponse)(nil),      // 11: wendycloud.data.v1.CommitEpisodeResponse
+	(*QueryEpisodesRequest)(nil),       // 12: wendycloud.data.v1.QueryEpisodesRequest
+	(*QueryEpisodesResponse)(nil),      // 13: wendycloud.data.v1.QueryEpisodesResponse
+	(*GetEpisodeRequest)(nil),          // 14: wendycloud.data.v1.GetEpisodeRequest
+	(*Episode)(nil),                    // 15: wendycloud.data.v1.Episode
+	(*EpisodeFileInfo)(nil),            // 16: wendycloud.data.v1.EpisodeFileInfo
 }
 var file_cloud_data_ingest_proto_depIdxs = []int32{
-	2,  // 0: wendycloud.data.v1.EpisodeManifest.files:type_name -> wendycloud.data.v1.EpisodeFileManifest
-	1,  // 1: wendycloud.data.v1.BeginEpisodeUploadRequest.manifest:type_name -> wendycloud.data.v1.EpisodeManifest
-	0,  // 2: wendycloud.data.v1.BeginEpisodeUploadResponse.state:type_name -> wendycloud.data.v1.EpisodeState
-	4,  // 3: wendycloud.data.v1.BeginEpisodeUploadResponse.files:type_name -> wendycloud.data.v1.FileUploadState
-	0,  // 4: wendycloud.data.v1.CommitEpisodeResponse.state:type_name -> wendycloud.data.v1.EpisodeState
-	9,  // 5: wendycloud.data.v1.CommitEpisodeResponse.files:type_name -> wendycloud.data.v1.FileVerification
-	0,  // 6: wendycloud.data.v1.QueryEpisodesRequest.state:type_name -> wendycloud.data.v1.EpisodeState
-	14, // 7: wendycloud.data.v1.QueryEpisodesResponse.episodes:type_name -> wendycloud.data.v1.Episode
-	0,  // 8: wendycloud.data.v1.Episode.state:type_name -> wendycloud.data.v1.EpisodeState
-	15, // 9: wendycloud.data.v1.Episode.files:type_name -> wendycloud.data.v1.EpisodeFileInfo
-	3,  // 10: wendycloud.data.v1.DataIngestService.BeginEpisodeUpload:input_type -> wendycloud.data.v1.BeginEpisodeUploadRequest
-	6,  // 11: wendycloud.data.v1.DataIngestService.UploadEpisodeChunk:input_type -> wendycloud.data.v1.EpisodeChunk
-	8,  // 12: wendycloud.data.v1.DataIngestService.CommitEpisode:input_type -> wendycloud.data.v1.CommitEpisodeRequest
-	11, // 13: wendycloud.data.v1.DataIngestService.QueryEpisodes:input_type -> wendycloud.data.v1.QueryEpisodesRequest
-	13, // 14: wendycloud.data.v1.DataIngestService.GetEpisode:input_type -> wendycloud.data.v1.GetEpisodeRequest
-	5,  // 15: wendycloud.data.v1.DataIngestService.BeginEpisodeUpload:output_type -> wendycloud.data.v1.BeginEpisodeUploadResponse
-	7,  // 16: wendycloud.data.v1.DataIngestService.UploadEpisodeChunk:output_type -> wendycloud.data.v1.EpisodeChunkAck
-	10, // 17: wendycloud.data.v1.DataIngestService.CommitEpisode:output_type -> wendycloud.data.v1.CommitEpisodeResponse
-	12, // 18: wendycloud.data.v1.DataIngestService.QueryEpisodes:output_type -> wendycloud.data.v1.QueryEpisodesResponse
-	14, // 19: wendycloud.data.v1.DataIngestService.GetEpisode:output_type -> wendycloud.data.v1.Episode
-	15, // [15:20] is the sub-list for method output_type
-	10, // [10:15] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	3,  // 0: wendycloud.data.v1.EpisodeManifest.files:type_name -> wendycloud.data.v1.EpisodeFileManifest
+	1,  // 1: wendycloud.data.v1.EpisodeFileManifest.role:type_name -> wendycloud.data.v1.EpisodeFileRole
+	2,  // 2: wendycloud.data.v1.BeginEpisodeUploadRequest.manifest:type_name -> wendycloud.data.v1.EpisodeManifest
+	0,  // 3: wendycloud.data.v1.BeginEpisodeUploadResponse.state:type_name -> wendycloud.data.v1.EpisodeState
+	5,  // 4: wendycloud.data.v1.BeginEpisodeUploadResponse.files:type_name -> wendycloud.data.v1.FileUploadState
+	0,  // 5: wendycloud.data.v1.CommitEpisodeResponse.state:type_name -> wendycloud.data.v1.EpisodeState
+	10, // 6: wendycloud.data.v1.CommitEpisodeResponse.files:type_name -> wendycloud.data.v1.FileVerification
+	0,  // 7: wendycloud.data.v1.QueryEpisodesRequest.state:type_name -> wendycloud.data.v1.EpisodeState
+	15, // 8: wendycloud.data.v1.QueryEpisodesResponse.episodes:type_name -> wendycloud.data.v1.Episode
+	0,  // 9: wendycloud.data.v1.Episode.state:type_name -> wendycloud.data.v1.EpisodeState
+	16, // 10: wendycloud.data.v1.Episode.files:type_name -> wendycloud.data.v1.EpisodeFileInfo
+	1,  // 11: wendycloud.data.v1.EpisodeFileInfo.role:type_name -> wendycloud.data.v1.EpisodeFileRole
+	4,  // 12: wendycloud.data.v1.DataIngestService.BeginEpisodeUpload:input_type -> wendycloud.data.v1.BeginEpisodeUploadRequest
+	7,  // 13: wendycloud.data.v1.DataIngestService.UploadEpisodeChunk:input_type -> wendycloud.data.v1.EpisodeChunk
+	9,  // 14: wendycloud.data.v1.DataIngestService.CommitEpisode:input_type -> wendycloud.data.v1.CommitEpisodeRequest
+	12, // 15: wendycloud.data.v1.DataIngestService.QueryEpisodes:input_type -> wendycloud.data.v1.QueryEpisodesRequest
+	14, // 16: wendycloud.data.v1.DataIngestService.GetEpisode:input_type -> wendycloud.data.v1.GetEpisodeRequest
+	6,  // 17: wendycloud.data.v1.DataIngestService.BeginEpisodeUpload:output_type -> wendycloud.data.v1.BeginEpisodeUploadResponse
+	8,  // 18: wendycloud.data.v1.DataIngestService.UploadEpisodeChunk:output_type -> wendycloud.data.v1.EpisodeChunkAck
+	11, // 19: wendycloud.data.v1.DataIngestService.CommitEpisode:output_type -> wendycloud.data.v1.CommitEpisodeResponse
+	13, // 20: wendycloud.data.v1.DataIngestService.QueryEpisodes:output_type -> wendycloud.data.v1.QueryEpisodesResponse
+	15, // 21: wendycloud.data.v1.DataIngestService.GetEpisode:output_type -> wendycloud.data.v1.Episode
+	17, // [17:22] is the sub-list for method output_type
+	12, // [12:17] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_cloud_data_ingest_proto_init() }
@@ -1430,7 +1522,7 @@ func file_cloud_data_ingest_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cloud_data_ingest_proto_rawDesc), len(file_cloud_data_ingest_proto_rawDesc)),
-			NumEnums:      1,
+			NumEnums:      2,
 			NumMessages:   15,
 			NumExtensions: 0,
 			NumServices:   1,

--- a/go/proto/gen/cloudpb/data_ingest.pb.go
+++ b/go/proto/gen/cloudpb/data_ingest.pb.go
@@ -77,10 +77,25 @@ func (EpisodeState) EnumDescriptor() ([]byte, []int) {
 // What a file is to the episode it belongs to. Mirrors the device manifest's
 // per-file `role`, one word for one thing across device, wire and catalog.
 //
-// UNSPECIFIED means CAPTURED. Devices built before this field existed never
-// set it and upload nothing but capture payload and capture metadata, so an
-// absent role has exactly the meaning it always had; readers must treat
-// UNSPECIFIED and CAPTURED identically and must never report "unknown role".
+// UNSPECIFIED carries exactly one meaning: the sender predates this field and
+// said nothing about roles. A file with no role is accounted as CAPTURED,
+// which is the meaning it carried before the field existed.
+//
+// That default is a best reading of a silent sender, not a proof about what
+// such senders produced. Derived files, including the playable remux, existed
+// on the device before the wire role did, so a manifest sealed in that window
+// can legitimately contain a derived file with no role on it.
+//
+// A sender that HAS a role but cannot express it on this enum MUST NOT send
+// UNSPECIFIED. Doing so books the file as capture payload, corrupts
+// capture-only accounting, and leaves no signal that anything was lost. Add
+// the role to this enum and send it.
+//
+// A reader that receives a role number it does not know must retain the
+// number as received, must not coerce it to CAPTURED, and must not fail the
+// episode. Carry it through storage, count its bytes in size totals, and
+// leave them out of capture-only sums. An unknown role means a newer peer,
+// not a corrupt one.
 type EpisodeFileRole int32
 
 const (
@@ -146,12 +161,29 @@ type EpisodeManifest struct {
 	// capture, a human-authored slug such as "forklift-failures". It is not an
 	// identifier minted by the cloud, and it is not unique over time; the
 	// (campaign, campaign_revision) pair is what identifies an exact plan.
+	//
+	// EMPTY when the episode has no campaign. A manual or otherwise ad-hoc
+	// capture is armed by an operator, not by a campaign file, so there is no
+	// campaign name to report; such an episode carries "manual" as its trigger
+	// reason and leaves both campaign fields empty together. This is ordinary
+	// traffic, not an edge case, so consumers must accept the empty value
+	// rather than reject or substitute it.
 	Campaign string `protobuf:"bytes,4,opt,name=campaign,proto3" json:"campaign,omitempty"`
-	// Lowercase hex SHA-256 of the canonical campaign plan, so always exactly
-	// 64 characters. The device computes it in WendyOS at
-	// go/internal/agent/data/campaign.go:219, as
-	// hex(sha256(json(campaign.planOnly()))), where planOnly() strips deployment
-	// state so only author-declared plan fields feed the digest.
+	// Revision digest of the campaign plan that armed this capture.
+	//
+	// EMPTY when the episode has no campaign, for the same reason `campaign` is
+	// empty: a manual or ad-hoc capture never had a plan to digest. Otherwise
+	// it is a lowercase hex SHA-256 and therefore exactly 64 characters. A
+	// consumer that validates 64 hex characters unconditionally will reject
+	// legitimate and common data; check the length only after finding the value
+	// non-empty.
+	//
+	// Derivation: the device serialises the campaign to canonical JSON with
+	// deployment state stripped, so that only author-declared plan fields feed
+	// the digest, and takes the lowercase hex SHA-256 of those bytes. Two
+	// devices running the same plan report the same revision. Described rather
+	// than cited by file and line: the implementation lives in another
+	// repository and any line number given here is stale on its next edit.
 	//
 	// String, not an integer: 256 bits of digest do not fit in a uint64, and no
 	// truncation of a hash preserves it as an identifier. It is a content
@@ -322,8 +354,10 @@ type EpisodeFileManifest struct {
 	TimeRangeEndNanos   int64 `protobuf:"varint,8,opt,name=time_range_end_nanos,json=timeRangeEndNanos,proto3" json:"time_range_end_nanos,omitempty"`
 	// Source-clock to canonical-clock mapping summary JSON, when present.
 	ClockMappingJson []byte `protobuf:"bytes,9,opt,name=clock_mapping_json,json=clockMappingJson,proto3" json:"clock_mapping_json,omitempty"`
-	// What this file is to the episode. Unset (UNSPECIFIED) means CAPTURED, so
-	// devices predating this field keep their existing meaning unchanged.
+	// What this file is to the episode. Unset (UNSPECIFIED) means the sender
+	// predates this field, and is accounted as CAPTURED. See EpisodeFileRole
+	// for what a sender must do with a role it cannot express, and what a
+	// reader must do with a role number it does not know.
 	Role          EpisodeFileRole `protobuf:"varint,10,opt,name=role,proto3,enum=wendycloud.data.v1.EpisodeFileRole" json:"role,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -681,8 +715,25 @@ type EpisodeChunkAck struct {
 	// persisted, then equals the file size. Never claims durability that
 	// does not exist.
 	CommittedOffset uint64 `protobuf:"varint,3,opt,name=committed_offset,json=committedOffset,proto3" json:"committed_offset,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// The episode the acknowledged path belongs to; echoes the `episode_id` of
+	// the chunk being acknowledged.
+	//
+	// A client MUST match an ack on the (episode_id, path) pair, never on path
+	// alone. EpisodeChunk carries episode_id per chunk, so one stream may carry
+	// chunks for more than one episode, and the server keys its assembler on
+	// the same pair. A path is unique only within an episode: two episodes on
+	// one stream that both contain "manifest.json" produce acks that path alone
+	// cannot tell apart, and a client matching on path credits one episode's
+	// committed offset to the other, then skips a file it never uploaded. That
+	// is silent data loss, not a retry.
+	//
+	// Added after `path`, so a server built before this field leaves it empty.
+	// A client that finds it empty cannot match safely on a multi-episode
+	// stream, and must keep to one stream per episode until the server carries
+	// the field.
+	EpisodeId     string `protobuf:"bytes,4,opt,name=episode_id,json=episodeId,proto3" json:"episode_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *EpisodeChunkAck) Reset() {
@@ -734,6 +785,13 @@ func (x *EpisodeChunkAck) GetCommittedOffset() uint64 {
 		return x.CommittedOffset
 	}
 	return 0
+}
+
+func (x *EpisodeChunkAck) GetEpisodeId() string {
+	if x != nil {
+		return x.EpisodeId
+	}
+	return ""
 }
 
 type CommitEpisodeRequest struct {
@@ -916,10 +974,20 @@ func (x *CommitEpisodeResponse) GetFiles() []*FileVerification {
 
 type QueryEpisodesRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Organization scope. With certificate-identity credentials this must
-	// match the caller's organization; with the PoC static read token it
-	// selects the organization to read (chosen debt until user auth carries
-	// org membership).
+	// Organization to read. This is a filter the caller supplies, not an
+	// identity the server verifies. With certificate-identity credentials it
+	// must match the organization on the certificate.
+	//
+	// AUTHORIZATION GAP, unresolved: the read credential today is a single
+	// shared bearer token that is scoped to no organization, and the server
+	// does NOT check that the caller is a member of the organization named
+	// here. Possession of that token therefore grants catalog read across every
+	// organization, obtained by passing a different number in this field. The
+	// field is not the defect and must not be removed, because a filter is the
+	// right shape once membership is enforced. A server-side membership check,
+	// against the caller's own credential rather than against this value, is
+	// REQUIRED before this RPC is exposed to anything but a trusted internal
+	// caller.
 	OrgId uint64 `protobuf:"varint,1,opt,name=org_id,json=orgId,proto3" json:"org_id,omitempty"`
 	// Optional filters; zero values mean "no filter".
 	AssetId                uint64       `protobuf:"varint,2,opt,name=asset_id,json=assetId,proto3" json:"asset_id,omitempty"`
@@ -1057,9 +1125,26 @@ func (x *QueryEpisodesResponse) GetEpisodes() []*Episode {
 }
 
 type GetEpisodeRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	OrgId         uint64                 `protobuf:"varint,1,opt,name=org_id,json=orgId,proto3" json:"org_id,omitempty"`
-	EpisodeId     string                 `protobuf:"bytes,2,opt,name=episode_id,json=episodeId,proto3" json:"episode_id,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Organization the named episode belongs to. Same caller-supplied filter as
+	// QueryEpisodesRequest.org_id, unverified in the same way, under the same
+	// shared read token.
+	//
+	// AUTHORIZATION GAP, sharper here than on the query: this RPC returns
+	// per-file retrieval URLs, short-lived signed object-storage URLs that read
+	// the stored bytes. Absent a membership check, the shared read token is not
+	// merely a cross-organization catalog read; it is a cross-organization
+	// data-egress capability. Name another organization's identifier here with
+	// one of its episode identifiers and the response hands back signed URLs to
+	// that organization's captured data. Those URLs are bearer capabilities in
+	// their own right: they work for anyone they are passed to, and revoking
+	// the read token afterwards does not revoke URLs already issued.
+	//
+	// The fix is authorization, not schema; the field stays. A server-side
+	// membership check is REQUIRED before this RPC is exposed to anything but a
+	// trusted internal caller.
+	OrgId         uint64 `protobuf:"varint,1,opt,name=org_id,json=orgId,proto3" json:"org_id,omitempty"`
+	EpisodeId     string `protobuf:"bytes,2,opt,name=episode_id,json=episodeId,proto3" json:"episode_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1276,7 +1361,9 @@ type EpisodeFileInfo struct {
 	// direct in local development).
 	RetrievalUrl string `protobuf:"bytes,6,opt,name=retrieval_url,json=retrievalUrl,proto3" json:"retrieval_url,omitempty"`
 	// What this file is to the episode, as recorded in the catalog. Unset
-	// (UNSPECIFIED) means CAPTURED, as on the upload manifest.
+	// (UNSPECIFIED) means the uploading sender predated the field, as on the
+	// upload manifest. A role the catalog did not recognise at write time is
+	// reported here as the number it arrived as, never rewritten to CAPTURED.
 	Role          EpisodeFileRole `protobuf:"varint,7,opt,name=role,proto3,enum=wendycloud.data.v1.EpisodeFileRole" json:"role,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1409,11 +1496,13 @@ const file_cloud_data_ingest_proto_rawDesc = "" +
 	"\x04path\x18\x02 \x01(\tR\x04path\x12\x16\n" +
 	"\x06offset\x18\x03 \x01(\x04R\x06offset\x12\x12\n" +
 	"\x04data\x18\x04 \x01(\fR\x04data\x12\x10\n" +
-	"\x03eof\x18\x05 \x01(\bR\x03eof\"y\n" +
+	"\x03eof\x18\x05 \x01(\bR\x03eof\"\x98\x01\n" +
 	"\x0fEpisodeChunkAck\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12'\n" +
 	"\x0freceived_offset\x18\x02 \x01(\x04R\x0ereceivedOffset\x12)\n" +
-	"\x10committed_offset\x18\x03 \x01(\x04R\x0fcommittedOffset\"5\n" +
+	"\x10committed_offset\x18\x03 \x01(\x04R\x0fcommittedOffset\x12\x1d\n" +
+	"\n" +
+	"episode_id\x18\x04 \x01(\tR\tepisodeId\"5\n" +
 	"\x14CommitEpisodeRequest\x12\x1d\n" +
 	"\n" +
 	"episode_id\x18\x01 \x01(\tR\tepisodeId\"\x9c\x01\n" +

--- a/go/proto/gen/cloudpb/data_ingest.pb.go
+++ b/go/proto/gen/cloudpb/data_ingest.pb.go
@@ -142,10 +142,21 @@ func (EpisodeFileRole) EnumDescriptor() ([]byte, []int) {
 type EpisodeManifest struct {
 	state     protoimpl.MessageState `protogen:"open.v1"`
 	EpisodeId string                 `protobuf:"bytes,1,opt,name=episode_id,json=episodeId,proto3" json:"episode_id,omitempty"`
-	// Must match the certificate identity of the uploading device.
-	OrgId            uint64 `protobuf:"varint,2,opt,name=org_id,json=orgId,proto3" json:"org_id,omitempty"`
-	AssetId          uint64 `protobuf:"varint,3,opt,name=asset_id,json=assetId,proto3" json:"asset_id,omitempty"`
-	Campaign         string `protobuf:"bytes,4,opt,name=campaign,proto3" json:"campaign,omitempty"`
+	// Campaign name: the `name:` field of the campaign file that armed this
+	// capture, a human-authored slug such as "forklift-failures". It is not an
+	// identifier minted by the cloud, and it is not unique over time; the
+	// (campaign, campaign_revision) pair is what identifies an exact plan.
+	Campaign string `protobuf:"bytes,4,opt,name=campaign,proto3" json:"campaign,omitempty"`
+	// Lowercase hex SHA-256 of the canonical campaign plan, so always exactly
+	// 64 characters. The device computes it in WendyOS at
+	// go/internal/agent/data/campaign.go:219, as
+	// hex(sha256(json(campaign.planOnly()))), where planOnly() strips deployment
+	// state so only author-declared plan fields feed the digest.
+	//
+	// String, not an integer: 256 bits of digest do not fit in a uint64, and no
+	// truncation of a hash preserves it as an identifier. It is a content
+	// digest rather than a sequence number, so it identifies the exact plan
+	// that produced this episode but does not order two revisions.
 	CampaignRevision string `protobuf:"bytes,5,opt,name=campaign_revision,json=campaignRevision,proto3" json:"campaign_revision,omitempty"`
 	// Trigger reason (e.g. "manual", "campaign-trigger", or the fired
 	// expression such as "model.uncertainty > 0.65").
@@ -157,16 +168,26 @@ type EpisodeManifest struct {
 	// from the device's clock-sandwich observations. system_clock_status is
 	// the device's own verdict ("ok", "conflict", ...); a "conflict" episode
 	// is flagged in the catalog, never silently resolved.
-	StartedUnixNanos    int64                  `protobuf:"varint,9,opt,name=started_unix_nanos,json=startedUnixNanos,proto3" json:"started_unix_nanos,omitempty"`
-	UtcOffsetLowerNanos int64                  `protobuf:"varint,10,opt,name=utc_offset_lower_nanos,json=utcOffsetLowerNanos,proto3" json:"utc_offset_lower_nanos,omitempty"`
-	UtcOffsetUpperNanos int64                  `protobuf:"varint,11,opt,name=utc_offset_upper_nanos,json=utcOffsetUpperNanos,proto3" json:"utc_offset_upper_nanos,omitempty"`
-	SystemClockStatus   string                 `protobuf:"bytes,12,opt,name=system_clock_status,json=systemClockStatus,proto3" json:"system_clock_status,omitempty"`
-	Files               []*EpisodeFileManifest `protobuf:"bytes,13,rep,name=files,proto3" json:"files,omitempty"`
+	StartedUnixNanos    int64  `protobuf:"varint,9,opt,name=started_unix_nanos,json=startedUnixNanos,proto3" json:"started_unix_nanos,omitempty"`
+	UtcOffsetLowerNanos int64  `protobuf:"varint,10,opt,name=utc_offset_lower_nanos,json=utcOffsetLowerNanos,proto3" json:"utc_offset_lower_nanos,omitempty"`
+	UtcOffsetUpperNanos int64  `protobuf:"varint,11,opt,name=utc_offset_upper_nanos,json=utcOffsetUpperNanos,proto3" json:"utc_offset_upper_nanos,omitempty"`
+	SystemClockStatus   string `protobuf:"bytes,12,opt,name=system_clock_status,json=systemClockStatus,proto3" json:"system_clock_status,omitempty"`
 	// The complete device manifest JSON (manifest v2), stored verbatim in the
 	// catalog attributes column.
+	//
+	// Deliberately bytes rather than map<string, string> or google.protobuf.
+	// Struct. This is not a flat key-value bag: it is a nested document (a
+	// files array, a per-file clock-mapping object, a trigger object, a device
+	// identity object), which a string map cannot hold at all. Struct could
+	// hold the shape but not the bytes, and byte fidelity is the point of the
+	// field: it is the artifact the device sealed, kept as sent so the catalog
+	// can be audited against the device rather than against our re-encoding of
+	// it. The typed fields above are what the catalog indexes on.
 	AttributesJson []byte `protobuf:"bytes,14,opt,name=attributes_json,json=attributesJson,proto3" json:"attributes_json,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Declared last by convention; field number 13 is unchanged.
+	Files         []*EpisodeFileManifest `protobuf:"bytes,13,rep,name=files,proto3" json:"files,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *EpisodeManifest) Reset() {
@@ -204,20 +225,6 @@ func (x *EpisodeManifest) GetEpisodeId() string {
 		return x.EpisodeId
 	}
 	return ""
-}
-
-func (x *EpisodeManifest) GetOrgId() uint64 {
-	if x != nil {
-		return x.OrgId
-	}
-	return 0
-}
-
-func (x *EpisodeManifest) GetAssetId() uint64 {
-	if x != nil {
-		return x.AssetId
-	}
-	return 0
 }
 
 func (x *EpisodeManifest) GetCampaign() string {
@@ -283,16 +290,16 @@ func (x *EpisodeManifest) GetSystemClockStatus() string {
 	return ""
 }
 
-func (x *EpisodeManifest) GetFiles() []*EpisodeFileManifest {
+func (x *EpisodeManifest) GetAttributesJson() []byte {
 	if x != nil {
-		return x.Files
+		return x.AttributesJson
 	}
 	return nil
 }
 
-func (x *EpisodeManifest) GetAttributesJson() []byte {
+func (x *EpisodeManifest) GetFiles() []*EpisodeFileManifest {
 	if x != nil {
-		return x.AttributesJson
+		return x.Files
 	}
 	return nil
 }
@@ -471,7 +478,7 @@ type FileUploadState struct {
 	Path  string                 `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
 	// Bytes durably stored in object storage for this file: 0 (not stored or
 	// partially stored; restart from 0) or the full file size (stored; skip).
-	CommittedOffset int64 `protobuf:"varint,2,opt,name=committed_offset,json=committedOffset,proto3" json:"committed_offset,omitempty"`
+	CommittedOffset uint64 `protobuf:"varint,2,opt,name=committed_offset,json=committedOffset,proto3" json:"committed_offset,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -513,7 +520,7 @@ func (x *FileUploadState) GetPath() string {
 	return ""
 }
 
-func (x *FileUploadState) GetCommittedOffset() int64 {
+func (x *FileUploadState) GetCommittedOffset() uint64 {
 	if x != nil {
 		return x.CommittedOffset
 	}
@@ -578,8 +585,20 @@ type EpisodeChunk struct {
 	Path      string                 `protobuf:"bytes,2,opt,name=path,proto3" json:"path,omitempty"`
 	// Byte offset of this chunk within the file; must equal the number of
 	// bytes already sent for the file (sequential, no gaps).
-	Offset int64 `protobuf:"varint,3,opt,name=offset,proto3" json:"offset,omitempty"`
-	// At most 1 MiB per chunk.
+	Offset uint64 `protobuf:"varint,3,opt,name=offset,proto3" json:"offset,omitempty"`
+	// At most 1 MiB of payload per chunk.
+	//
+	// Why 1 MiB: gRPC's default maximum received message size is 4 MiB, and
+	// that budget covers the whole encoded EpisodeChunk, not just this field.
+	// 1 MiB leaves room for path, offset and framing while staying well inside
+	// the default on every runtime, so neither end has to raise its limit to
+	// speak this protocol. It also bounds what one failed chunk costs to send
+	// again, which is what makes a retry cheap on a slow uplink. It is the
+	// device transfer worker's buffer size too, so cap and sender agree by
+	// construction rather than by luck.
+	//
+	// The cloud enforces this: an oversized chunk is INVALID_ARGUMENT naming
+	// the limit and the size received. The cap is a rule, not a request.
 	Data []byte `protobuf:"bytes,4,opt,name=data,proto3" json:"data,omitempty"`
 	// True on the last chunk of the file; the server then persists the file
 	// to object storage.
@@ -632,7 +651,7 @@ func (x *EpisodeChunk) GetPath() string {
 	return ""
 }
 
-func (x *EpisodeChunk) GetOffset() int64 {
+func (x *EpisodeChunk) GetOffset() uint64 {
 	if x != nil {
 		return x.Offset
 	}
@@ -657,11 +676,11 @@ type EpisodeChunkAck struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Path  string                 `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
 	// Contiguous bytes received (spooled server-side, not yet durable).
-	ReceivedOffset int64 `protobuf:"varint,2,opt,name=received_offset,json=receivedOffset,proto3" json:"received_offset,omitempty"`
+	ReceivedOffset uint64 `protobuf:"varint,2,opt,name=received_offset,json=receivedOffset,proto3" json:"received_offset,omitempty"`
 	// Bytes durably stored in object storage. Stays 0 until the eof chunk is
 	// persisted, then equals the file size. Never claims durability that
 	// does not exist.
-	CommittedOffset int64 `protobuf:"varint,3,opt,name=committed_offset,json=committedOffset,proto3" json:"committed_offset,omitempty"`
+	CommittedOffset uint64 `protobuf:"varint,3,opt,name=committed_offset,json=committedOffset,proto3" json:"committed_offset,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -703,14 +722,14 @@ func (x *EpisodeChunkAck) GetPath() string {
 	return ""
 }
 
-func (x *EpisodeChunkAck) GetReceivedOffset() int64 {
+func (x *EpisodeChunkAck) GetReceivedOffset() uint64 {
 	if x != nil {
 		return x.ReceivedOffset
 	}
 	return 0
 }
 
-func (x *EpisodeChunkAck) GetCommittedOffset() int64 {
+func (x *EpisodeChunkAck) GetCommittedOffset() uint64 {
 	if x != nil {
 		return x.CommittedOffset
 	}
@@ -769,6 +788,10 @@ type FileVerification struct {
 	ExpectedSha256 string                 `protobuf:"bytes,3,opt,name=expected_sha256,json=expectedSha256,proto3" json:"expected_sha256,omitempty"`
 	ActualSha256   string                 `protobuf:"bytes,4,opt,name=actual_sha256,json=actualSha256,proto3" json:"actual_sha256,omitempty"`
 	// Human-readable detail on failure (missing object, size mismatch, ...).
+	// Plain string rather than optional: `ok` is the discriminator, and the
+	// server sets detail on every failure and never on success, so empty and
+	// absent would mean the same thing. Presence here would add a has-check to
+	// every consumer without letting any of them decide anything new.
 	Detail        string `protobuf:"bytes,5,opt,name=detail,proto3" json:"detail,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1087,16 +1110,30 @@ func (x *GetEpisodeRequest) GetEpisodeId() string {
 
 // A catalog row plus its files.
 type Episode struct {
-	state            protoimpl.MessageState `protogen:"open.v1"`
-	EpisodeId        string                 `protobuf:"bytes,1,opt,name=episode_id,json=episodeId,proto3" json:"episode_id,omitempty"`
-	OrgId            uint64                 `protobuf:"varint,2,opt,name=org_id,json=orgId,proto3" json:"org_id,omitempty"`
-	AssetId          uint64                 `protobuf:"varint,3,opt,name=asset_id,json=assetId,proto3" json:"asset_id,omitempty"`
-	Campaign         string                 `protobuf:"bytes,4,opt,name=campaign,proto3" json:"campaign,omitempty"`
-	Trigger          string                 `protobuf:"bytes,5,opt,name=trigger,proto3" json:"trigger,omitempty"`
-	StartedUnixNanos int64                  `protobuf:"varint,6,opt,name=started_unix_nanos,json=startedUnixNanos,proto3" json:"started_unix_nanos,omitempty"`
-	EndedUnixNanos   int64                  `protobuf:"varint,7,opt,name=ended_unix_nanos,json=endedUnixNanos,proto3" json:"ended_unix_nanos,omitempty"`
-	State            EpisodeState           `protobuf:"varint,8,opt,name=state,proto3,enum=wendycloud.data.v1.EpisodeState" json:"state,omitempty"`
-	SizeBytes        uint64                 `protobuf:"varint,9,opt,name=size_bytes,json=sizeBytes,proto3" json:"size_bytes,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	EpisodeId string                 `protobuf:"bytes,1,opt,name=episode_id,json=episodeId,proto3" json:"episode_id,omitempty"`
+	// Owning tenant, as attested by the cloud. Unlike the upload manifest, this
+	// is server output, not a client claim: it reports the identity the episode
+	// was actually stored under. It stays on the response because a query with
+	// no asset filter spans assets, and a reader that cannot tell the rows
+	// apart would have to reach into attributes_json to do it.
+	OrgId   uint64 `protobuf:"varint,2,opt,name=org_id,json=orgId,proto3" json:"org_id,omitempty"`
+	AssetId uint64 `protobuf:"varint,3,opt,name=asset_id,json=assetId,proto3" json:"asset_id,omitempty"`
+	// Campaign name and its trigger, as recorded at capture time.
+	Campaign         string       `protobuf:"bytes,4,opt,name=campaign,proto3" json:"campaign,omitempty"`
+	Trigger          string       `protobuf:"bytes,5,opt,name=trigger,proto3" json:"trigger,omitempty"`
+	StartedUnixNanos int64        `protobuf:"varint,6,opt,name=started_unix_nanos,json=startedUnixNanos,proto3" json:"started_unix_nanos,omitempty"`
+	EndedUnixNanos   int64        `protobuf:"varint,7,opt,name=ended_unix_nanos,json=endedUnixNanos,proto3" json:"ended_unix_nanos,omitempty"`
+	State            EpisodeState `protobuf:"varint,8,opt,name=state,proto3,enum=wendycloud.data.v1.EpisodeState" json:"state,omitempty"`
+	// Total bytes the episode occupies in object storage: the sum of every
+	// file's size, derived files included. It is deliberately NOT capture-only.
+	// This number answers "what does this episode cost to store", which is what
+	// retention and quota act on, and it stays equal to the sum of the file
+	// sizes so the two can be checked against each other. A total that silently
+	// omitted some of its own parts would match neither storage nor the file
+	// list. Capture-only bytes are a filter over the per-file roles, e.g.
+	// summing size_bytes where role is CAPTURED or UNSPECIFIED.
+	SizeBytes uint64 `protobuf:"varint,9,opt,name=size_bytes,json=sizeBytes,proto3" json:"size_bytes,omitempty"`
 	// Clock correlation summary JSON (UTC offset bounds, clock status).
 	ClockCorrelationJson []byte `protobuf:"bytes,10,opt,name=clock_correlation_json,json=clockCorrelationJson,proto3" json:"clock_correlation_json,omitempty"`
 	// Full device manifest JSON as uploaded.
@@ -1328,12 +1365,10 @@ var File_cloud_data_ingest_proto protoreflect.FileDescriptor
 
 const file_cloud_data_ingest_proto_rawDesc = "" +
 	"\n" +
-	"\x17cloud/data_ingest.proto\x12\x12wendycloud.data.v1\"\xe1\x04\n" +
+	"\x17cloud/data_ingest.proto\x12\x12wendycloud.data.v1\"\xcd\x04\n" +
 	"\x0fEpisodeManifest\x12\x1d\n" +
 	"\n" +
-	"episode_id\x18\x01 \x01(\tR\tepisodeId\x12\x15\n" +
-	"\x06org_id\x18\x02 \x01(\x04R\x05orgId\x12\x19\n" +
-	"\basset_id\x18\x03 \x01(\x04R\aassetId\x12\x1a\n" +
+	"episode_id\x18\x01 \x01(\tR\tepisodeId\x12\x1a\n" +
 	"\bcampaign\x18\x04 \x01(\tR\bcampaign\x12+\n" +
 	"\x11campaign_revision\x18\x05 \x01(\tR\x10campaignRevision\x12\x18\n" +
 	"\atrigger\x18\x06 \x01(\tR\atrigger\x124\n" +
@@ -1343,9 +1378,9 @@ const file_cloud_data_ingest_proto_rawDesc = "" +
 	"\x16utc_offset_lower_nanos\x18\n" +
 	" \x01(\x03R\x13utcOffsetLowerNanos\x123\n" +
 	"\x16utc_offset_upper_nanos\x18\v \x01(\x03R\x13utcOffsetUpperNanos\x12.\n" +
-	"\x13system_clock_status\x18\f \x01(\tR\x11systemClockStatus\x12=\n" +
-	"\x05files\x18\r \x03(\v2'.wendycloud.data.v1.EpisodeFileManifestR\x05files\x12'\n" +
-	"\x0fattributes_json\x18\x0e \x01(\fR\x0eattributesJson\"\x81\x03\n" +
+	"\x13system_clock_status\x18\f \x01(\tR\x11systemClockStatus\x12'\n" +
+	"\x0fattributes_json\x18\x0e \x01(\fR\x0eattributesJson\x12=\n" +
+	"\x05files\x18\r \x03(\v2'.wendycloud.data.v1.EpisodeFileManifestR\x05filesJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x06org_idR\basset_id\"\x81\x03\n" +
 	"\x13EpisodeFileManifest\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12\x1d\n" +
 	"\n" +
@@ -1364,7 +1399,7 @@ const file_cloud_data_ingest_proto_rawDesc = "" +
 	"\bmanifest\x18\x01 \x01(\v2#.wendycloud.data.v1.EpisodeManifestR\bmanifest\"P\n" +
 	"\x0fFileUploadState\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12)\n" +
-	"\x10committed_offset\x18\x02 \x01(\x03R\x0fcommittedOffset\"\x8f\x01\n" +
+	"\x10committed_offset\x18\x02 \x01(\x04R\x0fcommittedOffset\"\x8f\x01\n" +
 	"\x1aBeginEpisodeUploadResponse\x126\n" +
 	"\x05state\x18\x01 \x01(\x0e2 .wendycloud.data.v1.EpisodeStateR\x05state\x129\n" +
 	"\x05files\x18\x02 \x03(\v2#.wendycloud.data.v1.FileUploadStateR\x05files\"\x7f\n" +
@@ -1372,13 +1407,13 @@ const file_cloud_data_ingest_proto_rawDesc = "" +
 	"\n" +
 	"episode_id\x18\x01 \x01(\tR\tepisodeId\x12\x12\n" +
 	"\x04path\x18\x02 \x01(\tR\x04path\x12\x16\n" +
-	"\x06offset\x18\x03 \x01(\x03R\x06offset\x12\x12\n" +
+	"\x06offset\x18\x03 \x01(\x04R\x06offset\x12\x12\n" +
 	"\x04data\x18\x04 \x01(\fR\x04data\x12\x10\n" +
 	"\x03eof\x18\x05 \x01(\bR\x03eof\"y\n" +
 	"\x0fEpisodeChunkAck\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12'\n" +
-	"\x0freceived_offset\x18\x02 \x01(\x03R\x0ereceivedOffset\x12)\n" +
-	"\x10committed_offset\x18\x03 \x01(\x03R\x0fcommittedOffset\"5\n" +
+	"\x0freceived_offset\x18\x02 \x01(\x04R\x0ereceivedOffset\x12)\n" +
+	"\x10committed_offset\x18\x03 \x01(\x04R\x0fcommittedOffset\"5\n" +
 	"\x14CommitEpisodeRequest\x12\x1d\n" +
 	"\n" +
 	"episode_id\x18\x01 \x01(\tR\tepisodeId\"\x9c\x01\n" +

--- a/go/proto/gen/cloudpb/data_ingest_grpc.pb.go
+++ b/go/proto/gen/cloudpb/data_ingest_grpc.pb.go
@@ -50,9 +50,11 @@ const (
 //
 // Authentication:
 //   - Begin/Upload/Commit require a device asset identity (mTLS client
-//     certificate SAN). Uploads are scoped to the asserted org and asset; a
-//     manifest whose org_id or asset_id differs from the certificate
-//     identity is rejected with PERMISSION_DENIED.
+//     certificate SAN). The owning organization and asset are read from that
+//     certificate and attested by the cloud; they are not carried on the
+//     request. Every catalog row and every storage object name is written
+//     from the certificate identity, so an upload cannot name a tenant it
+//     does not hold a certificate for.
 //   - QueryEpisodes/GetEpisode are read RPCs for users and services; the
 //     serving implementation defines the accepted credential.
 type DataIngestServiceClient interface {
@@ -156,9 +158,11 @@ func (c *dataIngestServiceClient) GetEpisode(ctx context.Context, in *GetEpisode
 //
 // Authentication:
 //   - Begin/Upload/Commit require a device asset identity (mTLS client
-//     certificate SAN). Uploads are scoped to the asserted org and asset; a
-//     manifest whose org_id or asset_id differs from the certificate
-//     identity is rejected with PERMISSION_DENIED.
+//     certificate SAN). The owning organization and asset are read from that
+//     certificate and attested by the cloud; they are not carried on the
+//     request. Every catalog row and every storage object name is written
+//     from the certificate identity, so an upload cannot name a tenant it
+//     does not hold a certificate for.
 //   - QueryEpisodes/GetEpisode are read RPCs for users and services; the
 //     serving implementation defines the accepted credential.
 type DataIngestServiceServer interface {

--- a/go/proto/gen/cloudpb/data_ingest_grpc.pb.go
+++ b/go/proto/gen/cloudpb/data_ingest_grpc.pb.go
@@ -43,7 +43,10 @@ const (
 //  2. UploadEpisodeChunk streams file chunks (at most 1 MiB of data per
 //     chunk, sequential offsets per file, eof on the last chunk). Each
 //     chunk is acknowledged with the received (spooled) offset and the
-//     committed (durably stored in object storage) offset.
+//     committed (durably stored in object storage) offset. An ack names the
+//     (episode_id, path) it belongs to and must be matched on that pair,
+//     because one stream may carry chunks for more than one episode and a
+//     path is unique only within an episode.
 //  3. CommitEpisode verifies the SHA-256 of every stored object against
 //     the manifest and flips the catalog state to `complete`, or `failed`
 //     with per-file detail on any mismatch.
@@ -56,7 +59,13 @@ const (
 //     from the certificate identity, so an upload cannot name a tenant it
 //     does not hold a certificate for.
 //   - QueryEpisodes/GetEpisode are read RPCs for users and services; the
-//     serving implementation defines the accepted credential.
+//     serving implementation defines the accepted credential. Both carry an
+//     org_id whose membership the server does not verify today, and the read
+//     credential in use is a single shared token scoped to no organization.
+//     GetEpisode returns signed object URLs, so that combination is a
+//     cross-organization data-egress path, not just a catalog read. Read the
+//     org_id documentation on QueryEpisodesRequest and GetEpisodeRequest
+//     before exposing either RPC beyond a trusted internal caller.
 type DataIngestServiceClient interface {
 	// Registers (or re-registers) an episode upload. Idempotent.
 	BeginEpisodeUpload(ctx context.Context, in *BeginEpisodeUploadRequest, opts ...grpc.CallOption) (*BeginEpisodeUploadResponse, error)
@@ -151,7 +160,10 @@ func (c *dataIngestServiceClient) GetEpisode(ctx context.Context, in *GetEpisode
 //  2. UploadEpisodeChunk streams file chunks (at most 1 MiB of data per
 //     chunk, sequential offsets per file, eof on the last chunk). Each
 //     chunk is acknowledged with the received (spooled) offset and the
-//     committed (durably stored in object storage) offset.
+//     committed (durably stored in object storage) offset. An ack names the
+//     (episode_id, path) it belongs to and must be matched on that pair,
+//     because one stream may carry chunks for more than one episode and a
+//     path is unique only within an episode.
 //  3. CommitEpisode verifies the SHA-256 of every stored object against
 //     the manifest and flips the catalog state to `complete`, or `failed`
 //     with per-file detail on any mismatch.
@@ -164,7 +176,13 @@ func (c *dataIngestServiceClient) GetEpisode(ctx context.Context, in *GetEpisode
 //     from the certificate identity, so an upload cannot name a tenant it
 //     does not hold a certificate for.
 //   - QueryEpisodes/GetEpisode are read RPCs for users and services; the
-//     serving implementation defines the accepted credential.
+//     serving implementation defines the accepted credential. Both carry an
+//     org_id whose membership the server does not verify today, and the read
+//     credential in use is a single shared token scoped to no organization.
+//     GetEpisode returns signed object URLs, so that combination is a
+//     cross-organization data-egress path, not just a catalog read. Read the
+//     org_id documentation on QueryEpisodesRequest and GetEpisodeRequest
+//     before exposing either RPC beyond a trusted internal caller.
 type DataIngestServiceServer interface {
 	// Registers (or re-registers) an episode upload. Idempotent.
 	BeginEpisodeUpload(context.Context, *BeginEpisodeUploadRequest) (*BeginEpisodeUploadResponse, error)


### PR DESCRIPTION
## Problem

#1842 seals each camera source with a browser-playable `cameras/<source>/playable.mp4` and marks it in the device manifest with `Role = FileRoleDerived`. The device therefore knows the file is an artifact computed from capture payload rather than capture payload itself.

`buildEpisodeManifest` in `go/internal/agent/services/data_transfer_worker.go` never sent that. It projected path, size, checksum, media type, format and source id, because `EpisodeFileManifest` had no role field. The remux reached the cloud carrying the camera's `source_id` and media type `video/mp4`, which on the catalog side is indistinguishable from a second camera capture on that source. A Business Intelligence query summing bytes per `source_id` roughly doubles every camera source. Only the verbatim manifest in `attributes_json` still held the truth, and nothing queries into it.

## Cause

The upload manifest is a projection of the device manifest, and the role was added to the device manifest after the projection was written. The wire had no field to project onto.

## Solution

Vendor the `EpisodeFileRole` addition into `Proto/cloud/data_ingest.proto` (matching wendylabsinc/service-protos#49 byte for byte, as this repository's copy already did), regenerate `cloudpb`, and map `data.File.Role` onto the enum in `buildEpisodeManifest`.

The mapping keeps one vocabulary across the three layers:

* empty (capture payload, capture metadata) maps to `EPISODE_FILE_ROLE_CAPTURED`
* `data.FileRoleDerived` maps to `EPISODE_FILE_ROLE_DERIVED`
* anything else maps to `EPISODE_FILE_ROLE_UNSPECIFIED`

Captured is sent explicitly rather than left at the default, so a manifest that went through this mapper is distinguishable on the wire from one written by an agent built before the field existed. The unrecognised case only arises when an older agent resumes an upload for an episode a newer build sealed; `UNSPECIFIED` is defined by the wire contract to mean captured, which is the pre-existing meaning, and the enum deliberately has no "unknown" member because no reader could act on one.

## The protoc version-stamp trap

The committed stubs under `go/proto/gen` were generated with a mix of protoc versions: 37 files stamped `v7.34.0`, 6 stamped `v7.35.1`, plus one `protoc-gen-go v1.36.11-devel` among 42 `v1.36.11`. Running `go/scripts/generate-proto.sh` therefore rewrites the stamp in 80 files and buries the real change.

Each regenerated file's own committed stamp is restored, and any file whose only difference was the stamp is reverted outright. The normalizer was verified as a true no-op: regenerating with **no** proto change leaves 80 files dirty, and after normalization the tree is clean. This pull request touches exactly one generated file, `go/proto/gen/cloudpb/data_ingest.pb.go`, and it contains no stamp lines in its diff.

One unrelated pre-existing drift surfaced during that check and is **not** included here: `go/proto/gen/appspb/v1/sensor_service.pb.go` is stale against its own `.proto`, whose comment was edited from "sensors and camera" to "sensor-read and camera" without regenerating. That belongs in its own change.

## Verification

* `CC=/usr/bin/clang go build ./go/...` passes
* `gofmt -l go/` is empty
* `go vet ./go/internal/agent/services/... ./go/internal/agent/data/...` is clean
* `go test ./go/internal/agent/services/... ./go/internal/agent/data/...` passes (`ok` for both packages)

Two new tests:

* `TestBuildEpisodeManifestCarriesFileRole` builds a manifest with an index, a raw segment and the derived remux, and asserts the wire carries `CAPTURED`, `CAPTURED`, `DERIVED` respectively.
* `TestEpisodeFileRoleUnknownDegradesToUnspecified` pins the three mapper cases including the unrecognised one.

## Dependency order

This branch is cut from `feat/episode-playable-at-seal`, so its commits appear in this diff. It **must** merge after both:

1. https://github.com/wendylabsinc/service-protos/pull/49 (defines the enum)
2. #1842 (defines `data.File.Role`)

and after https://github.com/wendylabsinc/cloud/pull/463, which persists the role in the catalog. The cloud service should be **deployed** before devices carrying #1842 start uploading: a derived file that reaches a service without that change is recorded as captured and stays that way.
