### PR TITLE
fix(proto): regenerate sensor_service stub for entitlement rename

### DIFF
--- a/go/proto/gen/appspb/v1/sensor_service.pb.go
+++ b/go/proto/gen/appspb/v1/sensor_service.pb.go
@@ -51,7 +51,7 @@ type SensorSource struct {
 	// frames on the two-plane data path, for example "/dev/video200". Empty when
 	// the source has no such node, which is the normal case: a node exists only
 	// for a source whose frames can be identified frame-for-frame, and only while
-	// an app entitled to BOTH sensors and camera is running.
+	// an app entitled to BOTH sensor-read and camera is running.
 	//
 	// An empty value is not an error and an app must handle it: it means the
 	// two-plane path is unavailable for this source and the app should fall back


### PR DESCRIPTION
## Problem

The generated Go stub `go/proto/gen/appspb/v1/sensor_service.pb.go` disagrees with its own source proto. On `SensorSource.loopback_node_path`, the proto documents the field as:

> an app entitled to BOTH **sensor-read** and camera is running

while the committed stub still says:

> an app entitled to BOTH **sensors** and camera is running

## Cause

This is leftover drift from the entitlement rename, where `sensors` became `sensor-read` and `data` became `episode-write`. `Proto/wendy/agent/apps/v1/sensor_service.proto` was edited as part of that rename, but the generated stub was never regenerated, so the pre-rename wording stayed committed.

Left alone, this does not break a build, but it does surface as unexplained churn: the next person to run `go/scripts/generate-proto.sh` for an unrelated reason picks up this comment change in their diff and has to work out whether it belongs to them.

## Solution

Regenerate the stubs and commit only the genuine content change.

The difficulty is the version stamps. The committed stubs carry a deliberate mix: roughly 37 files stamped `protoc v7.34.0`, 6 stamped `v7.35.1`, and one `protoc-gen-go v1.36.11-devel` among many `v1.36.11`. A local protoc is a single version (here it stamps `v7.36.0`), so a plain generator run rewrites the stamp line in all 80 generated files and buries the one real change.

The fix was to regenerate and then restore every regenerated file's protoc and protoc-gen-go stamp lines to that file's own committed value, read back per file from git. That leaves only real content differences.

The normalizer was proven to be a true no-op before being trusted: a control run regenerated with no proto change at all and then normalized, after which the only file still differing in the whole generated tree was `sensor_service.pb.go`, carrying exactly this comment. All 79 other generated files returned byte-identical.

## Verification

- `CC=/usr/bin/clang go build ./go/...` clean.
- `gofmt -l go/` empty.
- `CC=/usr/bin/clang go vet ./go/proto/gen/appspb/...` clean.
- `git diff --stat` on the commit: 1 file changed, 1 insertion, 1 deletion.
- The resulting stub comment text matches the proto comment text exactly, ignoring indentation.

## Notes

Based on `split/7-tools-and-example`, not `main`. The entitlement rename is unmerged, so `main` carries neither the new proto wording nor this stub, and there is nothing to fix there.