### PR TITLE
Fix CLI time sync on multi-interface hosts

### DIFF
--- a/go/internal/cli/timesync/sender.go
+++ b/go/internal/cli/timesync/sender.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/wendylabsinc/wendy/go/internal/agent/timesync"
 	"github.com/wendylabsinc/wendy/go/internal/shared/roughtime"
+	"golang.org/x/net/ipv4"
 )
 
 const (
@@ -138,41 +139,91 @@ func encodeProofPacket(result roughtime.Result) ([]byte, error) {
 }
 
 // BroadcastTime fetches a Roughtime proof and multicasts it as a WendyDatagram
-// on all active network interfaces. Best-effort: interface errors are skipped.
-// Returns an error only if all Roughtime servers are unreachable.
+// on all active multicast-capable network interfaces. Individual interface
+// errors are skipped, but an error is returned when no interface accepts the
+// packet so callers never report a broadcast that did not happen.
 func BroadcastTime(ctx context.Context) (roughtime.Result, error) {
 	pkt, result, err := FetchProofPacket(ctx)
 	if err != nil {
 		return roughtime.Result{}, err
 	}
-	sendMulticast(pkt) // best-effort
+	if err := sendMulticast(pkt); err != nil {
+		return roughtime.Result{}, err
+	}
 	return result, nil
 }
 
-func sendMulticast(pkt []byte) {
+type multicastPacketConn interface {
+	SetMulticastInterface(*net.Interface) error
+	SetMulticastTTL(int) error
+	WriteTo([]byte, *ipv4.ControlMessage, net.Addr) (int, error)
+	Close() error
+}
+
+var (
+	listMulticastInterfaces = net.Interfaces
+	newMulticastPacketConn  = func() (multicastPacketConn, error) {
+		conn, err := net.ListenPacket("udp4", "0.0.0.0:0")
+		if err != nil {
+			return nil, err
+		}
+		return ipv4.NewPacketConn(conn), nil
+	}
+)
+
+func sendMulticast(pkt []byte) error {
 	dst, err := net.ResolveUDPAddr("udp4", multicastAddr)
 	if err != nil {
-		return
+		return fmt.Errorf("resolving multicast destination: %w", err)
 	}
-	ifaces, err := net.Interfaces()
+	ifaces, err := listMulticastInterfaces()
 	if err != nil {
-		return
+		return fmt.Errorf("listing network interfaces: %w", err)
 	}
+
+	sent := 0
+	var failures []error
 	for _, iface := range ifaces {
-		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+		if iface.Flags&net.FlagUp == 0 ||
+			iface.Flags&net.FlagLoopback != 0 ||
+			iface.Flags&net.FlagMulticast == 0 {
 			continue
 		}
-		conn, err := net.DialUDP("udp4", &net.UDPAddr{}, dst)
+
+		conn, err := newMulticastPacketConn()
 		if err != nil {
+			failures = append(failures, fmt.Errorf("%s: opening UDP socket: %w", iface.Name, err))
 			continue
 		}
-		// Set TTL=1 (link-local).
-		if rc, err := conn.SyscallConn(); err == nil {
-			rc.Control(func(fd uintptr) { //nolint:errcheck
-				setMulticastTTL(fd, multicastTTL)
-			})
+
+		// Setting the outgoing interface is essential on multi-homed hosts. A
+		// wildcard UDP dial follows only the default multicast route, causing
+		// every iteration to leave through the same interface (for example Wi-Fi)
+		// even when the Wendy device is attached over USB Ethernet.
+		if err := conn.SetMulticastInterface(&iface); err != nil {
+			failures = append(failures, fmt.Errorf("%s: selecting multicast interface: %w", iface.Name, err))
+			_ = conn.Close()
+			continue
 		}
-		conn.Write(pkt) //nolint:errcheck
-		conn.Close()
+		if err := conn.SetMulticastTTL(multicastTTL); err != nil {
+			failures = append(failures, fmt.Errorf("%s: setting multicast TTL: %w", iface.Name, err))
+			_ = conn.Close()
+			continue
+		}
+		if _, err := conn.WriteTo(pkt, nil, dst); err != nil {
+			failures = append(failures, fmt.Errorf("%s: sending multicast packet: %w", iface.Name, err))
+			_ = conn.Close()
+			continue
+		}
+		sent++
+		_ = conn.Close()
 	}
+
+	if sent > 0 {
+		return nil
+	}
+	if len(failures) > 0 {
+		return fmt.Errorf("broadcasting time proof: %w", errors.Join(failures...))
+	}
+	return errors.New("broadcasting time proof: no active multicast-capable network interfaces")
 }

--- a/go/internal/cli/timesync/sender_test.go
+++ b/go/internal/cli/timesync/sender_test.go
@@ -2,10 +2,41 @@ package clitimesync
 
 import (
 	"context"
+	"errors"
+	"net"
+	"reflect"
 	"testing"
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/roughtime"
+	"golang.org/x/net/ipv4"
 )
+
+type fakeMulticastConn struct {
+	interfaceName string
+	ttl           int
+	destination   string
+	writes        int
+	interfaceErr  error
+	writeErr      error
+}
+
+func (c *fakeMulticastConn) SetMulticastInterface(iface *net.Interface) error {
+	c.interfaceName = iface.Name
+	return c.interfaceErr
+}
+
+func (c *fakeMulticastConn) SetMulticastTTL(ttl int) error {
+	c.ttl = ttl
+	return nil
+}
+
+func (c *fakeMulticastConn) WriteTo(_ []byte, _ *ipv4.ControlMessage, dst net.Addr) (int, error) {
+	c.destination = dst.String()
+	c.writes++
+	return 1, c.writeErr
+}
+
+func (c *fakeMulticastConn) Close() error { return nil }
 
 func TestFetchProofPacketMemoizes(t *testing.T) {
 	calls := 0
@@ -30,5 +61,115 @@ func TestFetchProofPacketMemoizes(t *testing.T) {
 	}
 	if len(pkt1) == 0 || string(pkt1) != string(pkt2) {
 		t.Fatal("expected identical non-empty packets across calls")
+	}
+}
+
+func TestSendMulticastSelectsEveryActiveInterface(t *testing.T) {
+	origInterfaces := listMulticastInterfaces
+	origNewConn := newMulticastPacketConn
+	t.Cleanup(func() {
+		listMulticastInterfaces = origInterfaces
+		newMulticastPacketConn = origNewConn
+	})
+
+	listMulticastInterfaces = func() ([]net.Interface, error) {
+		return []net.Interface{
+			{Name: "en0", Flags: net.FlagUp | net.FlagMulticast},
+			{Name: "en60", Flags: net.FlagUp | net.FlagMulticast},
+			{Name: "lo0", Flags: net.FlagUp | net.FlagLoopback | net.FlagMulticast},
+			{Name: "down0", Flags: net.FlagMulticast},
+			{Name: "point-to-point", Flags: net.FlagUp},
+		}, nil
+	}
+
+	var conns []*fakeMulticastConn
+	newMulticastPacketConn = func() (multicastPacketConn, error) {
+		conn := &fakeMulticastConn{}
+		conns = append(conns, conn)
+		return conn, nil
+	}
+
+	if err := sendMulticast([]byte("proof")); err != nil {
+		t.Fatalf("sendMulticast: %v", err)
+	}
+
+	var gotInterfaces []string
+	for _, conn := range conns {
+		gotInterfaces = append(gotInterfaces, conn.interfaceName)
+		if conn.ttl != multicastTTL {
+			t.Errorf("%s TTL = %d, want %d", conn.interfaceName, conn.ttl, multicastTTL)
+		}
+		if conn.destination != multicastAddr {
+			t.Errorf("%s destination = %q, want %q", conn.interfaceName, conn.destination, multicastAddr)
+		}
+		if conn.writes != 1 {
+			t.Errorf("%s writes = %d, want 1", conn.interfaceName, conn.writes)
+		}
+	}
+	if want := []string{"en0", "en60"}; !reflect.DeepEqual(gotInterfaces, want) {
+		t.Fatalf("selected interfaces = %v, want %v", gotInterfaces, want)
+	}
+}
+
+func TestSendMulticastRequiresOneSuccessfulWrite(t *testing.T) {
+	origInterfaces := listMulticastInterfaces
+	origNewConn := newMulticastPacketConn
+	t.Cleanup(func() {
+		listMulticastInterfaces = origInterfaces
+		newMulticastPacketConn = origNewConn
+	})
+
+	listMulticastInterfaces = func() ([]net.Interface, error) {
+		return []net.Interface{{Name: "en60", Flags: net.FlagUp | net.FlagMulticast}}, nil
+	}
+	newMulticastPacketConn = func() (multicastPacketConn, error) {
+		return &fakeMulticastConn{writeErr: errors.New("network unreachable")}, nil
+	}
+
+	err := sendMulticast([]byte("proof"))
+	if err == nil {
+		t.Fatal("sendMulticast succeeded without a successful write")
+	}
+	if got := err.Error(); got != "broadcasting time proof: en60: sending multicast packet: network unreachable" {
+		t.Fatalf("sendMulticast error = %q", got)
+	}
+}
+
+func TestSendMulticastContinuesAfterInterfaceFailure(t *testing.T) {
+	origInterfaces := listMulticastInterfaces
+	origNewConn := newMulticastPacketConn
+	t.Cleanup(func() {
+		listMulticastInterfaces = origInterfaces
+		newMulticastPacketConn = origNewConn
+	})
+
+	listMulticastInterfaces = func() ([]net.Interface, error) {
+		return []net.Interface{
+			{Name: "en0", Flags: net.FlagUp | net.FlagMulticast},
+			{Name: "en60", Flags: net.FlagUp | net.FlagMulticast},
+		}, nil
+	}
+
+	var conns []*fakeMulticastConn
+	newMulticastPacketConn = func() (multicastPacketConn, error) {
+		conn := &fakeMulticastConn{}
+		if len(conns) == 0 {
+			conn.interfaceErr = errors.New("unsupported interface")
+		}
+		conns = append(conns, conn)
+		return conn, nil
+	}
+
+	if err := sendMulticast([]byte("proof")); err != nil {
+		t.Fatalf("sendMulticast failed despite en60 succeeding: %v", err)
+	}
+	if len(conns) != 2 {
+		t.Fatalf("opened %d connections, want 2", len(conns))
+	}
+	if conns[0].writes != 0 {
+		t.Errorf("failed en0 writes = %d, want 0", conns[0].writes)
+	}
+	if conns[1].interfaceName != "en60" || conns[1].writes != 1 {
+		t.Errorf("en60 connection = {interface: %q, writes: %d}, want {interface: en60, writes: 1}", conns[1].interfaceName, conns[1].writes)
 	}
 }

--- a/go/internal/cli/timesync/sender_ttl_unix.go
+++ b/go/internal/cli/timesync/sender_ttl_unix.go
@@ -1,9 +1,0 @@
-//go:build linux || darwin
-
-package clitimesync
-
-import "syscall"
-
-func setMulticastTTL(fd uintptr, ttl int) {
-	syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, syscall.IP_MULTICAST_TTL, ttl) //nolint:errcheck
-}

--- a/go/internal/cli/timesync/sender_ttl_windows.go
+++ b/go/internal/cli/timesync/sender_ttl_windows.go
@@ -1,6 +1,0 @@
-//go:build windows
-
-package clitimesync
-
-// setMulticastTTL is a no-op on Windows; the default TTL is sufficient.
-func setMulticastTTL(_ uintptr, _ int) {}


### PR DESCRIPTION
## Summary

- send Roughtime multicast packets through every active multicast-capable interface
- explicitly select the outgoing interface so USB Ethernet devices receive the proof on multi-homed hosts
- return an error when no interface successfully sends a packet instead of reporting a false broadcast
- replace platform-specific TTL socket handling with `x/net/ipv4`

## Validation

- `go test -race ./go/internal/cli/timesync -count=1`
- `go test ./go/internal/cli/commands -run 'TestAutoSyncTimeAndRetry|TestMaybeFixClock' -count=1`
- Linux amd64 and Windows amd64 time-sync test cross-compilation
- live macOS smoke test: broadcast over USB `en60`, followed by a successful mTLS `device info` call to the attached Jetson
