### PR TITLE
CLI: show audio picker when default ID is omitted

### DIFF
--- a/go/internal/cli/assets/docs/hardware/microphone.mdx
+++ b/go/internal/cli/assets/docs/hardware/microphone.mdx
@@ -29,6 +29,8 @@ To set a specific audio device as the default:
 wendy device audio set-default --id 1
 ```
 
+In an interactive terminal, omit `--id` to choose from the audio device list.
+
 ## Monitor Microphone Levels
 
 Use the built-in VU meter to confirm the microphone is producing input:

--- a/go/internal/cli/assets/docs/hardware/speakers.mdx
+++ b/go/internal/cli/assets/docs/hardware/speakers.mdx
@@ -27,6 +27,12 @@ Choose the speaker or output device ID, then set it as default:
 wendy device audio set-default --id 2
 ```
 
+In an interactive terminal, omit `--id` to choose from the audio device list:
+
+```bash
+wendy device audio set-default
+```
+
 The selected output becomes the default sink, which is what apps play through unless they name a device explicitly.
 
 Device IDs come from the audio graph and are **not stable across reconnects** — a speaker that sleeps and wakes, or switches profile, comes back under a different ID. List the devices again rather than reusing an ID you saw earlier.

--- a/go/internal/cli/commands/audio.go
+++ b/go/internal/cli/commands/audio.go
@@ -128,7 +128,20 @@ func newAudioSetDefaultCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set-default",
 		Short: "Set the default audio device",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Long: "Set the default audio device. When --id is omitted in an interactive terminal, " +
+			"choose a device from the audio device list.",
+		Example: "  wendy device audio set-default\n" +
+			"  wendy device audio set-default --id 42",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			idSet := cmd.Flags().Changed("id")
+			if shouldOpenAudioSetDefaultTUI(idSet, isInteractiveTerminal(), jsonOutput) {
+				return runAudioTUI(cmd)
+			}
+			if !idSet {
+				return fmt.Errorf("required flag(s) \"id\" not set")
+			}
+
 			ctx := cmd.Context()
 			conn, err := connectToAgent(ctx)
 			if err != nil {
@@ -153,9 +166,12 @@ func newAudioSetDefaultCmd() *cobra.Command {
 	}
 
 	cmd.Flags().Uint32Var(&deviceID, "id", 0, "Audio device ID")
-	_ = cmd.MarkFlagRequired("id")
 
 	return cmd
+}
+
+func shouldOpenAudioSetDefaultTUI(idSet, interactive, json bool) bool {
+	return !idSet && interactive && !json
 }
 
 func newAudioMonitorCmd() *cobra.Command {

--- a/go/internal/cli/commands/audio_command_test.go
+++ b/go/internal/cli/commands/audio_command_test.go
@@ -1,0 +1,44 @@
+package commands
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestShouldOpenAudioSetDefaultTUI(t *testing.T) {
+	tests := []struct {
+		name        string
+		idSet       bool
+		interactive bool
+		json        bool
+		want        bool
+	}{
+		{name: "interactive without id", interactive: true, want: true},
+		{name: "interactive with id", idSet: true, interactive: true},
+		{name: "non-interactive without id"},
+		{name: "json on interactive terminal", interactive: true, json: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldOpenAudioSetDefaultTUI(tt.idSet, tt.interactive, tt.json); got != tt.want {
+				t.Fatalf("shouldOpenAudioSetDefaultTUI(%v, %v, %v) = %v, want %v", tt.idSet, tt.interactive, tt.json, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAudioSetDefaultStillRequiresIDNonInteractively(t *testing.T) {
+	originalInteractive := isInteractiveTerminalFn
+	isInteractiveTerminalFn = func() bool { return false }
+	t.Cleanup(func() { isInteractiveTerminalFn = originalInteractive })
+
+	cmd := newAudioSetDefaultCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), `required flag(s) "id" not set`) {
+		t.Fatalf("error = %v, want missing id error", err)
+	}
+}


### PR DESCRIPTION
## Summary

- open the existing audio device TUI when `device audio set-default` is run without `--id` in an interactive terminal
- preserve the required-ID error for non-interactive and JSON invocations
- document the interactive flow and cover the mode selection with tests

## Testing

- `go test ./internal/cli/commands -run Audio -count=1`
- `go test ./cmd/wendy -count=1`
- `go build ./cmd/wendy`
- `git diff --check`

The full `go test ./internal/cli/commands -count=1` run also completed all relevant audio coverage but has an unrelated existing macOS temp-path assertion failure in `TestBuildCmd_MultiService_BuildsFromManifestOnly` (`/private/var` versus `/var`).