### PR TITLE
Accept pki-core certificate chains when building CA pools (WDY-2339)

### DIFF
--- a/go/internal/agent/services/cloud_flusher.go
+++ b/go/internal/agent/services/cloud_flusher.go
@@ -14,6 +14,8 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
+
 	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 	colmetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
@@ -173,9 +175,7 @@ func (f *CloudFlusher) dial(ctx context.Context, host, certPEM, chainPEM string,
 	if err != nil {
 		caPool = x509.NewCertPool()
 	}
-	if chainPEM != "" {
-		caPool.AppendCertsFromPEM([]byte(chainPEM))
-	}
+	certs.AppendChainToPool(caPool, chainPEM)
 
 	tlsCfg := &tls.Config{
 		MinVersion:   tls.VersionTLS13,

--- a/go/internal/agent/services/notification_service.go
+++ b/go/internal/agent/services/notification_service.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
 	cloudpb "github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
 	systempb "github.com/wendylabsinc/wendy/go/proto/gen/systempb"
 )
@@ -574,7 +575,7 @@ func (s *CloudNotificationSender) connectionFor(
 	// SECURITY: The enrollment chain is controlled by Wendy Cloud and is also
 	// used by the existing telemetry flusher. Adding it supports direct local
 	// broker deployments whose server certificate uses the Wendy development CA.
-	if chainPEM != "" && !roots.AppendCertsFromPEM([]byte(chainPEM)) {
+	if chainPEM != "" && certs.AppendChainToPool(roots, chainPEM) == 0 {
 		return nil, fmt.Errorf("parse Wendy enrollment CA chain")
 	}
 	connection, err := grpc.NewClient(

--- a/go/internal/agent/services/tunnel_broker_client.go
+++ b/go/internal/agent/services/tunnel_broker_client.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 
+	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
 	cloudpb "github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
 )
 
@@ -171,7 +172,7 @@ func brokerTLSConfig(logger *zap.Logger, certPEM, keyPEM, chainPEM string) (*tls
 	if err != nil {
 		caPool = x509.NewCertPool()
 	}
-	if chainPEM != "" && !caPool.AppendCertsFromPEM([]byte(chainPEM)) {
+	if chainPEM != "" && certs.AppendChainToPool(caPool, chainPEM) == 0 {
 		return nil, fmt.Errorf("no valid CA certificates in chainPEM")
 	}
 	tlsCfg := &tls.Config{

--- a/go/internal/agent/services/tunnel_broker_tls_test.go
+++ b/go/internal/agent/services/tunnel_broker_tls_test.go
@@ -84,3 +84,32 @@ func TestBrokerTLSConfig_MalformedChainErrors(t *testing.T) {
 		t.Fatal("expected error for a malformed CA chain, got nil")
 	}
 }
+
+// TestBrokerTLSConfig_TrailingBytesChainAccepted is the regression guard for the
+// pki-core enrollment chain (WDY-2339). Those certificates carry trailing bytes
+// after the outer ASN.1 SEQUENCE, so x509.CertPool.AppendCertsFromPEM drops them
+// and reports false. brokerTLSConfig read that false as fatal, which meant a
+// device enrolled against pki-core came up provisioned and unable to build a
+// broker connection at all — the chain was not merely untrusted, the dial never
+// happened.
+func TestBrokerTLSConfig_TrailingBytesChainAccepted(t *testing.T) {
+	certPEM, keyPEM := ecdsaCertKeyPEM(t)
+
+	block, _ := pem.Decode([]byte(certPEM))
+	if block == nil {
+		t.Fatal("generated cert is not valid PEM")
+	}
+	der := append(append([]byte{}, block.Bytes...), 0x00, 0x00)
+	chainPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	if x509.NewCertPool().AppendCertsFromPEM(chainPEM) {
+		t.Fatal("AppendCertsFromPEM accepted a trailing-bytes chain; this guard no longer tests anything")
+	}
+
+	cfg, err := brokerTLSConfig(zap.NewNop(), certPEM, keyPEM, string(chainPEM))
+	if err != nil {
+		t.Fatalf("brokerTLSConfig rejected a pki-core chain: %v", err)
+	}
+	if cfg.VerifyConnection == nil {
+		t.Fatal("expected a VerifyConnection callback pinning the chain")
+	}
+}

--- a/go/internal/cli/clouddefaults/brokertls.go
+++ b/go/internal/cli/clouddefaults/brokertls.go
@@ -64,7 +64,7 @@ func BrokerTLSConfig(cert config.CertificateInfo, brokerURL string) (*tls.Config
 		// signed by the Wendy CA, not a public CA. Skip hostname verification but
 		// validate the chain against the stored Wendy CA bundle.
 		caPool := x509.NewCertPool()
-		if !caPool.AppendCertsFromPEM([]byte(cert.PemCertificateChain)) {
+		if certs.AppendChainToPool(caPool, cert.PemCertificateChain) == 0 {
 			return nil, fmt.Errorf("no valid CA certificates in PemCertificateChain")
 		}
 		tlsCfg.InsecureSkipVerify = true //nolint:gosec // Hostname verification is intentionally skipped for non-standard broker endpoints; VerifyConnection validates the chain against the Wendy CA.

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -2860,7 +2860,7 @@ func tlsClientDialer(certPEM, keyPEM, caPEM string, dial func(context.Context) (
 		return nil, fmt.Errorf("loading client certificate: %w", err)
 	}
 	caPool := x509.NewCertPool()
-	if !caPool.AppendCertsFromPEM([]byte(caPEM)) {
+	if certs.AppendChainToPool(caPool, caPEM) == 0 {
 		return nil, fmt.Errorf("no valid CA certificates found in caPEM")
 	}
 	tlsCfg := &tls.Config{
@@ -3013,7 +3013,7 @@ func startMTLSRegistryHTTPProxy(target, certPEM, keyPEM, caPEM string) (*mtlsReg
 		return nil, fmt.Errorf("parsing mTLS certificate: %w", err)
 	}
 	caPool := x509.NewCertPool()
-	if !caPool.AppendCertsFromPEM([]byte(caPEM)) {
+	if certs.AppendChainToPool(caPool, caPEM) == 0 {
 		return nil, fmt.Errorf("no valid CA certificates found in caPEM")
 	}
 
@@ -3084,7 +3084,7 @@ func startMTLSRegistryProxy(ctx context.Context, target string) (*registryProxy,
 		return nil, fmt.Errorf("loading client certificate: %w", err)
 	}
 	caPool := x509.NewCertPool()
-	if !caPool.AppendCertsFromPEM([]byte(certInfo.PemCertificateChain)) {
+	if certs.AppendChainToPool(caPool, certInfo.PemCertificateChain) == 0 {
 		return nil, fmt.Errorf("no valid CA certificates found in certInfo.PemCertificateChain")
 	}
 	tlsCfg := &tls.Config{

--- a/go/internal/cli/providers/microwendy.go
+++ b/go/internal/cli/providers/microwendy.go
@@ -17,6 +17,7 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/cli/liteclient"
 	"github.com/wendylabsinc/wendy/go/internal/cli/swifttoolchain"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 	"github.com/wendylabsinc/wendy/go/internal/shared/discovery"
 	"github.com/wendylabsinc/wendy/go/internal/shared/models"
@@ -732,9 +733,7 @@ func (p *MicroWendyProvider) connectClient(device models.ExternalDevice) (*litec
 					return nil, fmt.Errorf("wendy-lite provider: parsing mTLS cert: %w", err)
 				}
 				rootCAs := x509.NewCertPool()
-				if certInfo.PemCertificateChain != "" {
-					rootCAs.AppendCertsFromPEM([]byte(certInfo.PemCertificateChain))
-				}
+				certs.AppendChainToPool(rootCAs, certInfo.PemCertificateChain)
 				if err := client.ConnectWithMutualAuthentication(addr, cert, *rootCAs); err != nil {
 					connectErrs = append(connectErrs, err)
 				} else {

--- a/go/internal/shared/certs/mldsa.go
+++ b/go/internal/shared/certs/mldsa.go
@@ -164,6 +164,29 @@ func ParseCertsFromPEM(chainPEM []byte) ([]*x509.Certificate, error) {
 	return certs, nil
 }
 
+// AppendChainToPool adds every certificate in chainPEM to pool and returns how
+// many were added.
+//
+// It exists because x509.CertPool.AppendCertsFromPEM silently drops the
+// certificates pki-core issues: those carry trailing bytes after the outer
+// ASN.1 SEQUENCE, so x509.ParseCertificate rejects them (see
+// ParseCertsFromPEM). AppendCertsFromPEM then reports false, and callers that
+// treated false as fatal refused every ML-DSA chain outright rather than
+// merely failing to trust it. Use this instead of AppendCertsFromPEM for any
+// Wendy-issued chain, and treat a zero count — not a boolean — as the empty
+// case.
+func AppendChainToPool(pool *x509.CertPool, chainPEM string) int {
+	if chainPEM == "" {
+		return 0
+	}
+	// ParseCertsFromPEM skips what it cannot parse and never returns an error.
+	parsed, _ := ParseCertsFromPEM([]byte(chainPEM))
+	for _, cert := range parsed {
+		pool.AddCert(cert)
+	}
+	return len(parsed)
+}
+
 func mldsaCertSigAlgOID(cert *x509.Certificate) (asn1.ObjectIdentifier, error) {
 	var outer mldsaCertOuter
 	if _, err := asn1.Unmarshal(cert.Raw, &outer); err != nil {

--- a/go/internal/shared/certs/mldsa_test.go
+++ b/go/internal/shared/certs/mldsa_test.go
@@ -1,0 +1,61 @@
+package certs_test
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
+)
+
+// trailingBytesChainPEM re-encodes a certificate with extra bytes after the
+// outer ASN.1 SEQUENCE — the shape pki-core emits for ML-DSA certificates,
+// which makes x509.ParseCertificate fail with "trailing data".
+func trailingBytesChainPEM(t *testing.T, chainPEM []byte) []byte {
+	t.Helper()
+	block, _ := pem.Decode(chainPEM)
+	if block == nil {
+		t.Fatal("chainPEM is not valid PEM")
+	}
+	der := append(append([]byte{}, block.Bytes...), 0x00, 0x00)
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+// TestAppendChainToPool_TrailingBytes is the regression guard for the enrollment
+// chain: a device provisioned by pki-core stores a chain whose certificates
+// carry trailing bytes, AppendCertsFromPEM reports false for it, and every
+// caller that read that false as fatal refused to build a TLS config at all.
+func TestAppendChainToPool_TrailingBytes(t *testing.T) {
+	_, cleanPEM := selfSignedCert(t, "tenant-device-ca", "")
+	chainPEM := trailingBytesChainPEM(t, cleanPEM)
+
+	// The premise: this is exactly what the standard helper cannot do.
+	if x509.NewCertPool().AppendCertsFromPEM(chainPEM) {
+		t.Fatal("AppendCertsFromPEM accepted a trailing-bytes chain; AppendChainToPool is no longer needed")
+	}
+
+	pool := x509.NewCertPool()
+	if n := certs.AppendChainToPool(pool, string(chainPEM)); n != 1 {
+		t.Fatalf("AppendChainToPool added %d certificates, want 1", n)
+	}
+	if len(pool.Subjects()) != 1 { //nolint:staticcheck // Subjects is the only way to inspect a pool's contents.
+		t.Fatalf("pool holds %d subjects, want 1", len(pool.Subjects())) //nolint:staticcheck
+	}
+}
+
+// A well-formed chain still lands in the pool, and an empty one is reported as
+// zero rather than as an error — callers decide whether empty is fatal.
+func TestAppendChainToPool_CleanAndEmpty(t *testing.T) {
+	_, cleanPEM := selfSignedCert(t, "classical-ca", "")
+
+	pool := x509.NewCertPool()
+	if n := certs.AppendChainToPool(pool, string(cleanPEM)); n != 1 {
+		t.Fatalf("AppendChainToPool(clean chain) = %d, want 1", n)
+	}
+	if n := certs.AppendChainToPool(x509.NewCertPool(), ""); n != 0 {
+		t.Fatalf("AppendChainToPool(\"\") = %d, want 0", n)
+	}
+	if n := certs.AppendChainToPool(x509.NewCertPool(), "not-a-pem-chain"); n != 0 {
+		t.Fatalf("AppendChainToPool(garbage) = %d, want 0", n)
+	}
+}


### PR DESCRIPTION
Confirms and fixes the latent bug flagged in the WDY-2339 device-enrollment map.

## The bug

pki-core emits certificates with trailing bytes after the outer ASN.1 SEQUENCE, so `x509.ParseCertificate` rejects them with `trailing data`. The repo already knows this — `certs.ParseCertsFromPEM` strips to the exact outer element, and `certs.LeafCertificatePEM` exists so ML-DSA chain certs are never sent in a handshake.

`x509.CertPool.AppendCertsFromPEM` has no such tolerance. It drops every certificate in such a chain and returns `false`.

Six call sites treated that `false` as fatal, and the failure is worse than an untrusted chain. The device stores the issued chain as its only trust material, so once it is enrolled against pki-core:

- `brokerTLSConfig` returns `no valid CA certificates in chainPEM` — the tunnel broker dial never happens.
- The cloud notification sender returns `parse Wendy enrollment CA chain` — same.

Two other sites ignored the boolean and silently degraded to system roots only. That divergence — one hard-fail, one silent pin loss, from the same input — is what the ticket flagged as "one of the two is wrong". Both were.

## The fix

`certs.AppendChainToPool(pool, chainPEM) int` routes the append through the tolerant parser and returns a count instead of a boolean, so "empty chain" stays distinguishable from "ML-DSA chain". Every caller that puts a Wendy-issued chain into a `CertPool` now uses it: agent broker client, notification sender, telemetry flusher; CLI broker dialler, registry proxies, wendy-lite provider.

`mtls/server.go` and `certs.BuildServerVerifyConnection` are left alone — they already pair `AppendCertsFromPEM` with `ParseCertsFromPEM` and hand the parsed certs to the ML-DSA-aware verifier, so the pool there is only the classical fast path.

## Tests

A chain re-encoded with trailing bytes reproduces the pki-core shape from an ordinary ECDSA cert, so no ML-DSA material is needed. The tests assert `AppendCertsFromPEM` refuses it (the premise — it fails loudly if a future Go release starts accepting it), `AppendChainToPool` accepts it, and `brokerTLSConfig` builds a config from it. Both new tests were confirmed to fail against the pre-fix code.

Full local suite: 83 packages pass with `-race`. The only failures are the pre-existing `internal/agent/oci` GPU-entitlement tests, which fail identically on a clean tree here (no NVIDIA/Pi device nodes).

## Not in scope

The rest of WDY-2339 is untouched and still open: no ACME/EST client, `IdentityFromCert` still refuses SPIFFE identities (deferred to the WDY-2808 parser pass), and the trust anchor still arrives inline in the issuance response rather than pinned from the OS image.