### PR TITLE
cli: fix buildcache build after the flock refactor

### DIFF
--- a/go/internal/cli/commands/buildcache.go
+++ b/go/internal/cli/commands/buildcache.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/flock"
 )
 
 // The persistent build caches under ~/Library/Caches/wendy grow without bound:
@@ -238,13 +240,13 @@ func tryLockCacheUnit(dir string) (release func(), ok bool) {
 		}
 		return nil, false // unreadable lock: can't tell, leave the dir alone
 	}
-	locked, err := tryLockFile(f)
+	locked, err := flock.TryLock(f)
 	if err != nil || !locked {
 		_ = f.Close()
 		return nil, false
 	}
 	return func() {
-		_ = unlockFile(f)
+		_ = flock.Unlock(f)
 		_ = f.Close()
 	}, true
 }


### PR DESCRIPTION
## Problem
`internal/cli/commands` does not compile on `main`, failing Test, Vet, Detect API surface, and govulncheck on every open PR:

```
internal/cli/commands/buildcache.go:241:17: undefined: tryLockFile
internal/cli/commands/buildcache.go:247:7:  undefined: unlockFile
```

## Root cause
A semantic merge conflict landed via #1715. `623bff25c` added `tryLockCacheUnit` calling the local helpers `tryLockFile`/`unlockFile`; `9e1bf6586` ("one flock implementation") deleted `buildlock_unix.go` where those helpers lived and moved everything to `internal/shared/flock`, updating `buildlock.go` but not the two call sites in `buildcache.go`. Each branch compiled alone; combined on `main` the symbols are undefined. No textual conflict, so it merged silently.

## Fix
Point the two `buildcache.go` call sites at `flock.TryLock`/`flock.Unlock` (same signatures) and import the package. 3 lines.

## Verification
`go build ./go/...`, `go vet ./go/internal/cli/commands/`, and the cache/lock tests all pass.