### PR TITLE
cli: renew the client certificate before it expires, not after

### DIFF
--- a/go/internal/cli/commands/certrenew.go
+++ b/go/internal/cli/commands/certrenew.go
@@ -1,0 +1,360 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+)
+
+// Pre-expiry certificate renewal against pki-core's renew frontend (WDY-2829).
+//
+// WHY A PRE-FLIGHT AND NOT A FAILURE HANDLER. pki-core renews a certificate
+// only while the presented one is still VALID: possession is proven by the mTLS
+// handshake that carries it, and an expired leaf takes the grant-required
+// branch instead, which needs a cloud-signed grant rather than a plain renew.
+// So the cheap path exists strictly before expiry — reacting to an mTLS
+// rejection is already too late. That is why this runs when the auth entry is
+// resolved rather than hanging off offerCertRefreshAndRetry.
+//
+// Renewal is also budgeted, per lineage, and the budget is inherited rather
+// than requested: a plain operator leaf renews a fixed number of times and then
+// has to be re-minted, and an entitlement-bearing or over-duration operator
+// leaf is not renewable at all unless its tenant opted in. Both refusals arrive
+// as an explicit denial, so they are reported as themselves rather than
+// retried.
+const (
+	// renewLeadTime is how much remaining validity triggers a renewal attempt.
+	// It has to exceed the round trip plus any clock skew between CLI and
+	// pki-core, or the renew arrives after the leaf it is renewing has expired
+	// and takes the grant branch.
+	renewLeadTime = 15 * time.Minute
+
+	// renewEndpointEnv names pki-core's renew frontend, e.g.
+	// "https://renew.pki.example:8451/v1/renew".
+	//
+	// There is deliberately NO derivation from the cloud endpoint. Guessing a
+	// host and port from another service's address is what sent enrollment
+	// tokens to the wrong place in cleartext (WDY-2799); an unset endpoint here
+	// means "no renew frontend configured", which is a supported state.
+	renewEndpointEnv = "WENDY_PKI_RENEW_ENDPOINT"
+
+	renewRequestTimeout = 15 * time.Second
+)
+
+// renewUnavailableError says the cheap renewal could not be used and why. The
+// reason is user-facing: every branch that produces one has a different remedy,
+// and collapsing them into "refresh failed" is what made the old behaviour
+// misleading.
+type renewUnavailableError struct {
+	reason string
+	detail string
+}
+
+func (e renewUnavailableError) Error() string {
+	if e.detail != "" {
+		return e.reason + ": " + e.detail
+	}
+	return e.reason
+}
+
+var (
+	// errNoRenewEndpoint is not a failure: nothing is configured to renew
+	// against, so the pre-flight has nothing to offer and stays silent.
+	errNoRenewEndpoint = errors.New("no pki-core renew endpoint configured")
+	errCertExpired     = renewUnavailableError{reason: "your certificate has expired"}
+)
+
+// leafNotAfter returns the stored leaf's expiry. It normalises through
+// certs.LeafCertificatePEM first because pki-core leaves can carry trailing
+// ASN.1 bytes that defeat a raw x509 parse.
+func leafNotAfter(certPEM string) (time.Time, error) {
+	leafPEM, err := certs.LeafCertificatePEM(certPEM)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("extracting leaf certificate: %w", err)
+	}
+	// ParseCertsFromPEM is the ML-DSA-aware parser the mTLS paths use, so the
+	// pre-flight reads exactly the certificates the handshake can present.
+	leaves, err := certs.ParseCertsFromPEM([]byte(leafPEM))
+	if err != nil {
+		return time.Time{}, err
+	}
+	if len(leaves) == 0 {
+		return time.Time{}, errors.New("no certificate in stored leaf PEM")
+	}
+	return leaves[0].NotAfter, nil
+}
+
+// certNeedsRenewal reports whether the leaf is close enough to expiry to renew.
+func certNeedsRenewal(notAfter, now time.Time) bool {
+	return notAfter.Sub(now) < renewLeadTime
+}
+
+// renewEndpoint resolves the configured renew frontend, or "" when none is set.
+func renewEndpoint() string {
+	return strings.TrimSpace(os.Getenv(renewEndpointEnv))
+}
+
+// splitLeafAndChain splits a PEM bundle into its first certificate and the
+// remainder. pki-core answers a renewal with leaf-first chain in one blob,
+// while the CLI stores the two separately.
+func splitLeafAndChain(bundlePEM string) (leaf, chain string, err error) {
+	rest := []byte(bundlePEM)
+	var blocks []*pem.Block
+	for {
+		block, remainder := pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type == "CERTIFICATE" {
+			blocks = append(blocks, block)
+		}
+		rest = remainder
+	}
+	if len(blocks) == 0 {
+		return "", "", errors.New("renewal response carried no certificate")
+	}
+	var leafBuf, chainBuf bytes.Buffer
+	if err := pem.Encode(&leafBuf, blocks[0]); err != nil {
+		return "", "", fmt.Errorf("re-encoding renewed leaf: %w", err)
+	}
+	for _, b := range blocks[1:] {
+		if err := pem.Encode(&chainBuf, b); err != nil {
+			return "", "", fmt.Errorf("re-encoding renewed chain: %w", err)
+		}
+	}
+	return leafBuf.String(), chainBuf.String(), nil
+}
+
+// renewHTTPClientFor builds a client that presents the CURRENT certificate.
+// That handshake is the possession proof pki-core requires; the request body
+// carries no certificate of its own.
+func renewHTTPClientFor(cert config.CertificateInfo) (*http.Client, error) {
+	keyPEM, err := cert.PrivateKeyPEM()
+	if err != nil {
+		return nil, fmt.Errorf("loading current client key: %w", err)
+	}
+	tlsCfg, err := certs.LoadTLSConfig(cert.PemCertificate, cert.PemCertificateChain, keyPEM, "")
+	if err != nil {
+		return nil, fmt.Errorf("building renewal mTLS config: %w", err)
+	}
+	return &http.Client{
+		Timeout:   renewRequestTimeout,
+		Transport: &http.Transport{TLSClientConfig: tlsCfg},
+	}, nil
+}
+
+type renewRequestBody struct {
+	CSR string `json:"csr"`
+}
+
+type renewSuccessBody struct {
+	Certificate string `json:"certificate"`
+}
+
+type renewDetailBody struct {
+	Detail string `json:"detail"`
+}
+
+// renewViaPKICore exchanges a fresh CSR for a renewed certificate. It returns
+// the new leaf, chain and private key, leaving persistence to the caller so a
+// failed write cannot lose the still-valid current certificate.
+// renewCSRFor builds the renewal CSR. A renewal is a re-issue: new key, same
+// identity. The URN comes from stored config rather than the old CN, which may
+// be a legacy form carrying no parseable org.
+func renewCSRFor(current config.CertificateInfo) (csrPEM, keyPEM string, err error) {
+	cn, err := certCommonName(current.PemCertificate)
+	if err != nil {
+		return "", "", fmt.Errorf("reading current cert CN: %w", err)
+	}
+	newKeyPEM, err := certs.GenerateKeyPair()
+	if err != nil {
+		return "", "", fmt.Errorf("generating key pair: %w", err)
+	}
+	csr, err := certs.GenerateCSR([]byte(newKeyPEM), cn, storedCertIdentityURN(current))
+	if err != nil {
+		return "", "", fmt.Errorf("generating CSR: %w", err)
+	}
+	return csr, newKeyPEM, nil
+}
+
+func renewViaPKICoreImpl(ctx context.Context, endpoint string, auth *config.AuthConfig) (certPEM, chainPEM, keyPEM string, err error) {
+	if len(auth.Certificates) == 0 {
+		return "", "", "", errors.New("auth entry has no certificate to renew")
+	}
+	current := auth.Certificates[0]
+
+	csrPEM, newKeyPEM, err := renewCSRForFn(current)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	body, err := json.Marshal(renewRequestBody{CSR: csrPEM})
+	if err != nil {
+		return "", "", "", fmt.Errorf("encoding renewal request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return "", "", "", fmt.Errorf("building renewal request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client, err := renewHTTPClientForFn(current)
+	if err != nil {
+		return "", "", "", err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", "", "", fmt.Errorf("contacting renew frontend: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var ok renewSuccessBody
+		if err := json.NewDecoder(resp.Body).Decode(&ok); err != nil {
+			return "", "", "", fmt.Errorf("decoding renewal response: %w", err)
+		}
+		leaf, chain, err := splitLeafAndChain(ok.Certificate)
+		if err != nil {
+			return "", "", "", err
+		}
+		return leaf, chain, newKeyPEM, nil
+
+	case http.StatusAccepted:
+		// The presented certificate is no longer renewable on its own and needs a
+		// signed grant. Reported rather than retried: the CLI cannot mint one.
+		var d renewDetailBody
+		_ = json.NewDecoder(resp.Body).Decode(&d)
+		return "", "", "", renewUnavailableError{
+			reason: "this certificate can no longer be renewed on its own and needs an approved grant",
+			detail: d.Detail,
+		}
+
+	case http.StatusForbidden:
+		// Budget exhausted, or the lineage was never renewable — an
+		// entitlement-bearing or over-duration operator certificate is not
+		// renewable unless the tenant opted in. Either way a new certificate has
+		// to be issued from scratch.
+		var d renewDetailBody
+		_ = json.NewDecoder(resp.Body).Decode(&d)
+		return "", "", "", renewUnavailableError{
+			reason: "this certificate is not renewable, or its renewal budget is used up",
+			detail: d.Detail,
+		}
+
+	case http.StatusUnauthorized:
+		return "", "", "", renewUnavailableError{
+			reason: "the renew frontend did not accept the current certificate",
+		}
+
+	default:
+		return "", "", "", renewUnavailableError{
+			reason: fmt.Sprintf("the renew frontend answered %s", resp.Status),
+		}
+	}
+}
+
+// ensureFreshCertificate is the pre-flight: it renews the stored certificate
+// before it expires, and reports honestly when it cannot.
+//
+// Returning nil means "carry on with the stored certificate" — including when
+// nothing is configured to renew against, which is a supported state and not a
+// failure. A non-nil error is always something the user has to act on.
+func ensureFreshCertificate(ctx context.Context, auth *config.AuthConfig) error {
+	if auth == nil || len(auth.Certificates) == 0 {
+		return nil
+	}
+	notAfter, err := leafNotAfterFn(auth.Certificates[0].PemCertificate)
+	if err != nil {
+		// An unparseable stored certificate is not this function's problem to
+		// diagnose; the connection attempt reports it with better context.
+		return nil
+	}
+	if !certNeedsRenewal(notAfter, timeNowFn()) {
+		return nil
+	}
+
+	endpoint := renewEndpoint()
+	if endpoint == "" {
+		if timeNowFn().After(notAfter) {
+			// Nothing to renew against and the certificate is already dead: say so
+			// plainly instead of letting the caller discover it as a TLS error.
+			return errCertExpired
+		}
+		return nil
+	}
+	if timeNowFn().After(notAfter) {
+		// Past expiry the renew frontend requires a grant, so skip the round trip
+		// and report the remedy directly.
+		return errCertExpired
+	}
+
+	certPEM, chainPEM, keyPEM, err := renewViaPKICore(ctx, endpoint, auth)
+	if err != nil {
+		var unavailable renewUnavailableError
+		if errors.As(err, &unavailable) {
+			return unavailable
+		}
+		// A transport failure while the certificate is still valid is not fatal:
+		// the stored certificate has life left, so carry on and let the next run
+		// try again rather than blocking the command.
+		return nil
+	}
+
+	updated := auth.Certificates[0]
+	updated.PemCertificate = certPEM
+	updated.PemCertificateChain = chainPEM
+	updated.PemPrivateKey = keyPEM
+	if err := persistRenewedCertificate(auth, updated); err != nil {
+		return fmt.Errorf("saving renewed certificate: %w", err)
+	}
+	auth.Certificates[0] = updated
+	return nil
+}
+
+// persistRenewedCertificate writes the renewed material back to the matching
+// stored session. Indirected for tests.
+var persistRenewedCertificate = func(auth *config.AuthConfig, updated config.CertificateInfo) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+	for i := range cfg.Auth {
+		if cfg.Auth[i].CloudGRPC == auth.CloudGRPC && cfg.Auth[i].CloudDashboard == auth.CloudDashboard {
+			if len(cfg.Auth[i].Certificates) == 0 {
+				cfg.Auth[i].Certificates = []config.CertificateInfo{updated}
+			} else {
+				cfg.Auth[i].Certificates[0] = updated
+			}
+			return config.Save(cfg)
+		}
+	}
+	return errors.New("stored session for the renewed certificate no longer exists")
+}
+
+// These seams keep the pieces separately testable: the HTTP status mapping is
+// pki-core's contract and is worth pinning without standing up real mTLS, which
+// is pki-core's own possession proof and is covered there.
+var (
+	// timeNowFn is indirected so expiry arithmetic is testable.
+	timeNowFn = time.Now
+
+	leafNotAfterFn       = leafNotAfter
+	renewCSRForFn        = renewCSRFor
+	renewHTTPClientForFn = renewHTTPClientFor
+	renewViaPKICore      = renewViaPKICoreImpl
+)
+
+// ensureFreshCertificateFn is the pre-flight entry point, indirected so tests
+// of the callers do not perform network I/O.
+var ensureFreshCertificateFn = ensureFreshCertificate

--- a/go/internal/cli/commands/certrenew_test.go
+++ b/go/internal/cli/commands/certrenew_test.go
@@ -1,0 +1,312 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+)
+
+func TestCertNeedsRenewal(t *testing.T) {
+	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name     string
+		notAfter time.Time
+		want     bool
+	}{
+		{"fresh, hours left", now.Add(4 * time.Hour), false},
+		{"just outside the lead time", now.Add(renewLeadTime + time.Minute), false},
+		{"inside the lead time", now.Add(renewLeadTime - time.Minute), true},
+		{"already expired", now.Add(-time.Minute), true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := certNeedsRenewal(tc.notAfter, now); got != tc.want {
+				t.Errorf("certNeedsRenewal() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSplitLeafAndChain(t *testing.T) {
+	const leaf = "-----BEGIN CERTIFICATE-----\nQUFB\n-----END CERTIFICATE-----\n"
+	const inter = "-----BEGIN CERTIFICATE-----\nQkJC\n-----END CERTIFICATE-----\n"
+
+	t.Run("leaf and chain are split", func(t *testing.T) {
+		gotLeaf, gotChain, err := splitLeafAndChain(leaf + inter)
+		if err != nil {
+			t.Fatalf("splitLeafAndChain: %v", err)
+		}
+		if gotLeaf != leaf {
+			t.Errorf("leaf = %q, want %q", gotLeaf, leaf)
+		}
+		if gotChain != inter {
+			t.Errorf("chain = %q, want %q", gotChain, inter)
+		}
+	})
+
+	t.Run("leaf only yields an empty chain", func(t *testing.T) {
+		gotLeaf, gotChain, err := splitLeafAndChain(leaf)
+		if err != nil {
+			t.Fatalf("splitLeafAndChain: %v", err)
+		}
+		if gotLeaf != leaf || gotChain != "" {
+			t.Errorf("got (%q, %q), want (leaf, empty)", gotLeaf, gotChain)
+		}
+	})
+
+	t.Run("no certificate is an error", func(t *testing.T) {
+		if _, _, err := splitLeafAndChain("not pem at all"); err == nil {
+			t.Fatal("expected an error for a response carrying no certificate")
+		}
+	})
+}
+
+// stubPreflight pins the clock and the renew endpoint, and captures whatever
+// the pre-flight persists.
+func stubPreflight(t *testing.T, now time.Time, endpoint string) *config.CertificateInfo {
+	t.Helper()
+	origNow := timeNowFn
+	timeNowFn = func() time.Time { return now }
+	t.Cleanup(func() { timeNowFn = origNow })
+
+	t.Setenv(renewEndpointEnv, endpoint)
+
+	saved := new(config.CertificateInfo)
+	origPersist := persistRenewedCertificate
+	persistRenewedCertificate = func(_ *config.AuthConfig, updated config.CertificateInfo) error {
+		*saved = updated
+		return nil
+	}
+	t.Cleanup(func() { persistRenewedCertificate = origPersist })
+	return saved
+}
+
+func stubRenewCall(t *testing.T, certPEM, chainPEM, keyPEM string, err error) *int {
+	t.Helper()
+	calls := new(int)
+	orig := renewViaPKICore
+	renewViaPKICore = func(context.Context, string, *config.AuthConfig) (string, string, string, error) {
+		*calls++
+		return certPEM, chainPEM, keyPEM, err
+	}
+	t.Cleanup(func() { renewViaPKICore = orig })
+	return calls
+}
+
+func authWithLeaf() *config.AuthConfig {
+	return &config.AuthConfig{
+		CloudGRPC:    "api.wendy.sh:443",
+		Certificates: []config.CertificateInfo{{PemCertificate: "stored-leaf", OrganizationID: 7}},
+	}
+}
+
+func TestEnsureFreshCertificate(t *testing.T) {
+	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+
+	stubLeafExpiry := func(t *testing.T, notAfter time.Time, err error) {
+		t.Helper()
+		orig := leafNotAfterFn
+		leafNotAfterFn = func(string) (time.Time, error) { return notAfter, err }
+		t.Cleanup(func() { leafNotAfterFn = orig })
+	}
+
+	t.Run("fresh certificate is left alone", func(t *testing.T) {
+		stubPreflight(t, now, "https://renew.example:8451/v1/renew")
+		calls := stubRenewCall(t, "", "", "", nil)
+		stubLeafExpiry(t, now.Add(4*time.Hour), nil)
+
+		if err := ensureFreshCertificate(context.Background(), authWithLeaf()); err != nil {
+			t.Fatalf("ensureFreshCertificate() = %v, want nil", err)
+		}
+		if *calls != 0 {
+			t.Errorf("renew calls = %d, want 0 for a fresh certificate", *calls)
+		}
+	})
+
+	t.Run("near expiry renews and persists", func(t *testing.T) {
+		saved := stubPreflight(t, now, "https://renew.example:8451/v1/renew")
+		calls := stubRenewCall(t, "new-leaf", "new-chain", "new-key", nil)
+		stubLeafExpiry(t, now.Add(time.Minute), nil)
+
+		auth := authWithLeaf()
+		if err := ensureFreshCertificate(context.Background(), auth); err != nil {
+			t.Fatalf("ensureFreshCertificate() = %v, want nil", err)
+		}
+		if *calls != 1 {
+			t.Fatalf("renew calls = %d, want 1", *calls)
+		}
+		if saved.PemCertificate != "new-leaf" || saved.PemPrivateKey != "new-key" {
+			t.Errorf("persisted %+v, want the renewed material", *saved)
+		}
+		if auth.Certificates[0].PemCertificate != "new-leaf" {
+			t.Error("in-memory auth entry was not updated with the renewed leaf")
+		}
+		if saved.OrganizationID != 7 {
+			t.Errorf("OrganizationID = %d, want 7 carried forward", saved.OrganizationID)
+		}
+	})
+
+	t.Run("already expired skips the round trip and reports", func(t *testing.T) {
+		stubPreflight(t, now, "https://renew.example:8451/v1/renew")
+		calls := stubRenewCall(t, "", "", "", nil)
+		stubLeafExpiry(t, now.Add(-time.Minute), nil)
+
+		err := ensureFreshCertificate(context.Background(), authWithLeaf())
+		if !errors.Is(err, errCertExpired) {
+			t.Fatalf("ensureFreshCertificate() = %v, want errCertExpired", err)
+		}
+		if *calls != 0 {
+			t.Errorf("renew calls = %d, want 0: past expiry the renew frontend needs a grant", *calls)
+		}
+	})
+
+	t.Run("no endpoint configured stays silent while still valid", func(t *testing.T) {
+		stubPreflight(t, now, "")
+		calls := stubRenewCall(t, "", "", "", nil)
+		stubLeafExpiry(t, now.Add(time.Minute), nil)
+
+		if err := ensureFreshCertificate(context.Background(), authWithLeaf()); err != nil {
+			t.Fatalf("ensureFreshCertificate() = %v, want nil when nothing is configured to renew against", err)
+		}
+		if *calls != 0 {
+			t.Errorf("renew calls = %d, want 0", *calls)
+		}
+	})
+
+	t.Run("denial is surfaced, not swallowed", func(t *testing.T) {
+		stubPreflight(t, now, "https://renew.example:8451/v1/renew")
+		denial := renewUnavailableError{reason: "this certificate is not renewable, or its renewal budget is used up", detail: "renewal budget exhausted"}
+		stubRenewCall(t, "", "", "", denial)
+		stubLeafExpiry(t, now.Add(time.Minute), nil)
+
+		err := ensureFreshCertificate(context.Background(), authWithLeaf())
+		var got renewUnavailableError
+		if !errors.As(err, &got) {
+			t.Fatalf("ensureFreshCertificate() = %v, want a renewUnavailableError", err)
+		}
+		if got.detail != "renewal budget exhausted" {
+			t.Errorf("detail = %q, want the frontend's own detail carried through", got.detail)
+		}
+	})
+
+	t.Run("transport failure while still valid does not block the command", func(t *testing.T) {
+		stubPreflight(t, now, "https://renew.example:8451/v1/renew")
+		stubRenewCall(t, "", "", "", errors.New("dial tcp: connection refused"))
+		stubLeafExpiry(t, now.Add(time.Minute), nil)
+
+		if err := ensureFreshCertificate(context.Background(), authWithLeaf()); err != nil {
+			t.Fatalf("ensureFreshCertificate() = %v, want nil: the stored cert still has life left", err)
+		}
+	})
+
+	t.Run("unparseable stored certificate is not diagnosed here", func(t *testing.T) {
+		stubPreflight(t, now, "https://renew.example:8451/v1/renew")
+		calls := stubRenewCall(t, "", "", "", nil)
+		stubLeafExpiry(t, time.Time{}, errors.New("bad pem"))
+
+		if err := ensureFreshCertificate(context.Background(), authWithLeaf()); err != nil {
+			t.Fatalf("ensureFreshCertificate() = %v, want nil", err)
+		}
+		if *calls != 0 {
+			t.Errorf("renew calls = %d, want 0", *calls)
+		}
+	})
+
+	t.Run("no certificates is a no-op", func(t *testing.T) {
+		stubPreflight(t, now, "https://renew.example:8451/v1/renew")
+		if err := ensureFreshCertificate(context.Background(), &config.AuthConfig{}); err != nil {
+			t.Fatalf("ensureFreshCertificate() = %v, want nil", err)
+		}
+		if err := ensureFreshCertificate(context.Background(), nil); err != nil {
+			t.Fatalf("ensureFreshCertificate(nil) = %v, want nil", err)
+		}
+	})
+}
+
+// TestRenewStatusMapping pins the HTTP contract of pki-core's renew frontend:
+// each status has a different remedy, and collapsing them is what made the old
+// behaviour misleading.
+func TestRenewStatusMapping(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		body       any
+		wantErr    bool
+		wantDetail string
+	}{
+		{name: "200 returns the renewed chain", status: http.StatusOK,
+			body: renewSuccessBody{Certificate: "-----BEGIN CERTIFICATE-----\nQUFB\n-----END CERTIFICATE-----\n"}},
+		{name: "202 needs a grant", status: http.StatusAccepted,
+			body: map[string]string{"detail": "grant required"}, wantErr: true, wantDetail: "grant required"},
+		{name: "403 not renewable or budget used", status: http.StatusForbidden,
+			body: map[string]string{"detail": "renewal budget exhausted"}, wantErr: true, wantDetail: "renewal budget exhausted"},
+		{name: "401 possession not proven", status: http.StatusUnauthorized,
+			body: map[string]string{}, wantErr: true},
+		{name: "500 is reported as itself", status: http.StatusInternalServerError,
+			body: map[string]string{}, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/v1/renew" {
+					t.Errorf("path = %q, want /v1/renew", r.URL.Path)
+				}
+				if r.Method != http.MethodPost {
+					t.Errorf("method = %q, want POST", r.Method)
+				}
+				var got renewRequestBody
+				if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+					t.Errorf("request body did not decode: %v", err)
+				} else if got.CSR == "" {
+					t.Error("request carried no csr")
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				_ = json.NewEncoder(w).Encode(tc.body)
+			}))
+			defer srv.Close()
+
+			// Exercise the status mapping without real mTLS: the handshake is
+			// pki-core's possession proof and is covered there, not here.
+			origClient := renewHTTPClientForFn
+			renewHTTPClientForFn = func(config.CertificateInfo) (*http.Client, error) {
+				return srv.Client(), nil
+			}
+			t.Cleanup(func() { renewHTTPClientForFn = origClient })
+
+			origCSR := renewCSRForFn
+			renewCSRForFn = func(config.CertificateInfo) (csrPEM, keyPEM string, err error) {
+				return "csr-pem", "key-pem", nil
+			}
+			t.Cleanup(func() { renewCSRForFn = origCSR })
+
+			auth := &config.AuthConfig{Certificates: []config.CertificateInfo{{PemCertificate: "stored"}}}
+			certPEM, _, keyPEM, err := renewViaPKICoreImpl(context.Background(), srv.URL+"/v1/renew", auth)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error for status %d", tc.status)
+				}
+				var ru renewUnavailableError
+				if !errors.As(err, &ru) {
+					t.Fatalf("err = %v, want a renewUnavailableError", err)
+				}
+				if tc.wantDetail != "" && ru.detail != tc.wantDetail {
+					t.Errorf("detail = %q, want %q", ru.detail, tc.wantDetail)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("renewViaPKICore: %v", err)
+			}
+			if certPEM == "" || keyPEM != "key-pem" {
+				t.Errorf("got cert %q key %q, want the renewed leaf and the new key", certPEM, keyPEM)
+			}
+		})
+	}
+}

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"syscall"
 	"time"
+	"unicode"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
@@ -971,7 +972,45 @@ func pickAuthEntry(cloudGRPC string) (*config.AuthConfig, error) {
 	if isInteractiveTerminal() {
 		pick = pickAuthSessionFn
 	}
-	return config.ResolveAuth(cfg, cloudGRPC, pick)
+	auth, err := config.ResolveAuth(cfg, cloudGRPC, pick)
+	if err != nil {
+		return nil, err
+	}
+	// Pre-flight: renew the client certificate before it expires rather than
+	// after something rejects it (WDY-2829). pki-core renews only while the
+	// presented certificate is still valid, so this is the last point at which
+	// the cheap path is still available. A nil return means "carry on" —
+	// including when no renew frontend is configured.
+	//
+	// The renewal gets its own bounded context rather than the caller's: this
+	// helper is on 13 call paths that do not share a context parameter, and the
+	// request already carries its own timeout.
+	if rerr := ensureFreshCertificateFn(context.Background(), auth); rerr != nil {
+		reportStaleCertificate(rerr)
+	}
+	return auth, nil
+}
+
+// reportStaleCertificate prints why the stored certificate could not be renewed
+// and what to do about it. It does not fail the command: the connection attempt
+// is still worth making — the certificate may be accepted anyway, and a
+// connection error carries better context than a guess made here.
+func reportStaleCertificate(err error) {
+	if jsonOutput {
+		return
+	}
+	fmt.Fprintln(os.Stderr, tui.WarningMessage(capitalizeFirst(err.Error())+"."))
+	fmt.Fprintln(os.Stderr, "  Sign in again to get a new one: wendy auth login")
+}
+
+// capitalizeFirst upper-cases the first rune so an error string reads as a
+// sentence when printed as one.
+func capitalizeFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	r := []rune(s)
+	return string(unicode.ToUpper(r[0])) + string(r[1:])
 }
 
 func newDeviceUnenrollCmd() *cobra.Command {


### PR DESCRIPTION
- **Based on:** `feat/cli-oidc-login` — this PR targets Joannis's CLI feature branch, not `main`, and reaches `main` when that branch does.
- **Advances:** [WDY-2829 CLI operator-cert refresh always fails against hosted cloud → operators are booted to re-login when the cert expires](https://linear.app/wendylabsinc/issue/WDY-2829/cli-operator-cert-refresh-always-fails-against-hosted-cloud-operators)

> **In plain terms:** An operator whose certificate expired was pushed back to a browser sign-in. The CLI now renews the certificate quietly, shortly before it expires, so an ordinary working session no longer gets interrupted. When renewal genuinely is not possible — the certificate is already dead, or that certificate was never renewable — it says which, instead of offering a refresh that cannot work.

## Summary

- **Renews before expiry, not after rejection.** pki-core renews a certificate only while the presented one is still valid: possession is proven by the mTLS handshake that carries it, and an expired leaf takes the grant-required branch, which needs a cloud-signed grant rather than a plain renew. The cheap path therefore exists strictly *before* expiry, so reacting to an mTLS rejection was always too late. Past expiry the round trip is skipped entirely rather than spent learning that.
- **One choke point.** The check hooks `pickAuthEntry`, through which thirteen call paths across the device, cloud and fleet commands resolve their session — so it lands once rather than at each call site. It renews when less than 15 minutes of validity remains, leaves a fresh certificate untouched, and never fails a command: the connection attempt still happens, because a connection error carries better context than a guess made in the pre-flight.
- **Four statuses, four remedies.** Renewal is budgeted per lineage and the budget is inherited rather than requested — a plain operator leaf renews a fixed number of times and then needs a fresh mint, and an entitlement-bearing or over-duration operator leaf is not renewable at all unless its tenant opted in. Those arrive as explicit denials, each reported as itself with the frontend's own detail. Collapsing them into "refresh failed" is what made the old message useless.
- **The endpoint is explicit, never derived.** It comes from `WENDY_PKI_RENEW_ENDPOINT`. Deriving `host:8451` from the cloud endpoint would repeat the WDY-2799 shape, where a port heuristic quietly sent a bearer credential somewhere unintended. An unset endpoint is a supported state: the pre-flight then stays silent while the certificate is valid and only speaks up once it has actually expired.
- **No cloud changes.** Nothing outside `go/internal/cli/`. Cloud's `RefreshCertificate` stays device-only, which is correct as designed and is not what an operator should have been calling.

**Known gap, and it is now addressable here.** The remaining fallback — a *silent* re-mint through pki-core's identity frontend on a live wendy-auth session — needs the OAuth session fields `RefreshToken`, `DPoPPrivateKey`, `OAuthExpiresAt` and `PKIEndpoint`. All four are on this PR's base (`go/internal/shared/config/config.go`), so the two things that were out of reach on `main` are in reach here: sourcing the endpoint from `AuthConfig.PKIEndpoint` instead of `WENDY_PKI_RENEW_ENDPOINT`, and the silent re-mint itself. Neither is in this diff — the endpoint move is the one-liner, the re-mint is a separate change with its own tests — and until they land an expired or non-renewable certificate still ends at an honest message naming the reason and pointing at sign-in.

## Boundary changes
- **CLI:** a client certificate within 15 minutes of expiry is now renewed automatically when `WENDY_PKI_RENEW_ENDPOINT` is set, which changes no command's output on success. On a refusal or past expiry, commands print one warning naming the reason and pointing at `wendy auth login`; they do not fail on that basis. `--json` runs print nothing new. With the variable unset, behaviour is unchanged except that an already-expired certificate is now named as such before the connection is attempted.
- **Config:** new environment variable `WENDY_PKI_RENEW_ENDPOINT` (pki-core renew frontend URL, e.g. `https://renew.pki.example:8451/v1/renew`). Additive; unset is supported and is the default.

## Tests
- `go test ./go/internal/cli/commands/` — pass (full package, 36.3s), run against `feat/cli-oidc-login` after the rebase
- `go test ./go/internal/cli/commands/ -run 'CertNeedsRenewal|SplitLeafAndChain|EnsureFreshCertificate|RenewStatusMapping'` — 24 subtests: renewal-window table, leaf/chain PEM split, 8 pre-flight cases including *expired skips the round trip* and *denial is surfaced, not swallowed*, and a 5-case `httptest` table pinning the HTTP contract (200/202/403/401/500) with path, method and `csr` asserted
- `go build ./... && go vet ./go/internal/cli/... && gofmt -l go/internal/cli/` — clean

