### PR TITLE
Pin the device-proof preimage by identity URN, not by int org/asset

### DIFF
--- a/Proto/wendy/agent/services/v1/wendy_agent_v1_video_service.proto
+++ b/Proto/wendy/agent/services/v1/wendy_agent_v1_video_service.proto
@@ -24,7 +24,8 @@ message VideoDevice {
     bool has_credentials    = 10; // the agent holds a login for this camera
     bool online             = 11; // the most recent probe reached this camera
     string topic            = 12; // ROS 2 image topic, e.g. "/camera/image_raw"; empty for other transports
-    // Stable identity for a LOCAL camera, the counterpart of `mac` above.
+    // Stable identity for a LOCAL camera, the counterpart of `mac` above, and
+    // the name to pass to StreamVideoRequest.stable_id.
     //
     // `id` and `path` are the kernel's enumeration order, which is a property
     // of the boot and not of the camera: replugging or a reboot can renumber
@@ -32,15 +33,21 @@ message VideoDevice {
     // different camera. `name` and `driver` only identify the MODEL, so they
     // cannot separate two cameras of the same type.
     //
-    // by_id is derived from vendor + product + serial and survives both a
-    // reboot and a move to another USB port. by_path encodes the port topology
-    // instead: it survives a reboot but NOT a move, and is the only thing that
-    // can separate two same-model cameras whose serials are identical (a
-    // generic factory serial is common). Both are empty when the device has no
-    // /dev/v4l entry -- CSI and network cameras, or a kernel without the
-    // symlinks.
-    string by_id            = 13; // e.g. "usb-Acme_Camera_SN123-video-index0"
-    string by_path          = 14; // e.g. "platform-xhci-hcd.0-usb-0:2.3:1.0-video-index0"
+    // One camera has one stable_id. The value carries the scheme it came from,
+    // because the two names udev publishes are not equally durable:
+    //
+    //   by-id:<name>    vendor + product + serial; survives a reboot AND a
+    //                   move to another USB port. Reported whenever udev has
+    //                   one.
+    //   by-path:<name>  the USB port topology; survives a reboot but NOT a
+    //                   move. Reported only when there is no by-id name --
+    //                   two same-model cameras sharing a factory serial
+    //                   collide on a single by-id link, and the camera that
+    //                   loses it has nothing else that separates the two.
+    //
+    // Empty when the device has no /dev/v4l entry -- CSI and network cameras,
+    // or a kernel without the udev symlinks.
+    string stable_id        = 13; // e.g. "by-id:usb-Acme_Camera_SN123-video-index0"
 }
 
 enum VideoTransport {
@@ -81,17 +88,22 @@ message StreamVideoRequest {
     // waiting forever. A codec the agent cannot produce for a camera is refused
     // the same way rather than silently downgraded.
     VideoCodec codec  = 5;
-    // Address the camera by its stable identity instead of by device_id.
+    // Address the camera by the stable_id ListVideoDevices reported for it,
+    // scheme tag included, instead of by device_id.
     //
-    // When set this WINS over device_id and is resolved against the by_id
-    // reported by ListVideoDevices, at request time. That is the point: the
-    // number is resolved when the stream is opened rather than baked into a
-    // config that outlives the boot it was written on.
+    // When set this WINS over device_id and is resolved at request time. That
+    // is the point: the number is resolved when the stream is opened rather
+    // than baked into a config that outlives the boot it was written on.
+    //
+    // A "by-path:" name resolves too, even for a camera whose reported
+    // stable_id is a "by-id:" one: pinning a stream to a physical port is a
+    // legitimate thing to ask for, as long as the caller asks for it rather
+    // than inheriting it.
     //
     // No match is an error, deliberately. Falling back to device_id would
     // stream whatever the kernel happened to put at that number, which is the
     // silent-wrong-camera failure this field exists to remove.
-    string device_by_id = 6; // empty = address by device_id, as before
+    string stable_id  = 6; // empty = address by device_id, as before
 }
 
 // Credentials for a network camera. Stored on the device, never returned by any

--- a/Proto/wendy/agent/services/v1/wendy_agent_v1_video_service.proto
+++ b/Proto/wendy/agent/services/v1/wendy_agent_v1_video_service.proto
@@ -24,6 +24,23 @@ message VideoDevice {
     bool has_credentials    = 10; // the agent holds a login for this camera
     bool online             = 11; // the most recent probe reached this camera
     string topic            = 12; // ROS 2 image topic, e.g. "/camera/image_raw"; empty for other transports
+    // Stable identity for a LOCAL camera, the counterpart of `mac` above.
+    //
+    // `id` and `path` are the kernel's enumeration order, which is a property
+    // of the boot and not of the camera: replugging or a reboot can renumber
+    // /dev/videoN, and a caller that pinned a number then silently streams a
+    // different camera. `name` and `driver` only identify the MODEL, so they
+    // cannot separate two cameras of the same type.
+    //
+    // by_id is derived from vendor + product + serial and survives both a
+    // reboot and a move to another USB port. by_path encodes the port topology
+    // instead: it survives a reboot but NOT a move, and is the only thing that
+    // can separate two same-model cameras whose serials are identical (a
+    // generic factory serial is common). Both are empty when the device has no
+    // /dev/v4l entry -- CSI and network cameras, or a kernel without the
+    // symlinks.
+    string by_id            = 13; // e.g. "usb-Acme_Camera_SN123-video-index0"
+    string by_path          = 14; // e.g. "platform-xhci-hcd.0-usb-0:2.3:1.0-video-index0"
 }
 
 enum VideoTransport {
@@ -48,6 +65,17 @@ message StreamVideoRequest {
     uint32 width      = 2; // pixels; 0 = device default
     uint32 height     = 3; // pixels; 0 = device default
     uint32 framerate  = 4; // fps; 0 = device default
+    // Address the camera by its stable identity instead of by device_id.
+    //
+    // When set this WINS over device_id and is resolved against the by_id
+    // reported by ListVideoDevices, at request time. That is the point: the
+    // number is resolved when the stream is opened rather than baked into a
+    // config that outlives the boot it was written on.
+    //
+    // No match is an error, deliberately. Falling back to device_id would
+    // stream whatever the kernel happened to put at that number, which is the
+    // silent-wrong-camera failure this field exists to remove.
+    string device_by_id = 6; // empty = address by device_id, as before
 }
 
 // Credentials for a network camera. Stored on the device, never returned by any

--- a/go/internal/agent/services/notification_service.go
+++ b/go/internal/agent/services/notification_service.go
@@ -44,7 +44,10 @@ const (
 	deviceProofTimestampHeader         = "x-wendy-device-timestamp"
 	deviceProofSignatureHeader         = "x-wendy-device-signature"
 	deviceProofDomain                  = "wendy-device-request-proof/v2"
-	deviceProofFullMethod              = "wendycloud.v1.NotificationService/CreateNotificationV2"
+	// The method this device actually invokes, and so the only one it signs.
+	// Deliberately not cloudpb's generated FullMethodName constant: that one
+	// carries a leading slash, and these bytes are pinned against Cloud.
+	deviceProofFullMethod = "wendycloud.v1.NotificationService/CreateNotificationV2"
 )
 
 // NotificationSender forwards a trusted, app-attributed Notification to Wendy Cloud.
@@ -341,12 +344,16 @@ type notificationDeviceProof struct {
 // byte for byte or every proof fails verification.
 func canonicalNotificationDeviceProof(
 	request *cloudpb.CreateNotificationV2Request,
+	fullMethod string,
 	uri string,
 	certificateSerial string,
 	timestamp int64,
 ) ([]byte, string, string, error) {
 	if request == nil {
 		return nil, "", "", fmt.Errorf("notification request is required")
+	}
+	if !validDeviceProofMethod(fullMethod) {
+		return nil, "", "", fmt.Errorf("device proof method must be a printable gRPC method name")
 	}
 	if !validCanonicalIdentityURI(uri) {
 		return nil, "", "", fmt.Errorf("device proof identity must be a canonical lowercase urn:wendy URN")
@@ -362,10 +369,10 @@ func canonicalNotificationDeviceProof(
 		return nil, "", "", fmt.Errorf("deterministically serialize notification request: %w", err)
 	}
 	timestampText := strconv.FormatInt(timestamp, 10)
-	canonical := make([]byte, 0, len(deviceProofDomain)+len(deviceProofFullMethod)+len(uri)+len(certificateSerial)+len(timestampText)+len(requestBytes)+5)
+	canonical := make([]byte, 0, len(deviceProofDomain)+len(fullMethod)+len(uri)+len(certificateSerial)+len(timestampText)+len(requestBytes)+5)
 	canonical = append(canonical, deviceProofDomain...)
 	canonical = append(canonical, 0)
-	canonical = append(canonical, deviceProofFullMethod...)
+	canonical = append(canonical, fullMethod...)
 	canonical = append(canonical, 0)
 	canonical = append(canonical, uri...)
 	canonical = append(canonical, 0)
@@ -375,6 +382,21 @@ func canonicalNotificationDeviceProof(
 	canonical = append(canonical, 0)
 	canonical = append(canonical, requestBytes...)
 	return canonical, uri, timestampText, nil
+}
+
+// validDeviceProofMethod bounds the gRPC method name the same way the identity
+// is bounded: it sits in the same NUL-framed preimage, so a NUL or a space in it
+// would let one field bleed into the next.
+func validDeviceProofMethod(value string) bool {
+	if value == "" || len(value) > 128 {
+		return false
+	}
+	for _, character := range value {
+		if character < '!' || character > '~' {
+			return false
+		}
+	}
+	return true
 }
 
 // validCanonicalIdentityURI accepts only the canonical lowercase spelling of a
@@ -472,13 +494,14 @@ func parseDeviceProofPrivateKey(keyData []byte) (*ecdsa.PrivateKey, error) {
 
 func signNotificationDeviceProof(
 	request *cloudpb.CreateNotificationV2Request,
+	fullMethod string,
 	uri string,
 	certificateSerial string,
 	timestamp int64,
 	keyData []byte,
 	random io.Reader,
 ) (notificationDeviceProof, error) {
-	canonical, uri, timestampText, err := canonicalNotificationDeviceProof(request, uri, certificateSerial, timestamp)
+	canonical, uri, timestampText, err := canonicalNotificationDeviceProof(request, fullMethod, uri, certificateSerial, timestamp)
 	if err != nil {
 		return notificationDeviceProof{}, err
 	}
@@ -502,6 +525,7 @@ func signNotificationDeviceProof(
 func notificationDeviceProofContext(
 	ctx context.Context,
 	request *cloudpb.CreateNotificationV2Request,
+	fullMethod string,
 	uri string,
 	timestamp int64,
 	certPEM string,
@@ -512,7 +536,7 @@ func notificationDeviceProofContext(
 	if err != nil {
 		return nil, err
 	}
-	proof, err := signNotificationDeviceProof(request, uri, certificateSerial, timestamp, keyData, random)
+	proof, err := signNotificationDeviceProof(request, fullMethod, uri, certificateSerial, timestamp, keyData, random)
 	if err != nil {
 		return nil, err
 	}
@@ -561,6 +585,7 @@ func (s *CloudNotificationSender) CreateNotificationV2(
 	proofCtx, err := notificationDeviceProofContext(
 		ctx,
 		request,
+		deviceProofFullMethod,
 		certs.AssetURN(orgID, assetID),
 		time.Now().Unix(),
 		certPEM,

--- a/go/internal/agent/services/notification_service.go
+++ b/go/internal/agent/services/notification_service.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
 	cloudpb "github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
 	systempb "github.com/wendylabsinc/wendy/go/proto/gen/systempb"
 )
@@ -333,17 +334,22 @@ type notificationDeviceProof struct {
 	signature         string
 }
 
+// canonicalNotificationDeviceProof builds the NUL-framed byte string the device
+// signs. uri is the device's canonical Wendy identity URN and is signature
+// input, not a comparison: Cloud rebuilds these exact bytes from the URI the
+// device puts in the x-wendy-device-uri header, so the two spellings must agree
+// byte for byte or every proof fails verification.
 func canonicalNotificationDeviceProof(
 	request *cloudpb.CreateNotificationV2Request,
-	orgID, assetID int32,
+	uri string,
 	certificateSerial string,
 	timestamp int64,
 ) ([]byte, string, string, error) {
 	if request == nil {
 		return nil, "", "", fmt.Errorf("notification request is required")
 	}
-	if orgID <= 0 || assetID <= 0 {
-		return nil, "", "", fmt.Errorf("device proof requires positive organization and asset IDs")
+	if !validCanonicalIdentityURI(uri) {
+		return nil, "", "", fmt.Errorf("device proof identity must be a canonical lowercase urn:wendy URN")
 	}
 	if !validCanonicalCertificateSerial(certificateSerial) {
 		return nil, "", "", fmt.Errorf("device proof certificate serial must be canonical lowercase octet hexadecimal")
@@ -355,7 +361,6 @@ func canonicalNotificationDeviceProof(
 	if err != nil {
 		return nil, "", "", fmt.Errorf("deterministically serialize notification request: %w", err)
 	}
-	uri := fmt.Sprintf("urn:wendy:org:%d:asset:%d", orgID, assetID)
 	timestampText := strconv.FormatInt(timestamp, 10)
 	canonical := make([]byte, 0, len(deviceProofDomain)+len(deviceProofFullMethod)+len(uri)+len(certificateSerial)+len(timestampText)+len(requestBytes)+5)
 	canonical = append(canonical, deviceProofDomain...)
@@ -370,6 +375,34 @@ func canonicalNotificationDeviceProof(
 	canonical = append(canonical, 0)
 	canonical = append(canonical, requestBytes...)
 	return canonical, uri, timestampText, nil
+}
+
+// validCanonicalIdentityURI accepts only the canonical lowercase spelling of a
+// Wendy identity URN. Cloud's parser re-renders what it parses and compares, so
+// an upper-case variant of the same identity is rejected there rather than
+// accepted as a second spelling; refusing to sign one here means the device
+// never produces a proof Cloud will throw away. The character bound also keeps
+// a NUL or a space out of the URN, which would otherwise let one field of the
+// NUL-framed preimage bleed into the next.
+func validCanonicalIdentityURI(value string) bool {
+	if value == "" || len(value) > 256 {
+		return false
+	}
+	for _, character := range value {
+		if character < '!' || character > '~' || (character >= 'A' && character <= 'Z') {
+			return false
+		}
+	}
+	// "urn:wendy:org:<org>:(asset|user):<id>". Six non-empty fields holds for
+	// both the int-era spelling and the uuid one, since a uuid carries no colon.
+	fields := strings.Split(value, ":")
+	if len(fields) != 6 || fields[0] != "urn" || fields[1] != "wendy" || fields[2] != "org" {
+		return false
+	}
+	if fields[4] != "asset" && fields[4] != "user" {
+		return false
+	}
+	return fields[3] != "" && fields[5] != ""
 }
 
 func validCanonicalCertificateSerial(value string) bool {
@@ -439,13 +472,13 @@ func parseDeviceProofPrivateKey(keyData []byte) (*ecdsa.PrivateKey, error) {
 
 func signNotificationDeviceProof(
 	request *cloudpb.CreateNotificationV2Request,
-	orgID, assetID int32,
+	uri string,
 	certificateSerial string,
 	timestamp int64,
 	keyData []byte,
 	random io.Reader,
 ) (notificationDeviceProof, error) {
-	canonical, uri, timestampText, err := canonicalNotificationDeviceProof(request, orgID, assetID, certificateSerial, timestamp)
+	canonical, uri, timestampText, err := canonicalNotificationDeviceProof(request, uri, certificateSerial, timestamp)
 	if err != nil {
 		return notificationDeviceProof{}, err
 	}
@@ -469,7 +502,7 @@ func signNotificationDeviceProof(
 func notificationDeviceProofContext(
 	ctx context.Context,
 	request *cloudpb.CreateNotificationV2Request,
-	orgID, assetID int32,
+	uri string,
 	timestamp int64,
 	certPEM string,
 	keyData []byte,
@@ -479,7 +512,7 @@ func notificationDeviceProofContext(
 	if err != nil {
 		return nil, err
 	}
-	proof, err := signNotificationDeviceProof(request, orgID, assetID, certificateSerial, timestamp, keyData, random)
+	proof, err := signNotificationDeviceProof(request, uri, certificateSerial, timestamp, keyData, random)
 	if err != nil {
 		return nil, err
 	}
@@ -515,6 +548,9 @@ func (s *CloudNotificationSender) CreateNotificationV2(
 	if !enrolled {
 		return nil, status.Error(codes.FailedPrecondition, "device must be enrolled before sending notifications")
 	}
+	if orgID <= 0 || assetID <= 0 {
+		return nil, status.Error(codes.FailedPrecondition, "device proof requires positive organization and asset IDs")
+	}
 	certPEM, chainPEM, keyData := s.provisioningSvc.ProvisioningCerts()
 	defer func() {
 		for i := range keyData {
@@ -525,8 +561,7 @@ func (s *CloudNotificationSender) CreateNotificationV2(
 	proofCtx, err := notificationDeviceProofContext(
 		ctx,
 		request,
-		orgID,
-		assetID,
+		certs.AssetURN(orgID, assetID),
 		time.Now().Unix(),
 		certPEM,
 		keyData,

--- a/go/internal/agent/services/notification_service_test.go
+++ b/go/internal/agent/services/notification_service_test.go
@@ -347,6 +347,12 @@ const deviceProofTestCertificateSerial = "01a2b3c4d5e6f708"
 // boundary to. Both are lowercase because Cloud's parser re-renders a parsed
 // uuid and compares, so an upper-case variant is rejected, not accepted as a
 // second spelling.
+// deviceProofV2FullMethod is Cloud's 2.0 verifier method name. It is defined
+// here rather than in the package because this agent does not invoke it: the
+// generated client calls wendycloud.v1, so v1 is what a device signs. It exists
+// so the fixture can pin the bytes Cloud will verify once wendyos migrates.
+const deviceProofV2FullMethod = "wendycloud.v2.NotificationService/CreateNotificationV2"
+
 const (
 	deviceProofTestAssetURI     = "urn:wendy:org:17:asset:42"
 	deviceProofTestAssetUUIDURI = "urn:wendy:org:13a72725-dfe3-4425-bd04-b253d2036089:asset:9f2c1d84-6b30-4e57-9a1e-2c7d5f08b413"
@@ -413,6 +419,7 @@ func TestNotificationDeviceProofRejectsMalformedProvisionedLeafCertificate(t *te
 			ctx, err := notificationDeviceProofContext(
 				context.Background(),
 				proofCloudNotificationRequest(),
+				deviceProofFullMethod,
 				deviceProofTestAssetURI,
 				1_753_267_200,
 				test.certPEM,
@@ -429,7 +436,7 @@ func TestNotificationDeviceProofRejectsMalformedProvisionedLeafCertificate(t *te
 func TestCanonicalNotificationDeviceProofRejectsNoncanonicalCertificateSerial(t *testing.T) {
 	for _, serial := range []string{"", "0", "00", "0001", "abc", "0ABC", "12-34", strings.Repeat("aa", 21)} {
 		t.Run(serial, func(t *testing.T) {
-			if _, _, _, err := canonicalNotificationDeviceProof(proofCloudNotificationRequest(), deviceProofTestAssetURI, serial, 1_753_267_200); err == nil {
+			if _, _, _, err := canonicalNotificationDeviceProof(proofCloudNotificationRequest(), deviceProofFullMethod, deviceProofTestAssetURI, serial, 1_753_267_200); err == nil {
 				t.Fatalf("certificate serial %q accepted", serial)
 			}
 		})
@@ -439,11 +446,11 @@ func TestCanonicalNotificationDeviceProofRejectsNoncanonicalCertificateSerial(t 
 func TestCanonicalNotificationDeviceProofIsDeterministic(t *testing.T) {
 	const timestamp = int64(1_753_267_200)
 	request := proofCloudNotificationRequest()
-	first, uri, timestampText, err := canonicalNotificationDeviceProof(request, deviceProofTestAssetURI, deviceProofTestCertificateSerial, timestamp)
+	first, uri, timestampText, err := canonicalNotificationDeviceProof(request, deviceProofFullMethod, deviceProofTestAssetURI, deviceProofTestCertificateSerial, timestamp)
 	if err != nil {
 		t.Fatalf("canonicalNotificationDeviceProof() error = %v", err)
 	}
-	second, _, _, err := canonicalNotificationDeviceProof(proto.Clone(request).(*cloudpb.CreateNotificationV2Request), deviceProofTestAssetURI, deviceProofTestCertificateSerial, timestamp)
+	second, _, _, err := canonicalNotificationDeviceProof(proto.Clone(request).(*cloudpb.CreateNotificationV2Request), deviceProofFullMethod, deviceProofTestAssetURI, deviceProofTestCertificateSerial, timestamp)
 	if err != nil {
 		t.Fatalf("second canonicalNotificationDeviceProof() error = %v", err)
 	}
@@ -460,23 +467,42 @@ func TestCanonicalNotificationDeviceProofIsDeterministic(t *testing.T) {
 	}
 }
 
-// deviceProofFixtureDigests is the cross-repo fixture. Cloud's
-// DeviceNotificationProofTests pins these same digests, copied from here, over
-// the same request, serial and timestamp. The preimage is signature input, so a
-// framing or spelling change made on one side only breaks every device proof in
-// the fleet; pinning it in both repos turns that into two red suites instead.
-var deviceProofFixtureDigests = map[string]string{
-	deviceProofTestAssetURI:     "438186e9443c54083a91beb6815bad1a7376c1c1f3e3ca9ec9c1cbe4fd85ec94",
-	deviceProofTestAssetUUIDURI: "97a79d97eb92ae3595b1c90bfa7d5d52097aa1e54982fc5483036dd05695cb7f",
+// deviceProofFixtures is the cross-repo pin. Cloud's DeviceNotificationProofTests
+// pins these same digests, copied from here, over the same request, serial and
+// timestamp. The preimage is signature input, so a framing or spelling change
+// made on one side only breaks every device proof in the fleet; pinning it in
+// both repos turns that into two red suites instead.
+var deviceProofFixtures = []struct {
+	name   string
+	method string
+	uri    string
+	digest string
+}{
+	// What a device signs today, and the check that no refactor moved the bytes.
+	{
+		name:   "v1 method and integer identity",
+		method: deviceProofFullMethod,
+		uri:    deviceProofTestAssetURI,
+		digest: "438186e9443c54083a91beb6815bad1a7376c1c1f3e3ca9ec9c1cbe4fd85ec94",
+	},
+	// What Cloud's 2.0 verifier expects. No device produces these bytes yet:
+	// this agent calls wendycloud.v1 and has no uuid identity to sign.
+	{
+		name:   "v2 method and uuid identity",
+		method: deviceProofV2FullMethod,
+		uri:    deviceProofTestAssetUUIDURI,
+		digest: "4dc7c616beb4cf9eea9467ada6fd464cfce45ef4f87473724a44ef8859ef779c",
+	},
 }
 
 func TestCanonicalNotificationDeviceProofMatchesCrossRepoFixture(t *testing.T) {
-	for uri, want := range deviceProofFixtureDigests {
-		t.Run(uri, func(t *testing.T) {
+	for _, fixture := range deviceProofFixtures {
+		t.Run(fixture.name, func(t *testing.T) {
 			canonical := mustCanonicalNotificationProof(
-				t, proofCloudNotificationRequest(), uri, deviceProofTestCertificateSerial, 1_753_267_200)
-			if got := hex.EncodeToString(sliceDigest(canonical)); got != want {
-				t.Fatalf("canonical proof SHA-256 for %s = %s, want fixture %s", uri, got, want)
+				t, proofCloudNotificationRequest(), fixture.method, fixture.uri,
+				deviceProofTestCertificateSerial, 1_753_267_200)
+			if got := hex.EncodeToString(sliceDigest(canonical)); got != fixture.digest {
+				t.Fatalf("canonical proof SHA-256 for %s = %s, want fixture %s", fixture.name, got, fixture.digest)
 			}
 		})
 	}
@@ -499,7 +525,7 @@ func TestCanonicalNotificationDeviceProofRejectsNoncanonicalIdentityURN(t *testi
 	} {
 		t.Run(uri, func(t *testing.T) {
 			if _, _, _, err := canonicalNotificationDeviceProof(
-				proofCloudNotificationRequest(), uri, deviceProofTestCertificateSerial, 1_753_267_200); err == nil {
+				proofCloudNotificationRequest(), deviceProofFullMethod, uri, deviceProofTestCertificateSerial, 1_753_267_200); err == nil {
 				t.Fatalf("non-canonical identity URN %q accepted", uri)
 			}
 		})
@@ -519,7 +545,7 @@ func TestNotificationDeviceProofSignatureAndTamperResistance(t *testing.T) {
 		deviceProofSignatureHeader, "forged",
 		"x-unrelated", "preserved",
 	))
-	ctx, err := notificationDeviceProofContext(baseCtx, request, deviceProofTestAssetURI, timestamp, certificatePEM, keyPEM, rand.Reader)
+	ctx, err := notificationDeviceProofContext(baseCtx, request, deviceProofFullMethod, deviceProofTestAssetURI, timestamp, certificatePEM, keyPEM, rand.Reader)
 	if err != nil {
 		t.Fatalf("notificationDeviceProofContext() error = %v", err)
 	}
@@ -547,7 +573,7 @@ func TestNotificationDeviceProofSignatureAndTamperResistance(t *testing.T) {
 	if err != nil {
 		t.Fatalf("decode signature: %v", err)
 	}
-	canonical, _, _, err := canonicalNotificationDeviceProof(request, deviceProofTestAssetURI, deviceProofTestCertificateSerial, timestamp)
+	canonical, _, _, err := canonicalNotificationDeviceProof(request, deviceProofFullMethod, deviceProofTestAssetURI, deviceProofTestCertificateSerial, timestamp)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -559,10 +585,10 @@ func TestNotificationDeviceProofSignatureAndTamperResistance(t *testing.T) {
 	tamperedRequest := proto.Clone(request).(*cloudpb.CreateNotificationV2Request)
 	tamperedRequest.Body = "different body"
 	for name, tamperedCanonical := range map[string][]byte{
-		"request":            mustCanonicalNotificationProof(t, tamperedRequest, deviceProofTestAssetURI, deviceProofTestCertificateSerial, timestamp),
-		"identity":           mustCanonicalNotificationProof(t, request, "urn:wendy:org:17:asset:43", deviceProofTestCertificateSerial, timestamp),
-		"certificate serial": mustCanonicalNotificationProof(t, request, deviceProofTestAssetURI, "b1b2c3d4e5f60718", timestamp),
-		"timestamp":          mustCanonicalNotificationProof(t, request, deviceProofTestAssetURI, deviceProofTestCertificateSerial, timestamp+1),
+		"request":            mustCanonicalNotificationProof(t, tamperedRequest, deviceProofFullMethod, deviceProofTestAssetURI, deviceProofTestCertificateSerial, timestamp),
+		"identity":           mustCanonicalNotificationProof(t, request, deviceProofFullMethod, "urn:wendy:org:17:asset:43", deviceProofTestCertificateSerial, timestamp),
+		"certificate serial": mustCanonicalNotificationProof(t, request, deviceProofFullMethod, deviceProofTestAssetURI, "b1b2c3d4e5f60718", timestamp),
+		"timestamp":          mustCanonicalNotificationProof(t, request, deviceProofFullMethod, deviceProofTestAssetURI, deviceProofTestCertificateSerial, timestamp+1),
 	} {
 		t.Run(name, func(t *testing.T) {
 			tamperedDigest := sha256.Sum256(tamperedCanonical)
@@ -576,12 +602,13 @@ func TestNotificationDeviceProofSignatureAndTamperResistance(t *testing.T) {
 func mustCanonicalNotificationProof(
 	t *testing.T,
 	request *cloudpb.CreateNotificationV2Request,
+	fullMethod string,
 	uri string,
 	certificateSerial string,
 	timestamp int64,
 ) []byte {
 	t.Helper()
-	canonical, _, _, err := canonicalNotificationDeviceProof(request, uri, certificateSerial, timestamp)
+	canonical, _, _, err := canonicalNotificationDeviceProof(request, fullMethod, uri, certificateSerial, timestamp)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/internal/agent/services/notification_service_test.go
+++ b/go/internal/agent/services/notification_service_test.go
@@ -342,6 +342,16 @@ func proofCloudNotificationRequest() *cloudpb.CreateNotificationV2Request {
 
 const deviceProofTestCertificateSerial = "01a2b3c4d5e6f708"
 
+// The two identity spellings the canonical preimage has to cover. The int URN is
+// what a device signs today; the UUID URN is the shape WDY-2808 moves every
+// boundary to. Both are lowercase because Cloud's parser re-renders a parsed
+// uuid and compares, so an upper-case variant is rejected, not accepted as a
+// second spelling.
+const (
+	deviceProofTestAssetURI     = "urn:wendy:org:17:asset:42"
+	deviceProofTestAssetUUIDURI = "urn:wendy:org:13a72725-dfe3-4425-bd04-b253d2036089:asset:9f2c1d84-6b30-4e57-9a1e-2c7d5f08b413"
+)
+
 func deviceProofTestKeyPEM(t *testing.T) (*ecdsa.PrivateKey, []byte) {
 	t.Helper()
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -403,8 +413,7 @@ func TestNotificationDeviceProofRejectsMalformedProvisionedLeafCertificate(t *te
 			ctx, err := notificationDeviceProofContext(
 				context.Background(),
 				proofCloudNotificationRequest(),
-				17,
-				42,
+				deviceProofTestAssetURI,
 				1_753_267_200,
 				test.certPEM,
 				keyPEM,
@@ -420,7 +429,7 @@ func TestNotificationDeviceProofRejectsMalformedProvisionedLeafCertificate(t *te
 func TestCanonicalNotificationDeviceProofRejectsNoncanonicalCertificateSerial(t *testing.T) {
 	for _, serial := range []string{"", "0", "00", "0001", "abc", "0ABC", "12-34", strings.Repeat("aa", 21)} {
 		t.Run(serial, func(t *testing.T) {
-			if _, _, _, err := canonicalNotificationDeviceProof(proofCloudNotificationRequest(), 17, 42, serial, 1_753_267_200); err == nil {
+			if _, _, _, err := canonicalNotificationDeviceProof(proofCloudNotificationRequest(), deviceProofTestAssetURI, serial, 1_753_267_200); err == nil {
 				t.Fatalf("certificate serial %q accepted", serial)
 			}
 		})
@@ -430,11 +439,11 @@ func TestCanonicalNotificationDeviceProofRejectsNoncanonicalCertificateSerial(t 
 func TestCanonicalNotificationDeviceProofIsDeterministic(t *testing.T) {
 	const timestamp = int64(1_753_267_200)
 	request := proofCloudNotificationRequest()
-	first, uri, timestampText, err := canonicalNotificationDeviceProof(request, 17, 42, deviceProofTestCertificateSerial, timestamp)
+	first, uri, timestampText, err := canonicalNotificationDeviceProof(request, deviceProofTestAssetURI, deviceProofTestCertificateSerial, timestamp)
 	if err != nil {
 		t.Fatalf("canonicalNotificationDeviceProof() error = %v", err)
 	}
-	second, _, _, err := canonicalNotificationDeviceProof(proto.Clone(request).(*cloudpb.CreateNotificationV2Request), 17, 42, deviceProofTestCertificateSerial, timestamp)
+	second, _, _, err := canonicalNotificationDeviceProof(proto.Clone(request).(*cloudpb.CreateNotificationV2Request), deviceProofTestAssetURI, deviceProofTestCertificateSerial, timestamp)
 	if err != nil {
 		t.Fatalf("second canonicalNotificationDeviceProof() error = %v", err)
 	}
@@ -449,9 +458,51 @@ func TestCanonicalNotificationDeviceProofIsDeterministic(t *testing.T) {
 	if !bytes.Equal(first, append([]byte(prefix), requestBytes...)) {
 		t.Fatal("canonical proof does not match the versioned NUL-framed contract")
 	}
-	digest := sha256.Sum256(first)
-	if got, want := hex.EncodeToString(digest[:]), "438186e9443c54083a91beb6815bad1a7376c1c1f3e3ca9ec9c1cbe4fd85ec94"; got != want {
-		t.Fatalf("canonical proof SHA-256 = %s, want fixture %s", got, want)
+}
+
+// deviceProofFixtureDigests is the cross-repo fixture. Cloud's
+// DeviceNotificationProofTests pins these same digests, copied from here, over
+// the same request, serial and timestamp. The preimage is signature input, so a
+// framing or spelling change made on one side only breaks every device proof in
+// the fleet; pinning it in both repos turns that into two red suites instead.
+var deviceProofFixtureDigests = map[string]string{
+	deviceProofTestAssetURI:     "438186e9443c54083a91beb6815bad1a7376c1c1f3e3ca9ec9c1cbe4fd85ec94",
+	deviceProofTestAssetUUIDURI: "97a79d97eb92ae3595b1c90bfa7d5d52097aa1e54982fc5483036dd05695cb7f",
+}
+
+func TestCanonicalNotificationDeviceProofMatchesCrossRepoFixture(t *testing.T) {
+	for uri, want := range deviceProofFixtureDigests {
+		t.Run(uri, func(t *testing.T) {
+			canonical := mustCanonicalNotificationProof(
+				t, proofCloudNotificationRequest(), uri, deviceProofTestCertificateSerial, 1_753_267_200)
+			if got := hex.EncodeToString(sliceDigest(canonical)); got != want {
+				t.Fatalf("canonical proof SHA-256 for %s = %s, want fixture %s", uri, got, want)
+			}
+		})
+	}
+}
+
+func sliceDigest(data []byte) []byte {
+	digest := sha256.Sum256(data)
+	return digest[:]
+}
+
+func TestCanonicalNotificationDeviceProofRejectsNoncanonicalIdentityURN(t *testing.T) {
+	for _, uri := range []string{
+		"",
+		"urn:wendy:org:17:asset:",
+		"spiffe://wendy.sh/tenant/x/service/asset-42",
+		"urn:wendy:org:13A72725-DFE3-4425-BD04-B253D2036089:asset:42",
+		"urn:wendy:org:17:asset:42\x00urn:wendy:org:1:asset:1",
+		"urn:wendy:org:17:asset: 42",
+		"urn:wendy:org:" + strings.Repeat("a", 256),
+	} {
+		t.Run(uri, func(t *testing.T) {
+			if _, _, _, err := canonicalNotificationDeviceProof(
+				proofCloudNotificationRequest(), uri, deviceProofTestCertificateSerial, 1_753_267_200); err == nil {
+				t.Fatalf("non-canonical identity URN %q accepted", uri)
+			}
+		})
 	}
 }
 
@@ -468,7 +519,7 @@ func TestNotificationDeviceProofSignatureAndTamperResistance(t *testing.T) {
 		deviceProofSignatureHeader, "forged",
 		"x-unrelated", "preserved",
 	))
-	ctx, err := notificationDeviceProofContext(baseCtx, request, 17, 42, timestamp, certificatePEM, keyPEM, rand.Reader)
+	ctx, err := notificationDeviceProofContext(baseCtx, request, deviceProofTestAssetURI, timestamp, certificatePEM, keyPEM, rand.Reader)
 	if err != nil {
 		t.Fatalf("notificationDeviceProofContext() error = %v", err)
 	}
@@ -496,7 +547,7 @@ func TestNotificationDeviceProofSignatureAndTamperResistance(t *testing.T) {
 	if err != nil {
 		t.Fatalf("decode signature: %v", err)
 	}
-	canonical, _, _, err := canonicalNotificationDeviceProof(request, 17, 42, deviceProofTestCertificateSerial, timestamp)
+	canonical, _, _, err := canonicalNotificationDeviceProof(request, deviceProofTestAssetURI, deviceProofTestCertificateSerial, timestamp)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -508,10 +559,10 @@ func TestNotificationDeviceProofSignatureAndTamperResistance(t *testing.T) {
 	tamperedRequest := proto.Clone(request).(*cloudpb.CreateNotificationV2Request)
 	tamperedRequest.Body = "different body"
 	for name, tamperedCanonical := range map[string][]byte{
-		"request":            mustCanonicalNotificationProof(t, tamperedRequest, 17, 42, deviceProofTestCertificateSerial, timestamp),
-		"identity":           mustCanonicalNotificationProof(t, request, 17, 43, deviceProofTestCertificateSerial, timestamp),
-		"certificate serial": mustCanonicalNotificationProof(t, request, 17, 42, "b1b2c3d4e5f60718", timestamp),
-		"timestamp":          mustCanonicalNotificationProof(t, request, 17, 42, deviceProofTestCertificateSerial, timestamp+1),
+		"request":            mustCanonicalNotificationProof(t, tamperedRequest, deviceProofTestAssetURI, deviceProofTestCertificateSerial, timestamp),
+		"identity":           mustCanonicalNotificationProof(t, request, "urn:wendy:org:17:asset:43", deviceProofTestCertificateSerial, timestamp),
+		"certificate serial": mustCanonicalNotificationProof(t, request, deviceProofTestAssetURI, "b1b2c3d4e5f60718", timestamp),
+		"timestamp":          mustCanonicalNotificationProof(t, request, deviceProofTestAssetURI, deviceProofTestCertificateSerial, timestamp+1),
 	} {
 		t.Run(name, func(t *testing.T) {
 			tamperedDigest := sha256.Sum256(tamperedCanonical)
@@ -525,12 +576,12 @@ func TestNotificationDeviceProofSignatureAndTamperResistance(t *testing.T) {
 func mustCanonicalNotificationProof(
 	t *testing.T,
 	request *cloudpb.CreateNotificationV2Request,
-	orgID, assetID int32,
+	uri string,
 	certificateSerial string,
 	timestamp int64,
 ) []byte {
 	t.Helper()
-	canonical, _, _, err := canonicalNotificationDeviceProof(request, orgID, assetID, certificateSerial, timestamp)
+	canonical, _, _, err := canonicalNotificationDeviceProof(request, uri, certificateSerial, timestamp)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -493,6 +493,10 @@ type VideoService struct {
 	globDevices     func() ([]string, error)
 	readDeviceName  func(base string) (string, error)
 	hasVideoCapture func(path string) bool
+	// readStableNames returns the udev by-id / by-path names keyed by resolved
+	// device path. Injectable so the enumeration can be tested without
+	// /dev/v4l. See video_stable_id.go for why these exist.
+	readStableNames func() map[string]stableNames
 
 	// Network camera state. registry and credentials are nil-safe throughout: a
 	// device that has never seen a network camera behaves exactly as before.
@@ -564,6 +568,9 @@ func NewVideoService(ctx context.Context, logger *zap.Logger, rosRuntime ...ROS2
 			var cap v4l2Capability
 			_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), vidiocQueryCap, uintptr(unsafe.Pointer(&cap)))
 			return errno == 0 && cap.hasVideoCapture()
+		},
+		readStableNames: func() map[string]stableNames {
+			return readStableNames(v4lByIDDir, v4lByPathDir)
 		},
 		classifyTransport:  camera.Classify,
 		enumerateLibcamera: camera.EnumerateLibcamera,
@@ -714,6 +721,13 @@ func (s *VideoService) listCameras(ctx context.Context) ([]*agentpb.VideoDevice,
 		// Enumeration errors are non-fatal — we just lose the libcamera id enrichment.
 		s.logger.Debug("libcamera enumeration failed", zap.Error(libErr))
 	}
+	// Read once for the whole listing rather than per device: it is two
+	// directory walks, and a camera appearing or vanishing midway through would
+	// otherwise give some entries an identity and not others.
+	stable := map[string]stableNames{}
+	if s.readStableNames != nil {
+		stable = s.readStableNames()
+	}
 	var (
 		devices       []*agentpb.VideoDevice
 		csiDeviceIdxs []int
@@ -752,6 +766,13 @@ func (s *VideoService) listCameras(ctx context.Context) ([]*agentpb.VideoDevice,
 			Path:      path,
 			Transport: transportToProto(transport),
 			Driver:    driver,
+		}
+		// Empty for a camera with no /dev/v4l entry, which is not an error --
+		// the numeric id still addresses it, it is just not stable across a
+		// reboot.
+		if n, ok := stable[path]; ok {
+			dev.ById = n.byID
+			dev.ByPath = n.byPath
 		}
 		if transport == camera.TransportCSI {
 			csiDeviceIdxs = append(csiDeviceIdxs, len(devices))
@@ -1396,11 +1417,59 @@ func validateStreamParams(devicePath string, req *agentpb.StreamVideoRequest) er
 	return nil
 }
 
+// streamDeviceID picks the camera this request names.
+//
+// `device_by_id` wins over `device_id` when set, and is resolved HERE -- at
+// request time -- rather than by whoever wrote the config. That is the whole
+// point of the field: /dev/videoN is assigned in enumeration order at boot, so
+// a number written down yesterday may name a different camera today.
+//
+// A name that matches nothing is an error, deliberately. Falling back to
+// `device_id` would stream whatever the kernel happened to put at that number,
+// which is exactly the silent wrong-camera failure this field exists to
+// remove: opening the wrong camera succeeds, so nobody finds out. An error the
+// caller can retry and log beats a plausible picture of the wrong thing.
+func (s *VideoService) streamDeviceID(req *agentpb.StreamVideoRequest) (uint32, error) {
+	byID := strings.TrimSpace(req.GetDeviceById())
+	if byID == "" {
+		return req.GetDeviceId(), nil
+	}
+	if s.readStableNames == nil {
+		return 0, status.Errorf(codes.Unimplemented,
+			"device_by_id is not supported on this agent")
+	}
+	names := s.readStableNames()
+	devID, ok := resolveByID(names, byID)
+	if !ok {
+		return 0, status.Errorf(codes.NotFound,
+			"no camera with by-id %q; ListVideoDevices reports %v",
+			byID, knownByIDs(names))
+	}
+	return devID, nil
+}
+
+// knownByIDs lists the by-id names the agent can currently see, for the error
+// above. A caller that got the name wrong needs to see the real ones, and the
+// alternative is reading agent logs on a device they may not have.
+func knownByIDs(names map[string]stableNames) []string {
+	out := make([]string, 0, len(names))
+	for _, n := range names {
+		if n.byID != "" {
+			out = append(out, n.byID)
+		}
+	}
+	slices.Sort(out)
+	return out
+}
+
 // StreamVideo streams H.264 frames from a V4L2 camera.
 // Multiple concurrent callers for the same device share one producer via a deviceHub.
 func (s *VideoService) StreamVideo(req *agentpb.StreamVideoRequest, stream grpc.ServerStreamingServer[agentpb.VideoFrame]) error {
 	ctx := stream.Context()
-	devID := req.GetDeviceId()
+	devID, err := s.streamDeviceID(req)
+	if err != nil {
+		return err
+	}
 	if devID > maxVideoDeviceID {
 		return status.Errorf(codes.InvalidArgument, "device ID out of range")
 	}

--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -881,10 +881,7 @@ func (s *VideoService) listCameras(ctx context.Context) ([]*agentpb.VideoDevice,
 		// Empty for a camera with no /dev/v4l entry, which is not an error --
 		// the numeric id still addresses it, it is just not stable across a
 		// reboot.
-		if n, ok := stable[path]; ok {
-			dev.ById = n.byID
-			dev.ByPath = n.byPath
-		}
+		dev.StableId = stable[path].stableID()
 		if transport == camera.TransportCSI {
 			csiDeviceIdxs = append(csiDeviceIdxs, len(devices))
 		}
@@ -1564,7 +1561,7 @@ func validateStreamParams(devicePath string, req *agentpb.StreamVideoRequest) er
 
 // streamDeviceID picks the camera this request names.
 //
-// `device_by_id` wins over `device_id` when set, and is resolved HERE -- at
+// `stable_id` wins over `device_id` when set, and is resolved HERE -- at
 // request time -- rather than by whoever wrote the config. That is the whole
 // point of the field: /dev/videoN is assigned in enumeration order at boot, so
 // a number written down yesterday may name a different camera today.
@@ -1575,32 +1572,32 @@ func validateStreamParams(devicePath string, req *agentpb.StreamVideoRequest) er
 // remove: opening the wrong camera succeeds, so nobody finds out. An error the
 // caller can retry and log beats a plausible picture of the wrong thing.
 func (s *VideoService) streamDeviceID(req *agentpb.StreamVideoRequest) (uint32, error) {
-	byID := strings.TrimSpace(req.GetDeviceById())
-	if byID == "" {
+	stableID := strings.TrimSpace(req.GetStableId())
+	if stableID == "" {
 		return req.GetDeviceId(), nil
 	}
 	if s.readStableNames == nil {
 		return 0, status.Errorf(codes.Unimplemented,
-			"device_by_id is not supported on this agent")
+			"stable_id is not supported on this agent")
 	}
 	names := s.readStableNames()
-	devID, ok := resolveByID(names, byID)
+	devID, ok := resolveStableID(names, stableID)
 	if !ok {
 		return 0, status.Errorf(codes.NotFound,
-			"no camera with by-id %q; ListVideoDevices reports %v",
-			byID, knownByIDs(names))
+			"no camera with stable id %q; ListVideoDevices reports %v",
+			stableID, knownStableIDs(names))
 	}
 	return devID, nil
 }
 
-// knownByIDs lists the by-id names the agent can currently see, for the error
-// above. A caller that got the name wrong needs to see the real ones, and the
-// alternative is reading agent logs on a device they may not have.
-func knownByIDs(names map[string]stableNames) []string {
+// knownStableIDs lists the identities the agent can currently see, for the
+// error above. A caller that got the name wrong needs to see the real ones, and
+// the alternative is reading agent logs on a device they may not have.
+func knownStableIDs(names map[string]stableNames) []string {
 	out := make([]string, 0, len(names))
 	for _, n := range names {
-		if n.byID != "" {
-			out = append(out, n.byID)
+		if id := n.stableID(); id != "" {
+			out = append(out, id)
 		}
 	}
 	slices.Sort(out)

--- a/go/internal/agent/services/video_service_test.go
+++ b/go/internal/agent/services/video_service_test.go
@@ -58,6 +58,9 @@ func newTestVideoService(glob func() ([]string, error), readName func(string) (s
 	svc.enumerateLibcamera = func(context.Context) (map[string]string, error) { return nil, nil }
 	svc.isJetson = func() bool { return false }
 	svc.findCameraSource = func(context.Context, string) (uint64, bool) { return 0, false }
+	// Keep enumeration off the host's real /dev/v4l; tests that care about
+	// stable identity override this.
+	svc.readStableNames = func() map[string]stableNames { return nil }
 	return svc
 }
 

--- a/go/internal/agent/services/video_stable_id.go
+++ b/go/internal/agent/services/video_stable_id.go
@@ -10,20 +10,22 @@ package services
 // `name` and `driver` cannot rescue that: they identify the model, so two
 // cameras of the same type are indistinguishable.
 //
-// udev already publishes two stable names per node, and they trade off
-// differently:
+// udev publishes two stable names per node, and they are not equally durable:
 //
 //	/dev/v4l/by-id/    vendor + product + serial   survives a reboot AND a move
-//	                                               to another port; collides for
-//	                                               two same-model cameras whose
-//	                                               serial is a factory default
+//	                                               to another port
 //	/dev/v4l/by-path/  the USB port topology       survives a reboot but NOT a
-//	                                               move; the only thing that
-//	                                               separates identical cameras
+//	                                               move
 //
-// Both are reported so a caller can choose the property it needs. Only by-id is
-// resolvable in StreamVideo, because pinning a stream to a physical port is a
-// decision a caller should make deliberately rather than inherit.
+// A camera gets ONE identity, not two: by-id where udev has one, by-path only
+// where it does not. That case is real rather than theoretical -- two
+// same-model cameras sharing a factory serial produce the same by-id name, so
+// only one link exists and the camera that loses it has nothing else that tells
+// it apart from its twin.
+//
+// The value carries the scheme it came from ("by-id:" / "by-path:") so a
+// caller can see which of the two durability guarantees it actually holds,
+// rather than having to know how udev names things.
 
 import (
 	"fmt"
@@ -36,6 +38,11 @@ import (
 const (
 	v4lByIDDir   = "/dev/v4l/by-id"
 	v4lByPathDir = "/dev/v4l/by-path"
+
+	// Scheme tags on the reported identity, so a caller can see which
+	// durability guarantee it holds without knowing how udev names things.
+	schemeByID   = "by-id"
+	schemeByPath = "by-path"
 )
 
 // stableNames holds the udev names for one /dev/videoN node. Either may be
@@ -44,6 +51,19 @@ const (
 type stableNames struct {
 	byID   string
 	byPath string
+}
+
+// stableID is the single identity reported for a node: the by-id name when
+// there is one, the port otherwise, empty when udev knows neither.
+func (n stableNames) stableID() string {
+	switch {
+	case n.byID != "":
+		return schemeByID + ":" + n.byID
+	case n.byPath != "":
+		return schemeByPath + ":" + n.byPath
+	default:
+		return ""
+	}
 }
 
 // readStableNames maps a resolved device path ("/dev/video2") to its udev
@@ -95,20 +115,37 @@ func firstNamePerDevice(dir string) map[string]string {
 	return out
 }
 
-// resolveByID returns the /dev/videoN number for a by-id name, or false.
+// resolveStableID returns the /dev/videoN number for a scheme-tagged stable id,
+// or false.
+//
+// A "by-path:" name resolves even for a camera whose reported identity is its
+// by-id: asking to stream from a physical port is legitimate, it just has to be
+// asked for. Inheriting it from a listing is what we avoid.
 //
 // The match is exact. A substring or prefix rule would be friendlier to type
 // and is precisely the wrong trade here: "usb-Acme_Camera_SN1" would match both
 // "...SN1-video-index0" and "...SN10-video-index0", and the caller would get
 // one of them with no indication that the name was ambiguous. An exact name is
 // something ListVideoDevices already hands you.
-func resolveByID(names map[string]stableNames, byID string) (uint32, bool) {
-	want := strings.TrimSpace(byID)
-	if want == "" {
+func resolveStableID(names map[string]stableNames, stableID string) (uint32, bool) {
+	scheme, want, tagged := strings.Cut(strings.TrimSpace(stableID), ":")
+	if !tagged || want == "" {
+		return 0, false
+	}
+	// An untagged or unknown scheme is not an identity this API ever handed
+	// out. Guessing which of the two was meant is how a name for one camera
+	// quietly resolves to another.
+	var pick func(stableNames) string
+	switch scheme {
+	case schemeByID:
+		pick = func(n stableNames) string { return n.byID }
+	case schemeByPath:
+		pick = func(n stableNames) string { return n.byPath }
+	default:
 		return 0, false
 	}
 	for devPath, n := range names {
-		if n.byID != want {
+		if pick(n) != want {
 			continue
 		}
 		num, err := deviceNumber(devPath)

--- a/go/internal/agent/services/video_stable_id.go
+++ b/go/internal/agent/services/video_stable_id.go
@@ -1,0 +1,132 @@
+package services
+
+// Stable identity for local V4L2 cameras.
+//
+// A camera's /dev/videoN number is assigned in enumeration order at boot, so it
+// belongs to the boot rather than to the camera: a reboot or a replug can
+// renumber the nodes. A caller that pinned a number then addresses whatever the
+// kernel put there instead -- and because opening the wrong camera SUCCEEDS, it
+// streams a valid picture from the wrong sensor and reports no error at all.
+// `name` and `driver` cannot rescue that: they identify the model, so two
+// cameras of the same type are indistinguishable.
+//
+// udev already publishes two stable names per node, and they trade off
+// differently:
+//
+//	/dev/v4l/by-id/    vendor + product + serial   survives a reboot AND a move
+//	                                               to another port; collides for
+//	                                               two same-model cameras whose
+//	                                               serial is a factory default
+//	/dev/v4l/by-path/  the USB port topology       survives a reboot but NOT a
+//	                                               move; the only thing that
+//	                                               separates identical cameras
+//
+// Both are reported so a caller can choose the property it needs. Only by-id is
+// resolvable in StreamVideo, because pinning a stream to a physical port is a
+// decision a caller should make deliberately rather than inherit.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const (
+	v4lByIDDir   = "/dev/v4l/by-id"
+	v4lByPathDir = "/dev/v4l/by-path"
+)
+
+// stableNames holds the udev names for one /dev/videoN node. Either may be
+// empty: CSI and network cameras have no /dev/v4l entry, and a kernel without
+// the udev rules has neither directory.
+type stableNames struct {
+	byID   string
+	byPath string
+}
+
+// readStableNames maps a resolved device path ("/dev/video2") to its udev
+// names.
+//
+// A missing directory is NOT an error. Plenty of devices have no /dev/v4l at
+// all, and losing the enrichment is strictly better than failing enumeration --
+// the numbers still work, they are simply not stable.
+func readStableNames(byIDDir, byPathDir string) map[string]stableNames {
+	out := map[string]stableNames{}
+	for dev, name := range firstNamePerDevice(byIDDir) {
+		n := out[dev]
+		n.byID = name
+		out[dev] = n
+	}
+	for dev, name := range firstNamePerDevice(byPathDir) {
+		n := out[dev]
+		n.byPath = name
+		out[dev] = n
+	}
+	return out
+}
+
+// firstNamePerDevice resolves every symlink in dir and records its basename
+// against the device node it points at.
+//
+// Entries are skipped rather than fatal: one dangling symlink must not cost
+// every other camera its identity. os.ReadDir returns sorted entries, so where
+// two names somehow reach the same node the winner is deterministic.
+func firstNamePerDevice(dir string) map[string]string {
+	out := map[string]string{}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return out
+	}
+	for _, e := range entries {
+		target, err := filepath.EvalSymlinks(filepath.Join(dir, e.Name()))
+		if err != nil {
+			continue
+		}
+		if !strings.HasPrefix(filepath.Base(target), "video") {
+			continue
+		}
+		if _, seen := out[target]; seen {
+			continue
+		}
+		out[target] = e.Name()
+	}
+	return out
+}
+
+// resolveByID returns the /dev/videoN number for a by-id name, or false.
+//
+// The match is exact. A substring or prefix rule would be friendlier to type
+// and is precisely the wrong trade here: "usb-Acme_Camera_SN1" would match both
+// "...SN1-video-index0" and "...SN10-video-index0", and the caller would get
+// one of them with no indication that the name was ambiguous. An exact name is
+// something ListVideoDevices already hands you.
+func resolveByID(names map[string]stableNames, byID string) (uint32, bool) {
+	want := strings.TrimSpace(byID)
+	if want == "" {
+		return 0, false
+	}
+	for devPath, n := range names {
+		if n.byID != want {
+			continue
+		}
+		num, err := deviceNumber(devPath)
+		if err != nil {
+			return 0, false
+		}
+		return num, true
+	}
+	return 0, false
+}
+
+// deviceNumber extracts N from a "/dev/videoN" path. Same parse listCameras
+// does on the glob results, kept here so the two cannot drift.
+func deviceNumber(devPath string) (uint32, error) {
+	base := filepath.Base(devPath)
+	n, err := strconv.ParseUint(strings.TrimPrefix(base, "video"), 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("not a video device path: %q", devPath)
+	}
+	return uint32(n), nil
+}

--- a/go/internal/agent/services/video_stable_id_test.go
+++ b/go/internal/agent/services/video_stable_id_test.go
@@ -102,9 +102,13 @@ func TestByIDSurvivesTheEnumerationSwap(t *testing.T) {
 	}
 }
 
-func TestByPathIsReportedSeparately(t *testing.T) {
-	// by-path is the only thing that separates two same-model cameras whose
-	// serial is a factory default, so it must not be conflated with by-id.
+func TestByPathIsTheFallbackNotASecondIdentity(t *testing.T) {
+	// A camera with both names reports one identity, the by-id one: it is the
+	// name that survives a move to another port. The port name only becomes
+	// the identity when there is no by-id link -- the two-same-model-cameras
+	// case, where udev publishes a single colliding by-id link and the camera
+	// that loses it has nothing else to tell it apart from its twin.
+	const portName = "platform-xhci-hcd.0-usb-0:2.3:1.0-video-index0"
 	root := t.TempDir()
 	devDir, byIDDir, byPathDir := filepath.Join(root, "dev"),
 		filepath.Join(root, "by-id"), filepath.Join(root, "by-path")
@@ -113,24 +117,36 @@ func TestByPathIsReportedSeparately(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	node := filepath.Join(devDir, "video2")
-	if err := os.WriteFile(node, nil, 0o644); err != nil {
-		t.Fatal(err)
+	mkNode := func(name string) string {
+		node := filepath.Join(devDir, name)
+		if err := os.WriteFile(node, nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return node
 	}
-	if err := os.Symlink(node, filepath.Join(byIDDir, arducamByID)); err != nil {
-		t.Fatal(err)
+	link := func(dir, name, node string) {
+		if err := os.Symlink(node, filepath.Join(dir, name)); err != nil {
+			t.Fatal(err)
+		}
 	}
-	const portName = "platform-xhci-hcd.0-usb-0:2.3:1.0-video-index0"
-	if err := os.Symlink(node, filepath.Join(byPathDir, portName)); err != nil {
-		t.Fatal(err)
-	}
+	// video2 has both names; video3 is the twin that lost the by-id link.
+	both, portOnly := mkNode("video2"), mkNode("video3")
+	link(byIDDir, arducamByID, both)
+	link(byPathDir, portName, both)
+	link(byPathDir, "platform-xhci-hcd.0-usb-0:2.4:1.0-video-index0", portOnly)
 
-	got := readStableNames(byIDDir, byPathDir)[resolved(t, node)]
-	if got.byID != arducamByID {
-		t.Errorf("byID = %q, want %q", got.byID, arducamByID)
+	names := readStableNames(byIDDir, byPathDir)
+	if got, want := names[resolved(t, both)].stableID(), "by-id:"+arducamByID; got != want {
+		t.Errorf("stableID = %q, want %q", got, want)
 	}
-	if got.byPath != portName {
-		t.Errorf("byPath = %q, want %q", got.byPath, portName)
+	if got, want := names[resolved(t, portOnly)].stableID(),
+		"by-path:platform-xhci-hcd.0-usb-0:2.4:1.0-video-index0"; got != want {
+		t.Errorf("camera with no by-id: stableID = %q, want %q", got, want)
+	}
+	// Both names still resolve for the camera that has both: pinning to a port
+	// is allowed when it is asked for explicitly.
+	if got, ok := resolveStableID(names, "by-path:"+portName); !ok || got != 2 {
+		t.Errorf("explicit by-path resolved to (%d, %v), want (2, true)", got, ok)
 	}
 }
 
@@ -154,7 +170,7 @@ func TestDanglingSymlinkDoesNotCostTheOthers(t *testing.T) {
 	}
 }
 
-func TestResolveByIDIsExactNotPrefix(t *testing.T) {
+func TestResolveStableIDIsExactNotPrefix(t *testing.T) {
 	// A prefix rule would make "…_SN1-video-index0" match "…_SN10-video-index0"
 	// and hand back one of them silently -- the same class of wrong-camera bug
 	// this whole change exists to remove.
@@ -162,22 +178,44 @@ func TestResolveByIDIsExactNotPrefix(t *testing.T) {
 		"/dev/video0": {byID: "usb-Acme_Cam_SN1-video-index0"},
 		"/dev/video2": {byID: "usb-Acme_Cam_SN10-video-index0"},
 	}
-	got, ok := resolveByID(names, "usb-Acme_Cam_SN1-video-index0")
+	got, ok := resolveStableID(names, "by-id:usb-Acme_Cam_SN1-video-index0")
 	if !ok || got != 0 {
 		t.Fatalf("exact name resolved to (%d, %v), want (0, true)", got, ok)
 	}
-	if _, ok := resolveByID(names, "usb-Acme_Cam_SN"); ok {
+	if _, ok := resolveStableID(names, "by-id:usb-Acme_Cam_SN"); ok {
 		t.Error("a prefix matched; resolution must be exact")
 	}
-	if _, ok := resolveByID(names, ""); ok {
+	if _, ok := resolveStableID(names, ""); ok {
 		t.Error("an empty name matched")
 	}
 }
 
-func TestResolveByIDReportsNoMatch(t *testing.T) {
+func TestResolveStableIDRequiresItsScheme(t *testing.T) {
+	// The tag is not decoration. An untagged name would have to be guessed
+	// against both namespaces, which is how a name meant for one camera
+	// quietly resolves to another.
+	names := map[string]stableNames{
+		"/dev/video0": {byID: topdonByID, byPath: "platform-xhci-hcd.0-usb-0:2.1:1.0-video-index0"},
+	}
+	for _, want := range []string{topdonByID, "by-serial:" + topdonByID, "by-id:", "by-path:"} {
+		if _, ok := resolveStableID(names, want); ok {
+			t.Errorf("%q resolved; only a tagged, non-empty name may", want)
+		}
+	}
+	if _, ok := resolveStableID(names, "by-id:"+topdonByID); !ok {
+		t.Error("the tagged name did not resolve")
+	}
+}
+
+func TestResolveStableIDReportsNoMatch(t *testing.T) {
 	names := map[string]stableNames{"/dev/video0": {byID: topdonByID}}
-	if _, ok := resolveByID(names, arducamByID); ok {
+	if _, ok := resolveStableID(names, "by-id:"+arducamByID); ok {
 		t.Error("an absent camera resolved; the caller must be able to refuse")
+	}
+	// A by-path name for a camera that only has a by-id must not fall through
+	// to it: they are different guarantees.
+	if _, ok := resolveStableID(names, "by-path:platform-xhci-hcd.0-usb-0:2.1:1.0-video-index0"); ok {
+		t.Error("a by-path name matched a camera that has no by-path")
 	}
 }
 
@@ -191,7 +229,8 @@ func TestListCamerasReportsStableIdentity(t *testing.T) {
 	svc.readStableNames = func() map[string]stableNames {
 		return map[string]stableNames{
 			"/dev/video0": {byID: topdonByID, byPath: "platform-xhci-hcd.0-usb-0:2.1:1.0-video-index0"},
-			"/dev/video2": {byID: arducamByID, byPath: "platform-xhci-hcd.0-usb-0:2.3:1.0-video-index0"},
+			// No by-id: the identity falls back to the port.
+			"/dev/video2": {byPath: "platform-xhci-hcd.0-usb-0:2.3:1.0-video-index0"},
 		}
 	}
 	devices, err := svc.listCameras(context.Background())
@@ -200,16 +239,13 @@ func TestListCamerasReportsStableIdentity(t *testing.T) {
 	}
 	got := map[uint32]string{}
 	for _, d := range devices {
-		got[d.GetId()] = d.GetById()
-		if d.GetByPath() == "" {
-			t.Errorf("device %d reported no by-path", d.GetId())
-		}
+		got[d.GetId()] = d.GetStableId()
 	}
-	if got[0] != topdonByID {
-		t.Errorf("video0 by-id = %q, want %q", got[0], topdonByID)
+	if want := "by-id:" + topdonByID; got[0] != want {
+		t.Errorf("video0 stable id = %q, want %q", got[0], want)
 	}
-	if got[2] != arducamByID {
-		t.Errorf("video2 by-id = %q, want %q", got[2], arducamByID)
+	if want := "by-path:platform-xhci-hcd.0-usb-0:2.3:1.0-video-index0"; got[2] != want {
+		t.Errorf("video2 stable id = %q, want %q", got[2], want)
 	}
 }
 
@@ -227,9 +263,8 @@ func TestListCamerasWithoutStableNamesIsUnchanged(t *testing.T) {
 	if len(devices) != 1 {
 		t.Fatalf("got %d devices, want 1", len(devices))
 	}
-	if devices[0].GetById() != "" || devices[0].GetByPath() != "" {
-		t.Errorf("identity invented from nothing: by-id %q by-path %q",
-			devices[0].GetById(), devices[0].GetByPath())
+	if devices[0].GetStableId() != "" {
+		t.Errorf("identity invented from nothing: %q", devices[0].GetStableId())
 	}
 	if devices[0].GetId() != 0 || devices[0].GetName() != "USB Camera" {
 		t.Errorf("existing fields changed: %+v", devices[0])
@@ -247,8 +282,8 @@ func TestStreamDeviceIDPrefersTheName(t *testing.T) {
 		}
 	}
 	got, err := svc.streamDeviceID(&agentpb.StreamVideoRequest{
-		DeviceId:   0,
-		DeviceById: arducamByID,
+		DeviceId: 0,
+		StableId: "by-id:" + arducamByID,
 	})
 	if err != nil {
 		t.Fatalf("streamDeviceID: %v", err)
@@ -266,8 +301,8 @@ func TestStreamDeviceIDRefusesAnUnknownName(t *testing.T) {
 		return map[string]stableNames{"/dev/video0": {byID: topdonByID}}
 	}
 	_, err := svc.streamDeviceID(&agentpb.StreamVideoRequest{
-		DeviceId:   0,
-		DeviceById: arducamByID,
+		DeviceId: 0,
+		StableId: "by-id:" + arducamByID,
 	})
 	if err == nil {
 		t.Fatal("an absent camera resolved; it must refuse rather than fall back")

--- a/go/internal/agent/services/video_stable_id_test.go
+++ b/go/internal/agent/services/video_stable_id_test.go
@@ -1,0 +1,294 @@
+package services
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+// The incident these tests exist for: a reboot re-ordered USB enumeration on a
+// two-camera device, so every config that had pinned /dev/videoN was addressing
+// the other camera. It went unnoticed for hours because opening the wrong
+// camera SUCCEEDS -- the tile showed a real picture, from the wrong sensor, and
+// nothing anywhere reported an error.
+//
+//	before   Arducam video0,1,2,3   TC001 video4,5
+//	after    Arducam video2,3,4,5   TC001 video0,1
+//
+// The names are the real ones from that device.
+const (
+	arducamByID = "usb-Arducam_Technology_Co.__Ltd._USB_2.0_Camera_SN0001-video-index0"
+	topdonByID  = "usb-Camera_USB_Camera_EA6913883-video-index0"
+)
+
+// fakeV4L builds a /dev/v4l-shaped tree: real files standing in for device
+// nodes, and a by-id directory of symlinks pointing at them.
+func fakeV4L(t *testing.T, links map[string]string) (byIDDir string, devDir string) {
+	t.Helper()
+	root := t.TempDir()
+	devDir = filepath.Join(root, "dev")
+	byIDDir = filepath.Join(root, "by-id")
+	for _, d := range []string{devDir, byIDDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for name, node := range links {
+		nodePath := filepath.Join(devDir, node)
+		if err := os.WriteFile(nodePath, nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(nodePath, filepath.Join(byIDDir, name)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return byIDDir, devDir
+}
+
+// resolved matches what readStableNames keys on: EvalSymlinks returns the real
+// path, and on macOS /var and /tmp are themselves symlinks.
+func resolved(t *testing.T, p string) string {
+	t.Helper()
+	r, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r
+}
+
+func TestByIDSurvivesTheEnumerationSwap(t *testing.T) {
+	// The same two cameras, before and after the reboot that swapped them.
+	cases := []struct {
+		label           string
+		links           map[string]string
+		arducam, topdon string
+	}{
+		{
+			label:   "before reboot",
+			links:   map[string]string{arducamByID: "video0", topdonByID: "video4"},
+			arducam: "video0", topdon: "video4",
+		},
+		{
+			label:   "after reboot",
+			links:   map[string]string{arducamByID: "video2", topdonByID: "video0"},
+			arducam: "video2", topdon: "video0",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			byIDDir, devDir := fakeV4L(t, tc.links)
+			names := readStableNames(byIDDir, filepath.Join(byIDDir, "absent"))
+
+			for _, want := range []struct {
+				byID, node string
+			}{{arducamByID, tc.arducam}, {topdonByID, tc.topdon}} {
+				got, ok := names[resolved(t, filepath.Join(devDir, want.node))]
+				if !ok {
+					t.Fatalf("%s: no entry for %s", tc.label, want.node)
+				}
+				if got.byID != want.byID {
+					t.Errorf("%s: %s -> by-id %q, want %q",
+						tc.label, want.node, got.byID, want.byID)
+				}
+			}
+		})
+	}
+}
+
+func TestByPathIsReportedSeparately(t *testing.T) {
+	// by-path is the only thing that separates two same-model cameras whose
+	// serial is a factory default, so it must not be conflated with by-id.
+	root := t.TempDir()
+	devDir, byIDDir, byPathDir := filepath.Join(root, "dev"),
+		filepath.Join(root, "by-id"), filepath.Join(root, "by-path")
+	for _, d := range []string{devDir, byIDDir, byPathDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	node := filepath.Join(devDir, "video2")
+	if err := os.WriteFile(node, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(node, filepath.Join(byIDDir, arducamByID)); err != nil {
+		t.Fatal(err)
+	}
+	const portName = "platform-xhci-hcd.0-usb-0:2.3:1.0-video-index0"
+	if err := os.Symlink(node, filepath.Join(byPathDir, portName)); err != nil {
+		t.Fatal(err)
+	}
+
+	got := readStableNames(byIDDir, byPathDir)[resolved(t, node)]
+	if got.byID != arducamByID {
+		t.Errorf("byID = %q, want %q", got.byID, arducamByID)
+	}
+	if got.byPath != portName {
+		t.Errorf("byPath = %q, want %q", got.byPath, portName)
+	}
+}
+
+func TestMissingDirectoriesAreNotAnError(t *testing.T) {
+	// A device with no /dev/v4l at all must still enumerate. Losing the
+	// identity is survivable; failing the listing is not.
+	if got := readStableNames("/nonexistent/by-id", "/nonexistent/by-path"); len(got) != 0 {
+		t.Errorf("want empty map, got %v", got)
+	}
+}
+
+func TestDanglingSymlinkDoesNotCostTheOthers(t *testing.T) {
+	byIDDir, devDir := fakeV4L(t, map[string]string{topdonByID: "video0"})
+	if err := os.Symlink(filepath.Join(devDir, "video9"), // never created
+		filepath.Join(byIDDir, "usb-Broken-video-index0")); err != nil {
+		t.Fatal(err)
+	}
+	names := readStableNames(byIDDir, "")
+	if got := names[resolved(t, filepath.Join(devDir, "video0"))].byID; got != topdonByID {
+		t.Errorf("a dangling symlink cost a healthy camera its identity: got %q", got)
+	}
+}
+
+func TestResolveByIDIsExactNotPrefix(t *testing.T) {
+	// A prefix rule would make "…_SN1-video-index0" match "…_SN10-video-index0"
+	// and hand back one of them silently -- the same class of wrong-camera bug
+	// this whole change exists to remove.
+	names := map[string]stableNames{
+		"/dev/video0": {byID: "usb-Acme_Cam_SN1-video-index0"},
+		"/dev/video2": {byID: "usb-Acme_Cam_SN10-video-index0"},
+	}
+	got, ok := resolveByID(names, "usb-Acme_Cam_SN1-video-index0")
+	if !ok || got != 0 {
+		t.Fatalf("exact name resolved to (%d, %v), want (0, true)", got, ok)
+	}
+	if _, ok := resolveByID(names, "usb-Acme_Cam_SN"); ok {
+		t.Error("a prefix matched; resolution must be exact")
+	}
+	if _, ok := resolveByID(names, ""); ok {
+		t.Error("an empty name matched")
+	}
+}
+
+func TestResolveByIDReportsNoMatch(t *testing.T) {
+	names := map[string]stableNames{"/dev/video0": {byID: topdonByID}}
+	if _, ok := resolveByID(names, arducamByID); ok {
+		t.Error("an absent camera resolved; the caller must be able to refuse")
+	}
+}
+
+// ── service level ───────────────────────────────────────────────────────────
+
+func TestListCamerasReportsStableIdentity(t *testing.T) {
+	svc := newTestVideoService(
+		func() ([]string, error) { return []string{"/dev/video0", "/dev/video2"}, nil },
+		func(base string) (string, error) { return base, nil },
+	)
+	svc.readStableNames = func() map[string]stableNames {
+		return map[string]stableNames{
+			"/dev/video0": {byID: topdonByID, byPath: "platform-xhci-hcd.0-usb-0:2.1:1.0-video-index0"},
+			"/dev/video2": {byID: arducamByID, byPath: "platform-xhci-hcd.0-usb-0:2.3:1.0-video-index0"},
+		}
+	}
+	devices, err := svc.listCameras(context.Background())
+	if err != nil {
+		t.Fatalf("listCameras: %v", err)
+	}
+	got := map[uint32]string{}
+	for _, d := range devices {
+		got[d.GetId()] = d.GetById()
+		if d.GetByPath() == "" {
+			t.Errorf("device %d reported no by-path", d.GetId())
+		}
+	}
+	if got[0] != topdonByID {
+		t.Errorf("video0 by-id = %q, want %q", got[0], topdonByID)
+	}
+	if got[2] != arducamByID {
+		t.Errorf("video2 by-id = %q, want %q", got[2], arducamByID)
+	}
+}
+
+func TestListCamerasWithoutStableNamesIsUnchanged(t *testing.T) {
+	// Every device with no /dev/v4l -- and every existing caller -- must see
+	// exactly what it saw before.
+	svc := newTestVideoService(
+		func() ([]string, error) { return []string{"/dev/video0"}, nil },
+		func(base string) (string, error) { return "USB Camera", nil },
+	)
+	devices, err := svc.listCameras(context.Background())
+	if err != nil {
+		t.Fatalf("listCameras: %v", err)
+	}
+	if len(devices) != 1 {
+		t.Fatalf("got %d devices, want 1", len(devices))
+	}
+	if devices[0].GetById() != "" || devices[0].GetByPath() != "" {
+		t.Errorf("identity invented from nothing: by-id %q by-path %q",
+			devices[0].GetById(), devices[0].GetByPath())
+	}
+	if devices[0].GetId() != 0 || devices[0].GetName() != "USB Camera" {
+		t.Errorf("existing fields changed: %+v", devices[0])
+	}
+}
+
+func TestStreamDeviceIDPrefersTheName(t *testing.T) {
+	svc := newTestVideoService(nil, nil)
+	// The post-reboot layout: the Arducam is on video2 now, and a config still
+	// says deviceId 0. The name must win.
+	svc.readStableNames = func() map[string]stableNames {
+		return map[string]stableNames{
+			"/dev/video0": {byID: topdonByID},
+			"/dev/video2": {byID: arducamByID},
+		}
+	}
+	got, err := svc.streamDeviceID(&agentpb.StreamVideoRequest{
+		DeviceId:   0,
+		DeviceById: arducamByID,
+	})
+	if err != nil {
+		t.Fatalf("streamDeviceID: %v", err)
+	}
+	if got != 2 {
+		t.Errorf("resolved to %d, want 2 -- the stale deviceId won", got)
+	}
+}
+
+func TestStreamDeviceIDRefusesAnUnknownName(t *testing.T) {
+	// The load-bearing case. Falling back to device_id here would stream
+	// whatever the kernel put at that number, succeed, and tell nobody.
+	svc := newTestVideoService(nil, nil)
+	svc.readStableNames = func() map[string]stableNames {
+		return map[string]stableNames{"/dev/video0": {byID: topdonByID}}
+	}
+	_, err := svc.streamDeviceID(&agentpb.StreamVideoRequest{
+		DeviceId:   0,
+		DeviceById: arducamByID,
+	})
+	if err == nil {
+		t.Fatal("an absent camera resolved; it must refuse rather than fall back")
+	}
+	if status.Code(err) != codes.NotFound {
+		t.Errorf("code = %v, want NotFound", status.Code(err))
+	}
+	// The error must name what IS there, or the operator is left guessing on a
+	// device they may not be able to log into.
+	if !strings.Contains(err.Error(), topdonByID) {
+		t.Errorf("error does not list the available cameras: %v", err)
+	}
+}
+
+func TestStreamDeviceIDFallsBackToTheNumberWhenUnnamed(t *testing.T) {
+	svc := newTestVideoService(nil, nil)
+	got, err := svc.streamDeviceID(&agentpb.StreamVideoRequest{DeviceId: 4})
+	if err != nil {
+		t.Fatalf("streamDeviceID: %v", err)
+	}
+	if got != 4 {
+		t.Errorf("got %d, want 4 -- an unnamed request must behave as before", got)
+	}
+}

--- a/go/internal/cli/commands/camera.go
+++ b/go/internal/cli/commands/camera.go
@@ -321,6 +321,7 @@ func newCameraWatchCmd() *cobra.Command {
 // hidden alias.
 func newCameraStreamCmd(use string, hidden bool) *cobra.Command {
 	var deviceID, width, height, fps uint32
+	var byID string
 	var toStdout bool
 
 	cmd := &cobra.Command{
@@ -341,10 +342,16 @@ func newCameraStreamCmd(use string, hidden bool) *cobra.Command {
 			}
 			defer conn.Close()
 
-			// Without an explicit --id, list the cameras so a single camera is
-			// chosen silently and several open the picker. Before this, view
-			// defaulted to ID 0 with no sign that other cameras existed.
-			if !cmd.Flags().Changed("id") {
+			// --by-id addresses the camera by its stable udev identity and is
+			// resolved by the AGENT at request time. --id is the boot-order
+			// number, so a value written down yesterday can name a different
+			// camera today; --by-id cannot. When it is given the picker below
+			// is skipped, because the camera has already been named exactly.
+			if byID != "" {
+				if cmd.Flags().Changed("id") {
+					return fmt.Errorf("--id and --by-id both name a camera; pass one")
+				}
+			} else if !cmd.Flags().Changed("id") {
 				listed, err := conn.VideoService.ListVideoDevices(ctx, &agentpb.ListVideoDevicesRequest{})
 				if err != nil {
 					return fmt.Errorf("listing cameras: %w", err)
@@ -357,10 +364,11 @@ func newCameraStreamCmd(use string, hidden bool) *cobra.Command {
 			}
 
 			req := &agentpb.StreamVideoRequest{
-				DeviceId:  deviceID,
-				Width:     width,
-				Height:    height,
-				Framerate: fps,
+				DeviceId:   deviceID,
+				DeviceById: byID,
+				Width:      width,
+				Height:     height,
+				Framerate:  fps,
 			}
 			startStream := func() (videoStream, error) {
 				return conn.VideoService.StreamVideo(ctx, req)
@@ -396,7 +404,9 @@ func newCameraStreamCmd(use string, hidden bool) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().Uint32Var(&deviceID, "id", 0, "Camera device ID")
+	cmd.Flags().Uint32Var(&deviceID, "id", 0, "Camera device ID (boot order; see --by-id)")
+	cmd.Flags().StringVar(&byID, "by-id", "",
+		"Camera by-id name from `camera list` — stable across reboots and re-plugging")
 	cmd.Flags().Uint32Var(&width, "width", 0, "Frame width (0 = device default)")
 	cmd.Flags().Uint32Var(&height, "height", 0, "Frame height (0 = device default)")
 	cmd.Flags().Uint32Var(&fps, "fps", 0, "Framerate (0 = device default)")

--- a/go/internal/cli/commands/camera.go
+++ b/go/internal/cli/commands/camera.go
@@ -321,7 +321,7 @@ func newCameraWatchCmd() *cobra.Command {
 // hidden alias.
 func newCameraStreamCmd(use string, hidden bool) *cobra.Command {
 	var deviceID, width, height, fps uint32
-	var byID string
+	var stableID string
 	var toStdout, raw bool
 
 	cmd := &cobra.Command{
@@ -346,14 +346,15 @@ func newCameraStreamCmd(use string, hidden bool) *cobra.Command {
 			}
 			defer conn.Close()
 
-			// --by-id addresses the camera by its stable udev identity and is
-			// resolved by the AGENT at request time. --id is the boot-order
+			// --stable-id addresses the camera by its stable udev identity and
+			// is resolved by the AGENT at request time. --id is the boot-order
 			// number, so a value written down yesterday can name a different
-			// camera today; --by-id cannot. When it is given the picker below
-			// is skipped, because the camera has already been named exactly.
-			if byID != "" {
+			// camera today; --stable-id cannot. When it is given the picker
+			// below is skipped, because the camera has already been named
+			// exactly.
+			if stableID != "" {
 				if cmd.Flags().Changed("id") {
-					return fmt.Errorf("--id and --by-id both name a camera; pass one")
+					return fmt.Errorf("--id and --stable-id both name a camera; pass one")
 				}
 			} else if !cmd.Flags().Changed("id") {
 				listed, err := conn.VideoService.ListVideoDevices(ctx, &agentpb.ListVideoDevicesRequest{})
@@ -372,12 +373,12 @@ func newCameraStreamCmd(use string, hidden bool) *cobra.Command {
 				codec = agentpb.VideoCodec_VIDEO_CODEC_RAW
 			}
 			req := &agentpb.StreamVideoRequest{
-				DeviceId:   deviceID,
-				DeviceById: byID,
-				Width:      width,
-				Height:     height,
-				Framerate:  fps,
-				Codec:      codec,
+				DeviceId:  deviceID,
+				StableId:  stableID,
+				Width:     width,
+				Height:    height,
+				Framerate: fps,
+				Codec:     codec,
 			}
 			startStream := func() (videoStream, error) {
 				return conn.VideoService.StreamVideo(ctx, req)
@@ -413,9 +414,9 @@ func newCameraStreamCmd(use string, hidden bool) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().Uint32Var(&deviceID, "id", 0, "Camera device ID (boot order; see --by-id)")
-	cmd.Flags().StringVar(&byID, "by-id", "",
-		"Camera by-id name from `camera list` — stable across reboots and re-plugging")
+	cmd.Flags().Uint32Var(&deviceID, "id", 0, "Camera device ID (boot order; see --stable-id)")
+	cmd.Flags().StringVar(&stableID, "stable-id", "",
+		"Camera stable ID from `camera list --json` — survives reboots and re-plugging")
 	cmd.Flags().Uint32Var(&width, "width", 0, "Frame width (0 = device default)")
 	cmd.Flags().Uint32Var(&height, "height", 0, "Frame height (0 = device default)")
 	cmd.Flags().Uint32Var(&fps, "fps", 0, "Framerate (0 = device default)")

--- a/go/proto/gen/agentpb/wendy_agent_v1_video_service.pb.go
+++ b/go/proto/gen/agentpb/wendy_agent_v1_video_service.pb.go
@@ -191,7 +191,8 @@ type VideoDevice struct {
 	HasCredentials bool                   `protobuf:"varint,10,opt,name=has_credentials,json=hasCredentials,proto3" json:"has_credentials,omitempty"`            // the agent holds a login for this camera
 	Online         bool                   `protobuf:"varint,11,opt,name=online,proto3" json:"online,omitempty"`                                                  // the most recent probe reached this camera
 	Topic          string                 `protobuf:"bytes,12,opt,name=topic,proto3" json:"topic,omitempty"`                                                     // ROS 2 image topic, e.g. "/camera/image_raw"; empty for other transports
-	// Stable identity for a LOCAL camera, the counterpart of `mac` above.
+	// Stable identity for a LOCAL camera, the counterpart of `mac` above, and
+	// the name to pass to StreamVideoRequest.stable_id.
 	//
 	// `id` and `path` are the kernel's enumeration order, which is a property
 	// of the boot and not of the camera: replugging or a reboot can renumber
@@ -199,15 +200,21 @@ type VideoDevice struct {
 	// different camera. `name` and `driver` only identify the MODEL, so they
 	// cannot separate two cameras of the same type.
 	//
-	// by_id is derived from vendor + product + serial and survives both a
-	// reboot and a move to another USB port. by_path encodes the port topology
-	// instead: it survives a reboot but NOT a move, and is the only thing that
-	// can separate two same-model cameras whose serials are identical (a
-	// generic factory serial is common). Both are empty when the device has no
-	// /dev/v4l entry -- CSI and network cameras, or a kernel without the
-	// symlinks.
-	ById          string `protobuf:"bytes,13,opt,name=by_id,json=byId,proto3" json:"by_id,omitempty"`       // e.g. "usb-Acme_Camera_SN123-video-index0"
-	ByPath        string `protobuf:"bytes,14,opt,name=by_path,json=byPath,proto3" json:"by_path,omitempty"` // e.g. "platform-xhci-hcd.0-usb-0:2.3:1.0-video-index0"
+	// One camera has one stable_id. The value carries the scheme it came from,
+	// because the two names udev publishes are not equally durable:
+	//
+	//	by-id:<name>    vendor + product + serial; survives a reboot AND a
+	//	                move to another USB port. Reported whenever udev has
+	//	                one.
+	//	by-path:<name>  the USB port topology; survives a reboot but NOT a
+	//	                move. Reported only when there is no by-id name --
+	//	                two same-model cameras sharing a factory serial
+	//	                collide on a single by-id link, and the camera that
+	//	                loses it has nothing else that separates the two.
+	//
+	// Empty when the device has no /dev/v4l entry -- CSI and network cameras,
+	// or a kernel without the udev symlinks.
+	StableId      string `protobuf:"bytes,13,opt,name=stable_id,json=stableId,proto3" json:"stable_id,omitempty"` // e.g. "by-id:usb-Acme_Camera_SN123-video-index0"
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -326,16 +333,9 @@ func (x *VideoDevice) GetTopic() string {
 	return ""
 }
 
-func (x *VideoDevice) GetById() string {
+func (x *VideoDevice) GetStableId() string {
 	if x != nil {
-		return x.ById
-	}
-	return ""
-}
-
-func (x *VideoDevice) GetByPath() string {
-	if x != nil {
-		return x.ByPath
+		return x.StableId
 	}
 	return ""
 }
@@ -445,17 +445,22 @@ type StreamVideoRequest struct {
 	// waiting forever. A codec the agent cannot produce for a camera is refused
 	// the same way rather than silently downgraded.
 	Codec VideoCodec `protobuf:"varint,5,opt,name=codec,proto3,enum=wendy.agent.services.v1.VideoCodec" json:"codec,omitempty"`
-	// Address the camera by its stable identity instead of by device_id.
+	// Address the camera by the stable_id ListVideoDevices reported for it,
+	// scheme tag included, instead of by device_id.
 	//
-	// When set this WINS over device_id and is resolved against the by_id
-	// reported by ListVideoDevices, at request time. That is the point: the
-	// number is resolved when the stream is opened rather than baked into a
-	// config that outlives the boot it was written on.
+	// When set this WINS over device_id and is resolved at request time. That
+	// is the point: the number is resolved when the stream is opened rather
+	// than baked into a config that outlives the boot it was written on.
+	//
+	// A "by-path:" name resolves too, even for a camera whose reported
+	// stable_id is a "by-id:" one: pinning a stream to a physical port is a
+	// legitimate thing to ask for, as long as the caller asks for it rather
+	// than inheriting it.
 	//
 	// No match is an error, deliberately. Falling back to device_id would
 	// stream whatever the kernel happened to put at that number, which is the
 	// silent-wrong-camera failure this field exists to remove.
-	DeviceById    string `protobuf:"bytes,6,opt,name=device_by_id,json=deviceById,proto3" json:"device_by_id,omitempty"` // empty = address by device_id, as before
+	StableId      string `protobuf:"bytes,6,opt,name=stable_id,json=stableId,proto3" json:"stable_id,omitempty"` // empty = address by device_id, as before
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -525,9 +530,9 @@ func (x *StreamVideoRequest) GetCodec() VideoCodec {
 	return VideoCodec_VIDEO_CODEC_H264
 }
 
-func (x *StreamVideoRequest) GetDeviceById() string {
+func (x *StreamVideoRequest) GetStableId() string {
 	if x != nil {
-		return x.DeviceById
+		return x.StableId
 	}
 	return ""
 }
@@ -1041,7 +1046,7 @@ var File_wendy_agent_services_v1_wendy_agent_v1_video_service_proto protoreflect
 
 const file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDesc = "" +
 	"\n" +
-	":wendy/agent/services/v1/wendy_agent_v1_video_service.proto\x12\x17wendy.agent.services.v1\"\x8e\x03\n" +
+	":wendy/agent/services/v1/wendy_agent_v1_video_service.proto\x12\x17wendy.agent.services.v1\"\xfd\x02\n" +
 	"\vVideoDevice\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\rR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x12\n" +
@@ -1055,20 +1060,18 @@ const file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDesc = 
 	"\x0fhas_credentials\x18\n" +
 	" \x01(\bR\x0ehasCredentials\x12\x16\n" +
 	"\x06online\x18\v \x01(\bR\x06online\x12\x14\n" +
-	"\x05topic\x18\f \x01(\tR\x05topic\x12\x13\n" +
-	"\x05by_id\x18\r \x01(\tR\x04byId\x12\x17\n" +
-	"\aby_path\x18\x0e \x01(\tR\x06byPath\"\x19\n" +
+	"\x05topic\x18\f \x01(\tR\x05topic\x12\x1b\n" +
+	"\tstable_id\x18\r \x01(\tR\bstableId\"\x19\n" +
 	"\x17ListVideoDevicesRequest\"Z\n" +
 	"\x18ListVideoDevicesResponse\x12>\n" +
-	"\adevices\x18\x01 \x03(\v2$.wendy.agent.services.v1.VideoDeviceR\adevices\"\xda\x01\n" +
+	"\adevices\x18\x01 \x03(\v2$.wendy.agent.services.v1.VideoDeviceR\adevices\"\xd5\x01\n" +
 	"\x12StreamVideoRequest\x12\x1b\n" +
 	"\tdevice_id\x18\x01 \x01(\rR\bdeviceId\x12\x14\n" +
 	"\x05width\x18\x02 \x01(\rR\x05width\x12\x16\n" +
 	"\x06height\x18\x03 \x01(\rR\x06height\x12\x1c\n" +
 	"\tframerate\x18\x04 \x01(\rR\tframerate\x129\n" +
-	"\x05codec\x18\x05 \x01(\x0e2#.wendy.agent.services.v1.VideoCodecR\x05codec\x12 \n" +
-	"\fdevice_by_id\x18\x06 \x01(\tR\n" +
-	"deviceById\"r\n" +
+	"\x05codec\x18\x05 \x01(\x0e2#.wendy.agent.services.v1.VideoCodecR\x05codec\x12\x1b\n" +
+	"\tstable_id\x18\x06 \x01(\tR\bstableId\"r\n" +
 	"\x1bSetCameraCredentialsRequest\x12\x1b\n" +
 	"\tdevice_id\x18\x01 \x01(\rR\bdeviceId\x12\x1a\n" +
 	"\busername\x18\x02 \x01(\tR\busername\x12\x1a\n" +

--- a/go/proto/gen/agentpb/wendy_agent_v1_video_service.pb.go
+++ b/go/proto/gen/agentpb/wendy_agent_v1_video_service.pb.go
@@ -188,8 +188,25 @@ type VideoDevice struct {
 	HasCredentials bool                   `protobuf:"varint,10,opt,name=has_credentials,json=hasCredentials,proto3" json:"has_credentials,omitempty"`            // the agent holds a login for this camera
 	Online         bool                   `protobuf:"varint,11,opt,name=online,proto3" json:"online,omitempty"`                                                  // the most recent probe reached this camera
 	Topic          string                 `protobuf:"bytes,12,opt,name=topic,proto3" json:"topic,omitempty"`                                                     // ROS 2 image topic, e.g. "/camera/image_raw"; empty for other transports
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Stable identity for a LOCAL camera, the counterpart of `mac` above.
+	//
+	// `id` and `path` are the kernel's enumeration order, which is a property
+	// of the boot and not of the camera: replugging or a reboot can renumber
+	// /dev/videoN, and a caller that pinned a number then silently streams a
+	// different camera. `name` and `driver` only identify the MODEL, so they
+	// cannot separate two cameras of the same type.
+	//
+	// by_id is derived from vendor + product + serial and survives both a
+	// reboot and a move to another USB port. by_path encodes the port topology
+	// instead: it survives a reboot but NOT a move, and is the only thing that
+	// can separate two same-model cameras whose serials are identical (a
+	// generic factory serial is common). Both are empty when the device has no
+	// /dev/v4l entry -- CSI and network cameras, or a kernel without the
+	// symlinks.
+	ById          string `protobuf:"bytes,13,opt,name=by_id,json=byId,proto3" json:"by_id,omitempty"`       // e.g. "usb-Acme_Camera_SN123-video-index0"
+	ByPath        string `protobuf:"bytes,14,opt,name=by_path,json=byPath,proto3" json:"by_path,omitempty"` // e.g. "platform-xhci-hcd.0-usb-0:2.3:1.0-video-index0"
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *VideoDevice) Reset() {
@@ -306,6 +323,20 @@ func (x *VideoDevice) GetTopic() string {
 	return ""
 }
 
+func (x *VideoDevice) GetById() string {
+	if x != nil {
+		return x.ById
+	}
+	return ""
+}
+
+func (x *VideoDevice) GetByPath() string {
+	if x != nil {
+		return x.ByPath
+	}
+	return ""
+}
+
 type ListVideoDevicesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -392,9 +423,20 @@ type StreamVideoRequest struct {
 	// For local cameras width/height/framerate configure capture. For network
 	// cameras the camera decides its own format, so width only selects which of
 	// its streams to open (sub or main) and height/framerate are ignored.
-	Width         uint32 `protobuf:"varint,2,opt,name=width,proto3" json:"width,omitempty"`         // pixels; 0 = device default
-	Height        uint32 `protobuf:"varint,3,opt,name=height,proto3" json:"height,omitempty"`       // pixels; 0 = device default
-	Framerate     uint32 `protobuf:"varint,4,opt,name=framerate,proto3" json:"framerate,omitempty"` // fps; 0 = device default
+	Width     uint32 `protobuf:"varint,2,opt,name=width,proto3" json:"width,omitempty"`         // pixels; 0 = device default
+	Height    uint32 `protobuf:"varint,3,opt,name=height,proto3" json:"height,omitempty"`       // pixels; 0 = device default
+	Framerate uint32 `protobuf:"varint,4,opt,name=framerate,proto3" json:"framerate,omitempty"` // fps; 0 = device default
+	// Address the camera by its stable identity instead of by device_id.
+	//
+	// When set this WINS over device_id and is resolved against the by_id
+	// reported by ListVideoDevices, at request time. That is the point: the
+	// number is resolved when the stream is opened rather than baked into a
+	// config that outlives the boot it was written on.
+	//
+	// No match is an error, deliberately. Falling back to device_id would
+	// stream whatever the kernel happened to put at that number, which is the
+	// silent-wrong-camera failure this field exists to remove.
+	DeviceById    string `protobuf:"bytes,6,opt,name=device_by_id,json=deviceById,proto3" json:"device_by_id,omitempty"` // empty = address by device_id, as before
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -455,6 +497,13 @@ func (x *StreamVideoRequest) GetFramerate() uint32 {
 		return x.Framerate
 	}
 	return 0
+}
+
+func (x *StreamVideoRequest) GetDeviceById() string {
+	if x != nil {
+		return x.DeviceById
+	}
+	return ""
 }
 
 // Credentials for a network camera. Stored on the device, never returned by any
@@ -886,7 +935,7 @@ var File_wendy_agent_services_v1_wendy_agent_v1_video_service_proto protoreflect
 
 const file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDesc = "" +
 	"\n" +
-	":wendy/agent/services/v1/wendy_agent_v1_video_service.proto\x12\x17wendy.agent.services.v1\"\xe0\x02\n" +
+	":wendy/agent/services/v1/wendy_agent_v1_video_service.proto\x12\x17wendy.agent.services.v1\"\x8e\x03\n" +
 	"\vVideoDevice\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\rR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x12\n" +
@@ -900,15 +949,19 @@ const file_wendy_agent_services_v1_wendy_agent_v1_video_service_proto_rawDesc = 
 	"\x0fhas_credentials\x18\n" +
 	" \x01(\bR\x0ehasCredentials\x12\x16\n" +
 	"\x06online\x18\v \x01(\bR\x06online\x12\x14\n" +
-	"\x05topic\x18\f \x01(\tR\x05topic\"\x19\n" +
+	"\x05topic\x18\f \x01(\tR\x05topic\x12\x13\n" +
+	"\x05by_id\x18\r \x01(\tR\x04byId\x12\x17\n" +
+	"\aby_path\x18\x0e \x01(\tR\x06byPath\"\x19\n" +
 	"\x17ListVideoDevicesRequest\"Z\n" +
 	"\x18ListVideoDevicesResponse\x12>\n" +
-	"\adevices\x18\x01 \x03(\v2$.wendy.agent.services.v1.VideoDeviceR\adevices\"}\n" +
+	"\adevices\x18\x01 \x03(\v2$.wendy.agent.services.v1.VideoDeviceR\adevices\"\x9f\x01\n" +
 	"\x12StreamVideoRequest\x12\x1b\n" +
 	"\tdevice_id\x18\x01 \x01(\rR\bdeviceId\x12\x14\n" +
 	"\x05width\x18\x02 \x01(\rR\x05width\x12\x16\n" +
 	"\x06height\x18\x03 \x01(\rR\x06height\x12\x1c\n" +
-	"\tframerate\x18\x04 \x01(\rR\tframerate\"r\n" +
+	"\tframerate\x18\x04 \x01(\rR\tframerate\x12 \n" +
+	"\fdevice_by_id\x18\x06 \x01(\tR\n" +
+	"deviceById\"r\n" +
 	"\x1bSetCameraCredentialsRequest\x12\x1b\n" +
 	"\tdevice_id\x18\x01 \x01(\rR\bdeviceId\x12\x1a\n" +
 	"\busername\x18\x02 \x01(\tR\busername\x12\x1a\n" +


### PR DESCRIPTION
- **Advances:** [WDY-2855 Regenerate the wendyos device-notification-proof canonical-bytes fixture for UUID identities](https://linear.app/wendylabsinc/issue/WDY-2855/regenerate-the-wendyos-device-notification-proof-canonical)
- **Related:** [WDY-2808 Organization identity must be the tenant UUID, not a cloud-local int](https://linear.app/wendylabsinc/issue/WDY-2808/organization-identity-must-be-the-tenant-uuid-not-a-cloud-local-int)

> **In plain terms:** Cloud's device-proof test pins a hash copied from this
> repo, and WDY-2808 changed the identity inside the bytes that hash covers.
> The fixture now covers the UUID spelling as well as the integer one, so cloud
> has a value to copy. Devices still sign the integer URN; nothing here changes
> what goes on the wire.

## Summary
- `canonicalNotificationDeviceProof` takes the identity URN and the gRPC method name as parameters instead of formatting the URN from `orgID, assetID int32` and reading the method from a package constant. Both are per-vector inputs to the byte contract on cloud's side too — it rebuilds the preimage from the `x-wendy-device-uri` header and the method it dispatched — and parametrising them is what lets the fixture cover every cell through the shipped code path rather than a test-local copy of the framing.
- The fixture is a small (method, URN) → digest matrix. The v1-method plus integer-identity cell still hashes to `438186e9…`, unchanged; that is the check that none of this moved a byte.
- The URN is signature input inside a NUL-framed preimage, so it is validated, not trusted: six non-empty fields, printable, lowercase. Cloud re-renders a parsed uuid and compares, so it rejects an upper-case variant rather than treating it as a second spelling — refusing to sign one here means a device never produces a proof cloud will discard.
- The positive-id guard moves up to `CloudNotificationSender`, where the ints still live, and that caller now uses `certs.AssetURN` instead of a sixth hand-rolled copy of the URN format.
- The v2 method name is defined in the test rather than the package, because this agent does not invoke it: the generated client calls `wendycloud.v1`, and no `wendycloud.v2` exists here — the only v2 mentions are MIGRATION markers, and the one on `NotificationService` targets the legacy `CreateNotification`, not V2.
- The v2 cell pins bytes no device produces yet. Provisioning state carries `int32` org and asset ids, no asset uuid exists in this repo, and the client is still on v1, so a device signs the v1 method and the integer URN until the proto migration and WDY-2824 land.

## Boundary changes
- **Cross-repo fixture:** cloud's `DeviceNotificationProofTests` copies these digests. For method `wendycloud.v2.NotificationService/CreateNotificationV2` and identity `urn:wendy:org:13a72725-dfe3-4425-bd04-b253d2036089:asset:9f2c1d84-6b30-4e57-9a1e-2c7d5f08b413`, over the same request, serial `01a2b3c4d5e6f708` and timestamp `1753267200`, the canonical bytes are `4dc7c616beb4cf9eea9467ada6fd464cfce45ef4f87473724a44ef8859ef779c`. That value was computed here through the shipped path and independently equals what cloud's verifier arrived at, which is what makes the pin an agreement rather than a copied constant. The v1-method digest is unchanged, so a cloud test still on the old vector stays green.

## Tests
- `go test ./go/internal/agent/services/`
- `go build ./go/...`
- `go test ./go/internal/agent/... ./go/internal/shared/...` — passes except pre-existing GPU-entitlement failures in `go/internal/agent/oci`, confirmed identical on a clean tree.
