### PR TITLE
feat(proto): describe buffer shape on the app-facing sensor sample

### DIFF
--- a/Examples/WendyDataModelApp/proto/wendy/agent/apps/v1/sensor_service.proto
+++ b/Examples/WendyDataModelApp/proto/wendy/agent/apps/v1/sensor_service.proto
@@ -127,6 +127,20 @@ message SensorSample {
   uint64 dropped_before = 8;
   // boot_id is the kernel boot the timestamps belong to.
   string boot_id = 9;
+  // sample_rate_hz, channels and duration_nanos describe a payload that carries
+  // a BUFFER of equally spaced samples rather than a single instant. When
+  // sample_rate_hz is non-zero, boottime_nanos names the FIRST sample in the
+  // payload, and the k-th sample (zero-based, counting frames of `channels`
+  // interleaved values) lies at
+  // boottime_nanos + k * 1000000000 / sample_rate_hz. duration_nanos is the
+  // span the whole payload covers, derived from its length. A consumer must
+  // count samples into the buffer rather than assume a fixed chunk size,
+  // because a producer may deliver buffers of varying length. All three are
+  // zero for a single-instant sample, such as a camera frame, which is the
+  // compatible default.
+  uint32 sample_rate_hz = 10;
+  uint32 channels = 11;
+  int64 duration_nanos = 12;
 }
 
 message FrameIdentitySubscribeRequest {

--- a/Proto/wendy/agent/apps/v1/sensor_service.proto
+++ b/Proto/wendy/agent/apps/v1/sensor_service.proto
@@ -127,6 +127,20 @@ message SensorSample {
   uint64 dropped_before = 8;
   // boot_id is the kernel boot the timestamps belong to.
   string boot_id = 9;
+  // sample_rate_hz, channels and duration_nanos describe a payload that carries
+  // a BUFFER of equally spaced samples rather than a single instant. When
+  // sample_rate_hz is non-zero, boottime_nanos names the FIRST sample in the
+  // payload, and the k-th sample (zero-based, counting frames of `channels`
+  // interleaved values) lies at
+  // boottime_nanos + k * 1000000000 / sample_rate_hz. duration_nanos is the
+  // span the whole payload covers, derived from its length. A consumer must
+  // count samples into the buffer rather than assume a fixed chunk size,
+  // because a producer may deliver buffers of varying length. All three are
+  // zero for a single-instant sample, such as a camera frame, which is the
+  // compatible default.
+  uint32 sample_rate_hz = 10;
+  uint32 channels = 11;
+  int64 duration_nanos = 12;
 }
 
 message FrameIdentitySubscribeRequest {

--- a/go/internal/agent/services/sensor_service.go
+++ b/go/internal/agent/services/sensor_service.go
@@ -41,6 +41,20 @@ type SensorSample struct {
 	// DroppedBefore counts samples lost between the producer and this
 	// subscriber since the previous delivered sample.
 	DroppedBefore uint64
+	// SampleRateHz, Channels and DurationNanos describe a Payload that carries
+	// a BUFFER of equally spaced samples rather than a single instant. When
+	// SampleRateHz is non-zero, BootNanos names the FIRST sample in the
+	// payload, and the k-th sample (zero-based, counting frames of Channels
+	// interleaved values) lies at
+	// BootNanos + k * 1000000000 / SampleRateHz. DurationNanos is the span the
+	// whole payload covers, derived from its length. A consumer must count
+	// samples into the buffer rather than assume a fixed chunk size, because a
+	// producer may deliver buffers of varying length. All three are zero for a
+	// single-instant sample, such as a camera frame, which is the compatible
+	// default.
+	SampleRateHz  uint32
+	Channels      uint32
+	DurationNanos int64
 }
 
 // sensorSubscription is one live subscription to a source's producer.
@@ -336,6 +350,10 @@ func sensorSampleMessage(sample SensorSample) *appspbv1.SensorSample {
 		Payload: sample.Payload, Encoding: sample.Encoding,
 		PayloadSelfContained: sample.SelfContained, DroppedBefore: sample.DroppedBefore,
 		BootId: data.BootID(),
+		// Zero for a single-instant sample, which is every sample any provider
+		// produces today; a buffer-delivering producer sets all three.
+		SampleRateHz: sample.SampleRateHz, Channels: sample.Channels,
+		DurationNanos: sample.DurationNanos,
 	}
 }
 

--- a/go/internal/agent/services/sensor_service_test.go
+++ b/go/internal/agent/services/sensor_service_test.go
@@ -148,6 +148,63 @@ func TestSubscribeStreamsIdentifiedSamples(t *testing.T) {
 	}
 }
 
+// TestSensorSampleMessageCarriesBufferFields pins the buffer-shape half of the
+// sample contract. Every other field models a sample as a single instant, which
+// is right for a camera frame and wrong for any source that delivers a buffer:
+// at 48 kHz a 100 ms payload holds 4,800 samples, so without a sample rate an
+// event at the last of them is indistinguishable from one at the first. The
+// zero case is asserted alongside it because that is what every single-instant
+// source reports and what makes the addition compatible.
+func TestSensorSampleMessageCarriesBufferFields(t *testing.T) {
+	const (
+		rate     = uint32(48000)
+		duration = int64(100 * time.Millisecond)
+	)
+	buffered := sensorSampleMessage(SensorSample{
+		SourceID: "alsa:hw:0,0", SampleID: 7,
+		BootNanos: int64(time.Second), UncertaintyNanos: 1000,
+		Payload: make([]byte, 9600), Encoding: "s16le",
+		SampleRateHz: rate, Channels: 1, DurationNanos: duration,
+	})
+	if got := buffered.GetSampleRateHz(); got != rate {
+		t.Errorf("sample_rate_hz = %d, want %d", got, rate)
+	}
+	if got := buffered.GetChannels(); got != 1 {
+		t.Errorf("channels = %d, want 1", got)
+	}
+	if got := buffered.GetDurationNanos(); got != duration {
+		t.Errorf("duration_nanos = %d, want %d", got, duration)
+	}
+	// The fields exist so a consumer can place the k-th sample of the buffer,
+	// which is the thing a single boottime_nanos cannot express. The last
+	// sample of this payload must land inside the span it declares and strictly
+	// after the first.
+	const k = 4799
+	first := buffered.GetBoottimeNanos()
+	last := first + int64(k)*int64(time.Second)/int64(buffered.GetSampleRateHz())
+	if last <= first || last >= first+buffered.GetDurationNanos() {
+		t.Errorf("sample %d lands at %d, outside the buffer span [%d, %d)",
+			k, last, first, first+buffered.GetDurationNanos())
+	}
+
+	// A single-instant sample leaves all three zero. A consumer reading zero
+	// must keep treating boottime_nanos as the time of the whole payload,
+	// exactly as it did before these fields existed.
+	instant := sensorSampleMessage(SensorSample{
+		SourceID: "v4l2:/dev/video0", SampleID: 1,
+		BootNanos: int64(time.Second), UncertaintyNanos: 1000,
+		Payload: []byte{1}, Encoding: "h264", SelfContained: true,
+	})
+	if instant.GetSampleRateHz() != 0 || instant.GetChannels() != 0 || instant.GetDurationNanos() != 0 {
+		t.Errorf("a single-instant sample reports buffer shape %d Hz / %d channels / %d ns, want zeros",
+			instant.GetSampleRateHz(), instant.GetChannels(), instant.GetDurationNanos())
+	}
+	// The rest of the sample must be untouched by the addition.
+	if instant.GetBoottimeNanos() != int64(time.Second) || instant.GetTimestampUncertaintyNanos() != 1000 {
+		t.Errorf("the single-instant sample lost its bracketed boot time: %+v", instant)
+	}
+}
+
 func TestSubscribeRejectsMalformedRequests(t *testing.T) {
 	service := NewSensorService("sh.wendy.test", nil)
 	service.AddProvider(&fakeSensorProvider{sourceID: "a"})

--- a/go/internal/agent/services/video_service_sensor_test.go
+++ b/go/internal/agent/services/video_service_sensor_test.go
@@ -147,6 +147,44 @@ func TestCameraSensorSubscriptionReportsDropsPerSample(t *testing.T) {
 	}
 }
 
+// TestCameraSensorSamplesKeepZeroBufferFields pins camera samples to
+// single-instant semantics. sample_rate_hz, channels and duration_nanos exist
+// for a source that hands over a BUFFER of equally spaced samples; a camera
+// frame is one instant, so all three must stay zero and boottime_nanos must
+// remain the time of the whole payload. A camera provider that started
+// reporting a rate would tell an app to count samples into a frame.
+func TestCameraSensorSamplesKeepZeroBufferFields(t *testing.T) {
+	hub, cancel := newSampleHub(new(atomic.Uint64))
+	defer cancel()
+	subID, frames, err := hub.subscribe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	subscription := &cameraSensorSubscription{hub: hub, subID: subID, frames: frames}
+	hub.broadcast(&videoFrame{
+		data:      []byte{0, 0, 0, 1, 0x67, 1},
+		codec:     agentpb.VideoCodec_VIDEO_CODEC_H264,
+		auAligned: true,
+	})
+	sample, err := subscription.Next(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sample.SampleRateHz != 0 || sample.Channels != 0 || sample.DurationNanos != 0 {
+		t.Errorf("a camera sample reports buffer shape %d Hz / %d channels / %d ns, want zeros",
+			sample.SampleRateHz, sample.Channels, sample.DurationNanos)
+	}
+	// The same must hold on the wire, which is what an app actually reads.
+	message := sensorSampleMessage(sample)
+	if message.GetSampleRateHz() != 0 || message.GetChannels() != 0 || message.GetDurationNanos() != 0 {
+		t.Errorf("the camera sample message reports buffer shape %d Hz / %d channels / %d ns, want zeros",
+			message.GetSampleRateHz(), message.GetChannels(), message.GetDurationNanos())
+	}
+	if message.GetBoottimeNanos() == 0 {
+		t.Error("the camera sample lost its boot-clock receipt")
+	}
+}
+
 // TestCameraCaptureIndexCarriesSampleIdentity is the other half of the tee: the
 // episode's own index must name the frame with the identifier the model saw, so
 // the two can be joined without duplicating a single byte of video.

--- a/go/proto/gen/appspb/v1/sensor_service.pb.go
+++ b/go/proto/gen/appspb/v1/sensor_service.pb.go
@@ -303,7 +303,21 @@ type SensorSample struct {
 	// explanation for gaps in sample_id.
 	DroppedBefore uint64 `protobuf:"varint,8,opt,name=dropped_before,json=droppedBefore,proto3" json:"dropped_before,omitempty"`
 	// boot_id is the kernel boot the timestamps belong to.
-	BootId        string `protobuf:"bytes,9,opt,name=boot_id,json=bootId,proto3" json:"boot_id,omitempty"`
+	BootId string `protobuf:"bytes,9,opt,name=boot_id,json=bootId,proto3" json:"boot_id,omitempty"`
+	// sample_rate_hz, channels and duration_nanos describe a payload that carries
+	// a BUFFER of equally spaced samples rather than a single instant. When
+	// sample_rate_hz is non-zero, boottime_nanos names the FIRST sample in the
+	// payload, and the k-th sample (zero-based, counting frames of `channels`
+	// interleaved values) lies at
+	// boottime_nanos + k * 1000000000 / sample_rate_hz. duration_nanos is the
+	// span the whole payload covers, derived from its length. A consumer must
+	// count samples into the buffer rather than assume a fixed chunk size,
+	// because a producer may deliver buffers of varying length. All three are
+	// zero for a single-instant sample, such as a camera frame, which is the
+	// compatible default.
+	SampleRateHz  uint32 `protobuf:"varint,10,opt,name=sample_rate_hz,json=sampleRateHz,proto3" json:"sample_rate_hz,omitempty"`
+	Channels      uint32 `protobuf:"varint,11,opt,name=channels,proto3" json:"channels,omitempty"`
+	DurationNanos int64  `protobuf:"varint,12,opt,name=duration_nanos,json=durationNanos,proto3" json:"duration_nanos,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -399,6 +413,27 @@ func (x *SensorSample) GetBootId() string {
 		return x.BootId
 	}
 	return ""
+}
+
+func (x *SensorSample) GetSampleRateHz() uint32 {
+	if x != nil {
+		return x.SampleRateHz
+	}
+	return 0
+}
+
+func (x *SensorSample) GetChannels() uint32 {
+	if x != nil {
+		return x.Channels
+	}
+	return 0
+}
+
+func (x *SensorSample) GetDurationNanos() int64 {
+	if x != nil {
+		return x.DurationNanos
+	}
+	return 0
 }
 
 type FrameIdentitySubscribeRequest struct {
@@ -633,7 +668,7 @@ const file_wendy_agent_apps_v1_sensor_service_proto_rawDesc = "" +
 	"\x16SensorSubscribeRequest\x12\x1d\n" +
 	"\n" +
 	"source_ids\x18\x01 \x03(\tR\tsourceIds\x12\x14\n" +
-	"\x05model\x18\x02 \x01(\tR\x05model\"\xdb\x02\n" +
+	"\x05model\x18\x02 \x01(\tR\x05model\"\xc4\x03\n" +
 	"\fSensorSample\x12\x1b\n" +
 	"\tsource_id\x18\x01 \x01(\tR\bsourceId\x12\x1b\n" +
 	"\tsample_id\x18\x02 \x01(\x04R\bsampleId\x12%\n" +
@@ -643,7 +678,11 @@ const file_wendy_agent_apps_v1_sensor_service_proto_rawDesc = "" +
 	"\bencoding\x18\x06 \x01(\tR\bencoding\x124\n" +
 	"\x16payload_self_contained\x18\a \x01(\bR\x14payloadSelfContained\x12%\n" +
 	"\x0edropped_before\x18\b \x01(\x04R\rdroppedBefore\x12\x17\n" +
-	"\aboot_id\x18\t \x01(\tR\x06bootId\"T\n" +
+	"\aboot_id\x18\t \x01(\tR\x06bootId\x12$\n" +
+	"\x0esample_rate_hz\x18\n" +
+	" \x01(\rR\fsampleRateHz\x12\x1a\n" +
+	"\bchannels\x18\v \x01(\rR\bchannels\x12%\n" +
+	"\x0eduration_nanos\x18\f \x01(\x03R\rdurationNanos\"T\n" +
 	"\x1dFrameIdentitySubscribeRequest\x12\x1d\n" +
 	"\n" +
 	"source_ids\x18\x01 \x03(\tR\tsourceIds\x12\x14\n" +


### PR DESCRIPTION
## Problem

`SensorSample` in `Proto/wendy/agent/apps/v1/sensor_service.proto` models every
sample as a single instant. It carries `boottime_nanos` and
`timestamp_uncertainty_nanos` and nothing else about time. That is right for a
camera frame and wrong for any source that delivers a BUFFER of samples. At
48 kHz mono a 100 ms audio buffer holds 4,800 samples, so an event at sample
4,799 is indistinguishable from one at sample 0.

Tom asked precisely this in review: is a 32 ms chunk all one "time", or a start
time an app must count samples into? The answer is the latter, and until now
the wire format did not say so.

## Cause

The episode's own audio index already records sample rate, channels and
duration, so capture and the app-facing surface disagree about what a sample
is. The wire format never named which of the two readings applies, so the
answer lived nowhere a consumer could read it. An app that wanted to place an
event inside a buffer had to guess a chunk size, which a producer is free to
vary.

## Solution

Three additive fields on `SensorSample`, at the next free numbers 10, 11 and
12:

```proto
  uint32 sample_rate_hz = 10;
  uint32 channels = 11;
  int64 duration_nanos = 12;
```

The proto comment carries the contract: when `sample_rate_hz` is non-zero,
`boottime_nanos` names the FIRST sample in the payload, and the k-th sample
(zero-based, counting frames of `channels` interleaved values) lies at
`boottime_nanos + k * 1000000000 / sample_rate_hz`. `duration_nanos` is the
span the whole payload covers, derived from its length. A consumer must count
samples into the buffer rather than assume a fixed chunk size, because a
producer may deliver buffers of varying length.

The harness-internal `SensorSample` struct in
`go/internal/agent/services/sensor_service.go` mirrors the three fields as
`SampleRateHz`, `Channels` and `DurationNanos`, carrying the same contract in
its doc comment, and `sensorSampleMessage` maps them.

## Compatibility and scope

- **Additive and proto3-compatible.** The three fields are previously unused
  numbers with zero defaults. An old consumer reading a new message ignores
  them; a new consumer reading an old message sees zeros, which is exactly the
  single-instant reading it already implements. No field was renumbered,
  removed or retyped, and no service method changed.
- **Camera keeps zeros.** `video_service_sensor.go` is untouched. Camera is the
  only sensor provider today, it produces single-instant frames, and it goes on
  reporting zeros for all three.
- **No provider populates the fields yet.** Audio is deliberately not a sensor
  provider in this release, which
  `TestSubscribeNamesAnUnimplementedSourceKind` pins. This change is the wire
  contract a future audio provider will fill in, not a behaviour change.

## Generated output

`go/scripts/generate-proto.sh` removes and regenerates every package, and the
committed stubs carry a mix of protoc stamps that no single local protoc
reproduces (`appspb` and `agentpb/v2` say v7.35.1, `cloudpb` says v7.34.0;
local protoc is libprotoc 36.0 and stamps v7.36.0). `protoc-gen-go v1.36.11`
and `protoc-gen-go-grpc 1.6.2` match the committed stamps exactly.

Following the prior art in `1f57306b1`, the v7.35.1 stamp was restored in
`appspb/v1` and every other generated package was restored outright. The commit
therefore carries exactly one generated file:

- `go/proto/gen/appspb/v1/sensor_service.pb.go`

`sensor_service_grpc.pb.go` is byte-identical after the stamp restore, as no
service method changed, and `git status --porcelain go/proto/gen` reports
`appspb/v1` alone.

One extra hunk in that stub is worth calling out: the comment on
`SensorSource.loopback_node_path` still described the old `sensors`
entitlement, while its source proto had already been renamed to `sensor-read`.
Regeneration corrects it. This is the same correction `1f57306b1` made, on a
branch that is not an ancestor of `split/7-tools-and-example`, so the stale
comment is still present on this base. It is a genuine fix, not version churn.

## The example's proto copy

`Examples/WendyDataModelApp/proto/wendy/agent/apps/v1/sensor_service.proto` is
a build-time copy, not a deliberate snapshot: the example's Docker build
context is the example directory and cannot reach `Proto/`, so it generates its
Python stubs from the copy, and `TestExampleSensorProtoMatchesCanonical` in
`go/internal/shared/appconfig/wendy_data_model_app_test.go` fails if the two
drift. It carries the identical edit. The example's Python client reads named
fields off the message rather than enumerating them, so the three additions are
transparent to it.

## Tests

New:

- `TestSensorSampleMessageCarriesBufferFields` covers the internal struct to
  proto message mapping, checks that the k-th sample of a declared buffer lands
  inside the span the buffer declares, and pins that a single-instant sample
  leaves all three fields at zero with the rest of the sample untouched.
- `TestCameraSensorSamplesKeepZeroBufferFields`, added to the camera
  subscription coverage in `video_service_sensor_test.go`, pins camera samples
  to single-instant semantics on both the internal struct and the wire message.

Both were mutation-checked: removing the mapping in `sensorSampleMessage` makes
`TestSensorSampleMessageCarriesBufferFields` fail on all three fields.

## Verification

| Check | Result |
| --- | --- |
| `CC=/usr/bin/clang go build ./go/...` | clean |
| `CC=/usr/bin/clang go test -race ./go/internal/agent/services/...` | 743 pass, 0 fail, 2 skip (baseline before the change: 741 pass, 0 fail, 2 skip) |
| `CC=/usr/bin/clang go test -race ./go/internal/shared/appconfig/...` | pass, including `TestExampleSensorProtoMatchesCanonical` |
| `gofmt -l go/` | empty |
| `go vet` on touched packages | clean |
| `git status --porcelain go/proto/gen` | `appspb/v1/sensor_service.pb.go` only |

The two new tests account for the entire delta from 741 to 743.
`TestSubscribeStreamsIdentifiedSamples` and
`TestSubscribeNamesAnUnimplementedSourceKind` both still pass.
