### PR TITLE
fix(agent): backdate audio segment stamps past the chunk and capture delay

### DIFF
--- a/go/internal/agent/audio/alsa.go
+++ b/go/internal/agent/audio/alsa.go
@@ -321,10 +321,30 @@ func SetAlsaVolume(ctx context.Context, card uint64, percent uint32) (uint32, er
 	return actual, nil
 }
 
+// arecordPeriodTimeArg and arecordBufferTimeArg bound how much audio arecord
+// lets accumulate in the device buffer before handing it over. Without them
+// arecord takes the driver's default, which MEASURED on a Jetson Orin Nano with
+// a Logitech C920 microphone left 208 ms of backlog ahead of every read: the
+// samples a caller stamps are already a fifth of a second old, and no honest
+// uncertainty can be published over a delay that large. Ten millisecond periods
+// four deep is the conventional xrun-safe low-latency shape and caps the
+// backlog at 40 ms.
+//
+// The units are time rather than frames deliberately. sampleRate is a
+// parameter, so a frame count would bound the backlog differently at every
+// rate, while a time bound holds at all of them.
+const (
+	arecordPeriodTimeArg = "--period-time=10000" // 10 ms periods
+	arecordBufferTimeArg = "--buffer-time=40000" // four periods, 40 ms of device buffer
+)
+
 // ArecordCommand builds an arecord invocation that emits raw s16le PCM on
 // stdout from device (an ALSA -D argument, e.g. "plughw:0,0"), matching
 // pw-record's output shape so a caller can treat either source the same way
 // once the process is running.
+//
+// pw-record takes its latency from startCapture's latency argument; arecord has
+// no equivalent and silently ignores it, so this path carries its own bound.
 func ArecordCommand(ctx context.Context, device string, sampleRate, channels uint32) *exec.Cmd {
 	return exec.CommandContext(ctx, "arecord",
 		"-q",
@@ -333,6 +353,8 @@ func ArecordCommand(ctx context.Context, device string, sampleRate, channels uin
 		"-r", strconv.FormatUint(uint64(sampleRate), 10),
 		"-c", strconv.FormatUint(uint64(channels), 10),
 		"-t", "raw",
+		arecordPeriodTimeArg,
+		arecordBufferTimeArg,
 		"-",
 	)
 }

--- a/go/internal/agent/audio/alsa_test.go
+++ b/go/internal/agent/audio/alsa_test.go
@@ -294,8 +294,35 @@ func TestAlsaVolumeNoControl(t *testing.T) {
 
 func TestArecordCommand(t *testing.T) {
 	cmd := ArecordCommand(context.Background(), "plughw:1,0", 44100, 2)
-	want := []string{"arecord", "-q", "-D", "plughw:1,0", "-f", "S16_LE", "-r", "44100", "-c", "2", "-t", "raw", "-"}
+	want := []string{
+		"arecord", "-q", "-D", "plughw:1,0", "-f", "S16_LE", "-r", "44100", "-c", "2", "-t", "raw",
+		"--period-time=10000", "--buffer-time=40000", "-",
+	}
 	if !reflect.DeepEqual(cmd.Args, want) {
 		t.Errorf("ArecordCommand args = %v, want %v", cmd.Args, want)
+	}
+}
+
+// TestArecordCommandBoundsDeviceBacklog pins the buffering flags at every
+// sample rate. Without them arecord accepts the driver default, which measured
+// 208 ms of backlog on a Jetson Orin Nano: audio already that stale by the time
+// a caller reads it, and far outside the delay envelope the audio capture
+// adapter publishes as its uncertainty. The flags are the only thing keeping
+// this path inside that envelope, and nothing else would notice their loss.
+func TestArecordCommandBoundsDeviceBacklog(t *testing.T) {
+	for _, rate := range []uint32{16000, 44100, 48000} {
+		cmd := ArecordCommand(context.Background(), "plughw:0,0", rate, 1)
+		for _, want := range []string{"--period-time=10000", "--buffer-time=40000"} {
+			found := false
+			for _, arg := range cmd.Args {
+				if arg == want {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("ArecordCommand at %d Hz does not bound the device buffer: %v lacks %q", rate, cmd.Args, want)
+			}
+		}
 	}
 }

--- a/go/internal/agent/services/data_audio_adapter.go
+++ b/go/internal/agent/services/data_audio_adapter.go
@@ -27,11 +27,17 @@ import (
 // map hardware capture timestamps instead of the agent receipt, and support
 // per-crossing pre-roll from the rolling buffer.
 const (
-	audioSampleRate      = 48000
-	audioChannels        = 1
-	audioBytesPerSample  = 2
-	audioBytesPerSecond  = audioSampleRate * audioChannels * audioBytesPerSample
-	audioChunkBytes      = audioBytesPerSecond / 10 // ~100 ms per read
+	audioSampleRate     = 48000
+	audioChannels       = 1
+	audioBytesPerSample = 2
+	audioBytesPerSecond = audioSampleRate * audioChannels * audioBytesPerSample
+	// audioChunkBytes is the size of the read buffer, not the size of a read.
+	// A pipe read returns whatever the capture process has produced: MEASURED
+	// on a Jetson Orin Nano with a Logitech C920 microphone, reads arrive as
+	// 8192 bytes (4096 frames, 85.33 ms), never the 9600 this bound would
+	// suggest. Every duration derived from a chunk must therefore use the
+	// length actually read.
+	audioChunkBytes      = audioBytesPerSecond / 10
 	audioSegmentDuration = 10 * time.Second
 	audioSegmentBytes    = int64(audioBytesPerSecond) * int64(audioSegmentDuration/time.Second)
 	// defaultAudioFragment is the sealed duration when a threshold source omits
@@ -40,6 +46,25 @@ const (
 	// audioLevelField is the only field the audio threshold trigger understands.
 	audioLevelField = "level_db"
 	wavHeaderBytes  = 44
+	// audioPipelineDelayEstimate is the capture delay still outstanding once
+	// the chunk in hand has been accounted for: audio already sitting in the
+	// device buffer when that chunk was handed over, plus its transit through
+	// the capture subprocess pipe. MEASURED on a Jetson Orin Nano with a
+	// Logitech C920 microphone over 60 reads, the ALSA device delay ran 12.6 ms
+	// to 20.9 ms and pipe transit about 4 ms, giving 16.6 ms to 24.9 ms and
+	// centring near 20 ms. The 102 ms by which the oldest sample in a chunk was
+	// stale on that hardware is this residue plus the 85.33 ms chunk itself.
+	audioPipelineDelayEstimate = 20 * time.Millisecond
+	// audioPipelineDelayBound is the uncertainty half-width published alongside
+	// a corrected stamp. It covers a residual delay anywhere between 0 and
+	// 40 ms, which absorbs the period-size and scheduling variation a single
+	// point measurement cannot pin down, and contains the arecord fallback path
+	// now that audio.ArecordCommand bounds its device buffer to 40 ms.
+	audioPipelineDelayBound = 20 * time.Millisecond
+	// audioMappingSegment labels a stamp corrected by the two constants above,
+	// so a reader can tell corrected audio stamps from the uncorrected
+	// "receipt-bracket-v1" stamps the camera adapters still publish.
+	audioMappingSegment = "receipt-minus-pipeline-v1"
 )
 
 // audioStream is the PCM source the capture loop reads from. It is an interface
@@ -61,6 +86,10 @@ type audioDataAdapter struct {
 	audio *AudioService
 	// openStream is a seam over the real PCM capture; tests inject fake PCM.
 	openStream func(ctx context.Context, deviceID uint32) (audioStream, error)
+	// captureReceipt is a seam over data.CaptureReceipt, threaded into every
+	// capture this adapter starts; tests script the clock so the stamping
+	// arithmetic can be asserted exactly. Nil means read the real clock.
+	captureReceipt func() (int64, int64, int64, error)
 }
 
 func newAudioDataAdapter(audioSvc *AudioService) dataCaptureAdapter {
@@ -253,6 +282,7 @@ func (a *audioDataAdapter) startOne(ctx context.Context, session data.CaptureSes
 		source: source, session: session, dir: dir, stream: stream, index: index,
 		ctx: captureCtx, cancel: cancel, done: make(chan struct{}), ready: make(chan error, 1),
 		mode: mode, op: op, threshold: threshold, fragmentBytes: fragmentBytes, notes: notes,
+		captureReceipt: a.captureReceipt,
 	}
 	go c.run()
 	select {
@@ -402,7 +432,7 @@ func (c *audioCapture) handleThresholdChunk(pcm []byte) error {
 			c.missedCrossings++
 		} else {
 			level := float64(peak)
-			if err := c.beginSegment(&level); err != nil {
+			if err := c.beginSegment(&level, len(pcm)); err != nil {
 				return err
 			}
 			c.sealing = true
@@ -440,7 +470,7 @@ func (c *audioCapture) handleThresholdChunk(pcm []byte) error {
 // handleContinuousChunk appends PCM to a rotating WAV segment.
 func (c *audioCapture) handleContinuousChunk(pcm []byte) error {
 	if c.seg == nil {
-		if err := c.beginSegment(nil); err != nil {
+		if err := c.beginSegment(nil, len(pcm)); err != nil {
 			return err
 		}
 	}
@@ -458,10 +488,22 @@ func (c *audioCapture) handleContinuousChunk(pcm []byte) error {
 
 // beginSegment stamps the segment start on the canonical episode timeline and
 // opens a WAV file with a placeholder header (patched on finish).
-func (c *audioCapture) beginSegment(triggerLevel *float64) error {
+//
+// firstChunkBytes is the length of the chunk that opened the segment, which has
+// already been read from the capture pipe by the time the clock is read. The
+// segment stamp labels that chunk's FIRST sample, so the receipt has to be
+// walked back past the whole chunk and past the delay still outstanding behind
+// it. Passing the length rather than assuming audioChunkBytes matters: a pipe
+// read routinely returns less than the buffer holds.
+func (c *audioCapture) beginSegment(triggerLevel *float64, firstChunkBytes int) error {
 	canonical, uncertainty, receipt, err := c.canonicalTime()
 	if err != nil {
 		return err
+	}
+	canonical -= pcmDurationNanos(firstChunkBytes) + int64(audioPipelineDelayEstimate)
+	uncertainty += int64(audioPipelineDelayBound)
+	if uncertainty > c.maxCanonicalError {
+		c.maxCanonicalError = uncertainty
 	}
 	c.segNumber++
 	prefix := "segment"
@@ -530,12 +572,12 @@ func (c *audioCapture) finishSegment(truncated bool) error {
 		CanonicalEpisodeNanos:     c.segCanonical - c.session.RequestBootNanos,
 		CanonicalUncertaintyNanos: c.segUncert,
 		AgentReceiptBootNanos:     c.segReceipt,
-		MappingSegment:            "receipt-bracket-v1",
+		MappingSegment:            audioMappingSegment,
 		Segment:                   c.segRel,
 		ByteSize:                  dataBytes,
 		SampleRate:                audioSampleRate,
 		Channels:                  audioChannels,
-		DurationNanos:             dataBytes * int64(time.Second) / int64(audioBytesPerSecond),
+		DurationNanos:             pcmDurationNanos(int(dataBytes)),
 		Mode:                      c.mode,
 		TriggerLevelDb:            c.segTrigger,
 		Truncated:                 truncated,
@@ -546,6 +588,10 @@ func (c *audioCapture) finishSegment(truncated bool) error {
 	return err
 }
 
+// canonicalTime reads the agent receipt and the half-width of the clock bracket
+// it was taken in. Both are reported raw: the bracket measures how long the two
+// CLOCK_BOOTTIME reads took and nothing else, and it is beginSegment that folds
+// in the capture delay the receipt knows nothing about.
 func (c *audioCapture) canonicalTime() (canonical, uncertainty, receipt int64, err error) {
 	before, mid, after, err := c.receiptNow()
 	if err != nil {
@@ -553,10 +599,13 @@ func (c *audioCapture) canonicalTime() (canonical, uncertainty, receipt int64, e
 	}
 	canonical = mid
 	uncertainty = (after - before + 1) / 2
-	if uncertainty > c.maxCanonicalError {
-		c.maxCanonicalError = uncertainty
-	}
 	return canonical, uncertainty, mid, nil
+}
+
+// pcmDurationNanos converts a count of captured bytes to the time they span at
+// the fixed s16le / 48 kHz / mono capture format.
+func pcmDurationNanos(n int) int64 {
+	return int64(n) * int64(time.Second) / int64(audioBytesPerSecond)
 }
 
 // finish flushes any in-progress segment and folds accounting into the result.

--- a/go/internal/agent/services/data_audio_adapter_test.go
+++ b/go/internal/agent/services/data_audio_adapter_test.go
@@ -3,11 +3,13 @@ package services
 import (
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/wendylabsinc/wendy/go/internal/agent/audio"
 	"github.com/wendylabsinc/wendy/go/internal/agent/data"
@@ -30,29 +32,96 @@ func (f *fakeAudioStream) Read(b []byte) (int, error) {
 func (f *fakeAudioStream) Close()      {}
 func (f *fakeAudioStream) Err() string { return "" }
 
-func silentChunk() []byte { return make([]byte, audioChunkBytes) }
+// pcmChunk is silence of an arbitrary length. Anything shorter than
+// audioChunkBytes is a short read: the capture loop offers a 9600-byte buffer
+// and the fake, like a real capture pipe, fills only part of it. Hardware does
+// exactly this, delivering 8192 bytes per read on a Jetson Orin Nano.
+func pcmChunk(n int) []byte { return make([]byte, n) }
 
-func loudChunk() []byte {
-	b := make([]byte, audioChunkBytes)
+// loudPCMChunk is a chunk of near full-scale s16 samples, well above any
+// sensible level threshold.
+func loudPCMChunk(n int) []byte {
+	b := make([]byte, n)
 	for i := 0; i+1 < len(b); i += 2 {
-		binary.LittleEndian.PutUint16(b[i:], 0x7FFF) // near full-scale s16
+		binary.LittleEndian.PutUint16(b[i:], 0x7FFF)
 	}
 	return b
 }
 
-// runAudioCapture drives the adapter with a scripted PCM stream and returns the
+func silentChunk() []byte { return pcmChunk(audioChunkBytes) }
+
+func loudChunk() []byte { return loudPCMChunk(audioChunkBytes) }
+
+// fillOneSegment returns the chunks that fill exactly one rotating segment,
+// opening with a read of firstBytes so a test can tell which chunk started
+// which segment. The total is exact, so the next chunk after these begins a new
+// segment.
+func fillOneSegment(firstBytes int) [][]byte {
+	chunks := [][]byte{pcmChunk(firstBytes)}
+	remaining := int(audioSegmentBytes) - firstBytes
+	for remaining >= audioChunkBytes {
+		chunks = append(chunks, pcmChunk(audioChunkBytes))
+		remaining -= audioChunkBytes
+	}
+	if remaining > 0 {
+		chunks = append(chunks, pcmChunk(remaining))
+	}
+	return chunks
+}
+
+// audioReceipt is one scripted CLOCK_BOOTTIME bracket: the reads either side of
+// the instant the capture stamps a segment with.
+type audioReceipt struct{ before, mid, after int64 }
+
+// bracket is the half-width canonicalTime derives from the bracket, which is
+// the clock-read jitter alone.
+func (r audioReceipt) bracket() int64 { return (r.after - r.before + 1) / 2 }
+
+// bootReceipt builds a bracket of the given half-width centred on mid. Callers
+// pass instants at least a second past boot, as CLOCK_BOOTTIME always is by the
+// time audio is flowing, so the backdating and the episode-offset subtraction
+// are exercised against realistic values rather than against zero.
+func bootReceipt(mid, halfWidth time.Duration) audioReceipt {
+	return audioReceipt{before: int64(mid - halfWidth), mid: int64(mid), after: int64(mid + halfWidth)}
+}
+
+// scriptedReceipts drives the captureReceipt seam, handing out one bracket per
+// beginSegment call and repeating the last once the script runs out, so a test
+// scripts only the segments it asserts on.
+func scriptedReceipts(brackets ...audioReceipt) func() (int64, int64, int64, error) {
+	var i int
+	return func() (int64, int64, int64, error) {
+		r := brackets[i]
+		if i < len(brackets)-1 {
+			i++
+		}
+		return r.before, r.mid, r.after, nil
+	}
+}
+
+// audioRun scripts one capture: the PCM the fake stream yields, the clock the
+// capture reads, and the instant the episode was requested.
+type audioRun struct {
+	capture          *data.SourceCapture
+	chunks           [][]byte
+	receipts         func() (int64, int64, int64, error)
+	requestBootNanos int64
+}
+
+// runAudioCaptureWith drives the adapter with a scripted run and returns the
 // capture result plus the audio output directory.
-func runAudioCapture(t *testing.T, capture *data.SourceCapture, chunks [][]byte) (data.CaptureResult, string) {
+func runAudioCaptureWith(t *testing.T, run audioRun) (data.CaptureResult, string) {
 	t.Helper()
 	sessionDir := t.TempDir()
-	source := data.Source{ID: "audio:0", Kind: "audio", ClockDomain: "TEST_CAPTURE/AGENT_RECEIPT", Healthy: true, Detail: "test mic", Capture: capture}
+	source := data.Source{ID: "audio:0", Kind: "audio", ClockDomain: "TEST_CAPTURE/AGENT_RECEIPT", Healthy: true, Detail: "test mic", Capture: run.capture}
 	adapter := &audioDataAdapter{
 		audio: &AudioService{},
 		openStream: func(context.Context, uint32) (audioStream, error) {
-			return &fakeAudioStream{chunks: chunks}, nil
+			return &fakeAudioStream{chunks: run.chunks}, nil
 		},
+		captureReceipt: run.receipts,
 	}
-	session := data.CaptureSession{ID: "ep", Directory: sessionDir, RequestBootNanos: 0}
+	session := data.CaptureSession{ID: "ep", Directory: sessionDir, RequestBootNanos: run.requestBootNanos}
 	running, err := adapter.Start(context.Background(), session, []data.Source{source})
 	if err != nil {
 		t.Fatalf("adapter start: %v", err)
@@ -68,6 +137,34 @@ func runAudioCapture(t *testing.T, capture *data.SourceCapture, chunks [][]byte)
 		t.Fatalf("expected 1 capture result, got %d", len(results))
 	}
 	return results[0], filepath.Join(sessionDir, "audio", safeCaptureName(source.ID))
+}
+
+// runAudioCapture drives the adapter with a scripted PCM stream over the real
+// clock, for tests that assert on sealing behaviour rather than on stamps.
+func runAudioCapture(t *testing.T, capture *data.SourceCapture, chunks [][]byte) (data.CaptureResult, string) {
+	t.Helper()
+	return runAudioCaptureWith(t, audioRun{capture: capture, chunks: chunks})
+}
+
+// readAudioIndex parses index.jsonl, one record per sealed segment.
+func readAudioIndex(t *testing.T, dir string) []audioIndexRecord {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(dir, "index.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var records []audioIndexRecord
+	for _, line := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+		if line == "" {
+			continue
+		}
+		var record audioIndexRecord
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("index line %q: %v", line, err)
+		}
+		records = append(records, record)
+	}
+	return records
 }
 
 func wavFragments(t *testing.T, dir string) []string {
@@ -165,6 +262,214 @@ func TestAudioThresholdCountsMissedCrossingsDuringSeal(t *testing.T) {
 	}
 	if result.Drops == nil || *result.Drops != 1 {
 		t.Fatalf("expected exactly 1 missed crossing during the seal, got %v", result.Drops)
+	}
+}
+
+// TestAudioSegmentStampBackdatesChunkAndPipeline pins the whole stamping
+// arithmetic on one segment. The clock is read only after a chunk has been
+// pulled off the capture pipe, so the receipt describes the moment the chunk
+// arrived, not the moment its first sample was captured. The segment stamp
+// labels that first sample, so it has to be walked back past the chunk and past
+// the delay still outstanding behind it, and the published uncertainty has to
+// widen to cover that delay rather than reporting clock-read jitter alone.
+func TestAudioSegmentStampBackdatesChunkAndPipeline(t *testing.T) {
+	const (
+		chunkBytes    = 4800 // 50 ms of s16le 48 kHz mono
+		chunkNanos    = int64(50 * time.Millisecond)
+		requestBoot   = int64(500 * time.Millisecond)
+		clockHalfWide = 3 * time.Microsecond
+	)
+	stamp := bootReceipt(5*time.Second, clockHalfWide)
+
+	result, dir := runAudioCaptureWith(t, audioRun{
+		chunks:           [][]byte{pcmChunk(chunkBytes)},
+		receipts:         scriptedReceipts(stamp),
+		requestBootNanos: requestBoot,
+	})
+
+	records := readAudioIndex(t, dir)
+	if len(records) != 1 {
+		t.Fatalf("got %d index records, want 1: %+v", len(records), records)
+	}
+	record := records[0]
+
+	wantCanonical := stamp.mid - chunkNanos - int64(audioPipelineDelayEstimate) - requestBoot
+	if record.CanonicalEpisodeNanos != wantCanonical {
+		t.Errorf("canonical_episode_nanos = %d, want %d (receipt %d less the %v chunk, the %v pipeline delay and the %v episode offset)",
+			record.CanonicalEpisodeNanos, wantCanonical, stamp.mid,
+			time.Duration(chunkNanos), audioPipelineDelayEstimate, time.Duration(requestBoot))
+	}
+	if record.AgentReceiptBootNanos != stamp.mid {
+		t.Errorf("agent_receipt_boottime_nanos = %d, want the raw receipt %d", record.AgentReceiptBootNanos, stamp.mid)
+	}
+	wantUncertainty := stamp.bracket() + int64(audioPipelineDelayBound)
+	if record.CanonicalUncertaintyNanos != wantUncertainty {
+		t.Errorf("canonical_uncertainty_nanos = %d, want %d (clock bracket %d plus the %v delay bound)",
+			record.CanonicalUncertaintyNanos, wantUncertainty, stamp.bracket(), audioPipelineDelayBound)
+	}
+	if record.MappingSegment != "receipt-minus-pipeline-v1" {
+		t.Errorf("mapping_segment = %q, want %q so a reader can tell corrected stamps from legacy ones",
+			record.MappingSegment, "receipt-minus-pipeline-v1")
+	}
+	if record.DurationNanos != chunkNanos {
+		t.Errorf("duration_nanos = %d, want %d", record.DurationNanos, chunkNanos)
+	}
+	if result.ActualOffset == nil || *result.ActualOffset != wantCanonical {
+		t.Errorf("result.ActualOffset = %v, want %d", result.ActualOffset, wantCanonical)
+	}
+	if result.MappingError == nil || *result.MappingError != wantUncertainty {
+		t.Errorf("result.MappingError = %v, want %d so the campaign summary agrees with the segment",
+			result.MappingError, wantUncertainty)
+	}
+}
+
+// TestAudioShortReadStampAndDurationUseBytes proves every duration comes from
+// the bytes actually read rather than from audioChunkBytes. A pipe read returns
+// whatever the capture process has produced, and on hardware that is 8192 bytes
+// rather than the 9600 the buffer holds; assuming the buffer size would put
+// every stamp out by the difference.
+func TestAudioShortReadStampAndDurationUseBytes(t *testing.T) {
+	const (
+		firstBytes  = 3000
+		secondBytes = 5000
+		// 3000 bytes at 96000 bytes per second is 31.25 ms.
+		firstNanos  = int64(31_250_000)
+		requestBoot = int64(1500 * time.Millisecond)
+	)
+	if got := pcmDurationNanos(firstBytes); got != firstNanos {
+		t.Fatalf("pcmDurationNanos(%d) = %d, want %d", firstBytes, got, firstNanos)
+	}
+	stamp := bootReceipt(7*time.Second, 2*time.Microsecond)
+
+	_, dir := runAudioCaptureWith(t, audioRun{
+		chunks:           [][]byte{pcmChunk(firstBytes), pcmChunk(secondBytes)},
+		receipts:         scriptedReceipts(stamp),
+		requestBootNanos: requestBoot,
+	})
+
+	records := readAudioIndex(t, dir)
+	if len(records) != 1 {
+		t.Fatalf("got %d index records, want 1: %+v", len(records), records)
+	}
+	record := records[0]
+
+	wantCanonical := stamp.mid - firstNanos - int64(audioPipelineDelayEstimate) - requestBoot
+	if record.CanonicalEpisodeNanos != wantCanonical {
+		t.Errorf("canonical_episode_nanos = %d, want %d (backdated by the 3000 bytes actually read, not by the 9600-byte buffer)",
+			record.CanonicalEpisodeNanos, wantCanonical)
+	}
+	if record.ByteSize != firstBytes+secondBytes {
+		t.Errorf("byte_size = %d, want %d", record.ByteSize, firstBytes+secondBytes)
+	}
+	// 8000 bytes at 96000 bytes per second is 83.333333 ms.
+	if want := int64(83_333_333); record.DurationNanos != want {
+		t.Errorf("duration_nanos = %d, want %d (the total bytes sealed)", record.DurationNanos, want)
+	}
+}
+
+// TestAudioThresholdFragmentStampBackdates covers the threshold path, where the
+// segment opens on the chunk that crossed the level rather than on the first
+// chunk of the stream. The crossing chunk is short, so an assumed chunk length
+// would misplace the fragment start.
+func TestAudioThresholdFragmentStampBackdates(t *testing.T) {
+	const (
+		crossingBytes = 4800 // 50 ms, exactly the configured fragment
+		crossingNanos = int64(50 * time.Millisecond)
+		requestBoot   = int64(2 * time.Second)
+	)
+	stamp := bootReceipt(9*time.Second, 4*time.Microsecond)
+
+	result, dir := runAudioCaptureWith(t, audioRun{
+		capture:          &data.SourceCapture{Mode: "threshold", Trigger: "level_db > -20", Fragment: "50ms"},
+		chunks:           [][]byte{silentChunk(), loudPCMChunk(crossingBytes), silentChunk()},
+		receipts:         scriptedReceipts(stamp),
+		requestBootNanos: requestBoot,
+	})
+
+	if result.Count != 1 {
+		t.Fatalf("result.Count = %d, want 1 sealed fragment", result.Count)
+	}
+	records := readAudioIndex(t, dir)
+	if len(records) != 1 {
+		t.Fatalf("got %d index records, want 1: %+v", len(records), records)
+	}
+	record := records[0]
+
+	wantCanonical := stamp.mid - crossingNanos - int64(audioPipelineDelayEstimate) - requestBoot
+	if record.CanonicalEpisodeNanos != wantCanonical {
+		t.Errorf("canonical_episode_nanos = %d, want %d (backdated by the crossing chunk, not by the silent chunk before it)",
+			record.CanonicalEpisodeNanos, wantCanonical)
+	}
+	if record.CanonicalUncertaintyNanos != stamp.bracket()+int64(audioPipelineDelayBound) {
+		t.Errorf("canonical_uncertainty_nanos = %d, want %d", record.CanonicalUncertaintyNanos, stamp.bracket()+int64(audioPipelineDelayBound))
+	}
+	if record.Mode != "threshold" || record.TriggerLevelDb == nil {
+		t.Errorf("record does not describe a threshold fragment: %+v", record)
+	}
+	if record.MappingSegment != "receipt-minus-pipeline-v1" {
+		t.Errorf("mapping_segment = %q, want %q", record.MappingSegment, "receipt-minus-pipeline-v1")
+	}
+	if record.DurationNanos != crossingNanos {
+		t.Errorf("duration_nanos = %d, want %d", record.DurationNanos, crossingNanos)
+	}
+}
+
+// TestAudioSegmentRotationRestampsPerSegment proves the correction is applied
+// per segment rather than once at capture start. Each rotation opens on a chunk
+// of a different length, and each must be stamped from its own receipt and its
+// own opening chunk.
+func TestAudioSegmentRotationRestampsPerSegment(t *testing.T) {
+	const requestBoot = int64(3 * time.Second)
+	firstBytes := []int{4800, 2400, 3000}
+	firstNanos := []int64{50_000_000, 25_000_000, 31_250_000}
+	stamps := []audioReceipt{
+		bootReceipt(11*time.Second, 1*time.Microsecond),
+		bootReceipt(21*time.Second, 5*time.Microsecond),
+		bootReceipt(31*time.Second, 9*time.Microsecond),
+	}
+
+	var chunks [][]byte
+	chunks = append(chunks, fillOneSegment(firstBytes[0])...)
+	chunks = append(chunks, fillOneSegment(firstBytes[1])...)
+	chunks = append(chunks, pcmChunk(firstBytes[2]))
+
+	result, dir := runAudioCaptureWith(t, audioRun{
+		chunks:           chunks,
+		receipts:         scriptedReceipts(stamps...),
+		requestBootNanos: requestBoot,
+	})
+
+	if result.Count != 3 {
+		t.Fatalf("result.Count = %d, want 3 (two rotations plus the segment sealed at stop)", result.Count)
+	}
+	records := readAudioIndex(t, dir)
+	if len(records) != 3 {
+		t.Fatalf("got %d index records, want 3: %+v", len(records), records)
+	}
+	for i, record := range records {
+		wantCanonical := stamps[i].mid - firstNanos[i] - int64(audioPipelineDelayEstimate) - requestBoot
+		if record.CanonicalEpisodeNanos != wantCanonical {
+			t.Errorf("segment %d canonical_episode_nanos = %d, want %d (its own receipt less its own opening chunk)",
+				i+1, record.CanonicalEpisodeNanos, wantCanonical)
+		}
+		if record.AgentReceiptBootNanos != stamps[i].mid {
+			t.Errorf("segment %d agent_receipt_boottime_nanos = %d, want %d", i+1, record.AgentReceiptBootNanos, stamps[i].mid)
+		}
+		wantUncertainty := stamps[i].bracket() + int64(audioPipelineDelayBound)
+		if record.CanonicalUncertaintyNanos != wantUncertainty {
+			t.Errorf("segment %d canonical_uncertainty_nanos = %d, want %d", i+1, record.CanonicalUncertaintyNanos, wantUncertainty)
+		}
+	}
+	for i := 0; i < 2; i++ {
+		if records[i].ByteSize != audioSegmentBytes {
+			t.Errorf("segment %d byte_size = %d, want a full segment of %d", i+1, records[i].ByteSize, audioSegmentBytes)
+		}
+		if want := int64(audioSegmentDuration); records[i].DurationNanos != want {
+			t.Errorf("segment %d duration_nanos = %d, want %d", i+1, records[i].DurationNanos, want)
+		}
+	}
+	if records[2].ByteSize != int64(firstBytes[2]) {
+		t.Errorf("final segment byte_size = %d, want %d", records[2].ByteSize, firstBytes[2])
 	}
 }
 

--- a/go/internal/cli/assets/docs/wendy-data-platform-demo.md
+++ b/go/internal/cli/assets/docs/wendy-data-platform-demo.md
@@ -289,12 +289,14 @@ Enrollment is untouched by the demo, so there is nothing to restore there.
   directory was created or that a topic was subscribed, so a recorder that
   fails just after that window reports a successful start and surfaces the
   failure only at Stop.
-- The audio capture's `canonical_uncertainty_nanos` is the width of the
-  `clock_gettime` bracket taken in `beginSegment`, which runs after a chunk of
-  pulse-code modulation (PCM) data has already been read from the pipe. The
-  published uncertainty therefore describes the read of the clock, not the
-  buffering delay ahead of it, and understates the true error on a segment
-  start.
+- The audio capture now backdates a segment stamp past the chunk of pulse-code
+  modulation (PCM) data it read and past a constant for the delay still
+  outstanding behind it, and publishes a 20 ms uncertainty half-width to cover
+  that constant (`mapping_segment` reads `receipt-minus-pipeline-v1`). The
+  constant is an estimate, not a reading: nothing queries the actual ALSA or
+  PipeWire delay per chunk, so a device whose buffering departs markedly from
+  the Jetson Orin Nano the constants were measured on could fall outside the
+  published bound.
 - `wendy data download` mutates its own `--output` flag variable when the flag
   is empty, so re-running the same command object in one process writes to the
   first episode's directory.


### PR DESCRIPTION
## Problem

Every audio segment WendyOS captures carries a start time that is systematically
late, labelled with an accuracy it does not have.

Measured on a Jetson Orin Nano with a Logitech C920 microphone over 60 reads:

| Quantity | Measured |
| --- | --- |
| Bytes per pipe read | 8192 (4096 frames, 85.33 ms at 48 kHz), not the 9600 the code assumed |
| Age of the newest sample in a chunk when stamped | 16.6 ms |
| Age of the oldest sample, which is what the segment time labels | about 102 ms |
| Published `canonical_uncertainty_nanos` | about 4.9 microseconds |
| ALSA device delay | 12.6 ms to 20.9 ms |
| Pipe transit | about 4 ms |
| `arecord` fallback device backlog | 208 ms |

So the value published was roughly 102 ms late while claiming microsecond
accuracy, off by about four orders of magnitude. That is exactly the kind of
figure a downstream consumer trusts and should not.

## Cause

`beginSegment` in `go/internal/agent/services/data_audio_adapter.go` read the
clock only after a chunk of pulse-code modulation (PCM) data had already been
pulled off the capture subprocess pipe, then labelled that segment's first
sample with the instant of the read. Two distinct errors followed.

The stamp ignored the chunk. The receipt describes when the chunk arrived, not
when its first sample was captured, so the whole chunk plus whatever delay sat
behind it went unaccounted for. The code also assumed each read returned
`audioChunkBytes`, which hardware never did.

The uncertainty measured the wrong thing entirely. `canonicalTime` brackets two
back-to-back `CLOCK_BOOTTIME` reads and reports half that width, so it
quantified our own clock-read jitter and said nothing whatsoever about capture
latency. Nothing anywhere in the repository reads ALSA or PipeWire delay
(verified exhaustively: zero `snd_pcm` hits, no `pw-cli` or `pw-dump` latency
reads), so no other code path was making up the difference.

Separately, the `arecord` fallback passed no buffering flags at all. The
`"100ms"` latency argument `defaultOpenStream` supplies is PipeWire-only and is
silently dropped on that path, leaving the driver default in place: 208 ms of
backlog ahead of every read.

## Solution

`beginSegment` now takes the length of the chunk that opened the segment and
computes:

```
segCanonical = receiptMid - pcmDurationNanos(firstChunkBytes) - audioPipelineDelayEstimate
segUncert    = clockBracketHalfWidth + audioPipelineDelayBound
```

`audioPipelineDelayEstimate` is 20 ms, the delay still outstanding once the
chunk in hand is accounted for: the 12.6 ms to 20.9 ms ALSA device delay plus
about 4 ms of pipe transit gives 16.6 ms to 24.9 ms, centring near 20 ms. The
102 ms total observed is that residue plus the 85.33 ms chunk.

`audioPipelineDelayBound` is also 20 ms, covering a residual delay anywhere
between 0 and 40 ms. It absorbs the period-size and scheduling variation a
single point measurement cannot pin down, and it contains the `arecord` path now
that its buffer is bounded.

**The reported uncertainty grows from about 5 microseconds to about 20
milliseconds, and that widening is the fix, not a regression.** The old figure
was measuring clock-read jitter, which is not the quantity the field claims to
describe. Twenty milliseconds is what we can actually defend.

Every duration comes from the bytes actually read, never from `audioChunkBytes`.
Hardware delivers 8192-byte reads and a plain pipe `Read` can short-read at any
time, so the constant was never a safe stand-in.

`AgentReceiptBootNanos` still records the raw receipt and `canonicalTime` still
reports the raw clock bracket. The correction is applied in `beginSegment`, so
both primitives stay honest about what they are. The capture result's
`mapping_error_nanos` now tracks the corrected uncertainty rather than the
bracket alone, so the campaign summary agrees with the per-segment figure.

The audio `mapping_segment` becomes `"receipt-minus-pipeline-v1"`, so a
downstream reader can distinguish corrected stamps from legacy ones. The camera
adapters keep `"receipt-bracket-v1"`, which their own tests pin.

`ArecordCommand` gains `--period-time=10000` and `--buffer-time=40000`: 10 ms
periods four deep, the conventional low-latency shape that is still safe against
underruns. Time units rather than frame counts because the function takes
`sampleRate` as a parameter, and a time bound holds identically at every rate.
This collapses the measured 208 ms backlog to at most 40 ms, inside the estimate
plus bound envelope. **Note that this affects the audio streaming path as well
as episode capture**: `startCapture` in `audio_service.go` is the only
production caller, so live streaming inherits the same bounded latency, which is
desirable.

No negative-stamp clamp is added. The correction is roughly one chunk plus
20 ms, and `CLOCK_BOOTTIME` at the first chunk is always seconds past boot, so
production cannot go negative.

## Tests

Audio stamping was completely untested: nothing asserted `DurationNanos`,
`canonical_episode_nanos`, `canonical_uncertainty_nanos` or `mapping_segment`
for audio, and the fake stream never short-read. Five tests are new.

- `TestAudioSegmentStampBackdatesChunkAndPipeline` pins the whole arithmetic on
  one segment with a scripted clock, a 4800-byte chunk and a non-zero
  `RequestBootNanos`, so the episode-offset subtraction is genuinely exercised.
- `TestAudioShortReadStampAndDurationUseBytes` drives 3000-byte then 5000-byte
  reads and asserts the stamp backdates by 31.25 ms, not by the buffer size.
- `TestAudioThresholdFragmentStampBackdates` covers the threshold path, where
  the segment opens on the crossing chunk rather than the first chunk.
- `TestAudioSegmentRotationRestampsPerSegment` scripts three receipts across two
  rotations and asserts each segment is stamped from its own receipt and its own
  opening chunk.
- `TestArecordCommandBoundsDeviceBacklog` pins the buffering flags at several
  sample rates.

Each of the four stamping tests was confirmed to fail against the old behaviour,
both with the correction removed and with the chunk length replaced by
`audioChunkBytes`.

The adapter gained a `captureReceipt` seam mirroring the existing `openStream`
seam, so the scripted clock reaches the capture through the real `Start` path
rather than through a hand-built struct.

The "Open gaps" entry in `wendy-data-platform-demo.md` that described this
defect is rewritten to describe what actually remains: the delay is an estimate
from one measurement campaign, not a per-chunk reading of ALSA or PipeWire.

## Verification

- `CC=/usr/bin/clang go build ./go/...` clean.
- `CC=/usr/bin/clang go test -race ./go/internal/agent/services/... ./go/internal/agent/audio/...` passes.
  Before: 761 passed, 2 skipped, 0 failed. After: 766 passed, 2 skipped, 0 failed.
- `gofmt -l go/` empty; `go vet` clean on both touched packages.
