### PR TITLE
fix(data): drain the seal and fence the pre-roll flush

### DIFF
--- a/go/internal/agent/data/campaign.go
+++ b/go/internal/agent/data/campaign.go
@@ -138,7 +138,13 @@ type CampaignTrigger struct {
 }
 
 type CampaignCapture struct {
-	Buffer       string            `json:"buffer" yaml:"buffer"`
+	Buffer string `json:"buffer" yaml:"buffer"`
+	// Drain holds the episode open for late application records after its
+	// capture adapters stop. An empty value takes DefaultSealDrain; "0s" opts
+	// out. The omitempty tag is load-bearing: planOnly is marshalled to JSON to
+	// compute Revision, so a field rendered on every campaign would change the
+	// revision digest of every already-deployed campaign.
+	Drain        string            `json:"drain,omitempty" yaml:"drain,omitempty"`
 	AfterTrigger string            `json:"after_trigger" yaml:"after_trigger"`
 	Triggers     []CampaignTrigger `json:"triggers" yaml:"triggers"`
 }
@@ -266,6 +272,12 @@ func (c Campaign) validate() error {
 	if err != nil || buffer < 0 || buffer > preRollWindow {
 		return fmt.Errorf("capture.buffer must be a duration from 0s through %s", preRollWindow)
 	}
+	if c.Capture.Drain != "" {
+		drain, drainErr := time.ParseDuration(c.Capture.Drain)
+		if drainErr != nil || drain < 0 || drain > maxSealDrain {
+			return fmt.Errorf("capture.drain must be a duration from 0s through %s", maxSealDrain)
+		}
+	}
 	after, err := time.ParseDuration(c.Capture.AfterTrigger)
 	if err != nil || after <= 0 || after > 24*time.Hour {
 		return errors.New("capture.after_trigger must be a duration greater than 0s and no more than 24h")
@@ -311,6 +323,18 @@ func (c Campaign) validate() error {
 
 func (c Campaign) BufferDuration() time.Duration {
 	d, _ := time.ParseDuration(c.Capture.Buffer)
+	return d
+}
+
+// DrainDuration is how long an episode this campaign triggers stays open for
+// late application records after its capture adapters stop. A campaign that
+// declares nothing takes DefaultSealDrain, so asynchronous scoring is filed
+// correctly by default; "drain: 0s" opts out and seals immediately.
+func (c Campaign) DrainDuration() time.Duration {
+	if c.Capture.Drain == "" {
+		return DefaultSealDrain
+	}
+	d, _ := time.ParseDuration(c.Capture.Drain)
 	return d
 }
 

--- a/go/internal/agent/data/campaign_test.go
+++ b/go/internal/agent/data/campaign_test.go
@@ -372,3 +372,70 @@ func TestResolveROS2SelectorSkipsUnhealthyGraphs(t *testing.T) {
 		t.Fatal("an unhealthy graph resolved through the fallback path")
 	}
 }
+
+// drainDigestPinYAML is a campaign that declares no drain. Its revision digest
+// is pinned below at the value the digest had before capture.drain existed.
+const drainDigestPinYAML = `version: 1
+name: drain-digest-pin
+sources:
+  - telemetry: true
+capture:
+  buffer: 1s
+  after_trigger: 5s
+  triggers:
+    - event: pinned
+upload: {when: wifi, destination: example-episodes}
+export: {annotation: cvat}
+`
+
+// drainDigestPinRevision is the SHA-256 of drainDigestPinYAML's canonical plan,
+// recorded before capture.drain was added. Every deployed campaign is
+// identified by this digest, so a drain-less plan must keep hashing to exactly
+// the same value; that is what the omitempty tag on CampaignCapture.Drain buys.
+// Changing this constant to match new output would be defeating the test.
+const drainDigestPinRevision = "bbb81df5f017616a7c3156f7aaeb064ed00e632ae01546cfce265610a4129e23"
+
+func TestCampaignDrainValidation(t *testing.T) {
+	withDrain := func(drain string) []byte {
+		return []byte(strings.Replace(drainDigestPinYAML, "  buffer: 1s\n", "  buffer: 1s\n  drain: "+drain+"\n", 1))
+	}
+	for _, drain := range []string{"-1s", "31s", "notaduration"} {
+		if _, err := ParseCampaign(withDrain(drain)); err == nil || !strings.Contains(err.Error(), "capture.drain") {
+			t.Errorf("capture.drain %q was accepted: %v", drain, err)
+		}
+	}
+	// An absent drain takes the default, so campaigns get the post-seal drain
+	// without being rewritten.
+	base, err := ParseCampaign([]byte(drainDigestPinYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if base.DrainDuration() != DefaultSealDrain {
+		t.Fatalf("absent capture.drain gives %s, want the %s default", base.DrainDuration(), DefaultSealDrain)
+	}
+	// An explicit zero is the opt-out, and must be distinguishable from absent.
+	optedOut, err := ParseCampaign(withDrain("0s"))
+	if err != nil {
+		t.Fatalf("capture.drain 0s was rejected: %v", err)
+	}
+	if optedOut.DrainDuration() != 0 {
+		t.Fatalf("capture.drain 0s gives %s, want 0s", optedOut.DrainDuration())
+	}
+	accepted, err := ParseCampaign(withDrain("30s"))
+	if err != nil {
+		t.Fatalf("capture.drain at the upper bound was rejected: %v", err)
+	}
+	if accepted.DrainDuration() != maxSealDrain {
+		t.Fatalf("capture.drain 30s gives %s, want %s", accepted.DrainDuration(), maxSealDrain)
+	}
+	// The digest pin. A campaign that says nothing about the drain must hash
+	// exactly as it did before the field existed, or every already-deployed
+	// campaign silently changes revision on upgrade.
+	if base.Revision != drainDigestPinRevision {
+		t.Fatalf("a drain-less campaign now hashes to %s, want the pre-existing %s: capture.drain must stay omitempty", base.Revision, drainDigestPinRevision)
+	}
+	// A declared drain is part of the plan and must change the digest.
+	if optedOut.Revision == base.Revision {
+		t.Fatal("declaring capture.drain did not change the revision hash")
+	}
+}

--- a/go/internal/agent/data/manager.go
+++ b/go/internal/agent/data/manager.go
@@ -32,6 +32,17 @@ const (
 	// them where a device wants a different bound.
 	DefaultMaxQuotaBytes = int64(50 << 30)
 	DefaultReserveBytes  = int64(5 << 30)
+	// DefaultSealDrain is how long an episode that captures applications stays
+	// open for late application records after its capture adapters have shut
+	// down. An application that scores asynchronously writes its prediction
+	// after the samples it read, so without a drain that write lands past the
+	// seal and is filed against a later episode. The manager itself applies no
+	// default: the value arrives through StartOptions.DrainDuration, and the
+	// policy of using this default lives at the service call sites.
+	DefaultSealDrain = 2 * time.Second
+	// maxSealDrain bounds the configurable drain. Beyond this the wait stops
+	// being a seal detail and becomes an unannounced extension of the episode.
+	maxSealDrain = 30 * time.Second
 )
 
 var ErrNoActiveEpisode = errors.New("no active episode")
@@ -145,8 +156,15 @@ func (m *Manager) Sources(ctx context.Context) []Source {
 }
 
 type bufferedRecord struct {
+	// bootNanos is the record's presentation stamp: the client's own
+	// CLOCK_BOOTTIME value when it was accepted, otherwise the agent receipt.
+	// It is what the pre-roll offset is derived from, and a client can move it.
 	bootNanos int64
-	encoded   []byte
+	// receiptNanos is the agent-authoritative CLOCK_BOOTTIME reading taken when
+	// the record arrived. No client can influence it, so it is the timestamp
+	// that decides ring eviction and pre-roll window membership.
+	receiptNanos int64
+	encoded      []byte
 }
 
 type ApplicationRecord struct {
@@ -173,6 +191,11 @@ type storedApplicationRecord struct {
 	TimestampUncertaintyNanos int64  `json:"timestamp_uncertainty_nanos"`
 	AgentReceiptBootNanos     int64  `json:"agent_receipt_boottime_nanos"`
 	ClientTimestampAccepted   bool   `json:"client_timestamp_accepted"`
+	// PrerollFlushed marks a record this episode received from the pre-roll ring
+	// rather than live. It is provenance, not a defect: a pre-trigger record is
+	// legitimately replayed into an episode that started after it arrived. The
+	// key is absent on live-recorded lines, so those stay byte-identical.
+	PrerollFlushed bool `json:"preroll_flushed,omitempty"`
 }
 
 // SetConsensusProvider configures a fresh direct observation at episode start
@@ -192,6 +215,12 @@ type activeEpisode struct {
 	// capturesApplications reports whether the applications source was
 	// selected; episodes that excluded it receive no application records.
 	capturesApplications bool
+	// drain is how long this episode stays in m.active after its capture
+	// adapters have stopped, so that a record an application writes about the
+	// samples it just read is still filed into this episode instead of the
+	// next one. Zero or less means no drain, and it is honoured only for
+	// episodes that capture applications.
+	drain time.Duration
 	// modelInputs is the append handle for the model-input ledger, opened on
 	// the first sample a model consumed (see openModelInputLedger). It is not
 	// fsynced per sample: at sensor rates that would dominate the write path,
@@ -244,6 +273,11 @@ func bootID() string {
 	}
 	return strings.TrimSpace(string(b))
 }
+
+// readBootIDForAcceptance is the boot identity RecordApplication checks a
+// client's claimed one against. It is a variable so a test can present both a
+// healthy agent identity and an unavailable one without a real /proc.
+var readBootIDForAcceptance = bootID
 
 func deviceIdentity(currentBootID string) DeviceIdentity {
 	hostname, _ := os.Hostname()
@@ -459,7 +493,7 @@ func (m *Manager) Start(opts StartOptions) (Manifest, error) {
 		_ = os.RemoveAll(dir)
 		return Manifest{}, err
 	}
-	a := &activeEpisode{key: key, dir: dir, manifest: manifest, capturesApplications: capturesApplications, awaitConsensus: deferConsensus}
+	a := &activeEpisode{key: key, dir: dir, manifest: manifest, capturesApplications: capturesApplications, drain: opts.DrainDuration, awaitConsensus: deferConsensus}
 	ctx, cancel := context.WithCancel(context.Background())
 	a.cancel = cancel
 	a.done = make(chan struct{})
@@ -562,6 +596,9 @@ func (m *Manager) ApplyCaptureResults(key string, results []CaptureResult) error
 
 // Interrupt finalizes an active episode after adapter startup failed. Existing
 // monotonic data is retained for auditability and is never silently deleted.
+// An interrupted episode drains for late application records exactly as a
+// stopped one does: the records an application still owes are no less its own
+// for the episode having ended badly.
 func (m *Manager) Interrupt(key, reason string) (Manifest, error) {
 	m.mu.Lock()
 	a := m.active[key]
@@ -576,6 +613,7 @@ func (m *Manager) Interrupt(key, reason string) (Manifest, error) {
 	if a.done != nil {
 		<-a.done
 	}
+	m.drainSeal(a)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.active[key] != a {
@@ -763,7 +801,16 @@ func (m *Manager) RecordApplication(appID string, record ApplicationRecord) (str
 		return "rejected", err
 	}
 	receipt := before + (after-before)/2
-	accepted := record.ClientBootID == bootID() && record.ClientBootNanos >= 0 && abs64(record.ClientBootNanos-receipt) <= preRollWindow.Nanoseconds()
+	// bootID reports the literal "unavailable" when the kernel boot identity
+	// cannot be read, so comparing against it unguarded would let a client that
+	// sends "unavailable" match on exactly the hosts where the agent has no
+	// boot identity to check against, and have its arbitrary timestamp trusted.
+	// An agent that cannot name its own boot cannot vouch for a client's, so it
+	// accepts no client timestamp at all. Reading it once per record also drops
+	// one /proc read from the per-record path.
+	agentBootID := readBootIDForAcceptance()
+	accepted := agentBootID != "unavailable" && record.ClientBootID == agentBootID &&
+		record.ClientBootNanos >= 0 && abs64(record.ClientBootNanos-receipt) <= preRollWindow.Nanoseconds()
 	stamp := receipt
 	if accepted {
 		stamp = record.ClientBootNanos
@@ -799,7 +846,7 @@ func (m *Manager) RecordApplication(appID string, record ApplicationRecord) (str
 		m.mu.Unlock()
 		return "rejected", err
 	}
-	m.preRoll = append(m.preRoll, bufferedRecord{bootNanos: stamp, encoded: b})
+	m.preRoll = append(m.preRoll, bufferedRecord{bootNanos: stamp, receiptNanos: receipt, encoded: b})
 	m.preRollBytes += len(b)
 	m.evictPreRoll(receipt)
 	observer := m.appObserver
@@ -813,9 +860,15 @@ func (m *Manager) RecordApplication(appID string, record ApplicationRecord) (str
 	return "buffered", nil
 }
 
+// evictPreRoll drops ring entries that have aged out of the pre-roll window or
+// that no longer fit the byte budget. Age is measured on the agent receipt, not
+// on the presentation stamp: the ring is appended in receipt order, so the head
+// is always the oldest arrival and dropping from the front is provably correct.
+// Measuring the client-supplied stamp instead let one forward-dated entry sit at
+// the head and hold back the eviction of genuinely older entries behind it.
 func (m *Manager) evictPreRoll(now int64) {
 	cutoff := now - preRollWindow.Nanoseconds()
-	for len(m.preRoll) > 0 && (m.preRoll[0].bootNanos < cutoff || m.preRollBytes > preRollLimit) {
+	for len(m.preRoll) > 0 && (m.preRoll[0].receiptNanos < cutoff || m.preRollBytes > preRollLimit) {
 		m.preRollBytes -= len(m.preRoll[0].encoded)
 		m.preRoll = m.preRoll[1:]
 		m.preRollLost++
@@ -826,6 +879,15 @@ func (m *Manager) evictPreRoll(now int64) {
 // starting episode. The ring buffer is not consumed: with per-campaign
 // concurrency another campaign's later episode is entitled to the same
 // pre-trigger records on its own timeline.
+//
+// Admission is the intersection of two timelines. A record enters the window
+// only when both its agent receipt and its presentation stamp fall inside it.
+// Testing the stamp alone let an accepted client choose which later episode
+// windows it appeared in, by back- or forward-dating its own CLOCK_BOOTTIME
+// within the five minute acceptance band; requiring the receipt as well means
+// a record can only reach a window it was physically present for. The offset
+// arithmetic still uses the stamp, so ActualOffset keeps its meaning and
+// offsets stay within [-window, 0].
 func (m *Manager) flushPreRoll(dir string, origin int64, requested time.Duration) (uint64, *int64, error) {
 	window := preRollWindow
 	if requested > 0 && requested < window {
@@ -835,7 +897,7 @@ func (m *Manager) flushPreRoll(dir string, origin int64, requested time.Duration
 	var count uint64
 	var earliest *int64
 	for _, r := range m.preRoll {
-		if r.bootNanos < cutoff || r.bootNanos > origin {
+		if r.receiptNanos < cutoff || r.receiptNanos > origin || r.bootNanos < cutoff || r.bootNanos > origin {
 			continue
 		}
 		var stored storedApplicationRecord
@@ -843,6 +905,7 @@ func (m *Manager) flushPreRoll(dir string, origin int64, requested time.Duration
 			continue
 		}
 		stored.EpisodeNanos = r.bootNanos - origin
+		stored.PrerollFlushed = true
 		if earliest == nil || stored.EpisodeNanos < *earliest {
 			value := stored.EpisodeNanos
 			earliest = &value
@@ -873,8 +936,27 @@ func abs64(v int64) int64 {
 	return v
 }
 
+// drainSeal holds an episode open for late application records after its
+// capture adapters have stopped and before it is finalized. It must be called
+// with m.mu released: the whole point is that RecordApplication proceeds
+// normally throughout, so records written about the samples the episode just
+// produced are still filed into that episode. Episodes that do not capture
+// applications have nothing to wait for and never sleep.
+func (m *Manager) drainSeal(a *activeEpisode) {
+	if a.capturesApplications && a.drain > 0 {
+		time.Sleep(a.drain)
+	}
+}
+
 // Stop finalizes the episode keyed by the given campaign name
 // (AdHocEpisodeKey for campaign-less episodes).
+//
+// For an episode that captures applications the window for application records
+// does not close when the capture adapters do: the episode stays in m.active
+// for its configured drain (see drainSeal) so an application that scores
+// asynchronously can still file its verdict here. StoppedEpisodeNS is stamped
+// in finalizeLocked, after the drain, so records that arrive during the drain
+// carry an EpisodeNanos below it exactly as live ones do.
 func (m *Manager) Stop(key string) (Manifest, error) {
 	m.mu.Lock()
 	a := m.active[key]
@@ -889,6 +971,7 @@ func (m *Manager) Stop(key string) (Manifest, error) {
 	if a.done != nil {
 		<-a.done
 	}
+	m.drainSeal(a)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.active[key] != a {

--- a/go/internal/agent/data/model.go
+++ b/go/internal/agent/data/model.go
@@ -301,13 +301,20 @@ type StartOptions struct {
 	Calibrations          map[string][]byte
 	CalibrationRevisions  map[string]string
 	PreRollDuration       time.Duration
-	Trigger               EpisodeTrigger
-	CollectorVersion      string
-	ModelVersions         map[string]string
-	RequestedTopics       []string
-	Privacy               []PrivacyTransformation
-	Upload                WorkflowState
-	Labeling              WorkflowState
+	// DrainDuration holds an episode that captures applications open for this
+	// long after its capture adapters stop, so an application that scores
+	// asynchronously files its verdict into the episode it read rather than
+	// into the next one. Zero or less means no drain. The manager applies no
+	// default of its own; callers choose the policy, and the service call sites
+	// use data.DefaultSealDrain.
+	DrainDuration    time.Duration
+	Trigger          EpisodeTrigger
+	CollectorVersion string
+	ModelVersions    map[string]string
+	RequestedTopics  []string
+	Privacy          []PrivacyTransformation
+	Upload           WorkflowState
+	Labeling         WorkflowState
 }
 
 type EpisodeInfo struct {

--- a/go/internal/agent/data/seal_drain_test.go
+++ b/go/internal/agent/data/seal_drain_test.go
@@ -1,0 +1,499 @@
+package data
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestSealDrainFilesLateRecordsIntoTheirOwnEpisode pins the post-seal drain.
+//
+// This is the asynchronous scoring case: an application consumes samples from
+// an episode, spends time computing a prediction, and writes the prediction
+// only after capture has stopped. Before the drain existed that record was
+// acknowledged as "buffered", a documented success, and then flushed into the
+// NEXT episode with a negative offset that presented it as that episode's
+// pre-trigger context. The prediction was filed against the wrong recording,
+// silently, with a plausible-looking timestamp.
+//
+// With the drain the episode stays open for its configured window, so the late
+// record is acknowledged "recorded" and lands in the episode it belongs to.
+func TestSealDrainFilesLateRecordsIntoTheirOwnEpisode(t *testing.T) {
+	root := t.TempDir()
+	m, err := NewManager(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	started, err := m.Start(StartOptions{Name: "scored", Sources: []string{"applications"}, DrainDuration: time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A record written while the episode is live is recorded into it.
+	duringState, err := m.RecordApplication("com.example.scorer", ApplicationRecord{
+		Version: 1, Type: "event", Name: "during-episode",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if duringState != "recorded" {
+		t.Fatalf("record written during the episode: state=%q, want %q", duringState, "recorded")
+	}
+
+	// Stop runs on its own goroutine so the test can write into the drain
+	// window. Waiting on the episode's own done channel is what makes this
+	// deterministic rather than timing-dependent: that channel closes only
+	// after Stop has cancelled the sampler, which means Stop has reached the
+	// drain and is sleeping in it. No wall-clock sleep synchronises anything
+	// here.
+	m.mu.Lock()
+	a := m.active[AdHocEpisodeKey]
+	m.mu.Unlock()
+	if a == nil {
+		t.Fatal("episode is not active immediately after Start")
+	}
+	type stopResult struct {
+		manifest Manifest
+		err      error
+	}
+	stopped := make(chan stopResult, 1)
+	begin := time.Now()
+	go func() {
+		manifest, stopErr := m.Stop(AdHocEpisodeKey)
+		stopped <- stopResult{manifest, stopErr}
+	}()
+	<-a.done
+
+	// The late prediction. Same app, same episode's data, and the write lands
+	// after capture has shut down but inside the drain.
+	lateState, err := m.RecordApplication("com.example.scorer", ApplicationRecord{
+		Version: 1, Type: "prediction", Name: "after-seal", Model: "detector",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lateState != "recorded" {
+		t.Fatalf("record written inside the drain: state=%q, want %q", lateState, "recorded")
+	}
+
+	result := <-stopped
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if result.manifest.State != "complete" {
+		t.Fatalf("episode did not seal cleanly: state=%q", result.manifest.State)
+	}
+	// The window above is only a window because Stop waits in it. Asserting the
+	// wait directly means removing the drain fails this test deterministically,
+	// rather than leaving the outcome to whichever goroutine the scheduler
+	// happens to favour.
+	if elapsed := time.Since(begin); elapsed < 900*time.Millisecond {
+		t.Fatalf("Stop returned after %s, want at least the configured 1s drain", elapsed)
+	}
+
+	dir, err := m.episodeDir(started.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := recordNames(t, readEvents(t, dir))
+	if !containsName(names, "during-episode") || !containsName(names, "after-seal") {
+		t.Fatalf("sealed episode holds %v, want both during-episode and after-seal", names)
+	}
+
+	manifest, failures, err := m.Inspect(started.ID, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(failures) != 0 {
+		t.Fatalf("sealed episode failed verification after the drain write: %v", failures)
+	}
+	for _, source := range manifest.Sources {
+		if source.Source.ID == "applications" && source.Count != uint64(len(names)) {
+			t.Fatalf("manifest applications count=%d, but %d record(s) are on disk", source.Count, len(names))
+		}
+	}
+
+	// Past the drain the episode really is sealed, and a record is buffered for
+	// whatever starts next rather than being added to it.
+	afterDrainState, err := m.RecordApplication("com.example.scorer", ApplicationRecord{
+		Version: 1, Type: "prediction", Name: "after-drain", Model: "detector",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterDrainState != "buffered" {
+		t.Fatalf("record written after the drain: state=%q, want %q", afterDrainState, "buffered")
+	}
+	firstEpisodeRaw := readEvents(t, dir)
+	if containsName(recordNames(t, firstEpisodeRaw), "after-drain") {
+		t.Fatal("a record written after the drain reached the sealed episode")
+	}
+
+	// The ring is deliberately not consumed by a flush, so a following episode
+	// receives the whole pre-trigger window: the record written after the drain
+	// and the one written inside it alike. Both arrive marked as flushed, which
+	// is what lets a consumer tell replayed pre-trigger context apart from a
+	// record this episode observed live.
+	second, err := m.Start(StartOptions{Name: "unrelated", Sources: []string{"applications"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = m.Stop(AdHocEpisodeKey); err != nil {
+		t.Fatal(err)
+	}
+	secondDir, err := m.episodeDir(second.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondRaw := readEvents(t, secondDir)
+	secondNames := recordNames(t, secondRaw)
+	if !containsName(secondNames, "after-drain") || !containsName(secondNames, "after-seal") {
+		t.Fatalf("second episode holds %v, want both after-drain and after-seal from the pre-roll ring", secondNames)
+	}
+	for i, stored := range decodeRecords(t, secondRaw) {
+		if !stored.PrerollFlushed {
+			t.Fatalf("second episode line %d (%s) is not marked preroll_flushed", i, stored.Name)
+		}
+		if stored.EpisodeNanos >= 0 {
+			t.Fatalf("second episode line %d (%s) has offset %d, want a negative pre-trigger offset", i, stored.Name, stored.EpisodeNanos)
+		}
+	}
+	// A live-recorded line must stay byte-identical to what it was before the
+	// provenance key existed, so the key is absent rather than false.
+	for i, raw := range jsonLines(firstEpisodeRaw) {
+		var fields map[string]json.RawMessage
+		if err = json.Unmarshal(raw, &fields); err != nil {
+			t.Fatal(err)
+		}
+		if _, present := fields["preroll_flushed"]; present {
+			t.Fatalf("live-recorded line %d carries preroll_flushed: %s", i, raw)
+		}
+	}
+}
+
+// TestInterruptDrainsLateRecordsLikeStop pins that an episode finalized after a
+// failed adapter start honours the same drain. An application's outstanding
+// verdict is no less its own for the episode having ended badly.
+func TestInterruptDrainsLateRecordsLikeStop(t *testing.T) {
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := m.Start(StartOptions{Name: "interrupted", Sources: []string{"applications"}, DrainDuration: time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.mu.Lock()
+	a := m.active[AdHocEpisodeKey]
+	m.mu.Unlock()
+	if a == nil {
+		t.Fatal("episode is not active immediately after Start")
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, interruptErr := m.Interrupt(AdHocEpisodeKey, "camera adapter failed to start")
+		done <- interruptErr
+	}()
+	<-a.done
+
+	state, err := m.RecordApplication("com.example.scorer", ApplicationRecord{
+		Version: 1, Type: "prediction", Name: "after-interrupt", Model: "detector",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state != "recorded" {
+		t.Fatalf("record written inside the interrupt drain: state=%q, want %q", state, "recorded")
+	}
+	if err = <-done; err != nil {
+		t.Fatal(err)
+	}
+	dir, err := m.episodeDir(started.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsName(recordNames(t, readEvents(t, dir)), "after-interrupt") {
+		t.Fatal("the interrupted episode did not receive the record written during its drain")
+	}
+}
+
+// TestDrainSkippedWithoutApplicationsSource pins that an episode which never
+// captures application records does not pay for a drain it has nothing to wait
+// for. This is what keeps telemetry-only episodes, and the many tests that use
+// them, fast.
+func TestDrainSkippedWithoutApplicationsSource(t *testing.T) {
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = m.Start(StartOptions{Name: "telemetry-only", Sources: []string{"telemetry"}, DrainDuration: 5 * time.Second}); err != nil {
+		t.Fatal(err)
+	}
+	begin := time.Now()
+	if _, err = m.Stop(AdHocEpisodeKey); err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(begin); elapsed >= time.Second {
+		t.Fatalf("telemetry-only episode took %s to stop, want well under 1s: the drain must not apply", elapsed)
+	}
+}
+
+// TestFlushPreRollAdmitsOnReceiptAndStampIntersection pins the flush fence. A
+// ring entry reaches an episode only when both its agent receipt and its
+// presentation stamp fall inside the requested window. The stamp alone is
+// client-supplied, so testing it alone let an accepted client pick which later
+// episode windows it appeared in.
+func TestFlushPreRollAdmitsOnReceiptAndStampIntersection(t *testing.T) {
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	if err = os.WriteFile(filepath.Join(dir, "events.jsonl"), nil, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	const origin = int64(1_000_000_000_000)
+	second := time.Second.Nanoseconds()
+	outside := (10 * time.Minute).Nanoseconds()
+
+	for _, entry := range []struct {
+		name    string
+		receipt int64
+		stamp   int64
+	}{
+		// Both timestamps inside the window. The stamp is deliberately not the
+		// receipt so the resulting offset proves which one the arithmetic uses.
+		{"both-in", origin - second, origin - 2*second},
+		// Received before the window opened, forward-dated to look present.
+		{"receipt-too-old", origin - outside, origin - second},
+		// Received inside the window, back-dated out of it.
+		{"stamp-back-dated", origin - second, origin - outside},
+		// Received inside the window, stamped into the episode's future.
+		{"stamp-after-origin", origin - second, origin + second},
+		// Received after the episode began, back-dated into its pre-roll.
+		{"receipt-after-origin", origin + second, origin - second},
+	} {
+		stored := storedApplicationRecord{
+			ApplicationRecord:     ApplicationRecord{Version: 1, Type: "event", Name: entry.name},
+			AppID:                 "com.example.app",
+			AgentReceiptBootNanos: entry.receipt,
+		}
+		encoded, marshalErr := json.Marshal(stored)
+		if marshalErr != nil {
+			t.Fatal(marshalErr)
+		}
+		m.preRoll = append(m.preRoll, bufferedRecord{bootNanos: entry.stamp, receiptNanos: entry.receipt, encoded: encoded})
+	}
+
+	count, earliest, err := m.flushPreRoll(dir, origin, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("flushed %d record(s), want exactly the one whose receipt and stamp are both in the window", count)
+	}
+	records := decodeRecords(t, readEvents(t, dir))
+	if len(records) != 1 || records[0].Name != "both-in" {
+		t.Fatalf("flushed %+v, want only both-in", recordNames(t, readEvents(t, dir)))
+	}
+	if !records[0].PrerollFlushed {
+		t.Fatal("flushed record is not marked preroll_flushed")
+	}
+	if records[0].EpisodeNanos != -2*second {
+		t.Fatalf("offset=%d, want %d derived from the presentation stamp", records[0].EpisodeNanos, -2*second)
+	}
+	if earliest == nil || *earliest != -2*second {
+		t.Fatalf("earliest offset=%v, want %d", earliest, -2*second)
+	}
+}
+
+// TestBackdatedClientStampCannotPlantIntoNarrowWindow pins that a client cannot
+// place a record into an episode's pre-roll by choosing its own timestamp. The
+// record here is genuinely accepted, so its stamp is the client's, and a narrow
+// buffer must still exclude it.
+func TestBackdatedClientStampCannotPlantIntoNarrowWindow(t *testing.T) {
+	restore := stubBootIDForAcceptance(t, "0f2a1c3e-test-boot-id")
+	defer restore()
+
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	now, err := readBootTime()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Back-date by four minutes, which stays inside the five minute acceptance
+	// band and far outside the 50ms buffer below. Where the boot clock has not
+	// been running that long yet, back-date by half of it instead: the stamp
+	// still has to be non-negative to be accepted at all.
+	backdate := (4 * time.Minute).Nanoseconds()
+	if now-backdate < 0 {
+		backdate = now / 2
+	}
+	stamp := now - backdate
+	state, err := m.RecordApplication("com.example.app", ApplicationRecord{
+		Version: 1, Type: "event", Name: "back-dated",
+		ClientBootNanos: stamp,
+		ClientBootID:    "0f2a1c3e-test-boot-id",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state != "buffered" {
+		t.Fatalf("state=%q, want buffered", state)
+	}
+	// Without an accepted client stamp there would be no back-dating to fence
+	// off, so the premise is checked rather than assumed.
+	if len(m.preRoll) != 1 {
+		t.Fatalf("pre-roll ring holds %d entries, want 1", len(m.preRoll))
+	}
+	buffered := decodeRecords(t, append(append([]byte(nil), m.preRoll[0].encoded...), '\n'))[0]
+	if !buffered.ClientTimestampAccepted || m.preRoll[0].bootNanos != stamp {
+		t.Fatalf("the client stamp was not accepted, so this test would not exercise the fence: accepted=%v stamp=%d want=%d",
+			buffered.ClientTimestampAccepted, m.preRoll[0].bootNanos, stamp)
+	}
+
+	started, err := m.Start(StartOptions{Sources: []string{"applications"}, PreRollDuration: 50 * time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = m.Stop(AdHocEpisodeKey); err != nil {
+		t.Fatal(err)
+	}
+	dir, err := m.episodeDir(started.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if names := recordNames(t, readEvents(t, dir)); len(names) != 0 {
+		t.Fatalf("a record back-dated four minutes reached a 50ms pre-roll window: %v", names)
+	}
+}
+
+// TestRecordsNeverAcceptedWhenBootIDUnavailable pins the boot identity check.
+// bootID reports the literal "unavailable" when the kernel boot identity cannot
+// be read, so an unguarded equality let a client that sends "unavailable" match
+// on exactly the hosts where the agent has nothing to check against, and have
+// its arbitrary timestamp trusted.
+func TestRecordsNeverAcceptedWhenBootIDUnavailable(t *testing.T) {
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := m.Start(StartOptions{Sources: []string{"applications"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	restore := stubBootIDForAcceptance(t, "unavailable")
+	arbitrary := int64(42)
+	if _, err = m.RecordApplication("com.example.app", ApplicationRecord{
+		Version: 1, Type: "event", Name: "agent-has-no-boot-id",
+		ClientBootNanos: arbitrary, ClientBootID: "unavailable",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	restore()
+
+	// Against a healthy agent identity, neither an empty nor an "unavailable"
+	// client value may match.
+	restore = stubBootIDForAcceptance(t, "0f2a1c3e-test-boot-id")
+	defer restore()
+	for _, claimed := range []string{"", "unavailable"} {
+		if _, err = m.RecordApplication("com.example.app", ApplicationRecord{
+			Version: 1, Type: "event", Name: "claims-" + claimed,
+			ClientBootNanos: arbitrary, ClientBootID: claimed,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, err = m.Stop(AdHocEpisodeKey); err != nil {
+		t.Fatal(err)
+	}
+	dir, err := m.episodeDir(started.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	records := decodeRecords(t, readEvents(t, dir))
+	if len(records) != 3 {
+		t.Fatalf("recorded %d line(s), want 3", len(records))
+	}
+	for _, stored := range records {
+		if stored.ClientTimestampAccepted {
+			t.Fatalf("%s: client_timestamp_accepted=true, want false", stored.Name)
+		}
+		if stored.EpisodeNanos != stored.AgentReceiptBootNanos-started.RequestBootNanos {
+			t.Fatalf("%s: offset=%d is not derived from the agent receipt (%d - %d)",
+				stored.Name, stored.EpisodeNanos, stored.AgentReceiptBootNanos, started.RequestBootNanos)
+		}
+		if stored.EpisodeNanos == arbitrary-started.RequestBootNanos {
+			t.Fatalf("%s: the arbitrary client stamp was trusted", stored.Name)
+		}
+	}
+}
+
+// stubBootIDForAcceptance replaces the boot identity RecordApplication checks
+// against and returns the restore function. Tests using it must not run in
+// parallel with each other.
+func stubBootIDForAcceptance(t *testing.T, id string) func() {
+	t.Helper()
+	previous := readBootIDForAcceptance
+	readBootIDForAcceptance = func() string { return id }
+	return func() { readBootIDForAcceptance = previous }
+}
+
+func readEvents(t *testing.T, dir string) []byte {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(dir, "events.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func jsonLines(raw []byte) [][]byte {
+	var out [][]byte
+	for _, line := range bytes.Split(bytes.TrimSpace(raw), []byte("\n")) {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		out = append(out, line)
+	}
+	return out
+}
+
+func decodeRecords(t *testing.T, raw []byte) []storedApplicationRecord {
+	t.Helper()
+	var out []storedApplicationRecord
+	for _, line := range jsonLines(raw) {
+		var stored storedApplicationRecord
+		if err := json.Unmarshal(line, &stored); err != nil {
+			t.Fatalf("bad JSONL line %q: %v", line, err)
+		}
+		out = append(out, stored)
+	}
+	return out
+}
+
+func recordNames(t *testing.T, raw []byte) []string {
+	t.Helper()
+	var names []string
+	for _, stored := range decodeRecords(t, raw) {
+		names = append(names, stored.Name)
+	}
+	return names
+}
+
+func containsName(names []string, want string) bool {
+	for _, n := range names {
+		if n == want {
+			return true
+		}
+	}
+	return false
+}

--- a/go/internal/agent/services/data_service.go
+++ b/go/internal/agent/services/data_service.go
@@ -63,6 +63,10 @@ type DataService struct {
 	// campaign-less episode started through the Start RPC.
 	activeCaptures map[string][]runningDataCapture
 	autoStopCancel map[string]context.CancelFunc
+	// adHocDrain is the post-seal drain applied to episodes started through the
+	// Start RPC, which carry no campaign to declare one. Campaign episodes take
+	// their own value from the plan.
+	adHocDrain time.Duration
 }
 
 type dataCaptureAdapter interface {
@@ -75,7 +79,7 @@ type runningDataCapture interface {
 }
 
 func NewDataService(m *data.Manager) *DataService {
-	s := &DataService{manager: m, activeCaptures: make(map[string][]runningDataCapture), autoStopCancel: make(map[string]context.CancelFunc)}
+	s := &DataService{manager: m, activeCaptures: make(map[string][]runningDataCapture), autoStopCancel: make(map[string]context.CancelFunc), adHocDrain: data.DefaultSealDrain}
 	m.SetSourceProvider(s.discoverAdapterSources)
 	m.SetApplicationObserver(s.observeApplicationRecord)
 	return s
@@ -135,7 +139,7 @@ func (s *DataService) Start(ctx context.Context, req *agentpbv2.DataStartRequest
 	for _, c := range req.GetCalibrations() {
 		cal[c.GetSource()] = c.GetContents()
 	}
-	return s.startCapture(ctx, data.StartOptions{Name: req.GetName(), Sources: req.GetSources(), ExcludeSources: req.GetExcludeSources(), RequireUTCUncertainty: time.Duration(req.GetRequireUtcUncertaintyNanos()), Calibrations: cal, CollectorVersion: version.Version})
+	return s.startCapture(ctx, data.StartOptions{Name: req.GetName(), Sources: req.GetSources(), ExcludeSources: req.GetExcludeSources(), RequireUTCUncertainty: time.Duration(req.GetRequireUtcUncertaintyNanos()), Calibrations: cal, DrainDuration: s.adHocDrain, CollectorVersion: version.Version})
 }
 
 func (s *DataService) startCapture(ctx context.Context, opts data.StartOptions) (*agentpbv2.DataEpisode, error) {
@@ -346,6 +350,7 @@ func (s *DataService) triggerCampaign(ctx context.Context, campaign data.Campaig
 		Sources:              sources,
 		SourceCaptures:       captures,
 		PreRollDuration:      campaign.BufferDuration(),
+		DrainDuration:        campaign.DrainDuration(),
 		Trigger:              data.EpisodeTrigger{Reason: reason, CampaignName: campaign.Name, CampaignRevision: campaign.Revision, Expression: expression},
 		CollectorVersion:     version.Version,
 		ModelVersions:        campaign.Models,

--- a/go/internal/agent/services/data_service_adversarial_test.go
+++ b/go/internal/agent/services/data_service_adversarial_test.go
@@ -69,7 +69,11 @@ func TestLegacyPersistedCampaignStillTriggersAfterUpgrade(t *testing.T) {
 	if _, err := manager.RecordApplication("test.app", data.ApplicationRecord{Version: 1, Type: "event", Name: "emergency_stop"}); err != nil {
 		t.Fatal(err)
 	}
-	deadline := time.Now().Add(2 * time.Second)
+	// The fixture deliberately declares no capture.drain, because a campaign
+	// persisted by the previous release could not have. It therefore takes the
+	// default post-seal drain on top of its 30ms after_trigger, and the wait
+	// here has to allow for that.
+	deadline := time.Now().Add(data.DefaultSealDrain + 3*time.Second)
 	for time.Now().Before(deadline) {
 		list, listErr := manager.List()
 		if listErr != nil {
@@ -90,6 +94,10 @@ func TestLegacyPersistedCampaignStillTriggersAfterUpgrade(t *testing.T) {
 	t.Fatal("legacy persisted campaign no longer triggers after the upgrade")
 }
 
+// deployTestCampaign arms a campaign whose episodes seal as soon as
+// after_trigger expires. The post-seal drain is switched off because these
+// tests exercise the campaign lifecycle rather than late application records,
+// and the default two second drain would otherwise dominate every timing here.
 func deployTestCampaign(t *testing.T, service *DataService, name, afterTrigger string) {
 	t.Helper()
 	yaml := fmt.Sprintf(`version: 1
@@ -98,6 +106,7 @@ sources:
   - telemetry: true
 capture:
   buffer: 10ms
+  drain: 0s
   after_trigger: %s
   triggers:
     - event: trigger-%s
@@ -117,6 +126,9 @@ func TestStopPrefersAdHocThenRefusesAmbiguousCampaigns(t *testing.T) {
 		t.Fatal(err)
 	}
 	service := NewDataService(manager)
+	// The ad-hoc Start RPC carries the default drain; this test is about which
+	// episode Stop picks, not about waiting for one.
+	service.adHocDrain = 0
 	deployTestCampaign(t, service, "stop-a", "10s")
 	deployTestCampaign(t, service, "stop-b", "10s")
 	first, err := service.CampaignTrigger(context.Background(), &agentpbv2.DataCampaignTriggerRequest{Name: "stop-a"})
@@ -172,6 +184,11 @@ func TestServiceConcurrentTriggerRecordAndStopStress(t *testing.T) {
 	}
 	manager.SetWarnLogger(func(string) {})
 	service := NewDataService(manager)
+	// This test races the episode lifecycle, and its ad-hoc goroutine starts
+	// and stops twenty applications episodes in a row. The default drain would
+	// add two seconds to each of them without exercising anything this test is
+	// about.
+	service.adHocDrain = 0
 	campaigns := []string{"stress-x", "stress-y", "stress-z"}
 	for _, name := range campaigns {
 		deployTestCampaign(t, service, name, "40ms")

--- a/go/internal/agent/services/data_service_test.go
+++ b/go/internal/agent/services/data_service_test.go
@@ -33,6 +33,7 @@ sources:
   - camera: front
 capture:
   buffer: 10ms
+  drain: 0s
   after_trigger: 30ms
   triggers:
     - event: emergency_stop
@@ -95,6 +96,7 @@ sources:
   - telemetry: true
 capture:
   buffer: 1s
+  drain: 0s
   after_trigger: 30ms
   triggers:
     - event: emergency_stop
@@ -132,6 +134,11 @@ export: {annotation: cvat}
 	}
 	t.Fatal("application event did not produce a finalized episode")
 }
+
+// deployEventCampaign arms a campaign that an application event triggers. Like
+// deployTestCampaign it opts out of the post-seal drain: these tests measure
+// the campaign lifecycle, and the default drain would add two seconds to every
+// episode without exercising anything they assert.
 func deployEventCampaign(t *testing.T, service *DataService, name, event string) {
 	t.Helper()
 	yaml := []byte(`version: 1
@@ -140,6 +147,7 @@ sources:
   - telemetry: true
 capture:
   buffer: 1s
+  drain: 0s
   after_trigger: 150ms
   triggers:
     - event: ` + event + `
@@ -291,5 +299,35 @@ func TestDataServiceRunsAdaptersAndSealsResults(t *testing.T) {
 	}
 	if len(manifest.Sources) != 1 || manifest.Sources[0].Count != 9 || manifest.Sources[0].Drops == nil || *manifest.Sources[0].Drops != 3 {
 		t.Fatalf("adapter results not sealed: %+v", manifest.Sources)
+	}
+}
+
+// TestAdHocEpisodesCarryTheDefaultSealDrain pins the policy for the Start RPC.
+// An ad-hoc episode has no campaign plan to declare a drain of its own, so the
+// service supplies the default; without it a `wendy data record` session would
+// seal the moment capture stopped and file an application's late verdict into
+// whatever recorded next.
+func TestAdHocEpisodesCarryTheDefaultSealDrain(t *testing.T) {
+	manager, err := data.NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := NewDataService(manager)
+	if service.adHocDrain != data.DefaultSealDrain {
+		t.Fatalf("ad-hoc drain = %s, want the %s default", service.adHocDrain, data.DefaultSealDrain)
+	}
+	// Shortened so the assertion below costs a fifth of a second rather than
+	// the full default. What is under test is that the value reaches the
+	// episode at all.
+	service.adHocDrain = 200 * time.Millisecond
+	if _, err = service.Start(context.Background(), &agentpbv2.DataStartRequest{Sources: []string{"applications"}}); err != nil {
+		t.Fatal(err)
+	}
+	begin := time.Now()
+	if _, err = service.Stop(context.Background(), &agentpbv2.DataStopRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(begin); elapsed < 150*time.Millisecond {
+		t.Fatalf("ad-hoc Stop returned after %s; the configured drain did not reach the episode", elapsed)
 	}
 }

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
@@ -34,6 +34,14 @@ wendy data inspect <episode-id>
 wendy data download <episode-id> --output ./commissioning-episode
 ```
 
+`wendy data stop` seals an Episode that captures application records only after
+its post-seal drain has elapsed, so the command takes up to two seconds longer
+than the capture itself. That wait is what lets an app file a prediction about
+the samples the Episode just produced into that Episode. Campaigns set it with
+`capture.drain`; an ad-hoc Episode started by `wendy data record` uses the two
+second default whenever it includes the applications source, which it does
+unless `--source` or `--exclude-source` leaves it out.
+
 `sources` prints an aligned table whose `DETAIL` column carries the device's own
 description of each source, truncated to keep the table readable. A single kind
 can dominate a board: an NVIDIA Jetson exposes 20 internal audio-DMA routing
@@ -137,8 +145,28 @@ mode is not implemented for its kind; those sources record continuously for
 now.
 
 `capture.buffer` must be a Go-style duration from `0s` through `5m`.
-`capture.after_trigger` must be greater than `0s` and no more than `24h`. At
-least one trigger is required, and each trigger selects exactly one condition:
+`capture.after_trigger` must be greater than `0s` and no more than `24h`.
+
+`capture.drain` is the opposite end of the same idea: `buffer` decides how much
+happened *before* the trigger that the Episode keeps, and `drain` decides how
+long the Episode stays open for application records *after* capture stops. An
+app that scores asynchronously reads samples, spends time computing, and writes
+its prediction once the Episode has already finished recording. Without a drain
+that write arrives too late, is acknowledged `buffered`, and is then replayed
+into whichever Episode records next, where it appears as that Episode's
+pre-trigger context. The drain keeps the Episode open long enough for the
+verdict to be filed against the recording it was computed from.
+
+It must be a duration from `0s` through `30s`. Omitting it takes the default of
+`2s`, so campaigns get the behavior without being rewritten; `drain: 0s` opts
+out and seals the moment capture stops. Only Episodes that capture application
+records wait at all, so a telemetry-only or camera-only plan pays nothing for
+the default. The wait is added to the Episode's own lifetime, after
+`after_trigger` has expired, and it is included in the `stopped_episode_nanos`
+the manifest records.
+
+At least one trigger is required, and each trigger selects exactly one
+condition:
 
 | Trigger | Description |
 |---|---|
@@ -173,6 +201,7 @@ sources:
 
 capture:
   buffer: 10s
+  drain: 2s
   after_trigger: 20s
   triggers:
     - event: emergency_stop
@@ -268,6 +297,14 @@ start at the trigger. Their manifest entries preserve both the requested offset
 and the achieved offset; campaign deployment prints a warning when sensor
 pre-roll was requested. Unknown drop counts are displayed as unknown, never as
 zero.
+
+A record the ring replays into an Episode is written with
+`preroll_flushed: true` in `events.jsonl`. Records the Episode observed live
+omit the key entirely, so the two are distinguishable offline without changing
+any existing line. Window membership is decided on both the agent's own receipt time and the
+record's presentation timestamp: a record reaches an Episode's pre-roll only if
+it physically arrived inside that window, so a client cannot place itself into
+a later Episode by choosing its own `client_boottime_nanos`.
 
 ## Concurrency and retention
 


### PR DESCRIPTION
## Problem

An application record that arrives after its Episode seals is acknowledged `buffered`, which the protocol documents as a success. It is then appended to the pre-roll ring and flushed into the **next** Episode with a negative offset that presents it as that Episode's pre-trigger context.

For a user this means an app that scores asynchronously, the ordinary shape for anything that reads samples, computes for a while, and writes a verdict, has its prediction filed against the wrong recording. Silently, with a plausible-looking timestamp, and with an acknowledgement that says it worked. Training data assembled from those Episodes pairs an outcome with inputs it was never computed from.

There is a reproduction of this on `verify/seal-drain-probe`; it is ported here as a regression test.

Two adjacent holes came out of the same read:

* Pre-roll window membership was decided only on the record's presentation timestamp, which is client-supplied whenever the client's boot identity matches. An accepted client could therefore choose which future Episode windows it appeared in by back-dating or forward-dating its own `client_boottime_nanos` within the five minute acceptance band.
* `bootID()` returns the literal string `"unavailable"` when `/proc/sys/kernel/random/boot_id` cannot be read. The acceptance check compared the client's claimed identity against that return value directly, so a client sending `"unavailable"` matched on exactly the hosts where the agent has no boot identity to check against, and had its arbitrary timestamp trusted.

## Cause

`Stop` removed the Episode from the manager's active set as soon as the capture adapters had shut down. The window for application records closed at the same instant as the window for sensor samples, even though the two have different natural end points: a camera stops producing frames when it is told to, while an app is still holding the samples it was given and has not finished with them. Everything downstream then behaved correctly for a record with no Episode: buffer it, and hand it to whatever starts next.

The flush admission test read `r.bootNanos` only. That field holds the client's stamp when the client's timestamp was accepted, so the one value deciding membership was the one value the client controls. Eviction had the same problem from the other side: it aged the ring head on `bootNanos`, so a single forward-dated entry sitting at the front could hold back the eviction of genuinely older entries behind it.

## Solution

**The drain.** An Episode that captures `applications` now stays in `m.active` for a bounded drain between adapter shutdown and finalize, so late records land as `recorded` in their own Episode. The drain runs inside the existing unlocked window between waiting on the sampler's done channel and re-acquiring `m.mu`, in both `Stop` and `Interrupt`. `m.mu` is deliberately not held: `RecordApplication` proceeds normally throughout, which is the whole point, and the services-before-data lock order is untouched.

The manager applies no default of its own. The value arrives through `StartOptions.DrainDuration`, and policy lives at the service call sites, which keeps every existing direct-manager test unchanged. Campaigns take `capture.drain`, a duration from `0s` through `30s` defaulting to `2s`; the ad-hoc `Start` remote procedure call takes `DefaultSealDrain`. Telemetry-only Episodes skip the drain entirely, so they pay nothing.

`capture.drain` carries `omitempty`. That tag is load-bearing rather than cosmetic: `planOnly` is marshalled to JSON to compute a campaign's `Revision`, so a field rendered on every campaign would change the revision digest of every already-deployed campaign. `TestCampaignDrainValidation` pins a drain-less campaign's digest to the value it had before the field existed.

**The flush fence.** `bufferedRecord` gains `receiptNanos`, the agent-authoritative reading taken when the record arrived. Flush admission becomes an intersection: a record enters a window only when **both** its receipt and its presentation stamp fall inside it, so a record can only reach a window it was physically present for. The offset arithmetic still derives from the stamp, so offsets stay in `[-window, 0]` and `ActualOffset` keeps its meaning. Eviction now ages on the receipt; because the ring is appended in receipt order, head-drop becomes provably correct.

**Provenance.** Records the ring replays into an Episode carry `preroll_flushed: true`. Live-recorded lines omit the key entirely and stay byte-identical to what they were before.

**The boot identity check.** Acceptance now refuses any client timestamp when the agent's own boot identity is unavailable. An agent that cannot name its own boot cannot vouch for a client's. Hoisting the read also drops one `/proc` read per record.

## What this does NOT fix

A late verdict about the previous Episode and a fresh event between Episodes have identical time signatures. Both arrive with no Episode active, both are buffered, and nothing in the record distinguishes them.

Admission is kept rather than tightened, deliberately. The between-Episodes flush is a pinned feature: `TestApplicationPreRollHasNegativeCanonicalOffsets` asserts it, and a `model.uncertainty` trigger fires on exactly such a pre-trigger prediction. Refusing those records would break campaign triggering.

Disambiguation therefore moves offline, and this change supplies the evidence for it: `preroll_flushed` says the record was replayed rather than observed, `agent_receipt_boottime_nanos` says when the agent actually saw it, and a prediction's `inputs` list can be joined against the earlier Episode's model-input ledger to establish which recording it was computed from.

## Behaviour change

`wendy data stop` gains up to two seconds by default. Only Episodes that capture application records wait; `drain: 0s` opts a campaign out.

## Tests

`go/internal/agent/data/seal_drain_test.go` ports the characterization probe as a regression test, `TestSealDrainFilesLateRecordsIntoTheirOwnEpisode`. It synchronises on the Episode's own done channel rather than on wall-clock sleeps, and asserts the duration of `Stop` directly so that removing the drain fails it deterministically rather than leaving the outcome to the scheduler (verified: 5 failures in 5 runs with the drain removed).

Added alongside it: `TestInterruptDrainsLateRecordsLikeStop`, `TestDrainSkippedWithoutApplicationsSource`, `TestFlushPreRollAdmitsOnReceiptAndStampIntersection`, `TestBackdatedClientStampCannotPlantIntoNarrowWindow`, `TestRecordsNeverAcceptedWhenBootIDUnavailable`, `TestCampaignDrainValidation`, and `TestAdHocEpisodesCarryTheDefaultSealDrain`.

Confirmed still passing untouched: `TestApplicationPreRollHasNegativeCanonicalOffsets`, `TestRecordsRouteOnlyToEpisodesCapturingApplications`, and the four hardening tests in `app_data_socket_hardening_test.go` that use `buffered` as the no-Episode success signal. The acknowledgement state set `{recorded, buffered, rejected}` is unchanged.

Four services campaign fixtures gained `drain: 0s`, and the ad-hoc drain is switched off in two adversarial tests. These exercise the campaign lifecycle rather than late records, and the default drain added roughly 80 seconds to the package without exercising anything they assert. `TestLegacyPersistedCampaignStillTriggersAfterUpgrade` deliberately keeps no drain field, because a campaign persisted by the previous release could not have had one; its wait was widened to allow for the default instead, which is the case it is there to prove.

## Verification

| | Baseline `c9ba66bbf` | This branch |
|---|---|---|
| `go/internal/agent/data` | 40 pass, 0 fail | 47 pass, 0 fail |
| `go/internal/agent/services` | 741 pass, 0 fail, 2 skip | 742 pass, 0 fail, 2 skip |

`CC=/usr/bin/clang go build ./go/...` clean, `gofmt -l go/` empty, `go vet` clean on both touched packages. Test runs are `-race -count=1`.

One caveat worth recording: `TestAppDataRateLimitIsPerAppNotPerConnection` is flaky, failing with a broken pipe roughly one full-suite run in four. It is **pre-existing and unrelated to this change**, measured at 74 failures per 3000 iterations on the baseline against 72 per 3000 on this branch. The cause is in the test rather than the product: `serveConn` checks the token bucket before reading a frame, so an over-budget connection is rejected and closed without the server ever reading it, and the test's write to that connection races the close. It is filed separately.
