### PR TITLE
cli: keep local VMs out of the Local device list

### DIFF
--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -150,6 +150,10 @@ func main() {
 	// renamed.
 	services.ReassertHostnameAdvertisement(logger)
 
+	// Advertise the board id, so `wendy discover` can tell a local VM from a
+	// device on the sighting alone. A no-op once the record is in place.
+	services.EnsureDeviceTypeAdvertisement(logger)
+
 	// Time sync: apply config-partition floor immediately, then start
 	// background Roughtime + multicast sync.
 	timesyncMgr := timesync.NewManager(logger, configPath)

--- a/go/internal/agent/services/devicetype_advertisement.go
+++ b/go/internal/agent/services/devicetype_advertisement.go
@@ -1,0 +1,104 @@
+package services
+
+import (
+	"os"
+	"regexp"
+	"strings"
+
+	"go.uber.org/zap"
+)
+
+// deviceTypePath is where the image records the board this agent runs on
+// (BOARD=..., or a bare board id on older images).
+const deviceTypePath = "/etc/wendyos/device-type"
+
+// advertisableDeviceType bounds what goes into the TXT record: board ids are
+// short lowercase tokens, and anything else would be a malformed file's
+// content being written into XML.
+var advertisableDeviceType = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,62}$`)
+
+// EnsureDeviceTypeAdvertisement stamps the board id into the mDNS
+// advertisement as a devicetype TXT record. Call it once at agent startup.
+//
+// The record lets `wendy discover` classify a sighting before -- or instead
+// of -- reaching the agent. That matters for the local VM: its announcement
+// escapes QEMU's user-mode network one way, carrying an address the host
+// cannot dial, and the CLI has to know it is a VM without a probe.
+//
+// Best-effort and quiet by design: when the record already says the right
+// thing it touches nothing and leaves avahi-daemon alone -- this runs on every
+// agent start, and a needless restart would drop the advertisement.
+func EnsureDeviceTypeAdvertisement(logger *zap.Logger) {
+	ensureDeviceTypeAdvertisement(logger, deviceTypePath, avahiServiceFile, func() bool {
+		return restartAvahiDaemon(logger)
+	})
+}
+
+// ensureDeviceTypeAdvertisement is the testable core of
+// EnsureDeviceTypeAdvertisement, with the paths and the avahi restart injected.
+func ensureDeviceTypeAdvertisement(logger *zap.Logger, deviceTypePath, serviceFile string, restartAvahi func() bool) {
+	data, err := os.ReadFile(deviceTypePath)
+	if err != nil {
+		// Absent on an image that never wrote one, and on desktop installs.
+		if !os.IsNotExist(err) {
+			logger.Warn("Could not read device type", zap.String("path", deviceTypePath), zap.Error(err))
+		}
+		return
+	}
+	deviceType, _ := parseDeviceType(string(data))
+	if !advertisableDeviceType.MatchString(deviceType) {
+		return
+	}
+
+	service, err := os.ReadFile(serviceFile)
+	if err != nil {
+		// Absent on a non-WendyOS host, where there is no advertisement.
+		if !os.IsNotExist(err) {
+			logger.Warn("Could not read avahi service file", zap.String("path", serviceFile), zap.Error(err))
+		}
+		return
+	}
+
+	content := avahiContentWithDeviceType(string(service), deviceType)
+	if content == string(service) {
+		return // already advertising it
+	}
+	if err := os.WriteFile(serviceFile, []byte(content), 0o644); err != nil {
+		logger.Warn("Could not write avahi service file", zap.String("path", serviceFile), zap.Error(err))
+		return
+	}
+	if restartAvahi() {
+		logger.Info("Advertising device type over mDNS", zap.String("deviceType", deviceType))
+	}
+}
+
+// avahiContentWithDeviceType returns content with the devicetype TXT record of
+// the _wendyos._udp block set to deviceType, adding the record when the block
+// has none. Other service blocks in the file are left alone. The block walk
+// mirrors configpartition.updateWendyOSServicePort; it lives here because
+// configpartition imports this package, not the other way round.
+func avahiContentWithDeviceType(content, deviceType string) string {
+	const typeTag = "<type>_wendyos._udp</type>"
+	typeIdx := strings.Index(content, typeTag)
+	if typeIdx < 0 {
+		return content
+	}
+	serviceStart := strings.LastIndex(content[:typeIdx], "<service")
+	if serviceStart < 0 {
+		serviceStart = typeIdx
+	}
+	closeOffset := strings.Index(content[typeIdx:], "</service>")
+	if closeOffset < 0 {
+		return content
+	}
+	serviceEnd := typeIdx + closeOffset + len("</service>")
+
+	block := content[serviceStart:serviceEnd]
+	if strings.Contains(block, "<txt-record>devicetype=") {
+		block = replaceAvahiTXTRecord(block, "devicetype", deviceType)
+	} else {
+		block = strings.Replace(block, "</service>",
+			"    <txt-record>devicetype="+deviceType+"</txt-record>\n  </service>", 1)
+	}
+	return content[:serviceStart] + block + content[serviceEnd:]
+}

--- a/go/internal/agent/services/devicetype_advertisement_test.go
+++ b/go/internal/agent/services/devicetype_advertisement_test.go
@@ -1,0 +1,167 @@
+package services
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// deviceTypeFixture writes the device-type and avahi service files into a temp
+// dir and returns their paths. Empty content means the file is not created.
+func deviceTypeFixture(t *testing.T, deviceType, serviceContent string) (deviceTypePath, servicePath string) {
+	t.Helper()
+	dir := t.TempDir()
+	deviceTypePath = filepath.Join(dir, "device-type")
+	servicePath = filepath.Join(dir, "wendyos-mdns.service")
+	if deviceType != "" {
+		if err := os.WriteFile(deviceTypePath, []byte(deviceType), 0o644); err != nil {
+			t.Fatalf("writing device-type fixture: %v", err)
+		}
+	}
+	if serviceContent != "" {
+		if err := os.WriteFile(servicePath, []byte(serviceContent), 0o644); err != nil {
+			t.Fatalf("writing avahi fixture: %v", err)
+		}
+	}
+	return deviceTypePath, servicePath
+}
+
+func countRestarts(n *int) func() bool {
+	return func() bool {
+		*n++
+		return true
+	}
+}
+
+// The board id goes into the advertisement so the CLI can tell what a sighting
+// is before it can reach the agent -- a VM's announcement may carry an
+// address nothing on the host can dial.
+func TestEnsureDeviceTypeAdvertisementAddsTheRecord(t *testing.T) {
+	dtPath, svcPath := deviceTypeFixture(t, "BOARD=vm-arm64\nMACHINE=vm-arm64-wendyos\nSTORAGE=disk\n", avahiFixture)
+
+	restarts := 0
+	ensureDeviceTypeAdvertisement(zap.NewNop(), dtPath, svcPath, countRestarts(&restarts))
+
+	got := readFile(t, svcPath)
+	const record = "<txt-record>devicetype=vm-arm64</txt-record>"
+	recordAt := strings.Index(got, record)
+	if recordAt < 0 {
+		t.Fatalf("devicetype TXT record not added:\n%s", got)
+	}
+	if typeAt := strings.Index(got, "<type>_wendyos._udp</type>"); typeAt > recordAt || strings.Index(got, "</service>") < recordAt {
+		t.Errorf("devicetype record landed outside the _wendyos._udp block:\n%s", got)
+	}
+	// Records the agent owns elsewhere must survive untouched.
+	for _, keep := range []string{"<txt-record>tls=true</txt-record>", "<port>50052</port>", "<txt-record>name=brave-dolphin</txt-record>"} {
+		if !strings.Contains(got, keep) {
+			t.Errorf("%s was clobbered:\n%s", keep, got)
+		}
+	}
+	if restarts != 1 {
+		t.Errorf("avahi restarts = %d, want 1", restarts)
+	}
+}
+
+// This runs on every agent start. Once the record is in place nothing may be
+// written or restarted: a needless avahi restart drops the advertisement.
+func TestEnsureDeviceTypeAdvertisementIsQuietWhenCurrent(t *testing.T) {
+	current := strings.Replace(avahiFixture, "  </service>",
+		"    <txt-record>devicetype=vm-arm64</txt-record>\n  </service>", 1)
+	dtPath, svcPath := deviceTypeFixture(t, "BOARD=vm-arm64\n", current)
+
+	restarts := 0
+	ensureDeviceTypeAdvertisement(zap.NewNop(), dtPath, svcPath, countRestarts(&restarts))
+
+	if got := readFile(t, svcPath); got != current {
+		t.Errorf("service file rewritten although already current:\n%s", got)
+	}
+	if restarts != 0 {
+		t.Errorf("avahi restarts = %d, want 0", restarts)
+	}
+}
+
+func TestEnsureDeviceTypeAdvertisementReplacesAStaleRecord(t *testing.T) {
+	stale := strings.Replace(avahiFixture, "  </service>",
+		"    <txt-record>devicetype=old-board</txt-record>\n  </service>", 1)
+	dtPath, svcPath := deviceTypeFixture(t, "BOARD=vm-arm64\n", stale)
+
+	restarts := 0
+	ensureDeviceTypeAdvertisement(zap.NewNop(), dtPath, svcPath, countRestarts(&restarts))
+
+	got := readFile(t, svcPath)
+	if !strings.Contains(got, "<txt-record>devicetype=vm-arm64</txt-record>") || strings.Contains(got, "old-board") {
+		t.Errorf("stale devicetype record not replaced:\n%s", got)
+	}
+	if strings.Count(got, "devicetype=") != 1 {
+		t.Errorf("want exactly one devicetype record:\n%s", got)
+	}
+	if restarts != 1 {
+		t.Errorf("avahi restarts = %d, want 1", restarts)
+	}
+}
+
+// Older images wrote the board as a bare string; the record still has to say
+// what it is.
+func TestEnsureDeviceTypeAdvertisementReadsLegacyPlainDeviceType(t *testing.T) {
+	dtPath, svcPath := deviceTypeFixture(t, "jetson-orin-nano\n", avahiFixture)
+
+	ensureDeviceTypeAdvertisement(zap.NewNop(), dtPath, svcPath, func() bool { return true })
+
+	if got := readFile(t, svcPath); !strings.Contains(got, "<txt-record>devicetype=jetson-orin-nano</txt-record>") {
+		t.Errorf("legacy device-type not advertised:\n%s", got)
+	}
+}
+
+// No device-type file (an image that never wrote one, or a desktop install)
+// means nothing to advertise and nothing to touch.
+func TestEnsureDeviceTypeAdvertisementWithoutDeviceType(t *testing.T) {
+	dtPath, svcPath := deviceTypeFixture(t, "", avahiFixture)
+
+	restarts := 0
+	ensureDeviceTypeAdvertisement(zap.NewNop(), dtPath, svcPath, countRestarts(&restarts))
+
+	if got := readFile(t, svcPath); got != avahiFixture {
+		t.Errorf("service file changed with no device type known:\n%s", got)
+	}
+	if restarts != 0 {
+		t.Errorf("avahi restarts = %d, want 0", restarts)
+	}
+}
+
+// A host with no avahi service file (the Linux desktop install) is not an
+// error and must not restart anything.
+func TestEnsureDeviceTypeAdvertisementMissingServiceFile(t *testing.T) {
+	dtPath, svcPath := deviceTypeFixture(t, "BOARD=vm-arm64\n", "")
+
+	restarts := 0
+	ensureDeviceTypeAdvertisement(zap.NewNop(), dtPath, svcPath, countRestarts(&restarts))
+
+	if _, err := os.Stat(svcPath); !os.IsNotExist(err) {
+		t.Errorf("a service file was created where none existed (stat err %v)", err)
+	}
+	if restarts != 0 {
+		t.Errorf("avahi restarts = %d, want 0", restarts)
+	}
+}
+
+// Only the WendyOS block is ours; a second service in the same file (SSH,
+// say) must not grow a devicetype record.
+func TestEnsureDeviceTypeAdvertisementLeavesOtherServiceBlocksAlone(t *testing.T) {
+	withSSH := strings.Replace(avahiFixture, "</service-group>",
+		"  <service>\n    <type>_ssh._tcp</type>\n    <port>22</port>\n  </service>\n</service-group>", 1)
+	dtPath, svcPath := deviceTypeFixture(t, "BOARD=vm-arm64\n", withSSH)
+
+	ensureDeviceTypeAdvertisement(zap.NewNop(), dtPath, svcPath, func() bool { return true })
+
+	got := readFile(t, svcPath)
+	if strings.Count(got, "devicetype=") != 1 {
+		t.Errorf("want exactly one devicetype record:\n%s", got)
+	}
+	sshAt := strings.Index(got, "<type>_ssh._tcp</type>")
+	if recordAt := strings.Index(got, "devicetype="); recordAt > sshAt {
+		t.Errorf("devicetype record landed in the SSH block:\n%s", got)
+	}
+}

--- a/go/internal/cli/assets/docs/installation/wendyos-virtual-machine.mdx
+++ b/go/internal/cli/assets/docs/installation/wendyos-virtual-machine.mdx
@@ -165,14 +165,16 @@ machine; the difference is whether anything *else* can reach the VM.
 
 | `--net` | Setup needed | Listed by `wendy discover` | On your network |
 | --- | --- | --- | --- |
-| `user` (default) | none | Yes — as a local VM | No |
-| `shared` | one-time `socket_vmnet` install, **macOS only** | Yes — over mDNS, like a device | Yes |
+| `user` (default) | none | Yes — Simulator tab | No |
+| `shared` | one-time `socket_vmnet` install, **macOS only** | Yes — Simulator tab | Yes |
 
 The default forwards the agent's port to your machine and needs no privileges.
-It carries no multicast, so the VM answers no mDNS and no other machine can see
-it — but `wendy discover` still lists it, because the CLI knows about VMs on
-this machine directly and probes the forwarded port. It appears as `vm:<name>`,
-and the **Simulator** tab shows stopped ones too.
+Nothing on your network can reach the guest. Its mDNS announcement does leak
+out (QEMU passes the guest's multicast through one way), advertising an address
+nobody can dial — `wendy discover` recognises that sighting as your VM and
+keeps it off the **Local** tab. Either way a VM is listed only on the
+**Simulator** tab, which shows stopped ones too; in JSON output it is under
+`simulators` as `vm:<name>`.
 
 Choose `shared` when you need the VM to behave like a real device on the wire —
 to test mDNS itself, or to reach it from another machine:

--- a/go/internal/cli/assets/docs/installation/wendyos-virtual-machine.mdx
+++ b/go/internal/cli/assets/docs/installation/wendyos-virtual-machine.mdx
@@ -166,18 +166,21 @@ machine; the difference is whether anything *else* can reach the VM.
 | `--net` | Setup needed | Listed by `wendy discover` | On your network |
 | --- | --- | --- | --- |
 | `user` (default) | none | Yes — Simulator tab | No |
-| `shared` | one-time `socket_vmnet` install, **macOS only** | Yes — Simulator tab | Yes |
+| `shared` | one-time `socket_vmnet` install, **macOS only** | Yes — Local tab via mDNS | Host-shared segment |
 
 The default forwards the agent's port to your machine and needs no privileges.
 Nothing on your network can reach the guest. Its mDNS announcement does leak
 out (QEMU passes the guest's multicast through one way), advertising an address
 nobody can dial — `wendy discover` recognises that sighting as your VM and
-keeps it off the **Local** tab. Either way a VM is listed only on the
+keeps it off the **Local** tab. A user-mode VM is listed only on the
 **Simulator** tab, which shows stopped ones too; in JSON output it is under
 `simulators` as `vm:<name>`.
 
-Choose `shared` when you need the VM to behave like a real device on the wire —
-to test mDNS itself, or to reach it from another machine:
+Choose `shared` to test mDNS or reach the guest directly by IP on the host's
+vmnet segment. Its reachable entry stays on **Local** (and in JSON's
+`lanDevices`); the **Simulator** tab still lists its local lifecycle state.
+This is not a bridge onto the physical LAN; reachability from another machine
+depends on routing and the helper's configuration:
 
 ```sh
 wendy vm start dev --net shared

--- a/go/internal/cli/assets/skills/wendy-contributing/references/system-internals.md
+++ b/go/internal/cli/assets/skills/wendy-contributing/references/system-internals.md
@@ -111,8 +111,12 @@ virtualize mode. The image is now UEFI-bootable, which removes one obstacle, but
 does not expose (it offers a virtio console, `hvc0`) — so a VZ guest would very
 likely boot mute. UTM in *emulate* mode runs QEMU and should behave like QEMU.
 
-`--net user` (the default) forwards the agent port but carries no multicast, so
-`wendy discover` cannot see the VM; `--net shared` uses `socket_vmnet` and can.
+`--net user` (the default) forwards the agent port; nothing else can reach the
+guest, but its mDNS announcement still leaks out through SLIRP one way, with an
+undialable 10.0.2.15 address. `wendy discover` files a VM under the Simulator
+tab either way (by the agent's `devicetype` TXT record or the hostname the VM
+reported), never among Local devices; `--net shared` uses `socket_vmnet` and
+puts the VM on the real network.
 See the *WendyOS in a Virtual Machine* installation guide for the full flow.
 
 ## Offline Container Image Bundling

--- a/go/internal/cli/assets/skills/wendy-contributing/references/system-internals.md
+++ b/go/internal/cli/assets/skills/wendy-contributing/references/system-internals.md
@@ -113,10 +113,10 @@ likely boot mute. UTM in *emulate* mode runs QEMU and should behave like QEMU.
 
 `--net user` (the default) forwards the agent port; nothing else can reach the
 guest, but its mDNS announcement still leaks out through SLIRP one way, with an
-undialable 10.0.2.15 address. `wendy discover` files a VM under the Simulator
-tab either way (by the agent's `devicetype` TXT record or the hostname the VM
-reported), never among Local devices; `--net shared` uses `socket_vmnet` and
-puts the VM on the real network.
+undialable 10.0.2.15 address. `wendy discover` files user-mode VMs under the
+Simulator tab and filters leaked announcements using the agent's `devicetype`
+TXT record or a learned hostname. `--net shared` uses `socket_vmnet` to put the
+VM on a host-shared segment; its reachable mDNS entry stays on Local.
 See the *WendyOS in a Virtual Machine* installation guide for the full flow.
 
 ## Offline Container Image Bundling

--- a/go/internal/cli/commands/discover.go
+++ b/go/internal/cli/commands/discover.go
@@ -39,14 +39,7 @@ func newDiscoverCmd() *cobra.Command {
 		Short: "Discover local and cloud WendyOS devices",
 		Long:  "Continuously discover WendyOS devices in Local and Cloud tabs until Ctrl+C. Use --timeout to scan local devices once for a fixed duration.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts := discovery.DiscoveryOptions{
-				// The continuous TUI path streams LAN devices directly via
-				// lanStreamFn/startLANStream and never reads opts.LAN, so
-				// setting it unconditionally here only affects the JSON and
-				// one-shot paths below — both want the CLI's cache+probe LAN
-				// collection instead of the old mDNS-only confirmation.
-				LAN: cliLANStreamOptions(),
-			}
+			var opts discovery.DiscoveryOptions
 
 			switch discoverType {
 			case "usb":
@@ -70,11 +63,17 @@ func newDiscoverCmd() *cobra.Command {
 
 			timeoutSet := cmd.Flags().Changed("timeout")
 
+			// Only the JSON and one-shot paths read opts.LAN; the continuous
+			// TUI streams LAN devices itself (startLANStream). Both want the
+			// CLI's cache+probe collection, and building it here rather than
+			// up front spares the TUI a second simulator filter, whose
+			// learners would dial every booting VM twice.
 			if jsonOutput {
 				if !timeoutSet {
 					timeout = 5 * time.Second
 				}
 				opts.Timeout = timeout
+				opts.LAN = cliLANStreamOptions(cmd.Context())
 				// JSON output always lists every target so scripts/MCP keep the
 				// full set regardless of WENDY_SHOW_LOCAL_DEVICES.
 				return discoverJSON(cmd.Context(), opts)
@@ -82,6 +81,7 @@ func newDiscoverCmd() *cobra.Command {
 
 			if timeoutSet {
 				opts.Timeout = timeout
+				opts.LAN = cliLANStreamOptions(cmd.Context())
 				return discoverOnce(cmd.Context(), opts, providers.ShowLocalDevices())
 			}
 			return discoverContinuous(cmd.Context(), opts, providers.ShowLocalDevices())
@@ -471,7 +471,7 @@ func (m discoverModel) scanEthernet() tea.Cmd {
 // model just mirrors whatever it reports. Prober must be set: with a nil
 // Prober a cached row can never be confirmed offline.
 func (m discoverModel) startLANStream() tea.Cmd {
-	events := lanStreamFn(m.ctx, discovery.StreamOptions{UseCache: true, Prober: lanProber})
+	events := lanStreamFn(m.ctx, cliLANStreamOptions(m.ctx))
 	return waitLANEvent(events)
 }
 
@@ -609,6 +609,13 @@ func (m discoverModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		delay := m.ethernetInterval.delay(env.DiscoverEthernetInterval())
 		return m, delayThen(delay, m.scanEthernet())
 	case lanEventMsg:
+		if msg.ev.Kind == discovery.LANRetracted {
+			// Listed, then found to be one of this machine's VMs: it belongs
+			// on the Simulator tab, not here.
+			m.removeLANDevice(discoverycache.Key(msg.ev.Device.ID, msg.ev.Device.DisplayName))
+			m.refreshTable()
+			return m, waitLANEvent(msg.ch)
+		}
 		// A superseded identity is this same device under a stale,
 		// connect-minted hostname key; dropping it keeps one row per device.
 		if msg.ev.Supersedes != "" {
@@ -1281,6 +1288,32 @@ func discoverTableItems(collection *models.DevicesCollection) []discoverTableIte
 			lanName:       lanName,
 			lanKey:        lanKey,
 			defaultDevice: defaultDevice,
+		})
+	}
+	for _, d := range collection.Simulators {
+		// The one-shot table has no Simulator tab, so the type column is what
+		// tells a VM apart from a device on the network.
+		const deviceType = "Simulator"
+		address := preferredLANAddress(d)
+		items = append(items, discoverTableItem{
+			picker: tui.PickerItem{
+				Name:          discovery.SanitiseDisplayName(d.DisplayName),
+				Type:          deviceType,
+				Address:       address,
+				AgentVersion:  discovery.SanitiseDisplayName(d.AgentVersion),
+				AgentOutdated: agentBehindCLI(version.Version, d.AgentVersion),
+				OS:            d.OS,
+				OSVersion:     d.OSVersion,
+				DedupKey:      d.ID,
+				SortKey:       deviceSortKey(d.DisplayName, ""),
+			},
+			info: discoverDeviceInfo{
+				Name:    d.DisplayName,
+				Type:    deviceType,
+				Address: address,
+				Version: d.AgentVersion,
+			},
+			defaultDevice: d.ID,
 		})
 	}
 	for _, d := range collection.ExternalDevices {

--- a/go/internal/cli/commands/discover_stream_test.go
+++ b/go/internal/cli/commands/discover_stream_test.go
@@ -99,7 +99,7 @@ func searchLANEventMsg(cmd tea.Cmd) (lanEventMsg, bool) {
 // exists (deleted with its last caller), so any accidental reintroduction of
 // a call to it fails the build, not just this test.
 func TestCLILANStreamOptions_UsesCacheAndProber(t *testing.T) {
-	opts := cliLANStreamOptions()
+	opts := cliLANStreamOptions(context.Background())
 	if !opts.UseCache {
 		t.Error("UseCache = false; want true so cached rows appear instantly")
 	}

--- a/go/internal/cli/commands/fleet_lan.go
+++ b/go/internal/cli/commands/fleet_lan.go
@@ -107,7 +107,7 @@ func discoverFleetLAN(ctx context.Context, timeout time.Duration) ([]models.LAND
 	if timeout <= 0 {
 		timeout = fleetLANDiscoverTimeout
 	}
-	devices, err := discovery.CollectLAN(ctx, cliLANStreamOptions(), timeout)
+	devices, err := discovery.CollectLAN(ctx, cliLANStreamOptions(ctx), timeout)
 	if err != nil {
 		return nil, fmt.Errorf("discovering LAN devices: %w", err)
 	}

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -600,7 +600,7 @@ var getAgentVersionAtAddress = func(ctx context.Context, address string) (bool, 
 }
 
 var discoverLANDevices = func(ctx context.Context, timeout time.Duration) ([]models.LANDevice, error) {
-	return discovery.CollectLAN(ctx, cliLANStreamOptions(), timeout)
+	return discovery.CollectLAN(ctx, cliLANStreamOptions(ctx), timeout)
 }
 
 var isInteractiveTerminalFn = func() bool {
@@ -803,13 +803,15 @@ func lanRowState(ev discovery.LANEvent) (probe tui.ProbeState, insecure bool) {
 
 // cliLANStreamOptions is the CLI's single definition of how a LAN scan should
 // run: read/write the on-disk cache (so a device seen in a prior run appears
-// instantly) and confirm every candidate with lanProber (an agent probe),
-// never a bare mDNS sighting. Every CLI surface that collects LAN devices —
-// one-shot/JSON discover, MCP's device_list, fleet commands, and the batch
-// helpers below — shares this so they all get the same cache+probe
-// acceleration.
-func cliLANStreamOptions() discovery.StreamOptions {
-	return discovery.StreamOptions{UseCache: true, Prober: lanProber}
+// instantly), confirm every candidate with lanProber (an agent probe), never a
+// bare mDNS sighting, and keep this machine's own VMs out of the list (see
+// simulatorFilter). Every CLI surface that collects LAN devices — the discover
+// TUI, the run picker, one-shot/JSON discover, MCP's device_list, fleet
+// commands, and the batch helpers below — shares this so they all get the
+// same cache+probe acceleration and the same idea of what a device is. ctx
+// bounds the filter's background learning; pass the session's.
+func cliLANStreamOptions(ctx context.Context) discovery.StreamOptions {
+	return discovery.StreamOptions{UseCache: true, Prober: lanProber, Exclude: newSimulatorFilter(ctx)}
 }
 
 // SelectedDevice represents either a gRPC agent, BLE device, or an external provider device.
@@ -3770,49 +3772,24 @@ func pickDeviceWithCloudAuth(ctx context.Context, excludeProviders map[string]bo
 	p := tea.NewProgram(newDevicePickerModel(discoverCtx, picker, cloudAuth, defaultOrgID))
 
 	sendLANItem := func(dev models.LANDevice, insecure bool, probe tui.ProbeState) {
-		devCopy := dev
-		// While the probe is still in flight the Agent/OS columns show a
-		// spinner, so suppress the no-access hint until we actually know the
-		// probe failed.
-		hint := ""
-		if probe != tui.ProbePending {
-			hint = lanNoAccessHint(&devCopy, dev.AgentVersion)
-		}
-		p.Send(devicePickerLocalMsg{msg: tui.PickerAddMsg{Items: []tui.PickerItem{{
-			Name:          dev.DisplayName,
-			Type:          "LAN",
-			USB:           dev.USB,
-			Address:       preferredLANAddress(dev),
-			AgentVersion:  dev.AgentVersion,
-			AgentOutdated: agentBehindCLI(version.Version, dev.AgentVersion),
-			OS:            dev.OS,
-			OSVersion:     dev.OSVersion,
-			Provisioned:   lanProvisionedDisplay(&devCopy),
-			Hint:          hint,
-			Probe:         probe,
-			DedupKey:      deviceDedupKey(dev.HostKey(), dev.DisplayName),
-			SortKey:       deviceSortKey(dev.DisplayName, dev.USB),
-			Insecure:      insecure,
-			Value: &pickerEntry{mergedDevice: &models.DiscoveredDevice{
-				DisplayName:     dev.DisplayName,
-				AgentVersion:    dev.AgentVersion,
-				OS:              dev.OS,
-				OSVersion:       dev.OSVersion,
-				CPUArchitecture: dev.CPUArchitecture,
-				LAN:             &devCopy,
-			}},
-		}}}})
+		p.Send(devicePickerLocalMsg{msg: tui.PickerAddMsg{Items: []tui.PickerItem{lanPickerItem(dev, insecure, probe)}}})
 	}
 	// Streaming LAN discovery — cached rows appear instantly, live sightings
 	// and probe outcomes follow, and the engine itself handles offline
 	// detection and retry (see discovery.StreamLAN). Prober must be set: with
 	// a nil Prober a cached row can never be confirmed offline.
-	events := lanStreamFn(discoverCtx, discovery.StreamOptions{UseCache: true, Prober: lanProber})
+	events := lanStreamFn(discoverCtx, cliLANStreamOptions(discoverCtx))
 	go func() {
 		// ev.Supersedes needs no handling here: picker rows dedup by hostname
 		// (deviceDedupKey/HostKey), so a superseded connect-minted row and the
 		// TXT-id row that replaces it are already the same row.
 		for ev := range events {
+			if ev.Kind == discovery.LANRetracted {
+				// Listed, then found to be one of this machine's VMs: it
+				// belongs on the Simulator tab, not here.
+				p.Send(devicePickerLocalMsg{msg: lanPickerRemoveMsg(ev.Device)})
+				continue
+			}
 			probe, insecure := lanRowState(ev)
 			sendLANItem(ev.Device, insecure, probe)
 		}
@@ -3927,6 +3904,48 @@ func pickDeviceWithCloudAuth(ctx context.Context, excludeProviders map[string]bo
 	default:
 		return connectLocalPickerChoice(ctx, choice.Local, suppressUpdateCheck)
 	}
+}
+
+// lanPickerItem is the run picker's row for a LAN device.
+func lanPickerItem(dev models.LANDevice, insecure bool, probe tui.ProbeState) tui.PickerItem {
+	devCopy := dev
+	// While the probe is still in flight the Agent/OS columns show a
+	// spinner, so suppress the no-access hint until we actually know the
+	// probe failed.
+	hint := ""
+	if probe != tui.ProbePending {
+		hint = lanNoAccessHint(&devCopy, dev.AgentVersion)
+	}
+	return tui.PickerItem{
+		Name:          dev.DisplayName,
+		Type:          "LAN",
+		USB:           dev.USB,
+		Address:       preferredLANAddress(dev),
+		AgentVersion:  dev.AgentVersion,
+		AgentOutdated: agentBehindCLI(version.Version, dev.AgentVersion),
+		OS:            dev.OS,
+		OSVersion:     dev.OSVersion,
+		Provisioned:   lanProvisionedDisplay(&devCopy),
+		Hint:          hint,
+		Probe:         probe,
+		DedupKey:      deviceDedupKey(dev.HostKey(), dev.DisplayName),
+		SortKey:       deviceSortKey(dev.DisplayName, dev.USB),
+		Insecure:      insecure,
+		Value: &pickerEntry{mergedDevice: &models.DiscoveredDevice{
+			DisplayName:     dev.DisplayName,
+			AgentVersion:    dev.AgentVersion,
+			OS:              dev.OS,
+			OSVersion:       dev.OSVersion,
+			CPUArchitecture: dev.CPUArchitecture,
+			LAN:             &devCopy,
+		}},
+	}
+}
+
+// lanPickerRemoveMsg takes back the row lanPickerItem built for dev, under the
+// same key it was added with.
+func lanPickerRemoveMsg(dev models.LANDevice) tui.PickerRemoveMsg {
+	return tui.PickerRemoveMsg{Key: deviceDedupKey(dev.HostKey(), dev.DisplayName)}
 }
 
 // connectLocalPickerChoice turns a Local-tab selection into a connection. Lifted

--- a/go/internal/cli/commands/mcp.go
+++ b/go/internal/cli/commands/mcp.go
@@ -38,7 +38,7 @@ func newMCPServeCmd() *cobra.Command {
 			}
 			srv := wendymcp.New(cfg, connectWithAutoTLS)
 			srv.SetLANDiscoverer(func(ctx context.Context, timeout time.Duration) ([]models.LANDevice, error) {
-				return discovery.CollectLAN(ctx, cliLANStreamOptions(), timeout)
+				return discovery.CollectLAN(ctx, cliLANStreamOptions(ctx), timeout)
 			})
 			address := deviceFlag
 			if address == "" {

--- a/go/internal/cli/commands/vm.go
+++ b/go/internal/cli/commands/vm.go
@@ -355,9 +355,9 @@ func vmPrintReachability(out io.Writer, net vm.NetConfig, hostPort int) {
 		return
 	}
 	fmt.Fprintf(out, "Once it boots, reach it with 'wendy --device 127.0.0.1:%d device info', "+
-		"or pick it out of 'wendy discover'.\n", hostPort)
-	fmt.Fprintln(out, "It is not on your network, though: user-mode networking carries no mDNS, "+
-		"so no other machine can see it. Use --net shared for that.")
+		"or pick it from the Simulator tab of 'wendy discover'.\n", hostPort)
+	fmt.Fprintln(out, "It is not on your network, though: nothing else can reach a user-mode VM. "+
+		"Use --net shared for that.")
 }
 
 // ensureQEMUFn resolves the emulator, prompting to install it where that is

--- a/go/internal/cli/commands/vm_discover.go
+++ b/go/internal/cli/commands/vm_discover.go
@@ -221,6 +221,8 @@ func newSimulatorFilter(ctx context.Context) *simulatorFilter {
 	if err != nil {
 		return f // an unreadable store leaves the board signal, which needs no store
 	}
+	// Finish seeding before publishing the map to any learner goroutine.
+	var learners []vm.Status
 	for _, st := range statuses {
 		if st.Meta.Hostname != "" {
 			// Stopped VMs count too: a stale sighting or cache row of one has
@@ -229,8 +231,11 @@ func newSimulatorFilter(ctx context.Context) *simulatorFilter {
 			continue
 		}
 		if st.Running && st.State.NetMode == vm.NetUser && st.State.AgentPort != 0 {
-			go f.learn(ctx, st.Name, st.State.AgentPort)
+			learners = append(learners, st)
 		}
+	}
+	for _, st := range learners {
+		go f.learn(ctx, st.Name, st.State.AgentPort)
 	}
 	return f
 }

--- a/go/internal/cli/commands/vm_discover.go
+++ b/go/internal/cli/commands/vm_discover.go
@@ -196,13 +196,11 @@ var (
 	simulatorHostnameAskBudget = 3 * time.Second
 )
 
-// simulatorFilter is the CLI's discovery.LANFilter: it keeps the VMs this
-// machine runs out of every LAN device list, so they appear only under the
-// Simulator tab. Two positive signals, either of which is enough and neither
-// of which a real device trips:
+// simulatorFilter suppresses leaked user-network announcements, not all VMs.
+// At the default SLIRP address, it uses either of two signals:
 //   - the device type is a VM board, whether from the devicetype TXT record
 //     (classified on the sighting itself) or from an agent probe;
-//   - the hostname is one a VM in the local store has reported. This is what
+//   - with no board advertised, the hostname is one a local VM reported. This
 //     catches a user-mode VM's leaked announcement, which advertises an
 //     address (10.0.2.15) no probe can reach, on images whose agent predates
 //     the TXT record.
@@ -253,6 +251,13 @@ func (f *simulatorFilter) Exclude(dev models.LANDevice) bool {
 		// Preserve directly reachable shared/network VMs. The launcher uses
 		// QEMU's default user-network guest address for leaked announcements.
 		return dev.IPAddress == "10.0.2.15"
+	}
+	// A hostname is a reusable label, not a durable device identity. Never
+	// hide a physical board or a normally addressed device just because a VM
+	// (including a stopped one) once used its name. Legacy images without a
+	// board TXT record get the fallback only at the leaked SLIRP address.
+	if dev.DeviceType != "" || dev.IPAddress != "10.0.2.15" {
+		return false
 	}
 	host := dev.HostKey()
 	if host == "" {

--- a/go/internal/cli/commands/vm_discover.go
+++ b/go/internal/cli/commands/vm_discover.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -31,12 +32,31 @@ var vmStatusesFn = func() ([]vm.Status, error) {
 	return store.Statuses()
 }
 
+// vmRecordHostnameFn remembers the hostname a VM's guest reported. A seam so
+// tests never write to the developer's real VM store.
+var vmRecordHostnameFn = func(name, hostname string) error {
+	store, err := vm.NewStore()
+	if err != nil {
+		return err
+	}
+	return store.RecordHostname(name, hostname)
+}
+
+// vmHostAddr maps a guest agent port onto the host side of a VM's forward.
+// The forward maps host port onto the guest's plaintext port and port+1 onto
+// its mTLS port, so a guest port shifts by the same delta to reach the host.
+func vmHostAddr(hostPort, guestPort int) string {
+	return fmt.Sprintf("127.0.0.1:%d", hostPort+guestPort-defaultAgentPort)
+}
+
 // probeLocalVMDevices returns a row for every running user-mode VM whose agent
-// answers on its forwarded loopback port.
+// answers on its forwarded loopback port, and records each guest's hostname so
+// its stray mDNS announcement is recognised from then on.
 //
-// Shared-mode VMs are skipped: mDNS already finds them, so a row here would
-// list them twice. User-mode VMs are the ones discovery can never see, because
-// SLIRP carries no multicast.
+// Shared-mode VMs are skipped: they are on a real segment where mDNS finds
+// them, and the simulator filter files that sighting under the Simulator tab
+// by the board the agent reports. User-mode VMs are reachable only through
+// the forward, so this probe is the only way to list them with an address.
 func probeLocalVMDevices(ctx context.Context) []models.LANDevice {
 	statuses, err := vmStatusesFn()
 	if err != nil {
@@ -69,12 +89,7 @@ func probeLocalVMDevices(ctx context.Context) []models.LANDevice {
 		wg.Add(1)
 		go func(i int, c candidate) {
 			defer wg.Done()
-			// The forward maps host c.port onto the guest's plaintext port and
-			// c.port+1 onto its mTLS port, so a guest port shifts by the same
-			// delta to reach the host side.
-			hostAddrFor := func(guestPort int) string {
-				return fmt.Sprintf("127.0.0.1:%d", c.port+guestPort-defaultAgentPort)
-			}
+			hostAddrFor := func(guestPort int) string { return vmHostAddr(c.port, guestPort) }
 			if !anyAgentPortAnswers(pctx, hostAddrFor) {
 				return
 			}
@@ -84,6 +99,9 @@ func probeLocalVMDevices(ctx context.Context) []models.LANDevice {
 			}
 			defer conn.Close()
 			isMTLS := conn.IsMTLS
+			// Best-effort: a store that cannot be written costs the next session
+			// one re-learn, nothing more.
+			_ = vmRecordHostnameFn(c.name, resp.GetHostname())
 			advertisedPort := c.port
 			if isMTLS {
 				advertisedPort += agentMTLSPortOffset
@@ -151,6 +169,140 @@ func discoverLocalTargets(ctx context.Context, opts discovery.DiscoveryOptions) 
 	// Merged in even when LAN discovery failed, so the rows are there for a
 	// caller that renders a partial result. Both of today's callers surface
 	// the error instead, which is why the error is still returned.
-	collection.LANDevices = append(collection.LANDevices, vms...)
+	attachSimulators(collection, vms)
 	return collection, err
+}
+
+// attachSimulators lists the VM rows apart from the LAN devices. A VM is
+// reached like a LAN device but is not one, and a JSON reader asking for
+// devices on the network must not have to filter it out.
+func attachSimulators(collection *models.DevicesCollection, vms []models.LANDevice) {
+	collection.Simulators = append(collection.Simulators, vms...)
+}
+
+// isSimulatorBoard reports whether a device type names one of the Builder's
+// VM boards (vmDeviceKey and its x86 sibling). A positive signal: no physical
+// board id starts this way, so a real device can never be filed as a VM.
+func isSimulatorBoard(deviceType string) bool {
+	return strings.HasPrefix(deviceType, "vm-")
+}
+
+// simulatorHostnameRetry is how often the filter re-asks a running VM that has
+// not answered yet, and simulatorHostnameAskBudget bounds one ask: QEMU's
+// forward accepts before the guest listens, so a booting VM passes the connect
+// gate and then hangs the TLS ladder without a bound.
+var (
+	simulatorHostnameRetry     = 2 * time.Second
+	simulatorHostnameAskBudget = 3 * time.Second
+)
+
+// simulatorFilter is the CLI's discovery.LANFilter: it keeps the VMs this
+// machine runs out of every LAN device list, so they appear only under the
+// Simulator tab. Two positive signals, either of which is enough and neither
+// of which a real device trips:
+//   - the device type is a VM board, whether from the devicetype TXT record
+//     (classified on the sighting itself) or from an agent probe;
+//   - the hostname is one a VM in the local store has reported. This is what
+//     catches a user-mode VM's leaked announcement, which advertises an
+//     address (10.0.2.15) no probe can reach, on images whose agent predates
+//     the TXT record.
+type simulatorFilter struct {
+	mu        sync.Mutex
+	hostnames map[string]bool // in LANDevice.HostKey form
+	changed   chan struct{}
+}
+
+// newSimulatorFilter loads every hostname the VM store has on record and, for
+// each running user-mode VM without one, starts asking its agent. ctx bounds
+// those learners; tie it to the discovery session.
+func newSimulatorFilter(ctx context.Context) *simulatorFilter {
+	f := &simulatorFilter{hostnames: make(map[string]bool), changed: make(chan struct{}, 1)}
+	statuses, err := vmStatusesFn()
+	if err != nil {
+		return f // an unreadable store leaves the board signal, which needs no store
+	}
+	for _, st := range statuses {
+		if st.Meta.Hostname != "" {
+			// Stopped VMs count too: a stale sighting or cache row of one has
+			// to go the same way.
+			f.hostnames[vmHostKey(st.Meta.Hostname)] = true
+			continue
+		}
+		if st.Running && st.State.NetMode == vm.NetUser && st.State.AgentPort != 0 {
+			go f.learn(ctx, st.Name, st.State.AgentPort)
+		}
+	}
+	return f
+}
+
+// vmHostKey normalises a hostname the way LANDevice.HostKey does, so a
+// recorded name and a sighting's compare equal regardless of case or a
+// trailing .local.
+func vmHostKey(hostname string) string {
+	return models.LANDevice{Hostname: hostname}.HostKey()
+}
+
+func (f *simulatorFilter) Exclude(dev models.LANDevice) bool {
+	if isSimulatorBoard(dev.DeviceType) {
+		return true
+	}
+	host := dev.HostKey()
+	if host == "" {
+		return false // a display name alone is no identity
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.hostnames[host]
+}
+
+func (f *simulatorFilter) Changed() <-chan struct{} { return f.changed }
+
+// learn asks a running VM's agent for its hostname over the loopback forward,
+// retrying while the guest boots, then records it and signals the session to
+// re-check what it has listed. Bounded by the boot budget: a VM that never
+// answers is one that never announced itself either.
+func (f *simulatorFilter) learn(ctx context.Context, name string, port int) {
+	deadline := time.Now().Add(simulatorBootTimeout())
+	for {
+		if hostname := askVMHostname(ctx, name, port); hostname != "" {
+			// Best-effort: a store that cannot be written costs the next
+			// session one re-learn, nothing more.
+			_ = vmRecordHostnameFn(name, hostname)
+			f.mu.Lock()
+			f.hostnames[vmHostKey(hostname)] = true
+			f.mu.Unlock()
+			// Non-blocking: one pending signal covers any number of learners,
+			// since the session re-checks everything on each.
+			select {
+			case f.changed <- struct{}{}:
+			default:
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(simulatorHostnameRetry):
+		}
+	}
+}
+
+// askVMHostname makes one bounded attempt to read the guest's hostname
+// through the forward at port; "" when the agent is not answering yet.
+func askVMHostname(ctx context.Context, name string, port int) string {
+	actx, cancel := context.WithTimeout(ctx, simulatorHostnameAskBudget)
+	defer cancel()
+	hostAddrFor := func(guestPort int) string { return vmHostAddr(port, guestPort) }
+	if !anyAgentPortAnswers(actx, hostAddrFor) {
+		return ""
+	}
+	conn, resp, err := probeSimulatorAgent(actx, name, hostAddrFor(defaultAgentPort))
+	if err != nil || resp == nil {
+		return ""
+	}
+	defer conn.Close()
+	return resp.GetHostname()
 }

--- a/go/internal/cli/commands/vm_discover.go
+++ b/go/internal/cli/commands/vm_discover.go
@@ -54,8 +54,8 @@ func vmHostAddr(hostPort, guestPort int) string {
 // its stray mDNS announcement is recognised from then on.
 //
 // Shared-mode VMs are skipped: they are on a real segment where mDNS finds
-// them, and the simulator filter files that sighting under the Simulator tab
-// by the board the agent reports. User-mode VMs are reachable only through
+// them. Those reachable sightings stay on Local; only leaked user-network
+// sightings are filtered. User-mode VMs are reachable only through
 // the forward, so this probe is the only way to list them with an address.
 func probeLocalVMDevices(ctx context.Context) []models.LANDevice {
 	statuses, err := vmStatusesFn()
@@ -249,7 +249,10 @@ func vmHostKey(hostname string) string {
 
 func (f *simulatorFilter) Exclude(dev models.LANDevice) bool {
 	if isSimulatorBoard(dev.DeviceType) {
-		return true
+		// A board id identifies a VM, not its owner or networking mode.
+		// Preserve directly reachable shared/network VMs. The launcher uses
+		// QEMU's default user-network guest address for leaked announcements.
+		return dev.IPAddress == "10.0.2.15"
 	}
 	host := dev.HostKey()
 	if host == "" {

--- a/go/internal/cli/commands/vm_discover_filter_test.go
+++ b/go/internal/cli/commands/vm_discover_filter_test.go
@@ -83,6 +83,30 @@ func awaitChanged(t *testing.T, f *simulatorFilter) {
 	}
 }
 
+func TestSimulatorFilterSeedsBeforeStartingLearners(t *testing.T) {
+	port := listenLoopback(t)
+	statuses := []vm.Status{runningVM("new", vm.NetUser, port)}
+	// A large seed set makes the constructor/learner overlap observable under
+	// -race in the old implementation, without timing sleeps.
+	for i := 0; i < 50000; i++ {
+		statuses = append(statuses, vm.Status{Meta: vm.Meta{Hostname: fmt.Sprintf("known-%d", i)}})
+	}
+	stubVMStatuses(t, statuses...)
+	stubAgentVersion(t, func(string) (*agentpb.GetAgentVersionResponse, error) {
+		return &agentpb.GetAgentVersionResponse{Hostname: "learned"}, nil
+	})
+	recordedHostnames(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	f := newSimulatorFilter(ctx)
+	awaitChanged(t, f)
+	for _, host := range []string{"known-0", "known-49999", "learned"} {
+		if !f.Exclude(models.LANDevice{Hostname: host}) {
+			t.Fatalf("hostname %s was lost", host)
+		}
+	}
+}
+
 // A VM board is a positive signal: no real board reports vm-*.
 func TestSimulatorFilterExcludesVMBoards(t *testing.T) {
 	stubVMStatuses(t)

--- a/go/internal/cli/commands/vm_discover_filter_test.go
+++ b/go/internal/cli/commands/vm_discover_filter_test.go
@@ -112,13 +112,27 @@ func TestSimulatorFilterExcludesVMBoards(t *testing.T) {
 	stubVMStatuses(t)
 	f := newSimulatorFilter(context.Background())
 	for _, dt := range []string{"vm-arm64", "vm-x86-64"} {
-		if !f.Exclude(models.LANDevice{DeviceType: dt, Hostname: "wendyos-gentle-forest.local"}) {
+		if !f.Exclude(models.LANDevice{DeviceType: dt, Hostname: "wendyos-gentle-forest.local", IPAddress: "10.0.2.15"}) {
 			t.Errorf("%s was not excluded", dt)
 		}
 	}
 	for _, dt := range []string{"jetson-orin-nano", "rpi5", ""} {
 		if f.Exclude(models.LANDevice{DeviceType: dt, Hostname: "orin.local"}) {
 			t.Errorf("%q was excluded", dt)
+		}
+	}
+}
+
+func TestSimulatorFilterPreservesReachableNetworkVMs(t *testing.T) {
+	shared := runningVM("shared", vm.NetShared, 0)
+	shared.Meta.Hostname = "shared"
+	stubVMStatuses(t, shared)
+	f := newSimulatorFilter(context.Background())
+	for _, host := range []string{"shared.local", "another-hosts-vm.local"} {
+		for _, addr := range []string{"192.168.64.2", "192.168.1.20", "fd00::2"} {
+			if f.Exclude(models.LANDevice{Hostname: host, IPAddress: addr, DeviceType: "vm-arm64"}) {
+				t.Fatalf("reachable VM %s at %s was hidden", host, addr)
+			}
 		}
 	}
 }

--- a/go/internal/cli/commands/vm_discover_filter_test.go
+++ b/go/internal/cli/commands/vm_discover_filter_test.go
@@ -1,0 +1,306 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+	"github.com/wendylabsinc/wendy/go/internal/cli/vm"
+	"github.com/wendylabsinc/wendy/go/internal/shared/discovery"
+	"github.com/wendylabsinc/wendy/go/internal/shared/models"
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+// listenLoopback opens a TCP listener standing in for a VM's forwarded agent
+// port, so the pre-dial gate passes, and returns its port.
+func listenLoopback(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+// stubAgentVersion answers GetAgentVersion with whatever fn says for the
+// address dialed.
+func stubAgentVersion(t *testing.T, fn func(addr string) (*agentpb.GetAgentVersionResponse, error)) {
+	t.Helper()
+	saved := dialAgentLadderFn
+	dialAgentLadderFn = func(_ context.Context, target dialTarget) (*grpcclient.AgentConnection, error, error) {
+		if !strings.HasPrefix(target.PinKey, vmDeviceIDPrefix) {
+			t.Errorf("VM probe lost named identity: %+v", target)
+		}
+		resp, err := fn(target.Addr)
+		if err != nil {
+			return nil, nil, err
+		}
+		return &grpcclient.AgentConnection{AgentService: &fakeAgentVersionClient{resp: resp}}, nil, nil
+	}
+	t.Cleanup(func() { dialAgentLadderFn = saved })
+}
+
+// recordedHostnames captures what the code under test asks the VM store to
+// remember, keyed by VM name, without touching the developer's real store.
+func recordedHostnames(t *testing.T) func() map[string]string {
+	t.Helper()
+	var mu sync.Mutex
+	got := map[string]string{}
+	saved := vmRecordHostnameFn
+	vmRecordHostnameFn = func(name, hostname string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		got[name] = hostname
+		return nil
+	}
+	t.Cleanup(func() { vmRecordHostnameFn = saved })
+	return func() map[string]string {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make(map[string]string, len(got))
+		for k, v := range got {
+			out[k] = v
+		}
+		return out
+	}
+}
+
+func awaitChanged(t *testing.T, f *simulatorFilter) {
+	t.Helper()
+	select {
+	case <-f.Changed():
+	case <-time.After(5 * time.Second):
+		t.Fatal("the filter never reported learning a hostname")
+	}
+}
+
+// A VM board is a positive signal: no real board reports vm-*.
+func TestSimulatorFilterExcludesVMBoards(t *testing.T) {
+	stubVMStatuses(t)
+	f := newSimulatorFilter(context.Background())
+	for _, dt := range []string{"vm-arm64", "vm-x86-64"} {
+		if !f.Exclude(models.LANDevice{DeviceType: dt, Hostname: "wendyos-gentle-forest.local"}) {
+			t.Errorf("%s was not excluded", dt)
+		}
+	}
+	for _, dt := range []string{"jetson-orin-nano", "rpi5", ""} {
+		if f.Exclude(models.LANDevice{DeviceType: dt, Hostname: "orin.local"}) {
+			t.Errorf("%q was excluded", dt)
+		}
+	}
+}
+
+// The hostname a VM once reported identifies its sightings from then on --
+// a stopped VM's too, whose stale cache row has to go the same way.
+func TestSimulatorFilterExcludesKnownVMHostnames(t *testing.T) {
+	stubVMStatuses(t, vm.Status{Name: "sim", Exists: true, Meta: vm.Meta{Hostname: "wendyos-gentle-forest"}})
+	f := newSimulatorFilter(context.Background())
+	if !f.Exclude(models.LANDevice{Hostname: "WendyOS-Gentle-Forest.local."}) {
+		t.Error("the VM's own hostname was not excluded; case and the .local suffix must not matter")
+	}
+	if f.Exclude(models.LANDevice{Hostname: "wendyos-brave-dolphin.local"}) {
+		t.Error("another device's hostname was excluded")
+	}
+	if f.Exclude(models.LANDevice{DisplayName: "Gentle Forest"}) {
+		t.Error("a display name alone is not an identity")
+	}
+}
+
+// A running VM the CLI has never talked to has no hostname on record. The
+// filter asks its agent over the loopback forward, records the answer for
+// good, and tells the session to re-check what it already listed.
+func TestSimulatorFilterLearnsARunningVMsHostname(t *testing.T) {
+	port := listenLoopback(t)
+	stubVMStatuses(t, runningVM("sim", vm.NetUser, port))
+	stubAgentVersion(t, func(addr string) (*agentpb.GetAgentVersionResponse, error) {
+		if addr != fmt.Sprintf("127.0.0.1:%d", port) {
+			return nil, fmt.Errorf("unexpected address %s", addr)
+		}
+		return &agentpb.GetAgentVersionResponse{Hostname: "wendyos-gentle-forest"}, nil
+	})
+	recorded := recordedHostnames(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	f := newSimulatorFilter(ctx)
+	awaitChanged(t, f)
+	if !f.Exclude(models.LANDevice{Hostname: "wendyos-gentle-forest.local"}) {
+		t.Error("the learned hostname is not excluded")
+	}
+	if got := recorded(); got["sim"] != "wendyos-gentle-forest" {
+		t.Errorf("recorded = %v, want sim -> wendyos-gentle-forest", got)
+	}
+}
+
+// The agent is the last thing up in the guest, and QEMU's forward accepts
+// long before it answers. The learner keeps asking rather than giving up on
+// the first refusal.
+func TestSimulatorFilterKeepsAskingWhileTheGuestBoots(t *testing.T) {
+	port := listenLoopback(t)
+	stubVMStatuses(t, runningVM("sim", vm.NetUser, port))
+	var attempts atomic.Int32
+	stubAgentVersion(t, func(string) (*agentpb.GetAgentVersionResponse, error) {
+		if attempts.Add(1) < 3 {
+			return nil, errors.New("connection reset by peer")
+		}
+		return &agentpb.GetAgentVersionResponse{Hostname: "wendyos-gentle-forest"}, nil
+	})
+	recordedHostnames(t)
+	saved := simulatorHostnameRetry
+	simulatorHostnameRetry = 10 * time.Millisecond
+	t.Cleanup(func() { simulatorHostnameRetry = saved })
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	f := newSimulatorFilter(ctx)
+	awaitChanged(t, f)
+	if n := attempts.Load(); n < 3 {
+		t.Errorf("attempts = %d, want the learner to have retried", n)
+	}
+	if !f.Exclude(models.LANDevice{Hostname: "wendyos-gentle-forest.local"}) {
+		t.Error("the learned hostname is not excluded")
+	}
+}
+
+// A VM already on record, a stopped one, and a shared-mode one (no forward to
+// ask on) give the learner nothing to do: nothing is dialed for them.
+func TestSimulatorFilterAsksOnlyVMsItCanReachAndDoesNotKnow(t *testing.T) {
+	port := listenLoopback(t)
+	known := runningVM("sim", vm.NetUser, port)
+	known.Meta.Hostname = "wendyos-gentle-forest"
+	stubVMStatuses(t, known, vm.Status{Name: "off", Exists: true}, runningVM("shared", vm.NetShared, 0))
+	var asked atomic.Int32
+	stubAgentVersion(t, func(string) (*agentpb.GetAgentVersionResponse, error) {
+		asked.Add(1)
+		return &agentpb.GetAgentVersionResponse{Hostname: "wendyos-x"}, nil
+	})
+	recordedHostnames(t)
+
+	f := newSimulatorFilter(context.Background())
+	select {
+	case <-f.Changed():
+		t.Fatal("the filter learned something with nothing left to learn")
+	case <-time.After(100 * time.Millisecond):
+	}
+	if n := asked.Load(); n != 0 {
+		t.Errorf("agent asked %d times, want 0", n)
+	}
+	if !f.Exclude(models.LANDevice{Hostname: "wendyos-gentle-forest.local"}) {
+		t.Error("the hostname already on record is not excluded")
+	}
+}
+
+// Every CLI LAN session gets the filter, so no surface lists a VM as a device.
+func TestCLIStreamOptionsExcludeSimulators(t *testing.T) {
+	stubVMStatuses(t, vm.Status{Name: "sim", Exists: true, Meta: vm.Meta{Hostname: "wendyos-gentle-forest"}})
+	opts := cliLANStreamOptions(context.Background())
+	if opts.Exclude == nil {
+		t.Fatal("no simulator filter installed on the CLI's LAN stream options")
+	}
+	if !opts.Exclude.Exclude(models.LANDevice{Hostname: "wendyos-gentle-forest.local"}) {
+		t.Error("the installed filter does not exclude a known VM hostname")
+	}
+}
+
+// The probe has the guest's answer in hand; recording the hostname there means
+// the next session recognises the VM's sighting from the start.
+func TestProbeRecordsTheHostnameItLearns(t *testing.T) {
+	port := listenLoopback(t)
+	stubVMStatuses(t, runningVM("sim", vm.NetUser, port))
+	stubAgentVersion(t, func(string) (*agentpb.GetAgentVersionResponse, error) {
+		return &agentpb.GetAgentVersionResponse{Hostname: "wendyos-gentle-forest", Version: "1"}, nil
+	})
+	recorded := recordedHostnames(t)
+
+	got := probeLocalVMDevices(context.Background())
+	if len(got) != 1 || got[0].ID != "vm:sim" || got[0].AgentVersion != "1" {
+		t.Fatalf("probeLocalVMDevices() = %+v, want the one VM row", got)
+	}
+	if r := recorded(); r["sim"] != "wendyos-gentle-forest" {
+		t.Errorf("recorded = %v, want sim -> wendyos-gentle-forest", r)
+	}
+}
+
+// So does the wait `wendy run --device sim` goes through before it deploys.
+func TestWaitForSimulatorReadyRecordsTheHostname(t *testing.T) {
+	stubAgentVersion(t, func(string) (*agentpb.GetAgentVersionResponse, error) {
+		return &agentpb.GetAgentVersionResponse{Hostname: "wendyos-gentle-forest"}, nil
+	})
+	recorded := recordedHostnames(t)
+
+	if err := waitForSimulatorReady(context.Background(), "sim", "127.0.0.1:50051", time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if r := recorded(); r["sim"] != "wendyos-gentle-forest" {
+		t.Errorf("recorded = %v, want sim -> wendyos-gentle-forest", r)
+	}
+}
+
+// VM rows belong in their own list, never among LAN devices.
+func TestLocalVMRowsAreListedAsSimulatorsNotLANDevices(t *testing.T) {
+	c := &models.DevicesCollection{LANDevices: []models.LANDevice{{ID: "dev-1", DisplayName: "orin"}}}
+	attachSimulators(c, []models.LANDevice{{ID: "vm:sim", DisplayName: "sim"}})
+	if len(c.LANDevices) != 1 || c.LANDevices[0].ID != "dev-1" {
+		t.Errorf("LANDevices = %+v, want only the real device", c.LANDevices)
+	}
+	if len(c.Simulators) != 1 || c.Simulators[0].ID != "vm:sim" {
+		t.Errorf("Simulators = %+v, want the VM row", c.Simulators)
+	}
+}
+
+// The one-shot table has no tabs, so a simulator is told apart by its type.
+func TestDiscoverTableShowsSimulatorsWithTheirOwnType(t *testing.T) {
+	items := discoverTableItems(&models.DevicesCollection{Simulators: []models.LANDevice{
+		{ID: "vm:sim", DisplayName: "sim", IPAddress: "127.0.0.1", Port: 50051, DeviceType: "vm-arm64", AgentVersion: "1"},
+	}})
+	if len(items) != 1 {
+		t.Fatalf("items = %+v, want one simulator row", items)
+	}
+	if items[0].picker.Type != "Simulator" {
+		t.Errorf("Type = %q, want Simulator", items[0].picker.Type)
+	}
+	if items[0].picker.Name != "sim" || items[0].picker.Address != "127.0.0.1:50051" {
+		t.Errorf("row = %+v, want sim at 127.0.0.1:50051", items[0].picker)
+	}
+}
+
+// A retracted LAN row leaves the discover table, and its probe state with it.
+func TestDiscoverModelDropsARetractedLANRow(t *testing.T) {
+	m := newDiscoverModel(context.Background(), discovery.DiscoveryOptions{}, false)
+	dev := models.LANDevice{ID: "vm-1", DisplayName: "Gentle Forest", Hostname: "wendyos-gentle-forest.local", IPAddress: "10.0.2.15", Port: 50051}
+	updated, _ := m.Update(lanFoundEvent(dev))
+	m = updated.(discoverModel)
+	if len(m.collection.LANDevices) != 1 {
+		t.Fatal("the row was not added")
+	}
+
+	updated, _ = m.Update(lanEventMsg{ev: discovery.LANEvent{Kind: discovery.LANRetracted, Device: dev}})
+	m = updated.(discoverModel)
+	if len(m.collection.LANDevices) != 0 {
+		t.Errorf("retracted row still listed: %+v", m.collection.LANDevices)
+	}
+	if _, ok := m.probe[probeKey(dev)]; ok {
+		t.Error("probe state for the retracted row lingers")
+	}
+}
+
+// The run picker takes a row back under the very key it was added with.
+func TestLANPickerRemoveKeyMatchesTheAddedRow(t *testing.T) {
+	dev := models.LANDevice{ID: "vm-1", DisplayName: "Gentle Forest", Hostname: "wendyos-gentle-forest.local"}
+	item := lanPickerItem(dev, false, tui.ProbePending)
+	if item.DedupKey == "" {
+		t.Fatal("LAN rows must carry a dedup key")
+	}
+	if got := lanPickerRemoveMsg(dev).Key; !strings.EqualFold(got, item.DedupKey) {
+		t.Errorf("remove key %q does not match the row's dedup key %q", got, item.DedupKey)
+	}
+}

--- a/go/internal/cli/commands/vm_discover_filter_test.go
+++ b/go/internal/cli/commands/vm_discover_filter_test.go
@@ -101,7 +101,7 @@ func TestSimulatorFilterSeedsBeforeStartingLearners(t *testing.T) {
 	f := newSimulatorFilter(ctx)
 	awaitChanged(t, f)
 	for _, host := range []string{"known-0", "known-49999", "learned"} {
-		if !f.Exclude(models.LANDevice{Hostname: host}) {
+		if !f.Exclude(models.LANDevice{Hostname: host, IPAddress: "10.0.2.15"}) {
 			t.Fatalf("hostname %s was lost", host)
 		}
 	}
@@ -137,12 +137,31 @@ func TestSimulatorFilterPreservesReachableNetworkVMs(t *testing.T) {
 	}
 }
 
+func TestSimulatorFilterDoesNotTreatRememberedNamesAsDeviceIdentity(t *testing.T) {
+	stubVMStatuses(t, vm.Status{Name: "stopped", Exists: true, Meta: vm.Meta{Hostname: "lab-device"}})
+	f := newSimulatorFilter(context.Background())
+	for _, dev := range []models.LANDevice{
+		{Hostname: "lab-device.local", IPAddress: "192.168.1.20", DeviceType: "rpi5"},
+		{Hostname: "lab-device.local", IPAddress: "10.0.2.15", DeviceType: "rpi5"},
+		{Hostname: "lab-device.local", IPAddress: "192.168.64.2"},
+		{Hostname: "lab-device.local", IPAddress: "fd00::2"},
+		{Hostname: "lab-device.local"},
+	} {
+		if f.Exclude(dev) {
+			t.Fatalf("hostname collision hid a device: %+v", dev)
+		}
+	}
+	if !f.Exclude(models.LANDevice{Hostname: "lab-device.local", IPAddress: "10.0.2.15"}) {
+		t.Fatal("legacy leaked announcement must still be filtered")
+	}
+}
+
 // The hostname a VM once reported identifies its sightings from then on --
 // a stopped VM's too, whose stale cache row has to go the same way.
 func TestSimulatorFilterExcludesKnownVMHostnames(t *testing.T) {
 	stubVMStatuses(t, vm.Status{Name: "sim", Exists: true, Meta: vm.Meta{Hostname: "wendyos-gentle-forest"}})
 	f := newSimulatorFilter(context.Background())
-	if !f.Exclude(models.LANDevice{Hostname: "WendyOS-Gentle-Forest.local."}) {
+	if !f.Exclude(models.LANDevice{Hostname: "WendyOS-Gentle-Forest.local.", IPAddress: "10.0.2.15"}) {
 		t.Error("the VM's own hostname was not excluded; case and the .local suffix must not matter")
 	}
 	if f.Exclude(models.LANDevice{Hostname: "wendyos-brave-dolphin.local"}) {
@@ -171,7 +190,7 @@ func TestSimulatorFilterLearnsARunningVMsHostname(t *testing.T) {
 
 	f := newSimulatorFilter(ctx)
 	awaitChanged(t, f)
-	if !f.Exclude(models.LANDevice{Hostname: "wendyos-gentle-forest.local"}) {
+	if !f.Exclude(models.LANDevice{Hostname: "wendyos-gentle-forest.local", IPAddress: "10.0.2.15"}) {
 		t.Error("the learned hostname is not excluded")
 	}
 	if got := recorded(); got["sim"] != "wendyos-gentle-forest" {
@@ -204,7 +223,7 @@ func TestSimulatorFilterKeepsAskingWhileTheGuestBoots(t *testing.T) {
 	if n := attempts.Load(); n < 3 {
 		t.Errorf("attempts = %d, want the learner to have retried", n)
 	}
-	if !f.Exclude(models.LANDevice{Hostname: "wendyos-gentle-forest.local"}) {
+	if !f.Exclude(models.LANDevice{Hostname: "wendyos-gentle-forest.local", IPAddress: "10.0.2.15"}) {
 		t.Error("the learned hostname is not excluded")
 	}
 }
@@ -232,7 +251,7 @@ func TestSimulatorFilterAsksOnlyVMsItCanReachAndDoesNotKnow(t *testing.T) {
 	if n := asked.Load(); n != 0 {
 		t.Errorf("agent asked %d times, want 0", n)
 	}
-	if !f.Exclude(models.LANDevice{Hostname: "wendyos-gentle-forest.local"}) {
+	if !f.Exclude(models.LANDevice{Hostname: "wendyos-gentle-forest.local", IPAddress: "10.0.2.15"}) {
 		t.Error("the hostname already on record is not excluded")
 	}
 }
@@ -244,7 +263,7 @@ func TestCLIStreamOptionsExcludeSimulators(t *testing.T) {
 	if opts.Exclude == nil {
 		t.Fatal("no simulator filter installed on the CLI's LAN stream options")
 	}
-	if !opts.Exclude.Exclude(models.LANDevice{Hostname: "wendyos-gentle-forest.local"}) {
+	if !opts.Exclude.Exclude(models.LANDevice{Hostname: "wendyos-gentle-forest.local", IPAddress: "10.0.2.15"}) {
 		t.Error("the installed filter does not exclude a known VM hostname")
 	}
 }

--- a/go/internal/cli/commands/vm_ensure.go
+++ b/go/internal/cli/commands/vm_ensure.go
@@ -132,8 +132,9 @@ func waitForSimulatorAgent(ctx context.Context, name, addr string, budget time.D
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		conn, _, err := connectSimulatorAgent(waitCtx, name, addr)
+		conn, resp, err := connectSimulatorAgent(waitCtx, name, addr)
 		if err == nil {
+			_ = vmRecordHostnameFn(name, resp.GetHostname())
 			return conn, nil
 		}
 		if blocksUnauthenticatedFallback(err) {

--- a/go/internal/cli/commands/vm_ensure.go
+++ b/go/internal/cli/commands/vm_ensure.go
@@ -112,10 +112,7 @@ func ensureSimulatorRunning(ctx context.Context, name string) (addr string, star
 	// Sticky, so a VM pushed off the default port keeps the address next time.
 	// Skipped when the record could not be read: writing it back would persist
 	// an empty one and lose the VM's provenance.
-	if meta, ok := store.ReadMeta(name); ok && meta.AgentPort != port {
-		meta.AgentPort = port
-		_ = store.WriteMeta(meta)
-	}
+	_ = store.RecordAgentPort(name, port)
 	return fmt.Sprintf("127.0.0.1:%d", port), true, nil
 }
 

--- a/go/internal/cli/tui/picker.go
+++ b/go/internal/cli/tui/picker.go
@@ -185,6 +185,14 @@ type PickerSetMsg struct {
 	Items []PickerItem
 }
 
+// PickerRemoveMsg drops the item whose DedupKey (or Name, when it has none)
+// matches Key, case-insensitively like every other key comparison here. It is
+// how a discovery source takes a row back -- a LAN sighting that turned out to
+// be a local VM. An unknown key is a no-op.
+type PickerRemoveMsg struct {
+	Key string
+}
+
 // PickerModel is a Bubble Tea model that presents a live-updating list of
 // items and lets the user select one with arrow keys + Enter.
 type PickerModel struct {
@@ -566,6 +574,12 @@ func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case PickerDoneMsg:
 		m.scanning = false
+
+	case PickerRemoveMsg:
+		cursorKey := m.currentCursorKey()
+		if m.removeItemByKey(strings.ToLower(msg.Key)) {
+			m.refreshTableWithCursorKey(cursorKey)
+		}
 
 	case PickerSetMsg:
 		cursorKey := m.currentCursorKey()

--- a/go/internal/cli/tui/picker_remove_test.go
+++ b/go/internal/cli/tui/picker_remove_test.go
@@ -1,0 +1,35 @@
+package tui
+
+import "testing"
+
+// A LAN row the discovery engine takes back (it turned out to be a local VM)
+// has to leave the picker, keyed exactly as it was added and case-insensitively
+// like every other key comparison here. A key nobody holds is a no-op.
+func TestPickerRemoveMsgDropsTheRowByDedupKey(t *testing.T) {
+	m := NewPicker()
+	updated, _ := m.Update(PickerAddMsg{Items: []PickerItem{
+		{Name: "Gentle Forest", DedupKey: "wendyos-gentle-forest"},
+		{Name: "orin", DedupKey: "orin"},
+	}})
+	m = updated.(PickerModel)
+
+	updated, _ = m.Update(PickerRemoveMsg{Key: "WENDYOS-gentle-forest"})
+	m = updated.(PickerModel)
+	if len(m.items) != 1 || m.items[0].Name != "orin" {
+		t.Fatalf("items after remove = %+v, want only orin", m.items)
+	}
+
+	updated, _ = m.Update(PickerRemoveMsg{Key: "nobody"})
+	m = updated.(PickerModel)
+	if len(m.items) != 1 {
+		t.Fatalf("removing an unknown key changed the list: %+v", m.items)
+	}
+
+	// The index must be consistent after a removal, or re-adding the row
+	// would be dropped as a duplicate.
+	updated, _ = m.Update(PickerAddMsg{Items: []PickerItem{{Name: "Gentle Forest", DedupKey: "wendyos-gentle-forest"}}})
+	m = updated.(PickerModel)
+	if len(m.items) != 2 {
+		t.Fatalf("re-adding a removed row was dropped: %+v", m.items)
+	}
+}

--- a/go/internal/cli/vm/metadata_update_test.go
+++ b/go/internal/cli/vm/metadata_update_test.go
@@ -1,0 +1,83 @@
+package vm
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestMetadataUpdateExcludesOtherWritersAndLifecycleOperations(t *testing.T) {
+	s := newTestStore(t)
+	createTestVM(t, s, "dev", Meta{ImageVersion: "original"})
+	other := &Store{Root: s.Root}
+	err := s.updateMeta("dev", func(m *Meta) bool {
+		// The callback runs between reading and replacing the record. Separate
+		// lock handles model competing CLI processes at the dangerous instant.
+		for label, op := range map[string]func() error{
+			"hostname": func() error { return other.RecordHostname("dev", "competing") },
+			"port":     func() error { return other.RecordAgentPort("dev", 50100) },
+			"remove":   func() error { return other.Remove("dev") },
+			"start": func() error {
+				lock, err := other.acquireRunLock("dev")
+				if lock != nil {
+					lock.Close()
+				}
+				return err
+			},
+		} {
+			if err := op(); !errors.Is(err, ErrLifecycleBusy) {
+				t.Errorf("%s during metadata update = %v", label, err)
+			}
+		}
+		m.Hostname = "learned"
+		return true
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := other.RecordAgentPort("dev", 50100); err != nil {
+		t.Fatal(err)
+	}
+	if err := other.RecordHostname("dev", "renamed"); err != nil {
+		t.Fatal(err)
+	}
+	m, ok := s.ReadMeta("dev")
+	if !ok || m.Hostname != "renamed" || m.AgentPort != 50100 || m.ImageVersion != "original" || m.MAC == "" {
+		t.Fatalf("metadata fields lost: %+v", m)
+	}
+}
+
+func TestMetadataUpdatesRespectLifecycleLockBeforeReading(t *testing.T) {
+	s := newTestStore(t)
+	createTestVM(t, s, "dev", Meta{})
+	lock, err := s.acquireLifecycleLock("dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, op := range []func() error{
+		func() error { return s.RecordHostname("dev", "learned") },
+		func() error { return s.RecordAgentPort("dev", 50100) },
+	} {
+		if err := op(); !errors.Is(err, ErrLifecycleBusy) {
+			t.Errorf("update while lifecycle busy = %v", err)
+		}
+	}
+	lock.Close()
+	if err := s.Remove("dev"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RecordHostname("dev", "stale"); err == nil {
+		t.Fatal("updated removed VM")
+	}
+	if _, err := os.Stat(s.Dir("dev")); !os.IsNotExist(err) {
+		t.Fatalf("update recreated removed directory: %v", err)
+	}
+	createTestVM(t, s, "dev", Meta{ImageVersion: "replacement"})
+	if err := s.RecordAgentPort("dev", 50102); err != nil {
+		t.Fatal(err)
+	}
+	m, _ := s.ReadMeta("dev")
+	if m.ImageVersion != "replacement" || m.Hostname != "" || m.AgentPort != 50102 {
+		t.Fatalf("replacement clobbered: %+v", m)
+	}
+}

--- a/go/internal/cli/vm/net.go
+++ b/go/internal/cli/vm/net.go
@@ -75,9 +75,12 @@ func PickHostPort(preferred, tries int) (int, error) {
 type NetMode string
 
 const (
-	// NetUser forwards the agent port over SLIRP. Needs no privileges, but
-	// SLIRP carries no multicast, so mDNS never reaches the host and the VM is
-	// reachable only by address.
+	// NetUser forwards the agent port over SLIRP. Needs no privileges, and
+	// the VM is reachable only by the forwarded address: nothing on the
+	// network can route to the guest. Its mDNS announcement does escape,
+	// though -- SLIRP passes guest multicast out through a host socket, one
+	// way -- so the host and its LAN hear a service whose address (10.0.2.15)
+	// they cannot dial. The CLI recognises and hides that sighting.
 	NetUser NetMode = "user"
 
 	// NetShared puts the guest on a vmnet segment the host also has an

--- a/go/internal/cli/vm/state.go
+++ b/go/internal/cli/vm/state.go
@@ -30,6 +30,11 @@ type Meta struct {
 	// AgentPort is the host port this VM last bound successfully. Sticky, so a
 	// VM forced off the default port keeps the address the user wrote down.
 	AgentPort int `json:"agentPort,omitempty"`
+
+	// Hostname is what the guest calls itself, learned the first time the CLI
+	// reaches its agent. It is how a stray mDNS announcement of this VM is
+	// recognised as such, and it is stable across reboots.
+	Hostname string `json:"hostname,omitempty"`
 }
 
 // State describes one run of a VM. Its absence means the VM is not running.
@@ -118,6 +123,27 @@ func (s *Store) ReadMeta(name string) (m Meta, ok bool) {
 	}
 	m.Name = name
 	return m, true
+}
+
+// RecordHostname stores the hostname the guest reports. An empty hostname says
+// nothing and is ignored. An unreadable record is left alone rather than
+// replaced by a hostname-only one, which would lose the VM's provenance.
+func (s *Store) RecordHostname(name, hostname string) error {
+	if hostname == "" {
+		return nil
+	}
+	if err := ValidName(name); err != nil {
+		return err
+	}
+	m, ok := s.ReadMeta(name)
+	if !ok {
+		return fmt.Errorf("VM %q has no readable record at %s", name, s.MetaPath(name))
+	}
+	if m.Hostname == hostname {
+		return nil
+	}
+	m.Hostname = hostname
+	return s.WriteMeta(m)
 }
 
 // WriteState records the current run.

--- a/go/internal/cli/vm/state.go
+++ b/go/internal/cli/vm/state.go
@@ -105,7 +105,8 @@ func writeJSON(path string, v any) error {
 	return os.Rename(tmp, path)
 }
 
-// WriteMeta records a VM's durable provenance.
+// WriteMeta records a complete metadata snapshot. Production callers must
+// hold the lifecycle lock; field updates should use updateMeta instead.
 func (s *Store) WriteMeta(m Meta) error { return writeJSON(s.MetaPath(m.Name), m) }
 
 // ReadMeta returns a VM's durable record and whether it was actually read; a
@@ -132,17 +133,46 @@ func (s *Store) RecordHostname(name, hostname string) error {
 	if hostname == "" {
 		return nil
 	}
-	if err := ValidName(name); err != nil {
+	return s.updateMeta(name, func(m *Meta) bool {
+		if m.Hostname == hostname {
+			return false
+		}
+		m.Hostname = hostname
+		return true
+	})
+}
+
+// RecordAgentPort updates the sticky port without replacing a concurrently
+// learned hostname or another field from an old metadata snapshot.
+func (s *Store) RecordAgentPort(name string, port int) error {
+	if port < 1 || port > 65535 {
+		return fmt.Errorf("invalid agent port %d", port)
+	}
+	return s.updateMeta(name, func(m *Meta) bool {
+		if m.AgentPort == port {
+			return false
+		}
+		m.AgentPort = port
+		return true
+	})
+}
+
+// updateMeta serializes the entire read/modify/replace operation with other
+// metadata writers, creation, startup, and removal. Busy updates are best-effort
+// at CLI call sites: skip them rather than publishing an obsolete snapshot.
+func (s *Store) updateMeta(name string, update func(*Meta) bool) error {
+	lock, err := s.acquireLifecycleLock(name)
+	if err != nil {
 		return err
 	}
+	defer lock.Close() // Lock-only handle; no file data is written through it.
 	m, ok := s.ReadMeta(name)
 	if !ok {
 		return fmt.Errorf("VM %q has no readable record at %s", name, s.MetaPath(name))
 	}
-	if m.Hostname == hostname {
+	if !update(&m) {
 		return nil
 	}
-	m.Hostname = hostname
 	return s.WriteMeta(m)
 }
 

--- a/go/internal/cli/vm/state_test.go
+++ b/go/internal/cli/vm/state_test.go
@@ -343,3 +343,62 @@ func TestReapOnANeverStartedVMCreatesNoLockFile(t *testing.T) {
 		t.Errorf("a status read created %s; reads must not", s.LockPath("dev"))
 	}
 }
+
+// The hostname a VM's guest reports is how a leaked mDNS sighting of it is
+// recognised. It is learned on first contact and kept beside the provenance,
+// which must survive the write.
+func TestRecordHostnameSurvivesAlongsideProvenance(t *testing.T) {
+	s := newTestStore(t)
+	createTestVM(t, s, "dev", Meta{ImageVersion: "0.19.0", ImageSource: "pr/249"})
+
+	if err := s.RecordHostname("dev", "wendyos-gentle-forest"); err != nil {
+		t.Fatalf("RecordHostname() = %v", err)
+	}
+	got, ok := s.ReadMeta("dev")
+	if !ok {
+		t.Fatal("ReadMeta() reported the record unreadable")
+	}
+	if got.Hostname != "wendyos-gentle-forest" {
+		t.Errorf("Hostname = %q, want wendyos-gentle-forest", got.Hostname)
+	}
+	if got.ImageVersion != "0.19.0" || got.ImageSource != "pr/249" {
+		t.Errorf("provenance clobbered: %+v", got)
+	}
+}
+
+// A record that cannot be read must not be replaced by a hostname-only one:
+// that would silently lose where the image came from.
+func TestRecordHostnameRefusesToClobberAnUnreadableRecord(t *testing.T) {
+	s := newTestStore(t)
+	createTestVM(t, s, "dev", Meta{ImageVersion: "0.19.0"})
+	const garbage = "{not json"
+	if err := os.WriteFile(s.MetaPath("dev"), []byte(garbage), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.RecordHostname("dev", "wendyos-gentle-forest"); err == nil {
+		t.Fatal("RecordHostname() = nil, want an error for an unreadable record")
+	}
+	data, err := os.ReadFile(s.MetaPath("dev"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != garbage {
+		t.Errorf("unreadable record was overwritten:\n%s", data)
+	}
+}
+
+// An empty hostname says nothing; recording it must not erase what is known.
+func TestRecordHostnameIgnoresEmpty(t *testing.T) {
+	s := newTestStore(t)
+	createTestVM(t, s, "dev", Meta{})
+	if err := s.RecordHostname("dev", "wendyos-gentle-forest"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RecordHostname("dev", ""); err != nil {
+		t.Fatalf("RecordHostname(\"\") = %v, want nil", err)
+	}
+	if got, _ := s.ReadMeta("dev"); got.Hostname != "wendyos-gentle-forest" {
+		t.Errorf("Hostname = %q after recording empty, want the earlier value kept", got.Hostname)
+	}
+}

--- a/go/internal/shared/discovery/mdns.go
+++ b/go/internal/shared/discovery/mdns.go
@@ -34,7 +34,8 @@ type MDNSService struct {
 // then "id" then falls back to the resolved display name; mTLS is signaled
 // by tls=="true"; assetid/orgid are accepted only when they parse as
 // positive integers (0 or unparseable stays the zero value, meaning
-// unknown/unprovisioned); and "name" becomes the friendly mesh name.
+// unknown/unprovisioned); "name" becomes the friendly mesh name; and
+// "devicetype" is the agent's board id, kept until a probe verifies it.
 //
 // A sighting that carries neither a hostname nor a usable displayname TXT
 // record falls back to the DNS-SD instance name for both the display name and
@@ -82,6 +83,12 @@ func lanDeviceFromService(svc MDNSService) models.LANDevice {
 	}
 	if v, ok := svc.TXTRecords["name"]; ok {
 		dev.MeshName = v
+	}
+	// The agent stamps its board id here so a sighting can be classified
+	// before any probe -- in particular a local VM, whose announcement may
+	// carry an address nothing on the host can reach.
+	if v, ok := svc.TXTRecords["devicetype"]; ok {
+		dev.DeviceType = v
 	}
 	return dev
 }

--- a/go/internal/shared/discovery/mdns_test.go
+++ b/go/internal/shared/discovery/mdns_test.go
@@ -341,3 +341,16 @@ func TestBrowseMDNSServicesTimeoutCap(t *testing.T) {
 		t.Fatalf("returned after %v, want close to the %v timeout", elapsed, timeout)
 	}
 }
+
+// A VM's agent advertises its board in a devicetype TXT record, so a sighting
+// can be classified before -- or instead of -- an agent probe: a user-mode VM's
+// announcement leaks onto the LAN with an address nothing can reach.
+func TestLANDeviceFromServiceReadsDeviceTypeTXTRecord(t *testing.T) {
+	svc := MDNSService{Hostname: "wendyos-gentle-forest.local", TXTRecords: map[string]string{"devicetype": "vm-arm64"}}
+	if got := lanDeviceFromService(svc).DeviceType; got != "vm-arm64" {
+		t.Fatalf("DeviceType = %q, want vm-arm64 from the devicetype TXT record", got)
+	}
+	if got := lanDeviceFromService(MDNSService{Hostname: "orin.local"}).DeviceType; got != "" {
+		t.Fatalf("DeviceType = %q with no devicetype record, want empty", got)
+	}
+}

--- a/go/internal/shared/discovery/stream.go
+++ b/go/internal/shared/discovery/stream.go
@@ -16,10 +16,11 @@ import (
 type LANEventKind int
 
 const (
-	LANCached  LANEventKind = iota // cache entry, not yet verified this run
-	LANFound                       // live-confirmed (mDNS resolve or probe)
-	LANUpdated                     // an already-emitted device changed
-	LANOffline                     // cached entry failed verification
+	LANCached    LANEventKind = iota // cache entry, not yet verified this run
+	LANFound                         // live-confirmed (mDNS resolve or probe)
+	LANUpdated                       // an already-emitted device changed
+	LANOffline                       // cached entry failed verification
+	LANRetracted                     // a listed device is excluded after all; drop its row
 )
 
 // LANEvent is a single update emitted while streaming LAN discovery results.
@@ -54,6 +55,27 @@ type LANProber func(ctx context.Context, dev models.LANDevice) (models.LANDevice
 type StreamOptions struct {
 	UseCache bool      // emit cached entries and persist discoveries
 	Prober   LANProber // nil = no probing (mDNS-only confirmation)
+	Exclude  LANFilter // nil = nothing is excluded
+}
+
+// LANFilter keeps sightings a consumer never wants as device rows out of a
+// session altogether. The CLI uses it for the VMs it runs itself: they belong
+// in a Simulator list, not among LAN devices, yet a user-mode VM's mDNS
+// announcement still escapes onto the host's LAN interface (SLIRP forwards
+// guest multicast one way), so the engine has to know to drop it. An excluded
+// identity is never emitted, probed or persisted, and one that was listed
+// before the filter could tell is taken back with a LANRetracted event and
+// deleted from the cache.
+type LANFilter interface {
+	// Exclude reports whether dev must not be listed. It runs on the engine
+	// goroutine for every cached entry, live sighting and probe result, so it
+	// has to be cheap.
+	Exclude(dev models.LANDevice) bool
+	// Changed delivers a value whenever Exclude's answer may have changed
+	// for a device the session already listed (the CLI learns a VM's
+	// hostname a moment after the session starts); the session then
+	// re-checks everything it holds. May return nil, meaning never.
+	Changed() <-chan struct{}
 }
 
 // Package seams. These are vars, not consts, so tests can swap the backend and
@@ -191,8 +213,12 @@ func CollectLAN(ctx context.Context, opts StreamOptions, timeout time.Duration) 
 			if ev.Supersedes != "" {
 				delete(devices, ev.Supersedes)
 			}
-			if ev.Kind == LANFound || ev.Kind == LANUpdated {
-				devices[discoverycache.Key(ev.Device.ID, ev.Device.DisplayName)] = ev.Device
+			key := discoverycache.Key(ev.Device.ID, ev.Device.DisplayName)
+			switch ev.Kind {
+			case LANRetracted:
+				delete(devices, key)
+			case LANFound, LANUpdated:
+				devices[key] = ev.Device
 				if probesDoneClosed {
 					armSettle()
 				}
@@ -331,6 +357,12 @@ func runLANStream(ctx context.Context, opts StreamOptions, out chan<- LANEvent, 
 		defer flush.Stop()
 		flushC = flush.C
 	}
+	// Nil with no filter, or a filter that never changes its mind; a nil
+	// channel simply never fires.
+	var changedC <-chan struct{}
+	if opts.Exclude != nil {
+		changedC = opts.Exclude.Changed()
+	}
 
 	for {
 		select {
@@ -346,6 +378,46 @@ func runLANStream(ctx context.Context, opts StreamOptions, out chan<- LANEvent, 
 			s.handleRetry(key)
 		case <-flushC:
 			s.flush()
+		case <-changedC:
+			s.retractExcluded()
+		}
+	}
+}
+
+// excluded asks the consumer's filter, when there is one, whether dev must
+// stay out of the session.
+func (s *lanStream) excluded(dev models.LANDevice) bool {
+	return s.opts.Exclude != nil && s.opts.Exclude.Exclude(dev)
+}
+
+// retract takes back a listed identity the filter now rejects: its row, its
+// cache entry and its place in the settle gate all go. Every identity in
+// states has been emitted at least once, so the consumer always has a row to
+// drop.
+func (s *lanStream) retract(key string) {
+	st, known := s.states[key]
+	if !known {
+		return
+	}
+	delete(s.states, key)
+	if s.cache != nil {
+		s.cache.Delete(key)
+		s.dirty = true
+	}
+	// A probe still in flight lost its target: its result arrives under a key
+	// nobody holds and handleProbeResult discards it. Retired from the settle
+	// gate here as well, so a retraction between scheduling and result cannot
+	// leave a batch scan waiting on it.
+	s.probeConcluded(key)
+	s.emit(LANEvent{Kind: LANRetracted, Device: st.dev})
+}
+
+// retractExcluded re-checks every listed identity after the filter reported a
+// change of mind. Deleting from a map mid-range is safe in Go.
+func (s *lanStream) retractExcluded() {
+	for key, st := range s.states {
+		if s.excluded(st.dev) {
+			s.retract(key)
 		}
 	}
 }
@@ -383,6 +455,14 @@ func (s *lanStream) emitCached() {
 			continue
 		}
 		if _, dup := s.states[key]; dup {
+			continue
+		}
+		if s.excluded(entry.Device()) {
+			// A leftover from before the consumer knew to exclude it (a VM
+			// cached by an older build). Forgotten now, or it would re-seed
+			// every session for the rest of its TTL.
+			s.cache.Delete(key)
+			s.dirty = true
 			continue
 		}
 		st := &lanDeviceState{dev: entry.Device(), fromCache: true, persisted: entry.LastSeen}
@@ -432,6 +512,14 @@ func (s *lanStream) handleSighting(svc MDNSService) {
 		// identity to key a row (or a cache entry) by, and every such sighting
 		// would collapse onto the same empty key as a nameless, un-dialable
 		// row. Drop it rather than emit or persist it.
+		return
+	}
+	if s.excluded(dev) {
+		// Never a row: not listed, not probed, not persisted. Checked before
+		// the annotator, whose first use may shell out. If this identity was
+		// listed earlier (the filter has learned something since), that row
+		// goes too.
+		s.retract(key)
 		return
 	}
 	s.annotate(&dev)
@@ -603,6 +691,13 @@ func (s *lanStream) handleProbeResult(res lanProbeResult) {
 	st.probeConfirmed = true
 	st.offline = false
 	st.dev = applyProbe(st.dev, res.dev)
+	if s.excluded(st.dev) {
+		// The probe is what revealed it -- an agent that reports a VM board
+		// but advertises no devicetype record -- so the row shown on the
+		// sighting is taken back here.
+		s.retract(res.key)
+		return
+	}
 	s.persist(st, time.Now())
 
 	kind := LANUpdated
@@ -755,7 +850,12 @@ func (s *lanStream) flush() {
 func applySighting(stored, sighted models.LANDevice) models.LANDevice {
 	dev := sighted
 	dev.AgentVersion = stored.AgentVersion
-	dev.DeviceType = stored.DeviceType
+	// The advertisement's device type fills in only what nothing better has
+	// supplied: a probe-verified (or earlier-cached) type is never downgraded
+	// by a later announcement.
+	if stored.DeviceType != "" {
+		dev.DeviceType = stored.DeviceType
+	}
 	dev.OS = stored.OS
 	dev.OSVersion = stored.OSVersion
 	dev.CPUArchitecture = stored.CPUArchitecture
@@ -863,6 +963,7 @@ func mdnsFieldsChanged(old, updated models.LANDevice) bool {
 		old.AssetID != updated.AssetID ||
 		old.OrgID != updated.OrgID ||
 		old.MeshName != updated.MeshName ||
+		old.DeviceType != updated.DeviceType ||
 		old.NetworkInterface != updated.NetworkInterface
 }
 

--- a/go/internal/shared/discovery/stream.go
+++ b/go/internal/shared/discovery/stream.go
@@ -527,6 +527,16 @@ func (s *lanStream) handleSighting(svc MDNSService) {
 		// listed earlier (the filter has learned something since), that row
 		// goes too.
 		s.retract(key)
+		// A prior connect or no-ID advertisement may have listed this same
+		// host under a hostname-derived key. Retire that row too, without
+		// migrating it onto the excluded identity or probing it again.
+		if host := dev.HostKey(); host != "" && !hostDerivedIdentity(dev) {
+			for oldKey, st := range s.states {
+				if hostDerivedIdentity(st.dev) && st.dev.HostKey() == host {
+					s.retract(oldKey)
+				}
+			}
+		}
 		return
 	}
 	s.annotate(&dev)

--- a/go/internal/shared/discovery/stream.go
+++ b/go/internal/shared/discovery/stream.go
@@ -217,6 +217,13 @@ func CollectLAN(ctx context.Context, opts StreamOptions, timeout time.Duration) 
 			switch ev.Kind {
 			case LANRetracted:
 				delete(devices, key)
+				// A rejected sighting cannot justify ending an empty scan.
+				// Wait for a real result (or the overall timeout) as we would
+				// on a cold cache that had never confirmed anything.
+				if len(devices) == 0 && settleTimer != nil {
+					settleTimer.Stop()
+					settleC = nil
+				}
 			case LANFound, LANUpdated:
 				devices[key] = ev.Device
 				if probesDoneClosed {

--- a/go/internal/shared/discovery/stream_filter_test.go
+++ b/go/internal/shared/discovery/stream_filter_test.go
@@ -1,0 +1,246 @@
+package discovery
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/discoverycache"
+	"github.com/wendylabsinc/wendy/go/internal/shared/models"
+)
+
+// testFilter is a LANFilter whose verdict a test can change mid-session.
+type testFilter struct {
+	mu      sync.Mutex
+	exclude func(models.LANDevice) bool
+	changed chan struct{}
+}
+
+func (f *testFilter) Exclude(dev models.LANDevice) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.exclude(dev)
+}
+
+func (f *testFilter) Changed() <-chan struct{} { return f.changed }
+
+// set swaps the verdict and, when the filter was built with a change channel,
+// tells the session to re-check what it already listed.
+func (f *testFilter) set(fn func(models.LANDevice) bool) {
+	f.mu.Lock()
+	f.exclude = fn
+	f.mu.Unlock()
+	if f.changed != nil {
+		f.changed <- struct{}{}
+	}
+}
+
+func excludeVMBoards(dev models.LANDevice) bool { return strings.HasPrefix(dev.DeviceType, "vm-") }
+
+func cacheHas(t *testing.T, path, id string) bool {
+	t.Helper()
+	c, err := discoverycache.LoadFrom(path)
+	if err != nil {
+		t.Fatalf("loading cache: %v", err)
+	}
+	for _, e := range c.Entries() {
+		if e.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// A sighting's advertised device type is worth keeping until a probe says
+// better; a probe-verified type is never downgraded by a later announcement.
+func TestApplySightingKeepsTXTDeviceTypeWhenNothingBetterIsKnown(t *testing.T) {
+	stored := models.LANDevice{ID: "dev-1", DisplayName: "sim"}
+	sighted := models.LANDevice{ID: "dev-1", DisplayName: "sim", DeviceType: "vm-arm64"}
+	if got := applySighting(stored, sighted).DeviceType; got != "vm-arm64" {
+		t.Fatalf("DeviceType = %q, want the sighting's vm-arm64 when the stored row has none", got)
+	}
+	stored.DeviceType = "jetson-orin-nano"
+	if got := applySighting(stored, sighted).DeviceType; got != "jetson-orin-nano" {
+		t.Fatalf("DeviceType = %q, want the stored type kept over the advertisement", got)
+	}
+	if !mdnsFieldsChanged(models.LANDevice{ID: "dev-1"}, models.LANDevice{ID: "dev-1", DeviceType: "vm-arm64"}) {
+		t.Fatal("a newly advertised device type must count as a change, or consumers never see it")
+	}
+}
+
+// A row the filter rejects at load is a stale leftover (a VM cached before the
+// filter existed): it must neither be shown nor probed, and the next save must
+// forget it rather than let it re-seed every later session for the TTL.
+func TestStreamExcludedCachedEntryIsDroppedAndForgotten(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "devices.json")
+	seedCache(t, path,
+		discoverycache.Entry{ID: "vm-1", DisplayName: "Gentle Forest", Hostname: "wendyos-gentle-forest.local", IP: "10.0.2.15", Port: 50051},
+		discoverycache.Entry{ID: "dev-1", DisplayName: "orin", Hostname: "orin.local", IP: "10.0.0.5", Port: 50051})
+
+	fb := newFakeBackend()
+	useStreamSeams(t, fb.fn, cacheLoaderFor(path))
+
+	prober := func(_ context.Context, dev models.LANDevice) (models.LANDevice, error) {
+		if dev.ID == "vm-1" {
+			t.Errorf("excluded cached row was probed: %+v", dev)
+		}
+		dev.AgentVersion = "1"
+		return dev, nil
+	}
+	filter := &testFilter{exclude: func(dev models.LANDevice) bool { return dev.Hostname == "wendyos-gentle-forest.local" }}
+
+	events, stop := startStream(t, StreamOptions{UseCache: true, Prober: prober, Exclude: filter})
+	for _, ev := range collectEvents(t, events, 2, 5*time.Second) { // orin: cached, then confirmed
+		if ev.Device.ID != "dev-1" {
+			t.Fatalf("excluded cached row reached the consumer: %+v", ev)
+		}
+	}
+	expectQuiet(t, events, 150*time.Millisecond)
+	stop()
+
+	if cacheHas(t, path, "vm-1") {
+		t.Fatal("excluded cached row survived the session's save")
+	}
+	if !cacheHas(t, path, "dev-1") {
+		t.Fatal("the real device's entry was lost")
+	}
+}
+
+// A sighting the filter rejects outright -- here by the devicetype TXT record
+// -- never becomes a row: no event, no probe, no cache entry.
+func TestStreamExcludedSightingIsNeitherEmittedNorProbedNorCached(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "devices.json")
+	fb := newFakeBackend()
+	useStreamSeams(t, fb.fn, cacheLoaderFor(path))
+
+	var probed atomic.Int32
+	prober := func(_ context.Context, dev models.LANDevice) (models.LANDevice, error) {
+		probed.Add(1)
+		return dev, nil
+	}
+	filter := &testFilter{exclude: excludeVMBoards}
+
+	events, stop := startStream(t, StreamOptions{UseCache: true, Prober: prober, Exclude: filter})
+	leak := wendyService("vm-1", "Gentle Forest", "wendyos-gentle-forest.local", "10.0.2.15", 50051)
+	leak.TXTRecords["devicetype"] = "vm-arm64"
+	fb.emit(t, leak)
+	fb.emit(t, wendyService("dev-1", "orin", "orin.local", "10.0.0.5", 50051))
+
+	for _, ev := range collectEvents(t, events, 2, 5*time.Second) { // orin: found, then probed
+		if ev.Device.ID != "dev-1" {
+			t.Fatalf("excluded sighting reached the consumer: %+v", ev)
+		}
+	}
+	expectQuiet(t, events, 150*time.Millisecond)
+	stop()
+
+	if n := probed.Load(); n != 1 {
+		t.Fatalf("probes = %d, want only the real device's", n)
+	}
+	if cacheHas(t, path, "vm-1") {
+		t.Fatal("excluded sighting was persisted")
+	}
+}
+
+// A sighting with no devicetype record (an older agent) is listed, then its
+// probe reports a VM board: the row that was already shown must be taken back,
+// and the cache entry the sighting wrote must go with it.
+func TestStreamProbeRevealingASimulatorRetractsTheRow(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "devices.json")
+	fb := newFakeBackend()
+	useStreamSeams(t, fb.fn, cacheLoaderFor(path))
+
+	prober := func(_ context.Context, dev models.LANDevice) (models.LANDevice, error) {
+		dev.DeviceType = "vm-arm64"
+		dev.AgentVersion = "1"
+		return dev, nil
+	}
+	filter := &testFilter{exclude: excludeVMBoards}
+
+	events, stop := startStream(t, StreamOptions{UseCache: true, Prober: prober, Exclude: filter})
+	fb.emit(t, wendyService("vm-1", "Gentle Forest", "wendyos-gentle-forest.local", "192.168.64.5", 50051))
+
+	got := collectEvents(t, events, 2, 5*time.Second)
+	if got[0].Kind != LANFound || got[0].Device.ID != "vm-1" {
+		t.Fatalf("first event must list the sighting: %+v", got[0])
+	}
+	if got[1].Kind != LANRetracted || got[1].Device.ID != "vm-1" {
+		t.Fatalf("second event must retract it once the probe reveals a VM: %+v", got[1])
+	}
+	expectQuiet(t, events, 150*time.Millisecond)
+	stop()
+
+	if cacheHas(t, path, "vm-1") {
+		t.Fatal("retracted row is still cached")
+	}
+}
+
+// The filter can learn things after a row was listed (the CLI finds out a VM's
+// hostname a moment later). When it says so, the session re-checks what it
+// has and retracts the rows that now match.
+func TestStreamFilterChangeRetractsAnAlreadyListedRow(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "devices.json")
+	fb := newFakeBackend()
+	useStreamSeams(t, fb.fn, cacheLoaderFor(path))
+
+	prober := func(_ context.Context, dev models.LANDevice) (models.LANDevice, error) {
+		dev.AgentVersion = "1"
+		return dev, nil
+	}
+	filter := &testFilter{exclude: func(models.LANDevice) bool { return false }, changed: make(chan struct{}, 1)}
+
+	events, stop := startStream(t, StreamOptions{UseCache: true, Prober: prober, Exclude: filter})
+	fb.emit(t, wendyService("vm-1", "Gentle Forest", "wendyos-gentle-forest.local", "10.0.2.15", 50051))
+	fb.emit(t, wendyService("dev-1", "orin", "orin.local", "10.0.0.5", 50051))
+	collectEvents(t, events, 4, 5*time.Second) // both found, both probed
+
+	filter.set(func(dev models.LANDevice) bool { return dev.Hostname == "wendyos-gentle-forest.local" })
+
+	got := collectEvents(t, events, 1, 5*time.Second)
+	if got[0].Kind != LANRetracted || got[0].Device.ID != "vm-1" {
+		t.Fatalf("expected the VM's row retracted after the filter changed, got %+v", got[0])
+	}
+	expectQuiet(t, events, 150*time.Millisecond)
+	stop()
+
+	if cacheHas(t, path, "vm-1") {
+		t.Fatal("retracted row is still cached")
+	}
+	if !cacheHas(t, path, "dev-1") {
+		t.Fatal("the real device's entry was lost")
+	}
+}
+
+// The batch collector is what JSON discover and MCP's device_list read; a row
+// retracted mid-scan must not be in what it returns.
+func TestCollectLANDropsRetractedRows(t *testing.T) {
+	shrinkDuration(t, &collectSettle, 50*time.Millisecond)
+
+	path := filepath.Join(t.TempDir(), "devices.json")
+	fb := newFakeBackend()
+	useStreamSeams(t, fb.fn, cacheLoaderFor(path))
+
+	prober := func(_ context.Context, dev models.LANDevice) (models.LANDevice, error) {
+		if dev.ID == "vm-1" {
+			dev.DeviceType = "vm-arm64"
+		}
+		dev.AgentVersion = "1"
+		return dev, nil
+	}
+	go func() {
+		fb.emit(t, wendyService("vm-1", "Gentle Forest", "wendyos-gentle-forest.local", "10.0.2.15", 50051))
+		fb.emit(t, wendyService("dev-1", "orin", "orin.local", "10.0.0.5", 50051))
+	}()
+
+	got, err := CollectLAN(context.Background(), StreamOptions{UseCache: true, Prober: prober, Exclude: &testFilter{exclude: excludeVMBoards}}, 5*time.Second)
+	if err != nil {
+		t.Fatalf("CollectLAN error: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "dev-1" {
+		t.Fatalf("CollectLAN = %+v, want only the real device", got)
+	}
+}

--- a/go/internal/shared/discovery/stream_filter_test.go
+++ b/go/internal/shared/discovery/stream_filter_test.go
@@ -244,3 +244,34 @@ func TestCollectLANDropsRetractedRows(t *testing.T) {
 		t.Fatalf("CollectLAN = %+v, want only the real device", got)
 	}
 }
+
+func TestCollectLANRetractionOfOnlyResultCancelsSettle(t *testing.T) {
+	backend := func(ctx context.Context, _ string, emit func(MDNSService)) error {
+		emit(wendyService("vm", "Guest", "guest.local", "10.0.2.15", 50051))
+		select {
+		case <-time.After(100 * time.Millisecond):
+		case <-ctx.Done():
+			return nil
+		}
+		classified := wendyService("vm", "Guest", "guest.local", "10.0.2.15", 50051)
+		classified.TXTRecords["devicetype"] = "vm-arm64"
+		emit(classified)
+		// Beyond the first sighting's settle window, within the scan budget.
+		select {
+		case <-time.After(700 * time.Millisecond):
+		case <-ctx.Done():
+			return nil
+		}
+		emit(wendyService("physical", "Pi", "pi.local", "192.168.1.20", 50051))
+		<-ctx.Done()
+		return nil
+	}
+	useStreamSeams(t, backend, nil)
+	got, err := CollectLAN(context.Background(), StreamOptions{Exclude: &testFilter{exclude: excludeVMBoards}}, 3*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].ID != "physical" {
+		t.Fatalf("scan lost the later physical device: %+v", got)
+	}
+}

--- a/go/internal/shared/discovery/stream_filter_test.go
+++ b/go/internal/shared/discovery/stream_filter_test.go
@@ -275,3 +275,29 @@ func TestCollectLANRetractionOfOnlyResultCancelsSettle(t *testing.T) {
 		t.Fatalf("scan lost the later physical device: %+v", got)
 	}
 }
+
+func TestExcludedSightingRetractsHostnameAliasAndCache(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "devices.json")
+	seedCache(t, path,
+		discoverycache.Entry{ID: "guest", DisplayName: "guest", Hostname: "guest.local", IP: "10.0.2.15"},
+		discoverycache.Entry{ID: "physical", DisplayName: "Pi", Hostname: "pi.local", IP: "192.168.1.20"})
+	fb := newFakeBackend()
+	useStreamSeams(t, fb.fn, cacheLoaderFor(path))
+	events, stop := startStream(t, StreamOptions{UseCache: true, Exclude: &testFilter{exclude: excludeVMBoards}})
+	collectEvents(t, events, 2, time.Second)
+	leak := wendyService("real-id", "Guest", "GUEST.local.", "10.0.2.15", 50051)
+	leak.TXTRecords["devicetype"] = "vm-arm64"
+	fb.emit(t, leak)
+	got := collectEvents(t, events, 1, time.Second)
+	if got[0].Kind != LANRetracted || got[0].Device.ID != "guest" {
+		t.Fatalf("alias not retracted: %+v", got)
+	}
+	expectQuiet(t, events, 100*time.Millisecond)
+	stop()
+	if cacheHas(t, path, "guest") || cacheHas(t, path, "real-id") {
+		t.Fatal("excluded VM remains cached")
+	}
+	if !cacheHas(t, path, "physical") {
+		t.Fatal("unrelated physical device was removed")
+	}
+}

--- a/go/internal/shared/models/devices.go
+++ b/go/internal/shared/models/devices.go
@@ -167,6 +167,10 @@ type DevicesCollection struct {
 	BluetoothDevices   []BluetoothDevice   `json:"bluetoothDevices"`
 	EthernetInterfaces []EthernetInterface `json:"ethernetDevices"`
 	ExternalDevices    []ExternalDevice    `json:"externalDevices,omitempty"`
+	// Simulators are the VMs this machine runs itself. Listed apart from
+	// LANDevices: they are reached like a LAN device but are not one, and a
+	// reader that wants devices on the network must not have to filter them.
+	Simulators []LANDevice `json:"simulators,omitempty"`
 }
 
 // DiscoveredDevice represents a single physical device that may have been
@@ -372,7 +376,8 @@ func (c *DevicesCollection) IsEmpty() bool {
 		len(c.LANDevices) == 0 &&
 		len(c.BluetoothDevices) == 0 &&
 		len(c.EthernetInterfaces) == 0 &&
-		len(c.ExternalDevices) == 0
+		len(c.ExternalDevices) == 0 &&
+		len(c.Simulators) == 0
 }
 
 // ToJSON returns a pretty-printed JSON representation of the collection.

--- a/go/internal/shared/models/devices_simulators_test.go
+++ b/go/internal/shared/models/devices_simulators_test.go
@@ -1,0 +1,26 @@
+package models
+
+import (
+	"strings"
+	"testing"
+)
+
+// Local VMs are listed apart from LAN devices: a JSON reader sees them under
+// their own key, and a collection holding only a simulator is not "nothing
+// found".
+func TestDevicesCollectionListsSimulatorsApart(t *testing.T) {
+	c := &DevicesCollection{Simulators: []LANDevice{{ID: "vm:sim", DisplayName: "sim", IPAddress: "127.0.0.1", Port: 50051}}}
+	if c.IsEmpty() {
+		t.Fatal("a collection holding only a simulator reported itself empty")
+	}
+	if len(c.LANDevices) != 0 {
+		t.Fatal("simulators must not be counted as LAN devices")
+	}
+	out, err := c.ToJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(out), `"simulators"`) {
+		t.Errorf("JSON lacks a simulators key:\n%s", out)
+	}
+}


### PR DESCRIPTION
Stacked on #1834. A VM started by the launcher showed up on the **Local** tab of `wendy discover` as well as the **Simulator** tab. This keeps VMs on the Simulator tab only, and makes sure a real device can never be filed as one.

## Root cause

The launcher assumed SLIRP carries no multicast. It carries none *inbound*, but libslirp's `sotranslate_out` only rewrites destinations inside the virtual 10.0.2.0/24: a guest packet to 224.0.0.251 goes out through a real host UDP socket unchanged, so the kernel emits it on the default-route interface. The guest's Avahi announcement of `_wendyos._udp` therefore reaches the host's own mDNSResponder (and every other machine on the LAN) with an A record of 10.0.2.15 that nothing can dial. Reproduced on a user-mode VM with `dns-sd -B _wendyos._udp local.` on the Mac: the service appears on `en0` seconds after the guest's Avahi starts. StreamLAN listed it as a device and cached it in `~/.wendy/devices.json` for an hour.

A second path: `discoverLocalTargets` merged the synthetic `vm:<name>` rows into `lanDevices` for the JSON and `--timeout` outputs.

## What changed

- **Discovery engine** (`internal/shared/discovery`): `StreamOptions.Exclude` takes a `LANFilter`. Excluded sightings are never emitted, probed or persisted; a row listed before the filter could tell is taken back with a new `LANRetracted` event and deleted from the cache; stale cached entries the filter rejects are purged at load. The `devicetype` TXT record maps onto `LANDevice.DeviceType` until a probe verifies it.
- **CLI classifier** (`simulatorFilter`, installed by `cliLANStreamOptions` on every LAN session): a row is a simulator when its agent-reported board starts with `vm-`, or its hostname is one a VM in the local store has reported. The hostname is learned over the loopback forward (by the probe, by the `--device sim` wait, and by a bounded learner for running VMs not yet known) and kept in the VM's `meta.json`.
- **Agent**: `EnsureDeviceTypeAdvertisement` stamps `devicetype=<BOARD>` into the `_wendyos._udp` block of the Avahi service file at startup, restarting Avahi only when the record changes. Classification then works on the sighting alone, for other machines on the LAN too.
- **Outputs**: `DevicesCollection.Simulators` (`simulators` in JSON) holds the VM rows; the one-shot table labels them `Simulator`; the discover TUI and run picker drop retracted rows (`PickerRemoveMsg`).
- Comments, the `vm start` message and the docs now describe the verified behaviour.

## Verification

- Unit tests for every piece, written first: engine exclusion/retraction/cache purge, `CollectLAN`, TXT parsing and precedence, VM store `RecordHostname`, picker removal, classifier and learner (real loopback listener), collection split, one-shot table, discover model, agent record stamping (7 cases).
- Live on a user-mode `sim` VM: `wendy discover --json` lists nothing under `lanDevices` and the VM under `simulators`; the stale "Gentle Forest" cache entry is purged at load; the TUI driven through a PTY shows no VM on Local and `sim running 127.0.0.1:50051` on the Simulator tab. After pushing the rebuilt agent with `device update --binary`, `dns-sd -L` shows `devicetype=vm-arm64`, and discover still keeps the VM off Local with the recorded hostname removed.
- `TestBuildCmd_MultiService_BuildsFromManifestOnly` fails on this Mac before and after this change (temp path vs its `/private` symlink form); unrelated.

Backup hardening not built, on purpose: guest-side Avahi suppression via `fw_cfg`, and vmnet lease MAC matching for shared mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pn6hwH8JiymmBYz4EjQ5F3
