### PR TITLE
feat(two-plane): carry frame identity in-band on the loopback buffer

### DIFF
--- a/Examples/WendyDataModelApp/proto/wendy/agent/apps/v1/sensor_service.proto
+++ b/Examples/WendyDataModelApp/proto/wendy/agent/apps/v1/sensor_service.proto
@@ -53,10 +53,16 @@ service SensorService {
   // scores is provably the frame the episode recorded, which is not true of an
   // app that opens the camera device itself.
   //
-  // The join key is loopback_sequence, which an app reads from the
+  // The primary join key is loopback_sequence, which an app reads from the
   // v4l2_buffer.sequence of the buffer it dequeued. See FrameIdentity for why
   // that number is assigned by the kernel rather than chosen by the agent, and
   // for what a consumer must do about dropped frames.
+  //
+  // The buffer's timestamp is a SECONDARY key carrying the same identity
+  // in-band. The agent stamps each buffer with boottime_nanos truncated to
+  // whole microseconds, so an app can match a dequeued buffer by
+  // boottime_nanos / 1000 as well, and can cross-check the sequence join it
+  // already made. See FrameIdentity for the exact derivation.
   //
   // This grants strictly less than Subscribe, which already carries every
   // identity field below alongside the payload. It does NOT grant the loopback
@@ -171,6 +177,22 @@ message FrameIdentitySubscribeRequest {
 // and requires no assumption that frames arrive in a particular order, which is
 // what makes the join trustworthy.
 //
+// # The buffer TIMESTAMP, unlike the sequence, is the agent's own
+//
+// That limit applies to the sequence field alone. Verified against v4l2loopback
+// v0.15.4, the same QBUF handler copies a writer-supplied timestamp through
+// verbatim and substitutes the module's own clock only when the writer supplies
+// a zero one. It also latches V4L2_BUF_FLAG_TIMESTAMP_COPY on the buffer, which
+// means precisely "this timestamp came from the writer"; DQBUF clears only the
+// QUEUED and DONE flags, so both the value and that flag reach the reader.
+//
+// The agent therefore stamps every buffer with this message's boottime_nanos,
+// truncated to whole microseconds by struct timeval. Identity rides IN BAND as
+// well as on this stream, and a reader that checks the COPY flag can prove the
+// value is the agent's rather than a clock reading. There is no separate field
+// for it here because it is exactly boottime_nanos / 1000: see
+// loopback_sequence below for the derivation and why it is exact.
+//
 // # Dropped frames: two different losses, two different signals
 //
 // A consumer that watches only one of these will believe frames were delivered
@@ -205,9 +227,26 @@ message FrameIdentity {
   int64 boottime_nanos = 3;
   int64 timestamp_uncertainty_nanos = 4;
   // loopback_sequence is the v4l2_buffer.sequence the KERNEL assigned to this
-  // frame on the node. It is the join key: match it against the sequence of the
-  // buffer dequeued from the node. See the message comment for why the agent
-  // cannot choose this value.
+  // frame on the node. It is the PRIMARY join key: match it against the
+  // sequence of the buffer dequeued from the node. See the message comment for
+  // why the agent cannot choose this value.
+  //
+  // The dequeued buffer's timestamp is a secondary key and a cross-check on
+  // that join, because the agent stamps it rather than the module. Its expected
+  // value is derived, not carried: a v4l2_buffer timestamp is a struct timeval,
+  // so the frame whose identity this is has
+  //
+  //     timestamp.tv_sec * 1000000 + timestamp.tv_usec == boottime_nanos / 1000
+  //
+  // The truncation to whole microseconds is exact rather than approximate,
+  // because 1000000000 divides evenly by 1000, so the equality is not a
+  // tolerance. Nothing in this message repeats that value: a second copy of a
+  // derivable number could only ever agree or rot.
+  //
+  // Two microsecond stamps cannot collide at any realistic frame rate: at 30
+  // frames per second consecutive frames are about 33333 microseconds apart.
+  // The sequence stays primary all the same, because it alone makes an
+  // application-side drop visible, as case 2 above describes.
   uint32 loopback_sequence = 5;
   // dropped_before counts samples lost between the producer and the node since
   // the previous frame written. It is the ONLY report of loss case 1 above,

--- a/Proto/wendy/agent/apps/v1/sensor_service.proto
+++ b/Proto/wendy/agent/apps/v1/sensor_service.proto
@@ -53,10 +53,16 @@ service SensorService {
   // scores is provably the frame the episode recorded, which is not true of an
   // app that opens the camera device itself.
   //
-  // The join key is loopback_sequence, which an app reads from the
+  // The primary join key is loopback_sequence, which an app reads from the
   // v4l2_buffer.sequence of the buffer it dequeued. See FrameIdentity for why
   // that number is assigned by the kernel rather than chosen by the agent, and
   // for what a consumer must do about dropped frames.
+  //
+  // The buffer's timestamp is a SECONDARY key carrying the same identity
+  // in-band. The agent stamps each buffer with boottime_nanos truncated to
+  // whole microseconds, so an app can match a dequeued buffer by
+  // boottime_nanos / 1000 as well, and can cross-check the sequence join it
+  // already made. See FrameIdentity for the exact derivation.
   //
   // This grants strictly less than Subscribe, which already carries every
   // identity field below alongside the payload. It does NOT grant the loopback
@@ -171,6 +177,22 @@ message FrameIdentitySubscribeRequest {
 // and requires no assumption that frames arrive in a particular order, which is
 // what makes the join trustworthy.
 //
+// # The buffer TIMESTAMP, unlike the sequence, is the agent's own
+//
+// That limit applies to the sequence field alone. Verified against v4l2loopback
+// v0.15.4, the same QBUF handler copies a writer-supplied timestamp through
+// verbatim and substitutes the module's own clock only when the writer supplies
+// a zero one. It also latches V4L2_BUF_FLAG_TIMESTAMP_COPY on the buffer, which
+// means precisely "this timestamp came from the writer"; DQBUF clears only the
+// QUEUED and DONE flags, so both the value and that flag reach the reader.
+//
+// The agent therefore stamps every buffer with this message's boottime_nanos,
+// truncated to whole microseconds by struct timeval. Identity rides IN BAND as
+// well as on this stream, and a reader that checks the COPY flag can prove the
+// value is the agent's rather than a clock reading. There is no separate field
+// for it here because it is exactly boottime_nanos / 1000: see
+// loopback_sequence below for the derivation and why it is exact.
+//
 // # Dropped frames: two different losses, two different signals
 //
 // A consumer that watches only one of these will believe frames were delivered
@@ -205,9 +227,26 @@ message FrameIdentity {
   int64 boottime_nanos = 3;
   int64 timestamp_uncertainty_nanos = 4;
   // loopback_sequence is the v4l2_buffer.sequence the KERNEL assigned to this
-  // frame on the node. It is the join key: match it against the sequence of the
-  // buffer dequeued from the node. See the message comment for why the agent
-  // cannot choose this value.
+  // frame on the node. It is the PRIMARY join key: match it against the
+  // sequence of the buffer dequeued from the node. See the message comment for
+  // why the agent cannot choose this value.
+  //
+  // The dequeued buffer's timestamp is a secondary key and a cross-check on
+  // that join, because the agent stamps it rather than the module. Its expected
+  // value is derived, not carried: a v4l2_buffer timestamp is a struct timeval,
+  // so the frame whose identity this is has
+  //
+  //     timestamp.tv_sec * 1000000 + timestamp.tv_usec == boottime_nanos / 1000
+  //
+  // The truncation to whole microseconds is exact rather than approximate,
+  // because 1000000000 divides evenly by 1000, so the equality is not a
+  // tolerance. Nothing in this message repeats that value: a second copy of a
+  // derivable number could only ever agree or rot.
+  //
+  // Two microsecond stamps cannot collide at any realistic frame rate: at 30
+  // frames per second consecutive frames are about 33333 microseconds apart.
+  // The sequence stays primary all the same, because it alone makes an
+  // application-side drop visible, as case 2 above describes.
   uint32 loopback_sequence = 5;
   // dropped_before counts samples lost between the producer and the node since
   // the previous frame written. It is the ONLY report of loss case 1 above,

--- a/go/internal/agent/services/hub_loopback_binding.go
+++ b/go/internal/agent/services/hub_loopback_binding.go
@@ -40,8 +40,46 @@ import (
 // (and identically in the write() path). dev->write_position is the module's
 // own monotonic count of frames written to that node. Whatever sequence value a
 // writer supplies is discarded. There is no module option, format flag, or
-// ioctl that disables this. So a design that says "sequence IS the sample id"
-// would be claiming a guarantee the kernel actively prevents us from keeping.
+// ioctl that disables this overwrite OF THE SEQUENCE. So a design that says
+// "sequence IS the sample id" would be claiming a guarantee the kernel actively
+// prevents us from keeping.
+//
+// # The timestamp, unlike the sequence, IS the writer's
+//
+// That limit is specific to the sequence field, and it would be wrong to read
+// it as "the writer controls nothing per buffer". Verified against v4l2loopback
+// v0.15.4, the version the Yocto recipe pins, the very same OUTPUT branch of
+// vidioc_qbuf hands the writer's timestamp straight through:
+//
+//	if (!(bufd->buffer.flags & V4L2_BUF_FLAG_TIMESTAMP_COPY) &&
+//	    (buf->timestamp.tv_sec == 0 && buf->timestamp.tv_usec == 0)) {
+//	        v4l2l_get_timestamp(&bufd->buffer);
+//	} else {
+//	        bufd->buffer.timestamp = buf->timestamp;
+//	        bufd->buffer.flags |= V4L2_BUF_FLAG_TIMESTAMP_COPY;
+//	        bufd->buffer.flags &= ~V4L2_BUF_FLAG_TIMESTAMP_MONOTONIC;
+//	}
+//
+// The module substitutes its own clock only for a writer that supplies a ZERO
+// timestamp. A nonzero one is copied verbatim and latches
+// V4L2_BUF_FLAG_TIMESTAMP_COPY, which says exactly "this value came from the
+// writer". On the read side vidioc_dqbuf's CAPTURE branch does
+// `*buf = dev->buffers[index].buffer;` and then unset_flags, which clears only
+// V4L2_BUF_FLAG_QUEUED and V4L2_BUF_FLAG_DONE, so both the timestamp and the
+// COPY flag reach the reading application intact.
+//
+// So identity does ride in-band after all, just not in the field the naive
+// design wanted. The pump stamps each buffer with the frame's canonical
+// CLOCK_BOOTTIME receipt truncated to whole microseconds by struct timeval,
+// which is the same number FrameIdentity.boottime_nanos carries divided by
+// 1000; the truncation is exact because 1e9 divides evenly by 1000. A consumer
+// can therefore check every frame it dequeues against the identity it resolved,
+// with no extra field on the wire and no side channel needed for the check.
+//
+// The sequence remains the PRIMARY join key and the timestamp is a secondary
+// one. Two reasons: the sequence is what makes an application-side drop visible
+// (see drop case 2 below), which a timestamp cannot do, and the sequence is
+// exact where microseconds are truncated. Nothing below changes.
 //
 // # What is sound instead: observe the kernel's number, publish the mapping
 //

--- a/go/internal/agent/services/hub_loopback_pump.go
+++ b/go/internal/agent/services/hub_loopback_pump.go
@@ -18,14 +18,22 @@ import (
 // Linux device with the module loaded (the ioctls themselves). Tests inject a
 // fake; the Linux build injects the real V4L2 OUTPUT writer.
 type loopbackFrameWriter interface {
-	// WriteFrame queues one whole access unit on the node's OUTPUT queue and
-	// returns the sequence the KERNEL assigned to it.
+	// WriteFrame queues one whole access unit on the node's OUTPUT queue,
+	// stamping it with boottimeNanos, and returns the sequence the KERNEL
+	// assigned to it.
 	//
-	// Returning the kernel's value rather than accepting one from the caller is
-	// the whole basis of the binding: v4l2loopback overwrites any sequence a
-	// writer supplies with its own write_position, and hands the result back on
-	// the same ioctl. See hub_loopback_binding.go for the full reasoning.
-	WriteFrame(data []byte) (sequence uint32, err error)
+	// The two directions are deliberate and not symmetric. Returning the
+	// kernel's sequence rather than accepting one from the caller is the whole
+	// basis of the binding: v4l2loopback overwrites any sequence a writer
+	// supplies with its own write_position, and hands the result back on the
+	// same ioctl. The timestamp goes the other way, because the module copies a
+	// nonzero writer timestamp through to the reader verbatim and flags it as
+	// writer-supplied. See hub_loopback_binding.go for the full reasoning.
+	//
+	// boottimeNanos is the frame's canonical CLOCK_BOOTTIME receipt, the same
+	// value the binding and FrameIdentity carry, so the in-band stamp and the
+	// control plane can never disagree about a frame.
+	WriteFrame(data []byte, boottimeNanos int64) (sequence uint32, err error)
 	// Close releases the node. The node itself outlives the writer.
 	Close() error
 }
@@ -208,7 +216,11 @@ func (p *hubLoopbackPump) pump(ctx context.Context, hub *deviceHub, subID int, f
 			drops := hub.drops(subID)
 			delta := drops - lastDrops
 
-			seq, err := writer.WriteFrame(frame.data)
+			// The stamp is the SAME canonical receipt the binding below
+			// records and FrameIdentity publishes, read from the one frame
+			// object, so the in-band value and the control-plane value cannot
+			// drift apart.
+			seq, err := writer.WriteFrame(frame.data, frame.receiptBootNanos)
 			if err != nil {
 				// A failed write is NOT a dropped frame: the kernel did not advance
 				// its counter and we record no binding, so the sample is simply

--- a/go/internal/agent/services/hub_loopback_pump_test.go
+++ b/go/internal/agent/services/hub_loopback_pump_test.go
@@ -21,6 +21,10 @@ import (
 type fakeLoopbackWriter struct {
 	nextSeq uint32
 	writes  [][]byte
+	// stamps records the boottime the pump handed to each write, in the same
+	// order as writes, so a test can assert the in-band identity the real writer
+	// would put on the v4l2 buffer.
+	stamps []int64
 	// failOn holds write indices (0-based) that should return an error.
 	failOn map[int]bool
 	closed bool
@@ -30,12 +34,14 @@ func newFakeLoopbackWriter(base uint32) *fakeLoopbackWriter {
 	return &fakeLoopbackWriter{nextSeq: base, failOn: map[int]bool{}}
 }
 
-func (f *fakeLoopbackWriter) WriteFrame(data []byte) (uint32, error) {
+func (f *fakeLoopbackWriter) WriteFrame(data []byte, boottimeNanos int64) (uint32, error) {
 	if f.failOn[len(f.writes)] {
 		f.writes = append(f.writes, nil)
+		f.stamps = append(f.stamps, boottimeNanos)
 		return 0, errors.New("simulated write failure")
 	}
 	f.writes = append(f.writes, append([]byte(nil), data...))
+	f.stamps = append(f.stamps, boottimeNanos)
 	seq := f.nextSeq
 	// The kernel advances its counter only for a frame it actually accepted.
 	f.nextSeq++
@@ -142,6 +148,49 @@ func TestPumpCarriesCanonicalIdentity(t *testing.T) {
 	if got.BootNanos != 1234567890123 || got.UncertaintyNanos != 750 {
 		t.Errorf("binding carried boot=%d unc=%d, want 1234567890123/750",
 			got.BootNanos, got.UncertaintyNanos)
+	}
+}
+
+// TestPumpStampsWriterWithCanonicalBoottime pins the in-band half of the
+// identity: the value the pump hands the writer, which the real writer puts in
+// the v4l2 buffer's timestamp, is the frame's canonical CLOCK_BOOTTIME receipt
+// and nothing else.
+//
+// It must be the SAME number the binding publishes. A pump that stamped a
+// locally read clock instead would still produce a plausible-looking timestamp
+// on the node, and a consumer cross-checking a sequence join against it would
+// then reject frames that were correctly identified. The whole value of the
+// in-band stamp is that it agrees with the control plane by construction.
+func TestPumpStampsWriterWithCanonicalBoottime(t *testing.T) {
+	hub, subID, frames := newPumpTestHub(t)
+	writer := newFakeLoopbackWriter(7)
+	pump := newHubLoopbackPump(zap.NewNop(), "v4l2:/dev/video0", "/dev/video200")
+
+	const wantBoot int64 = 1234567890123456789
+	frames <- bindableFrame(11, wantBoot, 250)
+	close(frames)
+	if err := pump.pump(context.Background(), hub, subID, frames, writer); err != nil {
+		t.Fatalf("pump returned %v", err)
+	}
+
+	if len(writer.stamps) != 1 {
+		t.Fatalf("writer saw %d stamps, want 1", len(writer.stamps))
+	}
+	if writer.stamps[0] != wantBoot {
+		t.Fatalf("writer was stamped %d, want the frame's canonical receipt %d",
+			writer.stamps[0], wantBoot)
+	}
+
+	// And the published identity carries the same number, so a consumer that
+	// derives the expected buffer timestamp as boottime_nanos/1000 will match
+	// what the node actually carries.
+	binding, ok := pump.Bindings().Lookup(7)
+	if !ok {
+		t.Fatal("binding not recorded")
+	}
+	if binding.BootNanos != writer.stamps[0] {
+		t.Fatalf("binding boot=%d but writer stamped %d; the two planes disagree",
+			binding.BootNanos, writer.stamps[0])
 	}
 }
 

--- a/go/internal/agent/services/hub_loopback_writer.go
+++ b/go/internal/agent/services/hub_loopback_writer.go
@@ -56,6 +56,18 @@ const (
 	// the capture path's v4l2BufTypeVideoCapture.
 	v4l2BufTypeVideoOutput = 2
 
+	// v4l2BufFlagTimestampCopy is V4L2_BUF_FLAG_TIMESTAMP_COPY from
+	// linux/videodev2.h: the buffer's timestamp came from the writer and was
+	// copied through verbatim, rather than being taken from a system clock.
+	//
+	// Setting it on the queued buffer is not what makes v4l2loopback honour our
+	// timestamp (it latches the flag itself for any nonzero writer timestamp),
+	// but it makes the intent explicit at the queue site and it is the value a
+	// reader will see, so a consumer can tell a writer-supplied stamp from the
+	// module's own. The capture path's sibling value, TIMESTAMP_MONOTONIC, is
+	// 0x2000; the flags field also carries the MASK 0xe000 those two live in.
+	v4l2BufFlagTimestampCopy = 0x00004000
+
 	// loopbackOutputBuffers is how many buffers the node's OUTPUT queue holds.
 	// Four is the conventional minimum that still lets a reader lag a few frames
 	// before a buffer is reused underneath it.
@@ -176,17 +188,50 @@ func (w *v4l2OutputWriter) configure() error {
 	return nil
 }
 
-// WriteFrame copies one access unit into the next buffer and queues it,
-// returning the sequence the kernel assigned.
+// WriteFrame copies one access unit into the next buffer, stamps it with the
+// frame's canonical CLOCK_BOOTTIME receipt and queues it, returning the
+// sequence the kernel assigned.
+//
+// # The sequence is the kernel's, and only the kernel's
 //
 // The returned value is read back out of the ioctl's own buffer struct, and
 // that is the entire basis of the binding: v4l2loopback overwrites whatever
 // sequence a writer supplies with its internal write_position and copies the
 // result back before advancing that counter, so this value names THIS frame and
 // is authoritative. Nothing here may substitute a locally computed number for
-// it; doing so would reintroduce precisely the arrival-order assumption the
-// design exists to avoid.
-func (w *v4l2OutputWriter) WriteFrame(data []byte) (uint32, error) {
+// the SEQUENCE; doing so would reintroduce precisely the arrival-order
+// assumption the design exists to avoid.
+//
+// # The timestamp, by contrast, is ours
+//
+// The same v0.15.4 QBUF handler that clobbers the sequence passes the timestamp
+// through untouched whenever a writer supplies a nonzero one:
+//
+//	} else {
+//	        bufd->buffer.timestamp = buf->timestamp;
+//	        bufd->buffer.flags |= V4L2_BUF_FLAG_TIMESTAMP_COPY;
+//	        bufd->buffer.flags &= ~V4L2_BUF_FLAG_TIMESTAMP_MONOTONIC;
+//	}
+//
+// (the if branch it belongs to takes the module's own clock only when the
+// writer's timestamp is zero and the COPY flag is not already latched). On the
+// read side vidioc_dqbuf's CAPTURE branch copies the whole buffer struct out
+// and unset_flags clears only QUEUED and DONE, so both the value and the COPY
+// flag reach the reader intact.
+//
+// So this queues the frame's canonical boottime receipt, truncated to whole
+// microseconds by struct timeval. The truncation is exact, not approximate:
+// 1e9 is divisible by 1000, so sec*1e6 + usec == boottimeNanos/1000 always. A
+// consumer derives the expected value from FrameIdentity.boottime_nanos by that
+// same division and needs no extra field on the wire to do it.
+//
+// This is a SECONDARY key and a cross-check, not a replacement for the
+// sequence. Microseconds cannot collide at any realistic frame rate (30 frames
+// per second is roughly 33,333 microseconds apart), but the sequence remains
+// the primary join because it is the number a reader gets on the same struct it
+// dequeues, and because it, not the timestamp, is what makes reader-side drops
+// visible as a gap.
+func (w *v4l2OutputWriter) WriteFrame(data []byte, boottimeNanos int64) (uint32, error) {
 	if len(w.buffers) == 0 {
 		return 0, fmt.Errorf("loopback node %s has no buffers", w.file.Name())
 	}
@@ -206,6 +251,8 @@ func (w *v4l2OutputWriter) WriteFrame(data []byte) (uint32, error) {
 	qbuf.setMemory(v4l2MemoryMmap)
 	v4l2BufSetBytesUsed(&qbuf, uint32(len(data)))
 	v4l2BufSetField(&qbuf, v4l2FieldNone)
+	qbuf.setTimestampNanos(boottimeNanos)
+	qbuf.setFlags(v4l2BufFlagTimestampCopy)
 	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(w.file.Fd()), vidiocQbuf, uintptr(unsafe.Pointer(&qbuf))); errno != 0 {
 		return 0, fmt.Errorf("VIDIOC_QBUF on %s: %w", w.file.Name(), errno)
 	}

--- a/go/internal/agent/services/hub_loopback_writer_test.go
+++ b/go/internal/agent/services/hub_loopback_writer_test.go
@@ -1,0 +1,75 @@
+package services
+
+import (
+	"encoding/binary"
+	"testing"
+	"time"
+)
+
+// TestV4L2BufferTimestampSetterRoundTrip pins the in-band frame identity the
+// two-plane data path writes onto every buffer it queues.
+//
+// This is a byte-layout test on purpose, and it asserts the RAW BYTES rather
+// than only round-tripping through the accessors. v4l2Buf is a fixed-size array
+// whose fields are reached by hand-computed offsets precisely because a Go
+// struct cannot be trusted to match a C struct containing a union and an
+// alignment-forcing struct timeval. A setter and a getter that agree with each
+// other while both pointing at the wrong offset would round-trip perfectly and
+// still put the timestamp somewhere the kernel never reads. So the offsets are
+// checked directly, against the same 12 seconds plus 3456 microseconds that the
+// decode test TestV4L2BufferTimestampMetadata pins from the other direction.
+func TestV4L2BufferTimestampSetterRoundTrip(t *testing.T) {
+	// A receipt with a sub-microsecond remainder, so the truncation struct
+	// timeval forces is actually exercised rather than being a no-op.
+	const nanos int64 = 12*int64(time.Second) + 3456*int64(time.Microsecond) + 789
+
+	var buffer v4l2Buf
+	buffer.setTimestampNanos(nanos)
+
+	// tv_sec at offset 24 and tv_usec at offset 32, the layout timestampNanos
+	// reads. Written as unsigned here only because that is how the decode test
+	// stages the same two fields; the values are positive so the bits match.
+	if sec := binary.LittleEndian.Uint64(buffer[24:32]); sec != 12 {
+		t.Errorf("tv_sec at offset 24 = %d, want 12", sec)
+	}
+	if usec := binary.LittleEndian.Uint64(buffer[32:40]); usec != 3456 {
+		t.Errorf("tv_usec at offset 32 = %d, want 3456", usec)
+	}
+
+	// Nothing may have landed outside those two fields. bytesused, flags and
+	// sequence all live in the same struct and a stray write into one of them
+	// would corrupt the queued buffer in a way no round-trip would reveal.
+	if buffer.bytesUsed() != 0 || buffer.flags() != 0 || buffer.sequence() != 0 || buffer.index() != 0 {
+		t.Errorf("setTimestampNanos disturbed a neighbouring field: index=%d bytesused=%d flags=%#x sequence=%d",
+			buffer.index(), buffer.bytesUsed(), buffer.flags(), buffer.sequence())
+	}
+
+	// The existing reader must see the value back, truncated to whole
+	// microseconds because struct timeval has no finer resolution.
+	wantTruncated := 12*int64(time.Second) + 3456*int64(time.Microsecond)
+	if got := buffer.timestampNanos(); got != wantTruncated {
+		t.Errorf("timestampNanos() = %d, want %d", got, wantTruncated)
+	}
+
+	// The identity a consumer relies on: it derives the expected buffer
+	// timestamp from FrameIdentity.boottime_nanos by dividing by 1000, with no
+	// second field on the wire. That works only because 1e9 divides evenly by
+	// 1000, which makes the truncation exact rather than approximate.
+	sec := int64(binary.LittleEndian.Uint64(buffer[24:32]))
+	usec := int64(binary.LittleEndian.Uint64(buffer[32:40]))
+	if got, want := sec*1_000_000+usec, nanos/1000; got != want {
+		t.Errorf("sec*1e6+usec = %d, want boottime_nanos/1000 = %d", got, want)
+	}
+
+	// And the flag that tells a reader the timestamp is the writer's own rather
+	// than a clock the module read for us.
+	buffer.setFlags(v4l2BufFlagTimestampCopy)
+	if got := buffer.flags(); got != 0x4000 {
+		t.Errorf("flags() = %#x after setFlags(v4l2BufFlagTimestampCopy), want 0x4000", got)
+	}
+	// Setting the flags must not have disturbed the timestamp either: they are
+	// adjacent fields in the same 88-byte array.
+	if got := buffer.timestampNanos(); got != wantTruncated {
+		t.Errorf("timestampNanos() = %d after setFlags, want %d", got, wantTruncated)
+	}
+}

--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -256,10 +256,25 @@ func (b *v4l2Buf) setIndex(i uint32) { *(*uint32)(unsafe.Pointer(&b[0])) = i }
 func (b *v4l2Buf) setType(t uint32)  { *(*uint32)(unsafe.Pointer(&b[4])) = t }
 func (b *v4l2Buf) bytesUsed() uint32 { return *(*uint32)(unsafe.Pointer(&b[8])) }
 func (b *v4l2Buf) flags() uint32     { return *(*uint32)(unsafe.Pointer(&b[12])) }
+func (b *v4l2Buf) setFlags(f uint32) { *(*uint32)(unsafe.Pointer(&b[12])) = f }
 func (b *v4l2Buf) timestampNanos() int64 {
 	sec := *(*int64)(unsafe.Pointer(&b[24]))
 	usec := *(*int64)(unsafe.Pointer(&b[32]))
 	return sec*int64(time.Second) + usec*int64(time.Microsecond)
+}
+
+// setTimestampNanos writes nanos into the struct timeval at offsets 24 and 32,
+// mirroring timestampNanos above exactly so a value written here reads back
+// through that accessor.
+//
+// The microsecond field truncates: struct timeval has no finer resolution. The
+// truncation is exact rather than lossy-and-rounded, because 1e9 is divisible
+// by 1000, so sec*1e6 + usec == nanos/1000 for any non-negative nanos. That
+// identity is what lets a consumer derive the expected buffer value from
+// FrameIdentity.boottime_nanos without a second field on the wire.
+func (b *v4l2Buf) setTimestampNanos(nanos int64) {
+	*(*int64)(unsafe.Pointer(&b[24])) = nanos / int64(time.Second)
+	*(*int64)(unsafe.Pointer(&b[32])) = (nanos % int64(time.Second)) / int64(time.Microsecond)
 }
 func (b *v4l2Buf) sequence() uint32   { return *(*uint32)(unsafe.Pointer(&b[56])) }
 func (b *v4l2Buf) setMemory(m uint32) { *(*uint32)(unsafe.Pointer(&b[60])) = m }

--- a/go/proto/gen/appspb/v1/sensor_service.pb.go
+++ b/go/proto/gen/appspb/v1/sensor_service.pb.go
@@ -511,6 +511,22 @@ func (x *FrameIdentitySubscribeRequest) GetModel() string {
 // and requires no assumption that frames arrive in a particular order, which is
 // what makes the join trustworthy.
 //
+// # The buffer TIMESTAMP, unlike the sequence, is the agent's own
+//
+// That limit applies to the sequence field alone. Verified against v4l2loopback
+// v0.15.4, the same QBUF handler copies a writer-supplied timestamp through
+// verbatim and substitutes the module's own clock only when the writer supplies
+// a zero one. It also latches V4L2_BUF_FLAG_TIMESTAMP_COPY on the buffer, which
+// means precisely "this timestamp came from the writer"; DQBUF clears only the
+// QUEUED and DONE flags, so both the value and that flag reach the reader.
+//
+// The agent therefore stamps every buffer with this message's boottime_nanos,
+// truncated to whole microseconds by struct timeval. Identity rides IN BAND as
+// well as on this stream, and a reader that checks the COPY flag can prove the
+// value is the agent's rather than a clock reading. There is no separate field
+// for it here because it is exactly boottime_nanos / 1000: see
+// loopback_sequence below for the derivation and why it is exact.
+//
 // # Dropped frames: two different losses, two different signals
 //
 // A consumer that watches only one of these will believe frames were delivered
@@ -546,9 +562,26 @@ type FrameIdentity struct {
 	BoottimeNanos             int64 `protobuf:"varint,3,opt,name=boottime_nanos,json=boottimeNanos,proto3" json:"boottime_nanos,omitempty"`
 	TimestampUncertaintyNanos int64 `protobuf:"varint,4,opt,name=timestamp_uncertainty_nanos,json=timestampUncertaintyNanos,proto3" json:"timestamp_uncertainty_nanos,omitempty"`
 	// loopback_sequence is the v4l2_buffer.sequence the KERNEL assigned to this
-	// frame on the node. It is the join key: match it against the sequence of the
-	// buffer dequeued from the node. See the message comment for why the agent
-	// cannot choose this value.
+	// frame on the node. It is the PRIMARY join key: match it against the
+	// sequence of the buffer dequeued from the node. See the message comment for
+	// why the agent cannot choose this value.
+	//
+	// The dequeued buffer's timestamp is a secondary key and a cross-check on
+	// that join, because the agent stamps it rather than the module. Its expected
+	// value is derived, not carried: a v4l2_buffer timestamp is a struct timeval,
+	// so the frame whose identity this is has
+	//
+	//	timestamp.tv_sec * 1000000 + timestamp.tv_usec == boottime_nanos / 1000
+	//
+	// The truncation to whole microseconds is exact rather than approximate,
+	// because 1000000000 divides evenly by 1000, so the equality is not a
+	// tolerance. Nothing in this message repeats that value: a second copy of a
+	// derivable number could only ever agree or rot.
+	//
+	// Two microsecond stamps cannot collide at any realistic frame rate: at 30
+	// frames per second consecutive frames are about 33333 microseconds apart.
+	// The sequence stays primary all the same, because it alone makes an
+	// application-side drop visible, as case 2 above describes.
 	LoopbackSequence uint32 `protobuf:"varint,5,opt,name=loopback_sequence,json=loopbackSequence,proto3" json:"loopback_sequence,omitempty"`
 	// dropped_before counts samples lost between the producer and the node since
 	// the previous frame written. It is the ONLY report of loss case 1 above,

--- a/go/proto/gen/appspb/v1/sensor_service_grpc.pb.go
+++ b/go/proto/gen/appspb/v1/sensor_service_grpc.pb.go
@@ -78,10 +78,16 @@ type SensorServiceClient interface {
 	// scores is provably the frame the episode recorded, which is not true of an
 	// app that opens the camera device itself.
 	//
-	// The join key is loopback_sequence, which an app reads from the
+	// The primary join key is loopback_sequence, which an app reads from the
 	// v4l2_buffer.sequence of the buffer it dequeued. See FrameIdentity for why
 	// that number is assigned by the kernel rather than chosen by the agent, and
 	// for what a consumer must do about dropped frames.
+	//
+	// The buffer's timestamp is a SECONDARY key carrying the same identity
+	// in-band. The agent stamps each buffer with boottime_nanos truncated to
+	// whole microseconds, so an app can match a dequeued buffer by
+	// boottime_nanos / 1000 as well, and can cross-check the sequence join it
+	// already made. See FrameIdentity for the exact derivation.
 	//
 	// This grants strictly less than Subscribe, which already carries every
 	// identity field below alongside the payload. It does NOT grant the loopback
@@ -187,10 +193,16 @@ type SensorServiceServer interface {
 	// scores is provably the frame the episode recorded, which is not true of an
 	// app that opens the camera device itself.
 	//
-	// The join key is loopback_sequence, which an app reads from the
+	// The primary join key is loopback_sequence, which an app reads from the
 	// v4l2_buffer.sequence of the buffer it dequeued. See FrameIdentity for why
 	// that number is assigned by the kernel rather than chosen by the agent, and
 	// for what a consumer must do about dropped frames.
+	//
+	// The buffer's timestamp is a SECONDARY key carrying the same identity
+	// in-band. The agent stamps each buffer with boottime_nanos truncated to
+	// whole microseconds, so an app can match a dequeued buffer by
+	// boottime_nanos / 1000 as well, and can cross-check the sequence join it
+	// already made. See FrameIdentity for the exact derivation.
 	//
 	// This grants strictly less than Subscribe, which already carries every
 	// identity field below alongside the payload. It does NOT grant the loopback


### PR DESCRIPTION
## Problem

On the two-plane camera path the agent feeds frames into a v4l2loopback node so an application can read them with ordinary tooling (ffmpeg, GStreamer, OpenCV). Each frame carries a harness identity, `sample_id` plus a canonical `CLOCK_BOOTTIME` receipt. Until now that identity reached the application only through a separate gRPC stream, `SubscribeFrameIdentity`, joined on the kernel's buffer sequence number. Nothing about the frame on the node said who it was.

Worse, five comments in the tree justified that arrangement with a claim that is simply false. They asserted, in various wordings, that the writer controls no per-buffer field at all, one of them going as far as "There is no module option, format flag, or ioctl that disables this."

## Cause

The sequence half of that claim is correct, and it generalised into a claim about the whole buffer that nobody re-checked against the module source.

Verified by reading upstream v4l2loopback at tag **v0.15.4**, the version our Yocto recipe pins:

**The sequence claim is correct and stands.** `vidioc_qbuf`'s `V4L2_BUF_TYPE_VIDEO_OUTPUT` branch, at line 1915:

```c
bufd->buffer.sequence = dev->write_position;
```

Unconditional. A writer-supplied sequence is always discarded, which is why the binding observes the kernel's number rather than choosing one.

**The timestamp claim is wrong.** Nine lines earlier, in the same branch (lines 1886 to 1895):

```c
if (!(bufd->buffer.flags & V4L2_BUF_FLAG_TIMESTAMP_COPY) &&
    (buf->timestamp.tv_sec == 0 &&
     buf->timestamp.tv_usec == 0)) {
        v4l2l_get_timestamp(&bufd->buffer);
} else {
        bufd->buffer.timestamp = buf->timestamp;
        bufd->buffer.flags |= V4L2_BUF_FLAG_TIMESTAMP_COPY;
        bufd->buffer.flags &= ~V4L2_BUF_FLAG_TIMESTAMP_MONOTONIC;
}
```

The module reads its own clock only when the writer supplies a **zero** timestamp. A nonzero one is copied through verbatim, and the module latches `V4L2_BUF_FLAG_TIMESTAMP_COPY`, which means precisely "this value came from the writer".

And it survives to the reader. `vidioc_dqbuf`'s CAPTURE branch (lines 2027 to 2028) copies the whole struct out and then clears two bits only:

```c
*buf = dev->buffers[index].buffer;
unset_flags(buf->flags);
```

```c
#define unset_flags(flags)                      \
        do {                                    \
                flags &= ~V4L2_BUF_FLAG_QUEUED; \
                flags &= ~V4L2_BUF_FLAG_DONE;   \
        } while (0)
```

So both the timestamp value and the COPY flag reach the reading application intact. Identity can ride in-band, and no side channel is needed for the join key.

## Solution

The agent now stamps every buffer it queues with that frame's canonical `CLOCK_BOOTTIME` receipt, the same number the binding records and `FrameIdentity` publishes, read from the one frame object so the two planes cannot drift apart. It also sets the COPY flag at the queue site.

- `v4l2Buf` gains `setTimestampNanos` (offsets 24 and 32) and `setFlags` (offset 12), mirroring the existing reader's layout exactly.
- `v4l2BufFlagTimestampCopy = 0x00004000` is added next to the writer's other constants, its only user. No such constant existed in the repository before; the value is `V4L2_BUF_FLAG_TIMESTAMP_COPY` from `linux/videodev2.h`.
- `loopbackFrameWriter` widens to `WriteFrame(data []byte, boottimeNanos int64)`. The two directions are deliberately asymmetric: the sequence comes back from the kernel, the timestamp goes out from us.

**No new proto field.** A consumer derives the expected buffer value as `boottime_nanos / 1000`. Truncation to whole microseconds is exact rather than approximate, because 1000000000 divides evenly by 1000, so `sec * 1000000 + usec == nanos / 1000` holds for any non-negative value. A second copy of a derivable number on the wire could only ever agree or rot.

`loopback_sequence` stays the **primary** join key. The timestamp is an in-band secondary and a cross-check. Two reasons: the sequence alone makes an application-side drop visible as a gap, which a timestamp cannot do, and the sequence is exact where microseconds are truncated. At 30 frames per second consecutive frames are about 33333 microseconds apart, so microsecond truncation cannot collide.

All five comments are corrected in lockstep, each citing the same v0.15.4 verification, each keeping the accurate sequence reasoning, and each dropping only the overreach to "the writer controls nothing":

1. `FrameIdentity`'s message comment in `sensor_service.proto`
2. the `loopback_sequence` field comment
3. the `SubscribeFrameIdentity` method comment
4. the "Why sample_id cannot be written into v4l2_buffer.sequence" section in `hub_loopback_binding.go`
5. the `WriteFrame` doc in `hub_loopback_writer.go`

## Still unverified on hardware

The software half is complete and tested. The ioctl path is not.

The `UNVERIFIED ON HARDWARE` header at the top of `hub_loopback_writer.go` is **deliberately retained**. Nothing in this branch has run against a live v4l2loopback node on a device, and this change adds two more field writes to the very ioctl that header is about. Martien is updating a Jetson to a release that ships the module and will run the hardware gate separately. No hardware verification is claimed here.

What *is* verified is the module's source behaviour, quoted above, and the byte layout of what we write, pinned by a test that asserts raw offsets rather than only round-tripping through the accessors.

## Testing

New `hub_loopback_writer_test.go` (the writer had no test file before):

- `TestV4L2BufferTimestampSetterRoundTrip` asserts the raw bytes at offsets 24 and 32 through `binary.LittleEndian`, mirroring the existing decode test `TestV4L2BufferTimestampMetadata` and its 12 seconds plus 3456 microseconds; that `timestampNanos()` reads back the microsecond-truncated value; that `sec * 1000000 + usec == nanos / 1000`; that no neighbouring field was disturbed; and that `setFlags(v4l2BufFlagTimestampCopy)` makes `flags()` read `0x4000`. A setter and a getter that agree with each other while both pointing at the wrong offset would round-trip perfectly and still put the timestamp where the kernel never reads, which is why the offsets are checked directly.
- `TestPumpStampsWriterWithCanonicalBoottime` asserts a frame with a known `receiptBootNanos` reaches the writer with exactly that value, and that the published binding carries the same number.

Every existing pump test recompiles against the widened fake signature with **no behavioural edits**, which is itself a check that the change is additive. The only edits to `hub_loopback_pump_test.go` are the fake's signature, a `stamps` field on it, and the new test.

**Both new tests were mutation-checked.** Writing `tv_sec` at offset 40 instead of 24 fails the setter test on four assertions; moving `setFlags` to offset 16 fails it on the flag assertion; making the pump pass `frame.tsNs` instead of `frame.receiptBootNanos` fails the pump test. Each mutation was reverted and the suite re-run green.

Regenerating the stubs rewrites the protoc version stamp in all 80 generated files, because the committed tree carries a mix of stamps by package that no single local protoc reproduces (the local protoc stamps `v7.36.0`; `appspb` is committed at `v7.35.1`). Following the prior art in `1f57306b1`, the `v7.35.1` stamp was restored in the appspb output and every other generated package was restored, so `git status --porcelain go/proto/gen` shows only `appspb/v1`. The generated diff is comment-only.

The example app's build-time copy of the proto at `Examples/WendyDataModelApp/proto/` is updated identically; it is not a snapshot, and `TestExampleSensorProtoMatchesCanonical` fails on drift.

### Results

| Check | Result |
|---|---|
| `CC=/usr/bin/clang go build ./go/...` | exit 0 |
| `CC=/usr/bin/clang go test -race ./go/internal/agent/services/... ./go/internal/shared/appconfig/...` | 916 pass before, **918 pass after**, 0 fail, 2 skip |
| `gofmt -l go/` | empty |
| `go vet` on touched packages | clean |

The two extra passes are exactly the two new tests.
