### PR TITLE
agent: reject a trailing hyphen in the device name

### DIFF
--- a/go/internal/agent/configpartition/apply.go
+++ b/go/internal/agent/configpartition/apply.go
@@ -257,8 +257,8 @@ func applyWendyConf(logger *zap.Logger, cfgDir string) {
 // characters for the name; longer names produce an invalid hostname label.
 const maxDeviceNameLen = 55
 
-// validDeviceName reports whether name satisfies the WendyOS device name rules:
-// starts with a lowercase letter, followed by 2–54 lowercase letters, digits, or hyphens.
+// validDeviceName: letter-led, 3-55 chars of [a-z0-9-], no trailing hyphen so the
+// derived "wendyos-<name>" stays a valid DNS label. Mirrors is_valid_device_name.
 func validDeviceName(name string) bool {
 	if len(name) < 3 || len(name) > maxDeviceNameLen {
 		return false
@@ -275,12 +275,12 @@ func validDeviceName(name string) bool {
 			return false
 		}
 	}
-	return true
+	return name[len(name)-1] != '-'
 }
 
 func applyDeviceName(logger *zap.Logger, name string) error {
 	if !validDeviceName(name) {
-		return fmt.Errorf("invalid device name %q: must match ^[a-z][a-z0-9-]{2,54}$", name)
+		return fmt.Errorf("invalid device name %q: must match ^[a-z][a-z0-9-]{1,53}[a-z0-9]$", name)
 	}
 
 	const deviceNamePath = "/etc/wendyos/device-name"

--- a/go/internal/agent/configpartition/apply_test.go
+++ b/go/internal/agent/configpartition/apply_test.go
@@ -294,6 +294,7 @@ func TestValidDeviceName(t *testing.T) {
 		"has space",                             // space
 		strings.Repeat("a", maxDeviceNameLen+1), // one over the cap
 		"valid_but_underscore",                  // underscore not allowed
+		"trailing-hyphen-",                      // trailing hyphen -> invalid derived hostname
 	}
 	for _, name := range invalid {
 		if validDeviceName(name) {


### PR DESCRIPTION
Match is_valid_device_name in generate-device-name.sh so a config-partition name cannot derive an invalid wendyos-<name> hostname label.

Refs: WDY-2843