### PR TITLE
cli: make VM lifecycle commands interactive

### DIFF
--- a/go/internal/cli/assets/docs/installation/wendyos-virtual-machine.mdx
+++ b/go/internal/cli/assets/docs/installation/wendyos-virtual-machine.mdx
@@ -293,6 +293,10 @@ wendy vm stop dev      # request graceful guest shutdown
 wendy vm rm dev        # delete a VM and its disk
 ```
 
+The VM name is optional for `start`, `stop`, `logs`, and `rm` in an interactive
+terminal. Leave it out to choose a VM from a list; scripts should continue to
+pass the name explicitly.
+
 `vm stop` waits up to two minutes for the guest to shut down and flush its
 filesystems. If QMP is unavailable or the guest does not finish, it reports an
 error without killing the VM. Shut down inside an older guest without QMP, or

--- a/go/internal/cli/commands/vm.go
+++ b/go/internal/cli/commands/vm.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/go/internal/cli/vm"
 )
 
@@ -119,11 +120,15 @@ func newVMStartCmd() *cobra.Command {
 	var o vmStartOptions
 
 	cmd := &cobra.Command{
-		Use:   "start <name>",
+		Use:   "start [name]",
 		Short: "Start a VM and attach to its console",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runVMStart(cmd, args[0], o)
+			name, err := resolveVMName(args, "start")
+			if err != nil {
+				return err
+			}
+			return runVMStart(cmd, name, o)
 		},
 	}
 	cmd.Flags().StringVar(&o.netMode, "net", string(vm.NetUser),
@@ -458,11 +463,15 @@ func vmListJSON(statuses []vm.Status) []vmListEntry {
 func newVMStopCmd() *cobra.Command {
 	var force bool
 	cmd := &cobra.Command{
-		Use:   "stop <name>",
+		Use:   "stop [name]",
 		Short: "Stop a VM running in the background",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runVMStop(cmd, args[0], force)
+			name, err := resolveVMName(args, "stop")
+			if err != nil {
+				return err
+			}
+			return runVMStop(cmd, name, force)
 		},
 	}
 	cmd.Flags().BoolVar(&force, "force", false, "Kill the VM instead of asking it to power off")
@@ -501,18 +510,22 @@ func runVMStop(cmd *cobra.Command, name string, force bool) error {
 func newVMLogsCmd() *cobra.Command {
 	var follow bool
 	cmd := &cobra.Command{
-		Use:   "logs <name>",
+		Use:   "logs [name]",
 		Short: "Show a backgrounded VM's console output",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			name, err := resolveVMName(args, "show logs for")
+			if err != nil {
+				return err
+			}
 			store, err := vm.NewStore()
 			if err != nil {
 				return err
 			}
-			if err := vm.ValidName(args[0]); err != nil {
+			if err := vm.ValidName(name); err != nil {
 				return err
 			}
-			return streamFile(cmd.Context(), cmd.OutOrStdout(), store.LogPath(args[0]), follow)
+			return streamFile(cmd.Context(), cmd.OutOrStdout(), store.LogPath(name), follow)
 		},
 	}
 	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "Keep printing as the guest writes")
@@ -574,12 +587,15 @@ func reopenIfReplaced(f *os.File, path string) (*os.File, error) {
 func newVMRemoveCmd() *cobra.Command {
 	var force bool
 	cmd := &cobra.Command{
-		Use:     "rm <name>",
+		Use:     "rm [name]",
 		Short:   "Delete a VM and its disk",
-		Args:    cobra.ExactArgs(1),
+		Args:    cobra.MaximumNArgs(1),
 		Aliases: []string{"remove"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			name := args[0]
+			name, err := resolveVMName(args, "remove")
+			if err != nil {
+				return err
+			}
 			store, err := vm.NewStore()
 			if err != nil {
 				return err
@@ -610,6 +626,45 @@ func newVMRemoveCmd() *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&force, "force", false, "Stop the VM first if it is running")
 	return cmd
+}
+
+// resolveVMName keeps explicitly named invocations scriptable and opens the
+// picker only when a person omitted the name in an interactive terminal.
+func resolveVMName(args []string, action string) (string, error) {
+	if len(args) == 1 {
+		return args[0], nil
+	}
+	if jsonOutput || !isInteractiveTerminalFn() {
+		return "", fmt.Errorf("no VM name specified; run in an interactive terminal or pass the VM name as an argument")
+	}
+	return pickVMNameFn(action)
+}
+
+// pickVMNameFn is a seam for command tests: a real picker owns the process TTY
+// and cannot be driven through cobra's in-memory input and output buffers.
+var pickVMNameFn = pickVMName
+
+func pickVMName(action string) (string, error) {
+	statuses, err := vmStatusesFn()
+	if err != nil {
+		return "", err
+	}
+	if len(statuses) == 0 {
+		return "", fmt.Errorf("no VMs found; create one with 'wendy vm create <name>'")
+	}
+
+	items := make([]tui.PickerItem, 0, len(statuses))
+	for _, st := range statuses {
+		items = append(items, tui.PickerItem{
+			Name:      st.Name,
+			Type:      vmStateLabel(st),
+			Address:   vmAddress(st),
+			OSVersion: st.Meta.ImageVersion,
+			Value:     st.Name,
+		})
+	}
+
+	return pickFromItemsWithColumns("Select a VM to "+action, items, simulatorPickerColumns())
 }
 
 // The VM's manifest key is its WENDYOS_BOARD_ID, the same string the image

--- a/go/internal/cli/commands/vm_test.go
+++ b/go/internal/cli/commands/vm_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -66,19 +67,92 @@ func TestVMCreateRejectsALocalImageCombinedWithAVersion(t *testing.T) {
 	}
 }
 
-func TestVMSubcommandsRejectTheWrongNumberOfNames(t *testing.T) {
-	// Args != nil is not enough: ArbitraryArgs would satisfy it and let a
-	// missing VM name through to be dropped silently.
-	for _, name := range []string{"create", "start", "stop", "logs", "rm"} {
+func TestVMInteractiveSubcommandsAcceptAnOptionalName(t *testing.T) {
+	for _, name := range []string{"start", "stop", "logs", "rm"} {
 		c := vmSubcommand(t, name)
-		for _, args := range [][]string{{}, {"one", "two"}} {
-			if err := c.Args(c, args); err == nil {
-				t.Errorf("%q accepted %d names, want exactly 1", name, len(args))
-			}
+		if err := c.Args(c, nil); err != nil {
+			t.Errorf("%q rejected an omitted name: %v", name, err)
 		}
 		if err := c.Args(c, []string{"dev"}); err != nil {
 			t.Errorf("%q rejected a single name: %v", name, err)
 		}
+		if err := c.Args(c, []string{"one", "two"}); err == nil {
+			t.Errorf("%q accepted two names", name)
+		}
+	}
+
+	create := vmSubcommand(t, "create")
+	if err := create.Args(create, nil); err == nil {
+		t.Error("create accepted an omitted name; it is not an interactive lifecycle command")
+	}
+}
+
+func TestResolveVMNameUsesTheExplicitNameWithoutAPicker(t *testing.T) {
+	originalPicker := pickVMNameFn
+	pickVMNameFn = func(string) (string, error) {
+		t.Fatal("explicit VM name unexpectedly opened the picker")
+		return "", nil
+	}
+	t.Cleanup(func() { pickVMNameFn = originalPicker })
+
+	got, err := resolveVMName([]string{"dev"}, "stop")
+	if err != nil || got != "dev" {
+		t.Fatalf("resolveVMName(explicit) = %q, %v; want dev, nil", got, err)
+	}
+}
+
+func TestResolveVMNamePicksWhenInteractive(t *testing.T) {
+	originalInteractive, originalPicker := isInteractiveTerminalFn, pickVMNameFn
+	isInteractiveTerminalFn = func() bool { return true }
+	pickVMNameFn = func(action string) (string, error) {
+		if action != "stop" {
+			t.Errorf("picker action = %q, want stop", action)
+		}
+		return "dev", nil
+	}
+	t.Cleanup(func() {
+		isInteractiveTerminalFn = originalInteractive
+		pickVMNameFn = originalPicker
+	})
+
+	got, err := resolveVMName(nil, "stop")
+	if err != nil || got != "dev" {
+		t.Fatalf("resolveVMName(interactive) = %q, %v; want dev, nil", got, err)
+	}
+}
+
+func TestResolveVMNameRequiresANameWhenNonInteractive(t *testing.T) {
+	originalInteractive := isInteractiveTerminalFn
+	isInteractiveTerminalFn = func() bool { return false }
+	t.Cleanup(func() { isInteractiveTerminalFn = originalInteractive })
+
+	_, err := resolveVMName(nil, "stop")
+	if err == nil || !strings.Contains(err.Error(), "pass the VM name") {
+		t.Fatalf("resolveVMName(non-interactive) error = %v, want argument guidance", err)
+	}
+}
+
+func TestResolveVMNamePropagatesPickerCancellation(t *testing.T) {
+	originalInteractive, originalPicker := isInteractiveTerminalFn, pickVMNameFn
+	isInteractiveTerminalFn = func() bool { return true }
+	pickVMNameFn = func(string) (string, error) { return "", ErrUserCancelled }
+	t.Cleanup(func() {
+		isInteractiveTerminalFn = originalInteractive
+		pickVMNameFn = originalPicker
+	})
+
+	_, err := resolveVMName(nil, "remove")
+	if !errors.Is(err, ErrUserCancelled) {
+		t.Fatalf("resolveVMName(cancelled) = %v, want ErrUserCancelled", err)
+	}
+}
+
+func TestPickVMNameExplainsAnEmptyStore(t *testing.T) {
+	stubVMStatuses(t)
+
+	_, err := pickVMName("stop")
+	if err == nil || !strings.Contains(err.Error(), "wendy vm create") {
+		t.Fatalf("pickVMName(empty) error = %v, want create guidance", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- open a VM picker when start, stop, logs, or rm is called without a name
- preserve explicit-name behavior and provide non-interactive argument guidance
- document and test the interactive flow

## Testing

- go test ./go/internal/cli/commands -run 'TestVM|TestResolveVMName|TestPickVMName' -count=1\n- interactive TTY smoke test of wendy vm stop (quit without selection)