### PR TITLE
fix(agent): persist type-only entitlement labels on container create

### DIFF
--- a/go/internal/agent/containerd/helpers.go
+++ b/go/internal/agent/containerd/helpers.go
@@ -341,6 +341,14 @@ func wendyLabels(appName, serviceName, version string, restartPolicy *agentpb.Re
 	}
 
 	for k, v := range appconfig.BuildEntitlementAnnotations(entitlements) {
+		// containerd silently omits labels whose value is empty. Type-only
+		// entitlements (camera, notifications, GPU, and others) therefore need a
+		// non-empty presence marker so restart reconciliation can reconstruct
+		// them from persisted labels. ParseEntitlementAnnotation deliberately
+		// ignores unknown keys, so this round-trips as the original entitlement.
+		if v == "" {
+			v = "present=true"
+		}
 		labels[k] = v
 	}
 

--- a/go/internal/agent/containerd/helpers_test.go
+++ b/go/internal/agent/containerd/helpers_test.go
@@ -392,7 +392,7 @@ func TestWendyLabels_EntitlementsStoredAsKeyValue(t *testing.T) {
 		wantVal string
 	}{
 		{appconfig.EntitlementAnnotationKeyPrefix + appconfig.EntitlementNetwork, "mode=host"},
-		{appconfig.EntitlementAnnotationKeyPrefix + appconfig.EntitlementGPU, ""},
+		{appconfig.EntitlementAnnotationKeyPrefix + appconfig.EntitlementGPU, "present=true"},
 	}
 	for _, tc := range cases {
 		raw, ok := labels[tc.key]
@@ -401,6 +401,29 @@ func TestWendyLabels_EntitlementsStoredAsKeyValue(t *testing.T) {
 		}
 		if raw != tc.wantVal {
 			t.Errorf("%q value = %q; want %q", tc.key, raw, tc.wantVal)
+		}
+	}
+}
+
+func TestWendyLabels_TypeOnlyEntitlementsUseNonEmptyValues(t *testing.T) {
+	entitlements := []appconfig.Entitlement{
+		{Type: appconfig.EntitlementCamera},
+		{Type: appconfig.EntitlementNotifications},
+	}
+	labels := wendyLabels("app", "", "1.0", nil, entitlements, "", nil)
+
+	for _, entitlement := range entitlements {
+		key := appconfig.EntitlementAnnotationKeyPrefix + entitlement.Type
+		raw, ok := labels[key]
+		if !ok {
+			t.Fatalf("missing entitlement label %q", key)
+		}
+		if raw == "" {
+			t.Fatalf("entitlement label %q has an empty value; containerd drops empty-valued labels", key)
+		}
+		got := appconfig.ParseEntitlementAnnotation(entitlement.Type, raw)
+		if got.Type != entitlement.Type {
+			t.Fatalf("parsed entitlement type = %q, want %q", got.Type, entitlement.Type)
 		}
 	}
 }

--- a/go/internal/agent/containerd/helpers_test.go
+++ b/go/internal/agent/containerd/helpers_test.go
@@ -2,6 +2,7 @@ package containerd
 
 import (
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -732,5 +733,63 @@ func TestContainerArgs_DoesNotMutateImageConfig(t *testing.T) {
 	}
 	if len(cfg.Entrypoint) != 1 || cfg.Entrypoint[0] != "/app/server" {
 		t.Fatalf("image config entrypoint mutated: %q", cfg.Entrypoint)
+	}
+}
+
+// dropEmptyLabelValues mimics containerd's bolt metadata store, which silently
+// deletes any label whose value is the empty string when a container record is
+// written (boltutil writeMap). Tests that assert labels survive a container
+// create must round-trip through this, not just through the in-memory map.
+func dropEmptyLabelValues(labels map[string]string) map[string]string {
+	persisted := make(map[string]string, len(labels))
+	for k, v := range labels {
+		if v == "" {
+			continue
+		}
+		persisted[k] = v
+	}
+	return persisted
+}
+
+// TestChunkDiffCreateLabels_RoundTripThroughContainerd covers the label set a
+// chunk-diff deploy produces end to end: the CLI marshals the AppConfig
+// (deployByChunkDiff), the agent's RunContainer handler unmarshals it, and
+// CreateContainerWithProgress builds the container labels via wendyLabels.
+// containerd then persists them, dropping empty-valued labels. Restart
+// reconciliation (RestoreAppSystemAPISockets) reconstructs entitlements from
+// what actually survives that store, so every entitlement — including type-only
+// ones like camera and episode-write, whose annotation value used to encode as
+// "" — must round-trip through parseEntitlementsFromAnnotations.
+func TestChunkDiffCreateLabels_RoundTripThroughContainerd(t *testing.T) {
+	appConfigJSON := []byte(`{
+		"appId": "sh.wendy.examples.flightrecorder",
+		"version": "1.0.0",
+		"entitlements": [
+			{"type": "camera"},
+			{"type": "episode-write"},
+			{"type": "sensor-read", "allowlist": ["front"]}
+		]
+	}`)
+	var cfg appconfig.AppConfig
+	if err := json.Unmarshal(appConfigJSON, &cfg); err != nil {
+		t.Fatalf("unmarshaling app config: %v", err)
+	}
+
+	labels := wendyLabels(cfg.AppID, "", cfg.Version, nil, cfg.Entitlements, cfg.Isolation, nil)
+	persisted := dropEmptyLabelValues(labels)
+
+	got := parseEntitlementsFromAnnotations(persisted)
+	for _, want := range []string{
+		appconfig.EntitlementCamera,
+		appconfig.EntitlementEpisodeWrite,
+		appconfig.EntitlementSensorRead,
+	} {
+		if !entitlementsContain(got, want) {
+			t.Errorf("entitlement %q did not survive the containerd label round-trip; persisted labels: %v", want, persisted)
+		}
+	}
+	sensors, ok := entitlementOfType(got, appconfig.EntitlementSensorRead)
+	if !ok || len(sensors.Allowlist) != 1 || sensors.Allowlist[0] != "front" {
+		t.Errorf("sensor-read allowlist did not survive the round-trip: %+v", sensors)
 	}
 }

--- a/go/internal/cli/assets/docs/wendy-data-platform-demo.md
+++ b/go/internal/cli/assets/docs/wendy-data-platform-demo.md
@@ -244,10 +244,13 @@ documentation.
    Without that, no record ever reaches the agent.
 4. After any agent restart the app's data socket listener is gone and the app
    gets ECONNREFUSED until the app is redeployed
-   (`device apps remove --force`, then `wendy run`). Cause: the chunk-diff
-   deploy path creates containers without `sh.wendy/entitlement.*` labels, so
-   `RestoreAppSystemAPISockets` skips them. Open bug; until it is fixed, order
-   the deploy agent first, app last.
+   (`device apps remove --force`, then `wendy run`). Cause: containerd's
+   metadata store drops labels with empty values, so type-only entitlements
+   (camera, episode-write) lost their `sh.wendy/entitlement.*` labels and
+   `RestoreAppSystemAPISockets` skipped the container. Fixed: `wendyLabels`
+   now writes a `present=true` marker for type-only entitlements. Containers
+   created by an older agent still carry the broken labels, so after updating
+   the agent redeploy the app once.
 5. An episode that exhausts its 5 upload attempts is terminally `failed` and is
    never retried; trigger a fresh episode after fixing connectivity.
 6. `wendy device apps start` streams logs and does not return with `--detach`
@@ -268,7 +271,6 @@ Enrollment is untouched by the demo, so there is nothing to restore there.
 
 ## Open gaps
 
-- Chunk-diff deploys omit entitlement labels (pitfall 4), which is an open bug.
 - Catalog read verification from the CLI needs a user bearer token; today the
   proof is the commit-gated `uploaded` state plus a direct ClickHouse read.
 - The graphics processing unit (GPU) variant of the app, using


### PR DESCRIPTION
## Problem

Apps deployed via the chunk-diff deploy path lose their `sh.wendy/entitlement.*` container labels. Observed on a real device: a container carried only `sh.wendy/app.id`, `sh.wendy/app.version`, and `sh.wendy/restart.policy`, even though the camera and data entitlements were applied to the Open Container Initiative (OCI) runtime spec. After a wendy-agent restart, `RestoreAppSystemAPISockets` (go/internal/agent/containerd/client.go) reconstructs socket listeners from persisted container labels; with the entitlement labels missing it skips the container, the app data socket listener is never re-created, and the app gets ECONNREFUSED on `/run/wendy/data/data.sock` until it is redeployed. This is pitfall 4 in the data platform demo runbook.

## Cause

The chunk-diff path does not have a separate container-create routine: `RunContainer` funnels into the same `CreateContainerWithProgress`, which builds the full label set with `wendyLabels()`. The labels are lost one layer lower. containerd's bolt metadata store silently deletes any label whose value is the empty string (`writeMap` in `core/metadata/boltutil/helpers.go`: `if v == "" { delete(labels, k) }`). `EntitlementAnnotationValue` encodes type-only entitlements — camera, episode-write, notifications, gpu, and others — as an empty string, so exactly those labels vanish when the container record is written. Parameterized entitlements (for example `sensor-read` with an allowlist, or `network` with a mode) have non-empty values and survive, which is why the loss surfaced with the data platform's camera and episode-write grants and looked chunk-diff-specific.

## Solution

- `wendyLabels()` now writes a `present=true` marker for entitlements whose annotation value would be empty, so the label survives containerd's empty-value drop. `ParseEntitlementAnnotation` ignores unknown parameter keys, so the marker parses back to the original type-only entitlement. This is a cherry-pick of 66788b77a (Oliver Taylor), which existed on an unmerged branch.
- New test `TestChunkDiffCreateLabels_RoundTripThroughContainerd` reproduces the chunk-diff deploy end to end: the AppConfig JSON as `deployByChunkDiff` sends it, `wendyLabels` as the create path builds it, containerd's empty-value drop, and `parseEntitlementsFromAnnotations` as `RestoreAppSystemAPISockets` reads it. The test fails without the fix with exactly the label set observed on the device.
- The demo runbook's pitfall 4 and open-gaps entry are updated. Note for operators: containers created by an older agent still carry the broken labels; after updating the agent, redeploy the app once.

## Testing

`go test ./internal/agent/containerd/ ./internal/agent/services/ ./internal/shared/appconfig/` passes. The new round-trip test fails before the fix and passes after.