### PR TITLE
Refuse an unmappable episode file role, and sync the acknowledgement contract

### DIFF
--- a/Proto/cloud/data_ingest.proto
+++ b/Proto/cloud/data_ingest.proto
@@ -15,7 +15,10 @@ package wendycloud.data.v1;
 //   2. UploadEpisodeChunk streams file chunks (at most 1 MiB of data per
 //      chunk, sequential offsets per file, eof on the last chunk). Each
 //      chunk is acknowledged with the received (spooled) offset and the
-//      committed (durably stored in object storage) offset.
+//      committed (durably stored in object storage) offset. An ack names the
+//      (episode_id, path) it belongs to and must be matched on that pair,
+//      because one stream may carry chunks for more than one episode and a
+//      path is unique only within an episode.
 //   3. CommitEpisode verifies the SHA-256 of every stored object against
 //      the manifest and flips the catalog state to `complete`, or `failed`
 //      with per-file detail on any mismatch.
@@ -28,7 +31,13 @@ package wendycloud.data.v1;
 //     from the certificate identity, so an upload cannot name a tenant it
 //     does not hold a certificate for.
 //   - QueryEpisodes/GetEpisode are read RPCs for users and services; the
-//     serving implementation defines the accepted credential.
+//     serving implementation defines the accepted credential. Both carry an
+//     org_id whose membership the server does not verify today, and the read
+//     credential in use is a single shared token scoped to no organization.
+//     GetEpisode returns signed object URLs, so that combination is a
+//     cross-organization data-egress path, not just a catalog read. Read the
+//     org_id documentation on QueryEpisodesRequest and GetEpisodeRequest
+//     before exposing either RPC beyond a trusted internal caller.
 service DataIngestService {
   // Registers (or re-registers) an episode upload. Idempotent.
   rpc BeginEpisodeUpload(BeginEpisodeUploadRequest) returns (BeginEpisodeUploadResponse);
@@ -59,10 +68,25 @@ enum EpisodeState {
 // What a file is to the episode it belongs to. Mirrors the device manifest's
 // per-file `role`, one word for one thing across device, wire and catalog.
 //
-// UNSPECIFIED means CAPTURED. Devices built before this field existed never
-// set it and upload nothing but capture payload and capture metadata, so an
-// absent role has exactly the meaning it always had; readers must treat
-// UNSPECIFIED and CAPTURED identically and must never report "unknown role".
+// UNSPECIFIED carries exactly one meaning: the sender predates this field and
+// said nothing about roles. A file with no role is accounted as CAPTURED,
+// which is the meaning it carried before the field existed.
+//
+// That default is a best reading of a silent sender, not a proof about what
+// such senders produced. Derived files, including the playable remux, existed
+// on the device before the wire role did, so a manifest sealed in that window
+// can legitimately contain a derived file with no role on it.
+//
+// A sender that HAS a role but cannot express it on this enum MUST NOT send
+// UNSPECIFIED. Doing so books the file as capture payload, corrupts
+// capture-only accounting, and leaves no signal that anything was lost. Add
+// the role to this enum and send it.
+//
+// A reader that receives a role number it does not know must retain the
+// number as received, must not coerce it to CAPTURED, and must not fail the
+// episode. Carry it through storage, count its bytes in size totals, and
+// leave them out of capture-only sums. An unknown role means a newer peer,
+// not a corrupt one.
 enum EpisodeFileRole {
   EPISODE_FILE_ROLE_UNSPECIFIED = 0;
   // Capture payload, or capture metadata written while recording.
@@ -85,6 +109,24 @@ message EpisodeManifest {
   // only ever compared against the uploading certificate before discarding.
   // The certificate is the sole source of both, so the wire no longer offers
   // a place to claim otherwise. Numbers stay reserved: never reuse them.
+  //
+  // DEPLOYMENT ORDER, load-bearing: deploy the cloud BEFORE the devices.
+  // A new device omits 2 and 3. An old cloud decodes the absent fields as
+  // zero, compares zero against the certificate identity, and rejects, so
+  // every upload from a new device to an old cloud fails with
+  // PERMISSION_DENIED. The reverse pairing is safe: an old device still sends
+  // both, and a new cloud parks them in unknown fields and ignores them.
+  //
+  // The same asymmetry makes a cloud ROLLBACK a fleet-wide outage once
+  // devices have shipped. It does not degrade a subset of uploads; every
+  // upload from every migrated device returns PERMISSION_DENIED until the
+  // cloud is rolled forward again. Treat the cloud side of this change as a
+  // one-way door and stage it accordingly.
+  //
+  // With the fields gone there is also no wire signal that distinguishes an
+  // old device from a new one, so migration progress cannot be measured from
+  // the manifest. Measure it from agent version reporting instead, and do not
+  // plan a rollout that depends on counting manifests.
   reserved 2, 3;
   reserved "org_id", "asset_id";
 
@@ -92,12 +134,29 @@ message EpisodeManifest {
   // capture, a human-authored slug such as "forklift-failures". It is not an
   // identifier minted by the cloud, and it is not unique over time; the
   // (campaign, campaign_revision) pair is what identifies an exact plan.
+  //
+  // EMPTY when the episode has no campaign. A manual or otherwise ad-hoc
+  // capture is armed by an operator, not by a campaign file, so there is no
+  // campaign name to report; such an episode carries "manual" as its trigger
+  // reason and leaves both campaign fields empty together. This is ordinary
+  // traffic, not an edge case, so consumers must accept the empty value
+  // rather than reject or substitute it.
   string campaign = 4;
-  // Lowercase hex SHA-256 of the canonical campaign plan, so always exactly
-  // 64 characters. The device computes it in WendyOS at
-  // go/internal/agent/data/campaign.go:219, as
-  // hex(sha256(json(campaign.planOnly()))), where planOnly() strips deployment
-  // state so only author-declared plan fields feed the digest.
+  // Revision digest of the campaign plan that armed this capture.
+  //
+  // EMPTY when the episode has no campaign, for the same reason `campaign` is
+  // empty: a manual or ad-hoc capture never had a plan to digest. Otherwise
+  // it is a lowercase hex SHA-256 and therefore exactly 64 characters. A
+  // consumer that validates 64 hex characters unconditionally will reject
+  // legitimate and common data; check the length only after finding the value
+  // non-empty.
+  //
+  // Derivation: the device serialises the campaign to canonical JSON with
+  // deployment state stripped, so that only author-declared plan fields feed
+  // the digest, and takes the lowercase hex SHA-256 of those bytes. Two
+  // devices running the same plan report the same revision. Described rather
+  // than cited by file and line: the implementation lives in another
+  // repository and any line number given here is stale on its next edit.
   //
   // String, not an integer: 256 bits of digest do not fit in a uint64, and no
   // truncation of a hash preserves it as an identifier. It is a content
@@ -155,8 +214,10 @@ message EpisodeFileManifest {
   int64 time_range_end_nanos = 8;
   // Source-clock to canonical-clock mapping summary JSON, when present.
   bytes clock_mapping_json = 9;
-  // What this file is to the episode. Unset (UNSPECIFIED) means CAPTURED, so
-  // devices predating this field keep their existing meaning unchanged.
+  // What this file is to the episode. Unset (UNSPECIFIED) means the sender
+  // predates this field, and is accounted as CAPTURED. See EpisodeFileRole
+  // for what a sender must do with a role it cannot express, and what a
+  // reader must do with a role number it does not know.
   EpisodeFileRole role = 10;
 }
 
@@ -209,6 +270,23 @@ message EpisodeChunkAck {
   // persisted, then equals the file size. Never claims durability that
   // does not exist.
   uint64 committed_offset = 3;
+  // The episode the acknowledged path belongs to; echoes the `episode_id` of
+  // the chunk being acknowledged.
+  //
+  // A client MUST match an ack on the (episode_id, path) pair, never on path
+  // alone. EpisodeChunk carries episode_id per chunk, so one stream may carry
+  // chunks for more than one episode, and the server keys its assembler on
+  // the same pair. A path is unique only within an episode: two episodes on
+  // one stream that both contain "manifest.json" produce acks that path alone
+  // cannot tell apart, and a client matching on path credits one episode's
+  // committed offset to the other, then skips a file it never uploaded. That
+  // is silent data loss, not a retry.
+  //
+  // Added after `path`, so a server built before this field leaves it empty.
+  // A client that finds it empty cannot match safely on a multi-episode
+  // stream, and must keep to one stream per episode until the server carries
+  // the field.
+  string episode_id = 4;
 }
 
 message CommitEpisodeRequest {
@@ -235,10 +313,20 @@ message CommitEpisodeResponse {
 }
 
 message QueryEpisodesRequest {
-  // Organization scope. With certificate-identity credentials this must
-  // match the caller's organization; with the PoC static read token it
-  // selects the organization to read (chosen debt until user auth carries
-  // org membership).
+  // Organization to read. This is a filter the caller supplies, not an
+  // identity the server verifies. With certificate-identity credentials it
+  // must match the organization on the certificate.
+  //
+  // AUTHORIZATION GAP, unresolved: the read credential today is a single
+  // shared bearer token that is scoped to no organization, and the server
+  // does NOT check that the caller is a member of the organization named
+  // here. Possession of that token therefore grants catalog read across every
+  // organization, obtained by passing a different number in this field. The
+  // field is not the defect and must not be removed, because a filter is the
+  // right shape once membership is enforced. A server-side membership check,
+  // against the caller's own credential rather than against this value, is
+  // REQUIRED before this RPC is exposed to anything but a trusted internal
+  // caller.
   uint64 org_id = 1;
 
   // Optional filters; zero values mean "no filter".
@@ -257,6 +345,23 @@ message QueryEpisodesResponse {
 }
 
 message GetEpisodeRequest {
+  // Organization the named episode belongs to. Same caller-supplied filter as
+  // QueryEpisodesRequest.org_id, unverified in the same way, under the same
+  // shared read token.
+  //
+  // AUTHORIZATION GAP, sharper here than on the query: this RPC returns
+  // per-file retrieval URLs, short-lived signed object-storage URLs that read
+  // the stored bytes. Absent a membership check, the shared read token is not
+  // merely a cross-organization catalog read; it is a cross-organization
+  // data-egress capability. Name another organization's identifier here with
+  // one of its episode identifiers and the response hands back signed URLs to
+  // that organization's captured data. Those URLs are bearer capabilities in
+  // their own right: they work for anyone they are passed to, and revoking
+  // the read token afterwards does not revoke URLs already issued.
+  //
+  // The fix is authorization, not schema; the field stays. A server-side
+  // membership check is REQUIRED before this RPC is exposed to anything but a
+  // trusted internal caller.
   uint64 org_id = 1;
   string episode_id = 2;
 }
@@ -304,6 +409,8 @@ message EpisodeFileInfo {
   // direct in local development).
   string retrieval_url = 6;
   // What this file is to the episode, as recorded in the catalog. Unset
-  // (UNSPECIFIED) means CAPTURED, as on the upload manifest.
+  // (UNSPECIFIED) means the uploading sender predated the field, as on the
+  // upload manifest. A role the catalog did not recognise at write time is
+  // reported here as the number it arrived as, never rewritten to CAPTURED.
   EpisodeFileRole role = 7;
 }

--- a/go/internal/agent/services/data_transfer_worker.go
+++ b/go/internal/agent/services/data_transfer_worker.go
@@ -490,6 +490,32 @@ func (w *DataTransferWorker) uploadEpisode(ctx context.Context, client cloudpb.D
 	}
 
 	// Drain acks concurrently so large uploads do not deadlock on flow control.
+	//
+	// The acks are read and discarded, not matched. That is deliberate, and it
+	// is why the (episode_id, path) matching rule the wire contract states for
+	// EpisodeChunkAck does not apply to this client today.
+	//
+	// Nothing here is keyed on an ack. Resume offsets come from
+	// BeginEpisodeUpload's per-file FileUploadState, above, which is scoped to
+	// one episode by construction; the acks contribute no state. Draining them
+	// serves two other purposes: gRPC flow control stalls a large upload if the
+	// receive side is never read, and a server-side stream error arrives here
+	// rather than being lost.
+	//
+	// The contract's hazard is a client that matches acks on `path` alone while
+	// one stream carries chunks for several episodes, which credits one
+	// episode's committed offset to another. This client cannot hit it from
+	// either direction: it matches on nothing, and it opens exactly one
+	// UploadEpisodeChunk stream per episode, here inside uploadEpisode, which
+	// processEpisode calls once per manifest. That is precisely the "keep to one
+	// stream per episode" fallback the contract requires of a client that cannot
+	// rely on the new episode_id field, and a server built before that field
+	// leaves it empty anyway.
+	//
+	// TestUploadStreamCarriesOneEpisode pins the one-stream-per-episode
+	// invariant. Batching several episodes onto a single stream, or using ack
+	// offsets to drive resume, means matching on the (episode_id, path) pair
+	// first; do not do one without the other.
 	ackErrCh := make(chan error, 1)
 	go func() {
 		for {
@@ -623,6 +649,10 @@ func buildEpisodeManifest(mf data.Manifest) (*cloudpb.EpisodeManifest, error) {
 	}
 	files := make([]*cloudpb.EpisodeFileManifest, 0, len(mf.Files))
 	for _, f := range mf.Files {
+		role, err := episodeFileRole(f.Role)
+		if err != nil {
+			return nil, fmt.Errorf("file %s: %w", f.Path, err)
+		}
 		files = append(files, &cloudpb.EpisodeFileManifest{
 			Path:      f.Path,
 			SizeBytes: uint64(f.Size),
@@ -630,7 +660,7 @@ func buildEpisodeManifest(mf data.Manifest) (*cloudpb.EpisodeManifest, error) {
 			MediaType: f.MediaType,
 			Format:    f.Format,
 			SourceId:  f.SourceID,
-			Role:      episodeFileRole(f.Role),
+			Role:      role,
 		})
 	}
 	var lower, upper int64
@@ -666,20 +696,33 @@ func buildEpisodeManifest(mf data.Manifest) (*cloudpb.EpisodeManifest, error) {
 // mapper is distinguishable on the wire from one written by an agent built
 // before the field existed.
 //
-// Any other string maps to UNSPECIFIED, which the wire contract defines as
-// captured. The enum has no "unknown" member and inventing one would force
-// every reader to handle a state it cannot act on, so an unrecognised role
-// degrades to the pre-existing meaning instead. That only arises when an
-// older agent resumes an upload for an episode a newer build sealed; adding a
-// role to data.File must add it here in the same change.
-func episodeFileRole(role string) cloudpb.EpisodeFileRole {
+// Any other string is a hard error rather than a value on the wire. The wire
+// contract gives UNSPECIFIED exactly one meaning, "the sender predates this
+// field", and states that a sender holding a role it cannot express MUST NOT
+// send UNSPECIFIED: doing so books the file as capture payload, corrupts
+// capture-only accounting, and tells the reader nothing was lost, so no
+// reader can flag it. The enum has no "unknown" member to fall back to, and
+// inventing one is not ours to do.
+//
+// Failing is the honest option because the role string is produced by this
+// same repository. Every value comes from a data.FileRole constant that seal
+// wrote, so a role this mapper does not know is a programming error on our
+// own side: someone added a role to the manifest and did not extend this
+// switch or the wire enum. It is deterministic, so a retry re-sends the same
+// manifest and fails identically. buildEpisodeManifest's error reaches
+// processEpisode as verifyErr, which marks the episode failed with the
+// offending role recorded and does not spin on it. The gap then surfaces on
+// the first episode that carries the new role, which is the whole point;
+// silently mis-accounting every such file forever is the alternative.
+func episodeFileRole(role string) (cloudpb.EpisodeFileRole, error) {
 	switch role {
 	case "":
-		return cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_CAPTURED
+		return cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_CAPTURED, nil
 	case data.FileRoleDerived:
-		return cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_DERIVED
+		return cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_DERIVED, nil
 	default:
-		return cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_UNSPECIFIED
+		return cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_UNSPECIFIED,
+			fmt.Errorf("unmappable manifest file role %q: add it to the EpisodeFileRole wire enum and to episodeFileRole", role)
 	}
 }
 

--- a/go/internal/agent/services/data_transfer_worker_test.go
+++ b/go/internal/agent/services/data_transfer_worker_test.go
@@ -9,6 +9,8 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -42,6 +44,11 @@ type fakeIngestServer struct {
 
 	beginCalls  int
 	commitCalls int
+
+	// Distinct episode ids seen on each UploadEpisodeChunk stream, one entry
+	// per stream opened. The client must keep to one episode per stream while
+	// it does not match acks on the (episode_id, path) pair.
+	streamEpisodes []map[string]bool
 
 	// Incoming request metadata recorded by startFakeIngest, per call kind, so
 	// tests can assert on what the client actually put on the wire.
@@ -98,6 +105,10 @@ func (s *fakeIngestServer) BeginEpisodeUpload(_ context.Context, req *cloudpb.Be
 }
 
 func (s *fakeIngestServer) UploadEpisodeChunk(stream grpc.BidiStreamingServer[cloudpb.EpisodeChunk, cloudpb.EpisodeChunkAck]) error {
+	seen := map[string]bool{}
+	s.mu.Lock()
+	s.streamEpisodes = append(s.streamEpisodes, seen)
+	s.mu.Unlock()
 	for {
 		chunk, err := stream.Recv()
 		if err == io.EOF {
@@ -107,6 +118,7 @@ func (s *fakeIngestServer) UploadEpisodeChunk(stream grpc.BidiStreamingServer[cl
 			return err
 		}
 		s.mu.Lock()
+		seen[chunk.GetEpisodeId()] = true
 		s.received[chunk.GetPath()] = append(s.received[chunk.GetPath()], chunk.GetData()...)
 		recv := int64(len(s.received[chunk.GetPath()]))
 		var committed int64
@@ -115,7 +127,14 @@ func (s *fakeIngestServer) UploadEpisodeChunk(stream grpc.BidiStreamingServer[cl
 			committed = recv
 		}
 		s.mu.Unlock()
-		if err := stream.Send(&cloudpb.EpisodeChunkAck{Path: chunk.GetPath(), ReceivedOffset: uint64(recv), CommittedOffset: uint64(committed)}); err != nil {
+		// A server that carries the field echoes the chunk's episode_id, so the
+		// ack names the (episode_id, path) pair the contract matches on.
+		if err := stream.Send(&cloudpb.EpisodeChunkAck{
+			EpisodeId:       chunk.GetEpisodeId(),
+			Path:            chunk.GetPath(),
+			ReceivedOffset:  uint64(recv),
+			CommittedOffset: uint64(committed),
+		}); err != nil {
 			return err
 		}
 	}
@@ -625,18 +644,125 @@ func TestBuildEpisodeManifestCarriesFileRole(t *testing.T) {
 	}
 }
 
-// TestEpisodeFileRoleUnknownDegradesToUnspecified documents that a role string
-// this build does not know is sent as UNSPECIFIED, which the wire contract
-// defines as captured. The enum has no "unknown" member on purpose, so the only
-// honest option is the pre-existing meaning rather than a fabricated one.
-func TestEpisodeFileRoleUnknownDegradesToUnspecified(t *testing.T) {
-	if got := episodeFileRole("some-future-role"); got != cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_UNSPECIFIED {
-		t.Errorf("unknown role = %v, want UNSPECIFIED", got)
+// TestEpisodeFileRoleUnmappableFails pins the wire contract's rule that a
+// sender holding a role it cannot express MUST NOT send UNSPECIFIED, because
+// UNSPECIFIED means only "the sender predates this field" and is accounted as
+// capture payload. A role string this build does not know is a programming
+// error in this repository, so the mapper refuses it instead of quietly
+// booking the file as capture.
+//
+// The error assertions are what stop the old degrade-to-UNSPECIFIED default
+// from coming back: restoring it makes episodeFileRole return a nil error, and
+// both the mapper case and the buildEpisodeManifest case below fail.
+func TestEpisodeFileRoleUnmappableFails(t *testing.T) {
+	got, err := episodeFileRole("some-future-role")
+	if err == nil {
+		t.Errorf("unknown role returned %v and no error, want an error refusing to map it", got)
 	}
-	if got := episodeFileRole(""); got != cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_CAPTURED {
-		t.Errorf("empty role = %v, want CAPTURED", got)
+	if err != nil && !strings.Contains(err.Error(), "some-future-role") {
+		t.Errorf("error %q does not name the offending role", err)
 	}
-	if got := episodeFileRole(data.FileRoleDerived); got != cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_DERIVED {
-		t.Errorf("derived role = %v, want DERIVED", got)
+	if got != cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_UNSPECIFIED {
+		// The zero value is the only thing a failed mapping may return; what
+		// matters is that it never reaches the wire.
+		t.Errorf("unknown role value = %v, want the zero value alongside the error", got)
+	}
+
+	if got, err := episodeFileRole(""); err != nil || got != cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_CAPTURED {
+		t.Errorf("empty role = %v (err %v), want CAPTURED and no error", got, err)
+	}
+	if got, err := episodeFileRole(data.FileRoleDerived); err != nil || got != cloudpb.EpisodeFileRole_EPISODE_FILE_ROLE_DERIVED {
+		t.Errorf("derived role = %v (err %v), want DERIVED and no error", got, err)
+	}
+}
+
+// TestBuildEpisodeManifestRejectsUnmappableRole proves the refusal is not
+// confined to the mapper: a manifest carrying an unknown role produces no
+// EpisodeManifest at all, so nothing is uploaded under a wrong role. The
+// caller must propagate the error rather than drop it.
+func TestBuildEpisodeManifestRejectsUnmappableRole(t *testing.T) {
+	mf := data.Manifest{
+		ID: "ep-unmappable",
+		Files: []data.File{
+			{Path: "cameras/front/000001.h264", Size: 1, SHA256: "a"},
+			{Path: "cameras/front/thumbnail.jpg", Size: 1, SHA256: "b", Role: "some-future-role"},
+		},
+	}
+	got, err := buildEpisodeManifest(mf)
+	if err == nil {
+		t.Fatalf("buildEpisodeManifest accepted an unmappable role and returned %v, want an error", got)
+	}
+	if got != nil {
+		t.Errorf("buildEpisodeManifest returned a manifest alongside the error: %v", got)
+	}
+	if !strings.Contains(err.Error(), "some-future-role") {
+		t.Errorf("error %q does not name the offending role", err)
+	}
+	if !strings.Contains(err.Error(), "cameras/front/thumbnail.jpg") {
+		t.Errorf("error %q does not name the offending file", err)
+	}
+}
+
+// TestUploadStreamCarriesOneEpisode pins the invariant that lets the upload
+// loop read acks without matching them.
+//
+// The wire contract requires an ack to be matched on the (episode_id, path)
+// pair, because one stream may carry chunks for several episodes and a path is
+// unique only within an episode. This client matches on nothing: it drains acks
+// for flow control and error surfacing, and takes resume offsets from
+// BeginEpisodeUpload instead. The contract's fallback for a client that cannot
+// match is to keep to one stream per episode, which is what uploadEpisode does
+// by opening its stream per manifest.
+//
+// So this test guards the assumption rather than the ack handling. Two pending
+// episodes in one pass must produce two streams, each carrying exactly one
+// episode id. If someone batches episodes onto a shared stream, this fails, and
+// the ack matching has to be built before it can pass again.
+func TestUploadStreamCarriesOneEpisode(t *testing.T) {
+	mgr, root := newTestManager(t)
+	writeFixtureEpisode(t, root, "ep-one", "", "pending", map[string][]byte{
+		"video/000001.jpg": []byte("first episode payload"),
+	})
+	writeFixtureEpisode(t, root, "ep-two", "", "pending", map[string][]byte{
+		"video/000002.jpg": []byte("second episode payload"),
+	})
+
+	srv := newFakeIngestServer()
+	client := startFakeIngest(t, srv)
+	w := newTestWorker(mgr, client)
+
+	if err := w.runPass(context.Background()); err != nil {
+		t.Fatalf("runPass: %v", err)
+	}
+
+	for _, id := range []string{"ep-one", "ep-two"} {
+		if got := uploadState(t, mgr, id).State; got != uploadStateUploaded {
+			t.Fatalf("episode %s state = %q, want uploaded", id, got)
+		}
+	}
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+
+	if len(srv.streamEpisodes) != 2 {
+		t.Fatalf("opened %d upload streams for 2 episodes, want 2", len(srv.streamEpisodes))
+	}
+	all := map[string]bool{}
+	for i, seen := range srv.streamEpisodes {
+		if len(seen) != 1 {
+			ids := make([]string, 0, len(seen))
+			for id := range seen {
+				ids = append(ids, id)
+			}
+			sort.Strings(ids)
+			t.Errorf("stream %d carried %d episodes (%v), want exactly 1; "+
+				"a multi-episode stream requires matching acks on (episode_id, path)", i, len(seen), ids)
+		}
+		for id := range seen {
+			all[id] = true
+		}
+	}
+	if !all["ep-one"] || !all["ep-two"] {
+		t.Errorf("streams carried %v, want both ep-one and ep-two", all)
 	}
 }

--- a/go/proto/gen/cloudpb/data_ingest.pb.go
+++ b/go/proto/gen/cloudpb/data_ingest.pb.go
@@ -77,10 +77,25 @@ func (EpisodeState) EnumDescriptor() ([]byte, []int) {
 // What a file is to the episode it belongs to. Mirrors the device manifest's
 // per-file `role`, one word for one thing across device, wire and catalog.
 //
-// UNSPECIFIED means CAPTURED. Devices built before this field existed never
-// set it and upload nothing but capture payload and capture metadata, so an
-// absent role has exactly the meaning it always had; readers must treat
-// UNSPECIFIED and CAPTURED identically and must never report "unknown role".
+// UNSPECIFIED carries exactly one meaning: the sender predates this field and
+// said nothing about roles. A file with no role is accounted as CAPTURED,
+// which is the meaning it carried before the field existed.
+//
+// That default is a best reading of a silent sender, not a proof about what
+// such senders produced. Derived files, including the playable remux, existed
+// on the device before the wire role did, so a manifest sealed in that window
+// can legitimately contain a derived file with no role on it.
+//
+// A sender that HAS a role but cannot express it on this enum MUST NOT send
+// UNSPECIFIED. Doing so books the file as capture payload, corrupts
+// capture-only accounting, and leaves no signal that anything was lost. Add
+// the role to this enum and send it.
+//
+// A reader that receives a role number it does not know must retain the
+// number as received, must not coerce it to CAPTURED, and must not fail the
+// episode. Carry it through storage, count its bytes in size totals, and
+// leave them out of capture-only sums. An unknown role means a newer peer,
+// not a corrupt one.
 type EpisodeFileRole int32
 
 const (
@@ -146,12 +161,29 @@ type EpisodeManifest struct {
 	// capture, a human-authored slug such as "forklift-failures". It is not an
 	// identifier minted by the cloud, and it is not unique over time; the
 	// (campaign, campaign_revision) pair is what identifies an exact plan.
+	//
+	// EMPTY when the episode has no campaign. A manual or otherwise ad-hoc
+	// capture is armed by an operator, not by a campaign file, so there is no
+	// campaign name to report; such an episode carries "manual" as its trigger
+	// reason and leaves both campaign fields empty together. This is ordinary
+	// traffic, not an edge case, so consumers must accept the empty value
+	// rather than reject or substitute it.
 	Campaign string `protobuf:"bytes,4,opt,name=campaign,proto3" json:"campaign,omitempty"`
-	// Lowercase hex SHA-256 of the canonical campaign plan, so always exactly
-	// 64 characters. The device computes it in WendyOS at
-	// go/internal/agent/data/campaign.go:219, as
-	// hex(sha256(json(campaign.planOnly()))), where planOnly() strips deployment
-	// state so only author-declared plan fields feed the digest.
+	// Revision digest of the campaign plan that armed this capture.
+	//
+	// EMPTY when the episode has no campaign, for the same reason `campaign` is
+	// empty: a manual or ad-hoc capture never had a plan to digest. Otherwise
+	// it is a lowercase hex SHA-256 and therefore exactly 64 characters. A
+	// consumer that validates 64 hex characters unconditionally will reject
+	// legitimate and common data; check the length only after finding the value
+	// non-empty.
+	//
+	// Derivation: the device serialises the campaign to canonical JSON with
+	// deployment state stripped, so that only author-declared plan fields feed
+	// the digest, and takes the lowercase hex SHA-256 of those bytes. Two
+	// devices running the same plan report the same revision. Described rather
+	// than cited by file and line: the implementation lives in another
+	// repository and any line number given here is stale on its next edit.
 	//
 	// String, not an integer: 256 bits of digest do not fit in a uint64, and no
 	// truncation of a hash preserves it as an identifier. It is a content
@@ -322,8 +354,10 @@ type EpisodeFileManifest struct {
 	TimeRangeEndNanos   int64 `protobuf:"varint,8,opt,name=time_range_end_nanos,json=timeRangeEndNanos,proto3" json:"time_range_end_nanos,omitempty"`
 	// Source-clock to canonical-clock mapping summary JSON, when present.
 	ClockMappingJson []byte `protobuf:"bytes,9,opt,name=clock_mapping_json,json=clockMappingJson,proto3" json:"clock_mapping_json,omitempty"`
-	// What this file is to the episode. Unset (UNSPECIFIED) means CAPTURED, so
-	// devices predating this field keep their existing meaning unchanged.
+	// What this file is to the episode. Unset (UNSPECIFIED) means the sender
+	// predates this field, and is accounted as CAPTURED. See EpisodeFileRole
+	// for what a sender must do with a role it cannot express, and what a
+	// reader must do with a role number it does not know.
 	Role          EpisodeFileRole `protobuf:"varint,10,opt,name=role,proto3,enum=wendycloud.data.v1.EpisodeFileRole" json:"role,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -681,8 +715,25 @@ type EpisodeChunkAck struct {
 	// persisted, then equals the file size. Never claims durability that
 	// does not exist.
 	CommittedOffset uint64 `protobuf:"varint,3,opt,name=committed_offset,json=committedOffset,proto3" json:"committed_offset,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// The episode the acknowledged path belongs to; echoes the `episode_id` of
+	// the chunk being acknowledged.
+	//
+	// A client MUST match an ack on the (episode_id, path) pair, never on path
+	// alone. EpisodeChunk carries episode_id per chunk, so one stream may carry
+	// chunks for more than one episode, and the server keys its assembler on
+	// the same pair. A path is unique only within an episode: two episodes on
+	// one stream that both contain "manifest.json" produce acks that path alone
+	// cannot tell apart, and a client matching on path credits one episode's
+	// committed offset to the other, then skips a file it never uploaded. That
+	// is silent data loss, not a retry.
+	//
+	// Added after `path`, so a server built before this field leaves it empty.
+	// A client that finds it empty cannot match safely on a multi-episode
+	// stream, and must keep to one stream per episode until the server carries
+	// the field.
+	EpisodeId     string `protobuf:"bytes,4,opt,name=episode_id,json=episodeId,proto3" json:"episode_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *EpisodeChunkAck) Reset() {
@@ -734,6 +785,13 @@ func (x *EpisodeChunkAck) GetCommittedOffset() uint64 {
 		return x.CommittedOffset
 	}
 	return 0
+}
+
+func (x *EpisodeChunkAck) GetEpisodeId() string {
+	if x != nil {
+		return x.EpisodeId
+	}
+	return ""
 }
 
 type CommitEpisodeRequest struct {
@@ -916,10 +974,20 @@ func (x *CommitEpisodeResponse) GetFiles() []*FileVerification {
 
 type QueryEpisodesRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Organization scope. With certificate-identity credentials this must
-	// match the caller's organization; with the PoC static read token it
-	// selects the organization to read (chosen debt until user auth carries
-	// org membership).
+	// Organization to read. This is a filter the caller supplies, not an
+	// identity the server verifies. With certificate-identity credentials it
+	// must match the organization on the certificate.
+	//
+	// AUTHORIZATION GAP, unresolved: the read credential today is a single
+	// shared bearer token that is scoped to no organization, and the server
+	// does NOT check that the caller is a member of the organization named
+	// here. Possession of that token therefore grants catalog read across every
+	// organization, obtained by passing a different number in this field. The
+	// field is not the defect and must not be removed, because a filter is the
+	// right shape once membership is enforced. A server-side membership check,
+	// against the caller's own credential rather than against this value, is
+	// REQUIRED before this RPC is exposed to anything but a trusted internal
+	// caller.
 	OrgId uint64 `protobuf:"varint,1,opt,name=org_id,json=orgId,proto3" json:"org_id,omitempty"`
 	// Optional filters; zero values mean "no filter".
 	AssetId                uint64       `protobuf:"varint,2,opt,name=asset_id,json=assetId,proto3" json:"asset_id,omitempty"`
@@ -1057,9 +1125,26 @@ func (x *QueryEpisodesResponse) GetEpisodes() []*Episode {
 }
 
 type GetEpisodeRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	OrgId         uint64                 `protobuf:"varint,1,opt,name=org_id,json=orgId,proto3" json:"org_id,omitempty"`
-	EpisodeId     string                 `protobuf:"bytes,2,opt,name=episode_id,json=episodeId,proto3" json:"episode_id,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Organization the named episode belongs to. Same caller-supplied filter as
+	// QueryEpisodesRequest.org_id, unverified in the same way, under the same
+	// shared read token.
+	//
+	// AUTHORIZATION GAP, sharper here than on the query: this RPC returns
+	// per-file retrieval URLs, short-lived signed object-storage URLs that read
+	// the stored bytes. Absent a membership check, the shared read token is not
+	// merely a cross-organization catalog read; it is a cross-organization
+	// data-egress capability. Name another organization's identifier here with
+	// one of its episode identifiers and the response hands back signed URLs to
+	// that organization's captured data. Those URLs are bearer capabilities in
+	// their own right: they work for anyone they are passed to, and revoking
+	// the read token afterwards does not revoke URLs already issued.
+	//
+	// The fix is authorization, not schema; the field stays. A server-side
+	// membership check is REQUIRED before this RPC is exposed to anything but a
+	// trusted internal caller.
+	OrgId         uint64 `protobuf:"varint,1,opt,name=org_id,json=orgId,proto3" json:"org_id,omitempty"`
+	EpisodeId     string `protobuf:"bytes,2,opt,name=episode_id,json=episodeId,proto3" json:"episode_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1276,7 +1361,9 @@ type EpisodeFileInfo struct {
 	// direct in local development).
 	RetrievalUrl string `protobuf:"bytes,6,opt,name=retrieval_url,json=retrievalUrl,proto3" json:"retrieval_url,omitempty"`
 	// What this file is to the episode, as recorded in the catalog. Unset
-	// (UNSPECIFIED) means CAPTURED, as on the upload manifest.
+	// (UNSPECIFIED) means the uploading sender predated the field, as on the
+	// upload manifest. A role the catalog did not recognise at write time is
+	// reported here as the number it arrived as, never rewritten to CAPTURED.
 	Role          EpisodeFileRole `protobuf:"varint,7,opt,name=role,proto3,enum=wendycloud.data.v1.EpisodeFileRole" json:"role,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1409,11 +1496,13 @@ const file_cloud_data_ingest_proto_rawDesc = "" +
 	"\x04path\x18\x02 \x01(\tR\x04path\x12\x16\n" +
 	"\x06offset\x18\x03 \x01(\x04R\x06offset\x12\x12\n" +
 	"\x04data\x18\x04 \x01(\fR\x04data\x12\x10\n" +
-	"\x03eof\x18\x05 \x01(\bR\x03eof\"y\n" +
+	"\x03eof\x18\x05 \x01(\bR\x03eof\"\x98\x01\n" +
 	"\x0fEpisodeChunkAck\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12'\n" +
 	"\x0freceived_offset\x18\x02 \x01(\x04R\x0ereceivedOffset\x12)\n" +
-	"\x10committed_offset\x18\x03 \x01(\x04R\x0fcommittedOffset\"5\n" +
+	"\x10committed_offset\x18\x03 \x01(\x04R\x0fcommittedOffset\x12\x1d\n" +
+	"\n" +
+	"episode_id\x18\x04 \x01(\tR\tepisodeId\"5\n" +
 	"\x14CommitEpisodeRequest\x12\x1d\n" +
 	"\n" +
 	"episode_id\x18\x01 \x01(\tR\tepisodeId\"\x9c\x01\n" +

--- a/go/proto/gen/cloudpb/data_ingest_grpc.pb.go
+++ b/go/proto/gen/cloudpb/data_ingest_grpc.pb.go
@@ -43,7 +43,10 @@ const (
 //  2. UploadEpisodeChunk streams file chunks (at most 1 MiB of data per
 //     chunk, sequential offsets per file, eof on the last chunk). Each
 //     chunk is acknowledged with the received (spooled) offset and the
-//     committed (durably stored in object storage) offset.
+//     committed (durably stored in object storage) offset. An ack names the
+//     (episode_id, path) it belongs to and must be matched on that pair,
+//     because one stream may carry chunks for more than one episode and a
+//     path is unique only within an episode.
 //  3. CommitEpisode verifies the SHA-256 of every stored object against
 //     the manifest and flips the catalog state to `complete`, or `failed`
 //     with per-file detail on any mismatch.
@@ -56,7 +59,13 @@ const (
 //     from the certificate identity, so an upload cannot name a tenant it
 //     does not hold a certificate for.
 //   - QueryEpisodes/GetEpisode are read RPCs for users and services; the
-//     serving implementation defines the accepted credential.
+//     serving implementation defines the accepted credential. Both carry an
+//     org_id whose membership the server does not verify today, and the read
+//     credential in use is a single shared token scoped to no organization.
+//     GetEpisode returns signed object URLs, so that combination is a
+//     cross-organization data-egress path, not just a catalog read. Read the
+//     org_id documentation on QueryEpisodesRequest and GetEpisodeRequest
+//     before exposing either RPC beyond a trusted internal caller.
 type DataIngestServiceClient interface {
 	// Registers (or re-registers) an episode upload. Idempotent.
 	BeginEpisodeUpload(ctx context.Context, in *BeginEpisodeUploadRequest, opts ...grpc.CallOption) (*BeginEpisodeUploadResponse, error)
@@ -151,7 +160,10 @@ func (c *dataIngestServiceClient) GetEpisode(ctx context.Context, in *GetEpisode
 //  2. UploadEpisodeChunk streams file chunks (at most 1 MiB of data per
 //     chunk, sequential offsets per file, eof on the last chunk). Each
 //     chunk is acknowledged with the received (spooled) offset and the
-//     committed (durably stored in object storage) offset.
+//     committed (durably stored in object storage) offset. An ack names the
+//     (episode_id, path) it belongs to and must be matched on that pair,
+//     because one stream may carry chunks for more than one episode and a
+//     path is unique only within an episode.
 //  3. CommitEpisode verifies the SHA-256 of every stored object against
 //     the manifest and flips the catalog state to `complete`, or `failed`
 //     with per-file detail on any mismatch.
@@ -164,7 +176,13 @@ func (c *dataIngestServiceClient) GetEpisode(ctx context.Context, in *GetEpisode
 //     from the certificate identity, so an upload cannot name a tenant it
 //     does not hold a certificate for.
 //   - QueryEpisodes/GetEpisode are read RPCs for users and services; the
-//     serving implementation defines the accepted credential.
+//     serving implementation defines the accepted credential. Both carry an
+//     org_id whose membership the server does not verify today, and the read
+//     credential in use is a single shared token scoped to no organization.
+//     GetEpisode returns signed object URLs, so that combination is a
+//     cross-organization data-egress path, not just a catalog read. Read the
+//     org_id documentation on QueryEpisodesRequest and GetEpisodeRequest
+//     before exposing either RPC beyond a trusted internal caller.
 type DataIngestServiceServer interface {
 	// Registers (or re-registers) an episode upload. Idempotent.
 	BeginEpisodeUpload(context.Context, *BeginEpisodeUploadRequest) (*BeginEpisodeUploadResponse, error)


### PR DESCRIPTION
Driven by the wire-contract change in `wendylabsinc/service-protos` pull request #38, commit `4c632b2`, which rewrote the `EpisodeFileRole` documentation and added `episode_id` to `EpisodeChunkAck`.

### A note on the base branch

This targets `feat/episode-file-role-wire` (pull request #1845), not `split/7-tools-and-example`. `episodeFileRole` and the `EpisodeFileRole` enum exist only on #1845; `split/7-tools-and-example` has neither the function, nor the generated type, nor the enum in its vendored proto, so this change cannot be expressed against it. #1845 already targets `split/7-tools-and-example`, so this lands there behind it. Retarget if you would rather fold it into #1845 directly.

## Problem

Two separate ways the device disagreed with the contract.

First, `episodeFileRole` mapped any role string it did not recognise to `EPISODE_FILE_ROLE_UNSPECIFIED`. The contract now gives `UNSPECIFIED` exactly one meaning, "the sender predates this field", and states that a sender holding a role it cannot express must not send it. A file with an unmapped role would be accounted as capture payload by every reader, and the same contract tells readers not to flag it, so the loss would be silent and permanent. Nothing hits this today because `derived` is the only non-empty role, which is exactly why it is worth fixing now: the trap springs on whoever adds the third role.

Second, `EpisodeChunkAck` gained `episode_id = 4`, and the contract now requires a client to match an acknowledgement on the `(episode_id, path)` pair, never on `path` alone. The vendored proto and the generated Go code predated the field, so the device could not have matched on the pair even if it wanted to.

## Cause

The old `default:` branch was a deliberate but now outdated reading: it treated an unknown role as a compatibility case, degrading to the pre-existing meaning because the enum has no "unknown" member. The contract has since ruled that reading out for senders, keeping it only for readers. `Proto/cloud/data_ingest.proto` is a hand-maintained copy rather than a submodule, so it does not move when service-protos does.

## Solution

`episodeFileRole` returns `(cloudpb.EpisodeFileRole, error)` and refuses a role it cannot map; `buildEpisodeManifest` propagates the error, naming both the file and the offending role string. Failing is the honest option here because the role string is produced by this same repository: every value comes from a `data.FileRole` constant that seal wrote, so an unknown one is a programming error on our own side, not a newer peer. It is deterministic, so retrying re-sends the same manifest. The error reaches `processEpisode` as `verifyErr`, which marks the episode failed with the reason recorded and does not spin on it. No proto value was invented.

The vendored proto is synced from `4c632b2` and `cloudpb` regenerated. The generation script removes and rewrites the whole generated tree, and the committed stubs carry a mix of protoc stamps that no single local protoc reproduces, so each file's committed stamps were restored afterwards and every package that was not meant to change was restored, following the prior art in `1f57306b1`. `git status --porcelain go/proto/gen` lists only `cloudpb/data_ingest.pb.go` and `cloudpb/data_ingest_grpc.pb.go`, and the non-comment part of that diff is the `EpisodeId` field, its getter, and the descriptor bytes.

On whether the device should now use the field: it should not, and the reasoning is written down rather than left implicit. The upload loop does not match acknowledgements at all. It reads and discards them, purely so gRPC flow control does not stall a large upload and so a server-side stream error is not lost; resume offsets come from `BeginEpisodeUpload`'s per-file `FileUploadState`, which is scoped to one episode by construction. The hazard the contract describes needs a client that keys on `path` while one stream carries several episodes, and this client keys on nothing and opens exactly one stream per episode inside `uploadEpisode`. That is the contract's own stated fallback for a client that cannot match on the pair, and it is what a server built before the field would require anyway. `TestUploadStreamCarriesOneEpisode` pins the invariant, so batching episodes onto a shared stream now fails until the pair matching is built. The test double also echoes `episode_id` on its acknowledgements, so it matches what a contract-carrying server sends.

## Verification

- `CC=/usr/bin/clang go build ./go/...` exits 0 (the `ld: ignoring duplicate libraries: '-lobjc'` warning is pre-existing).
- `CC=/usr/bin/clang go test -race ./go/internal/agent/services/... ./go/internal/agent/data/...`: 791 passed before, 793 passed after, 0 failed, 2 skipped throughout.
- `gofmt -l go/` empty; `go vet` clean on the touched packages.
- Mutation check: restoring the old `default:` branch, returning `UNSPECIFIED` with a nil error, fails both `TestEpisodeFileRoleUnmappableFails` and `TestBuildEpisodeManifestRejectsUnmappableRole`. Restoring the fix returns them to green.
