### PR TITLE
fix(agent): mint one sample identity per physical camera frame

### DIFF
--- a/go/internal/agent/services/data_camera_adapter_test.go
+++ b/go/internal/agent/services/data_camera_adapter_test.go
@@ -429,7 +429,7 @@ func TestStartOneRecordsRequestedVersusAchievedOnCollision(t *testing.T) {
 			case <-stop:
 				return
 			case <-time.After(5 * time.Millisecond):
-				existing.broadcast(testH264Frame(testRAUFrame))
+				existing.produce(testH264Frame(testRAUFrame))
 			}
 		}
 	}()
@@ -471,7 +471,7 @@ func TestDeviceHubCountsSubscriberDrops(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i := 0; i < 6; i++ {
-		hub.broadcast(&videoFrame{data: []byte{byte(i)}})
+		hub.produce(&videoFrame{data: []byte{byte(i)}})
 	}
 	if got := hub.unsubscribe(id); got != 2 {
 		t.Fatalf("drops = %d, want 2", got)

--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -339,7 +339,8 @@ type videoFrame struct {
 	// be truncated mid-IDR.
 	auAligned bool
 	// sampleID is the harness-wide identity of this sample within its source,
-	// assigned by the hub at broadcast so that EVERY consumer of the frame — an
+	// assigned by the hub in produce, once per physical frame arriving from the
+	// producer and never again for a further plane, so that EVERY consumer of the frame — an
 	// app subscribing through SensorService, the episode capture adapter, a
 	// dashboard viewer — names it identically. It is what makes an episode able
 	// to say "this is the frame the model saw". The counter is owned by the
@@ -347,7 +348,7 @@ type videoFrame struct {
 	// a producer is torn down and restarted mid-episode.
 	sampleID uint64
 	// receiptBootNanos is the agent's bracketed CLOCK_BOOTTIME receipt of this
-	// frame, taken once at broadcast so all consumers agree; the bracket
+	// frame, taken once in produce so all consumers agree; the bracket
 	// half-width is receiptUncertaintyNanos. Zero when the clock read failed.
 	receiptBootNanos        int64
 	receiptUncertaintyNanos int64
@@ -460,30 +461,69 @@ func (h *deviceHub) terminalErr() error {
 // malfunctioning or compromised device from triggering memory exhaustion.
 const maxFrameBytes = 2 * 1024 * 1024 // 2 MiB
 
-// broadcast delivers a frame to all subscribers, dropping for slow consumers.
-// Returns false when there are no subscribers left (producer should stop).
-// Late-joining subscribers receive whatever frame the producer sends next;
-// they will not see an IDR/keyframe until the next one arrives naturally (at most
-// one GOP interval away for GStreamer pipelines with key-int-max set).
+// frameTooLarge reports whether a frame exceeds what the hub is willing to
+// distribute. It is the single place the limit is applied, so the identity
+// minted in produce and the delivery done by broadcast can never disagree
+// about which frames exist.
+func frameTooLarge(frame *videoFrame) bool {
+	return len(frame.data) > maxFrameBytes
+}
+
+// produce takes one physical frame from the camera producer, stamps it with its
+// harness-wide identity and agent receipt, and delivers it. Every producer path
+// funnels through here (see the closure in runProducer), and this is the ONLY
+// place a sample identity is minted.
+//
+// Minting belongs to the arrival of a frame, not to a delivery of it. The hub
+// can deliver one physical frame on more than one plane — encoded video to
+// viewers, to the sensor subscribers a model app reads, and to episode capture;
+// and, where the producer tees it, the uncompressed capture frame to analytic
+// subscribers — and each plane is a separate broadcast call. Minting inside
+// broadcast made a single camera frame consume one identifier per plane, so the
+// encoded stream's identifiers came out [2 4 6] with no drops recorded. That
+// breaks two contracts at once: hub_loopback_binding reads a jump in sample_id
+// on a dense loopback sequence as a producer-side drop, so every frame read as
+// a drop; and the model-input ledger's sample_id is supposed to name the
+// episode index entry for the same frame, so the join returned nothing at all.
+//
+// An oversized frame is dropped here without consuming an identifier, so a gap
+// in sample_id always means a sample that existed and was lost, never one that
+// never existed.
+func (h *deviceHub) produce(frame *videoFrame) bool {
+	if frameTooLarge(frame) {
+		return true // oversized frame: drop silently, keep the hub alive
+	}
+	// Stamp the identity and receipt before the frame becomes shared: it is
+	// immutable from the moment the first subscriber can see it, and every
+	// consumer must read the same values.
+	if h.sampleSeq != nil {
+		frame.sampleID = h.sampleSeq.Add(1)
+	}
+	if before, receipt, after, err := data.CaptureReceipt(); err == nil {
+		frame.receiptBootNanos, frame.receiptUncertaintyNanos = receipt, (after-before+1)/2
+	}
+	return h.broadcast(frame)
+}
+
+// broadcast delivers an already-stamped frame to all subscribers, dropping for
+// slow consumers. Returns false when there are no subscribers left (producer
+// should stop). Late-joining subscribers receive whatever frame the producer
+// sends next; they will not see an IDR/keyframe until the next one arrives
+// naturally (at most one GOP interval away for GStreamer pipelines with
+// key-int-max set).
+//
+// This is delivery only: it mints nothing. Call produce for a frame arriving
+// from the producer, and broadcast to put an existing frame onto a further
+// plane. A second plane must never consume a second identifier for the same
+// physical frame.
 //
 // Sends are performed while holding h.mu so that runProducer cannot close
 // subscriber channels concurrently — sending on a closed channel panics. With
 // maxSubscribersPerHub = 16 and non-blocking selects, the lock is held for
 // O(16) nanoseconds, making the contention cost negligible.
 func (h *deviceHub) broadcast(frame *videoFrame) bool {
-	if len(frame.data) > maxFrameBytes {
+	if frameTooLarge(frame) {
 		return true // oversized frame: drop silently, keep the hub alive
-	}
-	// Stamp the identity and receipt before the frame becomes shared: it is
-	// immutable from the moment the first subscriber can see it, and every
-	// consumer must read the same values. An oversized frame is dropped above
-	// without consuming an identifier, so a gap in sample_id always means a
-	// sample that existed and was lost, never one that never existed.
-	if h.sampleSeq != nil {
-		frame.sampleID = h.sampleSeq.Add(1)
-	}
-	if before, receipt, after, err := data.CaptureReceipt(); err == nil {
-		frame.receiptBootNanos, frame.receiptUncertaintyNanos = receipt, (after-before+1)/2
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -1226,7 +1266,7 @@ func (s *VideoService) subscribeExistingHub(path string) (h *deviceHub, id int, 
 func (s *VideoService) runProducer(ctx context.Context, h *deviceHub, path string, req *agentpb.StreamVideoRequest) {
 	defer s.wg.Done()
 	broadcast := func(payload []byte, stamp frameTimestamp, codec agentpb.VideoCodec) bool {
-		return h.broadcast(&videoFrame{data: payload, tsNs: stamp.wallNs, codec: codec, nativeNs: stamp.nativeNs, nativeClock: stamp.nativeClock, nativeFlags: stamp.nativeFlags, sequence: stamp.sequence, sequenceValid: stamp.sequenceValid, auAligned: stamp.auAligned})
+		return h.produce(&videoFrame{data: payload, tsNs: stamp.wallNs, codec: codec, nativeNs: stamp.nativeNs, nativeClock: stamp.nativeClock, nativeFlags: stamp.nativeFlags, sequence: stamp.sequence, sequenceValid: stamp.sequenceValid, auAligned: stamp.auAligned})
 	}
 
 	// The hub key carries the source kind: network cameras key on "ip:<id>" and

--- a/go/internal/agent/services/video_service_plane_identity_test.go
+++ b/go/internal/agent/services/video_service_plane_identity_test.go
@@ -1,0 +1,86 @@
+package services
+
+import (
+	"sync/atomic"
+	"testing"
+
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+// TestASecondPlaneDeliveryConsumesNoSampleIdentity crosses the two features
+// that were, individually, both correct: the hub's per-source sample counter,
+// and the hub's willingness to deliver one physical camera frame on more than
+// one plane. The raw frame tap is the second plane in production — its
+// publishRaw hands the uncompressed capture frame to analytic subscribers as
+// its own videoFrame, through the same hub — and a per-broadcast counter made
+// each camera frame burn two identifiers, so the encoded stream came out with
+// identifiers [2 4 6] while the hub reported no drops at all.
+//
+// Two contracts break at once when that happens, and neither breaks loudly:
+//
+//   - hub_loopback_binding reads a jump in sample_id across a dense loopback
+//     sequence as a producer-side drop, so every frame reads as a drop.
+//   - the model-input ledger's sample_id is supposed to name the episode index
+//     entry for the same frame, so a join over it returns nothing.
+//
+// The regression got through because the two features were tested in files
+// that never met: the loopback and sensor tests never attach a second plane,
+// and the raw tap's tests never look at sample identities. This test is the
+// crossing. It asserts what a consumer actually relies on: with every frame
+// delivered, the encoded identifiers are dense, and the drop counter agrees.
+func TestASecondPlaneDeliveryConsumesNoSampleIdentity(t *testing.T) {
+	hub, cancel := newSampleHub(new(atomic.Uint64))
+	defer cancel()
+	subID, encoded, err := hub.subscribe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Marker bytes stand in for the two planes: the encoded frame a viewer,
+	// the sensor subscribers and episode capture read, and the second delivery
+	// of the same physical frame that the raw tap performs beside it.
+	const encodedPlane, secondPlane = byte(0xE0), byte(0x5A)
+
+	var ids []uint64
+	for i := 0; i < 3; i++ {
+		// One physical frame arriving from the producer.
+		if !hub.produce(&videoFrame{
+			data:      []byte{encodedPlane, byte(i)},
+			codec:     agentpb.VideoCodec_VIDEO_CODEC_H264,
+			auAligned: true,
+		}) {
+			t.Fatalf("frame %d: produce reported no subscribers", i)
+		}
+		// The same physical frame put onto a further plane, as its own
+		// videoFrame. This is the shape of the raw tap's publishRaw.
+		if !hub.broadcast(&videoFrame{data: []byte{secondPlane, byte(i)}}) {
+			t.Fatalf("frame %d: the second plane delivery reported no subscribers", i)
+		}
+		// Drained every round so the subscriber never falls behind: a drop
+		// here would be a legitimate reason for a gap, and this test is about
+		// gaps that have no reason at all.
+		for j := 0; j < 2; j++ {
+			frame := <-encoded
+			if frame.data[0] == encodedPlane {
+				ids = append(ids, frame.sampleID)
+			}
+		}
+	}
+
+	// Dense, one per physical frame, whatever else the hub delivered.
+	for i, id := range ids {
+		if id != uint64(i+1) {
+			t.Fatalf("encoded sample identifiers are %v, want [1 2 3]: a second plane delivery consumed an identifier, "+
+				"so every frame now reads as a producer-side drop", ids)
+		}
+	}
+	if len(ids) != 3 {
+		t.Fatalf("received %d encoded frame(s), want 3", len(ids))
+	}
+	// The corroborating half of the contract. A gap is only ever allowed to
+	// mean a sample that existed and was lost, and the hub is the thing that
+	// would have lost it.
+	if drops := hub.drops(subID); drops != 0 {
+		t.Fatalf("hub reported %d drop(s) for a subscriber that read every frame", drops)
+	}
+}

--- a/go/internal/agent/services/video_service_sensor_test.go
+++ b/go/internal/agent/services/video_service_sensor_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 // newSampleHub builds a hub with a sample counter but no producer, so a test
-// can broadcast frames by hand and inspect the identities they are stamped with.
+// can produce frames by hand and inspect the identities they are stamped with.
 func newSampleHub(seq *atomic.Uint64) (*deviceHub, context.CancelFunc) {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &deviceHub{
@@ -27,10 +27,10 @@ func newSampleHub(seq *atomic.Uint64) (*deviceHub, context.CancelFunc) {
 	}, cancel
 }
 
-// TestBroadcastAssignsMonotonicSampleIdentities is the foundation of the whole
+// TestProduceAssignsMonotonicSampleIdentities is the foundation of the whole
 // correlation: every consumer of a frame must see the same identifier for it,
-// and the identifiers must increase by one per delivered frame.
-func TestBroadcastAssignsMonotonicSampleIdentities(t *testing.T) {
+// and the identifiers must increase by one per produced frame.
+func TestProduceAssignsMonotonicSampleIdentities(t *testing.T) {
 	hub, cancel := newSampleHub(new(atomic.Uint64))
 	defer cancel()
 	_, first, err := hub.subscribe()
@@ -42,8 +42,8 @@ func TestBroadcastAssignsMonotonicSampleIdentities(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i := 0; i < 3; i++ {
-		if !hub.broadcast(&videoFrame{data: []byte{byte(i)}}) {
-			t.Fatal("broadcast reported no subscribers")
+		if !hub.produce(&videoFrame{data: []byte{byte(i)}}) {
+			t.Fatal("produce reported no subscribers")
 		}
 	}
 	for i := uint64(1); i <= 3; i++ {
@@ -70,8 +70,8 @@ func TestOversizedFrameConsumesNoSampleIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	hub.broadcast(&videoFrame{data: make([]byte, maxFrameBytes+1)})
-	hub.broadcast(&videoFrame{data: []byte{1}})
+	hub.produce(&videoFrame{data: make([]byte, maxFrameBytes+1)})
+	hub.produce(&videoFrame{data: []byte{1}})
 	frame := <-frames
 	if frame.sampleID != 1 {
 		t.Fatalf("sample id = %d, want 1: the dropped oversized frame consumed an identifier", frame.sampleID)
@@ -89,8 +89,8 @@ func TestSampleIdentitiesSurviveProducerRestart(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	hub.broadcast(&videoFrame{data: []byte{1}})
-	hub.broadcast(&videoFrame{data: []byte{2}})
+	hub.produce(&videoFrame{data: []byte{1}})
+	hub.produce(&videoFrame{data: []byte{2}})
 	<-frames
 	<-frames
 	cancel()
@@ -102,7 +102,7 @@ func TestSampleIdentitiesSurviveProducerRestart(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	restarted.broadcast(&videoFrame{data: []byte{3}})
+	restarted.produce(&videoFrame{data: []byte{3}})
 	if frame := <-restartedFrames; frame.sampleID != 3 {
 		t.Fatalf("sample id after producer restart = %d, want 3", frame.sampleID)
 	}
@@ -124,7 +124,7 @@ func TestCameraSensorSubscriptionReportsDropsPerSample(t *testing.T) {
 	subscription := &cameraSensorSubscription{hub: hub, subID: subID, frames: frames}
 	// The subscriber channel holds four frames; broadcasting six drops two.
 	for i := 0; i < 6; i++ {
-		hub.broadcast(&videoFrame{data: []byte{byte(i)}, codec: agentpb.VideoCodec_VIDEO_CODEC_H264, auAligned: true})
+		hub.produce(&videoFrame{data: []byte{byte(i)}, codec: agentpb.VideoCodec_VIDEO_CODEC_H264, auAligned: true})
 	}
 	ctx := context.Background()
 	var reported []uint64
@@ -161,7 +161,7 @@ func TestCameraSensorSamplesKeepZeroBufferFields(t *testing.T) {
 		t.Fatal(err)
 	}
 	subscription := &cameraSensorSubscription{hub: hub, subID: subID, frames: frames}
-	hub.broadcast(&videoFrame{
+	hub.produce(&videoFrame{
 		data:      []byte{0, 0, 0, 1, 0x67, 1},
 		codec:     agentpb.VideoCodec_VIDEO_CODEC_H264,
 		auAligned: true,
@@ -311,7 +311,7 @@ func TestCaptureAndModelSubscriberShareOneProducer(t *testing.T) {
 
 	const frames = 3
 	for i := 0; i < frames; i++ {
-		if !hub.broadcast(&videoFrame{
+		if !hub.produce(&videoFrame{
 			data:      []byte{0, 0, 0, 1, 0x67, byte(i)},
 			codec:     agentpb.VideoCodec_VIDEO_CODEC_H264,
 			auAligned: true,
@@ -346,7 +346,7 @@ func TestCaptureAndModelSubscriberShareOneProducer(t *testing.T) {
 
 	// One consumer leaving must not stop the producer for the other.
 	subscription.Close()
-	if !hub.broadcast(&videoFrame{data: []byte{1}, codec: agentpb.VideoCodec_VIDEO_CODEC_H264}) {
+	if !hub.produce(&videoFrame{data: []byte{1}, codec: agentpb.VideoCodec_VIDEO_CODEC_H264}) {
 		t.Fatal("the producer stopped when the model unsubscribed, starving the episode capture")
 	}
 }


### PR DESCRIPTION
Fixes finding 1 of the adversarial review of the Wendy Data Platform branches. Based on `split/7-tools-and-example`.

## Problem

The video hub minted a sample identity inside `broadcast`, once per broadcast call. That is correct only while a physical frame is delivered exactly once. It is not. The hub delivers one camera frame on more than one plane, and the raw frame tap on `main` routes uncompressed capture frames through the same `broadcast` as its own `videoFrame`. With a raw subscriber attached, each camera frame consumed two identifiers: the reviewer reproduced encoded `sample_id`s coming out `[2 4 6]` with `hub.drops(subID) == 0` throughout.

Two contracts break at once, and neither breaks loudly.

- `hub_loopback_binding.go` documents that a jump in `sample_id` across a dense loopback sequence means a producer-side drop, so every frame read as a drop.
- `data_camera_adapter.go` promises that a `sample_id` from the model-input ledger names the episode index entry for the same frame. An app recording identifiers on one plane while the episode index holds different ones for the same physical frames makes that join return nothing.

## Cause

Minting was attached to delivery rather than to arrival. Each feature is individually correct; only their crossing is wrong, and the two are tested in files that never meet (`video_raw_tap_test.go` versus the loopback and sensor tests), so nothing in the tree could observe it.

The raw tap itself is on `main` and not on this branch, so the collision cannot be staged here as written. The fix is structural and lands where the identity is minted, so the merged tree is correct without `publishRaw` being touched: it calls `broadcast`, which no longer mints.

## Solution

Split the hub's two jobs.

- `deviceHub.produce` takes a frame arriving from the camera producer, stamps it with its identity and agent receipt, and delivers it. It is the only place an identity is minted.
- `deviceHub.broadcast` is delivery only. Putting a frame onto a further plane costs no identifier.

The single producer entry point (the closure in `runProducer`, through which every capture path runs) calls `produce`. The size check both share moved into `frameTooLarge`, so an oversized frame is still dropped without consuming an identifier and a gap in `sample_id` still always means a sample that existed and was lost.

## Verification

`TestASecondPlaneDeliveryConsumesNoSampleIdentity` is the crossing the disjoint files let past: one hub with a subscriber, each physical frame produced and then delivered a second time in the shape `publishRaw` uses, asserting the encoded identifiers stay dense and the hub's drop counter agrees.

Mutation-checked: restoring the mint inside `broadcast` makes it report `[1 3 5]`, matching the reviewer's reproduction. Restored, green.

`CC=/usr/bin/clang go build ./go/...` exits 0. `CC=/usr/bin/clang go test -race ./go/internal/agent/...` is unchanged apart from the new test: the only failure is the known-environmental `TestSampleGPUFallsBackToTegrastatsForOrin` (no GPU on this Mac).
