### PR TITLE
fix(agent): a trigger during the post-seal drain starts the next Episode

### DIFF
--- a/go/internal/agent/data/example_campaign_test.go
+++ b/go/internal/agent/data/example_campaign_test.go
@@ -29,10 +29,13 @@ func TestShippedModelAppCampaignParses(t *testing.T) {
 	// episode would then hold payload bytes for only a subset of the samples
 	// the model saw, which is a weaker demonstration of the contract.
 	capture := campaign.Sources[0].Capture
+	if capture == nil {
+		t.Fatal("the camera source declares no capture block; the assertions below would pass vacuously")
+	}
 	if capture.EffectiveMode() != "continuous" {
 		t.Errorf("camera capture mode = %q, want continuous", capture.EffectiveMode())
 	}
-	if capture != nil && capture.Rate != 0 {
+	if capture.Rate != 0 {
 		t.Errorf("camera capture rate cap = %v, want none", capture.Rate)
 	}
 	if campaign.Upload.When != "always" {

--- a/go/internal/agent/data/manager.go
+++ b/go/internal/agent/data/manager.go
@@ -73,13 +73,32 @@ var (
 const AdHocEpisodeKey = ""
 
 type Manager struct {
-	mu             sync.Mutex
-	root           string
-	active         map[string]*activeEpisode
-	consensus      func(context.Context) (timesync.Consensus, error)
-	preRoll        []bufferedRecord
-	preRollBytes   int
-	preRollLost    uint64
+	mu     sync.Mutex
+	root   string
+	active map[string]*activeEpisode
+	// sealing holds episodes that have stopped capturing and are inside their
+	// post-seal drain. They still receive application records, but they no
+	// longer hold their campaign key: an episode whose cameras are already off
+	// must not make its campaign look busy to the trigger path, or a detection
+	// arriving during the drain is filed into a recording that captured
+	// nothing of it and no new episode is ever started for it. Ordering is
+	// irrelevant, so a slice is enough; a campaign can have several sealing
+	// episodes at once only if its drain outlasts its next episode.
+	sealing      []*activeEpisode
+	consensus    func(context.Context) (timesync.Consensus, error)
+	preRoll      []bufferedRecord
+	preRollBytes int
+	// preRollEvicted holds the agent receipt of every record the ring dropped
+	// while it was still inside its window, which happens only when the ring
+	// hits its byte budget. Records that simply aged out are not recorded here:
+	// they left because they were no longer pre-roll for anything, which is the
+	// ring working, not losing.
+	//
+	// Timestamps rather than a counter, because an episode's pre_roll_lost is
+	// supposed to name what THAT episode's window lost. A cumulative counter
+	// reported every episode's number as the agent's total since boot, which
+	// grows forever and is never that episode's loss.
+	preRollEvicted []int64
 	downloads      map[string]int
 	sourceProvider func(context.Context) []Source
 	appObserver    func(string, ApplicationRecord)
@@ -215,12 +234,17 @@ type activeEpisode struct {
 	// capturesApplications reports whether the applications source was
 	// selected; episodes that excluded it receive no application records.
 	capturesApplications bool
-	// drain is how long this episode stays in m.active after its capture
+	// drain is how long this episode stays open for records after its capture
 	// adapters have stopped, so that a record an application writes about the
 	// samples it just read is still filed into this episode instead of the
 	// next one. Zero or less means no drain, and it is honoured only for
 	// episodes that capture applications.
 	drain time.Duration
+	// draining reports that the episode has left m.active for m.sealing: its
+	// capture adapters have stopped, it still accepts application records for
+	// the rest of its drain, and it no longer holds its campaign key. Written
+	// and read under m.mu.
+	draining bool
 	// modelInputs is the append handle for the model-input ledger, opened on
 	// the first sample a model consumed (see openModelInputLedger). It is not
 	// fsynced per sample: at sensor rates that would dominate the write path,
@@ -472,7 +496,7 @@ func (m *Manager) Start(opts StartOptions) (Manifest, error) {
 		}
 	}
 	if capturesApplications {
-		manifest.PreRollLost = m.preRollLost
+		manifest.PreRollLost = m.preRollLostInWindowLocked(origin, opts.PreRollDuration)
 		preRollCount, earliestPreRoll, err := m.flushPreRoll(dir, origin, opts.PreRollDuration)
 		if err != nil {
 			_ = os.RemoveAll(dir)
@@ -543,9 +567,16 @@ func (m *Manager) ActiveSession(key string) (CaptureSession, bool) {
 	return CaptureSession{ID: a.manifest.ID, Directory: a.dir, RequestBootNanos: a.manifest.RequestBootNanos, BootID: a.manifest.BootID}, true
 }
 
-// ActiveEpisodeKeys returns the sorted concurrency keys of active episodes.
-// AdHocEpisodeKey marks a campaign-less episode; every other key is a
-// campaign name.
+// ActiveEpisodeKeys returns the sorted concurrency keys of episodes that are
+// still capturing. AdHocEpisodeKey marks a campaign-less episode; every other
+// key is a campaign name.
+//
+// An episode inside its post-seal drain is deliberately absent: it holds no key
+// any more, its capture adapters have stopped, and the next episode for that
+// campaign may start while it is still accepting late records. Callers that
+// mean "is this campaign busy" want exactly this list; callers that mean "which
+// episodes can still receive a record" want the drain window as well, and that
+// question is answered inside RecordApplication rather than here.
 func (m *Manager) ActiveEpisodeKeys() []string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -594,29 +625,40 @@ func (m *Manager) ApplyCaptureResults(key string, results []CaptureResult) error
 	return writeManifest(a.dir, a.manifest)
 }
 
-// Interrupt finalizes an active episode after adapter startup failed. Existing
-// monotonic data is retained for auditability and is never silently deleted.
-// An interrupted episode drains for late application records exactly as a
-// stopped one does: the records an application still owes are no less its own
-// for the episode having ended badly.
+// Interrupt finalizes an active episode that ended badly. Existing monotonic
+// data is retained for auditability and is never silently deleted. An
+// interrupted episode drains for late application records exactly as a stopped
+// one does: the records an application still owes are no less its own for the
+// episode having ended badly.
 func (m *Manager) Interrupt(key, reason string) (Manifest, error) {
-	m.mu.Lock()
-	a := m.active[key]
-	if a == nil {
-		m.mu.Unlock()
-		return Manifest{}, ErrNoActiveEpisode
+	return m.interrupt(key, reason, true)
+}
+
+// InterruptWithoutDrain finalizes an episode that never began capturing, and
+// returns immediately instead of serving its post-seal drain.
+//
+// The drain buys exactly one thing: time for an application to file a record
+// about the samples it read from this episode. An episode whose capture
+// adapters failed to start delivered no samples to anyone, so there is no such
+// record outstanding and nothing to wait for. Paying the drain there is pure
+// latency on a failing path, and the caller holds its own start/stop lock
+// across it, so a flapping camera would stall every other start and stop on the
+// device for one drain per attempt.
+//
+// Use this only where the absence of delivered samples is certain. Any episode
+// that captured, however briefly, must go through Interrupt.
+func (m *Manager) InterruptWithoutDrain(key, reason string) (Manifest, error) {
+	return m.interrupt(key, reason, false)
+}
+
+func (m *Manager) interrupt(key, reason string, drain bool) (Manifest, error) {
+	a, err := m.beginSeal(key, drain)
+	if err != nil {
+		return Manifest{}, err
 	}
-	if a.cancel != nil {
-		a.cancel()
-	}
-	m.mu.Unlock()
-	if a.done != nil {
-		<-a.done
-	}
-	m.drainSeal(a)
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if m.active[key] != a {
+	if !m.stillOpenLocked(a) {
 		return Manifest{}, ErrNoActiveEpisode
 	}
 	return m.finalizeLocked(a, "interrupted", reason)
@@ -816,10 +858,13 @@ func (m *Manager) RecordApplication(appID string, record ApplicationRecord) (str
 		stamp = record.ClientBootNanos
 	}
 	stored := storedApplicationRecord{ApplicationRecord: record, AppID: appID, AgentReceiptBootNanos: receipt, ClientTimestampAccepted: accepted, TimestampUncertaintyNanos: (after - before + 1) / 2}
-	// Every active episode that selected the applications source receives the
-	// record on its own timeline; episodes that excluded it are skipped.
+	// Every open episode that selected the applications source receives the
+	// record on its own timeline; episodes that excluded it are skipped. Open
+	// means capturing OR inside its post-seal drain: the drain exists precisely
+	// so a record written about the samples an episode just produced still
+	// reaches it, and an episode in that window has left m.active for m.sealing.
 	recorded := false
-	for _, a := range m.active {
+	for _, a := range m.openEpisodesLocked() {
 		if !a.capturesApplications {
 			continue
 		}
@@ -866,13 +911,49 @@ func (m *Manager) RecordApplication(appID string, record ApplicationRecord) (str
 // is always the oldest arrival and dropping from the front is provably correct.
 // Measuring the client-supplied stamp instead let one forward-dated entry sit at
 // the head and hold back the eviction of genuinely older entries behind it.
+// Only a record dropped while still inside its window is a loss, and the two
+// reasons are therefore counted apart: an entry that aged out is no longer
+// pre-roll for any episode that could start now, so its departure costs nobody
+// anything, while an entry evicted by the byte budget WOULD have reached the
+// next episode and did not.
 func (m *Manager) evictPreRoll(now int64) {
 	cutoff := now - preRollWindow.Nanoseconds()
 	for len(m.preRoll) > 0 && (m.preRoll[0].receiptNanos < cutoff || m.preRollBytes > preRollLimit) {
+		if m.preRoll[0].receiptNanos >= cutoff {
+			m.preRollEvicted = append(m.preRollEvicted, m.preRoll[0].receiptNanos)
+		}
 		m.preRollBytes -= len(m.preRoll[0].encoded)
 		m.preRoll = m.preRoll[1:]
-		m.preRollLost++
 	}
+	// The eviction log is itself a pre-roll window's worth of history: an
+	// eviction older than the widest window an episode can ask for can no
+	// longer be any episode's loss, so it is forgotten rather than accumulated.
+	kept := m.preRollEvicted[:0]
+	for _, receipt := range m.preRollEvicted {
+		if receipt >= cutoff {
+			kept = append(kept, receipt)
+		}
+	}
+	m.preRollEvicted = kept
+}
+
+// preRollLostInWindowLocked counts the records the ring dropped, while they
+// were still inside their window, that would have reached an episode starting
+// at origin with the requested pre-roll depth. This is what an episode's
+// pre_roll_lost has always claimed to mean.
+func (m *Manager) preRollLostInWindowLocked(origin int64, requested time.Duration) uint64 {
+	window := preRollWindow
+	if requested > 0 && requested < window {
+		window = requested
+	}
+	cutoff := origin - window.Nanoseconds()
+	var lost uint64
+	for _, receipt := range m.preRollEvicted {
+		if receipt >= cutoff && receipt <= origin {
+			lost++
+		}
+	}
+	return lost
 }
 
 // flushPreRoll copies the buffered records inside the requested window into a
@@ -936,33 +1017,56 @@ func abs64(v int64) int64 {
 	return v
 }
 
-// drainSeal holds an episode open for late application records after its
-// capture adapters have stopped and before it is finalized. It must be called
-// with m.mu released: the whole point is that RecordApplication proceeds
-// normally throughout, so records written about the samples the episode just
-// produced are still filed into that episode. Episodes that do not capture
-// applications have nothing to wait for and never sleep.
-func (m *Manager) drainSeal(a *activeEpisode) {
-	if a.capturesApplications && a.drain > 0 {
-		time.Sleep(a.drain)
+// openEpisodesLocked returns every episode that can still receive a record:
+// the capturing ones in m.active and the ones serving a post-seal drain in
+// m.sealing. Callers hold m.mu.
+func (m *Manager) openEpisodesLocked() []*activeEpisode {
+	open := make([]*activeEpisode, 0, len(m.active)+len(m.sealing))
+	for _, a := range m.active {
+		open = append(open, a)
 	}
+	return append(open, m.sealing...)
 }
 
-// Stop finalizes the episode keyed by the given campaign name
-// (AdHocEpisodeKey for campaign-less episodes).
+// wantsDrain reports whether this episode has a post-seal drain to serve.
+// Episodes that do not capture applications have nothing to wait for.
+func (a *activeEpisode) wantsDrain() bool {
+	return a.capturesApplications && a.drain > 0
+}
+
+// beginSeal ends capture for the episode keyed by key and serves its post-seal
+// drain, returning the episode ready to be finalized. It is the shared front
+// half of Stop and Interrupt.
 //
-// For an episode that captures applications the window for application records
-// does not close when the capture adapters do: the episode stays in m.active
-// for its configured drain (see drainSeal) so an application that scores
-// asynchronously can still file its verdict here. StoppedEpisodeNS is stamped
-// in finalizeLocked, after the drain, so records that arrive during the drain
-// carry an EpisodeNanos below it exactly as live ones do.
-func (m *Manager) Stop(key string) (Manifest, error) {
+// The drain exists so that a record an application writes about the samples it
+// has just read still lands in the episode those samples came from, so
+// RecordApplication has to proceed normally throughout and the sleep is
+// therefore taken with m.mu released.
+//
+// The campaign key is released BEFORE the sleep, not after. A draining episode
+// is no longer capturing: its cameras are off and its adapters have stopped.
+// Leaving it in m.active for the drain made its campaign look busy to the
+// trigger path, which skips any campaign named in ActiveEpisodeKeys, so a
+// matching record arriving inside the window was dropped outright -- not
+// queued, not delayed. With DefaultSealDrain at two seconds and every campaign
+// paying it (campaign plans always select the applications source), a second
+// person walking in within two seconds of the previous episode produced no
+// recording at all, while the detection itself was filed into the episode whose
+// cameras had already stopped. An event with no video is the exact failure this
+// platform exists to prevent.
+//
+// Moving the episode to m.sealing rather than merely flagging it keeps
+// Manager.Start's "one episode per key" rule doing the work it already does:
+// the key is genuinely free, so the next episode is admitted, and there is
+// still no way to have two capturing episodes for one campaign.
+// drain false skips the wait entirely; see InterruptWithoutDrain for the one
+// caller that may.
+func (m *Manager) beginSeal(key string, drain bool) (*activeEpisode, error) {
 	m.mu.Lock()
 	a := m.active[key]
 	if a == nil {
 		m.mu.Unlock()
-		return Manifest{}, ErrNoActiveEpisode
+		return nil, ErrNoActiveEpisode
 	}
 	if a.cancel != nil {
 		a.cancel()
@@ -971,10 +1075,56 @@ func (m *Manager) Stop(key string) (Manifest, error) {
 	if a.done != nil {
 		<-a.done
 	}
-	m.drainSeal(a)
+	if !drain || !a.wantsDrain() {
+		return a, nil
+	}
+	m.mu.Lock()
+	if m.active[key] != a {
+		m.mu.Unlock()
+		return nil, ErrNoActiveEpisode
+	}
+	delete(m.active, key)
+	a.draining = true
+	m.sealing = append(m.sealing, a)
+	m.mu.Unlock()
+	time.Sleep(a.drain)
+	return a, nil
+}
+
+// stillOpenLocked reports whether an episode returned by beginSeal is still the
+// manager's to finalize, which is the post-drain half of the identity check
+// Stop and Interrupt have always made.
+func (m *Manager) stillOpenLocked(a *activeEpisode) bool {
+	if !a.draining {
+		return m.active[a.key] == a
+	}
+	for _, sealing := range m.sealing {
+		if sealing == a {
+			return true
+		}
+	}
+	return false
+}
+
+// Stop finalizes the episode keyed by the given campaign name
+// (AdHocEpisodeKey for campaign-less episodes).
+//
+// For an episode that captures applications the window for application records
+// does not close when the capture adapters do: the episode stays open for its
+// configured drain (see beginSeal) so an application that scores asynchronously
+// can still file its verdict here. It gives up its campaign key as it enters
+// that window, so the campaign can start its next episode immediately.
+// StoppedEpisodeNS is stamped in finalizeLocked, after the drain, so records
+// that arrive during the drain carry an EpisodeNanos below it exactly as live
+// ones do.
+func (m *Manager) Stop(key string) (Manifest, error) {
+	a, err := m.beginSeal(key, true)
+	if err != nil {
+		return Manifest{}, err
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if m.active[key] != a {
+	if !m.stillOpenLocked(a) {
 		return Manifest{}, ErrNoActiveEpisode
 	}
 	return m.finalizeLocked(a, "complete", "")
@@ -1024,8 +1174,25 @@ func (m *Manager) finalizeLocked(a *activeEpisode, state, reason string) (Manife
 	if err := os.Rename(a.dir, final); err != nil {
 		return Manifest{}, err
 	}
-	delete(m.active, a.key)
+	m.forgetLocked(a)
 	return a.manifest, nil
+}
+
+// forgetLocked drops a finalized episode from whichever collection holds it:
+// m.active while it was capturing, m.sealing once it entered its drain and gave
+// up its campaign key.
+func (m *Manager) forgetLocked(a *activeEpisode) {
+	if !a.draining {
+		delete(m.active, a.key)
+		return
+	}
+	for i, sealing := range m.sealing {
+		if sealing != a {
+			continue
+		}
+		m.sealing = append(m.sealing[:i], m.sealing[i+1:]...)
+		return
+	}
 }
 
 // Status reports one active episode for status displays: the ad-hoc episode

--- a/go/internal/agent/data/model.go
+++ b/go/internal/agent/data/model.go
@@ -285,9 +285,14 @@ type Manifest struct {
 	Upload            WorkflowState           `json:"upload"`
 	Labeling          WorkflowState           `json:"labeling"`
 	RecoveryActions   []string                `json:"recovery_actions,omitempty"`
-	PreRollLost       uint64                  `json:"pre_roll_lost"`
-	PreRollAccounting string                  `json:"pre_roll_accounting"`
-	ModelIO           ModelIO                 `json:"model_io"`
+	// PreRollLost counts the application records that would have reached THIS
+	// episode's pre-roll window and did not, because the ring buffer hit its
+	// byte budget and dropped them while they were still inside their window.
+	// Records that merely aged out of the ring are not counted: they were no
+	// longer pre-roll for anything, so nothing was lost.
+	PreRollLost       uint64  `json:"pre_roll_lost"`
+	PreRollAccounting string  `json:"pre_roll_accounting"`
+	ModelIO           ModelIO `json:"model_io"`
 }
 
 type StartOptions struct {

--- a/go/internal/agent/data/model_io.go
+++ b/go/internal/agent/data/model_io.go
@@ -52,7 +52,10 @@ func (m *Manager) RecordModelInput(input ModelInput) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	var errs []error
-	for _, a := range m.active {
+	// Episodes inside their post-seal drain are included: they are still open
+	// for records, and before the drain gave up its campaign key they were
+	// literally in m.active, so this keeps the ledger's contents unchanged.
+	for _, a := range m.openEpisodesLocked() {
 		// The summary counters are folded into the in-memory manifest and
 		// written when the episode is sealed, exactly like the per-source
 		// capture counters: rewriting manifest.json once per sample would mean

--- a/go/internal/agent/data/seal_drain_test.go
+++ b/go/internal/agent/data/seal_drain_test.go
@@ -497,3 +497,84 @@ func containsName(names []string, want string) bool {
 	}
 	return false
 }
+
+// TestPreRollLostIsThisEpisodesLossNotTheAgentsTotal pins the meaning of the
+// manifest's pre_roll_lost.
+//
+// The field was set from a counter that ran for the manager's whole lifetime
+// and was never reset, so every episode published the agent's running total
+// since start as its own loss. It also counted entries that simply aged out of
+// the five minute ring, which are not losses at all: an entry past the window
+// is no longer pre-roll for any episode that could start now. A status field
+// that lies is worse than no status field, and this one lied twice.
+func TestPreRollLostIsThisEpisodesLossNotTheAgentsTotal(t *testing.T) {
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	now, err := readBootTime()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// One record that aged out of the ring long ago, and one dropped by the
+	// byte budget while it was still inside its window. Only the second is a
+	// loss, and only for an episode whose window covers it.
+	aged := now - (10 * time.Minute).Nanoseconds()
+	budgeted := now - time.Second.Nanoseconds()
+	// One pass per reason, so each is attributed on its own. First the entry
+	// that is simply past the window: it is pre-roll for nobody and its
+	// departure costs nothing.
+	m.preRoll = []bufferedRecord{{bootNanos: aged, receiptNanos: aged, encoded: []byte(`{"name":"aged-out"}`)}}
+	m.preRollBytes = len(m.preRoll[0].encoded)
+	m.evictPreRoll(now)
+	if len(m.preRollEvicted) != 0 {
+		t.Fatalf("an entry that aged out was counted as a loss: %v", m.preRollEvicted)
+	}
+	// Then the entry the byte budget takes while it is still inside its
+	// window. That one WOULD have reached the next episode and did not.
+	m.preRoll = []bufferedRecord{{bootNanos: budgeted, receiptNanos: budgeted, encoded: []byte(`{"name":"budget-evicted"}`)}}
+	m.preRollBytes = preRollLimit + 1
+	m.evictPreRoll(now)
+	m.preRollBytes = 0
+
+	if len(m.preRollEvicted) != 1 {
+		t.Fatalf("recorded %d in-window eviction(s), want exactly the one the byte budget dropped", len(m.preRollEvicted))
+	}
+
+	started, err := m.Start(StartOptions{Sources: []string{"applications"}, DrainDuration: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = m.Stop(AdHocEpisodeKey); err != nil {
+		t.Fatal(err)
+	}
+	manifest, _, err := m.Inspect(started.ID, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifest.PreRollLost != 1 {
+		t.Fatalf("pre_roll_lost = %d, want 1: the aged-out entry was never this episode's to lose", manifest.PreRollLost)
+	}
+
+	// A second episode must not inherit the first one's number. Nothing has
+	// been lost since, so its own loss is zero.
+	second, err := m.Start(StartOptions{
+		Sources:         []string{"applications"},
+		PreRollDuration: 100 * time.Millisecond,
+		DrainDuration:   0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = m.Stop(AdHocEpisodeKey); err != nil {
+		t.Fatal(err)
+	}
+	secondManifest, _, err := m.Inspect(second.ID, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secondManifest.PreRollLost != 0 {
+		t.Fatalf("second episode's pre_roll_lost = %d, want 0: its 100ms window does not reach the eviction a second before it, "+
+			"and the first episode's loss is not its own", secondManifest.PreRollLost)
+	}
+}

--- a/go/internal/agent/services/data_service.go
+++ b/go/internal/agent/services/data_service.go
@@ -175,7 +175,16 @@ func (s *DataService) startCapture(ctx context.Context, opts data.StartOptions) 
 		if applyErr := s.manager.ApplyCaptureResults(key, results); applyErr != nil {
 			s.manager.Warnf("recording capture results for episode key %q after a failed adapter start: %v", key, applyErr)
 		}
-		_, _ = s.manager.Interrupt(key, "capture_adapter_start_failed")
+		// Without the drain, deliberately. captureMu has been held since the top
+		// of this function and is what serialises every start and stop on the
+		// device, so a drain taken here is charged to every other caller: with
+		// the default two second drain a Start whose adapter errors took two
+		// seconds to return FailedPrecondition, and with capture.drain: 30s a
+		// flapping camera stalled the data service for thirty seconds per
+		// attempt. Nothing on this path needs the wait either: the adapters
+		// never started, so no application ever read a sample from this episode
+		// and no record about it can be outstanding.
+		_, _ = s.manager.InterruptWithoutDrain(key, "capture_adapter_start_failed")
 		return nil, status.Error(codes.FailedPrecondition, fmt.Sprintf("starting capture adapter: %v", startErr))
 	}
 	s.activeCaptures[key] = captures
@@ -384,8 +393,14 @@ func (s *DataService) triggerCampaign(ctx context.Context, campaign data.Campaig
 }
 
 func (s *DataService) observeApplicationRecord(_ string, record data.ApplicationRecord) {
-	// Triggers are dropped only for campaigns that already have an active
-	// episode; other campaigns (and ad-hoc recordings) capture independently.
+	// Triggers are dropped only for campaigns that are still CAPTURING; other
+	// campaigns (and ad-hoc recordings) capture independently. A campaign whose
+	// previous episode is inside its post-seal drain is not capturing, and
+	// ActiveEpisodeKeys no longer names it, so a record that matches during the
+	// drain starts the next episode instead of being dropped. That episode
+	// still has to wait for captureMu, which the stopping episode holds until
+	// its drain ends, so it begins up to one capture.drain late rather than not
+	// at all -- documented for operators in the data command reference.
 	activeKeys := map[string]bool{}
 	for _, key := range s.manager.ActiveEpisodeKeys() {
 		activeKeys[key] = true

--- a/go/internal/agent/services/data_service_seal_drain_test.go
+++ b/go/internal/agent/services/data_service_seal_drain_test.go
@@ -1,0 +1,278 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/data"
+	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
+)
+
+// TestTriggerDuringThePostSealDrainStartsTheNextEpisode pins the campaign
+// blind window closed.
+//
+// The trigger path skips any campaign named in ActiveEpisodeKeys, and the
+// post-seal drain used to keep the sealing episode in that list for its whole
+// window. A matching record arriving in that window was therefore dropped with
+// a bare continue: not queued, not delayed, lost. Every campaign pays a drain
+// (a campaign plan always selects the applications source) and the default is
+// two seconds, so a second person walking into frame within two seconds of the
+// previous episode produced no recording at all, while the detection itself was
+// filed into the episode whose cameras had already stopped. An event with no
+// video is precisely the failure this platform exists to prevent.
+//
+// This test deliberately declares NO capture.drain, so it runs against the two
+// second default rather than against the drain: 0s that every other campaign
+// test in this package opts into. That opt-out is how the defect survived
+// review in the first place: the default's interaction with the trigger path
+// was untested by construction. The cost is that this test takes about four
+// seconds; the default is the configuration that ships, so it is worth it.
+func TestTriggerDuringThePostSealDrainStartsTheNextEpisode(t *testing.T) {
+	manager, err := data.NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := NewDataService(manager)
+	yaml := []byte(`version: 1
+name: doorway
+sources:
+  - telemetry: true
+capture:
+  buffer: 1s
+  after_trigger: 30ms
+  triggers:
+    - event: person_detected
+upload: {when: wifi, destination: example-episodes}
+export: {annotation: cvat}
+`)
+	if _, err = service.CampaignDeploy(context.Background(), &agentpbv2.DataCampaignDeployRequest{CampaignYaml: yaml}); err != nil {
+		t.Fatal(err)
+	}
+	campaigns, err := manager.Campaigns()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The premise, checked rather than assumed: this campaign really is on the
+	// default drain, so the window under test is the shipped one.
+	if len(campaigns) != 1 || campaigns[0].DrainDuration() != data.DefaultSealDrain {
+		t.Fatalf("campaign drain = %v, want the %s default", campaigns, data.DefaultSealDrain)
+	}
+
+	record := func(name string) {
+		t.Helper()
+		if _, recordErr := manager.RecordApplication("test.app", data.ApplicationRecord{
+			Version: 1, Type: "event", Name: name,
+		}); recordErr != nil {
+			t.Fatal(recordErr)
+		}
+	}
+
+	// First person through the door.
+	record("person_detected")
+	// Second person, 300ms later. after_trigger is 30ms, so by now the first
+	// episode has stopped capturing and is somewhere inside its two second
+	// drain. The wait is a plain sleep on purpose: gating on anything the
+	// manager reports about the sealing episode would make the test's own
+	// timing depend on the behaviour it is checking.
+	time.Sleep(300 * time.Millisecond)
+	record("person_detected")
+
+	// Both events must produce a recording. The second episode cannot begin
+	// until the first has finished draining, because the data service holds
+	// captureMu across the stop, so allow for two full drains plus slack.
+	episodes := waitForFinalizedEpisodesBy(t, manager, 2, 4*data.DefaultSealDrain+5*time.Second)
+	if len(episodes) != 2 {
+		t.Fatalf("episodes = %d, want 2: a detection inside the post-seal drain produced no recording", len(episodes))
+	}
+	for _, episode := range episodes {
+		manifest, _, inspectErr := manager.Inspect(episode.ID, false)
+		if inspectErr != nil {
+			t.Fatal(inspectErr)
+		}
+		if manifest.Trigger.CampaignName != "doorway" || manifest.Trigger.Reason != "event:person_detected" {
+			t.Fatalf("episode %s has trigger %+v", episode.ID, manifest.Trigger)
+		}
+	}
+}
+
+// TestDrainingEpisodeReleasesItsCampaignKey is the fast, direct statement of
+// the same rule at the manager boundary: an episode inside its drain still
+// accepts records, and no longer holds its campaign key, so the campaign can
+// start its next episode. Both halves matter — releasing the key by sealing
+// early would close the window the drain exists for.
+func TestDrainingEpisodeReleasesItsCampaignKey(t *testing.T) {
+	manager, err := data.NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	const key = "doorway"
+	first, err := manager.Start(data.StartOptions{
+		Sources:       []string{"applications"},
+		DrainDuration: 2 * time.Second,
+		Trigger:       data.EpisodeTrigger{CampaignName: key, Reason: "event:person_detected"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stopped := make(chan error, 1)
+	go func() {
+		_, stopErr := manager.Stop(key)
+		stopped <- stopErr
+	}()
+
+	// Wait for the campaign key to come free. On its own that says nothing:
+	// the key also comes free when the episode finally seals. What separates
+	// the two is what happens NEXT, so the moment the key is free the episode
+	// is asked to prove it is still open. Fixed, the key is released as the
+	// drain begins and the record lands in the draining episode; unfixed, the
+	// key stays held for the whole drain and by the time it is free the
+	// episode is sealed and the record can only be buffered.
+	deadline := time.Now().Add(30 * time.Second)
+	for len(manager.ActiveEpisodeKeys()) != 0 && time.Now().Before(deadline) {
+		time.Sleep(2 * time.Millisecond)
+	}
+	if len(manager.ActiveEpisodeKeys()) != 0 {
+		t.Fatal("the episode never released its campaign key")
+	}
+	state, err := manager.RecordApplication("com.example.scorer", data.ApplicationRecord{
+		Version: 1, Type: "prediction", Name: "late-verdict", Model: "detector",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state != "recorded" {
+		t.Fatalf("with the campaign key free, a record's state is %q, want recorded: the key was only released "+
+			"once the episode had sealed, so a trigger matching during the drain had nothing to start and nothing to join",
+			state)
+	}
+
+	// The key really is free: the campaign's next episode starts while the
+	// previous one is still draining.
+	next, err := manager.Start(data.StartOptions{
+		Sources:       []string{"applications"},
+		DrainDuration: 0,
+		Trigger:       data.EpisodeTrigger{CampaignName: key, Reason: "event:person_detected"},
+	})
+	if err != nil {
+		t.Fatalf("starting the campaign's next episode during the previous drain: %v", err)
+	}
+	if next.ID == first.ID {
+		t.Fatal("the second episode reused the first episode's identity")
+	}
+	if err = <-stopped; err != nil {
+		t.Fatalf("the first episode failed to seal after its key was released: %v", err)
+	}
+	if _, err = manager.Stop(key); err != nil {
+		t.Fatal(err)
+	}
+	list, err := manager.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("finalized %d episode(s), want 2", len(list))
+	}
+	// The late verdict belongs to the episode whose samples it scored, not to
+	// the one that started after it.
+	firstManifest, _, err := manager.Inspect(first.ID, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, source := range firstManifest.Sources {
+		if source.Source.ID == "applications" && source.Count == 0 {
+			t.Fatal("the draining episode recorded no application records; the drain stopped doing its job")
+		}
+	}
+}
+
+// failingDataAdapter refuses to start, the way a camera adapter does when the
+// device is unplugged mid-flap.
+type failingDataAdapter struct{}
+
+func (failingDataAdapter) Discover(context.Context) []data.Source { return nil }
+
+func (failingDataAdapter) Start(context.Context, data.CaptureSession, []data.Source) (runningDataCapture, error) {
+	return nil, errors.New("camera busy")
+}
+
+// TestFailedAdapterStartDoesNotPayTheSealDrain pins the latency of the failing
+// start path.
+//
+// startCapture holds captureMu, the lock that serialises every start and stop
+// on the device, from its first line to its last. Finalizing the episode
+// through the draining Interrupt therefore charged the whole drain to every
+// other caller: a Start whose adapter errored took the full drain to return
+// FailedPrecondition, so a flapping camera with capture.drain: 30s stalled the
+// data service for thirty seconds per attempt. The drain buys time for an
+// application to file a record about samples it read from the episode, and an
+// episode whose adapters never started delivered no samples to anybody, so
+// there was never anything to wait for.
+func TestFailedAdapterStartDoesNotPayTheSealDrain(t *testing.T) {
+	manager, err := data.NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := NewDataService(manager)
+	service.addAdapter(failingDataAdapter{})
+	// Long enough that paying it could not be mistaken for scheduling noise,
+	// and long enough that the test fails fast rather than merely slowly.
+	service.adHocDrain = 10 * time.Second
+
+	begin := time.Now()
+	_, err = service.Start(context.Background(), &agentpbv2.DataStartRequest{Sources: []string{"applications"}})
+	elapsed := time.Since(begin)
+	if code := status.Code(err); code != codes.FailedPrecondition {
+		t.Fatalf("Start returned %v (code %s), want FailedPrecondition", err, code)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("a failed adapter start took %s to return, holding captureMu throughout; it must not pay the %s drain",
+			elapsed, service.adHocDrain)
+	}
+
+	// Skipping the drain must not skip the seal: the episode is finalized and
+	// its monotonic data retained, exactly as an interrupted episode always is.
+	list, err := manager.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("finalized %d episode(s), want the interrupted one", len(list))
+	}
+	manifest, _, err := manager.Inspect(list[0].ID, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifest.State != "interrupted" || manifest.Interruption != "capture_adapter_start_failed" {
+		t.Fatalf("episode state=%q interruption=%q, want interrupted/capture_adapter_start_failed",
+			manifest.State, manifest.Interruption)
+	}
+	// And the lock really is free again for the next caller.
+	if len(manager.ActiveEpisodeKeys()) != 0 {
+		t.Fatalf("episode keys still held after the failed start: %v", manager.ActiveEpisodeKeys())
+	}
+}
+
+// waitForFinalizedEpisodesBy is waitForFinalizedEpisodes with the deadline
+// spelled out, for tests that run against the default drain rather than
+// opting out of it.
+func waitForFinalizedEpisodesBy(t *testing.T, manager *data.Manager, want int, within time.Duration) []data.EpisodeInfo {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		list, err := manager.List()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(list) >= want && len(manager.ActiveEpisodeKeys()) == 0 {
+			return list
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out after %s waiting for %d finalized episodes", within, want)
+	return nil
+}

--- a/go/internal/agent/services/data_service_test.go
+++ b/go/internal/agent/services/data_service_test.go
@@ -313,13 +313,11 @@ func TestAdHocEpisodesCarryTheDefaultSealDrain(t *testing.T) {
 		t.Fatal(err)
 	}
 	service := NewDataService(manager)
-	if service.adHocDrain != data.DefaultSealDrain {
-		t.Fatalf("ad-hoc drain = %s, want the %s default", service.adHocDrain, data.DefaultSealDrain)
-	}
-	// Shortened so the assertion below costs a fifth of a second rather than
-	// the full default. What is under test is that the value reaches the
-	// episode at all.
-	service.adHocDrain = 200 * time.Millisecond
+
+	// The default, measured rather than restated. Comparing service.adHocDrain
+	// against data.DefaultSealDrain only reads the constructor back to itself:
+	// it cannot tell whether the value reaches the episode, which is the whole
+	// claim. Stopping an untouched ad-hoc episode can.
 	if _, err = service.Start(context.Background(), &agentpbv2.DataStartRequest{Sources: []string{"applications"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -327,7 +325,28 @@ func TestAdHocEpisodesCarryTheDefaultSealDrain(t *testing.T) {
 	if _, err = service.Stop(context.Background(), &agentpbv2.DataStopRequest{}); err != nil {
 		t.Fatal(err)
 	}
-	if elapsed := time.Since(begin); elapsed < 150*time.Millisecond {
+	// Slack below the default absorbs timer granularity without admitting a
+	// drain that was skipped or halved.
+	if elapsed := time.Since(begin); elapsed < data.DefaultSealDrain-200*time.Millisecond {
+		t.Fatalf("an ad-hoc Stop returned after %s; a `wendy data record` episode must serve the %s default drain",
+			elapsed, data.DefaultSealDrain)
+	}
+
+	// And the duration is a value the service supplies, not a constant baked
+	// into the episode: a different one produces a different wait.
+	service.adHocDrain = 200 * time.Millisecond
+	if _, err = service.Start(context.Background(), &agentpbv2.DataStartRequest{Sources: []string{"applications"}}); err != nil {
+		t.Fatal(err)
+	}
+	begin = time.Now()
+	if _, err = service.Stop(context.Background(), &agentpbv2.DataStopRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	elapsed := time.Since(begin)
+	if elapsed < 150*time.Millisecond {
 		t.Fatalf("ad-hoc Stop returned after %s; the configured drain did not reach the episode", elapsed)
+	}
+	if elapsed >= data.DefaultSealDrain {
+		t.Fatalf("ad-hoc Stop took %s with a 200ms drain configured; the episode ignored it and used the default", elapsed)
 	}
 }

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
@@ -159,11 +159,30 @@ verdict to be filed against the recording it was computed from.
 
 It must be a duration from `0s` through `30s`. Omitting it takes the default of
 `2s`, so campaigns get the behavior without being rewritten; `drain: 0s` opts
-out and seals the moment capture stops. Only Episodes that capture application
-records wait at all, so a telemetry-only or camera-only plan pays nothing for
-the default. The wait is added to the Episode's own lifetime, after
-`after_trigger` has expired, and it is included in the `stopped_episode_nanos`
-the manifest records.
+out and seals the moment capture stops. Every campaign Episode pays it: a
+campaign plan always selects the applications source, whatever `sources`
+declares, because that source is what arms the plan's triggers. A telemetry-only
+or camera-only campaign therefore waits exactly as long as any other one. Only
+an ad-hoc `wendy data record` Episode can avoid the wait, and only by leaving
+the applications source out with `--source` or `--exclude-source`, as described
+above. The wait is added
+to the Episode's own lifetime, after `after_trigger` has expired, and it is
+included in the `stopped_episode_nanos` the manifest records.
+
+A draining Episode has already stopped capturing, so it no longer holds its
+campaign. A trigger that matches during the drain starts the campaign's next
+Episode rather than being dropped. It does have to wait for the previous
+Episode to finish draining before it can begin, because starting and stopping
+capture are serialized on the device, so with the default the next Episode
+begins up to two seconds after the trigger that asked for it. Set `drain: 0s`
+on a campaign whose events arrive in bursts and whose applications write their
+records live rather than asynchronously.
+
+A failed capture adapter start is the one path that does not drain. That
+Episode never delivered a sample to any application, so no record about it can
+be outstanding; it is sealed as `interrupted` with reason
+`capture_adapter_start_failed` and `wendy data record` returns immediately
+instead of after the drain.
 
 At least one trigger is required, and each trigger selects exactly one
 condition:


### PR DESCRIPTION
Fixes findings 2, 3 and 5 of the adversarial review of the Wendy Data Platform branches, plus two of the smaller items the same review listed. Based on `split/7-tools-and-example`.

## Problem 1: a trigger during the post-seal drain was silently swallowed

`observeApplicationRecord` skips any campaign named in `ActiveEpisodeKeys`, and the post-seal drain deliberately kept the sealing Episode in that list for its whole window. For the length of the drain the campaign looked "already recording", so a matching record was dropped with a bare `continue`: not queued, not delayed, lost.

`DefaultSealDrain` is two seconds and every campaign pays it, because `campaign.go` selects the applications source unconditionally. The shipped reference campaign in `Examples/WendyDataModelApp` declares no drain, so a second person entering within two seconds of the previous Episode produced no recording, while the detection itself was filed into the Episode whose cameras had already stopped. An event with no video is exactly the failure this platform exists to prevent.

Reproduced by the reviewer: a campaign with `after_trigger: 30ms` and `drain: 1s`, two matching records 300 ms apart, produces one Episode; the same campaign with `drain: 0s` produces two.

## Problem 2: a failed adapter start paid the full drain while holding `captureMu`

`startCapture` called `Interrupt` on the adapter-start-failure path while holding `captureMu`, the lock that serializes every start and stop on the device. A `Start` whose adapter errored therefore took the whole drain to return `FailedPrecondition`, measured at 2.0017 seconds on the default. With `capture.drain: 30s` a flapping camera stalled the data service for thirty seconds per attempt.

## Cause

"Active" conflated two states: capturing, and open for records. The drain only needs the second.

## Solution

An Episode entering its drain leaves `m.active` for a new `m.sealing` collection, so it gives up its campaign key at the start of the window rather than at the end.

- `ActiveEpisodeKeys` names capturing Episodes only, so the trigger path is unblocked.
- `RecordApplication` reads both collections, so the drain still files late verdicts into the Episode that produced their samples.
- `Manager.Start` keeps doing the work it already did. The key is genuinely free, so there is still no way to have two capturing Episodes for one campaign.
- `Stop` and `Interrupt` share the front half of this in `beginSeal`.

For the failing start path, `Manager.InterruptWithoutDrain` finalizes an Episode that never began capturing and returns immediately. That Episode delivered no sample to any application, so no record about it can be outstanding. Every path that did capture still drains.

### Remaining semantics, deliberately

The next Episode still cannot begin until the previous one has finished draining, because `stopCaptureLocked` holds `captureMu` across the manager's `Stop`. So on the default a trigger matching inside a drain starts its Episode up to two seconds late rather than not at all. That is a large improvement on losing it outright and it is now documented for operators, but it is not nothing: an Episode that starts two seconds late has missed the event's video, and camera capture has no pre-roll ring to fall back on. Removing that last delay means splitting the manager's seal into two service-visible steps so `captureMu` can be released before the drain, which is a bigger change than this review asked for and belongs on its own.

## Solution: documentation (finding 5)

The `capture.drain` reference claimed "Only Episodes that capture application records wait at all, so a telemetry-only or camera-only plan pays nothing for the default." That is false: `campaign.go:442` is `selected := map[string]bool{"applications": true}`, unconditional, so no campaign plan can avoid the applications source and every campaign Episode pays the drain. The corrected text says so, keeps the ad-hoc case (which the same document already got right), and documents both behaviours above: a trigger matching during a drain starts the next Episode but waits for the previous one to finish draining, and a failed adapter start does not drain at all.

## Two smaller items from the same review

`Manifest.PreRollLost` was set from a counter cumulative for the manager's whole lifetime and never reset, so every Episode published the agent's total since start as its own loss. It also counted ring entries that simply aged out, which are not losses: an entry past the window is pre-roll for nobody. The manager now logs the receipt of each entry the byte budget dropped while it was still inside its window, and an Episode reports the ones its own window would have received.

`TestAdHocEpisodesCarryTheDefaultSealDrain` opened by comparing `service.adHocDrain` against `data.DefaultSealDrain`, which reads the constructor back to itself and cannot tell whether the value reaches the Episode. It now measures an untouched ad-hoc `Stop` against the default, then measures a configured one to prove the duration is supplied rather than baked in. `TestShippedModelAppCampaignParses` called `capture.EffectiveMode()` above its own `capture != nil` guard; the guard now comes first, as a `Fatal`, so the assertions below cannot pass vacuously.

## Verification

Four new tests, every one mutation-checked by reverting the corresponding fix.

| Test | Under mutation |
|---|---|
| `TestTriggerDuringThePostSealDrainStartsTheNextEpisode` | times out waiting for the second Episode |
| `TestDrainingEpisodeReleasesItsCampaignKey` | the record's state is `buffered`, not `recorded` |
| `TestFailedAdapterStartDoesNotPayTheSealDrain` | the failing `Start` takes 10.004 s |
| `TestPreRollLostIsThisEpisodesLossNotTheAgentsTotal` | an entry that aged out is counted as a loss |

`TestTriggerDuringThePostSealDrainStartsTheNextEpisode` deliberately declares no `capture.drain` and runs against the two second default, rather than the `drain: 0s` every other campaign test in the package opts into. That opt-out is how the defect stayed invisible; it costs the suite about four seconds and the default is what ships.

`CC=/usr/bin/clang go build ./go/...` exits 0. `CC=/usr/bin/clang go test -race ./go/internal/agent/...` is unchanged apart from the new tests: the only failure is the known-environmental `TestSampleGPUFallsBackToTegrastatsForOrin` (no GPU on this Mac).
