### PR TITLE
fix(agent): an audio segment stamp may not precede the Episode origin

### DIFF
--- a/go/internal/agent/services/data_audio_adapter.go
+++ b/go/internal/agent/services/data_audio_adapter.go
@@ -359,9 +359,16 @@ type audioCapture struct {
 	segUncert    int64
 	segReceipt   int64
 	segTrigger   *float64
+	// segClamped and segClampShortfall carry the origin clamp (see
+	// beginSegment) from the stamp to the segment's index record.
+	segClamped        bool
+	segClampShortfall int64
 
 	// Accounting.
-	missedCrossings   uint64
+	missedCrossings uint64
+	// clampedSegments counts segment stamps held at the episode origin because
+	// the pipeline correction would have placed them before it.
+	clampedSegments   uint64
 	maxCanonicalError int64
 	firstOffset       *int64
 	notes             []string
@@ -502,6 +509,24 @@ func (c *audioCapture) beginSegment(triggerLevel *float64, firstChunkBytes int) 
 	}
 	canonical -= pcmDurationNanos(firstChunkBytes) + int64(audioPipelineDelayEstimate)
 	uncertainty += int64(audioPipelineDelayBound)
+	// The correction is an estimate walking backwards, and nothing stops it
+	// walking back past the start of the episode. Audio has no pre-roll ring:
+	// capture begins when the episode does, so there are no samples from before
+	// the origin and a stamp before it would advertise pre-trigger audio that
+	// does not exist. A negative offset is how this tree says "pre-roll was
+	// achieved", and the audio adapter is never entitled to say it.
+	//
+	// So the stamp is held at the origin — and said so, rather than quietly
+	// maxed. The shortfall widens the published uncertainty, which keeps the
+	// true instant inside the bracket, and the segment's index record carries
+	// the flag and the amount so a reader can tell a bound from an estimate.
+	segmentClamped, clampShortfall := false, int64(0)
+	if shortfall := c.session.RequestBootNanos - canonical; shortfall > 0 {
+		canonical = c.session.RequestBootNanos
+		uncertainty += shortfall
+		segmentClamped, clampShortfall = true, shortfall
+		c.clampedSegments++
+	}
 	if uncertainty > c.maxCanonicalError {
 		c.maxCanonicalError = uncertainty
 	}
@@ -526,6 +551,8 @@ func (c *audioCapture) beginSegment(triggerLevel *float64, firstChunkBytes int) 
 	c.segUncert = uncertainty
 	c.segReceipt = receipt
 	c.segTrigger = triggerLevel
+	c.segClamped = segmentClamped
+	c.segClampShortfall = clampShortfall
 	if c.firstOffset == nil {
 		offset := canonical - c.session.RequestBootNanos
 		c.firstOffset = &offset
@@ -581,6 +608,8 @@ func (c *audioCapture) finishSegment(truncated bool) error {
 		Mode:                      c.mode,
 		TriggerLevelDb:            c.segTrigger,
 		Truncated:                 truncated,
+		ClampedToOrigin:           c.segClamped,
+		ClampShortfallNanos:       c.segClampShortfall,
 	}
 	b, _ := json.Marshal(record)
 	_, err := c.index.Write(append(b, '\n'))
@@ -623,6 +652,14 @@ func (c *audioCapture) finish() {
 	c.result.SourceID = c.source.ID
 	c.result.ClockDomain = c.source.ClockDomain
 	c.result.ActualOffset = c.firstOffset
+	if c.clampedSegments > 0 {
+		// Said in the manifest as well as per segment: an operator reading the
+		// episode summary should not have to open the audio index to learn that
+		// some stamps are bounds held at the origin rather than estimates.
+		c.notes = append(c.notes, fmt.Sprintf(
+			"%d segment stamp(s) clamped to the episode origin: the pipeline correction reached before it, and their canonical uncertainty is widened by the shortfall",
+			c.clampedSegments))
+	}
 	if c.maxCanonicalError > 0 {
 		maxError := c.maxCanonicalError
 		c.result.MappingError = &maxError
@@ -659,6 +696,18 @@ type audioIndexRecord struct {
 	Mode                      string   `json:"mode"`
 	TriggerLevelDb            *float64 `json:"trigger_level_db,omitempty"`
 	Truncated                 bool     `json:"truncated,omitempty"`
+	// ClampedToOrigin marks a stamp whose pipeline correction reached back past
+	// the episode origin and was held at it. Audio has no pre-roll ring, so it
+	// cannot have captured anything before the origin; the correction is an
+	// estimate and a segment opened within roughly a chunk of the origin can
+	// therefore be walked back further than the capture actually goes.
+	// CanonicalUncertaintyNanos is widened by the shortfall on such a record,
+	// so the true instant still lies inside the published bracket, and this
+	// flag says the stamp is a bound rather than an estimate.
+	ClampedToOrigin bool `json:"clamped_to_origin,omitempty"`
+	// ClampShortfallNanos is how far past the episode origin the correction
+	// would have reached. Present only alongside ClampedToOrigin.
+	ClampShortfallNanos int64 `json:"clamp_shortfall_nanos,omitempty"`
 }
 
 // writeWAVHeader writes a 44-byte canonical PCM WAV header at the file cursor.

--- a/go/internal/agent/services/data_audio_adapter_test.go
+++ b/go/internal/agent/services/data_audio_adapter_test.go
@@ -678,3 +678,131 @@ card 0: C920 [HD Pro Webcam C920], device 0: USB Audio [USB Audio]
 		t.Errorf("detail = %q, want %q", sources[0].Detail, want)
 	}
 }
+
+// TestAudioSegmentStampNeverPrecedesTheEpisodeOrigin pins the one direction the
+// backdating correction is not allowed to go.
+//
+// The correction walks the stamp back past the chunk in hand and past the
+// pipeline delay behind it, and nothing stopped it walking back past the start
+// of the episode. Audio has no pre-roll ring: capture opens when the episode
+// does, so there are no samples from before the origin. A negative ActualOffset
+// is how this tree says "pre-roll was achieved" (see the camera adapter and
+// data_service_test), so a negative audio offset advertises pre-trigger audio
+// that does not exist, on the strength of an estimated constant.
+//
+// The gap here is the realistic one the existing stamping tests dodge: an
+// episode origin at ten seconds and the first 8192-byte read a hundred
+// milliseconds later, which is what a Jetson Orin Nano with a Logitech C920
+// actually delivers. Unclamped that produced canonical_episode_nanos of
+// -5333333.
+func TestAudioSegmentStampNeverPrecedesTheEpisodeOrigin(t *testing.T) {
+	const (
+		// 8192 bytes is what a real pipe read returns: 85.333 ms of PCM.
+		chunkBytes    = 8192
+		origin        = int64(10 * time.Second)
+		receiptDelay  = int64(100 * time.Millisecond)
+		clockHalfWide = 3 * time.Microsecond
+	)
+	chunkNanos := pcmDurationNanos(chunkBytes)
+	stamp := bootReceipt(time.Duration(origin+receiptDelay), clockHalfWide)
+
+	// The premise, computed rather than asserted from memory: the uncorrected
+	// arithmetic really does reach back past the origin here, so this test
+	// exercises the clamp instead of quietly agreeing with an unclamped stamp.
+	wantShortfall := chunkNanos + int64(audioPipelineDelayEstimate) - receiptDelay
+	if wantShortfall <= 0 {
+		t.Fatalf("this gap does not reach past the origin (shortfall %d); the test would prove nothing", wantShortfall)
+	}
+
+	result, dir := runAudioCaptureWith(t, audioRun{
+		chunks:           [][]byte{pcmChunk(chunkBytes)},
+		receipts:         scriptedReceipts(stamp),
+		requestBootNanos: origin,
+	})
+
+	records := readAudioIndex(t, dir)
+	if len(records) != 1 {
+		t.Fatalf("got %d index records, want 1: %+v", len(records), records)
+	}
+	record := records[0]
+
+	if record.CanonicalEpisodeNanos != 0 {
+		t.Errorf("canonical_episode_nanos = %d, want 0: audio has no pre-roll ring, so a segment stamp may not precede the episode origin",
+			record.CanonicalEpisodeNanos)
+	}
+	// Clamped, and said so. A silent max would leave a reader unable to tell a
+	// bound from an estimate that happened to land on the origin.
+	if !record.ClampedToOrigin {
+		t.Error("clamped_to_origin is absent; the clamp must be visible in the record, not silent")
+	}
+	if record.ClampShortfallNanos != wantShortfall {
+		t.Errorf("clamp_shortfall_nanos = %d, want %d", record.ClampShortfallNanos, wantShortfall)
+	}
+	// And the uncertainty widened by the shortfall, so the instant the
+	// correction pointed at is still inside the published bracket.
+	wantUncertainty := stamp.bracket() + int64(audioPipelineDelayBound) + wantShortfall
+	if record.CanonicalUncertaintyNanos != wantUncertainty {
+		t.Errorf("canonical_uncertainty_nanos = %d, want %d (clock bracket %d, the %v delay bound, and the %d ns shortfall)",
+			record.CanonicalUncertaintyNanos, wantUncertainty, stamp.bracket(), audioPipelineDelayBound, wantShortfall)
+	}
+	if record.CanonicalEpisodeNanos-record.CanonicalUncertaintyNanos > -wantShortfall {
+		t.Error("the widened bracket does not reach back to where the correction pointed")
+	}
+
+	if result.ActualOffset == nil || *result.ActualOffset != 0 {
+		t.Errorf("result.ActualOffset = %v, want 0: a negative offset would claim pre-trigger audio that was never captured",
+			result.ActualOffset)
+	}
+	if result.MappingError == nil || *result.MappingError != wantUncertainty {
+		t.Errorf("result.MappingError = %v, want %d so the episode summary carries the widened bound",
+			result.MappingError, wantUncertainty)
+	}
+	if !strings.Contains(result.SourceDetail, "clamped to the episode origin") {
+		t.Errorf("source detail = %q, want it to name the clamp so an operator need not open the audio index",
+			result.SourceDetail)
+	}
+}
+
+// TestAudioSegmentStampIsNotClampedWhenItNeedNotBe is the other half: the clamp
+// must fire only when the correction really would reach past the origin. A
+// clamp that fired early would flatten genuine sub-origin arithmetic into a
+// pile of stamps all reading zero, which is a different lie.
+func TestAudioSegmentStampIsNotClampedWhenItNeedNotBe(t *testing.T) {
+	const (
+		chunkBytes    = 8192
+		origin        = int64(10 * time.Second)
+		receiptDelay  = int64(200 * time.Millisecond)
+		clockHalfWide = 3 * time.Microsecond
+	)
+	chunkNanos := pcmDurationNanos(chunkBytes)
+	stamp := bootReceipt(time.Duration(origin+receiptDelay), clockHalfWide)
+
+	result, dir := runAudioCaptureWith(t, audioRun{
+		chunks:           [][]byte{pcmChunk(chunkBytes)},
+		receipts:         scriptedReceipts(stamp),
+		requestBootNanos: origin,
+	})
+
+	records := readAudioIndex(t, dir)
+	if len(records) != 1 {
+		t.Fatalf("got %d index records, want 1: %+v", len(records), records)
+	}
+	record := records[0]
+	wantCanonical := receiptDelay - chunkNanos - int64(audioPipelineDelayEstimate)
+	if wantCanonical <= 0 {
+		t.Fatalf("this gap does reach past the origin; the test would prove nothing")
+	}
+	if record.CanonicalEpisodeNanos != wantCanonical {
+		t.Errorf("canonical_episode_nanos = %d, want the uncorrected %d", record.CanonicalEpisodeNanos, wantCanonical)
+	}
+	if record.ClampedToOrigin || record.ClampShortfallNanos != 0 {
+		t.Errorf("a stamp that lands after the origin was reported as clamped: %+v", record)
+	}
+	if record.CanonicalUncertaintyNanos != stamp.bracket()+int64(audioPipelineDelayBound) {
+		t.Errorf("canonical_uncertainty_nanos = %d, want the unwidened %d",
+			record.CanonicalUncertaintyNanos, stamp.bracket()+int64(audioPipelineDelayBound))
+	}
+	if strings.Contains(result.SourceDetail, "clamped") {
+		t.Errorf("source detail = %q mentions a clamp that did not happen", result.SourceDetail)
+	}
+}


### PR DESCRIPTION
Fixes finding 4 of the adversarial review of the Wendy Data Platform branches. Based on `split/7-tools-and-example`.

## Problem

`beginSegment` walks a segment's canonical stamp back past the chunk in hand and past the estimated pipeline delay behind it:

```go
canonical -= pcmDurationNanos(firstChunkBytes) + audioPipelineDelayEstimate
```

Unguarded. Whenever `receipt - RequestBootNanos` is smaller than the chunk duration plus 20 ms, `CanonicalEpisodeNanos` and `firstOffset` go negative. Reproduced with an Episode origin at 10 s and a first 8192-byte read 100 ms later, which is what a Jetson Orin Nano with a Logitech C920 actually delivers: `canonical_episode_nanos = -5333333`.

## Cause

A negative `ActualOffset` is how this tree says "pre-roll was achieved" (`data_service_test.go:129` asserts exactly that). Audio has no pre-roll ring: capture opens when the Episode does, so there are no samples from before the origin. The correction is an estimate, and it was allowed to place a stamp where the capture provably does not reach, so the manifest advertised pre-trigger audio that does not exist.

The existing stamping tests use a 4.5 second gap between origin and receipt that no real capture has, so none of them reached the case.

## Solution

The stamp is held at the Episode origin when the correction would pass it, and the clamp is reported rather than silently maxed.

- The shortfall widens the published `canonical_uncertainty_nanos`, so the instant the correction pointed at is still inside the bracket. The stamp becomes an honest bound instead of a wrong estimate.
- The segment's index record carries `clamped_to_origin` and `clamp_shortfall_nanos`, so a reader can tell a bound from an estimate that happened to land on the origin.
- The Episode's source detail names the clamp and how many segments it affected, so an operator reading the manifest summary need not open the audio index.

## Verification

Two new tests, both mutation-checked.

`TestAudioSegmentStampNeverPrecedesTheEpisodeOrigin` uses the realistic gap above and asserts the stamp, the flag, the shortfall, the widened uncertainty, the widened bracket still reaching back to where the correction pointed, and the manifest note. Reverting the clamp reproduces `canonical_episode_nanos = -5333333` and a negative `ActualOffset`.

`TestAudioSegmentStampIsNotClampedWhenItNeedNotBe` uses a 200 ms gap and asserts nothing is clamped, because a clamp that fired early would flatten genuine arithmetic into a pile of stamps all reading zero, which is a different lie.

`CC=/usr/bin/clang go build ./go/...` exits 0. `CC=/usr/bin/clang go test -race ./go/internal/agent/...` is unchanged apart from the new tests: the only failure is the known-environmental `TestSampleGPUFallsBackToTegrastatsForOrin` (no GPU on this Mac).
