### PR TITLE
Prepare verify and recover deployments on the agent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/vishvananda/netlink v1.3.1
 	go.bug.st/serial v1.6.4
+	go.etcd.io/bbolt v1.4.3
 	go.opentelemetry.io/proto/otlp v1.10.0
 	go.uber.org/zap v1.28.0
 	golang.org/x/net v0.57.0

--- a/go.sum
+++ b/go.sum
@@ -293,6 +293,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.bug.st/serial v1.6.4 h1:7FmqNPgVp3pu2Jz5PoPtbZ9jJO5gnEnZIvnI1lzve8A=
 go.bug.st/serial v1.6.4/go.mod h1:nofMJxTeNVny/m6+KaafC6vJGj3miwQZ6vW4BZUGJPI=
+go.etcd.io/bbolt v1.4.3 h1:dEadXpI6G79deX5prL3QRNP6JB8UxVkqo4UPnHaNXJo=
+go.etcd.io/bbolt v1.4.3/go.mod h1:tKQlpPaYCVFctUIgFKFnAlvbmB3tpy1vkTnDWohtc0E=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -389,6 +389,17 @@ func main() {
 
 	var wg sync.WaitGroup
 
+	// Resolve any interrupted app cutover before the restart monitor or RPC
+	// handlers can start a candidate whose readiness was never committed.
+	if recovery, ok := containerdClient.(interface{ RecoverDeployments(context.Context) error }); ok {
+		recoveryCtx, recoveryCancel := context.WithTimeout(ctx, 2*time.Minute)
+		recoveryErr := recovery.RecoverDeployments(recoveryCtx)
+		recoveryCancel()
+		if recoveryErr != nil {
+			logger.Error("Interrupted application deployment recovery failed", zap.Error(recoveryErr))
+		}
+	}
+
 	if monitor != nil {
 		wg.Add(1)
 		go func() {

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -30,7 +30,6 @@ import (
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/leases"
-	"github.com/containerd/containerd/v2/core/remotes/docker"
 	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/oci"
@@ -1060,6 +1059,17 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 	}
 	c.logger.Info("Creating container", logFields...)
 
+	// Resolve and validate the image before touching a currently running app.
+	// Verified deployments pin an immutable candidate reference during prepare;
+	// ordinary creates also benefit from failing an unavailable image here.
+	imageResolveStarted := time.Now()
+	report(&agentpb.CreateContainerProgress{Phase: agentpb.CreateContainerProgress_UNPACKING})
+	image, err := c.resolveDeploymentImage(ctx, imageName)
+	if err != nil {
+		return err
+	}
+	imageResolveDuration = time.Since(imageResolveStarted)
+
 	// Determine version from the app config or default.
 	version := appCfg.Version
 	if version == "" {
@@ -1119,7 +1129,12 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 			// service directly so the runtime clears the old task ID.
 			c.forceDeleteTask(ctx, containerName)
 		}
-		delErr := existing.Delete(ctx, containerd.WithSnapshotCleanup)
+		deleteOpts := []containerd.DeleteOpts{containerd.WithSnapshotCleanup}
+		if deploymentCreateFromContext(ctx) != nil {
+			// The hidden revision record retains this exact writable snapshot.
+			deleteOpts = nil
+		}
+		delErr := existing.Delete(ctx, deleteOpts...)
 		if delErr != nil && errdefs.IsFailedPrecondition(delErr) {
 			// A task exists again despite the kill above — most likely the
 			// restart monitor's tick winning a race against suppressRestarts
@@ -1140,7 +1155,7 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 					c.forceDeleteTask(ctx, containerName)
 				}
 			}
-			delErr = existing.Delete(ctx, containerd.WithSnapshotCleanup)
+			delErr = existing.Delete(ctx, deleteOpts...)
 		}
 		if delErr != nil && !errdefs.IsNotFound(delErr) {
 			return fmt.Errorf("deleting existing container %q during replace: %w", containerName, delErr)
@@ -1154,33 +1169,6 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 		}
 		replaceDuration = time.Since(phaseStarted)
 	}
-
-	// Try the local image store first. The device-local registry shares
-	// containerd's content store, so anything just pushed to it is already
-	// available via GetImage — pulling would just round-trip bytes over
-	// loopback. Fall back to a pull only on miss; use PlainHTTP for the
-	// local-registry case.
-	var image containerd.Image
-	var err error
-	phaseStarted = time.Now()
-	report(&agentpb.CreateContainerProgress{Phase: agentpb.CreateContainerProgress_UNPACKING})
-	image, err = c.client.GetImage(ctx, imageName)
-	if err != nil {
-		c.logger.Info("Image not in local store, attempting pull from registry",
-			zap.String("image", imageName),
-		)
-		pullOpts := []containerd.RemoteOpt{containerd.WithPullUnpack}
-		if isLocalRegistryImage(imageName) {
-			pullOpts = append(pullOpts,
-				containerd.WithResolver(docker.NewResolver(docker.ResolverOptions{PlainHTTP: true})),
-			)
-		}
-		image, err = c.client.Pull(ctx, imageName, pullOpts...)
-		if err != nil {
-			return fmt.Errorf("getting/pulling image %q: %w", imageName, err)
-		}
-	}
-	imageResolveDuration = time.Since(phaseStarted)
 
 	// Start D-Bus proxy if bluetooth entitlement is present. The returned
 	// socket directory is keyed by containerName (which includes the service
@@ -1424,6 +1412,10 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 		}
 	}
 	labels := wendyLabels(appID, serviceName, version, req.GetRestartPolicy(), appCfg.Entitlements, appCfg.Isolation, dependsOn)
+	if deployment := deploymentCreateFromContext(ctx); deployment != nil {
+		labels[labelDeploymentRevision] = deployment.revision
+		labels[labelDeploymentPending] = deployment.revision
+	}
 	if desiredNetworkIdentity != "" {
 		labels[labelKeyNetworkIdentity] = desiredNetworkIdentity
 		if reusedNetworkSandbox != nil {
@@ -1579,6 +1571,9 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 	// critical path. A prepared snapshot is single-use and has never backed a
 	// task, so runtime filesystem mutations can never leak across deployments.
 	snapshotKey := SnapshotKey(appID, serviceName)
+	if deployment := deploymentCreateFromContext(ctx); deployment != nil {
+		snapshotKey = deployment.snapshotKey
+	}
 	phaseStarted = time.Now()
 	snapshotOpt := containerd.WithNewSnapshot(snapshotKey, image)
 	var prepared *preparedSnapshot
@@ -2931,6 +2926,15 @@ func (c *Client) recreateContainer(ctx context.Context, ctr containerd.Container
 	if err != nil {
 		return fmt.Errorf("getting container info: %w", err)
 	}
+	if info.Labels[labelDeploymentRevision] != "" {
+		// A verified revision's writable snapshot is authoritative. Rebuilding
+		// from Image here could silently replace a rollback with a newer :latest.
+		if err := ctr.Delete(ctx); err != nil {
+			return fmt.Errorf("deleting orphaned revision metadata: %w", err)
+		}
+		_, err := c.client.ContainerService().Create(ctx, info)
+		return err
+	}
 
 	image, err := ctr.Image(ctx)
 	if err != nil {
@@ -4047,6 +4051,9 @@ func (c *Client) ListBootContainers(ctx context.Context) ([]services.BootContain
 
 		if info.Labels[labelKeyStoppedByUser] == "true" {
 			continue // user stopped it on purpose — stay down across reboot
+		}
+		if deploymentIsPending(info.Labels) {
+			continue // recovery must resolve the unverified candidate first
 		}
 		policy, maxRetries := parseRestartPolicyLabel(info.Labels[labelKeyRestartPolicy])
 		if policy == "no" {

--- a/go/internal/agent/containerd/deployment.go
+++ b/go/internal/agent/containerd/deployment.go
@@ -1,0 +1,723 @@
+package containerd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"strings"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/core/containers"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/leases"
+	"github.com/containerd/containerd/v2/core/remotes/docker"
+	"github.com/containerd/errdefs"
+	"github.com/containerd/typeurl/v2"
+	"github.com/google/uuid"
+	"github.com/opencontainers/image-spec/identity"
+	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	localoci "github.com/wendylabsinc/wendy/go/internal/agent/oci"
+	"github.com/wendylabsinc/wendy/go/internal/agent/services"
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+const (
+	labelDeploymentRevision = "sh.wendy/deployment.revision"
+	labelDeploymentPending  = "sh.wendy/deployment.pending"
+	labelRevisionContainer  = "sh.wendy/revision.container"
+	labelRevisionPhase      = "sh.wendy/revision.phase"
+	revisionExtension       = "sh.wendy/revision.metadata"
+	revisionMetadataType    = "wendy.internal/retained-container.v1"
+)
+
+type deploymentCreateKey struct{}
+type deploymentCreateOptions struct{ revision, snapshotKey string }
+
+func deploymentCreateFromContext(ctx context.Context) *deploymentCreateOptions {
+	v, _ := ctx.Value(deploymentCreateKey{}).(*deploymentCreateOptions)
+	return v
+}
+
+// A hidden containerd container is both the journal and the snapshot GC root.
+// It deliberately carries no Wendy app/version labels, so normal listings and
+// boot reconciliation never try to start it. The original metadata is encoded
+// separately: changing the journal's labels cannot change the rollback spec.
+type retainedMetadata struct {
+	Original         *retainedContainer `json:"original,omitempty"`
+	WasRunning       bool               `json:"wasRunning"`
+	Revision         string             `json:"revision"`
+	PreviousRevision string             `json:"previousRevision,omitempty"`
+	CandidateImage   string             `json:"candidateImage"`
+}
+type retainedContainer struct {
+	ID                                  string
+	Labels                              map[string]string
+	Image                               string
+	RuntimeName                         string
+	RuntimeOptions                      *anypb.Any
+	Spec                                *anypb.Any
+	SnapshotKey, Snapshotter, SandboxID string
+	Extensions                          map[string]*anypb.Any
+}
+
+func copyAny(v typeurl.Any) *anypb.Any {
+	if v == nil {
+		return nil
+	}
+	return &anypb.Any{TypeUrl: v.GetTypeUrl(), Value: append([]byte(nil), v.GetValue()...)}
+}
+func retainContainer(info containers.Container) *retainedContainer {
+	ext := make(map[string]*anypb.Any, len(info.Extensions))
+	for k, v := range info.Extensions {
+		ext[k] = copyAny(v)
+	}
+	return &retainedContainer{ID: info.ID, Labels: maps.Clone(info.Labels), Image: info.Image,
+		RuntimeName: info.Runtime.Name, RuntimeOptions: copyAny(info.Runtime.Options), Spec: copyAny(info.Spec),
+		SnapshotKey: info.SnapshotKey, Snapshotter: info.Snapshotter, SandboxID: info.SandboxID, Extensions: ext}
+}
+func (r *retainedContainer) container() containers.Container {
+	ext := make(map[string]typeurl.Any, len(r.Extensions))
+	for k, v := range r.Extensions {
+		ext[k] = copyAny(v)
+	}
+	return containers.Container{ID: r.ID, Labels: maps.Clone(r.Labels), Image: r.Image,
+		Runtime: containers.RuntimeInfo{Name: r.RuntimeName, Options: r.RuntimeOptions}, Spec: r.Spec,
+		SnapshotKey: r.SnapshotKey, Snapshotter: r.Snapshotter, SandboxID: r.SandboxID, Extensions: ext}
+}
+func encodeRevisionMetadata(m retainedMetadata) (typeurl.Any, error) {
+	b, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	return &anypb.Any{TypeUrl: revisionMetadataType, Value: b}, nil
+}
+func decodeRevisionMetadata(info containers.Container) (retainedMetadata, error) {
+	var m retainedMetadata
+	v := info.Extensions[revisionExtension]
+	if v == nil || v.GetTypeUrl() != revisionMetadataType {
+		return m, fmt.Errorf("invalid deployment journal %q", info.ID)
+	}
+	if err := json.Unmarshal(v.GetValue(), &m); err != nil {
+		return m, err
+	}
+	if m.Revision == "" || info.Labels[labelRevisionContainer] == "" {
+		return m, fmt.Errorf("incomplete deployment journal %q", info.ID)
+	}
+	if m.Original != nil && m.Original.ID != info.Labels[labelRevisionContainer] {
+		return m, fmt.Errorf("deployment journal container identity mismatch")
+	}
+	return m, nil
+}
+
+type deploymentTransaction struct {
+	c                                        *Client
+	req                                      *agentpb.CreateContainerRequest
+	cfg                                      *appconfig.AppConfig
+	journal                                  containers.Container
+	metadata                                 retainedMetadata
+	resume                                   func()
+	activated, committed, rolledBack, closed bool
+}
+
+var _ services.DeploymentRuntime = (*Client)(nil)
+var _ services.DeploymentRevisionRemover = (*Client)(nil)
+var _ services.DeploymentTransaction = (*deploymentTransaction)(nil)
+
+// resolveDeploymentImage does all fallible image work before cutover. It does
+// not allocate app-keyed sockets, stop proxies, or alter the existing task.
+func (c *Client) resolveDeploymentImage(ctx context.Context, imageName string) (containerd.Image, error) {
+	image, err := c.client.GetImage(ctx, imageName)
+	if err != nil {
+		if !errdefs.IsNotFound(err) {
+			return nil, fmt.Errorf("resolving image %q: %w", imageName, err)
+		}
+		pullOpts := []containerd.RemoteOpt{containerd.WithPullUnpack}
+		if isLocalRegistryImage(imageName) {
+			pullOpts = append(pullOpts, containerd.WithResolver(docker.NewResolver(docker.ResolverOptions{PlainHTTP: true})))
+		}
+		image, err = c.client.Pull(ctx, imageName, pullOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("getting/pulling image %q: %w", imageName, err)
+		}
+	}
+	if _, err = image.Spec(ctx); err != nil {
+		return nil, fmt.Errorf("reading image config for %q: %w", imageName, err)
+	}
+	unpacked, err := image.IsUnpacked(ctx, c.snapshotter)
+	if err != nil {
+		return nil, fmt.Errorf("checking image unpack: %w", err)
+	}
+	if !unpacked {
+		if err = c.UnpackImage(ctx, image, nil); err != nil {
+			return nil, fmt.Errorf("unpacking image %q: %w", imageName, err)
+		}
+	}
+	return image, nil
+}
+
+func (c *Client) PrepareDeployment(ctx context.Context, req *agentpb.CreateContainerRequest, cfg *appconfig.AppConfig) (_ services.DeploymentTransaction, retErr error) {
+	if req == nil || cfg == nil {
+		return nil, status.Error(codes.InvalidArgument, "deployment requires an app configuration")
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid app configuration: %v", err)
+	}
+	if appconfig.IsSharedNamespaceIsolation(cfg.Isolation) {
+		return nil, status.Error(codes.FailedPrecondition, "verified deployment of shared-namespace service groups is not supported; deploy an isolated service")
+	}
+	name := cfg.ContainerName()
+	if name != req.GetAppName() {
+		return nil, status.Error(codes.InvalidArgument, "deployment container name does not match app configuration")
+	}
+	if err := validateUserEnv(req.GetEnv()); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid environment: %v", err)
+	}
+	if err := c.requireDBusProxy(cfg, name); err != nil {
+		return nil, err
+	}
+	if entitlementsContain(cfg.Entitlements, appconfig.EntitlementNotifications) && c.systemAPISocketProvider == nil {
+		return nil, status.Error(codes.FailedPrecondition, "notifications entitlement requires the app System API socket manager")
+	}
+	if err := localoci.ApplyResourceLimits(localoci.DefaultSpec("rootfs", nil), cfg.ResolveResourcesForService(cfg.ServiceName)); err != nil {
+		return nil, err
+	}
+	ctx = c.withNamespace(ctx)
+	image, err := c.resolveDeploymentImage(ctx, normalizeImageName(req.GetImageName()))
+	if err != nil {
+		return nil, err
+	}
+
+	t := &deploymentTransaction{c: c, req: proto.Clone(req).(*agentpb.CreateContainerRequest), cfg: cfg}
+	t.metadata.Revision = uuid.NewString()
+	// The per-app service lock spans this transaction; suppression also excludes
+	// autonomous monitor restarts through health verification and rollback.
+	t.resume = c.suppressRestarts(name)
+	defer func() {
+		if retErr != nil {
+			t.resume()
+		}
+	}()
+	unlock := c.lockNetworkOperation(name)
+	defer unlock()
+	old, err := c.client.LoadContainer(ctx, name)
+	if err == nil {
+		info, err := old.Info(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if appconfig.IsSharedNamespaceIsolation(info.Labels[labelKeyIsolation]) {
+			return nil, status.Error(codes.FailedPrecondition, "the previous revision belongs to a shared-namespace group and cannot be rolled back independently")
+		}
+		if deploymentIsPending(info.Labels) {
+			return nil, status.Error(codes.FailedPrecondition, "the previous deployment is unresolved; recover it before starting another deployment")
+		}
+		t.metadata.Original = retainContainer(info)
+		t.metadata.PreviousRevision = info.Labels[labelDeploymentRevision]
+		if t.metadata.PreviousRevision == "" {
+			t.metadata.PreviousRevision = "legacy-" + t.metadata.Revision
+		}
+		if task, taskErr := old.Task(ctx, nil); taskErr == nil {
+			s, err := task.Status(ctx)
+			if err != nil {
+				return nil, err
+			}
+			t.metadata.WasRunning = s.Status == containerd.Running
+		} else if !errdefs.IsNotFound(taskErr) {
+			return nil, taskErr
+		}
+	} else if !errdefs.IsNotFound(err) {
+		return nil, err
+	}
+
+	// Pin the candidate under an immutable per-revision name. Another upload to
+	// :latest cannot change the image used between prepare and activation.
+	imageName := normalizeImageName("wendy-revision/" + t.metadata.Revision + ":candidate")
+	if _, err = c.client.ImageService().Create(ctx, images.Image{Name: imageName, Target: image.Target()}); err != nil {
+		return nil, fmt.Errorf("pinning candidate image: %w", err)
+	}
+	t.metadata.CandidateImage = imageName
+	t.req.ImageName = imageName
+	defer func() {
+		if retErr != nil {
+			_ = c.cleanupRuntimeOperation(func(ctx context.Context) error { return c.client.ImageService().Delete(ctx, imageName) })
+		}
+	}()
+	rootfs, err := image.RootFS(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("reading candidate rootfs: %w", err)
+	}
+	parent := identity.ChainID(rootfs).String()
+	prepared := c.takePreparedSnapshot(normalizeImageName(req.GetImageName()), parent)
+	if prepared == nil {
+		prepareCtx, release, err := c.client.WithLease(ctx, leases.WithExpiration(unpackLeaseExpiration))
+		if err != nil {
+			return nil, fmt.Errorf("leasing candidate snapshot: %w", err)
+		}
+		key := "wendy-deploy-" + t.Revision()
+		sn := c.client.SnapshotService(c.snapshotter)
+		if _, err := sn.Prepare(prepareCtx, key, parent); err != nil {
+			_ = c.cleanupRuntimeOperation(release)
+			return nil, fmt.Errorf("preparing candidate writable snapshot: %w", err)
+		}
+		prepared = &preparedSnapshot{key: key, parent: parent,
+			release: func() { _ = c.cleanupRuntimeOperation(release) },
+			remove: func() {
+				_ = c.cleanupRuntimeOperation(func(ctx context.Context) error { return sn.Remove(ctx, key) })
+			},
+		}
+	}
+	c.storePreparedSnapshot(imageName, prepared)
+	defer func() {
+		if retErr != nil {
+			c.takePreparedSnapshot(imageName, "").discard()
+		}
+	}()
+	encoded, err := encodeRevisionMetadata(t.metadata)
+	if err != nil {
+		return nil, err
+	}
+	journal := containers.Container{ID: "wendy-revision-" + t.metadata.Revision,
+		Labels:     map[string]string{labelRevisionContainer: name, labelRevisionPhase: "prepared"},
+		Runtime:    containers.RuntimeInfo{Name: "io.containerd.runc.v2"},
+		Extensions: map[string]typeurl.Any{revisionExtension: encoded}}
+	if original := t.metadata.Original; original != nil {
+		journal.Runtime = containers.RuntimeInfo{Name: original.RuntimeName, Options: original.RuntimeOptions}
+		journal.Spec = original.Spec
+		journal.SnapshotKey, journal.Snapshotter = original.SnapshotKey, original.Snapshotter
+		if original.Labels[labelDeploymentRevision] != "" {
+			// Verified images use immutable revision-specific aliases. Retain
+			// their content too; legacy :latest remains snapshot/spec-only.
+			journal.Image = original.Image
+		}
+	} else {
+		journal.Spec, err = typeurl.MarshalAny(&runtimespec.Spec{})
+		if err != nil {
+			return nil, err
+		}
+	}
+	t.journal, err = c.client.ContainerService().Create(ctx, journal)
+	if err != nil {
+		return nil, fmt.Errorf("retaining previous container revision: %w", err)
+	}
+	return t, nil
+}
+
+func (t *deploymentTransaction) Revision() string         { return t.metadata.Revision }
+func (t *deploymentTransaction) PreviousRevision() string { return t.metadata.PreviousRevision }
+func (t *deploymentTransaction) PreviousWasRunning() bool { return t.metadata.WasRunning }
+func (t *deploymentTransaction) setPhase(ctx context.Context, phase string) error {
+	t.journal.Labels[labelRevisionPhase] = phase
+	_, err := t.c.client.ContainerService().Update(t.c.withNamespace(ctx), t.journal, "labels")
+	return err
+}
+func (t *deploymentTransaction) Activate(ctx context.Context) error {
+	if t.closed || t.activated {
+		return fmt.Errorf("deployment has already been activated or closed")
+	}
+	if err := t.setPhase(ctx, "activating"); err != nil {
+		return err
+	}
+	t.activated = true // Rollback must run even if the graceful stop fails.
+	name := t.journal.Labels[labelRevisionContainer]
+	if t.metadata.Original != nil {
+		if err := t.c.StopContainer(ctx, name); err != nil {
+			return fmt.Errorf("stopping previous revision: %w", err)
+		}
+	}
+	ctx = context.WithValue(ctx, deploymentCreateKey{}, &deploymentCreateOptions{revision: t.Revision(), snapshotKey: "wendy-deploy-" + t.Revision()})
+	return t.c.CreateContainer(ctx, t.req, t.cfg)
+}
+func (t *deploymentTransaction) Commit(ctx context.Context) error {
+	if !t.activated || t.closed || t.rolledBack {
+		return fmt.Errorf("deployment is not active")
+	}
+	ctx = t.c.withNamespace(ctx)
+	info, err := t.c.client.ContainerService().Get(ctx, t.journal.Labels[labelRevisionContainer])
+	if err != nil {
+		return err
+	}
+	if info.Labels[labelDeploymentRevision] != t.Revision() {
+		return fmt.Errorf("active container revision changed during deployment")
+	}
+	delete(info.Labels, labelDeploymentPending)
+	if _, err = t.c.client.ContainerService().Update(ctx, info, "labels"); err != nil {
+		return err
+	}
+	// Removing pending is the durable commit point. A crash before updating the
+	// journal is recognized by RecoverDeployments and never rolls back success.
+	t.committed = true
+	if err := t.setPhase(ctx, "retained"); err != nil {
+		t.c.logger.Warn("Deployment committed; journal finalization will resume on restart", zap.Error(err))
+		return nil
+	}
+	if err := t.pruneOlderRevisions(ctx); err != nil {
+		t.c.logger.Warn("Deployment committed; older revision cleanup failed", zap.Error(err))
+	}
+	return nil
+}
+
+func (t *deploymentTransaction) Rollback(ctx context.Context) (<-chan services.ContainerOutput, error) {
+	if t.committed {
+		return nil, fmt.Errorf("cannot roll back a committed transaction")
+	}
+	if t.rolledBack {
+		return nil, nil
+	}
+	if !t.activated {
+		return nil, nil
+	}
+	ctx = t.c.withNamespace(ctx)
+	name := t.journal.Labels[labelRevisionContainer]
+	current, err := t.c.client.ContainerService().Get(ctx, name)
+	if err == nil && t.metadata.Original != nil && current.SnapshotKey == t.metadata.Original.SnapshotKey {
+		// Activation stopped the old task but failed before replacing metadata.
+		// Keep its snapshot and rebuild its transient resources before restarting.
+		if current.Labels[labelDeploymentRevision] == "" {
+			current.Labels[labelDeploymentRevision] = t.PreviousRevision()
+			if _, err := t.c.client.ContainerService().Update(ctx, current, "labels"); err != nil {
+				return nil, err
+			}
+		}
+	} else {
+		if err == nil {
+			if current.Labels[labelDeploymentRevision] != t.Revision() {
+				return nil, fmt.Errorf("refusing rollback: another revision now owns %q", name)
+			}
+			if err := t.c.StopContainer(ctx, name); err != nil {
+				return nil, err
+			}
+			if err := t.c.DeleteContainer(ctx, name, false); err != nil {
+				return nil, err
+			}
+		} else if !errdefs.IsNotFound(err) {
+			return nil, err
+		}
+		if t.metadata.Original != nil {
+			// Recreate metadata directly. Do not resolve Image, run CreateContainer,
+			// or allocate a new snapshot: :latest may already refer to bad code.
+			original := t.metadata.Original.container()
+			if original.Labels == nil {
+				original.Labels = make(map[string]string)
+			}
+			original.Labels[labelDeploymentRevision] = t.PreviousRevision()
+			if _, err := t.c.client.ContainerService().Create(ctx, original); err != nil {
+				return nil, fmt.Errorf("restoring retained container metadata: %w", err)
+			}
+		}
+	}
+	var output <-chan services.ContainerOutput
+	if original := t.metadata.Original; original != nil {
+		if err := t.c.restoreDeploymentResources(ctx, original); err != nil {
+			return nil, err
+		}
+		if t.metadata.WasRunning {
+			output, err = t.c.StartContainer(ctx, name, "", nil)
+			if err != nil {
+				return output, fmt.Errorf("restarting previous revision: %w", err)
+			}
+		}
+	}
+	t.rolledBack = true
+	if err := t.setPhase(ctx, "restored"); err != nil {
+		return output, err
+	}
+	return output, nil
+}
+
+func (c *Client) restoreDeploymentResources(ctx context.Context, r *retainedContainer) error {
+	appID, serviceName := r.Labels[labelKeyAppID], r.Labels[labelKeyServiceName]
+	if appID == "" {
+		appID = r.ID
+	}
+	if err := appconfig.ValidateAppID(appID); err != nil {
+		return err
+	}
+	if serviceName != "" {
+		if err := appconfig.ValidateServiceName(serviceName); err != nil {
+			return err
+		}
+	}
+	entitlements := parseEntitlementsFromAnnotations(r.Labels)
+	c.mu.Lock()
+	if c.appIsolation == nil {
+		c.appIsolation = make(map[string]string)
+	}
+	c.appIsolation[appID] = r.Labels[labelKeyIsolation]
+	c.mu.Unlock()
+	if entitlementsContain(entitlements, appconfig.EntitlementBluetooth) {
+		if c.proxyManager == nil {
+			return fmt.Errorf("restoring Bluetooth proxy: manager unavailable")
+		}
+		if _, err := c.proxyManager.Start(ctx, r.ID); err != nil {
+			return err
+		}
+	}
+	if entitlementsContain(entitlements, appconfig.EntitlementNotifications) {
+		if c.systemAPISocketProvider == nil {
+			return fmt.Errorf("restoring app System API socket: manager unavailable")
+		}
+		if _, err := c.systemAPISocketProvider.Ensure(appID, serviceName, []string{services.SystemAPICapabilityNotifications}); err != nil {
+			return err
+		}
+	}
+	// A stopped or replaced revision's saved network namespace path may no
+	// longer exist. StartContainer checks and recreates CNI/DNS from these labels.
+	return nil
+}
+
+func (t *deploymentTransaction) Close(ctx context.Context) error {
+	if t.closed {
+		return nil
+	}
+	t.closed = true
+	defer t.resume()
+	if t.committed || (t.activated && !t.rolledBack) {
+		return nil
+	}
+	ctx = t.c.withNamespace(ctx)
+	// The snapshot may still be waiting under the candidate alias if prepare
+	// was canceled, or activation failed before container creation consumed it.
+	t.c.takePreparedSnapshot(t.metadata.CandidateImage, "").discard()
+	// Metadata-only deletion: the restored/original live container owns this
+	// same writable snapshot. WithSnapshotCleanup here would destroy it.
+	err := t.c.client.ContainerService().Delete(ctx, t.journal.ID)
+	if errdefs.IsNotFound(err) {
+		err = nil
+	}
+	imageErr := t.c.client.ImageService().Delete(ctx, t.metadata.CandidateImage)
+	if errdefs.IsNotFound(imageErr) {
+		imageErr = nil
+	}
+	return errors.Join(err, imageErr)
+}
+
+func (t *deploymentTransaction) pruneOlderRevisions(ctx context.Context) error {
+	// Keep exactly one preceding revision per concrete container. Explicit
+	// snapshot deletion is safe only after excluding every current container's
+	// snapshot key; an interrupted prepared transaction may share that snapshot.
+	all, err := t.c.client.ContainerService().List(ctx)
+	if err != nil {
+		return err
+	}
+	live := map[string]bool{}
+	aliases := map[string]bool{}
+	for _, info := range all {
+		if info.Labels[labelRevisionContainer] == "" {
+			live[info.Snapshotter+"\x00"+info.SnapshotKey] = true
+		}
+	}
+	for _, info := range all {
+		if info.ID == t.journal.ID || info.Labels[labelRevisionContainer] != t.journal.Labels[labelRevisionContainer] {
+			continue
+		}
+		if info.Labels[labelRevisionPhase] != "retained" {
+			continue
+		}
+		if err := t.c.client.ContainerService().Delete(ctx, info.ID); err != nil {
+			return err
+		}
+		aliases[info.Image] = true
+		if info.SnapshotKey != "" && !live[info.Snapshotter+"\x00"+info.SnapshotKey] && info.SnapshotKey != t.journal.SnapshotKey {
+			if err := t.c.client.SnapshotService(info.Snapshotter).Remove(ctx, info.SnapshotKey); err != nil && !errdefs.IsNotFound(err) {
+				return err
+			}
+		}
+		if m, err := decodeRevisionMetadata(info); err == nil {
+			aliases[m.CandidateImage] = true
+		}
+	}
+	remaining, err := t.c.client.ContainerService().List(ctx)
+	if err != nil {
+		return err
+	}
+	for _, info := range remaining {
+		delete(aliases, info.Image)
+		if m, err := decodeRevisionMetadata(info); err == nil {
+			delete(aliases, m.CandidateImage)
+			if m.Original != nil {
+				delete(aliases, m.Original.Image)
+			}
+		}
+	}
+	for alias := range aliases {
+		// Never garbage collect arbitrary user image names or legacy :latest.
+		if !strings.HasPrefix(alias, "docker.io/wendy-revision/") {
+			continue
+		}
+		if err := t.c.client.ImageService().Delete(ctx, alias); err != nil && !errdefs.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+// DeleteDeploymentRevisions is called only after an explicit user deletion,
+// under the service's app lock. Internal replacement and rollback deletion must
+// retain these journals. A tombstone prevents interrupted cleanup from turning
+// a pending deployment into a request to restore an intentionally removed app.
+func (c *Client) DeleteDeploymentRevisions(ctx context.Context, containerNames []string) error {
+	return c.deleteDeploymentRevisions(ctx, containerNames, false)
+}
+
+func (c *Client) deleteDeploymentRevisions(ctx context.Context, containerNames []string, onlyDeleted bool) error {
+	ctx = c.withNamespace(ctx)
+	names := make(map[string]bool, len(containerNames))
+	for _, name := range containerNames {
+		if name != "" {
+			names[name] = true
+		}
+	}
+	all, err := c.client.ContainerService().List(ctx)
+	if err != nil {
+		return err
+	}
+	var deleted []containers.Container
+	var errs []error
+	for _, info := range all {
+		if !names[info.Labels[labelRevisionContainer]] || (onlyDeleted && info.Labels[labelRevisionPhase] != "deleted") {
+			continue
+		}
+		info.Labels[labelRevisionPhase] = "deleted"
+		if _, err := c.client.ContainerService().Update(ctx, info, "labels"); err != nil {
+			errs = append(errs, fmt.Errorf("tombstoning deployment journal %s: %w", info.ID, err))
+			continue
+		}
+		deleted = append(deleted, info)
+	}
+	if len(errs) > 0 {
+		// Keep successfully written tombstones if durable intent could not be
+		// recorded for the whole selection; report the incomplete deletion.
+		return errors.Join(errs...)
+	}
+	// Tombstone all selected records before removing any, so recovery can finish
+	// cleanup even if the process stops between two journal deletions.
+	type snapshotReference struct{ snapshotter, key string }
+	snapshotRefs := map[snapshotReference]bool{}
+	aliases := map[string]bool{}
+	for _, info := range deleted {
+		if err := c.client.ContainerService().Delete(ctx, info.ID); err != nil && !errdefs.IsNotFound(err) {
+			errs = append(errs, fmt.Errorf("deleting deployment journal %s: %w", info.ID, err))
+			continue
+		}
+		if info.SnapshotKey != "" {
+			snapshotRefs[snapshotReference{info.Snapshotter, info.SnapshotKey}] = true
+		}
+		aliases[info.Image] = true
+		if m, err := decodeRevisionMetadata(info); err == nil {
+			c.takePreparedSnapshot(m.CandidateImage, "").discard()
+			aliases[m.CandidateImage] = true
+			if m.Original != nil {
+				aliases[m.Original.Image] = true
+			}
+		}
+	}
+	remaining, err := c.client.ContainerService().List(ctx)
+	if err != nil {
+		return errors.Join(append(errs, err)...)
+	}
+	for _, info := range remaining {
+		// Protect both real containers and every remaining journal. A snapshot
+		// may be shared with a restored live revision or another GC root.
+		delete(snapshotRefs, snapshotReference{info.Snapshotter, info.SnapshotKey})
+		delete(aliases, info.Image)
+		if m, err := decodeRevisionMetadata(info); err == nil {
+			delete(aliases, m.CandidateImage)
+			if m.Original != nil {
+				delete(aliases, m.Original.Image)
+			}
+		}
+	}
+	for ref := range snapshotRefs {
+		if err := c.client.SnapshotService(ref.snapshotter).Remove(ctx, ref.key); err != nil && !errdefs.IsNotFound(err) {
+			errs = append(errs, fmt.Errorf("deleting retained snapshot %s: %w", ref.key, err))
+		}
+	}
+	for alias := range aliases {
+		if !strings.HasPrefix(alias, "docker.io/wendy-revision/") {
+			continue // --delete-image remains responsible for user image names.
+		}
+		if err := c.client.ImageService().Delete(ctx, alias); err != nil && !errdefs.IsNotFound(err) {
+			errs = append(errs, fmt.Errorf("deleting retained image %s: %w", alias, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// RecoverDeployments must run before the container restart monitor on startup.
+// Uncommitted candidates are rolled back using only durable local metadata.
+func (c *Client) RecoverDeployments(ctx context.Context) error {
+	ctx = c.withNamespace(ctx)
+	entries, err := c.client.ContainerService().List(ctx, fmt.Sprintf("labels.%q", labelRevisionContainer))
+	if err != nil {
+		return err
+	}
+	var deletedNames []string
+	for _, entry := range entries {
+		if entry.Labels[labelRevisionPhase] == "deleted" {
+			deletedNames = append(deletedNames, entry.Labels[labelRevisionContainer])
+		}
+	}
+	if len(deletedNames) > 0 {
+		// A newer deployment may exist for a name whose earlier deletion only
+		// partially cleaned up. Its journal remains an independent recovery root.
+		if err := c.deleteDeploymentRevisions(ctx, deletedNames, true); err != nil {
+			return fmt.Errorf("finishing deleted deployment cleanup: %w", err)
+		}
+		// Cleanup can remove other journals for the same deleted app. Never use
+		// a stale listing to resurrect one of those just-deleted records.
+		entries, err = c.client.ContainerService().List(ctx, fmt.Sprintf("labels.%q", labelRevisionContainer))
+		if err != nil {
+			return err
+		}
+	}
+	var errs []error
+	for _, entry := range entries {
+		phase := entry.Labels[labelRevisionPhase]
+		if phase == "retained" {
+			continue
+		}
+		m, err := decodeRevisionMetadata(entry)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		t := &deploymentTransaction{c: c, journal: entry, metadata: m, resume: c.suppressRestarts(entry.Labels[labelRevisionContainer]), activated: phase == "activating", rolledBack: phase == "restored"}
+		if t.activated {
+			current, currentErr := c.client.ContainerService().Get(ctx, entry.Labels[labelRevisionContainer])
+			if currentErr == nil && current.Labels[labelDeploymentRevision] == m.Revision && current.Labels[labelDeploymentPending] == "" {
+				t.committed = true
+				err = t.setPhase(ctx, "retained")
+			} else {
+				var output <-chan services.ContainerOutput
+				output, err = t.Rollback(ctx)
+				if output != nil {
+					go func() {
+						for range output {
+						}
+					}()
+				}
+			}
+		}
+		if closeErr := t.Close(ctx); closeErr != nil {
+			errs = append(errs, closeErr)
+		}
+		if err != nil {
+			errs = append(errs, fmt.Errorf("recovering deployment %s: %w", m.Revision, err))
+		} else {
+			c.logger.Info("Recovered deployment journal", zap.String("revision", m.Revision), zap.String("phase", phase))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// prevent premature deletion of a pending candidate by boot reconciliation.
+func deploymentIsPending(labels map[string]string) bool { return labels[labelDeploymentPending] != "" }

--- a/go/internal/agent/containerd/deployment_test.go
+++ b/go/internal/agent/containerd/deployment_test.go
@@ -1,0 +1,484 @@
+package containerd
+
+import (
+	"context"
+	"errors"
+	"maps"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"testing"
+	"time"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/core/containers"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/metadata"
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/containerd/containerd/v2/plugins/content/local"
+	"github.com/containerd/containerd/v2/plugins/snapshots/native"
+	"github.com/containerd/errdefs"
+	"github.com/containerd/typeurl/v2"
+	bolt "go.etcd.io/bbolt"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+type revisionContainerStore struct {
+	entries           map[string]containers.Container
+	failJournalUpdate bool
+	failJournalDelete bool
+}
+
+func (s *revisionContainerStore) Get(_ context.Context, id string) (containers.Container, error) {
+	v, ok := s.entries[id]
+	if !ok {
+		return v, errdefs.ErrNotFound
+	}
+	v.Labels = maps.Clone(v.Labels)
+	return v, nil
+}
+func (s *revisionContainerStore) List(_ context.Context, filters ...string) ([]containers.Container, error) {
+	var out []containers.Container
+	for _, v := range s.entries {
+		if len(filters) > 0 && v.Labels[labelRevisionContainer] == "" {
+			continue
+		}
+		v.Labels = maps.Clone(v.Labels)
+		out = append(out, v)
+	}
+	return out, nil
+}
+func (s *revisionContainerStore) Create(_ context.Context, v containers.Container) (containers.Container, error) {
+	if _, ok := s.entries[v.ID]; ok {
+		return v, errdefs.ErrAlreadyExists
+	}
+	v.Labels = maps.Clone(v.Labels)
+	s.entries[v.ID] = v
+	return v, nil
+}
+func (s *revisionContainerStore) Update(_ context.Context, v containers.Container, _ ...string) (containers.Container, error) {
+	if s.failJournalUpdate && v.Labels[labelRevisionContainer] != "" {
+		return v, errors.New("journal storage failure")
+	}
+	if _, ok := s.entries[v.ID]; !ok {
+		return v, errdefs.ErrNotFound
+	}
+	v.Labels = maps.Clone(v.Labels)
+	s.entries[v.ID] = v
+	return v, nil
+}
+func (s *revisionContainerStore) Delete(_ context.Context, id string) error {
+	if s.failJournalDelete && s.entries[id].Labels[labelRevisionContainer] != "" {
+		return errors.New("journal deletion failure")
+	}
+	if _, ok := s.entries[id]; !ok {
+		return errdefs.ErrNotFound
+	}
+	delete(s.entries, id)
+	return nil
+}
+
+func TestDeleteDeploymentRevisionsRemovesRollbackRoots(t *testing.T) {
+	for _, phase := range []string{"retained", "activating", "prepared"} {
+		t.Run(phase, func(t *testing.T) {
+			c, store, imgs, sn := revisionTestClient(t)
+			tx := revisionTestTransaction(t, c, store, phase)
+			previousAlias := "docker.io/wendy-revision/previous:candidate"
+			candidateAlias := "docker.io/wendy-revision/candidate:candidate"
+			tx.metadata.Original.Image = previousAlias
+			tx.metadata.CandidateImage = candidateAlias
+			tx.journal.Image = previousAlias
+			encoded, err := encodeRevisionMetadata(tx.metadata)
+			if err != nil {
+				t.Fatal(err)
+			}
+			tx.journal.Extensions[revisionExtension] = encoded
+			store.entries[tx.journal.ID] = tx.journal
+			if err := c.DeleteDeploymentRevisions(context.Background(), []string{"app"}); err != nil {
+				t.Fatal(err)
+			}
+			if len(store.entries) != 0 {
+				t.Fatalf("retained metadata survived explicit deletion: %v", store.entries)
+			}
+			if !reflect.DeepEqual(sn.removed, []string{tx.journal.SnapshotKey}) {
+				t.Fatalf("removed snapshots = %v", sn.removed)
+			}
+			slices.Sort(imgs.deleted)
+			if !reflect.DeepEqual(imgs.deleted, []string{candidateAlias, previousAlias}) {
+				t.Fatalf("removed immutable aliases = %v", imgs.deleted)
+			}
+			if err := c.RecoverDeployments(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+			if len(store.entries) != 0 {
+				t.Fatal("agent restart resurrected an explicitly deleted app")
+			}
+		})
+	}
+}
+
+func TestDeleteDeploymentRevisionsPreservesOtherSnapshotAndImageOwners(t *testing.T) {
+	c, store, imgs, sn := revisionTestClient(t)
+	tx := revisionTestTransaction(t, c, store, "retained")
+	alias := "docker.io/wendy-revision/shared:candidate"
+	tx.journal.Image = alias
+	store.entries[tx.journal.ID] = tx.journal
+	store.entries["other-live"] = containers.Container{ID: "other-live", Image: alias,
+		Snapshotter: tx.journal.Snapshotter, SnapshotKey: tx.journal.SnapshotKey}
+	other := tx.journal
+	other.ID = "other-journal"
+	other.Labels = map[string]string{labelRevisionContainer: "app-sibling", labelRevisionPhase: "retained"}
+	store.entries[other.ID] = other
+	if err := c.DeleteDeploymentRevisions(context.Background(), []string{"app"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(sn.removed) != 0 || len(imgs.deleted) != 0 {
+		t.Fatalf("deleted resources still in use: snapshots=%v images=%v", sn.removed, imgs.deleted)
+	}
+	if len(store.entries) != 2 {
+		t.Fatalf("deleted another container or journal: %v", store.entries)
+	}
+}
+
+func TestRecoverDeploymentDeletionTombstoneNeverRestoresApp(t *testing.T) {
+	c, store, _, sn := revisionTestClient(t)
+	tx := revisionTestTransaction(t, c, store, "activating")
+	store.failJournalDelete = true
+	if err := c.DeleteDeploymentRevisions(context.Background(), []string{"app"}); err == nil {
+		t.Fatal("expected cleanup failure")
+	}
+	if store.entries[tx.journal.ID].Labels[labelRevisionPhase] != "deleted" {
+		t.Fatal("cleanup failure did not persist deletion intent")
+	}
+	store.failJournalDelete = false
+	if err := c.RecoverDeployments(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.entries) != 0 || !reflect.DeepEqual(sn.removed, []string{tx.journal.SnapshotKey}) {
+		t.Fatalf("recovery failed to finish deletion: metadata=%v removed=%v", store.entries, sn.removed)
+	}
+}
+
+func TestRuntimeCleanupGetsFreshBoundedContext(t *testing.T) {
+	c, _, _, _ := revisionTestClient(t)
+	for range 2 {
+		var usedCtx context.Context
+		if err := c.cleanupRuntimeOperation(func(ctx context.Context) error {
+			usedCtx = ctx
+			deadline, ok := ctx.Deadline()
+			if !ok || time.Until(deadline) <= 4*time.Second || time.Until(deadline) > 5*time.Second {
+				t.Fatalf("cleanup deadline is not freshly bounded: %v, %v", deadline, ok)
+			}
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if !errors.Is(usedCtx.Err(), context.Canceled) {
+			t.Fatal("cleanup did not release its context")
+		}
+	}
+}
+
+func TestDeletedJournalRecoveryPreservesNewerDeploymentForSameApp(t *testing.T) {
+	c, store, _, sn := revisionTestClient(t)
+	old := revisionTestTransaction(t, c, store, "deleted").journal
+	old.ID = "older-deleted-journal"
+	store.entries[old.ID] = old
+	tx := revisionTestTransaction(t, c, store, "activating")
+	tx.metadata.Original.SnapshotKey = "newer-original-rootfs"
+	tx.metadata.Original.Labels[labelKeyAppVersion] = "newer-version"
+	tx.journal.SnapshotKey = tx.metadata.Original.SnapshotKey
+	encoded, err := encodeRevisionMetadata(tx.metadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx.journal.Extensions[revisionExtension] = encoded
+	store.entries[tx.journal.ID] = tx.journal
+	if err := c.RecoverDeployments(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	live := store.entries["app"]
+	if live.SnapshotKey != "newer-original-rootfs" || live.Labels[labelKeyAppVersion] != "newer-version" {
+		t.Fatalf("older deletion lost the newer deployment recovery state: %+v", live)
+	}
+	if !reflect.DeepEqual(sn.removed, []string{old.SnapshotKey}) {
+		t.Fatalf("deleted snapshots = %v; expected only older deleted rootfs", sn.removed)
+	}
+}
+
+type revisionImageStore struct {
+	images.Store
+	getCalls int
+	deleted  []string
+}
+
+func (s *revisionImageStore) Get(context.Context, string) (images.Image, error) {
+	s.getCalls++
+	return images.Image{}, errors.New("mutable image must not be consulted")
+}
+func (s *revisionImageStore) Delete(_ context.Context, name string, _ ...images.DeleteOpt) error {
+	s.deleted = append(s.deleted, name)
+	return nil
+}
+
+type revisionSnapshots struct {
+	snapshots.Snapshotter
+	removed []string
+}
+
+func (s *revisionSnapshots) Remove(_ context.Context, key string) error {
+	s.removed = append(s.removed, key)
+	return nil
+}
+
+func revisionTestClient(t *testing.T) (*Client, *revisionContainerStore, *revisionImageStore, *revisionSnapshots) {
+	t.Helper()
+	store := &revisionContainerStore{entries: map[string]containers.Container{}}
+	imgs := &revisionImageStore{}
+	sn := &revisionSnapshots{}
+	client, err := containerd.New("", containerd.WithServices(containerd.WithContainerStore(store), containerd.WithImageStore(imgs), containerd.WithSnapshotters(map[string]snapshots.Snapshotter{"overlayfs": sn})))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	return &Client{client: client, namespace: "test", logger: zap.NewNop()}, store, imgs, sn
+}
+func revisionOriginal() containers.Container {
+	return containers.Container{ID: "app", Labels: map[string]string{labelKeyAppID: "app", labelKeyAppVersion: "old", labelKeyRestartPolicy: "no"}, Image: "app:latest",
+		Runtime:     containers.RuntimeInfo{Name: "io.containerd.runc.v2", Options: &anypb.Any{TypeUrl: "runtime/options", Value: []byte{1, 2}}},
+		Spec:        &anypb.Any{TypeUrl: "runtime/spec", Value: []byte(`{"process":{"args":["old"],"env":["OLD=1"]}}`)},
+		Snapshotter: "overlayfs", SnapshotKey: "old-writable-rootfs", Extensions: map[string]typeurl.Any{"custom": &anypb.Any{TypeUrl: "custom/type", Value: []byte{3, 4}}}}
+}
+func revisionTestTransaction(t *testing.T, c *Client, store *revisionContainerStore, phase string) *deploymentTransaction {
+	t.Helper()
+	original := revisionOriginal()
+	m := retainedMetadata{Original: retainContainer(original), Revision: "candidate", PreviousRevision: "previous", CandidateImage: "wendy-revision/candidate:candidate"}
+	ext, err := encodeRevisionMetadata(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	journal := containers.Container{ID: "wendy-revision-candidate", Labels: map[string]string{labelRevisionContainer: "app", labelRevisionPhase: phase},
+		SnapshotKey: original.SnapshotKey, Snapshotter: original.Snapshotter, Spec: original.Spec, Runtime: original.Runtime, Extensions: map[string]typeurl.Any{revisionExtension: ext}}
+	store.entries[journal.ID] = journal
+	return &deploymentTransaction{c: c, journal: journal, metadata: m, resume: func() {}, activated: phase == "activating"}
+}
+
+func TestRetainedContainerRoundTripPreservesRuntimeSnapshotAndSpec(t *testing.T) {
+	original := revisionOriginal()
+	m := retainedMetadata{Original: retainContainer(original), Revision: "r", CandidateImage: "immutable"}
+	encoded, err := encodeRevisionMetadata(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	journal := containers.Container{ID: "hidden", Labels: map[string]string{labelRevisionContainer: original.ID}, Extensions: map[string]typeurl.Any{revisionExtension: encoded}}
+	got, err := decodeRevisionMetadata(journal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got.Original.container(), original) {
+		t.Fatalf("retained revision changed:\n%#v\n%#v", got.Original.container(), original)
+	}
+	original.Labels[labelKeyAppVersion] = "mutated"
+	if got.Original.Labels[labelKeyAppVersion] != "old" {
+		t.Fatal("retained labels alias mutable live metadata")
+	}
+}
+
+func TestRollbackRestoresExactSnapshotWithoutReadingMutableImage(t *testing.T) {
+	c, store, imgs, sn := revisionTestClient(t)
+	tx := revisionTestTransaction(t, c, store, "activating")
+	// Simulate failed candidate creation after the old metadata was removed.
+	if _, err := tx.Rollback(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	got := store.entries["app"]
+	want := revisionOriginal()
+	want.Labels[labelDeploymentRevision] = "previous"
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("restored metadata differs:\n%#v\n%#v", got, want)
+	}
+	if err := tx.Close(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if imgs.getCalls != 0 {
+		t.Fatal("rollback resolved the mutable image tag")
+	}
+	if len(sn.removed) != 0 {
+		t.Fatalf("rollback/close deleted retained rootfs: %v", sn.removed)
+	}
+	if _, ok := store.entries["app"]; !ok {
+		t.Fatal("close deleted the restored container")
+	}
+	if _, ok := store.entries[tx.journal.ID]; ok {
+		t.Fatal("restored journal was not cleaned up")
+	}
+}
+
+func TestCommitRetainsPreviousSnapshotAndCloseDoesNotDeleteIt(t *testing.T) {
+	c, store, _, sn := revisionTestClient(t)
+	tx := revisionTestTransaction(t, c, store, "activating")
+	store.entries["app"] = containers.Container{ID: "app", SnapshotKey: "candidate-rootfs", Snapshotter: "overlayfs", Labels: map[string]string{labelDeploymentRevision: "candidate", labelDeploymentPending: "candidate"}}
+	if err := tx.Commit(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Close(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	journal, ok := store.entries[tx.journal.ID]
+	if !ok || journal.SnapshotKey != "old-writable-rootfs" || journal.Labels[labelRevisionPhase] != "retained" {
+		t.Fatalf("previous snapshot not retained: %#v", journal)
+	}
+	if journal.Labels[labelKeyAppVersion] != "" || journal.Labels[labelKeyAppID] != "" {
+		t.Fatal("archive is visible as a runnable Wendy app")
+	}
+	if len(sn.removed) != 0 {
+		t.Fatalf("commit deleted rollback snapshot: %v", sn.removed)
+	}
+	if deploymentIsPending(store.entries["app"].Labels) {
+		t.Fatal("committed container remains pending")
+	}
+}
+
+func TestCommitCleanupFailureDoesNotTurnSuccessIntoRollbackFailure(t *testing.T) {
+	c, store, _, _ := revisionTestClient(t)
+	tx := revisionTestTransaction(t, c, store, "activating")
+	store.entries["app"] = containers.Container{ID: "app", Labels: map[string]string{labelDeploymentRevision: "candidate", labelDeploymentPending: "candidate"}}
+	store.failJournalUpdate = true
+	if err := tx.Commit(context.Background()); err != nil {
+		t.Fatalf("durably committed healthy revision reported failure: %v", err)
+	}
+	if !tx.committed || deploymentIsPending(store.entries["app"].Labels) {
+		t.Fatal("commit point not persisted")
+	}
+}
+
+func TestRecoverDeploymentAfterCutoverRestoresPriorRootfs(t *testing.T) {
+	c, store, imgs, sn := revisionTestClient(t)
+	revisionTestTransaction(t, c, store, "activating")
+	if err := c.RecoverDeployments(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := store.entries["app"].SnapshotKey; got != "old-writable-rootfs" {
+		t.Fatalf("snapshot=%q", got)
+	}
+	if imgs.getCalls != 0 || len(sn.removed) != 0 {
+		t.Fatal("recovery used mutable image or deleted retained snapshot")
+	}
+}
+
+func TestRecoverRecognizesDurableCommitBeforeJournalFinalization(t *testing.T) {
+	c, store, _, _ := revisionTestClient(t)
+	tx := revisionTestTransaction(t, c, store, "activating")
+	store.entries["app"] = containers.Container{ID: "app", SnapshotKey: "candidate-rootfs", Labels: map[string]string{labelDeploymentRevision: "candidate"}}
+	if err := c.RecoverDeployments(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if store.entries["app"].SnapshotKey != "candidate-rootfs" {
+		t.Fatal("recovery rolled back committed candidate")
+	}
+	if store.entries[tx.journal.ID].Labels[labelRevisionPhase] != "retained" {
+		t.Fatal("recovery did not finalize journal")
+	}
+}
+
+func TestCloseUnactivatedPreparationNeverRemovesExistingSnapshot(t *testing.T) {
+	c, store, _, sn := revisionTestClient(t)
+	tx := revisionTestTransaction(t, c, store, "prepared")
+	store.entries["app"] = revisionOriginal()
+	if err := tx.Close(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(sn.removed) != 0 || store.entries["app"].SnapshotKey != "old-writable-rootfs" {
+		t.Fatal("abandoned prepare disturbed old rootfs")
+	}
+}
+
+func TestRevisionPruneReleasesSupersededImageButKeepsPrevious(t *testing.T) {
+	c, store, imgs, _ := revisionTestClient(t)
+	tx := revisionTestTransaction(t, c, store, "activating")
+	oldAlias := "docker.io/wendy-revision/old:candidate"
+	previousAlias := "docker.io/wendy-revision/previous:candidate"
+	tx.metadata.Original.Image = previousAlias
+	tx.journal.Image = previousAlias
+	encoded, err := encodeRevisionMetadata(tx.metadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx.journal.Extensions[revisionExtension] = encoded
+	store.entries[tx.journal.ID] = tx.journal
+	oldMetadata := retainedMetadata{Revision: "previous", CandidateImage: previousAlias}
+	oldEncoded, err := encodeRevisionMetadata(oldMetadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.entries["older-journal"] = containers.Container{ID: "older-journal", Image: oldAlias,
+		Labels: map[string]string{labelRevisionContainer: "app", labelRevisionPhase: "retained"}, Extensions: map[string]typeurl.Any{revisionExtension: oldEncoded}}
+	if err := tx.pruneOlderRevisions(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(imgs.deleted, []string{oldAlias}) {
+		t.Fatalf("deleted images=%v; want only superseded alias", imgs.deleted)
+	}
+}
+
+func TestRetainedRevisionIsRealContainerdSnapshotGCRoot(t *testing.T) {
+	root := t.TempDir()
+	db, err := bolt.Open(filepath.Join(root, "metadata.db"), 0o600, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	content, err := local.NewStore(filepath.Join(root, "content"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	nativeSN, err := native.NewSnapshotter(filepath.Join(root, "snapshots"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = nativeSN.Close() })
+	mdb := metadata.NewDB(db, content, map[string]snapshots.Snapshotter{"native": nativeSN})
+	ctx := namespaces.WithNamespace(context.Background(), "revision-test")
+	if err := mdb.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	store := metadata.NewContainerStore(mdb)
+	sn := mdb.Snapshotter("native")
+	if _, err := sn.Prepare(ctx, "old-rootfs", ""); err != nil {
+		t.Fatal(err)
+	}
+	original := revisionOriginal()
+	original.Snapshotter, original.SnapshotKey = "native", "old-rootfs"
+	if _, err := store.Create(ctx, original); err != nil {
+		t.Fatal(err)
+	}
+	archive := original
+	archive.ID = "hidden-revision"
+	archive.Image = ""
+	archive.Labels = map[string]string{labelRevisionContainer: "app", labelRevisionPhase: "retained"}
+	if _, err := store.Create(ctx, archive); err != nil {
+		t.Fatal(err)
+	}
+	// Activation removes only old metadata; the hidden revision takes over
+	// ownership of the exact active snapshot, even after actual containerd GC.
+	if err := store.Delete(ctx, original.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := mdb.GarbageCollect(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sn.Stat(ctx, "old-rootfs"); err != nil {
+		t.Fatalf("retained rootfs was garbage collected: %v", err)
+	}
+	if err := store.Delete(ctx, archive.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := mdb.GarbageCollect(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sn.Stat(ctx, "old-rootfs"); !errdefs.IsNotFound(err) {
+		t.Fatalf("unreferenced rootfs should become collectible, got %v", err)
+	}
+}

--- a/go/internal/agent/containerd/prepare.go
+++ b/go/internal/agent/containerd/prepare.go
@@ -30,7 +30,7 @@ func (c *Client) PrepareImage(ctx context.Context, imageName string, layers []*a
 	releaseLease := true
 	defer func() {
 		if releaseLease {
-			if err := doneLease(cleanupCtx); err != nil {
+			if err := c.cleanupRuntimeOperation(doneLease); err != nil {
 				c.logger.Warn("Failed to release image preparation lease; relying on expiration backstop",
 					zap.Duration("expiration", unpackLeaseExpiration),
 					zap.Error(err),
@@ -109,8 +109,10 @@ func (c *Client) PrepareImage(ctx context.Context, imageName string, layers []*a
 		c.storePreparedSnapshot(normalizeImageName(imageName), &preparedSnapshot{
 			key:     preparedKey,
 			parent:  parentChainID,
-			release: func() { _ = doneLease(cleanupCtx) },
-			remove:  func() { _ = sn.Remove(cleanupCtx, preparedKey) },
+			release: func() { _ = c.cleanupRuntimeOperation(doneLease) },
+			remove: func() {
+				_ = c.cleanupRuntimeOperation(func(ctx context.Context) error { return sn.Remove(ctx, preparedKey) })
+			},
 		})
 		// The stored snapshot owns this lease until CreateContainer consumes or
 		// replaces it. The 30-minute expiration remains a crash/disconnect

--- a/go/internal/agent/containerd/prepared_snapshot.go
+++ b/go/internal/agent/containerd/prepared_snapshot.go
@@ -1,5 +1,18 @@
 package containerd
 
+import (
+	"context"
+	"time"
+)
+
+// Cleanup can run long after preparation and after its caller disconnects.
+// Allocate the deadline when cleanup starts, never when the snapshot is staged.
+func (c *Client) cleanupRuntimeOperation(operation func(context.Context) error) error {
+	ctx, cancel := context.WithTimeout(c.withNamespace(context.Background()), 5*time.Second)
+	defer cancel()
+	return operation(ctx)
+}
+
 // preparedSnapshot is a fresh active snapshot that has never backed a task.
 // remove and release are idempotent at the containerd layer; the small once
 // guards keep our bookkeeping deterministic under replacement/close races.

--- a/go/internal/agent/containerd/readiness.go
+++ b/go/internal/agent/containerd/readiness.go
@@ -1,0 +1,140 @@
+package containerd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/pkg/cio"
+	"github.com/wendylabsinc/wendy/go/internal/agent/services"
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+var _ services.ContainerReadinessProber = (*Client)(nil)
+
+func (c *Client) ProbeReadiness(ctx context.Context, name string, probe *appconfig.ReadinessConfig) error {
+	ctx = c.withNamespace(ctx)
+	ctr, err := c.runningContainerForApp(ctx, name)
+	if err != nil {
+		return err
+	}
+	task, err := ctr.Task(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("application process is not running: %w", err)
+	}
+	if err := readinessRunning(ctx, task); err != nil {
+		return err
+	}
+	if probe == nil {
+		return nil
+	}
+	if probe.Exec != nil {
+		if err := c.execReadiness(ctx, ctr, task, probe.Exec); err != nil {
+			return err
+		}
+	} else {
+		dial := func(ctx context.Context, network, address string) (net.Conn, error) {
+			return dialReadinessNamespace(ctx, task.Pid(), network, address)
+		}
+		if err := checkNetworkReadiness(ctx, probe, dial); err != nil {
+			return err
+		}
+	}
+	// A successful socket/HTTP/exec check must not hide a process that exited
+	// while the probe was running.
+	return readinessRunning(ctx, task)
+}
+
+func readinessRunning(ctx context.Context, task containerd.Task) error {
+	state, err := task.Status(ctx)
+	if err != nil {
+		return fmt.Errorf("reading application process state: %w", err)
+	}
+	if state.Status != containerd.Running {
+		return fmt.Errorf("application process is %s (exit code %d)", state.Status, state.ExitStatus)
+	}
+	return nil
+}
+
+func checkNetworkReadiness(ctx context.Context, probe *appconfig.ReadinessConfig, dial func(context.Context, string, string) (net.Conn, error)) error {
+	if tcp := probe.TCPSocket; tcp != nil {
+		conn, err := dial(ctx, "tcp4", net.JoinHostPort("127.0.0.1", strconv.Itoa(tcp.Port)))
+		if err != nil {
+			return fmt.Errorf("TCP readiness on port %d: %w", tcp.Port, err)
+		}
+		return conn.Close()
+	}
+	if get := probe.HTTPGet; get != nil {
+		transport := &http.Transport{DialContext: dial, DisableKeepAlives: true}
+		defer transport.CloseIdleConnections()
+		client := &http.Client{Transport: transport, CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+		path := get.Path
+		if path == "" {
+			path = "/"
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://127.0.0.1:"+strconv.Itoa(get.Port)+path, nil)
+		if err != nil {
+			return fmt.Errorf("HTTP readiness request: %w", err)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return fmt.Errorf("HTTP readiness: %w", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+			return fmt.Errorf("HTTP readiness returned %s", resp.Status)
+		}
+		return nil
+	}
+	return fmt.Errorf("readiness has no probe")
+}
+
+// Each exec attempt has independent bounded cleanup. In particular, cancellation
+// must not send Kill with an already-cancelled context and then wait forever.
+func (c *Client) execReadiness(ctx context.Context, ctr containerd.Container, task containerd.Task, command []string) error {
+	spec, err := ctr.Spec(ctx)
+	if err != nil || spec.Process == nil {
+		return fmt.Errorf("reading readiness process spec: %v", err)
+	}
+	process := *spec.Process
+	process.Args = append([]string(nil), command...)
+	process.Env = append([]string(nil), process.Env...)
+	process.Terminal = false
+	id := fmt.Sprintf("readiness-%d-%d", time.Now().UnixNano(), execCounter.Add(1))
+	proc, err := task.Exec(ctx, id, &process, cio.NewCreator(cio.WithStreams(nil, io.Discard, io.Discard)))
+	if err != nil {
+		return fmt.Errorf("creating readiness exec: %w", err)
+	}
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+		_, _ = proc.Delete(cleanupCtx, containerd.WithProcessKill)
+	}()
+	statusCh, err := proc.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("waiting for readiness exec: %w", err)
+	}
+	if err := proc.Start(ctx); err != nil {
+		return fmt.Errorf("starting readiness exec: %w", err)
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case exit, ok := <-statusCh:
+		if !ok {
+			return fmt.Errorf("readiness exec ended without an exit status")
+		}
+		if err := exit.Error(); err != nil {
+			return fmt.Errorf("readiness exec: %w", err)
+		}
+		if exit.ExitCode() != 0 {
+			return fmt.Errorf("readiness exec exited with code %d", exit.ExitCode())
+		}
+		return nil
+	}
+}

--- a/go/internal/agent/containerd/readiness_linux.go
+++ b/go/internal/agent/containerd/readiness_linux.go
@@ -1,0 +1,27 @@
+//go:build linux
+
+package containerd
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+)
+
+func dialReadinessNamespace(ctx context.Context, pid uint32, network, address string) (conn net.Conn, err error) {
+	// Only numeric IPv4 loopback is used: no host DNS resolver, proxy, or
+	// parallel IPv4/IPv6 dial can escape the target's network namespace.
+	netns, err := ns.GetNS(fmt.Sprintf("/proc/%d/ns/net", pid))
+	if err != nil {
+		return nil, fmt.Errorf("opening application network namespace: %w", err)
+	}
+	defer netns.Close()
+	err = netns.Do(func(ns.NetNS) error {
+		var dialErr error
+		conn, dialErr = (&net.Dialer{}).DialContext(ctx, "tcp4", address)
+		return dialErr
+	})
+	return conn, err
+}

--- a/go/internal/agent/containerd/readiness_other.go
+++ b/go/internal/agent/containerd/readiness_other.go
@@ -1,0 +1,13 @@
+//go:build !linux
+
+package containerd
+
+import (
+	"context"
+	"fmt"
+	"net"
+)
+
+func dialReadinessNamespace(context.Context, uint32, string, string) (net.Conn, error) {
+	return nil, fmt.Errorf("container network readiness requires a Linux runtime")
+}

--- a/go/internal/agent/containerd/readiness_test.go
+++ b/go/internal/agent/containerd/readiness_test.go
@@ -1,0 +1,64 @@
+package containerd
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+func TestHTTPReadinessStatusAndNoRedirect(t *testing.T) {
+	for _, code := range []int{200, 204, 302, 399, 400, 503} {
+		t.Run(strconv.Itoa(code), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.RequestURI() != "/health?ready=1" {
+					t.Errorf("path=%s", r.URL.RequestURI())
+				}
+				w.Header().Set("Location", "http://must-not-follow.invalid/")
+				w.WriteHeader(code)
+			}))
+			defer server.Close()
+			_, rawPort, _ := net.SplitHostPort(server.Listener.Addr().String())
+			port, _ := strconv.Atoi(rawPort)
+			err := checkNetworkReadiness(context.Background(), &appconfig.ReadinessConfig{HTTPGet: &appconfig.HTTPGetProbe{Port: port, Path: "/health?ready=1"}}, (&net.Dialer{}).DialContext)
+			if (err == nil) != (code >= 200 && code < 400) {
+				t.Fatalf("code=%d err=%v", code, err)
+			}
+		})
+	}
+}
+
+func TestNetworkReadinessDeadline(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { <-r.Context().Done() }))
+	defer server.Close()
+	_, rawPort, _ := net.SplitHostPort(server.Listener.Addr().String())
+	port, _ := strconv.Atoi(rawPort)
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	err := checkNetworkReadiness(ctx, &appconfig.ReadinessConfig{HTTPGet: &appconfig.HTTPGetProbe{Port: port}}, (&net.Dialer{}).DialContext)
+	if err == nil {
+		t.Fatal("hanging HTTP probe passed")
+	}
+}
+
+func TestTCPReadinessUsesLoopback(t *testing.T) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	port := listener.Addr().(*net.TCPAddr).Port
+	var address string
+	err = checkNetworkReadiness(context.Background(), &appconfig.ReadinessConfig{TCPSocket: &appconfig.TCPSocketProbe{Port: port}}, func(ctx context.Context, network, addr string) (net.Conn, error) {
+		address = addr
+		return (&net.Dialer{}).DialContext(ctx, network, addr)
+	})
+	if err != nil || address != "127.0.0.1:"+strconv.Itoa(port) {
+		t.Fatalf("address=%q err=%v", address, err)
+	}
+}

--- a/go/internal/agent/services/agent_service.go
+++ b/go/internal/agent/services/agent_service.go
@@ -392,6 +392,9 @@ func detectNvidiaGPUArch() string {
 
 func detectFeatureset() []string {
 	var features []string
+	if runtime.GOOS == "linux" {
+		features = append(features, "verified-deployment")
+	}
 
 	if _, err := os.Stat("/dev/nvidia0"); err == nil {
 		features = append(features, "gpu")

--- a/go/internal/agent/services/container_service.go
+++ b/go/internal/agent/services/container_service.go
@@ -69,10 +69,28 @@ type appMutex struct {
 
 // lockApp acquires the per-app lock for appName and returns an unlock function.
 func (a *appMutex) lockApp(appName string) func() {
-	v, _ := a.m.LoadOrStore(appName, &sync.Mutex{})
-	mu := v.(*sync.Mutex)
-	mu.Lock()
-	return mu.Unlock
+	// '_' is valid inside an app ID as well as between app and service. Lock
+	// each possible app prefix in order so a group stop and a service deploy
+	// cannot bypass one another through that ambiguity. Unrelated prefixes
+	// remain concurrent. Unlock is idempotent so streaming handlers can release
+	// after mutation while retaining a deferred cleanup on error paths.
+	var locks []*sync.Mutex
+	for i := 0; i <= len(appName); i++ {
+		if i == len(appName) || (i > 0 && appName[i] == '_') {
+			v, _ := a.m.LoadOrStore(appName[:i], &sync.Mutex{})
+			mu := v.(*sync.Mutex)
+			mu.Lock()
+			locks = append(locks, mu)
+		}
+	}
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			for i := len(locks) - 1; i >= 0; i-- {
+				locks[i].Unlock()
+			}
+		})
+	}
 }
 
 func NewContainerService(logger *zap.Logger, client ContainerdClient, opts ...ContainerServiceOption) *ContainerService {
@@ -193,6 +211,11 @@ func (s *ContainerService) CreateContainer(ctx context.Context, req *agentpb.Cre
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid app config: %v", err)
 	}
+	if err := appconfig.ValidateAppID(req.GetAppName()); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid app name: %v", err)
+	}
+	unlock := s.appMu.lockApp(req.GetAppName())
+	defer unlock()
 
 	if err := s.containerd.CreateContainer(ctx, req, appCfg); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create container: %v", err)
@@ -210,6 +233,11 @@ func (s *ContainerService) CreateContainerWithProgress(req *agentpb.CreateContai
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "invalid app config: %v", err)
 	}
+	if err := appconfig.ValidateAppID(req.GetAppName()); err != nil {
+		return status.Errorf(codes.InvalidArgument, "invalid app name: %v", err)
+	}
+	unlock := s.appMu.lockApp(req.GetAppName())
+	defer unlock()
 
 	onProgress := func(p *agentpb.CreateContainerProgress) {
 		if err := stream.Send(&agentpb.CreateContainerProgressResponse{
@@ -378,6 +406,11 @@ func (s *ContainerService) RunContainer(req *agentpb.RunContainerLayersRequest, 
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "invalid app config: %v", err)
 	}
+	if err := appconfig.ValidateAppID(req.GetAppName()); err != nil {
+		return status.Errorf(codes.InvalidArgument, "invalid app name: %v", err)
+	}
+	unlock := s.appMu.lockApp(req.GetAppName())
+	defer unlock()
 
 	// Verify the container image signature before assembling or creating the
 	// container. Contract for the cross-repo image signer (must match
@@ -461,7 +494,7 @@ func (s *ContainerService) RunContainer(req *agentpb.RunContainerLayersRequest, 
 		zap.Duration("create_container", createDur),
 		zap.Duration("total_before_start", time.Since(runStartedAt)))
 
-	return s.streamContainerOutput(ctx, req.GetAppName(), postStartAgentHookFromContext(ctx), nil, stream)
+	return s.streamContainerOutputWhileLocked(ctx, req.GetAppName(), postStartAgentHookFromContext(ctx), nil, stream, unlock)
 }
 
 func (s *ContainerService) StartContainer(req *agentpb.StartContainerRequest, stream grpc.ServerStreamingServer[agentpb.RunContainerLayersResponse]) error {
@@ -667,6 +700,25 @@ func (s *ContainerService) streamContainerOutput(
 	restartPolicy *agentpb.RestartPolicy,
 	stream grpc.ServerStreamingServer[agentpb.RunContainerLayersResponse],
 ) error {
+	if err := appconfig.ValidateAppID(appName); err != nil {
+		return status.Errorf(codes.InvalidArgument, "invalid app name: %v", err)
+	}
+	unlock := s.appMu.lockApp(appName)
+	defer unlock()
+	return s.streamContainerOutputWhileLocked(ctx, appName, postStartAgentCommand, restartPolicy, stream, unlock)
+}
+
+// RunContainer passes its existing lifecycle lock so another deployment cannot
+// replace the just-created container between creation and its first start.
+func (s *ContainerService) streamContainerOutputWhileLocked(
+	ctx context.Context,
+	appName string,
+	postStartAgentCommand string,
+	restartPolicy *agentpb.RestartPolicy,
+	stream grpc.ServerStreamingServer[agentpb.RunContainerLayersResponse],
+	unlock func(),
+) error {
+	defer unlock()
 	// Starting a container must not be abortable by the client that requested
 	// it. A detached `apps start` returns the instant the stream is opened and
 	// closes the connection, which cancels this RPC's context; if the start
@@ -703,6 +755,7 @@ func (s *ContainerService) streamContainerOutput(
 	}
 
 	s.registerContainerWithMonitor(startCtx, appName, restartPolicy)
+	unlock()
 
 	if err := stream.Send(&agentpb.RunContainerLayersResponse{
 		ResponseType: &agentpb.RunContainerLayersResponse_Started_{
@@ -759,6 +812,11 @@ func (s *ContainerService) AttachContainer(stream grpc.BidiStreamingServer[agent
 	if appName == "" {
 		return status.Error(codes.InvalidArgument, "app_name required as first message")
 	}
+	if err := appconfig.ValidateAppID(appName); err != nil {
+		return status.Errorf(codes.InvalidArgument, "invalid app name: %v", err)
+	}
+	unlock := s.appMu.lockApp(appName)
+	defer unlock()
 
 	ctx := stream.Context()
 	postStartAgentCommand := postStartAgentHookFromContext(ctx)
@@ -807,6 +865,7 @@ func (s *ContainerService) AttachContainer(stream grpc.BidiStreamingServer[agent
 			zap.String("app_name", appName), zap.Error(err))
 	}
 	s.registerContainerWithMonitor(startCtx, appName, nil)
+	unlock()
 
 	if err := stream.Send(&agentpb.RunContainerLayersResponse{
 		ResponseType: &agentpb.RunContainerLayersResponse_Started_{
@@ -1094,9 +1153,20 @@ func (s *ContainerService) DeleteContainer(ctx context.Context, req *agentpb.Del
 	if err := s.containerd.DeleteContainer(ctx, appName, req.GetDeleteImage()); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to delete container: %v", err)
 	}
+	var revisionCleanupErr error
+	if remover, ok := s.containerd.(DeploymentRevisionRemover); ok {
+		// Once the app is removed, a disconnected caller must not leave a
+		// rollback journal that could restore it on the next agent restart.
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		revisionCleanupErr = remover.DeleteDeploymentRevisions(cleanupCtx, ids)
+		cancel()
+	}
 
 	if req.GetDeleteVolumes() {
 		s.deleteVolumes(volumesToDelete)
+	}
+	if revisionCleanupErr != nil {
+		return nil, status.Errorf(codes.Internal, "container deleted but retained revision cleanup failed: %v", revisionCleanupErr)
 	}
 
 	s.logger.Info("App deleted",

--- a/go/internal/agent/services/container_service_test.go
+++ b/go/internal/agent/services/container_service_test.go
@@ -412,6 +412,79 @@ func TestDeleteContainer_Error(t *testing.T) {
 	}
 }
 
+type revisionDeletingRuntime struct {
+	*mockContainerdClient
+	deleted             bool
+	afterDelete         func()
+	revisionDeleteCalls [][]string
+	revisionDeleteErr   error
+	cleanupContextErr   error
+	cleanupHasDeadline  bool
+	cleanupBeforeDelete bool
+}
+
+func (m *revisionDeletingRuntime) DeleteContainer(ctx context.Context, name string, deleteImage bool) error {
+	if err := m.mockContainerdClient.DeleteContainer(ctx, name, deleteImage); err != nil {
+		return err
+	}
+	m.deleted = true
+	if m.afterDelete != nil {
+		m.afterDelete()
+	}
+	return nil
+}
+
+func (m *revisionDeletingRuntime) DeleteDeploymentRevisions(ctx context.Context, ids []string) error {
+	m.cleanupBeforeDelete = !m.deleted
+	m.revisionDeleteCalls = append(m.revisionDeleteCalls, append([]string(nil), ids...))
+	m.cleanupContextErr = ctx.Err()
+	_, m.cleanupHasDeadline = ctx.Deadline()
+	return m.revisionDeleteErr
+}
+
+func TestDeleteContainerCleansResolvedDeploymentRevisions(t *testing.T) {
+	for _, tc := range []struct {
+		name, appName         string
+		deleteErr, cleanupErr error
+		disconnect            bool
+		wantIDs               []string
+	}{
+		{name: "app group", appName: "myapp", wantIDs: []string{"myapp_alpha", "myapp_beta"}},
+		{name: "one service", appName: "myapp_alpha", wantIDs: []string{"myapp_alpha"}},
+		{name: "runtime failure preserves revisions", appName: "myapp", deleteErr: errors.New("delete failed")},
+		{name: "cleanup failure reported", appName: "myapp", cleanupErr: errors.New("cleanup failed"), wantIDs: []string{"myapp_alpha", "myapp_beta"}},
+		{name: "disconnect after deletion", appName: "myapp", disconnect: true, wantIDs: []string{"myapp_alpha", "myapp_beta"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			runtime := &revisionDeletingRuntime{mockContainerdClient: multiServiceMock(), revisionDeleteErr: tc.cleanupErr}
+			runtime.deleteErr = tc.deleteErr
+			if tc.disconnect {
+				runtime.afterDelete = cancel
+			}
+			svc := NewContainerService(zap.NewNop(), runtime)
+			_, err := svc.DeleteContainer(ctx, &agentpb.DeleteContainerRequest{AppName: tc.appName})
+			if wantErr := tc.deleteErr != nil || tc.cleanupErr != nil; (err != nil) != wantErr {
+				t.Fatalf("DeleteContainer error = %v; want error %v", err, wantErr)
+			}
+			if tc.wantIDs == nil {
+				if len(runtime.revisionDeleteCalls) != 0 {
+					t.Fatal("failed runtime deletion removed rollback revisions")
+				}
+				return
+			}
+			if !reflect.DeepEqual(runtime.revisionDeleteCalls, [][]string{tc.wantIDs}) {
+				t.Fatalf("revision deletion = %v; want %v", runtime.revisionDeleteCalls, tc.wantIDs)
+			}
+			if runtime.cleanupBeforeDelete || runtime.cleanupContextErr != nil || !runtime.cleanupHasDeadline {
+				t.Fatalf("cleanup must follow deletion with independent bounded context: before=%v err=%v deadline=%v",
+					runtime.cleanupBeforeDelete, runtime.cleanupContextErr, runtime.cleanupHasDeadline)
+			}
+		})
+	}
+}
+
 func TestListLayers(t *testing.T) {
 	layers := []*agentpb.LayerHeader{
 		{Digest: "sha256:abc123", Size: 1024},

--- a/go/internal/agent/services/deployment_runtime.go
+++ b/go/internal/agent/services/deployment_runtime.go
@@ -1,0 +1,41 @@
+package services
+
+import (
+	"context"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+// DeploymentRuntime is optional: runtimes that cannot preserve a previous
+// revision must reject verified deployment rather than silently downgrade it.
+type DeploymentRuntime interface {
+	PrepareDeployment(context.Context, *agentpb.CreateContainerRequest, *appconfig.AppConfig) (DeploymentTransaction, error)
+}
+
+// DeploymentRevisionRemover releases retained rollback state after an explicit
+// app deletion. Internal replacement/rollback deletion must not call it.
+type DeploymentRevisionRemover interface {
+	DeleteDeploymentRevisions(context.Context, []string) error
+}
+
+// DeploymentTransaction retains the prior container metadata and writable
+// snapshot independently of mutable image tags. The caller serializes all
+// lifecycle changes for the app and always closes the transaction. Activate
+// may fail after cutover, in which case Rollback must still be called.
+type DeploymentTransaction interface {
+	Revision() string
+	PreviousRevision() string
+	PreviousWasRunning() bool
+	Activate(context.Context) error
+	Commit(context.Context) error
+	Rollback(context.Context) (<-chan ContainerOutput, error)
+	Close(context.Context) error
+}
+
+// ContainerReadinessProber checks the actual container on the device. Network
+// probes run in its network namespace; exec probes use its runtime identity.
+// A nil probe still checks that the container's process is running.
+type ContainerReadinessProber interface {
+	ProbeReadiness(context.Context, string, *appconfig.ReadinessConfig) error
+}

--- a/go/internal/agent/services/deployment_service.go
+++ b/go/internal/agent/services/deployment_service.go
@@ -1,0 +1,386 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+// DeployContainer owns cutover, verification, and recovery as one serialized
+// operation. Prepare is cancellable; once cutover begins the agent completes
+// bounded verification and recovery even if the client disconnects.
+func (s *ContainerService) DeployContainer(req *agentpb.DeployContainerRequest, stream grpc.ServerStreamingServer[agentpb.RunContainerLayersResponse]) error {
+	return s.streamDeployment(req, stream, nil)
+}
+
+func (s *ContainerService) DeployContainerAttached(stream grpc.BidiStreamingServer[agentpb.DeployContainerInput, agentpb.RunContainerLayersResponse]) error {
+	first, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+	if first.GetDeployment() == nil {
+		return status.Error(codes.InvalidArgument, "first input must contain a deployment request")
+	}
+	stdinR, stdinW := io.Pipe()
+	defer stdinR.Close()
+	go func() {
+		defer stdinW.Close()
+		for {
+			input, err := stream.Recv()
+			if err != nil {
+				return
+			}
+			if data := input.GetStdinData(); len(data) > 0 {
+				if _, err := stdinW.Write(data); err != nil {
+					return
+				}
+			}
+		}
+	}()
+	return s.streamDeployment(first.GetDeployment(), stream, stdinR)
+}
+
+func (s *ContainerService) streamDeployment(req *agentpb.DeployContainerRequest, stream grpc.ServerStreamingServer[agentpb.RunContainerLayersResponse], stdin io.Reader) error {
+	events := make(chan *agentpb.RunContainerLayersResponse, 128)
+	done := make(chan error, 1)
+	// A slow or disconnected log reader must not hold verification, recovery,
+	// or the application lifecycle lock hostage in grpc.SendMsg.
+	go func() {
+		done <- s.deployContainer(req, &deploymentEventStream{ServerStreamingServer: stream, events: events}, stdin)
+	}()
+	for {
+		select {
+		case <-stream.Context().Done():
+			return status.FromContextError(stream.Context().Err()).Err()
+		case event := <-events:
+			if err := stream.Send(event); err != nil {
+				return err
+			}
+		case err := <-done:
+			for len(events) > 0 {
+				if sendErr := stream.Send(<-events); sendErr != nil {
+					return sendErr
+				}
+			}
+			return err
+		}
+	}
+}
+
+type deploymentEventStream struct {
+	grpc.ServerStreamingServer[agentpb.RunContainerLayersResponse]
+	events chan *agentpb.RunContainerLayersResponse
+}
+
+func (s *deploymentEventStream) Send(event *agentpb.RunContainerLayersResponse) error {
+	select {
+	case s.events <- event:
+		return nil
+	default:
+	}
+	if event.GetDeployment() != nil || event.GetStarted() != nil {
+		// There is one producer. Make room for a control event by dropping an
+		// old log event, mirroring the bounded live log manager's behavior.
+		select {
+		case <-s.events:
+		default:
+		}
+		s.events <- event
+	}
+	return nil
+}
+
+func (s *ContainerService) deployContainer(req *agentpb.DeployContainerRequest, stream grpc.ServerStreamingServer[agentpb.RunContainerLayersResponse], stdin io.Reader) error {
+	runtime, ok := s.containerd.(DeploymentRuntime)
+	if !ok {
+		return status.Error(codes.Unimplemented, "this runtime does not support recoverable deployments")
+	}
+	prober, ok := s.containerd.(ContainerReadinessProber)
+	if !ok {
+		return status.Error(codes.Unimplemented, "this runtime does not support agent-owned readiness")
+	}
+	candidate := req.GetContainer()
+	if candidate == nil {
+		return status.Error(codes.InvalidArgument, "container is required")
+	}
+	if err := appconfig.ValidateAppID(candidate.GetAppName()); err != nil {
+		return status.Errorf(codes.InvalidArgument, "invalid app name: %v", err)
+	}
+	if candidate.GetImageName() == "" {
+		return status.Error(codes.InvalidArgument, "image_name is required")
+	}
+	cfg, err := parseAppConfig(candidate.GetAppConfig())
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument, "invalid app config: %v", err)
+	}
+	if cfg.AppID == "" {
+		cfg.AppID = candidate.GetAppName()
+	}
+	if cfg.ContainerName() != candidate.GetAppName() {
+		return status.Error(codes.InvalidArgument, "app_name must match the app config container identity")
+	}
+	if err := cfg.Validate(); err != nil {
+		return status.Errorf(codes.InvalidArgument, "invalid app config: %v", err)
+	}
+	probe := appconfig.EffectiveReadiness(cfg)
+	if req.GetSkipImplicitReadiness() {
+		probe = nil
+		if cfg.Readiness.HasProbe() {
+			probe = cfg.Readiness
+		}
+	}
+	if req.GetRequireReadiness() && probe == nil {
+		return status.Error(codes.FailedPrecondition, "wait-ready requires a readiness probe or an HTTP entitlement")
+	}
+	if req.GetTimeoutSeconds() < 0 || req.GetTimeoutSeconds() > 3600 {
+		return status.Error(codes.InvalidArgument, "readiness timeout must be between 1 and 3600 seconds, or zero for the configured default")
+	}
+	if probe != nil && req.GetTimeoutSeconds() > 0 {
+		copy := *probe
+		copy.TimeoutSeconds = int(req.GetTimeoutSeconds())
+		probe = &copy
+	}
+	ctx := stream.Context()
+	unlock := s.appMu.lockApp(candidate.GetAppName())
+	defer unlock()
+	if err := ctx.Err(); err != nil {
+		return status.FromContextError(err).Err()
+	}
+	if err := s.verifyImageSignature(candidate.GetImageConfig(), candidate.GetImageSignature()); err != nil {
+		return err
+	}
+	if err := s.validateSignedLayerBinding(candidate.GetImageConfig(), candidate.GetLayers()); err != nil {
+		return err
+	}
+	if err := s.assembleDeploymentImage(ctx, candidate); err != nil {
+		return err
+	}
+	create := &agentpb.CreateContainerRequest{
+		ImageName: candidate.GetImageName(), AppName: candidate.GetAppName(), Cmd: candidate.GetCmd(),
+		AppConfig: candidate.GetAppConfig(), WorkingDir: candidate.GetWorkingDir(),
+		RestartPolicy: candidate.GetRestartPolicy(), UserArgs: candidate.GetUserArgs(), Env: candidate.GetEnv(),
+	}
+	tx, err := runtime.PrepareDeployment(ctx, create, cfg)
+	if err != nil {
+		return status.Errorf(codes.FailedPrecondition, "preparing deployment before cutover: %v", err)
+	}
+	// This independent deadline covers activation plus the readiness window.
+	// Recovery gets its own bounded budget even if activation exhausts this one.
+	readyTimeout := 30 * time.Second
+	if probe != nil {
+		readyTimeout = probe.Timeout()
+	}
+	operationCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), readyTimeout+2*time.Minute)
+	defer cancel()
+	closed := false
+	closeTx := func() {
+		if closed {
+			return
+		}
+		closed = true
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cleanupCancel()
+		if err := tx.Close(cleanupCtx); err != nil {
+			s.logger.Error("closing deployment transaction", zap.String("app_name", create.AppName), zap.Error(err))
+		}
+	}
+	defer closeTx()
+	if err := ctx.Err(); err != nil {
+		return status.FromContextError(err).Err()
+	}
+	result := &agentpb.DeploymentResult{
+		AppName: create.AppName, Revision: tx.Revision(), PreviousRevision: tx.PreviousRevision(),
+	}
+	var readCh <-chan ContainerOutput
+	var releaseDrain func()
+	activationErr := tx.Activate(operationCtx)
+	if activationErr == nil {
+		var output <-chan ContainerOutput
+		if stdin != nil {
+			output, activationErr = s.containerd.StartContainerWithStdin(operationCtx, create.AppName, stdin, postStartAgentHookFromContext(ctx), create.RestartPolicy)
+		} else {
+			output, activationErr = s.containerd.StartContainer(operationCtx, create.AppName, postStartAgentHookFromContext(ctx), create.RestartPolicy)
+		}
+		if activationErr == nil {
+			readCh, releaseDrain = s.guaranteeOutputDrain(create.AppName, output)
+			defer releaseDrain()
+		}
+	}
+	// Failed sends only stop delivery of events, never verification/recovery.
+	connected := true
+	send := func(event *agentpb.RunContainerLayersResponse) {
+		if connected && stream.Send(event) != nil {
+			connected = false
+		}
+	}
+	if activationErr == nil {
+		result.ReadinessChecked = probe != nil
+		send(&agentpb.RunContainerLayersResponse{ResponseType: &agentpb.RunContainerLayersResponse_Started_{Started: &agentpb.RunContainerLayersResponse_Started{}}})
+		checked := make(chan error, 1)
+		go func() { checked <- waitForAgentReadiness(operationCtx, prober, create.AppName, probe) }()
+	verify:
+		for {
+			select {
+			case activationErr = <-checked:
+				break verify
+			case output, ok := <-readCh:
+				if !ok || output.Done {
+					readCh = nil
+					continue // the process-state probe decides the outcome
+				}
+				for _, event := range deploymentOutputEvents(output) {
+					send(event)
+				}
+			}
+		}
+	}
+	if activationErr == nil {
+		activationErr = tx.Commit(operationCtx)
+	}
+	if activationErr != nil {
+		result.State = agentpb.DeploymentState_FAILED
+		result.Message = activationErr.Error()
+		recoveryCtx, recoveryCancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Minute)
+		recovered, recoveryErr := tx.Rollback(recoveryCtx)
+		recoveryCancel()
+		if recovered != nil {
+			_, release := s.guaranteeOutputDrain(create.AppName, recovered)
+			release()
+		}
+		if recoveryErr != nil {
+			result.State = agentpb.DeploymentState_ROLLBACK_FAILED
+			result.Message += "; recovery failed: " + recoveryErr.Error()
+		} else if result.PreviousRevision != "" {
+			result.State = agentpb.DeploymentState_ROLLED_BACK
+			result.Message += "; previous revision restored"
+		}
+		// Never let the restart monitor revive an unverified candidate after
+		// failed recovery releases its suppression lease.
+		monitorCtx, monitorCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		if recoveryErr != nil || result.PreviousRevision == "" {
+			if s.monitor != nil {
+				s.monitor.Unregister(create.AppName)
+				s.monitor.MarkExplicitStop(create.AppName)
+			}
+			_ = s.containerd.SetStoppedByUser(monitorCtx, create.AppName, true)
+		} else if tx.PreviousWasRunning() {
+			// Read the restored revision's policy, not the candidate override.
+			s.registerContainerWithMonitor(monitorCtx, create.AppName, nil)
+		} else if s.monitor != nil {
+			// Registration resets ExplicitStop. A rollback to a stopped revision
+			// must not silently start it on the monitor's next tick.
+			s.monitor.Unregister(create.AppName)
+			s.monitor.MarkExplicitStop(create.AppName)
+		}
+		monitorCancel()
+		closeTx()
+		unlock()
+		send(&agentpb.RunContainerLayersResponse{ResponseType: &agentpb.RunContainerLayersResponse_Deployment{Deployment: result}})
+		return nil
+	}
+	result.State = agentpb.DeploymentState_RUNNING
+	result.Message = "application started; no readiness probe configured"
+	if probe != nil {
+		result.State = agentpb.DeploymentState_READY
+		result.Message = "application readiness verified on the agent"
+	}
+	if s.monitor != nil {
+		s.monitor.ClearExplicitStop(create.AppName)
+	}
+	if err := s.containerd.SetStoppedByUser(operationCtx, create.AppName, false); err != nil {
+		s.logger.Warn("clearing deployment stop mark", zap.String("app_name", create.AppName), zap.Error(err))
+	}
+	s.registerContainerWithMonitor(operationCtx, create.AppName, create.RestartPolicy)
+	closeTx()
+	unlock() // log streaming must not block future deployments/stop/delete
+	send(&agentpb.RunContainerLayersResponse{ResponseType: &agentpb.RunContainerLayersResponse_Deployment{Deployment: result}})
+	for connected && readCh != nil {
+		select {
+		case <-ctx.Done():
+			return nil
+		case output, ok := <-readCh:
+			if !ok || output.Done {
+				return nil
+			}
+			for _, event := range deploymentOutputEvents(output) {
+				send(event)
+			}
+		}
+	}
+	return nil
+}
+
+func (s *ContainerService) assembleDeploymentImage(ctx context.Context, req *agentpb.RunContainerLayersRequest) error {
+	for _, layer := range req.GetLayers() {
+		if len(layer.GetChunkHashes()) == 0 {
+			continue
+		}
+		hashes := make([][32]byte, 0, len(layer.GetChunkHashes()))
+		for _, raw := range layer.GetChunkHashes() {
+			hash, err := to32(raw)
+			if err != nil {
+				return err
+			}
+			hashes = append(hashes, hash)
+		}
+		diffID := layer.GetDiffId()
+		if diffID == "" {
+			diffID = layer.GetDigest()
+		}
+		if err := s.containerd.AssembleLayerFromChunks(ctx, diffID, hashes); err != nil {
+			return status.Errorf(codes.Internal, "assembling candidate layer: %v", err)
+		}
+	}
+	if len(req.GetLayers()) > 0 {
+		if err := s.containerd.AssembleImage(ctx, req.GetImageName(), req.GetLayers(), req.GetImageConfig()); err != nil {
+			return status.Errorf(codes.Internal, "assembling candidate image: %v", err)
+		}
+	}
+	return nil
+}
+
+func waitForAgentReadiness(ctx context.Context, prober ContainerReadinessProber, name string, cfg *appconfig.ReadinessConfig) error {
+	if cfg == nil {
+		attemptCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+		return prober.ProbeReadiness(attemptCtx, name, nil)
+	}
+	ctx, cancel := context.WithTimeout(ctx, cfg.Timeout())
+	defer cancel()
+	var lastErr error
+	for {
+		attempt, stop := context.WithTimeout(ctx, cfg.ProbeTimeout())
+		lastErr = prober.ProbeReadiness(attempt, name, cfg)
+		stop()
+		if lastErr == nil && ctx.Err() == nil {
+			return nil
+		}
+		timer := time.NewTimer(cfg.Period())
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return fmt.Errorf("readiness did not pass within %s: %v (%w)", cfg.Timeout(), lastErr, ctx.Err())
+		case <-timer.C:
+		}
+	}
+}
+
+func deploymentOutputEvents(output ContainerOutput) []*agentpb.RunContainerLayersResponse {
+	var events []*agentpb.RunContainerLayersResponse
+	if len(output.Stdout) > 0 {
+		events = append(events, &agentpb.RunContainerLayersResponse{ResponseType: &agentpb.RunContainerLayersResponse_StdoutOutput{StdoutOutput: &agentpb.RunContainerLayersResponse_ConsoleOutput{Data: output.Stdout}}})
+	}
+	if len(output.Stderr) > 0 {
+		events = append(events, &agentpb.RunContainerLayersResponse{ResponseType: &agentpb.RunContainerLayersResponse_StderrOutput{StderrOutput: &agentpb.RunContainerLayersResponse_ConsoleOutput{Data: output.Stderr}}})
+	}
+	return events
+}

--- a/go/internal/agent/services/deployment_service_test.go
+++ b/go/internal/agent/services/deployment_service_test.go
@@ -1,0 +1,311 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"io"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type fakeDeploymentTransaction struct {
+	mu                                  sync.Mutex
+	calls                               []string
+	previous                            string
+	previousWasRunning                  bool
+	activateErr, commitErr, rollbackErr error
+	closed                              chan struct{}
+	once                                sync.Once
+}
+
+func (f *fakeDeploymentTransaction) record(name string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, name)
+}
+func (f *fakeDeploymentTransaction) Revision() string         { return "candidate-revision" }
+func (f *fakeDeploymentTransaction) PreviousRevision() string { return f.previous }
+func (f *fakeDeploymentTransaction) PreviousWasRunning() bool { return f.previousWasRunning }
+func (f *fakeDeploymentTransaction) Activate(context.Context) error {
+	f.record("activate")
+	return f.activateErr
+}
+func (f *fakeDeploymentTransaction) Commit(context.Context) error {
+	f.record("commit")
+	return f.commitErr
+}
+func (f *fakeDeploymentTransaction) Rollback(context.Context) (<-chan ContainerOutput, error) {
+	f.record("rollback")
+	return nil, f.rollbackErr
+}
+func (f *fakeDeploymentTransaction) Close(context.Context) error {
+	f.record("close")
+	f.once.Do(func() { close(f.closed) })
+	return nil
+}
+
+type fakeDeploymentRuntime struct {
+	*mockContainerdClient
+	tx         *fakeDeploymentTransaction
+	prepareErr error
+	prepared   atomic.Int32
+	probe      func(context.Context, *appconfig.ReadinessConfig) error
+}
+
+func (f *fakeDeploymentRuntime) PrepareDeployment(context.Context, *agentpb.CreateContainerRequest, *appconfig.AppConfig) (DeploymentTransaction, error) {
+	f.prepared.Add(1)
+	return f.tx, f.prepareErr
+}
+func (f *fakeDeploymentRuntime) ProbeReadiness(ctx context.Context, _ string, cfg *appconfig.ReadinessConfig) error {
+	if f.probe != nil {
+		return f.probe(ctx, cfg)
+	}
+	return nil
+}
+func newFakeDeploymentRuntime() *fakeDeploymentRuntime {
+	return &fakeDeploymentRuntime{mockContainerdClient: &mockContainerdClient{startOutputCh: make(chan ContainerOutput)}, tx: &fakeDeploymentTransaction{previous: "previous-revision", previousWasRunning: true, closed: make(chan struct{})}}
+}
+func deploymentTestRequest(probe bool) *agentpb.DeployContainerRequest {
+	config := `{"appId":"test-app"}`
+	if probe {
+		config = `{"appId":"test-app","readiness":{"tcpSocket":{"port":8080},"timeoutSeconds":1}}`
+	}
+	return &agentpb.DeployContainerRequest{Container: &agentpb.RunContainerLayersRequest{AppName: "test-app", ImageName: "test:latest", AppConfig: []byte(config)}}
+}
+
+func TestDeployContainerOutcomes(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		probe bool
+		setup func(*fakeDeploymentRuntime)
+		state agentpb.DeploymentState
+		calls []string
+	}{
+		{"ready", true, nil, agentpb.DeploymentState_READY, []string{"activate", "commit", "close"}},
+		{"running-is-not-ready", false, nil, agentpb.DeploymentState_RUNNING, []string{"activate", "commit", "close"}},
+		{"activation-rollback", true, func(f *fakeDeploymentRuntime) { f.tx.activateErr = errors.New("candidate create failed") }, agentpb.DeploymentState_ROLLED_BACK, []string{"activate", "rollback", "close"}},
+		{"start-rollback", true, func(f *fakeDeploymentRuntime) { f.startErr = errors.New("process start failed") }, agentpb.DeploymentState_ROLLED_BACK, []string{"activate", "rollback", "close"}},
+		{"commit-rollback", true, func(f *fakeDeploymentRuntime) { f.tx.commitErr = errors.New("persist failed") }, agentpb.DeploymentState_ROLLED_BACK, []string{"activate", "commit", "rollback", "close"}},
+		{"rollback-failure", true, func(f *fakeDeploymentRuntime) {
+			f.startErr = errors.New("start failed")
+			f.tx.rollbackErr = errors.New("old snapshot missing")
+		}, agentpb.DeploymentState_ROLLBACK_FAILED, []string{"activate", "rollback", "close"}},
+		{"first-deploy-failure", true, func(f *fakeDeploymentRuntime) { f.startErr = errors.New("start failed"); f.tx.previous = "" }, agentpb.DeploymentState_FAILED, []string{"activate", "rollback", "close"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFakeDeploymentRuntime()
+			if tc.setup != nil {
+				tc.setup(f)
+			}
+			client, cleanup := startContainerServer(t, f)
+			defer cleanup()
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			stream, err := client.DeployContainer(ctx, deploymentTestRequest(tc.probe))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var result *agentpb.DeploymentResult
+			for result == nil {
+				event, err := stream.Recv()
+				if err != nil {
+					t.Fatal(err)
+				}
+				result = event.GetDeployment()
+			}
+			if result.State != tc.state {
+				t.Fatalf("state=%v, want %v: %s", result.State, tc.state, result.Message)
+			}
+			checked := tc.probe && f.tx.activateErr == nil && f.startErr == nil
+			if result.ReadinessChecked != checked || result.Revision != "candidate-revision" {
+				t.Fatalf("bad result: %v", result)
+			}
+			f.tx.mu.Lock()
+			calls := append([]string(nil), f.tx.calls...)
+			f.tx.mu.Unlock()
+			if !reflect.DeepEqual(calls, tc.calls) {
+				t.Fatalf("calls=%v, want %v", calls, tc.calls)
+			}
+			cancel()
+			close(f.startOutputCh)
+		})
+	}
+}
+
+func TestRollbackKeepsPreviouslyStoppedRevisionOutOfRestartMonitor(t *testing.T) {
+	f := newFakeDeploymentRuntime()
+	f.tx.previousWasRunning = false
+	f.tx.activateErr = errors.New("candidate creation failed")
+	mon := &mockMonitorRegistrar{}
+	client, cleanup := startContainerServerWithMonitor(t, f, mon)
+	defer cleanup()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream, err := client.DeployContainer(ctx, deploymentTestRequest(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result *agentpb.DeploymentResult
+	for result == nil {
+		event, err := stream.Recv()
+		if err != nil {
+			t.Fatal(err)
+		}
+		result = event.GetDeployment()
+	}
+	if result.State != agentpb.DeploymentState_ROLLED_BACK {
+		t.Fatalf("result=%v", result)
+	}
+	if len(mon.registerCalls) != 0 {
+		t.Fatalf("stopped previous revision registered for restart: %v", mon.registerCalls)
+	}
+	if !reflect.DeepEqual(mon.unregisterCalls, []string{"test-app"}) {
+		t.Fatalf("unregister calls=%v", mon.unregisterCalls)
+	}
+	if len(f.stoppedByUserCalls) != 0 {
+		t.Fatalf("saved stop intent was changed: %v", f.stoppedByUserCalls)
+	}
+	close(f.startOutputCh)
+}
+
+func TestDeployContainerRejectsBeforePreparing(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		change func(*agentpb.DeployContainerRequest)
+		code   codes.Code
+	}{
+		{"probe-required", func(r *agentpb.DeployContainerRequest) { r.RequireReadiness = true }, codes.FailedPrecondition},
+		{"timeout-bound", func(r *agentpb.DeployContainerRequest) { r.TimeoutSeconds = 3601 }, codes.InvalidArgument},
+		{"identity", func(r *agentpb.DeployContainerRequest) { r.Container.AppName = "another-app" }, codes.InvalidArgument},
+		{"invalid-probe", func(r *agentpb.DeployContainerRequest) {
+			r.Container.AppConfig = []byte(`{"appId":"test-app","readiness":{"tcpSocket":{"port":0}}}`)
+		}, codes.InvalidArgument},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFakeDeploymentRuntime()
+			client, cleanup := startContainerServer(t, f)
+			defer cleanup()
+			r := deploymentTestRequest(false)
+			tc.change(r)
+			stream, err := client.DeployContainer(context.Background(), r)
+			if err == nil {
+				_, err = stream.Recv()
+			}
+			if status.Code(err) != tc.code {
+				t.Fatalf("error=%v", err)
+			}
+			if f.prepared.Load() != 0 {
+				t.Fatal("invalid request prepared a candidate")
+			}
+		})
+	}
+}
+
+func TestDeployContainerReadinessFailureRestoresPrevious(t *testing.T) {
+	f := newFakeDeploymentRuntime()
+	f.probe = func(context.Context, *appconfig.ReadinessConfig) error { return errors.New("HTTP 503") }
+	client, cleanup := startContainerServer(t, f)
+	defer cleanup()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream, err := client.DeployContainer(ctx, deploymentTestRequest(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		event, err := stream.Recv()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if r := event.GetDeployment(); r != nil {
+			if r.State != agentpb.DeploymentState_ROLLED_BACK || !strings.Contains(r.Message, "HTTP 503") {
+				t.Fatalf("result=%v", r)
+			}
+			break
+		}
+	}
+	if _, err := stream.Recv(); err != io.EOF {
+		t.Fatalf("failed deploy did not terminate: %v", err)
+	}
+	close(f.startOutputCh)
+}
+
+func TestDeployContainerDisconnectStillCommitsVerifiedCandidate(t *testing.T) {
+	f := newFakeDeploymentRuntime()
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	f.probe = func(ctx context.Context, _ *appconfig.ReadinessConfig) error {
+		close(entered)
+		select {
+		case <-release:
+			return ctx.Err()
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	client, cleanup := startContainerServer(t, f)
+	defer cleanup()
+	ctx, cancel := context.WithCancel(context.Background())
+	stream, err := client.DeployContainer(ctx, deploymentTestRequest(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event, err := stream.Recv(); err != nil || event.GetStarted() == nil {
+		t.Fatalf("start: %v %v", event, err)
+	}
+	<-entered
+	cancel()
+	close(release)
+	select {
+	case <-f.tx.closed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("disconnect abandoned transaction")
+	}
+	f.tx.mu.Lock()
+	calls := append([]string(nil), f.tx.calls...)
+	f.tx.mu.Unlock()
+	if !reflect.DeepEqual(calls, []string{"activate", "commit", "close"}) {
+		t.Fatalf("calls=%v", calls)
+	}
+	close(f.startOutputCh)
+}
+
+func TestReadinessHonorsParentDeadline(t *testing.T) {
+	f := newFakeDeploymentRuntime()
+	f.probe = func(ctx context.Context, _ *appconfig.ReadinessConfig) error { <-ctx.Done(); return ctx.Err() }
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	err := waitForAgentReadiness(ctx, f, "test-app", &appconfig.ReadinessConfig{TCPSocket: &appconfig.TCPSocketProbe{Port: 8080}, TimeoutSeconds: 30})
+	if !errors.Is(err, context.DeadlineExceeded) || time.Since(started) > time.Second {
+		t.Fatalf("unbounded readiness: %v", err)
+	}
+}
+
+func TestLifecycleLockSerializesServiceWithGroup(t *testing.T) {
+	var locks appMutex
+	unlock := locks.lockApp("app_with_underscores_service")
+	acquired := make(chan struct{})
+	go func() { release := locks.lockApp("app_with_underscores"); close(acquired); release() }()
+	select {
+	case <-acquired:
+		t.Fatal("group bypassed service lock")
+	case <-time.After(20 * time.Millisecond):
+	}
+	unlock()
+	unlock()
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("group lock not released")
+	}
+}

--- a/go/internal/agent/services/deployment_stream_test.go
+++ b/go/internal/agent/services/deployment_stream_test.go
@@ -1,0 +1,122 @@
+package services
+
+import (
+	"context"
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+type attachedDeploymentRuntime struct {
+	*fakeDeploymentRuntime
+	input  chan string
+	starts atomic.Int32
+}
+
+func (f *attachedDeploymentRuntime) StartContainerWithStdin(_ context.Context, _ string, stdin io.Reader, _ string, _ *agentpb.RestartPolicy) (<-chan ContainerOutput, error) {
+	f.starts.Add(1)
+	go func() {
+		data, _ := io.ReadAll(stdin)
+		f.input <- string(data)
+	}()
+	return f.startOutputCh, nil
+}
+
+func TestDeployContainerAttachedVerifiesOriginalProcessWithStdin(t *testing.T) {
+	f := &attachedDeploymentRuntime{fakeDeploymentRuntime: newFakeDeploymentRuntime(), input: make(chan string, 1)}
+	client, cleanup := startContainerServer(t, f)
+	defer cleanup()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream, err := client.DeployContainerAttached(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.Send(&agentpb.DeployContainerInput{Input: &agentpb.DeployContainerInput_Deployment{Deployment: deploymentTestRequest(true)}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.Send(&agentpb.DeployContainerInput{Input: &agentpb.DeployContainerInput_StdinData{StdinData: []byte("interactive input\n")}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.CloseSend(); err != nil {
+		t.Fatal(err)
+	}
+	for {
+		event, err := stream.Recv()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result := event.GetDeployment(); result != nil {
+			if result.State != agentpb.DeploymentState_READY || f.starts.Load() != 1 {
+				t.Fatalf("outcome=%v, starts=%d", result, f.starts.Load())
+			}
+			break
+		}
+	}
+	select {
+	case got := <-f.input:
+		if got != "interactive input\n" {
+			t.Fatalf("stdin=%q", got)
+		}
+	case <-ctx.Done():
+		t.Fatal("stdin was not forwarded")
+	}
+	close(f.startOutputCh)
+}
+
+func TestDeploymentOutcomeSurvivesSaturatedLogs(t *testing.T) {
+	stream := &deploymentEventStream{events: make(chan *agentpb.RunContainerLayersResponse, 8)}
+	log := &agentpb.RunContainerLayersResponse{ResponseType: &agentpb.RunContainerLayersResponse_StdoutOutput{StdoutOutput: &agentpb.RunContainerLayersResponse_ConsoleOutput{Data: []byte("log")}}}
+	for i := 0; i < 16; i++ {
+		_ = stream.Send(log)
+	}
+	result := &agentpb.DeploymentResult{State: agentpb.DeploymentState_ROLLED_BACK}
+	_ = stream.Send(&agentpb.RunContainerLayersResponse{ResponseType: &agentpb.RunContainerLayersResponse_Deployment{Deployment: result}})
+	for i := 0; i < 16; i++ {
+		_ = stream.Send(log)
+	}
+	for len(stream.events) > 0 {
+		if event := <-stream.events; event.GetDeployment() == result {
+			return
+		}
+	}
+	t.Fatal("slow log reader lost deployment outcome")
+}
+
+func TestDeployContainerCanSkipInheritedHTTPReadiness(t *testing.T) {
+	f := newFakeDeploymentRuntime()
+	f.probe = func(_ context.Context, probe *appconfig.ReadinessConfig) error {
+		if probe != nil {
+			t.Error("inherited HTTP entitlement became a service readiness probe")
+		}
+		return nil
+	}
+	client, cleanup := startContainerServer(t, f)
+	defer cleanup()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req := deploymentTestRequest(false)
+	req.Container.AppConfig = []byte(`{"appId":"test-app","entitlements":[{"type":"http","port":8080}]}`)
+	req.SkipImplicitReadiness = true
+	stream, err := client.DeployContainer(ctx, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		event, err := stream.Recv()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result := event.GetDeployment(); result != nil {
+			if result.State != agentpb.DeploymentState_RUNNING || result.ReadinessChecked {
+				t.Fatalf("result=%v", result)
+			}
+			break
+		}
+	}
+	close(f.startOutputCh)
+}

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -189,8 +189,8 @@ type ServiceConfig struct {
 	// Resources optionally caps this service's CPU/memory/PID usage, overriding
 	// any app-level resources wholesale.
 	Resources *ResourceLimits `json:"resources,omitempty"`
-	// Readiness gates only this service's postStart hooks — it never delays
-	// other services' startup order (that is dependsOn/WDY-879 territory).
+	// Readiness declares when this service is ready and gates its postStart
+	// hooks. It does not change the services' startup dependency order.
 	Readiness *ReadinessConfig `json:"readiness,omitempty"`
 	Hooks     *HooksConfig     `json:"hooks,omitempty"`
 }
@@ -297,15 +297,30 @@ type XcodeConfig struct {
 	Scheme string `json:"scheme,omitempty"`
 }
 
-// ReadinessConfig defines a probe the CLI uses to determine when the app is ready.
+// ReadinessConfig defines an agent-owned probe of the running app. At most one
+// probe may be set. Timing-only configs customize the implicit TCP probe for an
+// HTTP entitlement; without an explicit probe or HTTP entitlement, readiness is
+// not configured and the app can only be reported as running.
 type ReadinessConfig struct {
-	TCPSocket      *TCPSocketProbe `json:"tcpSocket,omitempty"`
-	TimeoutSeconds int             `json:"timeoutSeconds,omitempty"` // Default 30
+	TCPSocket           *TCPSocketProbe `json:"tcpSocket,omitempty"`
+	HTTPGet             *HTTPGetProbe   `json:"httpGet,omitempty"`
+	Exec                []string        `json:"exec,omitempty"`
+	TimeoutSeconds      int             `json:"timeoutSeconds,omitempty"`      // Whole readiness window; default 30.
+	PeriodSeconds       int             `json:"periodSeconds,omitempty"`       // Delay between attempts; default 1.
+	ProbeTimeoutSeconds int             `json:"probeTimeoutSeconds,omitempty"` // Per-attempt timeout; default 2.
 }
 
 // TCPSocketProbe checks readiness by dialing a TCP port.
 type TCPSocketProbe struct {
 	Port int `json:"port"`
+}
+
+// HTTPGetProbe checks an HTTP endpoint on the running app. A response status
+// from 200 through 399 is successful. Path is a local request path, optionally
+// including a query, and defaults to "/"; it cannot select another host.
+type HTTPGetProbe struct {
+	Port int    `json:"port"`
+	Path string `json:"path,omitempty"`
 }
 
 // HooksConfig holds optional lifecycle hook commands.
@@ -591,26 +606,6 @@ func ValidateEnv(prefix string, env map[string]string) error {
 func ValidateEnvKey(prefix, key string) error {
 	if !envVarNamePattern.MatchString(key) {
 		return fmt.Errorf("%s: %q is not a valid environment variable name (letters, digits and '_' only, not starting with a digit)", prefix, key)
-	}
-	return nil
-}
-
-// ValidateReadiness checks a readiness probe configuration: tcpSocket.port
-// must be 1-65535 and timeoutSeconds must be non-negative. prefix is used in
-// error messages (e.g. "readiness" for top-level, or
-// `services["foo"].readiness` for service-level readiness). A nil r is valid.
-func ValidateReadiness(prefix string, r *ReadinessConfig) error {
-	if r == nil {
-		return nil
-	}
-	if r.TCPSocket != nil {
-		port := r.TCPSocket.Port
-		if port < 1 || port > 65535 {
-			return fmt.Errorf("%s.tcpSocket.port must be between 1 and 65535, got %d", prefix, port)
-		}
-	}
-	if r.TimeoutSeconds < 0 {
-		return fmt.Errorf("%s.timeoutSeconds must not be negative, got %d", prefix, r.TimeoutSeconds)
 	}
 	return nil
 }

--- a/go/internal/shared/appconfig/readiness.go
+++ b/go/internal/shared/appconfig/readiness.go
@@ -1,0 +1,150 @@
+package appconfig
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+	"unicode"
+)
+
+const (
+	ReadinessMaxTimeoutSeconds      = 3600
+	ReadinessMaxPeriodSeconds       = 300
+	ReadinessMaxProbeTimeoutSeconds = 300
+)
+
+// HasProbe reports whether a probe was explicitly configured. An explicitly
+// empty exec list is still configured, so validation rejects it instead of
+// accidentally replacing it with an HTTP-entitlement probe.
+func (r *ReadinessConfig) HasProbe() bool {
+	return r != nil && (r.TCPSocket != nil || r.HTTPGet != nil || r.Exec != nil)
+}
+
+// Timeout is the total readiness deadline. Callers validate the config first.
+func (r *ReadinessConfig) Timeout() time.Duration {
+	if r == nil || r.TimeoutSeconds == 0 {
+		return 30 * time.Second
+	}
+	return time.Duration(r.TimeoutSeconds) * time.Second
+}
+
+// Period is the delay between a failed probe and the next attempt.
+func (r *ReadinessConfig) Period() time.Duration {
+	if r == nil || r.PeriodSeconds == 0 {
+		return time.Second
+	}
+	return time.Duration(r.PeriodSeconds) * time.Second
+}
+
+// ProbeTimeout is the maximum duration of one probe. The runner must also
+// enforce the remaining total readiness deadline, whichever is shorter.
+func (r *ReadinessConfig) ProbeTimeout() time.Duration {
+	if r == nil || r.ProbeTimeoutSeconds == 0 {
+		return 2 * time.Second
+	}
+	return time.Duration(r.ProbeTimeoutSeconds) * time.Second
+}
+
+// RequestPath returns the endpoint path, applying the default root path.
+func (p *HTTPGetProbe) RequestPath() string {
+	if p == nil || p.Path == "" {
+		return "/"
+	}
+	return p.Path
+}
+
+// EffectiveReadiness returns an explicit probe, or synthesizes the existing TCP
+// readiness behavior of an HTTP entitlement. Merely declaring an HTTP port does
+// not promise that GET / succeeds. An app with neither has no readiness probe.
+// The returned config must be treated as read-only by callers.
+func EffectiveReadiness(cfg *AppConfig) *ReadinessConfig {
+	if cfg == nil {
+		return nil
+	}
+	if cfg.Readiness.HasProbe() {
+		return cfg.Readiness
+	}
+	for _, e := range cfg.Entitlements {
+		if e.Type != EntitlementHTTP {
+			continue
+		}
+		r := ReadinessConfig{}
+		if cfg.Readiness != nil {
+			r = *cfg.Readiness
+		}
+		r.TCPSocket = &TCPSocketProbe{Port: e.Port}
+		return &r
+	}
+	return nil
+}
+
+// ValidateReadiness checks probe exclusivity, endpoint/command validity, and
+// bounded timing values. Zero timing values select defaults. A nil or timing-
+// only config is valid for backward-compatible HTTP-entitlement synthesis.
+func ValidateReadiness(prefix string, r *ReadinessConfig) error {
+	if r == nil {
+		return nil
+	}
+	probes := 0
+	if r.TCPSocket != nil {
+		probes++
+	}
+	if r.HTTPGet != nil {
+		probes++
+	}
+	if r.Exec != nil {
+		probes++
+	}
+	if probes > 1 {
+		return fmt.Errorf("%s must configure at most one of tcpSocket, httpGet, or exec", prefix)
+	}
+	if r.TCPSocket != nil {
+		if err := validateReadinessPort(prefix+".tcpSocket.port", r.TCPSocket.Port); err != nil {
+			return err
+		}
+	}
+	if r.HTTPGet != nil {
+		if err := validateReadinessPort(prefix+".httpGet.port", r.HTTPGet.Port); err != nil {
+			return err
+		}
+		p := r.HTTPGet.RequestPath()
+		u, err := url.ParseRequestURI(p)
+		if err != nil || !strings.HasPrefix(p, "/") || strings.HasPrefix(p, "//") ||
+			strings.ContainsAny(p, "\\#") || strings.ContainsFunc(p, func(c rune) bool { return unicode.IsSpace(c) || unicode.IsControl(c) }) ||
+			u == nil || u.IsAbs() || u.Host != "" || u.Fragment != "" {
+			return fmt.Errorf("%s.httpGet.path must be a local HTTP request path beginning with /, without a host, fragment, whitespace, or control characters", prefix)
+		}
+	}
+	if r.Exec != nil {
+		if len(r.Exec) == 0 || strings.TrimSpace(r.Exec[0]) == "" {
+			return fmt.Errorf("%s.exec must contain a non-empty command followed by optional arguments", prefix)
+		}
+		for i, arg := range r.Exec {
+			if strings.ContainsRune(arg, '\x00') {
+				return fmt.Errorf("%s.exec[%d] must not contain NUL", prefix, i)
+			}
+		}
+	}
+	for _, setting := range []struct {
+		name  string
+		value int
+		max   int
+	}{
+		{"timeoutSeconds", r.TimeoutSeconds, ReadinessMaxTimeoutSeconds},
+		{"periodSeconds", r.PeriodSeconds, ReadinessMaxPeriodSeconds},
+		{"probeTimeoutSeconds", r.ProbeTimeoutSeconds, ReadinessMaxProbeTimeoutSeconds},
+	} {
+		if setting.value < 0 || setting.value > setting.max {
+			return fmt.Errorf("%s.%s must be between 0 and %d (0 uses the default), got %d", prefix, setting.name, setting.max, setting.value)
+		}
+	}
+	return nil
+}
+
+func validateReadinessPort(field string, port int) error {
+	if port < 1 || port > 65535 {
+		return fmt.Errorf("%s must be between 1 and 65535, got %d", field, port)
+	}
+	return nil
+}

--- a/go/internal/shared/appconfig/readiness_test.go
+++ b/go/internal/shared/appconfig/readiness_test.go
@@ -1,0 +1,170 @@
+package appconfig
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+// Exercise the user-facing JSON contract against both the runtime validator and
+// editor schema, including empty exec arrays which Go's omitempty would erase
+// if tests constructed the value and marshaled it first.
+func TestReadinessValidationAndSchema(t *testing.T) {
+	var schemaDoc map[string]any
+	if err := json.Unmarshal([]byte(SchemaJSON), &schemaDoc); err != nil {
+		t.Fatal(err)
+	}
+	compiler := jsonschema.NewCompiler()
+	compiler.AssertFormat()
+	// This definition is self-contained. Compile it independently because other
+	// existing schema definitions use ECMAScript lookaheads unsupported by Go's
+	// regular-expression engine, which is this test validator's default.
+	const schemaURL = "https://wendy.dev/schemas/readiness-test.json"
+	if err := compiler.AddResource(schemaURL, defOf(t, schemaDoc, "readiness")); err != nil {
+		t.Fatal(err)
+	}
+	schema, err := compiler.Compile(schemaURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name  string
+		data  string
+		valid bool
+	}{
+		{"timing-only compatibility", `{"timeoutSeconds":180}`, true},
+		{"empty compatibility", `{}`, true},
+		{"tcp", `{"tcpSocket":{"port":8080}}`, true},
+		{"http default path", `{"httpGet":{"port":8080}}`, true},
+		{"http empty path default", `{"httpGet":{"port":8080,"path":""}}`, true},
+		{"http root", `{"httpGet":{"port":8080,"path":"/"}}`, true},
+		{"http path query", `{"httpGet":{"port":8080,"path":"/health/ready?check=dependencies&name=a%20b"}}`, true},
+		{"exec argv", `{"exec":["/usr/bin/check-ready","--mode","ready"]}`, true},
+		{"exec empty argument", `{"exec":["/usr/bin/check-ready",""]}`, true},
+		{"explicit timing", `{"tcpSocket":{"port":65535},"timeoutSeconds":3600,"periodSeconds":300,"probeTimeoutSeconds":300}`, true},
+		{"zero defaults", `{"exec":["true"],"timeoutSeconds":0,"periodSeconds":0,"probeTimeoutSeconds":0}`, true},
+		{"tcp port zero", `{"tcpSocket":{"port":0}}`, false},
+		{"tcp port high", `{"tcpSocket":{"port":65536}}`, false},
+		{"http port zero", `{"httpGet":{"port":0}}`, false},
+		{"http port negative", `{"httpGet":{"port":-1}}`, false},
+		{"http port high", `{"httpGet":{"port":65536}}`, false},
+		{"tcp and http", `{"tcpSocket":{"port":8080},"httpGet":{"port":8080}}`, false},
+		{"tcp and exec", `{"tcpSocket":{"port":8080},"exec":["true"]}`, false},
+		{"http and exec", `{"httpGet":{"port":8080},"exec":["true"]}`, false},
+		{"http relative path", `{"httpGet":{"port":8080,"path":"health"}}`, false},
+		{"http absolute url", `{"httpGet":{"port":8080,"path":"http://example.com/health"}}`, false},
+		{"http other authority", `{"httpGet":{"port":8080,"path":"//example.com/health"}}`, false},
+		{"http fragment", `{"httpGet":{"port":8080,"path":"/health#fragment"}}`, false},
+		{"http backslash", `{"httpGet":{"port":8080,"path":"/foo\\bar"}}`, false},
+		{"http whitespace", `{"httpGet":{"port":8080,"path":"/health ready"}}`, false},
+		{"http newline", `{"httpGet":{"port":8080,"path":"/health\n"}}`, false},
+		{"http NUL", `{"httpGet":{"port":8080,"path":"/health\u0000"}}`, false},
+		{"http invalid escape", `{"httpGet":{"port":8080,"path":"/health%xx"}}`, false},
+		{"exec empty list", `{"exec":[]}`, false},
+		{"exec empty command", `{"exec":[""]}`, false},
+		{"exec whitespace command", `{"exec":[" \t"]}`, false},
+		{"exec NUL command", `{"exec":["check\u0000ready"]}`, false},
+		{"exec NUL argument", `{"exec":["check-ready","a\u0000b"]}`, false},
+		{"negative timeout", `{"timeoutSeconds":-1}`, false},
+		{"excessive timeout", `{"timeoutSeconds":3601}`, false},
+		{"negative period", `{"periodSeconds":-1}`, false},
+		{"excessive period", `{"periodSeconds":301}`, false},
+		{"negative probe timeout", `{"probeTimeoutSeconds":-1}`, false},
+		{"excessive probe timeout", `{"probeTimeoutSeconds":301}`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var cfg ReadinessConfig
+			if err := json.Unmarshal([]byte(tc.data), &cfg); err != nil {
+				t.Fatal(err)
+			}
+			const prefix = `services["web"].readiness`
+			err := ValidateReadiness(prefix, &cfg)
+			if (err == nil) != tc.valid {
+				t.Errorf("ValidateReadiness() = %v, want valid=%v", err, tc.valid)
+			}
+			if err != nil && !strings.Contains(err.Error(), prefix) {
+				t.Errorf("error does not locate service readiness: %v", err)
+			}
+			var value any
+			if err := json.Unmarshal([]byte(tc.data), &value); err != nil {
+				t.Fatal(err)
+			}
+			if err := schema.Validate(value); (err == nil) != tc.valid {
+				t.Errorf("schema validation = %v, want valid=%v", err, tc.valid)
+			}
+		})
+	}
+}
+
+func TestEffectiveReadiness(t *testing.T) {
+	for _, cfg := range []*AppConfig{nil, {}, {Readiness: &ReadinessConfig{TimeoutSeconds: 180}}} {
+		if got := EffectiveReadiness(cfg); got != nil {
+			t.Errorf("EffectiveReadiness(%+v) = %+v, want no probe", cfg, got)
+		}
+	}
+	for _, probe := range []*ReadinessConfig{
+		{TCPSocket: &TCPSocketProbe{Port: 9000}},
+		{HTTPGet: &HTTPGetProbe{Port: 9000, Path: "/ready"}},
+		{Exec: []string{"check-ready"}},
+	} {
+		cfg := &AppConfig{Readiness: probe, Entitlements: []Entitlement{{Type: EntitlementHTTP, Port: 8080}}}
+		if got := EffectiveReadiness(cfg); got != probe {
+			t.Errorf("explicit probe replaced: got %+v, want %+v", got, probe)
+		}
+	}
+	for _, timing := range []*ReadinessConfig{nil, {TimeoutSeconds: 180, PeriodSeconds: 3, ProbeTimeoutSeconds: 5}} {
+		cfg := &AppConfig{Readiness: timing, Entitlements: []Entitlement{{Type: EntitlementHTTP, Port: 8080}}}
+		want := ReadinessConfig{TCPSocket: &TCPSocketProbe{Port: 8080}}
+		if timing != nil {
+			want.TimeoutSeconds, want.PeriodSeconds, want.ProbeTimeoutSeconds = 180, 3, 5
+		}
+		if got := EffectiveReadiness(cfg); !reflect.DeepEqual(got, &want) {
+			t.Errorf("synthesized readiness = %+v, want %+v", got, &want)
+		}
+		if cfg.Readiness != timing || (timing != nil && timing.TCPSocket != nil) {
+			t.Fatal("synthesis changed original config")
+		}
+	}
+	// An invalid explicit command is not silently replaced by port readiness.
+	cfg := &AppConfig{Readiness: &ReadinessConfig{Exec: []string{}}, Entitlements: []Entitlement{{Type: EntitlementHTTP, Port: 8080}}}
+	if got := EffectiveReadiness(cfg); got != cfg.Readiness || got.TCPSocket != nil {
+		t.Fatal("invalid explicit exec was replaced by implicit TCP probe")
+	}
+}
+
+func TestReadinessTimingDefaults(t *testing.T) {
+	for _, cfg := range []*ReadinessConfig{nil, {}} {
+		if cfg.Timeout() != 30*time.Second || cfg.ProbeTimeout() != 2*time.Second || cfg.Period() != time.Second {
+			t.Errorf("unexpected defaults for %+v", cfg)
+		}
+	}
+	cfg := &ReadinessConfig{TimeoutSeconds: 180, ProbeTimeoutSeconds: 5, PeriodSeconds: 3}
+	if cfg.Timeout() != 180*time.Second || cfg.ProbeTimeout() != 5*time.Second || cfg.Period() != 3*time.Second {
+		t.Fatal("explicit timing values not preserved")
+	}
+}
+
+func TestReadinessSchemaFieldParity(t *testing.T) {
+	var schema map[string]any
+	if err := json.Unmarshal([]byte(SchemaJSON), &schema); err != nil {
+		t.Fatal(err)
+	}
+	props := schemaProps(t, defOf(t, schema, "readiness"))
+	fields := jsonFieldNames(reflect.TypeOf(ReadinessConfig{}))
+	for key := range fields {
+		if _, ok := props[key]; !ok {
+			t.Errorf("schema omits readiness field %q", key)
+		}
+	}
+	for key := range props {
+		if !fields[key] {
+			t.Errorf("schema declares unknown readiness field %q", key)
+		}
+	}
+}

--- a/go/internal/shared/appconfig/wendy.schema.json
+++ b/go/internal/shared/appconfig/wendy.schema.json
@@ -366,8 +366,13 @@
     },
     "readiness": {
       "type": "object",
-      "description": "Probe configuration the CLI uses to determine when the app is ready.",
+      "description": "Agent-owned readiness probe of the running app. Configure at most one of tcpSocket, httpGet, or exec. Without an explicit probe, an http entitlement implies a TCP probe; otherwise only running state can be reported.",
       "additionalProperties": false,
+      "allOf": [
+        { "not": { "required": ["tcpSocket", "httpGet"] } },
+        { "not": { "required": ["tcpSocket", "exec"] } },
+        { "not": { "required": ["httpGet", "exec"] } }
+      ],
       "properties": {
         "tcpSocket": {
           "type": "object",
@@ -383,11 +388,55 @@
             }
           }
         },
+        "httpGet": {
+          "type": "object",
+          "description": "HTTP GET against the running app. Status codes 200 through 399 succeed.",
+          "required": ["port"],
+          "additionalProperties": false,
+          "properties": {
+            "port": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535
+            },
+            "path": {
+              "type": "string",
+              "format": "uri-reference",
+              "pattern": "^($|/([^/\\\\\\s#]|$)[^\\\\\\s#]*)$",
+              "default": "/",
+              "description": "Local request path, optionally including a query; defaults to /. No host, fragment, whitespace, or control characters."
+            }
+          }
+        },
+        "exec": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Command and optional arguments executed directly inside the running app, without an implicit shell. Exit code 0 succeeds.",
+          "prefixItems": [
+            { "type": "string", "minLength": 1, "pattern": "\\S", "not": { "pattern": "\u0000" } }
+          ],
+          "items": { "type": "string", "not": { "pattern": "\u0000" } }
+        },
         "timeoutSeconds": {
           "type": "integer",
           "minimum": 0,
+          "maximum": 3600,
           "default": 30,
-          "description": "Readiness timeout in seconds (default 30)."
+          "description": "Total readiness deadline in seconds. 0 selects the default of 30."
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 300,
+          "default": 1,
+          "description": "Delay after a failed probe before the next attempt, in seconds. 0 selects the default of 1."
+        },
+        "probeTimeoutSeconds": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 300,
+          "default": 2,
+          "description": "Maximum duration of one attempt, also bounded by the remaining total readiness deadline. 0 selects the default of 2 seconds."
         }
       }
     },


### PR DESCRIPTION
Part 2 of the verified-deployment stack, based on #1883 (`max/deployment-protocol`). Implements the agent transaction and readiness configuration behind the new RPC contract.

- Validate and pin the candidate image and prepare its writable snapshot before cutover. Retain the prior exact spec/snapshot and running/stopped state, then commit after agent-owned TCP/HTTP/exec readiness or restore the prior revision on failure.
- Return explicit READY/RUNNING/ROLLED_BACK/FAILED/ROLLBACK_FAILED outcomes; complete bounded verification/recovery after caller disconnect. Durable journals recover interrupted cutover before restart monitoring and retain one prior revision. Explicit removal cleans up retained journals and resources.
- Serialize conflicting lifecycle operations, preserve stdin on the original verified process, protect deployment outcomes from slow log readers, and bound cleanup. Shared-namespace groups are explicitly unsupported by the transaction.

Validation: standalone containerd, agent-services, schema, and CLI-command race suites passed on this branch, including rollback, interruption, stopped-state preservation, deletion recovery, and real containerd metadata GC. The complete stack also passed real Linux containerd/runc recovery and container-network-namespace probes; those opt-in integration tests, documentation, and CLI/MCP consumers are in #1882.

Readiness is checked at deployment time. Recovery is automatic and per container; it does not undo persistent-volume writes, migrations, or external effects, and does not add a manual rollback command. Cutover can interrupt service.

Split from #1882 to fit the repository's complete-security-review size limit. Merge after the protocol prerequisite, then merge #1882.
