### PR TITLE
Stop a wrong ingest route from killing the episode backlog

### DIFF
--- a/go/internal/agent/data/adversarial_test.go
+++ b/go/internal/agent/data/adversarial_test.go
@@ -567,30 +567,37 @@ func TestManagerConcurrentLifecycleStress(t *testing.T) {
 	}
 }
 
-// TestUploadStateVocabularyMatchesEviction pins the awaitingUpload state set
-// against the states the agent actually writes, so a renamed workflow state
-// cannot silently revert eviction to oldest-first.
+// TestUploadStateVocabularyMatchesEviction pins the eviction tier of every
+// upload state the agent writes, so a renamed workflow state cannot silently
+// change what gets deleted first under quota pressure.
 func TestUploadStateVocabularyMatchesEviction(t *testing.T) {
-	// States produced by this agent today: "local" (ad-hoc default) and
-	// "pending" (campaign episodes). "uploaded" is written by the future
-	// transfer worker. Anything unknown must stay protected (fail-safe).
-	for state, awaiting := range map[string]bool{
-		"":          false,
-		"local":     false,
-		"uploaded":  false,
-		"pending":   true,
-		"uploading": true,
-		"failed":    true,
+	// Tier 0 is evicted first, tier 2 last. "" and "local" never leave the
+	// device; "uploaded" has a copy in the cloud. "failed" sits between: the
+	// worker gave up, so it must not hold quota against live candidates, but
+	// its bytes are the only copy and RequeueFailedUploads can revive it, so it
+	// still outranks episodes that are already safe.
+	for state, tier := range map[string]int{
+		"":          0,
+		"local":     0,
+		"uploaded":  0,
+		"failed":    1,
+		"pending":   2,
+		"uploading": 2,
 	} {
-		if got := awaitingUpload(state); got != awaiting {
-			t.Errorf("awaitingUpload(%q) = %v, want %v", state, got, awaiting)
+		if got := evictionTier(state); got != tier {
+			t.Errorf("evictionTier(%q) = %d, want %d", state, got, tier)
 		}
+	}
+	// Fail-safe: a state this build has never heard of must be treated as still
+	// on its way out, not as safe to delete.
+	if got := evictionTier("some-future-state"); got != 2 {
+		t.Errorf("evictionTier(unknown) = %d, want 2 (most protected)", got)
 	}
 	var manifest Manifest
 	if err := json.Unmarshal([]byte(`{"upload":{"state":"pending"}}`), &manifest); err != nil {
 		t.Fatal(err)
 	}
-	if !awaitingUpload(manifest.Upload.State) {
+	if evictionTier(manifest.Upload.State) != 2 {
 		t.Fatal("persisted pending state lost eviction protection")
 	}
 }

--- a/go/internal/agent/data/manager.go
+++ b/go/internal/agent/data/manager.go
@@ -748,7 +748,7 @@ func (m *Manager) enforceQuota() error {
 		path          string
 		started, size int64
 		id, campaign  string
-		awaitUpload   bool
+		tier          int
 	}
 	var candidates []candidate
 	var used int64
@@ -776,14 +776,13 @@ func (m *Manager) enforceQuota() error {
 		})
 		used += size
 		if m.downloads[mf.ID] == 0 {
-			candidates = append(candidates, candidate{dir, mf.StartedUnixNanos, size, mf.ID, mf.Trigger.CampaignName, awaitingUpload(mf.Upload.State)})
+			candidates = append(candidates, candidate{dir, mf.StartedUnixNanos, size, mf.ID, mf.Trigger.CampaignName, evictionTier(mf.Upload.State)})
 		}
 	}
-	// Episodes that still await upload are evicted only after every uploaded or
-	// local-only episode; within each group the oldest goes first.
+	// Lower tier is evicted first; within a tier the oldest goes first.
 	sort.Slice(candidates, func(i, j int) bool {
-		if candidates[i].awaitUpload != candidates[j].awaitUpload {
-			return !candidates[i].awaitUpload
+		if candidates[i].tier != candidates[j].tier {
+			return candidates[i].tier < candidates[j].tier
 		}
 		return candidates[i].started < candidates[j].started
 	})
@@ -791,8 +790,11 @@ func (m *Manager) enforceQuota() error {
 		if used <= quota && free >= reserve {
 			break
 		}
-		if c.awaitUpload {
+		switch c.tier {
+		case 2:
 			m.warnf("evicting episode %s (campaign %s) before its upload completed to preserve the data quota", c.id, c.campaign)
+		case 1:
+			m.warnf("evicting episode %s (campaign %s), which failed to upload and was never retried, to preserve the data quota", c.id, c.campaign)
 		}
 		if err := os.RemoveAll(c.path); err != nil {
 			return fmt.Errorf("evicting %s: %w", filepath.Base(c.path), err)
@@ -809,12 +811,24 @@ func (m *Manager) enforceQuota() error {
 // awaitingUpload reports whether an episode's payload has not reached its
 // upload destination yet. Local-only episodes ("local" or empty) never upload
 // and are evictable; "uploaded" episodes already have a durable remote copy.
-func awaitingUpload(state string) bool {
+// evictionTier orders episodes for quota eviction, lowest evicted first.
+//
+// Three tiers rather than two. "uploaded" and "local" go first as before: one
+// has a copy in the cloud and the other was never meant to leave. "failed" sits
+// in the middle, because the worker gave up on it and it is not going anywhere
+// on its own; leaving it level with live candidates let a device whose route
+// was broken fill its quota with episodes that could never ship while newer
+// captures were pushed out. It still outranks data that is already safe, since
+// its bytes are the only copy and RequeueFailedUploads can bring it back.
+// "pending" and "uploading" are evicted last: they are still on their way out.
+func evictionTier(state string) int {
 	switch state {
 	case "", "local", "uploaded":
-		return false
+		return 0
+	case "failed":
+		return 1
 	}
-	return true
+	return 2
 }
 
 func (m *Manager) BeginDownload(id string) { m.mu.Lock(); defer m.mu.Unlock(); m.downloads[id]++ }
@@ -1235,6 +1249,54 @@ func (m *Manager) Status() *Manifest {
 // single source of truth for upload progress; the transfer worker consumes this
 // queue and calls UpdateUploadState to persist each transition. Episodes are
 // returned oldest-first so the backlog drains in capture order.
+// RequeueFailedUploads moves every "failed" episode back to "pending" and
+// returns how many it moved.
+//
+// "failed" means the worker gave up, not that the episode is unshippable: a
+// wrong endpoint, an expired certificate or a cloud outage long enough to
+// exhaust the retry budget all land here, and every one of them is fixed by a
+// change OUTSIDE the episode. Without this the fix arrives and the backlog
+// stays dead, because EpisodesAwaitingUpload only ever returns pending and
+// uploading, so nothing would look at those episodes again.
+//
+// The attempt counter resets with the state; keeping it would exhaust the
+// budget again on the first retry and undo the requeue.
+func (m *Manager) RequeueFailedUploads() (int, error) {
+	// Collect under the lock, then update outside it: UpdateUploadState takes
+	// the same mutex, so mutating in place here would deadlock.
+	m.mu.Lock()
+	entries, err := os.ReadDir(m.root)
+	if err != nil {
+		m.mu.Unlock()
+		return 0, err
+	}
+	var ids []string
+	for _, e := range entries {
+		if !e.IsDir() || strings.HasSuffix(e.Name(), ".partial") {
+			continue
+		}
+		mf, err := readManifest(filepath.Join(m.root, e.Name()))
+		if err != nil || mf.Upload.State != "failed" {
+			continue
+		}
+		ids = append(ids, mf.ID)
+	}
+	m.mu.Unlock()
+
+	moved := 0
+	for _, id := range ids {
+		if _, err := m.UpdateUploadState(id, func(ws *WorkflowState) {
+			ws.State = "pending"
+			ws.Attempts = 0
+			ws.NextAttemptUnixNanos = 0
+		}); err != nil {
+			continue
+		}
+		moved++
+	}
+	return moved, nil
+}
+
 func (m *Manager) EpisodesAwaitingUpload() ([]Manifest, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/go/internal/agent/data/manager_requeue_test.go
+++ b/go/internal/agent/data/manager_requeue_test.go
@@ -1,0 +1,98 @@
+package data
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func seedEpisode(t *testing.T, root, id, state string, attempts int) {
+	t.Helper()
+	dir := filepath.Join(root, id)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	mf := Manifest{ID: id}
+	mf.Upload.State = state
+	mf.Upload.Attempts = attempts
+	mf.Upload.LastError = "gave up"
+	b, err := json.Marshal(mf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "manifest.json"), b, 0o640); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestRequeueFailedUploadsRevivesTheBacklog covers the one-way door: before
+// this, "failed" was terminal because EpisodesAwaitingUpload only ever returned
+// pending and uploading. Fixing whatever broke uploads did nothing for anything
+// already given up on, so a device that spent a week failing kept that week's
+// data on disk permanently unshipped.
+func TestRequeueFailedUploadsRevivesTheBacklog(t *testing.T) {
+	root := t.TempDir()
+	m, err := NewManager(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedEpisode(t, root, "ep-failed", "failed", 5)
+	seedEpisode(t, root, "ep-uploaded", "uploaded", 0)
+	seedEpisode(t, root, "ep-pending", "pending", 2)
+
+	before, err := m.EpisodesAwaitingUpload()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(before) != 1 {
+		t.Fatalf("before requeue: %d episodes awaiting upload, want 1 (the failed one must be invisible)", len(before))
+	}
+
+	moved, err := m.RequeueFailedUploads()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if moved != 1 {
+		t.Fatalf("requeued %d, want 1", moved)
+	}
+
+	after, err := m.EpisodesAwaitingUpload()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != 2 {
+		t.Fatalf("after requeue: %d awaiting upload, want 2", len(after))
+	}
+	for _, mf := range after {
+		if mf.ID == "ep-failed" {
+			if mf.Upload.State != "pending" {
+				t.Errorf("state = %q, want pending", mf.Upload.State)
+			}
+			// A revived episode that kept its exhausted counter would fail
+			// again on the first attempt and undo the requeue.
+			if mf.Upload.Attempts != 0 {
+				t.Errorf("attempts = %d, want 0", mf.Upload.Attempts)
+			}
+		}
+	}
+}
+
+// An uploaded episode must not be dragged back into the queue.
+func TestRequeueFailedUploadsLeavesOtherStatesAlone(t *testing.T) {
+	root := t.TempDir()
+	m, err := NewManager(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedEpisode(t, root, "ep-uploaded", "uploaded", 0)
+	seedEpisode(t, root, "ep-local", "local", 0)
+
+	moved, err := m.RequeueFailedUploads()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if moved != 0 {
+		t.Fatalf("requeued %d, want 0", moved)
+	}
+}

--- a/go/internal/agent/services/data_transfer_worker.go
+++ b/go/internal/agent/services/data_transfer_worker.go
@@ -12,7 +12,9 @@ import (
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 
 	"github.com/wendylabsinc/wendy/go/internal/agent/data"
 	cloudpb "github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
@@ -38,6 +40,44 @@ const (
 	// backlog, to avoid busy-looping the disk scan.
 	transferIdlePause = 10 * time.Second
 )
+
+// errIngestBlocked wraps a failure that says the ROUTE is wrong rather than the
+// episode. Retrying cannot fix it and every other episode in the backlog will
+// fail identically, so the pass aborts instead of walking the queue and burning
+// each episode's retry budget against the same wall.
+type errIngestBlocked struct {
+	code  codes.Code
+	cause error
+}
+
+func (e *errIngestBlocked) Error() string {
+	return fmt.Sprintf("ingest endpoint rejected the request as %s: %v", e.code, e.cause)
+}
+func (e *errIngestBlocked) Unwrap() error { return e.cause }
+
+// ingestBlocked reports whether err is a route/configuration failure rather
+// than a transport one.
+//
+// These three codes share a property that no amount of retrying changes: the
+// endpoint understood us and refused. Unimplemented is the one that matters
+// most in practice, because dialling a host that does not serve
+// DataIngestService (the enrolled cloud host, when no ingest endpoint is
+// configured) returns exactly that, and treating it as transient quietly
+// converts every sealed episode on the device into a permanent failure.
+func ingestBlocked(err error) *errIngestBlocked {
+	if err == nil {
+		return nil
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		return nil
+	}
+	switch st.Code() {
+	case codes.Unimplemented, codes.Unauthenticated, codes.PermissionDenied:
+		return &errIngestBlocked{code: st.Code(), cause: err}
+	}
+	return nil
+}
 
 // Upload workflow states persisted in Manifest.Upload.State. These mirror the
 // vocabulary the data manager already understands (see awaitingUpload).
@@ -68,6 +108,9 @@ type DataTransferWorker struct {
 	factory         ingestClientFactory  // set in tests; production builds one from provisioningSvc
 
 	maxAttempts int
+	// lastBlockedCause is the most recent route-level rejection, so a blocked
+	// endpoint is reported once rather than once a minute forever.
+	lastBlockedCause string
 	// ingestHostOverride, when non-empty, replaces the provisioning cloud host
 	// as the DataIngestService dial target. Enrollment is still required (the
 	// asset identity and client certificate come from provisioning); only the
@@ -236,6 +279,15 @@ func (w *DataTransferWorker) Run(ctx context.Context) {
 		}
 	}
 
+	// A restart is usually what follows fixing whatever broke uploads, so give
+	// the episodes that exhausted their budget one more life. Bounded: this
+	// runs once per process, not per pass.
+	if moved, err := w.manager.RequeueFailedUploads(); err != nil {
+		w.logger.Warn("data transfer worker: requeue of failed episodes failed", zap.Error(err))
+	} else if moved > 0 {
+		w.logger.Info("data transfer worker: requeued previously failed episodes", zap.Int("episodes", moved))
+	}
+
 	w.logger.Info("data transfer worker: started")
 	attempt := 0
 	for {
@@ -247,7 +299,22 @@ func (w *DataTransferWorker) Run(ctx context.Context) {
 			if ctx.Err() != nil {
 				return
 			}
-			w.logger.Warn("data transfer worker: pass failed", zap.Error(err))
+			// A blocked route persists until someone changes configuration, so
+			// it would otherwise log identically every minute forever. Say it
+			// loudly once, then keep it at debug until the cause changes.
+			if blocked := ingestBlocked(err); blocked != nil {
+				if w.lastBlockedCause != blocked.Error() {
+					w.lastBlockedCause = blocked.Error()
+					w.logger.Error("data transfer worker: ingest endpoint is not accepting uploads; "+
+						"no episode will be retried against it and none has been marked failed",
+						zap.String("code", blocked.code.String()), zap.Error(blocked))
+				} else {
+					w.logger.Debug("data transfer worker: ingest still blocked", zap.Error(blocked))
+				}
+			} else {
+				w.lastBlockedCause = ""
+				w.logger.Warn("data transfer worker: pass failed", zap.Error(err))
+			}
 			w.backoff(ctx, attempt)
 			if attempt < 6 { // 2^6 = 64s > 60s cap
 				attempt++
@@ -299,7 +366,10 @@ func (w *DataTransferWorker) runPass(ctx context.Context) error {
 		if mf.Upload.State == uploadStatePending && mf.Upload.NextAttemptUnixNanos > now.UnixNano() {
 			continue
 		}
-		w.processEpisode(ctx, client, mf)
+		if err := w.processEpisode(ctx, client, mf); err != nil {
+			// Route failure: the rest of the backlog would fail identically.
+			return err
+		}
 	}
 	return nil
 }
@@ -357,10 +427,15 @@ func (w *DataTransferWorker) uploadRate(mf data.Manifest) int64 {
 // manifest; transient failures move the episode back to "pending" with a
 // backoff (or to "failed" once the retry ceiling is hit), verification failures
 // move it straight to "failed", and success marks it "uploaded".
-func (w *DataTransferWorker) processEpisode(ctx context.Context, client cloudpb.DataIngestServiceClient, mf data.Manifest) {
+//
+// It returns a non-nil error ONLY when the failure is the route rather than the
+// episode, which is the caller's signal to abandon the pass. The episode is
+// left exactly as it was found in that case: it did nothing wrong, so it keeps
+// its attempt count and its place in the queue.
+func (w *DataTransferWorker) processEpisode(ctx context.Context, client cloudpb.DataIngestServiceClient, mf data.Manifest) error {
 	if ok, reason := w.resolveShouldUpload(mf); !ok {
 		w.logger.Debug("data transfer worker: skipping episode", zap.String("episode", mf.ID), zap.String("reason", reason))
-		return
+		return nil
 	}
 
 	// Mark uploading (durably) before any network work so a crash mid-transfer
@@ -369,7 +444,7 @@ func (w *DataTransferWorker) processEpisode(ctx context.Context, client cloudpb.
 		ws.State = uploadStateUploading
 	}); err != nil {
 		w.logger.Warn("data transfer worker: mark uploading failed", zap.String("episode", mf.ID), zap.Error(err))
-		return
+		return nil
 	}
 	w.logger.Info("data transfer worker: uploading episode", zap.String("episode", mf.ID),
 		zap.Int("files", len(mf.Files)), zap.String("campaign", mf.Trigger.CampaignName))
@@ -388,7 +463,18 @@ func (w *DataTransferWorker) processEpisode(ctx context.Context, client cloudpb.
 			// Shutdown mid-transfer: leave the episode "uploading" so the next
 			// run resumes it. Nothing is silently dropped.
 			w.logger.Info("data transfer worker: shutdown mid-upload, episode left for resume", zap.String("episode", mf.ID))
-			return
+			return nil
+		}
+		if blocked := ingestBlocked(retryErr); blocked != nil {
+			// The route is wrong, not the episode. Put it back exactly as it
+			// was and let the caller stop the pass.
+			if _, err := w.manager.UpdateUploadState(mf.ID, func(ws *data.WorkflowState) {
+				ws.State = mf.Upload.State
+				ws.LastError = blocked.Error()
+			}); err != nil {
+				w.logger.Warn("data transfer worker: restore state failed", zap.String("episode", mf.ID), zap.Error(err))
+			}
+			return blocked
 		}
 		w.handleRetryable(mf, retryErr)
 	default:
@@ -398,10 +484,11 @@ func (w *DataTransferWorker) processEpisode(ctx context.Context, client cloudpb.
 			ws.NextAttemptUnixNanos = 0
 		}); err != nil {
 			w.logger.Warn("data transfer worker: mark uploaded failed", zap.String("episode", mf.ID), zap.Error(err))
-			return
+			return nil
 		}
 		w.logger.Info("data transfer worker: episode uploaded", zap.String("episode", mf.ID))
 	}
+	return nil
 }
 
 // handleRetryable records a retryable failure: it bumps the attempt count and

--- a/go/internal/agent/services/data_transfer_worker_test.go
+++ b/go/internal/agent/services/data_transfer_worker_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"io"
 	"net"
 	"os"
@@ -17,8 +18,10 @@ import (
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 
 	"github.com/wendylabsinc/wendy/go/internal/agent/data"
@@ -764,5 +767,98 @@ func TestUploadStreamCarriesOneEpisode(t *testing.T) {
 	}
 	if !all["ep-one"] || !all["ep-two"] {
 		t.Errorf("streams carried %v, want both ep-one and ep-two", all)
+	}
+}
+
+// startBareIngest starts a server that implements nothing, so every call
+// returns Unimplemented. This is not a contrived error: it is exactly what a
+// device gets today when no ingest endpoint is configured and the worker falls
+// back to dialling the enrolled cloud host, which serves the broker and not
+// DataIngestService.
+func startBareIngest(t *testing.T) cloudpb.DataIngestServiceClient {
+	t.Helper()
+	lis := bufconn.Listen(1024 * 1024)
+	g := grpc.NewServer()
+	cloudpb.RegisterDataIngestServiceServer(g, &cloudpb.UnimplementedDataIngestServiceServer{})
+	go func() { _ = g.Serve(lis) }()
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() { conn.Close(); g.Stop(); lis.Close() })
+	return cloudpb.NewDataIngestServiceClient(conn)
+}
+
+// TestBlockedRouteSpendsNoRetryBudget is the regression that matters most here.
+// Before this, an endpoint that does not serve the service was classified as a
+// transient transport failure, so every sealed episode on the device burned its
+// five attempts and was then marked permanently failed. The route being wrong
+// is not the episode's fault and must cost it nothing.
+func TestBlockedRouteSpendsNoRetryBudget(t *testing.T) {
+	mgr, root := newTestManager(t)
+	writeFixtureEpisode(t, root, "ep-blocked", "", "pending", map[string][]byte{"a.bin": []byte("x")})
+
+	w := newTestWorker(mgr, startBareIngest(t))
+	err := w.runPass(context.Background())
+	if err == nil {
+		t.Fatal("runPass returned nil; a blocked route must surface as a pass failure")
+	}
+	if ingestBlocked(err) == nil {
+		t.Fatalf("runPass error %v is not classified as blocked", err)
+	}
+
+	st := uploadState(t, mgr, "ep-blocked")
+	if st.State == uploadStateFailed {
+		t.Error("episode was marked failed because the endpoint was wrong")
+	}
+	if st.Attempts != 0 {
+		t.Errorf("attempts = %d, want 0: a blocked route must not consume the retry budget", st.Attempts)
+	}
+}
+
+// TestBlockedRouteStopsTheWholePass: every episode in the backlog would fail
+// identically, so the worker must stop rather than walk the queue.
+func TestBlockedRouteStopsTheWholePass(t *testing.T) {
+	mgr, root := newTestManager(t)
+	for _, id := range []string{"ep-1", "ep-2", "ep-3"} {
+		writeFixtureEpisode(t, root, id, "", "pending", map[string][]byte{"a.bin": []byte("x")})
+	}
+
+	w := newTestWorker(mgr, startBareIngest(t))
+	if err := w.runPass(context.Background()); err == nil {
+		t.Fatal("runPass returned nil on a blocked route")
+	}
+	for _, id := range []string{"ep-1", "ep-2", "ep-3"} {
+		if st := uploadState(t, mgr, id); st.Attempts != 0 {
+			t.Errorf("%s: attempts = %d, want 0", id, st.Attempts)
+		}
+	}
+}
+
+// TestBlockedClassification pins which codes are permanent. Getting this set
+// wrong in either direction is costly: too wide and a transient outage stops
+// uploads entirely, too narrow and a misconfiguration silently kills episodes.
+func TestBlockedClassification(t *testing.T) {
+	for code, want := range map[codes.Code]bool{
+		codes.Unimplemented:     true,
+		codes.Unauthenticated:   true,
+		codes.PermissionDenied:  true,
+		codes.Unavailable:       false,
+		codes.DeadlineExceeded:  false,
+		codes.ResourceExhausted: false,
+		codes.Internal:          false,
+		codes.Aborted:           false,
+	} {
+		if got := ingestBlocked(status.Error(code, "x")) != nil; got != want {
+			t.Errorf("ingestBlocked(%s) = %v, want %v", code, got, want)
+		}
+	}
+	if ingestBlocked(nil) != nil {
+		t.Error("ingestBlocked(nil) must be nil")
+	}
+	if ingestBlocked(errors.New("plain")) != nil {
+		t.Error("a non-status error is not a blocked route")
 	}
 }


### PR DESCRIPTION
## Problem

On a device with no ingest endpoint configured, every sealed episode ends up permanently `failed`, and nothing will ever ship it. That is the current default, not an edge case.

The worker falls back to the enrolled cloud host when `WENDY_DATA_INGEST_URL` is unset. That host serves the broker, which does not implement `DataIngestService`, so every call returns `Unimplemented`. `WENDY_DATA_INGEST_URL` is set in exactly one place in the tree: the demo document, by hand.

## Cause

Three defects that only bite together.

1. **No error was ever permanent.** Everything except a verification failure was a "retryable transport failure", so `Unimplemented` burned one of the five attempts per pass until the episode was marked `failed`.
2. **`failed` was terminal.** `EpisodesAwaitingUpload` returns only `pending` and `uploading`, so fixing the route did nothing for anything already given up on.
3. **Eviction had two tiers.** `failed` counted as awaiting upload, level with live candidates, so a broken device filled its quota with episodes that could never ship while newer captures were evicted.

## Solution

`Unimplemented`, `Unauthenticated` and `PermissionDenied` are now their own class: the endpoint understood us and refused, and retrying cannot change that. The episode keeps its attempt count and its queue position, and the **pass aborts** rather than walking the backlog to fail every episode identically. The cause is logged once, not once a minute for as long as it lasts.

`RequeueFailedUploads` moves `failed` back to `pending` with the counter reset, called once at worker startup, since a restart is usually what follows fixing the route.

Eviction gains a middle tier. `failed` is evicted before episodes still on their way out and after those already uploaded or deliberately local: its bytes are the only copy and it can now be revived, but it must not hold quota against live candidates.

## Verification

Build, vet and gofmt clean. Full `data` and `services` suites pass.

Five mutation checks, all caught:
- disabling the classification fails all three route tests
- a requeue that keeps the exhausted attempt counter fails
- folding `failed` back into the top eviction tier fails the vocabulary test

`TestBlockedClassification` pins the code set in both directions, since too wide stops uploads during a transient outage and too narrow silently kills episodes.

## Not in scope

Where the ingest endpoint should come from. Under the passthrough-mTLS design it is deliberately independent of the cloud host, so it becomes explicit configuration rather than a fallback; that lands with the infrastructure work.