### PR TITLE
Speed up template init with starters, defaults, and cached bundles

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/init.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/init.md
@@ -4,6 +4,38 @@ Creates a new Wendy project: a [`wendy.json`](../../../apps/wendy.json.md), scaf
 
 Run it with no arguments for an interactive wizard, or pass flags to script it end to end. Every prompt has a matching flag, so any wizard answer can be supplied up front.
 
+## Start and run a template
+
+```sh
+wendy init my-app --template fullstack --language python --run
+```
+
+The Web app starter opens one React page backed by a greeting endpoint. Choose
+**API**, **Web app**, **Camera**, or **Audio** in the WendyOS picker; **Browse
+examples** contains larger integrations such as the Device dashboard, AI, and
+robot apps. Wendy Lite offers Hello World and Blink. Direct `--template` names
+continue to work, and older catalogs without categories still display normally.
+
+Template defaults such as ports are accepted without prompting, even when a
+required credential still needs an answer. Use `--var` to override them. Git is
+initialized automatically unless the project is inside an existing repository;
+pass `--git-init=no` to opt out. The interactive language picker remembers your
+last successful choice when the selected template supports it; `--language`
+always overrides that preference. Scripts still supply a language explicitly
+when a template has more than one.
+
+`--run` starts the generated project using the normal build/deploy path and the
+global `--device` selection. If deployment fails, the generated files remain;
+fix the reported problem and run `wendy run` from the project directory.
+Omit `--run` to scaffold without deploying.
+
+The CLI downloads only the selected template bundle, checks its SHA-256, and
+caches it by content. Catalog indexes refresh after five minutes. Previously
+cached templates remain usable when the server is unreachable. Branches without
+bundles use the existing repository-archive download, so older branch previews
+continue working. Offline scaffolding does not imply that uncached runtime
+images, packages, or model weights can be downloaded without a connection.
+
 ## Usage
 
 ```sh
@@ -59,7 +91,7 @@ For ESP32, regular native ESP-IDF projects are recommended. Create them with the
 | `--here` | Scaffold into the current directory instead of creating a subdirectory. With no `[app-id]`/`--app-id`, infers the app ID from the current directory's name. |
 | `--target <name>` | Target platform: `wendyos`, `darwin`, or `wendy-lite`. Required when running non-interactively. |
 | `--language <name>` | Project language. `swift` or `python` for the plain wizard; templates may offer more. |
-| `--git-init <yes\|no>` | Initialize a git repo in the project directory. |
+| `--git-init <yes\|no>` | Initialize Git; defaults to yes outside an existing repository. |
 
 ### Template flags
 
@@ -68,6 +100,7 @@ For ESP32, regular native ESP-IDF projects are recommended. Create them with the
 | `--template [<name>]` | Scaffold from a template. Passing it **without** a value opens a picker filtered by target, auto-selecting when only one template exists for the target. With a value, `--target` becomes optional: it is inferred when the template's metadata maps to exactly one target. |
 | `--branch <name>` | Branch of the templates repo to read templates from. |
 | `--var KEY=VALUE` | Override a template variable. Repeatable. |
+| `--run` | Build and run the template immediately after scaffolding. |
 
 ### Entitlement flags
 

--- a/go/internal/cli/commands/init_cmd.go
+++ b/go/internal/cli/commands/init_cmd.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 )
 
 const (
@@ -75,6 +76,8 @@ type entitlementQuestion struct {
 
 type initOptions struct {
 	appID               string
+	run                 bool
+	ctx                 context.Context
 	here                bool
 	target              string
 	language            string
@@ -145,6 +148,9 @@ func newInitCmd() *cobra.Command {
 			"\"frameworks\" in wendy.json afterwards.",
 		Example: `  # Interactive wizard
   wendy init
+
+  # Create and launch a minimal Web app
+  wendy init my-app --template fullstack --language python --run
 
   # Scaffold from a template (interactive language picker)
   wendy init --template simple-api
@@ -229,6 +235,7 @@ func newInitCmd() *cobra.Command {
     --assistant skip`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.ctx = cmd.Context()
 			opts.appIDSet = cmd.Flags().Changed("app-id")
 			opts.targetSet = cmd.Flags().Changed("target")
 			opts.languageSet = cmd.Flags().Changed("language")
@@ -254,6 +261,7 @@ func newInitCmd() *cobra.Command {
 		},
 	}
 
+	cmd.Flags().BoolVar(&opts.run, "run", false, "Build and run the generated template immediately")
 	cmd.Flags().StringVar(&opts.appID, "app-id", "", "Application ID to write into wendy.json")
 	cmd.Flags().BoolVar(&opts.here, "here", false, "Scaffold into the current directory instead of creating a subdirectory")
 	cmd.Flags().StringVar(&opts.target, "target", "", "Target platform: wendyos (writes \"linux\" to wendy.json), wendy-lite, or darwin")
@@ -261,7 +269,7 @@ func newInitCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.template, "template", "", "Project template (e.g. simple-api, fullstack)")
 	cmd.Flags().StringVar(&opts.branch, "branch", "", fmt.Sprintf("Branch of the templates repo to use (default: %s)", templateRepoBranch))
 	cmd.Flags().StringSliceVar(&opts.vars, "var", nil, "Template variable override (repeatable, KEY=VALUE)")
-	cmd.Flags().StringVar(&opts.gitInit, "git-init", "", "Initialize a git repo in the project directory (yes or no)")
+	cmd.Flags().StringVar(&opts.gitInit, "git-init", "", "Initialize a git repo in the project directory (yes or no; default yes outside an existing repo)")
 	cmd.Flags().StringSliceVar(&opts.entitlements, "entitlement", nil, "App entitlement to enable (repeatable or comma-separated)")
 	cmd.Flags().BoolVar(&opts.allEntitlements, "all-entitlements", false, "Enable all entitlements (requires field flags for gpio, i2c, persist)")
 	cmd.Flags().BoolVar(&opts.noExtraEntitlements, "no-extra-entitlements", false, "Skip entitlement prompts and use only the default network entitlement")
@@ -327,6 +335,10 @@ func runInitWizard(args []string, opts initOptions) error {
 			return err
 		}
 		return runTemplateFlow(cwd, destDir, appID, tmpl, target, meta, opts)
+	}
+
+	if opts.run {
+		return fmt.Errorf("--run requires a template; choose one or pass --template=<name>")
 	}
 
 	// Standard wizard flow (no template) — check wendy.json doesn't already exist.
@@ -536,8 +548,8 @@ func templateItemsForTarget(target string, meta *repoMeta) []tui.PickerItem {
 	for _, t := range meta.Templates {
 		if templateTargetMatch(t, target) {
 			items = append(items, tui.PickerItem{
-				Name:        t.Name,
-				Description: t.Description,
+				Name:        templateDisplayName(t),
+				Description: templateDescription(t),
 				Value:       t.Name,
 			})
 		}
@@ -547,12 +559,7 @@ func templateItemsForTarget(target string, meta *repoMeta) []tui.PickerItem {
 
 // pickTemplateNameForTarget shows a picker with templates available for the given target.
 func pickTemplateNameForTarget(target string, meta *repoMeta) (string, error) {
-	fmt.Println()
-	items := templateItemsForTarget(target, meta)
-	if len(items) == 0 {
-		return "", fmt.Errorf("no templates available for %s", target)
-	}
-	return pickFromItems("Choose a template", items)
+	return pickStarterOrExample(target, meta, false)
 }
 
 // resolveBareTemplatePick handles a bare `--template` (rewritten to the
@@ -582,24 +589,66 @@ func resolveBareTemplatePick(target string, meta *repoMeta) (string, error) {
 
 // pickTemplateOrSkipForTarget shows templates for the given target plus a "No template" option.
 func pickTemplateOrSkipForTarget(target string, meta *repoMeta) (string, error) {
-	fmt.Println()
-	var items []tui.PickerItem
-	for _, t := range meta.Templates {
-		if templateTargetMatch(t, target) {
-			items = append(items, tui.PickerItem{
-				Name:        t.Name,
-				Description: t.Description,
-				Value:       t.Name,
-			})
+	return pickStarterOrExample(target, meta, true)
+}
+
+func templateDisplayName(t repoMetaTemplate) string {
+	if t.DisplayName != "" {
+		return t.DisplayName
+	}
+	return t.Name
+}
+
+func templateDescription(t repoMetaTemplate) string {
+	if t.Requirements != "" {
+		return t.Description + " · Requires: " + t.Requirements
+	}
+	return t.Description
+}
+
+func starterAndExampleItems(target string, meta *repoMeta) ([]tui.PickerItem, []tui.PickerItem) {
+	var starters, examples []tui.PickerItem
+	for i, t := range meta.Templates {
+		if !templateTargetMatch(t, target) {
+			continue
+		}
+		item := tui.PickerItem{Name: templateDisplayName(t), Description: templateDescription(t), Value: t.Name, SortKey: fmt.Sprintf("%04d", i)}
+		if t.Category == "example" {
+			examples = append(examples, item)
+		} else {
+			starters = append(starters, item)
 		}
 	}
-	items = append(items, tui.PickerItem{
-		Name:        "No template",
-		Description: "Configure target, language, and entitlements manually",
-		Value:       "",
-		SortKey:     "~",
-	})
-	return pickFromItems("Start from a template?", items)
+	return starters, examples
+}
+
+var pickInitTemplateItem = pickFromItems
+
+func pickStarterOrExample(target string, meta *repoMeta, allowManual bool) (string, error) {
+	starters, examples := starterAndExampleItems(target, meta)
+	if len(starters) == 0 {
+		starters, examples = examples, nil
+	}
+	if len(starters) == 0 && !allowManual {
+		return "", fmt.Errorf("no templates available for %s", target)
+	}
+	if len(examples) > 0 {
+		starters = append(starters, tui.PickerItem{Name: "Browse examples", Description: "AI, robotics, and device integrations", Value: "_examples", SortKey: "~1"})
+	}
+	if allowManual {
+		starters = append(starters, tui.PickerItem{Name: "No template", Description: "Configure an app manually", Value: "", SortKey: "~2"})
+	}
+	for {
+		choice, err := pickInitTemplateItem("What would you like to build?", starters)
+		if err != nil || choice != "_examples" {
+			return choice, err
+		}
+		items := append(append([]tui.PickerItem{}, examples...), tui.PickerItem{Name: "Back to starters", Value: "_back", SortKey: "~"})
+		choice, err = pickInitTemplateItem("Choose an example", items)
+		if err != nil || choice != "_back" {
+			return choice, err
+		}
+	}
 }
 
 // resolveTemplateLanguage picks the language for the template flow.
@@ -648,6 +697,12 @@ func resolveTemplateLanguage(target, tmpl string, meta *repoMeta, opts initOptio
 		return languages[0].Key, nil
 	}
 
+	if isInteractiveTerminal() {
+		if preferred := preferredTemplateLanguage(); templateLanguageAvailable(preferred, languages) {
+			cliNotice("Using %s from your last project; override with --language.", preferred)
+			return preferred, nil
+		}
+	}
 	items := templateLanguageItems(languages)
 	if !isInteractiveTerminal() {
 		printPickerItemsPlainText("Available languages for template "+tmpl, items)
@@ -874,11 +929,6 @@ func runTemplateFlow(cwd, destDir, appID, tmpl, target string, meta *repoMeta, o
 
 	cliSuccess("\nScaffolded %s project from template %q", language, tmpl)
 	cliLogln("  Directory: %s", tui.Path(destDir+"/"))
-	for _, v := range manifest.Variables {
-		if val, ok := vals[v.Name]; ok {
-			cliLogln("  %s: %v", v.Name, val)
-		}
-	}
 	if addedFrameworks {
 		cliLogln("  Frameworks added from flags: ros2")
 	}
@@ -891,7 +941,35 @@ func runTemplateFlow(cwd, destDir, appID, tmpl, target string, meta *repoMeta, o
 		return err
 	}
 
+	rememberTemplateLanguage(language)
+	if opts.run {
+		ctx := opts.ctx
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		return runInitializedTemplate(ctx, destDir)
+	}
 	return finishTemplateInit(cwd, destDir, appID)
+}
+
+var preferredTemplateLanguage = func() string {
+	if cfg, err := config.Load(); err == nil {
+		return cfg.PreferredTemplateLanguage
+	}
+	return ""
+}
+
+var rememberTemplateLanguage = func(language string) {
+	if cfg, err := config.Load(); err == nil {
+		cfg.PreferredTemplateLanguage = language
+		_ = config.Save(cfg)
+	}
+}
+
+var runInitializedTemplate = func(ctx context.Context, dir string) error {
+	return runWithInterruptContext(ctx, func(runCtx context.Context) error {
+		return runCommand(runCtx, runOptions{prefix: dir})
+	})
 }
 
 func finishTemplateInit(cwd, destDir, appID string) error {
@@ -1056,12 +1134,11 @@ func maybeGitInit(dir string, opts initOptions) error {
 			return fmt.Errorf("invalid --git-init value %q (expected yes or no)", opts.gitInit)
 		}
 	} else {
-		// Interactive yes/no prompt.
-		fmt.Println()
-		var err error
-		doInit, err = tui.ConfirmDefaultYes("Initialize a git repository?")
-		if err != nil {
-			return err
+		// A new starter should be ready to edit without another setup question.
+		// Avoid creating a nested repository when scaffolding within a checkout.
+		probe := exec.Command("git", "-C", dir, "rev-parse", "--is-inside-work-tree")
+		if output, err := probe.Output(); err == nil && strings.TrimSpace(string(output)) == "true" {
+			return nil
 		}
 	}
 

--- a/go/internal/cli/commands/template.go
+++ b/go/internal/cli/commands/template.go
@@ -56,7 +56,7 @@ type repoMetaTemplate struct {
 	Category     string   `json:"category,omitempty"`
 	Requirements string   `json:"requirements,omitempty"`
 	Description  string   `json:"description"`
-	Targets      []string `json:"targets"`   // optional; empty means all targets
+	Targets      []string `json:"targets"`   // optional; empty means WendyOS
 	Languages    []string `json:"languages"` // optional; empty means discover from repo layout
 }
 
@@ -459,7 +459,7 @@ func extractTemplateArchive(r io.Reader, language, templateName string) (map[str
 
 		// Sanitize: reject path traversal.
 		cleaned := filepath.Clean(relPath)
-		if filepath.IsAbs(cleaned) || strings.HasPrefix(cleaned, "..") {
+		if !filepath.IsLocal(cleaned) {
 			continue
 		}
 		relPath = cleaned
@@ -690,13 +690,23 @@ func validateVariable(v templateVariable, val interface{}) error {
 // Go text/template (so {{.VAR}}, {{if}}, {{range}}, etc. all work), and writes
 // to destDir. It renames directories named after the template to the app ID.
 func renderAndWriteTemplate(files map[string][]byte, destDir, appID, templateName string, vals map[string]interface{}) error {
+	root, err := os.OpenRoot(destDir)
+	if err != nil {
+		return fmt.Errorf("opening template destination: %w", err)
+	}
+	defer root.Close()
+
 	for relPath, content := range files {
 		// Rename template-named directories to app ID.
 		relPath = renameTemplatePath(relPath, templateName, appID)
 
-		destPath := filepath.Join(destDir, relPath)
+		if !filepath.IsLocal(relPath) {
+			return fmt.Errorf("template path escapes destination: %q", relPath)
+		}
 
-		if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		// Root also prevents an existing symlink in --here from escaping the
+		// project directory, including a symlink swapped during rendering.
+		if err := root.MkdirAll(filepath.Dir(relPath), 0o755); err != nil {
 			return fmt.Errorf("creating directory for %s: %w", relPath, err)
 		}
 
@@ -710,8 +720,8 @@ func renderAndWriteTemplate(files map[string][]byte, destDir, appID, templateNam
 			output = rendered
 		}
 
-		if err := os.WriteFile(destPath, output, 0o644); err != nil {
-			return fmt.Errorf("writing %s: %w", destPath, err)
+		if err := root.WriteFile(relPath, output, 0o644); err != nil {
+			return fmt.Errorf("writing %s: %w", relPath, err)
 		}
 	}
 

--- a/go/internal/cli/commands/template.go
+++ b/go/internal/cli/commands/template.go
@@ -51,10 +51,13 @@ type repoMeta struct {
 }
 
 type repoMetaTemplate struct {
-	Name        string   `json:"name"`
-	Description string   `json:"description"`
-	Targets     []string `json:"targets"`   // optional; empty means all targets
-	Languages   []string `json:"languages"` // optional; empty means discover from repo layout
+	Name         string   `json:"name"`
+	DisplayName  string   `json:"displayName,omitempty"`
+	Category     string   `json:"category,omitempty"`
+	Requirements string   `json:"requirements,omitempty"`
+	Description  string   `json:"description"`
+	Targets      []string `json:"targets"`   // optional; empty means all targets
+	Languages    []string `json:"languages"` // optional; empty means discover from repo layout
 }
 
 type repoMetaLanguage struct {
@@ -133,6 +136,11 @@ type templateVariable struct {
 // If ctx is cancelled, the in-flight request is aborted.
 func fetchRepoMeta(ctx context.Context, branch string) (*repoMeta, error) {
 	branch = resolveTemplateBranch(branch)
+	if index, err := fetchTemplateIndex(ctx, branch); err == nil && index != nil {
+		return &index.Catalog, nil
+	} else if templateFetchCancelled(err) {
+		return nil, err
+	}
 	url := fmt.Sprintf("%s/%s/%s/%s/meta.json",
 		strings.TrimRight(templateRawBaseURL, "/"), templateRepoOwner, templateRepoName, branch)
 
@@ -296,6 +304,11 @@ func (pr *progressReader) Read(p []byte) (int, error) {
 // If ctx is cancelled, the in-flight request is aborted.
 func downloadTemplateArchive(ctx context.Context, language, templateName, branch string, onProgress progressCallback) (map[string][]byte, *templateManifest, error) {
 	branch = resolveTemplateBranch(branch)
+	if index, err := fetchTemplateIndex(ctx, branch); err == nil && index != nil {
+		return downloadTemplateBundle(ctx, index, language, templateName, branch, onProgress)
+	} else if templateFetchCancelled(err) {
+		return nil, nil, err
+	}
 	// Use codeload directly to avoid an extra redirect through github.com for the
 	// repository archive download.
 	url := fmt.Sprintf("https://codeload.github.com/%s/%s/tar.gz/refs/heads/%s",
@@ -488,27 +501,10 @@ func extractTemplateArchive(r io.Reader, language, templateName string) (map[str
 // collectTemplateValues gathers values for all template variables.
 // It uses varOverrides (from --var flags) for non-interactive values,
 // falling back to bubbletea prompts for anything missing.
-// If all variables can be resolved without prompting (via overrides or defaults),
-// no interactive prompts are shown. Otherwise all non-overridden variables are
-// prompted interactively with defaults pre-filled.
+// Defaults are always accepted silently; only values without defaults prompt.
 func collectTemplateValues(manifest *templateManifest, appID string, varOverrides map[string]string) (map[string]interface{}, error) {
 	vals := map[string]interface{}{
 		"APP_ID": appID,
-	}
-
-	// Determine if any variables need interactive input.
-	needsPrompt := false
-	for _, v := range manifest.Variables {
-		if v.Name == "APP_ID" {
-			continue
-		}
-		if _, ok := varOverrides[v.Name]; ok {
-			continue
-		}
-		if v.Default == nil {
-			needsPrompt = true
-			break
-		}
 	}
 
 	for _, v := range manifest.Variables {
@@ -529,13 +525,15 @@ func collectTemplateValues(manifest *templateManifest, appID string, varOverride
 			continue
 		}
 
-		// If no prompting needed, use defaults silently.
-		if !needsPrompt && v.Default != nil {
+		// Use optional defaults even when another variable needs input.
+		if v.Default != nil {
 			vals[v.Name] = v.Default
 			continue
 		}
 
-		// Interactive prompt with default pre-filled.
+		if !isInteractiveTerminal() {
+			return nil, fmt.Errorf("template variable %s requires a value; pass --var %s=<value>", v.Name, v.Name)
+		}
 		val, err := promptForVariable(v)
 		if err != nil {
 			return nil, err

--- a/go/internal/cli/commands/template_bundle.go
+++ b/go/internal/cli/commands/template_bundle.go
@@ -125,7 +125,7 @@ func fetchTemplateIndex(ctx context.Context, branch string) (*templateBundleInde
 // Cache writes are best-effort and atomic; concurrent init processes must never
 // read half an index/archive. An unwritable cache must not prevent scaffolding.
 func cacheTemplateFile(path string, data []byte) {
-	if path == "" || os.MkdirAll(filepath.Dir(path), 0o755) != nil {
+	if path == "" || os.MkdirAll(filepath.Dir(path), 0o700) != nil {
 		return
 	}
 	f, err := os.CreateTemp(filepath.Dir(path), ".template-*")
@@ -146,6 +146,9 @@ func validTemplateBundle(bundle templateBundle) bool {
 }
 
 func verifyTemplateBundle(data []byte, bundle templateBundle) bool {
+	// This detects corruption and pins bytes to an index revision. Publisher
+	// authenticity comes from HTTPS to the Wendy-controlled origin, as it does
+	// for the existing GitHub archive path; this is not a signed-index protocol.
 	digest := sha256.Sum256(data)
 	return int64(len(data)) == bundle.Size && hex.EncodeToString(digest[:]) == bundle.SHA256
 }

--- a/go/internal/cli/commands/template_bundle.go
+++ b/go/internal/cli/commands/template_bundle.go
@@ -1,0 +1,201 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const maxTemplateBundleSize = 128 << 20
+
+var templateBundleBaseURL = "https://templates.wendy.dev"
+var templateBundleClient = &http.Client{Timeout: 30 * time.Second}
+var templateCacheRoot = func() (string, error) {
+	root, err := os.UserCacheDir()
+	return filepath.Join(root, "wendy", "templates"), err
+}
+
+type templateBundle struct {
+	Path   string `json:"path"`
+	SHA256 string `json:"sha256"`
+	Size   int64  `json:"size"`
+}
+
+type templateBundleIndex struct {
+	Version  int                       `json:"version"`
+	Revision string                    `json:"revision"`
+	Catalog  repoMeta                  `json:"catalog"`
+	Bundles  map[string]templateBundle `json:"bundles"`
+}
+
+func templateBranchURL(branch string) string {
+	parts := strings.Split(resolveTemplateBranch(branch), "/")
+	for i, part := range parts {
+		parts[i] = url.PathEscape(part)
+	}
+	return strings.TrimRight(templateBundleBaseURL, "/") + "/" + strings.Join(parts, "/")
+}
+
+func templateIndexCachePath(branch string) string {
+	root, err := templateCacheRoot()
+	if err != nil {
+		return ""
+	}
+	key := sha256.Sum256([]byte(templateBranchURL(branch)))
+	return filepath.Join(root, "indexes", hex.EncodeToString(key[:])+".json")
+}
+
+func parseTemplateIndex(data []byte) (*templateBundleIndex, error) {
+	var index templateBundleIndex
+	if err := json.Unmarshal(data, &index); err != nil {
+		return nil, err
+	}
+	if index.Version != 1 || index.Revision == "" || len(index.Catalog.Templates) == 0 || len(index.Bundles) == 0 {
+		return nil, fmt.Errorf("unsupported or incomplete template bundle index")
+	}
+	return &index, nil
+}
+
+// A nil index means this branch predates bundle publishing. Keep the GitHub
+// archive fallback so branch previews and older template repositories work.
+func fetchTemplateIndex(ctx context.Context, branch string) (*templateBundleIndex, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	cachePath := templateIndexCachePath(branch)
+	data, _ := os.ReadFile(cachePath)
+	cached, _ := parseTemplateIndex(data)
+	if cached != nil {
+		if info, err := os.Stat(cachePath); err == nil && time.Since(info.ModTime()) < 5*time.Minute {
+			return cached, nil
+		}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, templateBranchURL(branch)+"/template-index.json", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := templateBundleClient.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if cached != nil {
+			cliNotice("Offline: using cached templates at revision %s.", cached.Revision)
+			return cached, nil
+		}
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode >= 500 && cached != nil {
+			cliNotice("Template server unavailable: using cached revision %s.", cached.Revision)
+			return cached, nil
+		}
+		return nil, fmt.Errorf("fetching template index: HTTP %d", resp.StatusCode)
+	}
+	data, err = io.ReadAll(io.LimitReader(resp.Body, (4<<20)+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > 4<<20 {
+		return nil, fmt.Errorf("template index exceeds 4 MiB")
+	}
+	index, err := parseTemplateIndex(data)
+	if err != nil {
+		return nil, err
+	}
+	cacheTemplateFile(cachePath, data)
+	return index, nil
+}
+
+// Cache writes are best-effort and atomic; concurrent init processes must never
+// read half an index/archive. An unwritable cache must not prevent scaffolding.
+func cacheTemplateFile(path string, data []byte) {
+	if path == "" || os.MkdirAll(filepath.Dir(path), 0o755) != nil {
+		return
+	}
+	f, err := os.CreateTemp(filepath.Dir(path), ".template-*")
+	if err != nil {
+		return
+	}
+	defer os.Remove(f.Name())
+	_, writeErr := f.Write(data)
+	closeErr := f.Close()
+	if writeErr == nil && closeErr == nil {
+		_ = os.Rename(f.Name(), path)
+	}
+}
+
+func validTemplateBundle(bundle templateBundle) bool {
+	digest, err := hex.DecodeString(bundle.SHA256)
+	return err == nil && len(digest) == sha256.Size && bundle.Size > 0 && bundle.Size <= maxTemplateBundleSize && bundle.Path == "bundles/"+bundle.SHA256+".tar.gz"
+}
+
+func verifyTemplateBundle(data []byte, bundle templateBundle) bool {
+	digest := sha256.Sum256(data)
+	return int64(len(data)) == bundle.Size && hex.EncodeToString(digest[:]) == bundle.SHA256
+}
+
+func downloadTemplateBundle(ctx context.Context, index *templateBundleIndex, language, name, branch string, progress progressCallback) (map[string][]byte, *templateManifest, error) {
+	bundle, ok := index.Bundles[language+"/"+name]
+	if !ok || !validTemplateBundle(bundle) {
+		return nil, nil, fmt.Errorf("invalid or missing bundle for %s/%s at revision %s", language, name, index.Revision)
+	}
+	cachePath := ""
+	if root, err := templateCacheRoot(); err == nil {
+		cachePath = filepath.Join(root, "bundles", bundle.SHA256+".tar.gz")
+	}
+	if data, err := os.ReadFile(cachePath); err == nil && verifyTemplateBundle(data, bundle) {
+		if progress != nil {
+			progress(bundle.Size, bundle.Size)
+		}
+		return extractTemplateArchive(bytes.NewReader(data), language, name)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, templateBranchURL(branch)+"/"+bundle.Path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := templateBundleClient.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("downloading template bundle: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil, fmt.Errorf("downloading template bundle: HTTP %d", resp.StatusCode)
+	}
+	var reader io.Reader = io.LimitReader(resp.Body, bundle.Size+1)
+	if progress != nil {
+		reader = &progressReader{r: reader, total: bundle.Size, onProgress: progress}
+	}
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !verifyTemplateBundle(data, bundle) {
+		return nil, nil, fmt.Errorf("template bundle checksum or size mismatch")
+	}
+	files, manifest, err := extractTemplateArchive(bytes.NewReader(data), language, name)
+	if err != nil {
+		return nil, nil, err
+	}
+	cacheTemplateFile(cachePath, data)
+	return files, manifest, nil
+}
+
+func templateFetchCancelled(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}

--- a/go/internal/cli/commands/template_bundle_test.go
+++ b/go/internal/cli/commands/template_bundle_test.go
@@ -1,0 +1,325 @@
+package commands
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+)
+
+func serveTestBundle(t *testing.T) (*httptest.Server, *templateBundleIndex, *int) {
+	t.Helper()
+	data := buildTestTarball(t, "templates", "python", "fullstack", map[string]string{
+		"template.json": `{"name":"fullstack","variables":[{"name":"PORT","type":"integer","default":3001}]}`,
+		"wendy.json":    `{"appId":"{{.APP_ID}}","platform":"linux"}`,
+		"app.py":        "message = 'Hello from Wendy!'\n",
+		"README.md":     "# {{.APP_ID}}\n",
+	})
+	digest := sha256.Sum256(data)
+	hash := hex.EncodeToString(digest[:])
+	index := &templateBundleIndex{
+		Version: 1, Revision: "test-revision",
+		Catalog: repoMeta{
+			Templates: []repoMetaTemplate{{Name: "fullstack", DisplayName: "Web app", Category: "starter", Languages: []string{"python"}}},
+			Languages: []repoMetaLanguage{{Key: "python", Name: "Python"}},
+		},
+		Bundles: map[string]templateBundle{"python/fullstack": {Path: "bundles/" + hash + ".tar.gz", SHA256: hash, Size: int64(len(data))}},
+	}
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		switch r.URL.Path {
+		case "/topic/starters/template-index.json":
+			_ = json.NewEncoder(w).Encode(index)
+		case "/topic/starters/bundles/" + hash + ".tar.gz":
+			_, _ = w.Write(data)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	oldURL, oldClient, oldRoot := templateBundleBaseURL, templateBundleClient, templateCacheRoot
+	cache := t.TempDir()
+	templateBundleBaseURL, templateBundleClient = server.URL, server.Client()
+	templateCacheRoot = func() (string, error) { return cache, nil }
+	t.Cleanup(func() {
+		server.Close()
+		templateBundleBaseURL, templateBundleClient, templateCacheRoot = oldURL, oldClient, oldRoot
+	})
+	return server, index, &requests
+}
+
+func TestTemplateBundleCachedAndOffline(t *testing.T) {
+	server, _, requests := serveTestBundle(t)
+	ctx := context.Background()
+	meta, err := fetchRepoMeta(ctx, "topic/starters")
+	if err != nil || meta.Templates[0].Name != "fullstack" {
+		t.Fatalf("metadata: %+v %v", meta, err)
+	}
+	files, manifest, err := downloadTemplateArchive(ctx, "python", "fullstack", "topic/starters", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *requests != 2 {
+		t.Fatalf("got %d requests; want one index and one selected bundle", *requests)
+	}
+	vals, err := collectTemplateValues(manifest, "my-app", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	if err := renderAndWriteTemplate(files, dir, "my-app", "fullstack", vals); err != nil {
+		t.Fatal(err)
+	}
+	readme, _ := os.ReadFile(filepath.Join(dir, "README.md"))
+	if string(readme) != "# my-app\n" {
+		t.Fatalf("rendered README: %q", readme)
+	}
+	server.Close()
+	// A warm cache needs no network at all.
+	if _, _, err := downloadTemplateArchive(ctx, "python", "fullstack", "topic/starters", nil); err != nil {
+		t.Fatal(err)
+	}
+	// An expired index can still be used when the server is unreachable.
+	old := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(templateIndexCachePath("topic/starters"), old, old); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := downloadTemplateArchive(ctx, "python", "fullstack", "topic/starters", nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTemplateBundleRejectsCorruptionAndRepairsCache(t *testing.T) {
+	_, index, _ := serveTestBundle(t)
+	bundle := index.Bundles["python/fullstack"]
+	root, _ := templateCacheRoot()
+	path := filepath.Join(root, "bundles", bundle.SHA256+".tar.gz")
+	cacheTemplateFile(path, []byte("corrupt"))
+	if _, _, err := downloadTemplateBundle(context.Background(), index, "python", "fullstack", "topic/starters", nil); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(path)
+	if !verifyTemplateBundle(data, bundle) {
+		t.Fatal("cache was not repaired")
+	}
+	bundle.Size++
+	index.Bundles["python/fullstack"] = bundle
+	if _, _, err := downloadTemplateBundle(context.Background(), index, "python", "fullstack", "topic/starters", nil); err == nil || !strings.Contains(err.Error(), "checksum or size") {
+		t.Fatalf("expected integrity error, got %v", err)
+	}
+}
+
+func TestTemplateBundleLegacyAndCancellation(t *testing.T) {
+	_, _, _ = serveTestBundle(t)
+	index, err := fetchTemplateIndex(context.Background(), "legacy-branch")
+	if err != nil || index != nil {
+		t.Fatalf("404 should allow legacy fallback: %+v %v", index, err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, _, err := downloadTemplateArchive(ctx, "python", "fullstack", "topic/starters", nil); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected cancellation, got %v", err)
+	}
+}
+
+func TestTemplateBundleMetadataValidation(t *testing.T) {
+	hash := strings.Repeat("a", 64)
+	valid := templateBundle{Path: "bundles/" + hash + ".tar.gz", SHA256: hash, Size: 100}
+	if !validTemplateBundle(valid) {
+		t.Fatal("rejected valid metadata")
+	}
+	for _, invalid := range []templateBundle{
+		{Path: "../../secret", SHA256: hash, Size: 100},
+		{Path: valid.Path, SHA256: hash, Size: maxTemplateBundleSize + 1},
+		{Path: valid.Path, SHA256: "invalid", Size: 100},
+	} {
+		if validTemplateBundle(invalid) {
+			t.Fatalf("accepted invalid metadata: %+v", invalid)
+		}
+	}
+}
+
+func TestTemplateStarterPickerAndBack(t *testing.T) {
+	meta := &repoMeta{Templates: []repoMetaTemplate{
+		{Name: "simple-api", DisplayName: "API", Category: "starter"},
+		{Name: "camera-feed", DisplayName: "Camera", Category: "starter", Requirements: "A camera"},
+		{Name: "llm", Category: "example"},
+		{Name: "blink-led", Category: "starter", Targets: []string{targetWendyLite}},
+	}}
+	starters, examples := starterAndExampleItems(targetWendyOS, meta)
+	if len(starters) != 2 || len(examples) != 1 || starters[0].Name != "API" || !strings.Contains(starters[1].Description, "A camera") {
+		t.Fatalf("unexpected groups: %+v %+v", starters, examples)
+	}
+	original := pickInitTemplateItem
+	t.Cleanup(func() { pickInitTemplateItem = original })
+	answers := []string{"_examples", "_back", "_examples", "llm"}
+	pickInitTemplateItem = func(_ string, items []tui.PickerItem) (string, error) {
+		answer := answers[0]
+		answers = answers[1:]
+		for _, item := range items {
+			if item.Value == answer {
+				return answer, nil
+			}
+		}
+		t.Fatalf("answer %q missing from %+v", answer, items)
+		return "", nil
+	}
+	choice, err := pickStarterOrExample(targetWendyOS, meta, true)
+	if err != nil || choice != "llm" || len(answers) != 0 {
+		t.Fatalf("picker: %q %v", choice, err)
+	}
+}
+
+func TestTemplateMissingVariableDoesNotPromptForDefaults(t *testing.T) {
+	original := isInteractiveTerminalFn
+	isInteractiveTerminalFn = func() bool { return false }
+	t.Cleanup(func() { isInteractiveTerminalFn = original })
+	manifest := &templateManifest{Variables: []templateVariable{
+		{Name: "PORT", Type: "integer", Default: 3001},
+		{Name: "API_KEY", Type: "string", Required: true},
+	}}
+	_, err := collectTemplateValues(manifest, "demo", nil)
+	if err == nil || !strings.Contains(err.Error(), "--var API_KEY=") {
+		t.Fatalf("expected missing key error, got %v", err)
+	}
+	vals, err := collectTemplateValues(manifest, "demo", map[string]string{"API_KEY": "test"})
+	if err != nil || vals["PORT"] != 3001 {
+		t.Fatalf("defaults: %+v %v", vals, err)
+	}
+}
+
+func TestTemplateRunStartsGeneratedProject(t *testing.T) {
+	_, index, _ := serveTestBundle(t)
+	originalRun, originalRemember, originalInteractive := runInitializedTemplate, rememberTemplateLanguage, isInteractiveTerminalFn
+	t.Cleanup(func() {
+		runInitializedTemplate, rememberTemplateLanguage, isInteractiveTerminalFn = originalRun, originalRemember, originalInteractive
+	})
+	isInteractiveTerminalFn = func() bool { return false }
+	remembered := ""
+	rememberTemplateLanguage = func(language string) { remembered = language }
+	cwd := t.TempDir()
+	dest := filepath.Join(cwd, "my-app")
+	deploymentError := errors.New("test deployment failure")
+	called := false
+	runInitializedTemplate = func(ctx context.Context, dir string) error {
+		called = true
+		if dir != dest {
+			t.Fatalf("run prefix = %q, want %q", dir, dest)
+		}
+		if _, err := os.Stat(filepath.Join(dir, "app.py")); err != nil {
+			t.Fatal(err)
+		}
+		return deploymentError
+	}
+	err := runTemplateFlow(cwd, dest, "my-app", "fullstack", targetWendyOS, &index.Catalog, initOptions{
+		branch: "topic/starters", language: "python", languageSet: true,
+		gitInit: "no", gitInitSet: true, run: true,
+	})
+	if !called || !errors.Is(err, deploymentError) || remembered != "python" {
+		t.Fatalf("run=%v remembered=%q error=%v", called, remembered, err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "app.py")); err != nil {
+		t.Fatal("failed deployment removed the generated app")
+	}
+}
+
+func TestTemplateGitDefaultDoesNotCreateNestedRepository(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git unavailable")
+	}
+	parent := t.TempDir()
+	if err := maybeGitInit(parent, initOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(parent, ".git")); err != nil {
+		t.Fatal("default did not initialize Git")
+	}
+	child := filepath.Join(parent, "child")
+	if err := os.Mkdir(child, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := maybeGitInit(child, initOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(child, ".git")); !os.IsNotExist(err) {
+		t.Fatal("created a nested repository")
+	}
+}
+
+func TestTemplateRememberedLanguageHonorsExplicitOverride(t *testing.T) {
+	original, originalInteractive := preferredTemplateLanguage, isInteractiveTerminalFn
+	t.Cleanup(func() { preferredTemplateLanguage, isInteractiveTerminalFn = original, originalInteractive })
+	preferredTemplateLanguage = func() string { return "python" }
+	isInteractiveTerminalFn = func() bool { return true }
+	meta := &repoMeta{
+		Templates: []repoMetaTemplate{{Name: "fullstack", Languages: []string{"python", "swift"}}},
+		Languages: []repoMetaLanguage{{Key: "python", Name: "Python"}, {Key: "swift", Name: "Swift"}},
+	}
+	language, err := resolveTemplateLanguage(targetWendyOS, "fullstack", meta, initOptions{})
+	if err != nil || language != "python" {
+		t.Fatalf("remembered language: %q %v", language, err)
+	}
+	language, err = resolveTemplateLanguage(targetWendyOS, "fullstack", meta, initOptions{language: "swift", languageSet: true})
+	if err != nil || language != "swift" {
+		t.Fatalf("explicit override: %q %v", language, err)
+	}
+}
+
+// Run against locally built publisher output as a cross-repository contract
+// check: WENDY_TEMPLATE_BUNDLE_DIR=/path/to/output go test ... -run TestTemplatePublishedBundles.
+func TestTemplatePublishedBundles(t *testing.T) {
+	dir := os.Getenv("WENDY_TEMPLATE_BUNDLE_DIR")
+	if dir == "" {
+		t.Skip("set WENDY_TEMPLATE_BUNDLE_DIR to test publisher output")
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "template-index.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	index, err := parseTemplateIndex(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for key, bundle := range index.Bundles {
+		if !strings.HasSuffix(key, "/fullstack") {
+			continue
+		}
+		t.Run(key, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join(dir, bundle.Path))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !validTemplateBundle(bundle) || !verifyTemplateBundle(data, bundle) {
+				t.Fatal("invalid published bundle")
+			}
+			parts := strings.Split(key, "/")
+			files, manifest, err := extractTemplateArchive(strings.NewReader(string(data)), parts[0], parts[1])
+			if err != nil {
+				t.Fatal(err)
+			}
+			values, err := collectTemplateValues(manifest, "my-app", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			output := t.TempDir()
+			if err := renderAndWriteTemplate(files, output, "my-app", "fullstack", values); err != nil {
+				t.Fatal(err)
+			}
+			config, _ := os.ReadFile(filepath.Join(output, "wendy.json"))
+			if !json.Valid(config) {
+				t.Fatalf("invalid generated config: %s", config)
+			}
+		})
+	}
+}

--- a/go/internal/cli/commands/template_bundle_test.go
+++ b/go/internal/cli/commands/template_bundle_test.go
@@ -1,6 +1,9 @@
 package commands
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -321,5 +324,58 @@ func TestTemplatePublishedBundles(t *testing.T) {
 				t.Fatalf("invalid generated config: %s", config)
 			}
 		})
+	}
+}
+
+func TestTemplateArchiveRejectsEscapingPathsAndLinks(t *testing.T) {
+	var data bytes.Buffer
+	gz := gzip.NewWriter(&data)
+	archive := tar.NewWriter(gz)
+	entries := []struct {
+		name, body, link string
+		kind             byte
+	}{
+		{"template.json", `{"name":"fullstack"}`, "", tar.TypeReg},
+		{"app.py", "safe", "", tar.TypeReg},
+		{"../outside.py", "escape", "", tar.TypeReg},
+		{"nested/../../outside.py", "escape", "", tar.TypeReg},
+		{"/absolute.py", "escape", "", tar.TypeReg},
+		{"symlink", "", "../../outside", tar.TypeSymlink},
+		{"hardlink", "", "../../outside", tar.TypeLink},
+	}
+	for _, entry := range entries {
+		header := &tar.Header{Name: "templates/python/fullstack/" + entry.name, Typeflag: entry.kind, Linkname: entry.link, Size: int64(len(entry.body)), Mode: 0o644}
+		if err := archive.WriteHeader(header); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := archive.Write([]byte(entry.body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := archive.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	files, _, err := extractTemplateArchive(bytes.NewReader(data.Bytes()), "python", "fullstack")
+	if err != nil || len(files) != 1 || string(files["app.py"]) != "safe" {
+		t.Fatalf("extracted unsafe entries: %v %v", files, err)
+	}
+}
+
+func TestTemplateRenderConfinesSymlinksAndRenames(t *testing.T) {
+	output, outside := t.TempDir(), t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(output, "linked")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	for _, path := range []string{"linked/escape.txt", "../escape.txt", "fullstack/escape.txt"} {
+		err := renderAndWriteTemplate(map[string][]byte{path: []byte("escape")}, output, "../outside", "fullstack", nil)
+		if err == nil {
+			t.Fatalf("accepted escaping path %q", path)
+		}
+	}
+	if entries, err := os.ReadDir(outside); err != nil || len(entries) != 0 {
+		t.Fatalf("wrote outside project: %v %v", entries, err)
 	}
 }

--- a/go/internal/shared/config/config.go
+++ b/go/internal/shared/config/config.go
@@ -10,6 +10,9 @@ import (
 
 // Config represents the top-level CLI configuration.
 type Config struct {
+	// PreferredTemplateLanguage remembers the last successfully scaffolded language.
+	PreferredTemplateLanguage string `json:"preferredTemplateLanguage,omitempty"`
+
 	Auth          []AuthConfig     `json:"auth,omitempty"`
 	Analytics     *AnalyticsConfig `json:"analytics,omitempty"`
 	DefaultDevice string           `json:"defaultDevice,omitempty"`


### PR DESCRIPTION
Template initialization downloads the entire repository and exposes advanced examples alongside starter apps. It now shows starters first, fetches only the selected template bundle, and reuses verified cached bundles.

- Use catalog display names, starter/example categories, and hardware requirements; keep direct template identifiers and older catalogs working.
- Accept variable defaults independently, remember the last interactive language, initialize Git without a prompt outside existing repositories, and stop echoing all template variable values.
- Add `wendy init my-app --template fullstack --language python --run`, using the normal run path and retaining generated files after deployment failures.
- Cache content-addressed bundles and five-minute catalog indexes, support cached templates offline, and retain repository-archive fallback for branches without bundle indexes.

Validation: the full Go test suite, vet, formatting, security checks, and docs build pass in CI. Focused init/template/download/render tests also pass against the current real publisher output for all six Web app variants; shared config tests pass. Tests cover cache reuse/offline mode, corruption, integrity checks, cancellation, branch paths, picker navigation, explicit language overrides, Git defaults, and immediate-run failure behavior. Added archive traversal/link and destination-symlink regression tests; rendering now uses os.Root confinement. The new cache/init tests also passed with the race detector.

Release after the companion templates publisher is deployed. Existing CLI flags and old branch previews remain supported. Physical-device deployment latency and automatic inference of ambiguous device targets are follow-ups.

Companion PR: https://github.com/wendylabsinc/templates/pull/102

Review notes: cache directories use private permissions. SHA-256 pins bundle bytes to the downloaded index; publisher authenticity remains HTTPS to the Wendy-controlled origin, consistent with the existing GitHub archive path. Default Git initialization is an intentional part of the shorter setup flow and can be disabled with --git-init=no.
