### PR TITLE
cli: renew refresh-certs against pki-core, not the cloud mint

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/auth/refresh-certs.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/auth/refresh-certs.md
@@ -1,8 +1,65 @@
-Generates a new key pair and reissues mTLS certificates for each stored auth entry, replacing the existing certificates in place. Useful when certificates are close to expiry.
+# `wendy auth refresh-certs`
 
-The refreshed CSR carries the same authoritative identity URN
-(`urn:wendy:org:‹org›:user:‹userID›` for user sessions,
-`urn:wendy:org:‹org›:asset:‹assetID›` for device sessions) as a URI Subject
-Alternative Name, derived from the org, user, and asset fields stored in
-`~/.wendy/config.json`. Legacy session entries that predate org-scoped identity
-(no `org_id`) refresh with a CommonName-only CSR and receive no URI SAN.
+Renews the mTLS certificate of every stored auth session directly against
+[pki-core](../../../../pki/)'s renew frontend. Cloud is not in this path: it
+neither mints the certificate nor relays the request.
+
+A renewal is a re-issue, not a re-key of the same certificate: the CLI generates
+a new key pair, builds a CSR for it, and posts the CSR to the renew frontend
+over mTLS. Presenting the certificate being renewed *is* the proof of
+possession — the request body carries nothing but the CSR.
+
+The renewed certificate keeps the identity of the one it replaces, and the CLI
+does not get to assert what that identity is. pki-core reads the principal off
+the presented certificate and stamps it into the new leaf itself; any identity
+the CSR asserts is replaced or refused.
+
+## Usage
+
+```sh
+wendy auth refresh-certs
+```
+
+## The renew frontend
+
+`WENDY_PKI_RENEW_ENDPOINT` names pki-core's renew frontend, e.g.
+`https://renew.pki.example:8451/v1/renew`. Nothing is derived from the cloud
+endpoint. When it is unset there is no renew frontend configured — a supported
+state, in which the CLI never renews on its own and this command reports that
+nothing is configured to renew against.
+
+## It also runs by itself
+
+The CLI renews ahead of expiry without being asked: when an auth session is
+resolved and its certificate has less than 15 minutes of validity left, the
+renewal happens before the connection is attempted. This command is the manual
+trigger for the same path, and is useful when a certificate is close to expiry
+and you would rather not discover it mid-command.
+
+## What renewal will not do
+
+- **No renewal of a certificate pki-core did not issue.** The renew frontend
+  routes a request by the tenant identity on the presented certificate and
+  renews only lineages it recorded at first mint. A session predating that —
+  one whose certificate carries no pki-core tenant identity — has no renewal
+  path at all; log in again to be issued one that does.
+- **No roll-forward from an expired certificate.** Renewal requires a
+  currently-valid certificate to present. Once yours has expired the renew
+  frontend needs an approved grant, which the CLI cannot mint — log in again
+  with [`wendy cloud login`](../cloud/login.md), which issues a fresh
+  certificate outright.
+- **Renewals are budgeted per lineage, and the budget is inherited rather than
+  requested.** A plain operator certificate renews a fixed number of times and
+  then has to be re-minted.
+- **Entitlement-bearing and over-duration certificates are not renewable at
+  all** unless their tenant has opted in.
+
+Each of these arrives as an explicit refusal and is reported as itself, not
+retried as a generic failure. In an interactive terminal the refusals that only
+a new certificate can resolve offer to log you in again on the spot.
+
+## Related
+
+- [`wendy cloud login`](../cloud/login.md) — issue a fresh operator certificate.
+- [`wendy auth use`](./use.md) — choose which stored session is the default.
+- [PKI](../../../../pki/) — the three authorized certificate paths.

--- a/go/internal/cli/commands/auth.go
+++ b/go/internal/cli/commands/auth.go
@@ -662,7 +662,10 @@ func storedCertIdentityURN(cert config.CertificateInfo) string {
 	return ""
 }
 
-// refreshCertsForAuth generates a new CSR and refreshes certificates for a single auth entry.
+// refreshCertsForAuth renews one auth entry's certificate against pki-core's
+// renew frontend. Cloud is not in this path: it neither mints the certificate
+// nor relays the request. The certificate being replaced is itself the proof of
+// possession — it is presented in the mTLS handshake that carries the CSR.
 func refreshCertsForAuth(ctx context.Context, auth *config.AuthConfig) error {
 	if len(auth.Certificates) == 0 {
 		return fmt.Errorf("no existing certificates")
@@ -671,94 +674,34 @@ func refreshCertsForAuth(ctx context.Context, auth *config.AuthConfig) error {
 		return refreshOIDCCertificate(ctx, auth)
 	}
 
-	existingCert := auth.Certificates[0]
+	current := auth.Certificates[0]
 
-	cn, err := certCommonName(existingCert.PemCertificate)
-	if err != nil {
-		return fmt.Errorf("reading existing cert CN: %w", err)
+	// pki-core routes a renewal by the tenant SPIFFE principal on the presented
+	// certificate, and renews only lineages it issued itself. A leaf carrying no
+	// tenant principal is not renewable there by any route, so report that here
+	// rather than spend a round trip to be told the same thing as a bare 403.
+	if _, ok := tenantPrincipalFor(current.PemCertificate); !ok {
+		return errCertNotPKIIssued
 	}
 
-	// Carry the authoritative identity URN forward so the refreshed cert keeps
-	// its "urn:wendy:org:..." SAN. The org/user/asset are taken from the stored
-	// config (the cert's own CN may be a legacy "wendy/user/<uid>" that carries
-	// no parseable org).
-	identityURN := storedCertIdentityURN(existingCert)
-
-	// Generate new key pair.
-	newKeyPEM, err := certs.GenerateKeyPair()
-	if err != nil {
-		return fmt.Errorf("generating key pair: %w", err)
+	endpoint := renewEndpoint()
+	if endpoint == "" {
+		return errNoRenewEndpoint
 	}
 
-	csrPEM, err := certs.GenerateCSR([]byte(newKeyPEM), cn, []string{identityURN})
-	if err != nil {
-		return fmt.Errorf("generating CSR: %w", err)
-	}
-
-	// Connect to cloud using existing mTLS credentials.
-	var refreshTransport grpc.DialOption
-	if strings.HasSuffix(auth.CloudGRPC, ":443") {
-		existingKeyPEM, err := existingCert.PrivateKeyPEM()
-		if err != nil {
-			return fmt.Errorf("loading existing client key: %w", err)
-		}
-		tlsCfg, err := certs.LoadTLSConfig(
-			existingCert.PemCertificate,
-			existingCert.PemCertificateChain,
-			existingKeyPEM,
-			"",
-		)
-		if err != nil {
-			return fmt.Errorf("loading existing TLS config: %w", err)
-		}
-		refreshTransport = grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg))
-	} else {
-		refreshTransport = grpc.WithTransportCredentials(insecure.NewCredentials())
-	}
-	certConn, err := grpc.NewClient(auth.CloudGRPC, refreshTransport)
-	if err != nil {
-		return fmt.Errorf("connecting to cloud: %w", err)
-	}
-	defer certConn.Close()
-
-	certClient := cloudpb.NewCertificateServiceClient(certConn)
-
-	cloudCtx, err := cloudContext(ctx, auth)
+	certPEM, chainPEM, keyPEM, err := renewViaPKICore(ctx, endpoint, auth)
 	if err != nil {
 		return err
 	}
 
-	// Use RefreshCertificate RPC.
-	refreshResp, err := certClient.RefreshCertificate(cloudCtx, &cloudpb.RefreshCertificateRequest{
-		PemCsr: csrPEM,
-	})
-	if err != nil {
-		return fmt.Errorf("refreshing certificate: %w", err)
-	}
-
-	// The cloud reports refresh failures via a structured error field on an
-	// otherwise-successful response (not a gRPC status). Surface its code/message
-	// so the caller can react — an unauthorized code means the session expired and
-	// the user should log in again — instead of the generic "no certificate" below.
-	if respErr := refreshResp.GetError(); respErr != nil {
-		return cloudCertError{code: respErr.GetCode(), message: respErr.GetMessage()}
-	}
-
-	cert := refreshResp.GetCertificate()
-	if cert == nil {
-		return fmt.Errorf("no certificate returned from refresh")
-	}
-
-	// Update the auth entry with new certificates.
-	auth.Certificates = []config.CertificateInfo{
-		{
-			PemCertificate:      cert.GetPemCertificate(),
-			PemCertificateChain: cert.GetPemCertificateChain(),
-			PemPrivateKey:       newKeyPEM,
-			OrganizationID:      existingCert.OrganizationID,
-			UserID:              existingCert.UserID,
-		},
-	}
+	// Mutate the stored entry rather than rebuild it: a renewal replaces key
+	// material and nothing else. Rebuilding dropped the asset and principal
+	// fields, which is what identifies a device session to every later command.
+	updated := current
+	updated.PemCertificate = certPEM
+	updated.PemCertificateChain = chainPEM
+	updated.PemPrivateKey = keyPEM
+	auth.Certificates[0] = updated
 
 	// This cert has a later NotBefore than the one it replaces, so the proof kept
 	// for offline use has to move with it.

--- a/go/internal/cli/commands/auth_refresh_certs_test.go
+++ b/go/internal/cli/commands/auth_refresh_certs_test.go
@@ -1,0 +1,174 @@
+package commands
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+)
+
+const (
+	testTenantPrincipal = "spiffe://wendy.sh/tenant/0e6a3d2c-1f4b-4a37-9c8e-2b5d6f7a8c90/service/user-u1"
+	testLegacyURN       = "urn:wendy:org:7:user:u1"
+)
+
+// leafWithURIs mints a self-signed leaf carrying the given URI SANs. The
+// renewal pre-check reads those SANs and nothing else, so this is enough to
+// stand in for both a pki-core-issued leaf and a pre-teardown cloud one.
+func leafWithURIs(t *testing.T, uris ...string) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "wendy/user/u1"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	for _, raw := range uris {
+		u, err := url.Parse(raw)
+		if err != nil {
+			t.Fatalf("parsing SAN %q: %v", raw, err)
+		}
+		tmpl.URIs = append(tmpl.URIs, u)
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("creating certificate: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}
+
+// cancelledCtx keeps the post-renewal Roughtime proof refresh from reaching the
+// network: it is best-effort and fails immediately on an abandoned context.
+func cancelledCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return ctx
+}
+
+func TestRefreshCertsForAuthRenewsAgainstPKICore(t *testing.T) {
+	t.Setenv(renewEndpointEnv, "https://renew.pki.example:8451/v1/renew")
+
+	var gotEndpoint string
+	orig := renewViaPKICore
+	renewViaPKICore = func(_ context.Context, endpoint string, _ *config.AuthConfig) (string, string, string, error) {
+		gotEndpoint = endpoint
+		return "renewed-leaf", "renewed-chain", "renewed-key", nil
+	}
+	t.Cleanup(func() { renewViaPKICore = orig })
+
+	auth := &config.AuthConfig{
+		CloudGRPC: "api.example:443",
+		Certificates: []config.CertificateInfo{{
+			PemCertificate:      leafWithURIs(t, testTenantPrincipal, testLegacyURN),
+			PemCertificateChain: "old-chain",
+			PemPrivateKey:       "old-key",
+			OrganizationID:      7,
+			UserID:              "u1",
+			AssetID:             42,
+			PrincipalURI:        testTenantPrincipal,
+		}},
+	}
+
+	if err := refreshCertsForAuth(cancelledCtx(t), auth); err != nil {
+		t.Fatalf("refreshCertsForAuth() error = %v", err)
+	}
+
+	if gotEndpoint != "https://renew.pki.example:8451/v1/renew" {
+		t.Errorf("renewed against %q, want the configured renew frontend", gotEndpoint)
+	}
+	got := auth.Certificates[0]
+	if got.PemCertificate != "renewed-leaf" || got.PemCertificateChain != "renewed-chain" || got.PemPrivateKey != "renewed-key" {
+		t.Errorf("renewed material not stored: %+v", got)
+	}
+	// A renewal replaces key material only. Losing these silently re-labels the
+	// session as a different identity for every later command.
+	if got.OrganizationID != 7 || got.UserID != "u1" || got.AssetID != 42 || got.PrincipalURI != testTenantPrincipal {
+		t.Errorf("identity fields not carried through the renewal: %+v", got)
+	}
+}
+
+func TestRefreshCertsForAuthRefusesWhatPKICoreCannotRenew(t *testing.T) {
+	tests := []struct {
+		name     string
+		certPEM  string
+		endpoint string
+		want     error
+	}{
+		{
+			name:     "a leaf with no tenant principal is not pki-core's to renew",
+			certPEM:  leafWithURIs(t, testLegacyURN),
+			endpoint: "https://renew.pki.example:8451/v1/renew",
+			want:     errCertNotPKIIssued,
+		},
+		{
+			name:     "an unparseable certificate carries no principal either",
+			certPEM:  "not a pem at all",
+			endpoint: "https://renew.pki.example:8451/v1/renew",
+			want:     errCertNotPKIIssued,
+		},
+		{
+			name:    "no renew frontend configured",
+			certPEM: leafWithURIs(t, testTenantPrincipal),
+			want:    errNoRenewEndpoint,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(renewEndpointEnv, tc.endpoint)
+
+			orig := renewViaPKICore
+			renewViaPKICore = func(context.Context, string, *config.AuthConfig) (string, string, string, error) {
+				t.Fatal("renewal was attempted for a certificate pki-core cannot renew")
+				return "", "", "", nil
+			}
+			t.Cleanup(func() { renewViaPKICore = orig })
+
+			auth := &config.AuthConfig{
+				Certificates: []config.CertificateInfo{{PemCertificate: tc.certPEM}},
+			}
+			err := refreshCertsForAuth(cancelledCtx(t), auth)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("refreshCertsForAuth() error = %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+// The refusals a renewal cannot recover from have to reach the same re-login
+// offer the cloud path had, or `refresh-certs` dead-ends on an expired session.
+func TestRenewalRefusalsOfferRelogin(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"no tenant lineage", errCertNotPKIIssued, true},
+		{"expired certificate", errCertExpired, true},
+		{"budget exhausted", renewUnavailableError{reason: "not renewable", needsFreshCert: true}, true},
+		{"possession not proven", renewUnavailableError{reason: "not accepted", needsFreshCert: true}, true},
+		{"needs an approved grant", renewUnavailableError{reason: "needs a grant"}, false},
+		{"frontend was unreachable", renewUnavailableError{reason: "the renew frontend answered 503"}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isUnauthenticatedCloudError(tc.err); got != tc.want {
+				t.Errorf("isUnauthenticatedCloudError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/go/internal/cli/commands/certrenew.go
+++ b/go/internal/cli/commands/certrenew.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -58,6 +59,11 @@ const (
 type renewUnavailableError struct {
 	reason string
 	detail string
+
+	// needsFreshCert marks the refusals a renewal can never recover from — the
+	// lineage is gone, spent, or was never pki-core's — for which the remedy is
+	// a newly minted certificate rather than another renewal attempt.
+	needsFreshCert bool
 }
 
 func (e renewUnavailableError) Error() string {
@@ -70,28 +76,58 @@ func (e renewUnavailableError) Error() string {
 var (
 	// errNoRenewEndpoint is not a failure: nothing is configured to renew
 	// against, so the pre-flight has nothing to offer and stays silent.
-	errNoRenewEndpoint = errors.New("no pki-core renew endpoint configured")
-	errCertExpired     = renewUnavailableError{reason: "your certificate has expired"}
+	errNoRenewEndpoint = errors.New("no pki-core renew endpoint configured; set " + renewEndpointEnv)
+	errCertExpired     = renewUnavailableError{reason: "your certificate has expired", needsFreshCert: true}
+
+	// errCertNotPKIIssued is the pre-cloud-teardown session: a leaf minted
+	// before certificates carried a tenant principal. pki-core cannot route it
+	// to a tenant and holds no lineage record for it, so it is not renewable
+	// there by any route and only a fresh login replaces it.
+	errCertNotPKIIssued = renewUnavailableError{
+		reason:         "this certificate carries no pki-core tenant identity and cannot be renewed",
+		needsFreshCert: true,
+	}
 )
 
-// leafNotAfter returns the stored leaf's expiry. It normalises through
-// certs.LeafCertificatePEM first because pki-core leaves can carry trailing
-// ASN.1 bytes that defeat a raw x509 parse.
-func leafNotAfter(certPEM string) (time.Time, error) {
+// storedLeaf parses the leaf out of a stored certificate PEM. It normalises
+// through certs.LeafCertificatePEM first because pki-core leaves can carry
+// trailing ASN.1 bytes that defeat a raw x509 parse, and reads it back with
+// ParseCertsFromPEM — the ML-DSA-aware parser the mTLS paths use — so callers
+// see exactly the certificate the handshake can present.
+func storedLeaf(certPEM string) (*x509.Certificate, error) {
 	leafPEM, err := certs.LeafCertificatePEM(certPEM)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("extracting leaf certificate: %w", err)
+		return nil, fmt.Errorf("extracting leaf certificate: %w", err)
 	}
-	// ParseCertsFromPEM is the ML-DSA-aware parser the mTLS paths use, so the
-	// pre-flight reads exactly the certificates the handshake can present.
 	leaves, err := certs.ParseCertsFromPEM([]byte(leafPEM))
+	if err != nil {
+		return nil, err
+	}
+	if len(leaves) == 0 {
+		return nil, errors.New("no certificate in stored leaf PEM")
+	}
+	return leaves[0], nil
+}
+
+// leafNotAfter returns the stored leaf's expiry.
+func leafNotAfter(certPEM string) (time.Time, error) {
+	leaf, err := storedLeaf(certPEM)
 	if err != nil {
 		return time.Time{}, err
 	}
-	if len(leaves) == 0 {
-		return time.Time{}, errors.New("no certificate in stored leaf PEM")
+	return leaf.NotAfter, nil
+}
+
+// tenantPrincipalFor reports the tenant SPIFFE principal a stored certificate
+// carries, and whether it carries one at all. An unparseable certificate is
+// reported as carrying none: the connection attempt diagnoses that with better
+// context than a renewal can.
+func tenantPrincipalFor(certPEM string) (string, bool) {
+	leaf, err := storedLeaf(certPEM)
+	if err != nil {
+		return "", false
 	}
-	return leaves[0].NotAfter, nil
+	return certs.TenantPrincipalFromCert(leaf)
 }
 
 // certNeedsRenewal reports whether the leaf is close enough to expiry to renew.
@@ -248,13 +284,15 @@ func renewViaPKICoreImpl(ctx context.Context, endpoint string, auth *config.Auth
 		var d renewDetailBody
 		_ = json.NewDecoder(resp.Body).Decode(&d)
 		return "", "", "", renewUnavailableError{
-			reason: "this certificate is not renewable, or its renewal budget is used up",
-			detail: d.Detail,
+			reason:         "this certificate is not renewable, or its renewal budget is used up",
+			detail:         d.Detail,
+			needsFreshCert: true,
 		}
 
 	case http.StatusUnauthorized:
 		return "", "", "", renewUnavailableError{
-			reason: "the renew frontend did not accept the current certificate",
+			reason:         "the renew frontend did not accept the current certificate",
+			needsFreshCert: true,
 		}
 
 	default:

--- a/go/internal/cli/commands/helpers_cloudauth.go
+++ b/go/internal/cli/commands/helpers_cloudauth.go
@@ -32,11 +32,11 @@ func (e cloudCertError) Error() string {
 	return e.code.String()
 }
 
-// isUnauthenticatedCloudError reports whether err indicates the cloud rejected
-// the caller's identity — an expired or missing session — for which logging in
-// again is the remedy. It matches both the gRPC Unauthenticated status code
-// (transport-level rejection) and the structured CertificateError unauthorized
-// code carried in a response body.
+// isUnauthenticatedCloudError reports whether err means the caller's stored
+// identity is no longer usable and logging in again is the remedy. It matches
+// the gRPC Unauthenticated status code (transport-level rejection), the
+// structured CertificateError unauthorized code carried in a response body, and
+// a pki-core renewal refusal that only a freshly minted certificate resolves.
 func isUnauthenticatedCloudError(err error) bool {
 	if err == nil {
 		return false
@@ -44,6 +44,12 @@ func isUnauthenticatedCloudError(err error) bool {
 	var ce cloudCertError
 	if errors.As(err, &ce) {
 		return ce.code == cloudpb.CertificateErrorCode_CERTIFICATE_ERROR_UNAUTHORIZED
+	}
+	// pki-core reports the same situation as a renewal refusal: the lineage is
+	// spent, gone, or was never its own, and only a fresh mint replaces it.
+	var ru renewUnavailableError
+	if errors.As(err, &ru) {
+		return ru.needsFreshCert
 	}
 	// Unwrap toward a gRPC status; status.FromError does not unwrap %w chains on
 	// every grpc-go version, so walk the chain ourselves.

--- a/go/internal/shared/certs/orgident.go
+++ b/go/internal/shared/certs/orgident.go
@@ -61,6 +61,28 @@ func UserSPIFFEURI(tenantUUID, userID string) string {
 	return tenantSPIFFEPrefix + tenantUUID + "/service/user-" + userID
 }
 
+// TenantPrincipalFromCert returns the tenant SPIFFE principal a leaf carries,
+// and whether it carries exactly one.
+//
+// pki-core routes a renewal by this SAN alone — it reads the tenant out of the
+// certificate presented in the handshake rather than from the request — and
+// refuses a certificate that presents none or several. So "exactly one" is the
+// only answer that means renewable.
+func TenantPrincipalFromCert(leaf *x509.Certificate) (string, bool) {
+	var found string
+	for _, u := range leaf.URIs {
+		raw := u.String()
+		if !strings.HasPrefix(raw, tenantSPIFFEPrefix) {
+			continue
+		}
+		if found != "" {
+			return "", false
+		}
+		found = raw
+	}
+	return found, found != ""
+}
+
 // ParseIdentityURN parses a canonical Wendy identity URN —
 // "urn:wendy:org:<org>:(user|asset):<id>", the exact string IdentityKey
 // produces — back into a WendyIdentity.


### PR DESCRIPTION
- **Advances:** [WDY-2943 wendy CLI: move `device enroll` and `auth refresh-certs` onto the approved flows (they are updated, not deleted)](https://linear.app/wendylabsinc/issue/WDY-2943/wendy-cli-move-device-enroll-and-auth-refresh-certs-onto-the-approved)

> **In plain terms:** `wendy auth refresh-certs` renews your certificate against
> pki-core instead of asking cloud to mint a replacement. Same command, same
> flags, same output. A session whose certificate predates pki-core tenant
> identities has no renewal path at all — the command now says so and offers to
> log you in again instead of failing on a denied cloud call.

## Summary

- The non-OIDC branch of `refresh-certs` dialled `cloudpb.CertificateService.RefreshCertificate`. It now posts its CSR to pki-core's renew frontend over mTLS, reusing the client WDY-2829 built for the pre-expiry pre-flight — until now reachable only on a 15-minute timer. OIDC sessions already re-issued against pki-core and are untouched.
- pki-core routes a renewal by the tenant SPIFFE principal on the certificate presented in the handshake, and renews only lineages it recorded at first mint. A leaf carrying no tenant principal is refused here rather than after a round trip that can only answer 403.
- The refusals only a fresh certificate resolves — no tenant lineage, expired, budget exhausted, never renewable — now reach the same re-login offer the cloud path had. "Needs an approved grant" and transport failures deliberately do not.
- A renewal keeps the asset and principal fields of the entry it replaces. Rebuilding the stored certificate dropped them, which silently re-labelled a device session.
- **Pre-existing gap this makes reachable on demand:** pki-core replaces the CSR's URI SANs with its own principal, so a renewed operator leaf carries no `urn:wendy:org:…` SAN. That URN is the only identity `certs.IdentityFromCert` reads, and the agent's inbound org gate defaults to strict (`go/internal/agent/interceptor/mtls.go:180-185`), so it answers `PermissionDenied`; `build_service.go:296-303` refuses regardless of org mode. WDY-2829's merged pre-flight already produces the same leaf on a timer. Filed as [WDY-2968](https://linear.app/wendylabsinc/issue/WDY-2968/wendy-agent-read-the-tenant-spiffe-principal-as-an-identity-source-a): the fix is agent-side, reading the tenant principal as an identity source, and targets `main` as a compatible increment.
- Only `refresh-certs` moves here; `wendy device enroll`, the other half of WDY-2943, is unchanged and blocked on cloud #525.

## Boundary changes

- **CLI:** no command, flag, or output changes. `WENDY_PKI_RENEW_ENDPOINT` becomes load-bearing for this command — unset, it reports that nothing is configured to renew against rather than falling back to cloud.

## Tests

- `go test ./... -count=1` — 86 packages pass. The four `internal/agent/oci` GPU tests fail on any branch on a machine with no NVIDIA device.
- `go build ./...`, `go vet ./...`, `gofmt -l .` — clean.
