### PR TITLE
Read the tenant SPIFFE principal as the identity source

### DIFF
--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -532,8 +532,8 @@ func main() {
 	buildContextLocks := services.NewBuildContextLockSet()
 
 	registerAllServices := func(srv *grpc.Server) {
-		// MeshService's own-org check (assetIdentityFromContext / MeshDial)
-		// must reflect this device's *current* org, not a value captured once
+		// MeshService's own-tenant check (assetIdentityFromContext / MeshDial)
+		// must reflect this device's *current* tenant, not a value captured once
 		// at process start: a live BLE-provisioning event updates
 		// provisioningSvc's state without restarting the agent, and a stale
 		// org (e.g. 0/unknown from an unprovisioned boot) would silently
@@ -542,11 +542,10 @@ func main() {
 		// runs at most once per concrete server (plaintext agentServer, the
 		// local control socket, and the mTLS server), so this is at most a
 		// handful of cheap constructions over the process lifetime, not a hot
-		// path. orgID == 0 (never provisioned) intentionally matches the mTLS
-		// org interceptor's grace behavior: MeshService skips the org-equality
-		// check rather than reject every caller.
-		_, orgID, _, _ := provisioningSvc.ProvisioningInfo()
-		meshSvc := services.NewMeshService(logger, configPath, orgID)
+		// path. An unknown scope (never provisioned) intentionally matches the
+		// mTLS interceptor's grace behavior: MeshService skips the
+		// tenant-equality check rather than reject every caller.
+		meshSvc := services.NewMeshService(logger, configPath, deviceScope(provisioningSvc))
 		buildSvc := services.NewBuildService(logger, services.BuildServiceOptions{
 			ConfigPath:   configPath,
 			Chunks:       buildChunkSource,
@@ -563,9 +562,8 @@ func main() {
 			// spoofing gap this helper was written for.
 			PushTLS: func(targetAssetID int32) (*tls.Config, error) {
 				certPEM, chainPEM, keyData := provisioningSvc.ProvisioningCerts()
-				_, pushOrgID, _, _ := provisioningSvc.ProvisioningInfo()
 				return mtls.NewClientTLSConfigExpectingPeer(certPEM, chainPEM, string(keyData), logger,
-					pushOrgID, strconv.FormatInt(int64(targetAssetID), 10))
+					strconv.FormatInt(int64(targetAssetID), 10))
 			},
 		})
 
@@ -618,24 +616,29 @@ func main() {
 		// startMTLSServer is also invoked from inside the OnProvisioned callback,
 		// where taking the provisioning mutex would risk re-entrancy (see the comment
 		// at the startTunnelBroker closure). Both call sites already pass certPEM.
-		expectedOrg, haveOrg := deviceOrgFromCertPEM(certPEM)
+		expectedScope, haveScope := certs.ScopeFromCertPEM(certPEM)
 		effectiveMode := orgMode
-		if orgMode != interceptor.OrgModeOff && !haveOrg {
-			// Fail safe: the device cannot determine its own org, so it cannot
-			// meaningfully compare a client's org against it. Rather than brick the
+		if orgMode != interceptor.OrgModeOff && !haveScope {
+			// Fail safe: the device cannot determine its own tenant, so it cannot
+			// meaningfully compare a client's tenant against it. Rather than brick the
 			// device (rejecting all clients) or silently enforce against an unknown
-			// self-org, disable enforcement for this server and log loudly.
-			logger.Error("cannot determine device organization from own certificate; mTLS org enforcement DISABLED for this server",
+			// self-tenant, disable enforcement for this server and log loudly.
+			//
+			// A pki-core-issued leaf reaches here with a tenant SPIFFE principal
+			// and no urn:wendy org, which certs.ScopeFromCertPEM reads as a known
+			// scope — so an ACME-enrolled or renewed device no longer trips this
+			// branch and no longer disarms enforcement fleet-wide (WDY-2968).
+			logger.Error("cannot determine device tenant from own certificate; mTLS enforcement DISABLED for this server",
 				zap.String("configuredMode", orgMode.String()))
 			effectiveMode = interceptor.OrgModeOff
 		}
 		if effectiveMode != interceptor.OrgModeOff {
-			logger.Info("mTLS server enforcing org",
-				zap.Int32("org", expectedOrg),
+			logger.Info("mTLS server enforcing tenant",
+				zap.String("scope", expectedScope.String()),
 				zap.String("mode", effectiveMode.String()))
 		}
 
-		srv, err := mtls.NewServer(certPEM, chainPEM, keyPEM, logger, floor, expectedOrg, effectiveMode,
+		srv, err := mtls.NewServer(certPEM, chainPEM, keyPEM, logger, floor, expectedScope, effectiveMode,
 			// UnaryMTLSInterceptor and StreamMTLSInterceptor are embedded inside
 			// mtls.NewServer and run before these caller-provided interceptors.
 			grpc.ChainUnaryInterceptor(interceptor.UnaryErrorInterceptor(logger)),
@@ -1055,37 +1058,22 @@ func certNotBeforeFloor(certPEM string) time.Time {
 	return cert.NotBefore
 }
 
-// deviceOrgFromCertPEM parses the device's own leaf certificate (ML-DSA aware,
-// mirroring certNotBeforeFloor) and extracts its organization ID via
-// certs.OrgFromClientCert. It returns (org, true) when an org identity is present
-// and valid, and (0, false) on any parse/extract error or when the cert carries no
-// org identity. The caller treats (0, false) as "device org unknown".
-func deviceOrgFromCertPEM(certPEM string) (int32, bool) {
-	if certPEM == "" {
-		return 0, false
+// deviceScope reports the tenant this device's own current leaf belongs to,
+// falling back to the legacy org the provisioning record carries when the
+// certificate names no tenant at all.
+//
+// The certificate is the identity source, so it is read fresh on every call:
+// a BLE provisioning event or a pki-core renewal replaces it without
+// restarting the agent, and a scope captured at boot would outlive it.
+func deviceScope(provisioningSvc *services.ProvisioningService) certs.Scope {
+	certPEM, _, _ := provisioningSvc.ProvisioningCerts()
+	if scope, ok := certs.ScopeFromCertPEM(certPEM); ok {
+		return scope
 	}
-	block, _ := pem.Decode([]byte(certPEM))
-	if block == nil {
-		return 0, false
-	}
-	// ML-DSA certs from pki-core have trailing ASN.1 bytes that cause
-	// x509.ParseCertificate to fail. Strip them with the same fallback used by
-	// certNotBeforeFloor and internal/agent/mtls/mldsa_verify.go.
-	cert, err := x509.ParseCertificate(block.Bytes)
-	if err != nil {
-		var raw asn1.RawValue
-		if _, asn1Err := asn1.Unmarshal(block.Bytes, &raw); asn1Err == nil {
-			cert, err = x509.ParseCertificate(raw.FullBytes)
-		}
-	}
-	if err != nil {
-		return 0, false
-	}
-	org, hasOrg, err := certs.OrgFromClientCert(cert)
-	if err != nil || !hasOrg {
-		return 0, false
-	}
-	return org, true
+	// An unprovisioned device reports org 0, which Scope.Known reads as
+	// "unidentified" — the same grace the mTLS interceptor applies.
+	_, orgID, _, _ := provisioningSvc.ProvisioningInfo()
+	return certs.Scope{OrgID: orgID}
 }
 
 // ensureCNIBinDir (re)creates agentcontainerd.CNIBinDir with "bridge" and

--- a/go/internal/agent/interceptor/mtls.go
+++ b/go/internal/agent/interceptor/mtls.go
@@ -90,13 +90,15 @@ func peerAddr(ctx context.Context) string {
 // Subject CN is intentionally omitted from per-call logs to satisfy data-minimisation
 // requirements — it may contain a username or device identifier.
 //
-// Organization enforcement: after the certificate is structurally validated, the
-// caller's organization (extracted from the leaf via certs.OrgFromClientCert) is
-// compared against expectedOrgID under the given mode. This prevents a validly-issued
-// user cert from one organization being accepted by a device belonging to another
-// (cross-tenant access). Only org IDs (ints, non-PII), the serial, and the remote
-// address are logged — never the CN/subject, which may carry a username.
-func CheckMTLS(ctx context.Context, logger *zap.Logger, expectedOrgID int32, mode OrgMode) error {
+// Tenant enforcement: after the certificate is structurally validated, the
+// caller's tenant scope (extracted from the leaf via certs.ScopeFromCert — the
+// tenant SPIFFE principal pki-core stamps, or the legacy org URN on an old
+// chain) is compared against expected under the given mode. This prevents a
+// validly-issued user cert from one tenant being accepted by a device belonging
+// to another (cross-tenant access). Only the scope (a tenant UUID or an org id,
+// neither PII), the serial, and the remote address are logged — never the
+// CN/subject, which may carry a username.
+func CheckMTLS(ctx context.Context, logger *zap.Logger, expected certs.Scope, mode OrgMode) error {
 	p, ok := peer.FromContext(ctx)
 	if !ok || p.AuthInfo == nil {
 		logger.Warn("rejected unauthenticated gRPC caller",
@@ -150,40 +152,66 @@ func CheckMTLS(ctx context.Context, logger *zap.Logger, expectedOrgID int32, mod
 		zap.String("serial", leaf.SerialNumber.String()),
 	)
 
-	// Organization-equality enforcement. OrgModeOff disables the check entirely,
-	// preserving pre-WDY-1535 behaviour. For grace/strict we extract the cert's org
-	// and compare it to this device's org (expectedOrgID).
+	// Tenant-equality enforcement. OrgModeOff disables the check entirely,
+	// preserving pre-WDY-1535 behaviour. For grace/strict we extract the cert's
+	// scope and compare it to this device's own (expected).
 	if mode == OrgModeOff {
 		return nil
 	}
-	org, hasOrg, err := certs.OrgFromClientCert(leaf)
+	scope, known, err := certs.ScopeFromCert(leaf)
 	switch {
 	case err != nil:
-		// An org claim was present but malformed/ambiguous/non-positive. This is
-		// anomalous; reject in BOTH grace and strict. The CN/subject is not logged.
-		logger.Warn("rejected cert with undeterminable organization",
+		// An identity claim was present but malformed/ambiguous/non-positive.
+		// This is anomalous; reject in BOTH grace and strict. The CN/subject is
+		// not logged.
+		logger.Warn("rejected cert with undeterminable tenant",
 			zap.String("remote", peerAddr(ctx)),
 			zap.String("serial", leaf.SerialNumber.String()),
 			zap.Error(err))
-		return status.Errorf(codes.PermissionDenied, "certificate organization could not be determined")
-	case hasOrg && org == expectedOrgID:
+		return status.Errorf(codes.PermissionDenied, "certificate tenant could not be determined")
+	case known && scope.Matches(expected):
 		return nil
-	case hasOrg && org != expectedOrgID:
-		logger.Warn("rejected cert from non-permitted organization",
+	case known && scope.Comparable(expected):
+		// A different tenant, said in terms this device can check. Refused in
+		// grace as well as strict: grace forgives an identity it cannot read,
+		// never one it can read and that says someone else.
+		logger.Warn("rejected cert from non-permitted tenant",
 			zap.String("remote", peerAddr(ctx)),
 			zap.String("serial", leaf.SerialNumber.String()),
-			zap.Int32("presentedOrg", org),
-			zap.Int32("expectedOrg", expectedOrgID))
-		return status.Errorf(codes.PermissionDenied, "certificate organization not permitted")
-	default:
-		// !hasOrg: a legacy cert with no org identity.
+			zap.String("presented", scope.String()),
+			zap.String("expected", expected.String()))
+		return status.Errorf(codes.PermissionDenied, "certificate tenant not permitted")
+	case known:
+		// The caller named a tenant this device has no way to compare against
+		// its own — a SPIFFE-only caller reaching a device still on an
+		// old-chain certificate, or the reverse. There is no mapping between a
+		// tenant UUID and an int32 org, so this is unprovable rather than
+		// wrong, and it is exactly the state a fleet passes through while its
+		// certificates rotate. Strict refuses it; grace is the knob for the
+		// rotation window.
 		if mode == OrgModeStrict {
-			logger.Warn("rejected cert with no organization identity under strict mode",
+			logger.Warn("rejected cert whose tenant cannot be compared with this device's under strict mode",
+				zap.String("remote", peerAddr(ctx)),
+				zap.String("serial", leaf.SerialNumber.String()),
+				zap.String("presented", scope.String()),
+				zap.String("expected", expected.String()))
+			return status.Errorf(codes.PermissionDenied, "certificate tenant not permitted")
+		}
+		logger.Warn("client certificate names a tenant this device cannot compare with its own; allowed under grace mode (set WENDY_MTLS_ORG_ENFORCEMENT=strict once certificates have rotated)",
+			zap.String("remote", peerAddr(ctx)),
+			zap.String("serial", leaf.SerialNumber.String()),
+			zap.String("presented", scope.String()),
+			zap.String("expected", expected.String()))
+		return nil
+	default:
+		// !known: a legacy cert with no identity at all.
+		if mode == OrgModeStrict {
+			logger.Warn("rejected cert with no tenant identity under strict mode",
 				zap.String("remote", peerAddr(ctx)),
 				zap.String("serial", leaf.SerialNumber.String()))
-			return status.Errorf(codes.PermissionDenied, "certificate organization identity required")
+			return status.Errorf(codes.PermissionDenied, "certificate tenant identity required")
 		}
-		logger.Warn("client certificate has no organization identity; allowed under grace mode (set WENDY_MTLS_ORG_ENFORCEMENT=strict after cert rotation)",
+		logger.Warn("client certificate has no tenant identity; allowed under grace mode (set WENDY_MTLS_ORG_ENFORCEMENT=strict after cert rotation)",
 			zap.String("remote", peerAddr(ctx)),
 			zap.String("serial", leaf.SerialNumber.String()))
 		return nil
@@ -191,10 +219,10 @@ func CheckMTLS(ctx context.Context, logger *zap.Logger, expectedOrgID int32, mod
 }
 
 // UnaryMTLSInterceptor rejects unary calls that do not carry verified mTLS peer
-// credentials or whose client organization is not permitted under the given mode.
-func UnaryMTLSInterceptor(logger *zap.Logger, expectedOrgID int32, mode OrgMode) grpc.UnaryServerInterceptor {
+// credentials or whose client tenant is not permitted under the given mode.
+func UnaryMTLSInterceptor(logger *zap.Logger, expected certs.Scope, mode OrgMode) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		if err := CheckMTLS(ctx, logger, expectedOrgID, mode); err != nil {
+		if err := CheckMTLS(ctx, logger, expected, mode); err != nil {
 			return nil, err
 		}
 		return handler(ctx, req)
@@ -203,9 +231,9 @@ func UnaryMTLSInterceptor(logger *zap.Logger, expectedOrgID int32, mode OrgMode)
 
 // StreamMTLSInterceptor rejects streaming calls that do not carry verified mTLS peer
 // credentials or whose client organization is not permitted under the given mode.
-func StreamMTLSInterceptor(logger *zap.Logger, expectedOrgID int32, mode OrgMode) grpc.StreamServerInterceptor {
+func StreamMTLSInterceptor(logger *zap.Logger, expected certs.Scope, mode OrgMode) grpc.StreamServerInterceptor {
 	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		if err := CheckMTLS(ss.Context(), logger, expectedOrgID, mode); err != nil {
+		if err := CheckMTLS(ss.Context(), logger, expected, mode); err != nil {
 			return err
 		}
 		return handler(srv, ss)

--- a/go/internal/agent/interceptor/mtls_test.go
+++ b/go/internal/agent/interceptor/mtls_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -63,7 +64,7 @@ func ctxWithLeaf(leaf *x509.Certificate) context.Context {
 
 func TestCheckMTLS_OrgEnforcement(t *testing.T) {
 	logger := zap.NewNop()
-	const expectedOrg int32 = 7
+	expectedScope := certs.Scope{OrgID: 7}
 
 	tests := []struct {
 		name     string
@@ -160,7 +161,7 @@ func TestCheckMTLS_OrgEnforcement(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := ctxWithLeaf(tc.leaf)
-			err := CheckMTLS(ctx, logger, expectedOrg, tc.mode)
+			err := CheckMTLS(ctx, logger, expectedScope, tc.mode)
 			if got := status.Code(err); got != tc.wantCode {
 				t.Fatalf("CheckMTLS code = %v (err=%v); want %v", got, err, tc.wantCode)
 			}
@@ -173,7 +174,7 @@ func TestCheckMTLS_NoPeerCertificates(t *testing.T) {
 	ctx := peer.NewContext(context.Background(), &peer.Peer{
 		AuthInfo: credentials.TLSInfo{State: tls.ConnectionState{PeerCertificates: nil}},
 	})
-	err := CheckMTLS(ctx, logger, 7, OrgModeGrace)
+	err := CheckMTLS(ctx, logger, certs.Scope{OrgID: 7}, OrgModeGrace)
 	if got := status.Code(err); got != codes.Unauthenticated {
 		t.Fatalf("CheckMTLS code = %v (err=%v); want Unauthenticated", got, err)
 	}
@@ -217,5 +218,121 @@ func TestOrgModeString(t *testing.T) {
 		if got := tc.mode.String(); got != tc.want {
 			t.Fatalf("OrgMode(%d).String() = %q; want %q", tc.mode, got, tc.want)
 		}
+	}
+}
+
+const testTenant = "6f1b7d3c-6b7e-4a2f-9c1e-2b4a8d5e0f31"
+const otherTenant = "00000000-0000-4000-8000-000000000000"
+
+// TestCheckMTLS_TenantEnforcement covers what WDY-2968 changed: a peer whose
+// only identity is a tenant SPIFFE principal is a recognised caller, compared
+// against this device's own tenant. The three-way split matters — a tenant that
+// differs is refused under every mode, while a tenant that simply cannot be
+// compared with this device's is the rotation window grace exists for.
+func TestCheckMTLS_TenantEnforcement(t *testing.T) {
+	logger := zap.NewNop()
+	deviceTenant := certs.Scope{TenantUUID: testTenant}
+	deviceOrg := certs.Scope{OrgID: 7}
+
+	principal := func(t *testing.T, tenant, rest string) *x509.Certificate {
+		return buildLeaf(leafOptions{
+			uris: []*url.URL{mustParseURL(t, "spiffe://wendy.sh/tenant/"+tenant+"/"+rest)},
+		})
+	}
+
+	tests := []struct {
+		name     string
+		leaf     *x509.Certificate
+		expected certs.Scope
+		mode     OrgMode
+		wantCode codes.Code // codes.OK means "allowed"
+	}{
+		{
+			// The bug: before this, an operator leaf renewed by pki-core had no
+			// urn:wendy SAN, so strict answered PermissionDenied on every RPC.
+			name:     "same tenant, operator principal, strict",
+			leaf:     principal(t, testTenant, "operator/auth0|abc"),
+			expected: deviceTenant,
+			mode:     OrgModeStrict,
+			wantCode: codes.OK,
+		},
+		{
+			name:     "same tenant, cloud-relayed user principal, strict",
+			leaf:     principal(t, testTenant, "service/user-5"),
+			expected: deviceTenant,
+			mode:     OrgModeStrict,
+			wantCode: codes.OK,
+		},
+		{
+			name:     "different tenant is refused under strict",
+			leaf:     principal(t, otherTenant, "operator/auth0|abc"),
+			expected: deviceTenant,
+			mode:     OrgModeStrict,
+			wantCode: codes.PermissionDenied,
+		},
+		{
+			// Grace forgives an identity it cannot read, never one it can read
+			// and that says someone else.
+			name:     "different tenant is refused under grace too",
+			leaf:     principal(t, otherTenant, "operator/auth0|abc"),
+			expected: deviceTenant,
+			mode:     OrgModeGrace,
+			wantCode: codes.PermissionDenied,
+		},
+		{
+			name:     "incomparable scopes are refused under strict",
+			leaf:     principal(t, testTenant, "operator/auth0|abc"),
+			expected: deviceOrg,
+			mode:     OrgModeStrict,
+			wantCode: codes.PermissionDenied,
+		},
+		{
+			name:     "incomparable scopes are allowed under grace",
+			leaf:     principal(t, testTenant, "operator/auth0|abc"),
+			expected: deviceOrg,
+			mode:     OrgModeGrace,
+			wantCode: codes.OK,
+		},
+		{
+			// A transitional leaf carries both SANs, so an old-chain device can
+			// still compare the org it understands.
+			name: "transitional leaf matches an org-only device",
+			leaf: buildLeaf(leafOptions{uris: []*url.URL{
+				mustParseURL(t, "spiffe://wendy.sh/tenant/"+testTenant+"/service/asset-42"),
+				mustParseURL(t, "urn:wendy:org:7:asset:42"),
+			}}),
+			expected: deviceOrg,
+			mode:     OrgModeStrict,
+			wantCode: codes.OK,
+		},
+		{
+			name:     "off skips the check entirely",
+			leaf:     principal(t, otherTenant, "operator/auth0|abc"),
+			expected: deviceTenant,
+			mode:     OrgModeOff,
+			wantCode: codes.OK,
+		},
+		{
+			name:     "a malformed principal is anomalous, refused under grace",
+			leaf:     principal(t, "not-a-uuid", "operator/auth0|abc"),
+			expected: deviceTenant,
+			mode:     OrgModeGrace,
+			wantCode: codes.PermissionDenied,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := CheckMTLS(ctxWithLeaf(tc.leaf), logger, tc.expected, tc.mode)
+			if tc.wantCode == codes.OK {
+				if err != nil {
+					t.Fatalf("CheckMTLS = %v, want allowed", err)
+				}
+				return
+			}
+			if got := status.Code(err); got != tc.wantCode {
+				t.Fatalf("CheckMTLS code = %v (%v), want %v", got, err, tc.wantCode)
+			}
+		})
 	}
 }

--- a/go/internal/agent/mtls/mesh_resumption_pin_test.go
+++ b/go/internal/agent/mtls/mesh_resumption_pin_test.go
@@ -146,13 +146,14 @@ func TestNewClientTLSConfigExpectingPeerRejectsPinMismatchOnResume(t *testing.T)
 	peerCert := meshPeerCert(t, ca, caKey, "urn:wendy:org:7:asset:100")
 	addr := startMeshPeerServer(t, peerCert)
 
-	// The dialing side's own identity is irrelevant to peer pinning; the bare
-	// server above never requests a client certificate.
-	ownCertPEM, ownKeyPEM := testLeafCertificate(t, "dialer")
+	// The dialing side's own identity supplies the expected tenant (org 7,
+	// matching the server); the bare server above never requests a client
+	// certificate, so the cert itself is never presented.
+	ownCertPEM, ownKeyPEM := testLeafCertificate(t, "sh/wendy/7/1")
 
 	cache := tls.NewLRUClientSessionCache(4)
 
-	cfgX, err := NewClientTLSConfigExpectingPeer(ownCertPEM, chainPEM, ownKeyPEM, nil, 7, "100")
+	cfgX, err := NewClientTLSConfigExpectingPeer(ownCertPEM, chainPEM, ownKeyPEM, nil, "100")
 	if err != nil {
 		t.Fatalf("NewClientTLSConfigExpectingPeer(asset 100): %v", err)
 	}
@@ -188,7 +189,7 @@ func TestNewClientTLSConfigExpectingPeerRejectsPinMismatchOnResume(t *testing.T)
 	// server's real identity (asset 100, refreshed by dial 2's post-handshake
 	// ticket), so the server will happily accept resumption; the fix must
 	// catch the pin mismatch in VerifyConnection and fail the handshake.
-	cfgY, err := NewClientTLSConfigExpectingPeer(ownCertPEM, chainPEM, ownKeyPEM, nil, 7, "999")
+	cfgY, err := NewClientTLSConfigExpectingPeer(ownCertPEM, chainPEM, ownKeyPEM, nil, "999")
 	if err != nil {
 		t.Fatalf("NewClientTLSConfigExpectingPeer(asset 999): %v", err)
 	}

--- a/go/internal/agent/mtls/server.go
+++ b/go/internal/agent/mtls/server.go
@@ -83,9 +83,9 @@ func NewTLSConfig(certPEM, chainPEM, keyPEM string, logger *zap.Logger, notBefor
 // extraOpts; those run after the mandatory mTLS check.
 // logger may be nil; when provided, rejected client certificates are logged at WARN level.
 // notBeforeFloor is forwarded to NewTLSConfig; see its documentation for details.
-// expectedOrgID and orgMode are forwarded to the mandatory mTLS interceptors, which
-// enforce organization-equality between the connecting client cert and this device.
-func NewServer(certPEM, chainPEM, keyPEM string, logger *zap.Logger, notBeforeFloor time.Time, expectedOrgID int32, orgMode interceptor.OrgMode, extraOpts ...grpc.ServerOption) (*grpc.Server, error) {
+// expected and orgMode are forwarded to the mandatory mTLS interceptors, which
+// enforce tenant-equality between the connecting client cert and this device.
+func NewServer(certPEM, chainPEM, keyPEM string, logger *zap.Logger, notBeforeFloor time.Time, expected certs.Scope, orgMode interceptor.OrgMode, extraOpts ...grpc.ServerOption) (*grpc.Server, error) {
 	tlsConfig, err := NewTLSConfig(certPEM, chainPEM, keyPEM, logger, notBeforeFloor)
 	if err != nil {
 		return nil, fmt.Errorf("creating TLS config: %w", err)
@@ -96,8 +96,8 @@ func NewServer(certPEM, chainPEM, keyPEM string, logger *zap.Logger, notBeforeFl
 		grpc.Creds(creds),
 		// mTLS interceptors are mandatory: they run before any caller-provided interceptors
 		// so that no handler can be reached without a verified client certificate.
-		grpc.ChainUnaryInterceptor(interceptor.UnaryMTLSInterceptor(logger, expectedOrgID, orgMode)),
-		grpc.ChainStreamInterceptor(interceptor.StreamMTLSInterceptor(logger, expectedOrgID, orgMode)),
+		grpc.ChainUnaryInterceptor(interceptor.UnaryMTLSInterceptor(logger, expected, orgMode)),
+		grpc.ChainStreamInterceptor(interceptor.StreamMTLSInterceptor(logger, expected, orgMode)),
 		grpc.InitialWindowSize(8 * 1024 * 1024),
 		grpc.InitialConnWindowSize(16 * 1024 * 1024),
 		grpc.KeepaliveParams(keepalive.ServerParameters{
@@ -174,12 +174,22 @@ func NewClientTLSConfig(certPEM, chainPEM, keyPEM string, logger *zap.Logger) (*
 // could otherwise impersonate the mDNS-advertised target and MITM the
 // connection. The returned config's VerifyPeerCertificate runs the normal
 // chain check first, then requires the peer leaf to parse as a wendy asset
-// identity matching wantOrgID and wantAssetID exactly.
-func NewClientTLSConfigExpectingPeer(certPEM, chainPEM, keyPEM string, logger *zap.Logger, wantOrgID int32, wantAssetID string) (*tls.Config, error) {
+// identity with id wantAssetID, in this device's own tenant.
+//
+// The tenant is read off certPEM — this device's own leaf — rather than passed
+// in: the invariant a mesh dial enforces is "the same tenant I am in", and both
+// callers were already passing their own org. Deriving it here means a device
+// whose certificate has moved from a urn:wendy org to a pki-core tenant SPIFFE
+// principal compares like with like without either caller learning about it.
+// A device that cannot determine its own tenant skips the tenant half of the
+// check (the asset id still pins), mirroring the interceptor's grace behaviour
+// rather than bricking mesh on an unidentifiable leaf.
+func NewClientTLSConfigExpectingPeer(certPEM, chainPEM, keyPEM string, logger *zap.Logger, wantAssetID string) (*tls.Config, error) {
 	base, err := NewClientTLSConfig(certPEM, chainPEM, keyPEM, logger)
 	if err != nil {
 		return nil, err
 	}
+	ownScope, haveOwnScope := certs.ScopeFromCertPEM(certPEM)
 	chainVerify := base.VerifyPeerCertificate
 	pinnedVerify := func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 		if err := chainVerify(rawCerts, verifiedChains); err != nil {
@@ -199,12 +209,22 @@ func NewClientTLSConfigExpectingPeer(certPEM, chainPEM, keyPEM string, logger *z
 		if !found {
 			return errors.New("mtls: peer certificate carries no wendy identity")
 		}
-		if ident.EntityType != "asset" {
-			return fmt.Errorf("mtls: expected peer asset %s in org %d, got entity type %q", wantAssetID, wantOrgID, ident.EntityType)
+		if ident.EntityType != certs.EntityAsset {
+			return fmt.Errorf("mtls: expected peer asset %s in %s, got entity type %q", wantAssetID, ownScope, ident.EntityType)
 		}
-		if ident.OrgID != wantOrgID || ident.EntityID != wantAssetID {
-			return fmt.Errorf("mtls: expected peer asset %s in org %d, got asset %s in org %d",
-				wantAssetID, wantOrgID, ident.EntityID, ident.OrgID)
+		// wantAssetID is the int32 cloud asset id the mesh addresses peers by
+		// (mDNS TXT "assetid" → meshDialLAN). A device enrolled directly against
+		// pki-core over ACME is named "device/<deviceID>" instead and has no
+		// such id, so it cannot be reached over the mesh LAN path at all — the
+		// gap is in mesh addressing, not here, and closing it means teaching
+		// discovery to advertise the principal (WDY-2968 follow-up).
+		if ident.EntityID != wantAssetID {
+			return fmt.Errorf("mtls: expected peer asset %s in %s, got asset %s in %s",
+				wantAssetID, ownScope, ident.EntityID, ident.Scope())
+		}
+		if haveOwnScope && !ident.Scope().Matches(ownScope) {
+			return fmt.Errorf("mtls: expected peer asset %s in %s, got asset %s in %s",
+				wantAssetID, ownScope, ident.EntityID, ident.Scope())
 		}
 		return nil
 	}

--- a/go/internal/agent/mtls/server_test.go
+++ b/go/internal/agent/mtls/server_test.go
@@ -297,11 +297,12 @@ func testPeerLeafRaw(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey
 // exactly the expected asset in the expected org.
 func TestNewClientTLSConfigExpectingPeerPinsIdentity(t *testing.T) {
 	ca, caKey, chainPEM := testCAKeyPair(t)
-	// The config's own identity (used for the client cert we present); its
-	// content is irrelevant to peer verification.
-	ownCertPEM, ownKeyPEM := testLeafCertificate(t, "dialer")
+	// The config's own identity supplies the expected tenant: the peer's scope
+	// is compared against the scope of the certificate we ourselves present, so
+	// the dialer has to be an org-7 asset for the org half of the pin to bite.
+	ownCertPEM, ownKeyPEM := testLeafCertificate(t, "sh/wendy/7/1")
 
-	cfg, err := NewClientTLSConfigExpectingPeer(ownCertPEM, chainPEM, ownKeyPEM, nil, 7, "215")
+	cfg, err := NewClientTLSConfigExpectingPeer(ownCertPEM, chainPEM, ownKeyPEM, nil, "215")
 	if err != nil {
 		t.Fatalf("NewClientTLSConfigExpectingPeer: %v", err)
 	}

--- a/go/internal/agent/services/mesh_dialer.go
+++ b/go/internal/agent/services/mesh_dialer.go
@@ -256,7 +256,7 @@ func dialBoundContext(ctx context.Context) (sctx context.Context, cancel context
 // stream; once established the stream survives past ctx, and Close on the
 // returned conn tears it down.
 //
-// deviceID pins the expected peer identity (org + asset ID) on the TLS
+// deviceID pins the expected peer identity (tenant + asset ID) on the TLS
 // handshake itself: hostport comes from discoverOnLAN, which trusts an
 // unauthenticated mDNS TXT record (assetid) to pick the peer to dial. Without
 // pinning, chain validity alone would let any other device holding a cert
@@ -265,7 +265,7 @@ func dialBoundContext(ctx context.Context) (sctx context.Context, cancel context
 func (d *MeshDialer) meshDialLAN(ctx context.Context, hostport string, deviceID int32, port uint16) (net.Conn, error) {
 	ident := d.identity()
 	tlsCfg, err := mtls.NewClientTLSConfigExpectingPeer(ident.certPEM, ident.chainPEM, ident.keyPEM, d.logger,
-		ident.orgID, strconv.Itoa(int(deviceID)))
+		strconv.Itoa(int(deviceID)))
 	if err != nil {
 		return nil, fmt.Errorf("mesh: client TLS config: %w", err)
 	}

--- a/go/internal/agent/services/mesh_service.go
+++ b/go/internal/agent/services/mesh_service.go
@@ -34,24 +34,25 @@ type MeshService struct {
 	agentpbv2.UnimplementedWendyMeshServiceServer
 	logger           *zap.Logger
 	meshDisabledPath string
-	// expectedOrgID is this device's own org, used to enforce that a MeshDial
-	// caller belongs to the same org even when the server's mTLS org
-	// interceptor is disabled (WENDY_MTLS_ORG_ENFORCEMENT=off). <= 0 means the
-	// device could not determine its own org; see assetIdentityFromContext.
-	expectedOrgID int32
+	// expectedScope is this device's own tenant, used to enforce that a MeshDial
+	// caller belongs to the same tenant even when the server's mTLS
+	// interceptor is disabled (WENDY_MTLS_ORG_ENFORCEMENT=off). An unknown
+	// scope means the device could not identify itself; see
+	// assetIdentityFromContext.
+	expectedScope certs.Scope
 	dialLocal     func(addr string, timeout time.Duration) (net.Conn, error) // swapped in tests
 }
 
 // NewMeshService builds the serving side of the LAN-direct mesh path.
-// expectedOrgID is this device's own org (the same value passed to
-// mtls.NewServer as expectedOrg); pass <= 0 when the device cannot determine
-// its own org (main.go forces mTLS org enforcement off in that case too) —
-// MeshService then skips its own-org check rather than reject every caller.
-func NewMeshService(logger *zap.Logger, configPath string, expectedOrgID int32) *MeshService {
+// expectedScope is this device's own tenant (the same value passed to
+// mtls.NewServer); pass a zero Scope when the device cannot identify itself
+// (main.go forces mTLS enforcement off in that case too) — MeshService then
+// skips its own-tenant check rather than reject every caller.
+func NewMeshService(logger *zap.Logger, configPath string, expectedScope certs.Scope) *MeshService {
 	return &MeshService{
 		logger:           logger,
 		meshDisabledPath: filepath.Join(configPath, meshDisabledFile),
-		expectedOrgID:    expectedOrgID,
+		expectedScope:    expectedScope,
 		dialLocal: func(addr string, timeout time.Duration) (net.Conn, error) {
 			return net.DialTimeout("tcp", addr, timeout)
 		},
@@ -115,15 +116,15 @@ func (s *MeshService) assetIdentityFromContext(ctx context.Context) (certs.Wendy
 	if err != nil || !found {
 		return certs.WendyIdentity{}, status.Error(codes.PermissionDenied, "client certificate carries no wendy identity")
 	}
-	if ident.EntityType != "asset" {
+	if ident.EntityType != certs.EntityAsset {
 		return certs.WendyIdentity{}, status.Error(codes.PermissionDenied, "mesh dial requires an asset certificate")
 	}
-	// expectedOrgID <= 0 means this device could not determine its own org
-	// (main.go forces mTLS org enforcement off for the same reason): there is
+	// An unknown expectedScope means this device could not identify itself
+	// (main.go forces mTLS enforcement off for the same reason): there is
 	// nothing meaningful to compare against, so skip the check rather than
 	// reject every caller. Still requires the asset check above.
-	if s.expectedOrgID > 0 && ident.OrgID != s.expectedOrgID {
-		return certs.WendyIdentity{}, status.Error(codes.PermissionDenied, "mesh dial requires a same-organization asset certificate")
+	if s.expectedScope.Known() && !ident.Scope().Matches(s.expectedScope) {
+		return certs.WendyIdentity{}, status.Error(codes.PermissionDenied, "mesh dial requires a same-tenant asset certificate")
 	}
 	return ident, nil
 }

--- a/go/internal/agent/services/mesh_service_test.go
+++ b/go/internal/agent/services/mesh_service_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -120,16 +121,16 @@ func (f *ctxAwareMeshDialStream) Send(d *agentpbv2.MeshDialData) error {
 	}
 }
 
-// testOrgID is the device's own org used by newMeshServiceForTest; every
+// testScope is the device's own tenant used by newMeshServiceForTest; every
 // existing fixture cert in this file carries "urn:wendy:org:7:...", so this
-// must stay 7 for the pre-existing tests to keep passing under the new
-// same-org check.
-const testOrgID = 7
+// must stay org 7 for the pre-existing tests to keep passing under the
+// same-tenant check.
+var testScope = certs.Scope{OrgID: 7}
 
 func newMeshServiceForTest(t *testing.T) (*MeshService, string) {
 	t.Helper()
 	dir := t.TempDir()
-	return NewMeshService(zap.NewNop(), dir, testOrgID), dir
+	return NewMeshService(zap.NewNop(), dir, testScope), dir
 }
 
 func TestMeshDialRejectsUserCert(t *testing.T) {
@@ -157,14 +158,14 @@ func TestMeshDialRejectsCrossOrgAsset(t *testing.T) {
 
 // TestMeshDialSkipsOrgCheckWhenDeviceOrgUnknown mirrors the mTLS
 // interceptor's grace behavior: main.go forces org enforcement off when this
-// device could not determine its own org from its certificate (expectedOrgID
-// <= 0), because there is nothing meaningful to compare against. MeshService
-// must skip its own-org check in that case rather than reject every caller —
+// device could not determine its own tenant from its certificate (an unknown
+// Scope), because there is nothing meaningful to compare against. MeshService
+// must skip its own-tenant check in that case rather than reject every caller —
 // the request must still fail on other grounds (port 0) to prove the org gate
 // was skipped, not that the whole call short-circuited to success.
 func TestMeshDialSkipsOrgCheckWhenDeviceOrgUnknown(t *testing.T) {
 	dir := t.TempDir()
-	svc := NewMeshService(zap.NewNop(), dir, 0)
+	svc := NewMeshService(zap.NewNop(), dir, certs.Scope{})
 	in := make(chan *agentpbv2.MeshDialMessage, 1)
 	in <- &agentpbv2.MeshDialMessage{Content: &agentpbv2.MeshDialMessage_Open{Open: &agentpbv2.MeshDialOpen{Port: 0}}}
 	stream := &fakeMeshDialStream{ctx: ctxWithPeerCert(certWithURN(t, "urn:wendy:org:42:asset:215")), in: in}

--- a/go/internal/agent/services/shell_service.go
+++ b/go/internal/agent/services/shell_service.go
@@ -133,7 +133,7 @@ func clientAuditFields(ctx context.Context) []zap.Field {
 	fields = append(fields, zap.String("cert_serial", cert.SerialNumber.String()))
 	if ident, found, err := certs.IdentityFromCert(cert); err == nil && found {
 		fields = append(fields,
-			zap.Int32("org_id", ident.OrgID),
+			zap.String("scope", ident.Scope().String()),
 			zap.String("entity_type", ident.EntityType),
 			zap.String("entity_id", ident.EntityID),
 		)

--- a/go/internal/cli/assets/docs/pki/README.md
+++ b/go/internal/cli/assets/docs/pki/README.md
@@ -19,13 +19,32 @@ Subject CommonName:
 
 | Entity | URI SAN format |
 |--------|---------------|
-| User (CLI) | `urn:wendy:org:‹orgID›:user:‹userID›` |
-| Device / agent | `urn:wendy:org:‹orgID›:asset:‹assetID›` |
+| Operator (pki-core identity endpoint) | `spiffe://wendy.sh/tenant/‹uuid›/operator/‹sub›` |
+| User (CLI, cloud-relayed) | `spiffe://wendy.sh/tenant/‹uuid›/service/user-‹userID›` |
+| Device / agent (cloud-relayed) | `spiffe://wendy.sh/tenant/‹uuid›/service/asset-‹assetID›` |
+| Device (ACME / EST, direct) | `spiffe://wendy.sh/tenant/‹uuid›/device/‹deviceID›` |
+| User (CLI) — legacy chain | `urn:wendy:org:‹orgID›:user:‹userID›` |
+| Device / agent — legacy chain | `urn:wendy:org:‹orgID›:asset:‹assetID›` |
 
-The URI SAN is what `IdentityFromCert` (Go) and `OrgIdentity.identity(fromLeaf:)`
-(Swift) resolve first. The CommonName (`sh/wendy/‹org›/‹asset›` or
-`wendy/user/‹uid›`) is retained for backward compatibility but is treated as
-the fallback when no URI SAN is present.
+The **tenant SPIFFE principal is the identity**. It is what `IdentityFromCert`
+(Go) and `OrgIdentity.identity(fromLeaf:)` (Swift) resolve first, because it is
+the only identity pki-core carries across a renewal: the renew path replaces a
+CSR's URI SAN list wholesale with the principal read off the presented
+certificate, so a renewed leaf comes back with its `urn:wendy:org:…` SAN gone.
+
+The `urn:wendy:org:…` SAN is read second and only as a legacy old-chain
+identity. On a transitional leaf that carries both, the principal decides *who*
+the caller is and the URN contributes only its organisation, so a peer that can
+still compare nothing but organisations keeps working. The CommonName
+(`sh/wendy/‹org›/‹asset›` or `wendy/user/‹uid›`) is the last fallback, used only
+when no URI SAN is present.
+
+Two identities are compared in whichever vocabulary they share: tenant UUIDs
+when both carry one, organisations when both carry one. A pair with no shared
+vocabulary — a SPIFFE-only caller against an old-chain device, or the reverse —
+is **not** a match, because no mapping exists between a tenant UUID and an
+int32 organisation and answering "close enough" is exactly what a cross-tenant
+caller would need.
 
 Legacy tokens that carry no `org_id` claim (user enrollment only) produce a
 CSR with a CommonName only — no URI SAN — so existing enrollments continue to
@@ -75,7 +94,7 @@ The CLI verifies device server certificates on all mTLS connections (BLE, LAN gR
 
 ## Device identity pinning (default device)
 
-On the first successful connection to a hostname, the CLI records that hostname's identity in `~/.wendy/config.json` under `devicePins`: the **organisation**, the **cloud host** that issued its certificate, and the **asset id** from the device certificate's `urn:wendy:org:<org>:asset:<assetID>` URI SAN. Every later connection to that hostname is checked against the pin — this is what feeds `ServerVerifyOpts.ExpectedIdentity` above, so a wrong device is rejected during the TLS handshake itself, not after.
+On the first successful connection to a hostname, the CLI records that hostname's identity in `~/.wendy/config.json` under `devicePins`: the **organisation**, the **cloud host** that issued its certificate, and the **asset id** from the device certificate's identity SAN (the name of its tenant SPIFFE principal, or the legacy `urn:wendy:org:<org>:asset:<assetID>` URN on an old chain), and that **principal** when it has one. Every later connection to that hostname is checked against the pin — this is what feeds `ServerVerifyOpts.ExpectedIdentity` above, so a wrong device is rejected during the TLS handshake itself, not after.
 
 The pin is deliberately not a certificate fingerprint — a device legitimately rotates and re-enrolls certificates, and that must not look like an attack. What trips it is a change of *who* is answering:
 
@@ -93,12 +112,13 @@ The asset id is read only from a certificate that passed chain and org verificat
 
 ```sh
 wendy device unpin <hostname>
+wendy device unpin spiffe://wendy.sh/tenant/<uuid>/device/<id>
 wendy device unpin urn:wendy:org:<org>:asset:<id>
 ```
 
 This clears the local pin only — it never dials the device, so it works even when the device is offline, wiped, or gone. The next successful connection to that hostname records a fresh pin from scratch. Naming a device explicitly with `wendy device set-default <hostname>` has the same clearing effect, since typing the hostname is itself the user asserting "I mean that device."
 
-Both forms are accepted because the two stores are keyed differently. The identity-change refusals above name a hostname, and the hostname form clears it. The **SPKI** refusal (point 4 above) can only name the certificate identity URN, because that is what `known_devices.json` is keyed by and there is often no hostname to offer: `wendy device list` and the device picker dial the device's IP, and an agent that never advertises `orgid` in its mDNS records leaves nothing locally that maps a name to an asset. Copy the URN out of the refusal and pass it back — it clears the SPKI entry and any `devicePins` entry naming the same asset.
+Both forms are accepted because the two stores are keyed differently. The identity-change refusals above name a hostname, and the hostname form clears it (a pin records its device's principal on the first connect after the SPIFFE cutover, which is how the hostname form still reaches the SPKI entry). The **SPKI** refusal (point 4 above) can only name the certificate identity, because that is what `known_devices.json` is keyed by — the tenant SPIFFE principal for a pki-core-issued device, the legacy URN for an old chain and there is often no hostname to offer: `wendy device list` and the device picker dial the device's IP, and an agent that never advertises `orgid` in its mDNS records leaves nothing locally that maps a name to an asset. Copy the identity out of the refusal and pass it back — it clears the SPKI entry and any `devicePins` entry naming the same asset.
 
 Unpinning by hostname also clears pins filed under the device's *other* names (the cloud roster's asset name, its mesh name), because one device is legitimately pinned under several — but only when those pins name the same organisation and asset. Those alternate names come from mDNS, which is unauthenticated, so a pin naming a *different* asset is a different device's pin and is left alone. Whatever is cleared is printed, one line per entry, so an unpin never removes trust state silently.
 

--- a/go/internal/cli/cloudrequest/sign.go
+++ b/go/internal/cli/cloudrequest/sign.go
@@ -12,11 +12,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 	cloudpb "github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
 	"google.golang.org/grpc"
@@ -94,24 +93,27 @@ func newSigner(auth *config.AuthConfig) (*Signer, error) {
 	}, nil
 }
 
+// operatorTenant reads the tenant a session's principal belongs to.
+//
+// It used to insist on the kind "operator", which is what the AAA contract
+// §5.2 says pki-core's own identity endpoint stamps — but cloud relays its
+// leaves through the service-identity profile and stamps "service/user-<id>",
+// so a cloud-issued session was refused here for spelling. Both are legitimate
+// human-operator identities under the contract (D17 makes a service account a
+// normal user behind a different front door), so both are accepted and
+// certs.ParsePrincipal is the single place that decides so.
+//
+// A device or code-signing principal is still refused: neither is an actor
+// that may sign a privileged cloud mutation.
 func operatorTenant(principal string) (string, error) {
-	u, err := url.Parse(principal)
-	if err != nil || u.Scheme != "spiffe" || u.Host != "wendy.sh" || u.RawQuery != "" || u.Fragment != "" {
-		return "", fmt.Errorf("operator certificate has invalid principal URI %q", principal)
+	id, err := certs.ParsePrincipal(principal)
+	if err != nil {
+		return "", fmt.Errorf("operator certificate has invalid principal URI %q: %w", principal, err)
 	}
-	parts := strings.Split(strings.Trim(u.EscapedPath(), "/"), "/")
-	if len(parts) != 4 || parts[0] != "tenant" || parts[1] == "" || parts[2] != "operator" || parts[3] == "" {
-		return "", fmt.Errorf("operator certificate has invalid principal URI %q", principal)
+	if id.EntityType != certs.EntityUser {
+		return "", fmt.Errorf("operator certificate principal %q is a %s, not an operator", principal, id.EntityType)
 	}
-	tenant, err := url.PathUnescape(parts[1])
-	if err != nil || tenant == "" {
-		return "", fmt.Errorf("operator certificate has invalid tenant in principal URI %q", principal)
-	}
-	tenantID, err := uuid.Parse(tenant)
-	if err != nil || tenantID.String() != tenant {
-		return "", fmt.Errorf("operator certificate has non-canonical tenant UUID in principal URI %q", principal)
-	}
-	return tenant, nil
+	return id.TenantUUID, nil
 }
 
 func (s *Signer) unaryClientInterceptor() grpc.UnaryClientInterceptor {

--- a/go/internal/cli/cloudrequest/sign_test.go
+++ b/go/internal/cli/cloudrequest/sign_test.go
@@ -241,3 +241,27 @@ func TestNewSignerRejectsNonOperatorPrincipal(t *testing.T) {
 		t.Fatal("newSigner accepted a non-operator principal")
 	}
 }
+
+// A cloud-relayed session spells the same human "service/user-<id>" rather than
+// "operator/<sub>" (AAA contract D17). Refusing it was WDY-2968's spelling bug:
+// both are operator identities and both must sign.
+func TestNewSignerAcceptsRelayedUserPrincipal(t *testing.T) {
+	auth, _, _ := testAuth(t)
+	auth.Certificates[0].PrincipalURI = "spiffe://wendy.sh/tenant/" + testTenant + "/service/user-42"
+	signer, err := newSigner(auth)
+	if err != nil {
+		t.Fatalf("newSigner: %v", err)
+	}
+	if signer.tenantUUID != testTenant {
+		t.Fatalf("tenantUUID = %q, want %q", signer.tenantUUID, testTenant)
+	}
+}
+
+// A device leaf is not an actor that may sign a privileged cloud mutation.
+func TestNewSignerRejectsDevicePrincipal(t *testing.T) {
+	auth, _, _ := testAuth(t)
+	auth.Certificates[0].PrincipalURI = "spiffe://wendy.sh/tenant/" + testTenant + "/device/thor-1"
+	if _, err := newSigner(auth); err == nil {
+		t.Fatal("newSigner accepted a device principal as an operator")
+	}
+}

--- a/go/internal/cli/commands/cloud_pin_seed.go
+++ b/go/internal/cli/commands/cloud_pin_seed.go
@@ -53,7 +53,9 @@ func seedPinsFromCloudAssets(assets []*cloudpb.Asset, orgID int, cloudGRPC strin
 		if existing, ok := cfg.DevicePinFor(name); ok && existing == want {
 			continue
 		}
-		cfg.SetDevicePinFrom(name, orgID, cloudGRPC, want.AssetID, config.PinSourceCloud)
+		// The roster names an asset, not a principal; the principal is
+		// backfilled by enforceDeviceIdentity on the first real connect.
+		cfg.SetDevicePinFrom(name, orgID, cloudGRPC, want.AssetID, "", config.PinSourceCloud)
 		changed = true
 	}
 	if !changed {

--- a/go/internal/cli/commands/device_pin.go
+++ b/go/internal/cli/commands/device_pin.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 )
 
@@ -40,10 +41,14 @@ type observedDeviceIdentity struct {
 	mTLS bool
 	// orgID is the organisation of the CLI certificate that authenticated.
 	orgID int
-	// assetID is the device's cloud asset id from the verified server cert's
-	// "urn:wendy:org:<org>:asset:<assetID>" SAN. Empty when the agent's
-	// certificate carries no asset identity (legacy certs).
+	// assetID is the device's asset id from the verified server cert — the
+	// name of its tenant SPIFFE principal, or the legacy
+	// "urn:wendy:org:<org>:asset:<assetID>" SAN on an old chain. Empty when the
+	// agent's certificate carries no asset identity.
 	assetID string
+	// principal is the full tenant SPIFFE principal, when the cert carries one.
+	// Recorded into the pin so an unpin can reach the SPKI entry it keys.
+	principal string
 }
 
 // observeDeviceIdentity reads what conn proved about the device it reached.
@@ -54,8 +59,9 @@ func observeDeviceIdentity(conn *grpcclient.AgentConnection) observedDeviceIdent
 	obs := observedDeviceIdentity{mTLS: true, orgID: conn.CertInfo.OrganizationID}
 	// Only an "asset" entity is a device; a "user" URN on a server cert would
 	// be a misissued certificate, and pinning it would be meaningless.
-	if id, ok := conn.ObservedServerIdentity(); ok && id.EntityType == "asset" {
+	if id, ok := conn.ObservedServerIdentity(); ok && id.EntityType == certs.EntityAsset {
 		obs.assetID = id.EntityID
+		obs.principal = id.Principal
 	}
 	return obs
 }
@@ -104,11 +110,19 @@ func enforceDeviceIdentity(hostname string, obs observedDeviceIdentity) error {
 	cloud := cloudGRPCForOrg(cfg, obs.orgID)
 	switch cfg.EvaluateDevicePin(hostname, obs.orgID, cloud, obs.assetID) {
 	case config.PinMatch:
+		// Backfill the principal into a pin that matches but predates the SPIFFE
+		// cutover. Same silent upgrade as PinAdoptAsset: nothing about the trust
+		// decision changes, the pin just gains the key an unpin needs to find
+		// the device's SPKI entry.
+		if prev, ok := cfg.DevicePinFor(hostname); ok && prev.Principal == "" && obs.principal != "" {
+			cfg.SetDevicePinFrom(hostname, prev.OrgID, prev.CloudGRPC, prev.AssetID, obs.principal, cfg.PinSource(hostname))
+			_ = config.Save(cfg)
+		}
 		return nil
 	case config.PinFirstUse, config.PinAdoptAsset:
 		// PinAdoptAsset is a pin written before asset ids were recorded: org and
 		// cloud already match, so this is a silent upgrade, not a challenge.
-		cfg.SetDevicePin(hostname, obs.orgID, cloud, obs.assetID)
+		cfg.SetDevicePin(hostname, obs.orgID, cloud, obs.assetID, obs.principal)
 		_ = config.Save(cfg)
 		return nil
 	default: // config.PinMismatch

--- a/go/internal/cli/commands/device_pin_test.go
+++ b/go/internal/cli/commands/device_pin_test.go
@@ -470,7 +470,7 @@ func TestPickerPinKeyMatchesDeviceFlagKey(t *testing.T) {
 	}
 
 	cfg := &config.Config{}
-	cfg.SetDevicePin(pinKeyForLANDevice(lan), 7, "grpc.a.sh:443", "42")
+	cfg.SetDevicePin(pinKeyForLANDevice(lan), 7, "grpc.a.sh:443", "42", "")
 	if _, ok := cfg.DevicePinFor(flagKey); !ok {
 		t.Fatalf("a pin recorded for the picked device (key %q) is invisible to --device %q (key %q): pins under %v",
 			pinKeyForLANDevice(lan), deviceFlag, flagKey, cfg.DevicePins)
@@ -694,7 +694,7 @@ func TestDefaultDeviceNameForPrefersPinKey(t *testing.T) {
 	// The consequence, stated directly: the pin the picker just wrote has to be
 	// visible to every later connect keyed on the saved default.
 	cfg := &config.Config{}
-	cfg.SetDevicePin(picked.PinKey, 7, "grpc.a.sh:443", "42")
+	cfg.SetDevicePin(picked.PinKey, 7, "grpc.a.sh:443", "42", "")
 	if _, ok := cfg.DevicePinFor(pinKeyForAddr(got)); !ok {
 		t.Fatalf("the pin recorded under %q is invisible to a default of %q: every later connect keys on a name no pin was filed under, and enforcement is off",
 			picked.PinKey, got)

--- a/go/internal/cli/commands/device_unpin.go
+++ b/go/internal/cli/commands/device_unpin.go
@@ -59,12 +59,13 @@ type clearedPin struct {
 // exactly when a pin most needs clearing.
 func newDeviceUnpinCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "unpin <hostname|identity-urn>",
+		Use:   "unpin <hostname|identity>",
 		Short: "Clear the recorded identity pin for a device",
 		Long: "Clear the recorded identity pin for a device, so the next connection to it\n" +
 			"records a fresh identity instead of being challenged against the old one.\n" +
-			"Accepts either the hostname you connect to or the identity URN a refusal\n" +
-			"prints (urn:wendy:org:<org>:asset:<id>).\n" +
+			"Accepts either the hostname you connect to or the identity a refusal\n" +
+			"prints (spiffe://wendy.sh/tenant/<uuid>/device/<id>, or the legacy\n" +
+			"urn:wendy:org:<org>:asset:<id>).\n" +
 			"Use this after a legitimate reflash, factory reset, or re-enrollment —\n" +
 			"anything that made 'wendy device unpin' the CLI's own suggestion.",
 		Args: cobra.ExactArgs(1),
@@ -77,9 +78,10 @@ func newDeviceUnpinCmd() *cobra.Command {
 			}
 
 			var cleared []clearedPin
-			// Detect the URN form by parsing it, not by guessing at its shape: a
-			// hostname is never six colon-separated fields beginning
-			// "urn:wendy:org", and certs owns what a well-formed identity is.
+			// Detect the identity form by parsing it, not by guessing at its
+			// shape: a hostname is never a spiffe:// URI nor six colon-separated
+			// fields beginning "urn:wendy:org", and certs owns what a well-formed
+			// identity is.
 			if identity, urnErr := certs.ParseIdentityURN(target); urnErr == nil {
 				cleared = clearPinsForIdentity(cfg, identity)
 			} else {
@@ -243,13 +245,21 @@ func clearPinsGoverning(cfg *config.Config, pinKey string) []clearedPin {
 // configPinIdentityKey is the SPKI store key a config pin names, or "" for a
 // legacy pin written before asset ids were recorded — which names an
 // organisation and a cloud, not a device, and so identifies no SPKI entry.
+//
+// A recorded principal wins: the SPKI store files a pki-core-issued device
+// under its tenant SPIFFE principal, and the (org, asset) pair cannot be turned
+// back into one without the tenant. That is the whole reason DevicePin carries
+// it.
 func configPinIdentityKey(pin config.DevicePin) string {
+	if pin.Principal != "" {
+		return pin.Principal
+	}
 	if pin.AssetID == "" {
 		return ""
 	}
 	return certs.WendyIdentity{
 		OrgID:      int32(pin.OrgID),
-		EntityType: "asset",
+		EntityType: certs.EntityAsset,
 		EntityID:   pin.AssetID,
 	}.IdentityKey()
 }
@@ -289,7 +299,7 @@ func cachedIdentityKey(pinKey string) string {
 	}
 	return certs.WendyIdentity{
 		OrgID:      entry.OrgID,
-		EntityType: "asset",
+		EntityType: certs.EntityAsset,
 		EntityID:   strconv.Itoa(int(entry.AssetID)),
 	}.IdentityKey()
 }

--- a/go/internal/cli/commands/dial_target.go
+++ b/go/internal/cli/commands/dial_target.go
@@ -148,9 +148,7 @@ func newDialTargetCandidates(pinKey string, addrs []string) dialTarget {
 		return target
 	}
 	target.PinnedKey = key
-	if pin.AssetID != "" {
-		target.Expected = &certs.WendyIdentity{OrgID: int32(pin.OrgID), EntityType: "asset", EntityID: pin.AssetID}
-	}
+	target.Expected = expectedIdentityForPin(pin)
 	return target
 }
 
@@ -193,10 +191,30 @@ func pinKeyForAddr(addr string) string {
 // device's names — hostname, mesh name, or display name — is honoured here.
 func expectedIdentityFor(pinKey string) *certs.WendyIdentity {
 	pin, _, ok := governingPin(pinKey)
-	if !ok || pin.AssetID == "" {
+	if !ok {
 		return nil
 	}
-	return &certs.WendyIdentity{OrgID: int32(pin.OrgID), EntityType: "asset", EntityID: pin.AssetID}
+	return expectedIdentityForPin(pin)
+}
+
+// expectedIdentityForPin turns a stored pin into the identity a handshake must
+// match, or nil when the pin names no device.
+//
+// A recorded tenant SPIFFE principal is preferred over the (org, asset) pair:
+// certs.WendyIdentity.SameEntity compares principals when both sides carry one,
+// and a pki-core-issued leaf carries no org at all, so comparing the pair alone
+// would compare an id against a blank org and refuse the very device the pin
+// was written from.
+func expectedIdentityForPin(pin config.DevicePin) *certs.WendyIdentity {
+	if pin.Principal != "" {
+		if id, err := certs.ParsePrincipal(pin.Principal); err == nil {
+			return &id
+		}
+	}
+	if pin.AssetID == "" {
+		return nil
+	}
+	return &certs.WendyIdentity{OrgID: int32(pin.OrgID), EntityType: certs.EntityAsset, EntityID: pin.AssetID}
 }
 
 // pinCandidateKeys returns the keys a pin for pinKey may have been recorded

--- a/go/internal/cli/grpcclient/resumption_integration_test.go
+++ b/go/internal/cli/grpcclient/resumption_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/agent/interceptor"
 	"github.com/wendylabsinc/wendy/go/internal/agent/mtls"
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 	"go.uber.org/zap"
@@ -46,7 +47,7 @@ func TestConnectWithTLSResumesAcrossConnections(t *testing.T) {
 
 	pki := newIntegrationPKI(t) // same generator as Task 7, PEM for client too
 	srv, err := mtls.NewServer(pki.serverCertPEM, pki.caPEM, pki.serverKeyPEM,
-		zap.NewNop(), time.Time{}, 0, interceptor.OrgModeOff)
+		zap.NewNop(), time.Time{}, certs.Scope{}, interceptor.OrgModeOff)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}

--- a/go/internal/shared/certs/certs.go
+++ b/go/internal/shared/certs/certs.go
@@ -40,16 +40,16 @@ func GenerateKeyPair() (privateKeyPEM string, err error) {
 //
 // identityURIs are placed in the CSR as URI Subject Alternative Names; empty
 // strings are skipped, so passing none (or only "") omits the SAN entirely
-// (e.g. test fixtures). Callers pass the canonical Wendy identity URN — build
-// it with UserURN ("urn:wendy:org:<org>:user:<userID>") for CLI/user
-// certificates and AssetURN ("urn:wendy:org:<org>:asset:<assetID>") for
-// device/agent certificates. This is the authoritative identity
-// IdentityFromCert prefers over the legacy CommonName.
+// (e.g. test fixtures).
 //
-// A second URI is added for grant-relayed issuance: the tenant SPIFFE
-// principal from AssetSPIFFEURI/UserSPIFFEURI, which cloud requires the CSR to
-// carry before it will sign a relay grant (WDY-2498). Both SANs travel
-// together — see AssetSPIFFEURI for why the urn cannot simply be replaced.
+// Callers pass the tenant SPIFFE principal — AssetSPIFFEURI/UserSPIFFEURI —
+// which cloud requires the CSR to carry before it will sign a relay grant
+// (WDY-2498) and which is the identity IdentityFromCert resolves first.
+//
+// A legacy urn:wendy URN (UserURN/AssetURN) still travels alongside it on the
+// cloud-relayed path, so a peer running an older agent — one that reads nothing
+// but the URN — can still identify the holder. It is inert on anything pki-core
+// renews, which strips it; nothing should be built to depend on it.
 //
 // Only URI SANs are ever emitted. Never add a dNSName here: "service-identity"
 // is the one pki-core profile that consults the tenant domain allow-list, and

--- a/go/internal/shared/certs/mldsa.go
+++ b/go/internal/shared/certs/mldsa.go
@@ -101,7 +101,7 @@ type BlockingPinError interface {
 // returned by BuildServerVerifyConnection.
 type ServerVerifyOpts struct {
 	ChainPEM      string     // required: PEM-encoded CA chain for ML-DSA-aware chain verification
-	ExpectedOrgID int32      // 0 = accept any org (still extracted for pinning key)
+	ExpectedOrgID int32      // 0 = accept any org (still extracted for pinning key); never compared against a pki-core leaf, which carries no org
 	PinStore      PinChecker // nil = skip pinning
 	// ExpectedIdentity, when non-nil, requires the server leaf to carry an
 	// "asset" Wendy identity whose org and entity id match it exactly. This is
@@ -289,7 +289,14 @@ func BuildServerVerifyConnection(opts ServerVerifyOpts) (func(tls.ConnectionStat
 		// belongs to a different org. A cert with no Wendy identity (e.g. a legacy
 		// device not yet re-provisioned) is accepted, mirroring the server-side
 		// OrgModeGrace behaviour in interceptor/mtls.go.
-		if hasIdentity && opts.ExpectedOrgID != 0 && identity.OrgID != opts.ExpectedOrgID {
+		// identity.OrgID == 0 is a pki-core-issued leaf: it carries a tenant
+		// SPIFFE principal and no urn:wendy org, so there is no org to compare
+		// against this session's. Refusing it here would break every renewed or
+		// ACME-enrolled device against a session that knows only an int org, and
+		// asserting a match would be a claim neither side can support. The
+		// tenant-scoped checks that DO apply to such a leaf are Step 2b's
+		// principal pin below and the agent-side interceptor.
+		if hasIdentity && opts.ExpectedOrgID != 0 && identity.OrgID != 0 && identity.OrgID != opts.ExpectedOrgID {
 			return &OrgMismatchError{Want: opts.ExpectedOrgID, Got: identity.OrgID}
 		}
 
@@ -297,14 +304,18 @@ func BuildServerVerifyConnection(opts ServerVerifyOpts) (func(tls.ConnectionStat
 		// so a cross-org impostor still reports OrgMismatchError, whose remedy
 		// (fetch that org's cert) differs from this one's (wrong device).
 		if opts.ExpectedIdentity != nil {
-			if !hasIdentity || identity.EntityType != "asset" {
+			if !hasIdentity || identity.EntityType != EntityAsset {
 				return &IdentityMismatchError{
 					WantOrg:   opts.ExpectedIdentity.OrgID,
 					WantAsset: opts.ExpectedIdentity.EntityID,
 					GotOrg:    identity.OrgID,
 				}
 			}
-			if identity.OrgID != opts.ExpectedIdentity.OrgID || identity.EntityID != opts.ExpectedIdentity.EntityID {
+			// SameEntity compares principals when both sides have one and falls
+			// back to the legacy scope+id triple otherwise, so a pin recorded
+			// before the SPIFFE cutover and one recorded after each compare in
+			// their own terms rather than across them.
+			if !identity.SameEntity(*opts.ExpectedIdentity) {
 				return &IdentityMismatchError{
 					WantOrg:   opts.ExpectedIdentity.OrgID,
 					WantAsset: opts.ExpectedIdentity.EntityID,
@@ -319,7 +330,7 @@ func BuildServerVerifyConnection(opts ServerVerifyOpts) (func(tls.ConnectionStat
 		// what it just verified has failed at bookkeeping, and dropping an
 		// otherwise fully verified connection over that would turn a read-only
 		// config directory into a total loss of device access.
-		if opts.PinStore != nil && hasIdentity && identity.EntityType == "asset" {
+		if opts.PinStore != nil && hasIdentity && identity.EntityType == EntityAsset {
 			displayName := leaf.Subject.CommonName
 			if displayName == "" {
 				displayName = identity.IdentityKey()

--- a/go/internal/shared/certs/orgident.go
+++ b/go/internal/shared/certs/orgident.go
@@ -6,59 +6,187 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/google/uuid"
 )
 
 const wendyOrgURNPrefix = "urn:wendy:org:"
 
-// WendyIdentity holds the Wendy org and entity identity extracted from a certificate.
-type WendyIdentity struct {
+// tenantSPIFFEPrefix is the trust domain and tenant path pki-core mints every
+// current-chain leaf under: "spiffe://wendy.sh/tenant/<uuid>/<kind>/<name>".
+const tenantSPIFFEPrefix = "spiffe://wendy.sh/tenant/"
+
+// Principal kinds pki-core mints under a tenant, per the AAA contract §4.2/D17:
+// operator (a human), service (a service account — a machine user privileged
+// exactly as a human), device (a device leaf), signer (code signing, not an
+// actor). Cloud additionally spells its relayed leaves "service/user-<id>" and
+// "service/asset-<id>", which parse into the same user/asset entity types the
+// legacy URN produced.
+const (
+	kindOperator = "operator"
+	kindService  = "service"
+	kindDevice   = "device"
+	kindSigner   = "signer"
+)
+
+// EntityType values a WendyIdentity can carry. "signer" exists so a code-signing
+// leaf parses into something nameable and is then refused by the actor gates,
+// rather than being mistaken for an operator.
+const (
+	EntityUser   = "user"
+	EntityAsset  = "asset"
+	EntitySigner = "signer"
+)
+
+// Scope is the tenant an identity belongs to.
+//
+// pki-core is the identity authority and scopes everything it mints by tenant
+// UUID; the int32 org survives only on old-chain certificates that predate
+// tenant SPIFFE SANs. Both are carried because a transitional leaf presents
+// both SANs, and a comparison is only meaningful between two scopes expressed
+// in the same terms.
+type Scope struct {
+	TenantUUID string
 	OrgID      int32
-	EntityType string // "user" or "asset"
-	EntityID   string // numeric ID as string
 }
 
-// IdentityKey returns the canonical URN string used as a pin-store key.
+// Known reports whether this scope names anything at all.
+func (s Scope) Known() bool { return s.TenantUUID != "" || s.OrgID > 0 }
+
+// Matches reports whether two scopes provably name the same tenant.
+//
+// Tenant UUIDs are compared when both sides have one; otherwise the legacy org
+// is compared when both sides have one. A scope pair with no shared vocabulary
+// — a SPIFFE-only peer against an org-only expectation — is NOT a match: there
+// is no mapping between a tenant UUID and an int32 org, and answering "equal"
+// on an unprovable pair is exactly the silent disarming this replaces.
+func (s Scope) Matches(o Scope) bool {
+	if s.TenantUUID != "" && o.TenantUUID != "" {
+		return s.TenantUUID == o.TenantUUID
+	}
+	if s.OrgID > 0 && o.OrgID > 0 {
+		return s.OrgID == o.OrgID
+	}
+	return false
+}
+
+// Comparable reports whether two scopes are expressed in a shared vocabulary.
+//
+// It is what separates "a different tenant" from "no way to tell": Matches
+// returns false for both, but only the first is a cross-tenant attempt. A
+// caller that offers a migration grace period needs to forgive the second
+// without forgiving the first.
+func (s Scope) Comparable(o Scope) bool {
+	return (s.TenantUUID != "" && o.TenantUUID != "") || (s.OrgID > 0 && o.OrgID > 0)
+}
+
+// String renders a scope for logs. Neither half is PII.
+func (s Scope) String() string {
+	switch {
+	case s.TenantUUID != "" && s.OrgID > 0:
+		return fmt.Sprintf("tenant %s (org %d)", s.TenantUUID, s.OrgID)
+	case s.TenantUUID != "":
+		return "tenant " + s.TenantUUID
+	case s.OrgID > 0:
+		return fmt.Sprintf("org %d", s.OrgID)
+	default:
+		return "no scope"
+	}
+}
+
+// WendyIdentity holds the identity extracted from a certificate.
+//
+// Principal/TenantUUID are the authoritative pair — the tenant SPIFFE SAN
+// pki-core stamps on every leaf it issues or renews. OrgID/EntityType/EntityID
+// are the legacy urn:wendy reading, present only on old chains and on the
+// transitional leaves cloud mints carrying both SANs.
+type WendyIdentity struct {
+	OrgID      int32
+	EntityType string // "user", "asset" or "signer"
+	EntityID   string // user/asset id, or the device id for a device principal
+	TenantUUID string // pki-core tenant; "" on an old-chain certificate
+	Principal  string // full spiffe:// URI; "" on an old-chain certificate
+}
+
+// Scope returns the tenant this identity belongs to.
+func (w WendyIdentity) Scope() Scope {
+	return Scope{TenantUUID: w.TenantUUID, OrgID: w.OrgID}
+}
+
+// IdentityKey returns the canonical string used as a pin-store key: the SPIFFE
+// principal when the certificate carries one, and the legacy URN otherwise.
+//
+// The principal is the durable choice — pki-core carries it across every
+// renewal by construction, whereas the URN is dropped by any renewal — so a pin
+// filed under it survives the certificate lifecycle the URN does not.
 func (w WendyIdentity) IdentityKey() string {
+	if w.Principal != "" {
+		return w.Principal
+	}
+	return w.LegacyURN()
+}
+
+// LegacyURN returns the urn:wendy identity URN this identity would have carried
+// on an old chain, or "" when it has no legacy org reading. It is what a pin
+// written before the SPIFFE cutover is filed under.
+func (w WendyIdentity) LegacyURN() string {
+	if w.OrgID <= 0 || w.EntityType == "" || w.EntityID == "" {
+		return ""
+	}
 	return fmt.Sprintf("urn:wendy:org:%d:%s:%s", w.OrgID, w.EntityType, w.EntityID)
 }
 
-// UserURN returns the canonical Wendy identity URN for a user:
-// "urn:wendy:org:<org>:user:<userID>". This is the URI SAN a user (CLI)
-// certificate carries as its authoritative identity.
+// SameEntity reports whether two identities provably name the same principal.
+//
+// Principals are compared when both sides have one; otherwise the legacy
+// scope+type+id triple must match. As with Scope.Matches, a pair with no shared
+// vocabulary is not a match.
+func (w WendyIdentity) SameEntity(o WendyIdentity) bool {
+	if w.Principal != "" && o.Principal != "" {
+		return w.Principal == o.Principal
+	}
+	if w.EntityType != o.EntityType || w.EntityID == "" || w.EntityID != o.EntityID {
+		return false
+	}
+	return w.Scope().Matches(o.Scope())
+}
+
+// UserURN returns the legacy Wendy identity URN for a user:
+// "urn:wendy:org:<org>:user:<userID>".
 func UserURN(orgID int32, userID string) string {
-	return WendyIdentity{OrgID: orgID, EntityType: "user", EntityID: userID}.IdentityKey()
+	return WendyIdentity{OrgID: orgID, EntityType: EntityUser, EntityID: userID}.LegacyURN()
 }
 
-// AssetURN returns the canonical Wendy identity URN for an asset:
-// "urn:wendy:org:<org>:asset:<assetID>". This is the URI SAN a device (agent)
-// certificate carries as its authoritative identity.
+// AssetURN returns the legacy Wendy identity URN for an asset:
+// "urn:wendy:org:<org>:asset:<assetID>".
 func AssetURN(orgID, assetID int32) string {
-	return WendyIdentity{OrgID: orgID, EntityType: "asset", EntityID: strconv.Itoa(int(assetID))}.IdentityKey()
+	return WendyIdentity{OrgID: orgID, EntityType: EntityAsset, EntityID: strconv.Itoa(int(assetID))}.LegacyURN()
 }
 
-// tenantSPIFFEPrefix is the trust domain and tenant path Wendy Cloud mints
-// under. Cloud relays every client leaf through pki-core's "service-identity"
-// profile, so the principal kind is always "service" — never "device", which
-// pki-core would refuse for a profile-kind mismatch.
-const tenantSPIFFEPrefix = "spiffe://wendy.sh/tenant/"
-
-// AssetSPIFFEURI returns the canonical tenant SPIFFE principal for a device:
+// AssetSPIFFEURI returns the tenant SPIFFE principal cloud mints for a device
+// it relays through the service-identity profile:
 // "spiffe://wendy.sh/tenant/<tenantUUID>/service/asset-<assetID>".
 //
 // Cloud refuses to sign a grant unless the CSR carries exactly this URI SAN
-// (WDY-2498/WDY-2584), and pki-core then binds the grant principal to it. It is
-// carried *alongside* the urn:wendy AssetURN, not instead of it: the urn is what
-// the agent's own org gate reads out of a peer certificate, so dropping it would
-// silently disarm org-equality enforcement.
+// (WDY-2498/WDY-2584). A device enrolled directly against pki-core over
+// ACME/EST gets "device/<deviceID>" instead; both parse to an asset entity.
 func AssetSPIFFEURI(tenantUUID string, assetID int32) string {
 	return tenantSPIFFEPrefix + tenantUUID + "/service/asset-" + strconv.Itoa(int(assetID))
 }
 
-// UserSPIFFEURI returns the canonical tenant SPIFFE principal for an operator:
-// "spiffe://wendy.sh/tenant/<tenantUUID>/service/user-<userID>". See
-// AssetSPIFFEURI for why the kind is "service" and why it does not replace UserURN.
+// UserSPIFFEURI returns the tenant SPIFFE principal cloud mints for a user:
+// "spiffe://wendy.sh/tenant/<tenantUUID>/service/user-<userID>". A cert issued
+// by pki-core's own operator identity endpoint carries "operator/<sub>"; both
+// parse to a user entity.
 func UserSPIFFEURI(tenantUUID, userID string) string {
 	return tenantSPIFFEPrefix + tenantUUID + "/service/user-" + userID
+}
+
+// DeviceSPIFFEURI returns the tenant SPIFFE principal pki-core stamps on a leaf
+// enrolled over ACME or EST: "spiffe://wendy.sh/tenant/<tenantUUID>/device/<deviceID>".
+// The device id is path-shaped and may carry slashes.
+func DeviceSPIFFEURI(tenantUUID, deviceID string) string {
+	return tenantSPIFFEPrefix + tenantUUID + "/" + kindDevice + "/" + deviceID
 }
 
 // TenantPrincipalFromCert returns the tenant SPIFFE principal a leaf carries,
@@ -83,44 +211,140 @@ func TenantPrincipalFromCert(leaf *x509.Certificate) (string, bool) {
 	return found, found != ""
 }
 
-// ParseIdentityURN parses a canonical Wendy identity URN —
-// "urn:wendy:org:<org>:(user|asset):<id>", the exact string IdentityKey
-// produces — back into a WendyIdentity.
+// ParsePrincipal parses a tenant SPIFFE principal —
+// "spiffe://wendy.sh/tenant/<uuid>/<kind>/<name>" — into a WendyIdentity.
 //
-// It exists because that URN is user-facing: it is the key the device pin store
-// is filed under and the key an SPKI refusal prints, so `wendy device unpin`
-// has to accept it as an argument. Parsing goes through the same
-// parseWendyOrgURN the certificate path uses, so what the CLI accepts from a
-// user and what it reads out of a certificate can never drift apart — a second
-// hand-rolled parser here would be a second definition of what a Wendy identity
-// is.
-func ParseIdentityURN(urn string) (WendyIdentity, error) {
-	return parseWendyOrgURN(strings.TrimSpace(urn))
+// Every kind pki-core mints is accepted, because the parser is the one place
+// that decides what a Wendy identity is and a kind it refuses is an actor no
+// gate can see. The name of a device principal is path-shaped and keeps its
+// slashes; cloud's "service/user-<id>" and "service/asset-<id>" spellings are
+// unwrapped to the user/asset entity types the rest of the code compares on.
+func ParsePrincipal(principal string) (WendyIdentity, error) {
+	rest, ok := strings.CutPrefix(principal, tenantSPIFFEPrefix)
+	if !ok {
+		return WendyIdentity{}, fmt.Errorf("not a wendy tenant SPIFFE principal: %s", principal)
+	}
+	tenant, kindAndName, ok := strings.Cut(rest, "/")
+	if !ok {
+		return WendyIdentity{}, fmt.Errorf("SPIFFE principal has no kind: %s", principal)
+	}
+	// pki-core routes by the tenant UUID and compares it canonically, so a
+	// non-canonical spelling of the same tenant is a different string to every
+	// downstream comparison. Reject it here rather than let two spellings of one
+	// tenant fail to match each other.
+	if parsed, err := uuid.Parse(tenant); err != nil || parsed.String() != tenant {
+		return WendyIdentity{}, fmt.Errorf("SPIFFE principal has non-canonical tenant UUID: %s", principal)
+	}
+	kind, name, ok := strings.Cut(kindAndName, "/")
+	if !ok || name == "" {
+		return WendyIdentity{}, fmt.Errorf("SPIFFE principal has no name: %s", principal)
+	}
+
+	id := WendyIdentity{TenantUUID: tenant, Principal: principal, EntityID: name}
+	switch kind {
+	case kindOperator:
+		id.EntityType = EntityUser
+	case kindDevice:
+		id.EntityType = EntityAsset
+	case kindSigner:
+		id.EntityType = EntitySigner
+	case kindService:
+		// A service account is a machine user (AAA contract D17). Cloud encodes
+		// the entity it relayed in the name; anything else is a plain service
+		// account and reads as a user.
+		switch {
+		case strings.HasPrefix(name, "asset-"):
+			id.EntityType, id.EntityID = EntityAsset, strings.TrimPrefix(name, "asset-")
+		case strings.HasPrefix(name, "user-"):
+			id.EntityType, id.EntityID = EntityUser, strings.TrimPrefix(name, "user-")
+		default:
+			id.EntityType = EntityUser
+		}
+		if id.EntityID == "" {
+			return WendyIdentity{}, fmt.Errorf("SPIFFE principal has empty entity id: %s", principal)
+		}
+	default:
+		return WendyIdentity{}, fmt.Errorf("unknown SPIFFE principal kind %q: %s", kind, principal)
+	}
+	return id, nil
 }
 
-// IdentityFromCert extracts the Wendy org+entity identity from a certificate.
+// ParseIdentityURN parses either identity string a refusal can print — a tenant
+// SPIFFE principal or a legacy "urn:wendy:org:<org>:(user|asset):<id>" URN —
+// back into a WendyIdentity.
 //
-// Resolution order:
-//  1. SAN URI beginning with "urn:wendy:org:" (authoritative; exactly one allowed)
-//  2. CommonName "sh/wendy/<org>/<asset>" (legacy fallback)
-//  3. No identity: returns (zero, false, nil)
+// It exists because those strings are user-facing: one of them is the key the
+// device pin store is filed under and the key an SPKI refusal prints, so
+// `wendy device unpin` has to accept it as an argument. Both forms go through
+// the same parsers the certificate path uses, so what the CLI accepts from a
+// user and what it reads out of a certificate can never drift apart.
+func ParseIdentityURN(urn string) (WendyIdentity, error) {
+	s := strings.TrimSpace(urn)
+	if strings.HasPrefix(s, tenantSPIFFEPrefix) {
+		return ParsePrincipal(s)
+	}
+	return parseWendyOrgURN(s)
+}
+
+// IdentityFromCert extracts the Wendy identity from a certificate.
+//
+// Resolution order, SPIFFE first:
+//
+//  1. The tenant SPIFFE SAN "spiffe://wendy.sh/tenant/<uuid>/<kind>/<name>" —
+//     authoritative, exactly one allowed. This is what pki-core stamps on
+//     everything it issues and re-stamps on everything it renews.
+//  2. SAN URI "urn:wendy:org:<org>:..." — legacy old-chain reading, exactly one
+//     allowed. When a leaf carries both (the transitional shape cloud mints),
+//     the URN contributes only its org, so an old-chain peer comparing orgs
+//     still matches; the principal decides who the caller is.
+//  3. CommonName "sh/wendy/<org>/<asset>" — legacy old-chain fallback.
+//  4. No identity: returns (zero, false, nil).
 func IdentityFromCert(leaf *x509.Certificate) (WendyIdentity, bool, error) {
-	var wendyURNs []string
+	var principals, wendyURNs []string
 	for _, u := range leaf.URIs {
-		raw := u.String()
-		if strings.HasPrefix(raw, wendyOrgURNPrefix) {
+		switch raw := u.String(); {
+		case strings.HasPrefix(raw, tenantSPIFFEPrefix):
+			principals = append(principals, raw)
+		case strings.HasPrefix(raw, wendyOrgURNPrefix):
 			wendyURNs = append(wendyURNs, raw)
 		}
+	}
+	if len(principals) > 1 {
+		return WendyIdentity{}, false, fmt.Errorf("certificate contains %d tenant SPIFFE principals; expected at most one", len(principals))
 	}
 	if len(wendyURNs) > 1 {
 		return WendyIdentity{}, false, fmt.Errorf("certificate contains %d wendy org URNs; expected at most one", len(wendyURNs))
 	}
+
+	var legacy WendyIdentity
 	if len(wendyURNs) == 1 {
-		id, err := parseWendyOrgURN(wendyURNs[0])
+		parsed, err := parseWendyOrgURN(wendyURNs[0])
 		if err != nil {
 			return WendyIdentity{}, false, err
 		}
+		legacy = parsed
+	}
+
+	if len(principals) == 1 {
+		id, err := ParsePrincipal(principals[0])
+		if err != nil {
+			return WendyIdentity{}, false, err
+		}
+		// The legacy URN survives only as the org it names, so a peer that can
+		// still only compare orgs keeps working against this leaf — but only
+		// when the two SANs agree about which entity this is. A leaf whose URN
+		// names a different entity than its principal is misissued; the
+		// principal is authoritative, so the contradictory legacy claim
+		// contributes nothing rather than lending its org to an entity it does
+		// not describe.
+		if legacy.EntityType == "" || (legacy.EntityType == id.EntityType && legacy.EntityID == id.EntityID) {
+			id.OrgID = legacy.OrgID
+		}
 		return id, true, nil
+	}
+
+	if legacy.EntityType != "" {
+		return legacy, true, nil
 	}
 
 	cn := leaf.Subject.CommonName
@@ -135,11 +359,14 @@ func IdentityFromCert(leaf *x509.Certificate) (WendyIdentity, bool, error) {
 	return WendyIdentity{}, false, nil
 }
 
-// OrgFromClientCert extracts the org ID from a certificate. It is a wrapper
-// around IdentityFromCert that drops entity type and ID.
-func OrgFromClientCert(leaf *x509.Certificate) (orgID int32, hasOrg bool, err error) {
+// ScopeFromCert extracts the tenant scope a certificate belongs to. It is a
+// wrapper around IdentityFromCert that drops the entity.
+func ScopeFromCert(leaf *x509.Certificate) (scope Scope, known bool, err error) {
 	id, ok, err := IdentityFromCert(leaf)
-	return id.OrgID, ok, err
+	if err != nil || !ok {
+		return Scope{}, false, err
+	}
+	return id.Scope(), id.Scope().Known(), nil
 }
 
 // parseWendyOrgURN parses "urn:wendy:org:<org>:(user|asset):<id>" into a WendyIdentity.
@@ -159,7 +386,7 @@ func parseWendyOrgURN(uri string) (WendyIdentity, error) {
 		return WendyIdentity{}, fmt.Errorf("organization ID must be positive, got %d", orgID)
 	}
 	entityType := parts[4]
-	if entityType != "user" && entityType != "asset" {
+	if entityType != EntityUser && entityType != EntityAsset {
 		return WendyIdentity{}, fmt.Errorf("unknown entity type in wendy URN %q: %s", uri, entityType)
 	}
 	if parts[5] == "" {
@@ -185,5 +412,26 @@ func parseShWendyCN(cn string) (WendyIdentity, error) {
 	if parts[3] == "" {
 		return WendyIdentity{}, fmt.Errorf("empty asset ID in CommonName: %s", cn)
 	}
-	return WendyIdentity{OrgID: int32(orgID), EntityType: "asset", EntityID: parts[3]}, nil
+	return WendyIdentity{OrgID: int32(orgID), EntityType: EntityAsset, EntityID: parts[3]}, nil
+}
+
+// ScopeFromCertPEM parses a PEM-encoded leaf (ML-DSA aware, via
+// ParseCertsFromPEM) and returns the tenant scope it belongs to, or
+// (zero, false) when the PEM is unparseable or carries no identity.
+//
+// It is how a device answers "which tenant am I?" about its own certificate,
+// which is the value every peer's scope is compared against.
+func ScopeFromCertPEM(certPEM string) (Scope, bool) {
+	if certPEM == "" {
+		return Scope{}, false
+	}
+	parsed, err := ParseCertsFromPEM([]byte(certPEM))
+	if err != nil || len(parsed) == 0 {
+		return Scope{}, false
+	}
+	scope, known, err := ScopeFromCert(parsed[0])
+	if err != nil {
+		return Scope{}, false
+	}
+	return scope, known
 }

--- a/go/internal/shared/certs/orgident_test.go
+++ b/go/internal/shared/certs/orgident_test.go
@@ -17,7 +17,7 @@ func mustParseURL(t *testing.T, raw string) *url.URL {
 	return u
 }
 
-func TestOrgFromClientCert(t *testing.T) {
+func TestScopeFromCert(t *testing.T) {
 	tests := []struct {
 		name       string
 		cn         string
@@ -154,22 +154,22 @@ func TestOrgFromClientCert(t *testing.T) {
 				cert.URIs = append(cert.URIs, mustParseURL(t, raw))
 			}
 
-			org, hasOrg, err := OrgFromClientCert(cert)
+			scope, hasOrg, err := ScopeFromCert(cert)
 
 			if tc.wantErr {
 				if err == nil {
-					t.Errorf("OrgFromClientCert() error = nil, want non-nil")
+					t.Errorf("ScopeFromCert() error = nil, want non-nil")
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("OrgFromClientCert() unexpected error: %v", err)
+				t.Fatalf("ScopeFromCert() unexpected error: %v", err)
 			}
-			if org != tc.wantOrg {
-				t.Errorf("OrgFromClientCert() orgID = %d, want %d", org, tc.wantOrg)
+			if scope.OrgID != tc.wantOrg {
+				t.Errorf("ScopeFromCert() orgID = %d, want %d", scope.OrgID, tc.wantOrg)
 			}
 			if hasOrg != tc.wantHasOrg {
-				t.Errorf("OrgFromClientCert() hasOrg = %v, want %v", hasOrg, tc.wantHasOrg)
+				t.Errorf("ScopeFromCert() known = %v, want %v", hasOrg, tc.wantHasOrg)
 			}
 		})
 	}
@@ -248,7 +248,7 @@ func TestIdentityFromCert(t *testing.T) {
 	}
 }
 
-func TestOrgFromClientCert_StillWorks(t *testing.T) {
+func TestScopeFromCert_LegacyURN(t *testing.T) {
 	mustParseURI := func(raw string) *url.URL {
 		u, err := url.Parse(raw)
 		if err != nil {
@@ -259,8 +259,8 @@ func TestOrgFromClientCert_StillWorks(t *testing.T) {
 	cert := &x509.Certificate{
 		URIs: []*url.URL{mustParseURI("urn:wendy:org:7:asset:42")},
 	}
-	orgID, ok, err := OrgFromClientCert(cert)
-	if err != nil || !ok || orgID != 7 {
-		t.Errorf("OrgFromClientCert() = %d, %v, %v; want 7, true, nil", orgID, ok, err)
+	scope, ok, err := ScopeFromCert(cert)
+	if err != nil || !ok || scope != (Scope{OrgID: 7}) {
+		t.Errorf("ScopeFromCert() = %+v, %v, %v; want {OrgID:7}, true, nil", scope, ok, err)
 	}
 }

--- a/go/internal/shared/certs/spiffeident_test.go
+++ b/go/internal/shared/certs/spiffeident_test.go
@@ -1,0 +1,217 @@
+package certs
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"net/url"
+	"testing"
+)
+
+const testTenant = "6f1b7d3c-6b7e-4a2f-9c1e-2b4a8d5e0f31"
+
+func leafWithURIs(t *testing.T, cn string, uris ...string) *x509.Certificate {
+	t.Helper()
+	leaf := &x509.Certificate{Subject: pkix.Name{CommonName: cn}}
+	for _, raw := range uris {
+		u, err := url.Parse(raw)
+		if err != nil {
+			t.Fatalf("parsing test URI %q: %v", raw, err)
+		}
+		leaf.URIs = append(leaf.URIs, u)
+	}
+	return leaf
+}
+
+// TestParsePrincipal pins every principal kind pki-core mints. A kind the
+// parser refuses is an actor no gate can see, so the list is the contract.
+func TestParsePrincipal(t *testing.T) {
+	base := "spiffe://wendy.sh/tenant/" + testTenant
+	for _, tc := range []struct {
+		principal  string
+		entityType string
+		entityID   string
+	}{
+		{base + "/operator/auth0|abc", EntityUser, "auth0|abc"},
+		{base + "/service/user-5", EntityUser, "5"},
+		{base + "/service/asset-42", EntityAsset, "42"},
+		{base + "/service/ci-runner", EntityUser, "ci-runner"},
+		{base + "/device/box-01", EntityAsset, "box-01"},
+		{base + "/device/fleet-a/box-01", EntityAsset, "fleet-a/box-01"},
+		{base + "/signer/release", EntitySigner, "release"},
+	} {
+		got, err := ParsePrincipal(tc.principal)
+		if err != nil {
+			t.Fatalf("ParsePrincipal(%q): %v", tc.principal, err)
+		}
+		if got.EntityType != tc.entityType || got.EntityID != tc.entityID {
+			t.Errorf("ParsePrincipal(%q) = %s/%s, want %s/%s",
+				tc.principal, got.EntityType, got.EntityID, tc.entityType, tc.entityID)
+		}
+		if got.TenantUUID != testTenant {
+			t.Errorf("ParsePrincipal(%q) tenant = %q, want %q", tc.principal, got.TenantUUID, testTenant)
+		}
+		if got.Principal != tc.principal {
+			t.Errorf("ParsePrincipal(%q) did not round-trip the principal: %q", tc.principal, got.Principal)
+		}
+		if got.OrgID != 0 {
+			t.Errorf("ParsePrincipal(%q) invented org %d", tc.principal, got.OrgID)
+		}
+	}
+}
+
+func TestParsePrincipalRejects(t *testing.T) {
+	base := "spiffe://wendy.sh/tenant/" + testTenant
+	for _, principal := range []string{
+		"spiffe://wendy.sh/tenant/not-a-uuid/operator/x",
+		// Non-canonical (upper-case) UUID: pki-core routes by a canonical
+		// tenant, so two spellings of one tenant must not both parse or they
+		// would fail to match each other downstream.
+		"spiffe://wendy.sh/tenant/6F1B7D3C-6B7E-4A2F-9C1E-2B4A8D5E0F31/operator/x",
+		base + "/operator/",
+		base + "/wizard/x",
+		base + "/service/user-",
+		base,
+		"spiffe://other.example/tenant/" + testTenant + "/operator/x",
+		"urn:wendy:org:7:user:5",
+		"",
+	} {
+		if id, err := ParsePrincipal(principal); err == nil {
+			t.Errorf("ParsePrincipal(%q) accepted, got %+v", principal, id)
+		}
+	}
+}
+
+// TestIdentityFromCertPrefersPrincipal is the WDY-2968 core: a pki-core-renewed
+// leaf carries no urn:wendy SAN, and it must still be a recognised identity.
+func TestIdentityFromCertPrefersPrincipal(t *testing.T) {
+	principal := "spiffe://wendy.sh/tenant/" + testTenant + "/device/box-01"
+
+	// SPIFFE only — what every pki-core renewal and ACME enrollment produces.
+	id, ok, err := IdentityFromCert(leafWithURIs(t, "", principal))
+	if err != nil || !ok {
+		t.Fatalf("SPIFFE-only leaf: ok=%v err=%v, want a recognised identity", ok, err)
+	}
+	if id.EntityType != EntityAsset || id.EntityID != "box-01" || id.OrgID != 0 {
+		t.Errorf("SPIFFE-only leaf = %+v", id)
+	}
+	if id.IdentityKey() != principal {
+		t.Errorf("IdentityKey() = %q, want the principal", id.IdentityKey())
+	}
+	if !id.Scope().Known() {
+		t.Error("a leaf with a tenant principal must have a known scope; an unknown one disarms enforcement fleet-wide")
+	}
+
+	// Transitional leaf: both SANs, agreeing. The principal decides the entity,
+	// the URN lends its org so an old-chain peer can still compare.
+	both := leafWithURIs(t, "",
+		"spiffe://wendy.sh/tenant/"+testTenant+"/service/asset-42",
+		"urn:wendy:org:7:asset:42")
+	id, ok, err = IdentityFromCert(both)
+	if err != nil || !ok {
+		t.Fatalf("transitional leaf: ok=%v err=%v", ok, err)
+	}
+	if id.TenantUUID != testTenant || id.OrgID != 7 || id.EntityID != "42" {
+		t.Errorf("transitional leaf = %+v", id)
+	}
+	if id.LegacyURN() != "urn:wendy:org:7:asset:42" {
+		t.Errorf("LegacyURN() = %q", id.LegacyURN())
+	}
+
+	// Contradictory SANs: the principal is authoritative and the legacy claim
+	// contributes nothing, rather than lending its org to another entity.
+	conflict := leafWithURIs(t, "",
+		"spiffe://wendy.sh/tenant/"+testTenant+"/service/asset-42",
+		"urn:wendy:org:7:asset:99")
+	id, ok, err = IdentityFromCert(conflict)
+	if err != nil || !ok {
+		t.Fatalf("conflicting leaf: ok=%v err=%v", ok, err)
+	}
+	if id.EntityID != "42" || id.OrgID != 0 {
+		t.Errorf("conflicting leaf = %+v, want entity 42 and no inherited org", id)
+	}
+
+	// Two principals is refused for the same reason pki-core refuses it.
+	if _, _, err := IdentityFromCert(leafWithURIs(t, "",
+		"spiffe://wendy.sh/tenant/"+testTenant+"/device/a",
+		"spiffe://wendy.sh/tenant/"+testTenant+"/device/b")); err == nil {
+		t.Error("two tenant principals accepted; want an error")
+	}
+}
+
+func TestScopeMatching(t *testing.T) {
+	tenantA := Scope{TenantUUID: testTenant}
+	tenantB := Scope{TenantUUID: "00000000-0000-4000-8000-000000000000"}
+	org7 := Scope{OrgID: 7}
+	org9 := Scope{OrgID: 9}
+	both := Scope{TenantUUID: testTenant, OrgID: 7}
+
+	for _, tc := range []struct {
+		name              string
+		a, b              Scope
+		match, comparable bool
+	}{
+		{"same tenant", tenantA, tenantA, true, true},
+		{"different tenant", tenantA, tenantB, false, true},
+		{"same org", org7, org7, true, true},
+		{"different org", org7, org9, false, true},
+		{"tenant wins when both carry one", both, tenantA, true, true},
+		// The transition state: unprovable, deliberately not a match, and
+		// distinguishable from "different tenant" so grace can forgive it.
+		{"no shared vocabulary", tenantA, org7, false, false},
+		{"nothing known", Scope{}, org7, false, false},
+	} {
+		if got := tc.a.Matches(tc.b); got != tc.match {
+			t.Errorf("%s: Matches = %v, want %v", tc.name, got, tc.match)
+		}
+		if got := tc.a.Comparable(tc.b); got != tc.comparable {
+			t.Errorf("%s: Comparable = %v, want %v", tc.name, got, tc.comparable)
+		}
+	}
+
+	if (Scope{}).Known() {
+		t.Error("an empty scope must not read as known")
+	}
+}
+
+func TestSameEntity(t *testing.T) {
+	principal := "spiffe://wendy.sh/tenant/" + testTenant + "/device/box-01"
+	spiffe, err := ParsePrincipal(principal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	other, err := ParsePrincipal("spiffe://wendy.sh/tenant/" + testTenant + "/device/box-02")
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy := WendyIdentity{OrgID: 7, EntityType: EntityAsset, EntityID: "42"}
+
+	if !spiffe.SameEntity(spiffe) {
+		t.Error("a principal must match itself")
+	}
+	if spiffe.SameEntity(other) {
+		t.Error("different device principals must not match")
+	}
+	if !legacy.SameEntity(legacy) {
+		t.Error("a legacy identity must match itself")
+	}
+	if legacy.SameEntity(WendyIdentity{OrgID: 9, EntityType: EntityAsset, EntityID: "42"}) {
+		t.Error("same asset id in another org must not match")
+	}
+	// No shared vocabulary: a pin written before the cutover cannot vouch for a
+	// principal, and saying otherwise is what a substituted device would need.
+	if spiffe.SameEntity(legacy) {
+		t.Error("a principal must not match a legacy identity")
+	}
+}
+
+func TestParseIdentityURNAcceptsBothForms(t *testing.T) {
+	principal := "spiffe://wendy.sh/tenant/" + testTenant + "/device/box-01"
+	id, err := ParseIdentityURN("  " + principal + "  ")
+	if err != nil || id.Principal != principal {
+		t.Fatalf("ParseIdentityURN(principal) = %+v, %v", id, err)
+	}
+	id, err = ParseIdentityURN("urn:wendy:org:7:asset:42")
+	if err != nil || id.OrgID != 7 || id.EntityID != "42" {
+		t.Fatalf("ParseIdentityURN(urn) = %+v, %v", id, err)
+	}
+}

--- a/go/internal/shared/config/devicepin.go
+++ b/go/internal/shared/config/devicepin.go
@@ -31,6 +31,14 @@ type DevicePin struct {
 	CloudGRPC string `json:"cloudGRPC"`
 	AssetID   string `json:"assetId,omitempty"`
 	Source    string `json:"source,omitempty"`
+	// Principal is the tenant SPIFFE principal the device's certificate
+	// carries, when it has one. It is recorded — not compared — because it is
+	// the key the SPKI pin store files the device under, and `wendy device
+	// unpin <hostname>` has no other way to reach that entry: the (org, asset)
+	// pair a legacy pin holds cannot be turned back into a principal without
+	// the tenant. Empty for an old-chain device and for pins written before
+	// the SPIFFE cutover; backfilled on the next successful connect.
+	Principal string `json:"principal,omitempty"`
 }
 
 // PinVerdict is the result of comparing an observed device identity against the
@@ -108,18 +116,18 @@ func (c *Config) PinSource(hostname string) string {
 
 // SetDevicePinFrom records a pin and where it came from. A cloud-sourced write
 // is authoritative and overwrites whatever was there.
-func (c *Config) SetDevicePinFrom(hostname string, orgID int, cloudGRPC, assetID, source string) {
+func (c *Config) SetDevicePinFrom(hostname string, orgID int, cloudGRPC, assetID, principal, source string) {
 	if c.DevicePins == nil {
 		c.DevicePins = make(map[string]DevicePin)
 	}
 	c.DevicePins[normalizePinHost(hostname)] = DevicePin{
-		OrgID: orgID, CloudGRPC: cloudGRPC, AssetID: assetID, Source: source,
+		OrgID: orgID, CloudGRPC: cloudGRPC, AssetID: assetID, Principal: principal, Source: source,
 	}
 }
 
 // SetDevicePin records (or replaces) the pin for a hostname.
-func (c *Config) SetDevicePin(hostname string, orgID int, cloudGRPC, assetID string) {
-	c.SetDevicePinFrom(hostname, orgID, cloudGRPC, assetID, PinSourceLAN)
+func (c *Config) SetDevicePin(hostname string, orgID int, cloudGRPC, assetID, principal string) {
+	c.SetDevicePinFrom(hostname, orgID, cloudGRPC, assetID, principal, PinSourceLAN)
 }
 
 // ClearDevicePin drops the pin for a hostname. It is for the case where the

--- a/go/internal/shared/config/devicepin_test.go
+++ b/go/internal/shared/config/devicepin_test.go
@@ -16,7 +16,7 @@ func TestEvaluateDevicePin(t *testing.T) {
 		t.Fatalf("unpinned host: want PinFirstUse, got %v", v)
 	}
 
-	c.SetDevicePin("wendy-thor.local", 7, "grpc.wendy.dev:443", "42")
+	c.SetDevicePin("wendy-thor.local", 7, "grpc.wendy.dev:443", "42", "")
 
 	// Same org + cloud + asset (e.g. a renewed cert) must match.
 	if v := c.EvaluateDevicePin("wendy-thor.local", 7, "grpc.wendy.dev:443", "42"); v != PinMatch {
@@ -39,7 +39,7 @@ func TestEvaluateDevicePin(t *testing.T) {
 // every device in the fleet shares it.
 func TestEvaluateDevicePinDifferentAssetIsMismatch(t *testing.T) {
 	c := &Config{}
-	c.SetDevicePin("wendy-thor.local", 7, "grpc.wendy.dev:443", "42")
+	c.SetDevicePin("wendy-thor.local", 7, "grpc.wendy.dev:443", "42", "")
 
 	if v := c.EvaluateDevicePin("wendy-thor.local", 7, "grpc.wendy.dev:443", "43"); v != PinMismatch {
 		t.Fatalf("asset change within same org+cloud: want PinMismatch, got %v", v)
@@ -69,7 +69,7 @@ func TestEvaluateDevicePinAdoptsAssetForLegacyPin(t *testing.T) {
 // as a swapped device against a pin that does record one.
 func TestEvaluateDevicePinUnknownObservedAssetMatches(t *testing.T) {
 	c := &Config{}
-	c.SetDevicePin("wendy-thor.local", 7, "grpc.wendy.dev:443", "42")
+	c.SetDevicePin("wendy-thor.local", 7, "grpc.wendy.dev:443", "42", "")
 
 	if v := c.EvaluateDevicePin("wendy-thor.local", 7, "grpc.wendy.dev:443", ""); v != PinMatch {
 		t.Fatalf("unidentifiable asset: want PinMatch, got %v", v)
@@ -80,7 +80,7 @@ func TestEvaluateDevicePinUnknownObservedAssetMatches(t *testing.T) {
 // (case, trailing dot, .local) don't spuriously read as a different device.
 func TestEvaluateDevicePinNormalizesHostname(t *testing.T) {
 	c := &Config{}
-	c.SetDevicePin("Wendy-Thor.local.", 7, "grpc.wendy.dev:443", "42")
+	c.SetDevicePin("Wendy-Thor.local.", 7, "grpc.wendy.dev:443", "42", "")
 	if v := c.EvaluateDevicePin("wendy-thor", 7, "grpc.wendy.dev:443", "42"); v != PinMatch {
 		t.Fatalf("normalized host should match pin, got %v", v)
 	}
@@ -91,7 +91,7 @@ func TestEvaluateDevicePinNormalizesHostname(t *testing.T) {
 // device's next enrollment reads as a first use.
 func TestClearDevicePin(t *testing.T) {
 	c := &Config{}
-	c.SetDevicePin("wendy-thor.local", 7, "grpc.wendy.dev:443", "42")
+	c.SetDevicePin("wendy-thor.local", 7, "grpc.wendy.dev:443", "42", "")
 
 	c.ClearDevicePin("Wendy-Thor.local.") // cosmetic variant must hit the same key
 	if _, ok := c.DevicePinFor("wendy-thor"); ok {
@@ -106,7 +106,7 @@ func TestClearDevicePin(t *testing.T) {
 
 func TestDevicePinRoundTripsThroughConfig(t *testing.T) {
 	c := &Config{}
-	c.SetDevicePin("wendy-thor.local", 7, "grpc.wendy.dev:443", "42")
+	c.SetDevicePin("wendy-thor.local", 7, "grpc.wendy.dev:443", "42", "")
 
 	data, err := json.Marshal(c)
 	if err != nil {
@@ -131,8 +131,8 @@ func TestDevicePinSourcePrecedence(t *testing.T) {
 
 	t.Run("cloud write overwrites a lan pin", func(t *testing.T) {
 		c := &Config{}
-		c.SetDevicePinFrom(host, 7, "grpc.wendy.dev:443", "42", PinSourceLAN)
-		c.SetDevicePinFrom(host, 7, "grpc.wendy.dev:443", "99", PinSourceCloud)
+		c.SetDevicePinFrom(host, 7, "grpc.wendy.dev:443", "42", "", PinSourceLAN)
+		c.SetDevicePinFrom(host, 7, "grpc.wendy.dev:443", "99", "", PinSourceCloud)
 
 		pin, _ := c.DevicePinFor(host)
 		if pin.AssetID != "99" || pin.Source != PinSourceCloud {
@@ -142,7 +142,7 @@ func TestDevicePinSourcePrecedence(t *testing.T) {
 
 	t.Run("lan observation conflicting with a cloud pin is a mismatch", func(t *testing.T) {
 		c := &Config{}
-		c.SetDevicePinFrom(host, 7, "grpc.wendy.dev:443", "42", PinSourceCloud)
+		c.SetDevicePinFrom(host, 7, "grpc.wendy.dev:443", "42", "", PinSourceCloud)
 		if v := c.EvaluateDevicePin(host, 7, "grpc.wendy.dev:443", "43"); v != PinMismatch {
 			t.Fatalf("want PinMismatch, got %v", v)
 		}
@@ -150,7 +150,7 @@ func TestDevicePinSourcePrecedence(t *testing.T) {
 
 	t.Run("lan never backfills an asset into a cloud pin", func(t *testing.T) {
 		c := &Config{}
-		c.SetDevicePinFrom(host, 7, "grpc.wendy.dev:443", "", PinSourceCloud)
+		c.SetDevicePinFrom(host, 7, "grpc.wendy.dev:443", "", "", PinSourceCloud)
 		if v := c.EvaluateDevicePin(host, 7, "grpc.wendy.dev:443", "42"); v != PinMatch {
 			t.Fatalf("want PinMatch without adoption, got %v", v)
 		}

--- a/go/internal/shared/devicepin/spiffe_rename_test.go
+++ b/go/internal/shared/devicepin/spiffe_rename_test.go
@@ -1,0 +1,133 @@
+package devicepin_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"math/big"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/devicepin"
+)
+
+const renameTenant = "6f1b7d3c-6b7e-4a2f-9c1e-2b4a8d5e0f31"
+const renamePrincipal = "spiffe://wendy.sh/tenant/" + renameTenant + "/service/asset-42"
+
+// certWithKey mints a leaf carrying the given SAN URIs from a caller-supplied
+// key, so a test can present the SAME device key under two identity shapes —
+// which is exactly what a certificate rotating onto a pki-core chain does.
+func certWithKey(t *testing.T, key *ecdsa.PrivateKey, sanURIs ...string) *x509.Certificate {
+	t.Helper()
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-device"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+	}
+	for _, raw := range sanURIs {
+		u, err := url.Parse(raw)
+		if err != nil {
+			t.Fatalf("parsing SAN %q: %v", raw, err)
+		}
+		tmpl.URIs = append(tmpl.URIs, u)
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("ParseCertificate: %v", err)
+	}
+	return cert
+}
+
+// TestCheckAndUpdate_AdoptsLegacyPinUnderPrincipal is the WDY-2968 "device pins
+// survive an ACME-enrolled device's identity shape" criterion: the store keys a
+// pki-core-issued device by its principal, and the entry recorded before the
+// cutover is keyed by the URN. A transitional leaf carries both, which is the
+// one moment the two names are provably the same device.
+func TestCheckAndUpdate_AdoptsLegacyPinUnderPrincipal(t *testing.T) {
+	dir := t.TempDir()
+	store, err := devicepin.Open(dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Pinned before the cutover, under the URN.
+	legacy := certWithKey(t, key, "urn:wendy:org:7:asset:42")
+	if err := store.CheckAndUpdate(legacy, "My Device"); err != nil {
+		t.Fatalf("CheckAndUpdate legacy: %v", err)
+	}
+	if !store.Has("urn:wendy:org:7:asset:42") {
+		t.Fatal("legacy pin was not recorded")
+	}
+
+	// The same device, same key, now presenting both SANs.
+	transitional := certWithKey(t, key, renamePrincipal, "urn:wendy:org:7:asset:42")
+	if err := store.CheckAndUpdate(transitional, "My Device"); err != nil {
+		t.Fatalf("CheckAndUpdate transitional: %v", err)
+	}
+	if !store.Has(renamePrincipal) {
+		t.Error("pin was not carried over to the principal key")
+	}
+	if store.Has("urn:wendy:org:7:asset:42") {
+		t.Error("legacy pin key survived the rename; unpin would have to clear two entries")
+	}
+
+	// The rename must be persisted, not just held in memory: a second process
+	// that re-Opens the store would otherwise re-TOFU the device.
+	reopened, err := devicepin.Open(dir)
+	if err != nil {
+		t.Fatalf("re-Open: %v", err)
+	}
+	if !reopened.Has(renamePrincipal) {
+		t.Error("rename was not flushed to disk")
+	}
+
+	// And the carried-over fingerprint must still be enforced: a different key
+	// under the new name, while the pinned cert is live, is a mismatch — not a
+	// silent first use.
+	otherKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	imposter := certWithKey(t, otherKey, renamePrincipal)
+	var mismatch *devicepin.PinMismatchError
+	err = reopened.CheckAndUpdate(imposter, "My Device")
+	if err == nil {
+		t.Error("a key change under the carried-over pin was accepted")
+	} else if !errors.As(err, &mismatch) {
+		t.Errorf("want PinMismatchError, got %T: %v", err, err)
+	}
+}
+
+// TestCheckAndUpdate_SpiffeOnlyDeviceIsPinned covers the ACME case, where there
+// never was a URN to carry over.
+func TestCheckAndUpdate_SpiffeOnlyDeviceIsPinned(t *testing.T) {
+	dir := t.TempDir()
+	store, err := devicepin.Open(dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	principal := "spiffe://wendy.sh/tenant/" + renameTenant + "/device/box-01"
+	if err := store.CheckAndUpdate(certWithKey(t, key, principal), "Box 01"); err != nil {
+		t.Fatalf("CheckAndUpdate: %v", err)
+	}
+	if !store.Has(principal) {
+		t.Error("a SPIFFE-only device was not pinned; devicepin used to fail open on it")
+	}
+}

--- a/go/internal/shared/devicepin/store.go
+++ b/go/internal/shared/devicepin/store.go
@@ -106,11 +106,27 @@ func Open(dir string) (*Store, error) {
 // mismatch — so any change to it still forces the write through.
 func (s *Store) CheckAndUpdate(leaf *x509.Certificate, displayName string) error {
 	identity, ok, err := certs.IdentityFromCert(leaf)
-	if err != nil || !ok || identity.EntityType != "asset" {
+	if err != nil || !ok || identity.EntityType != certs.EntityAsset {
 		return nil
 	}
 
 	key := identity.IdentityKey()
+	// A device that moves onto a pki-core chain keeps its pin. Its leaf is filed
+	// under the SPIFFE principal now, but the entry recorded before the cutover
+	// is filed under the urn:wendy URN — and a transitional leaf carries both, so
+	// this is the one moment the two names are provably the same device. Carry
+	// the entry over under the new name instead of silently starting a fresh
+	// TOFU, which is what an attacker substituting the device would look like.
+	renamed := false
+	if legacy := identity.LegacyURN(); key != legacy && legacy != "" {
+		if _, pinnedNow := s.devices[key]; !pinnedNow {
+			if prior, hadLegacy := s.devices[legacy]; hadLegacy {
+				s.devices[key] = prior
+				delete(s.devices, legacy)
+				renamed = true
+			}
+		}
+	}
 	fingerprint := spkiFingerprint(leaf)
 	notAfter := leaf.NotAfter.UTC().Format(time.RFC3339)
 
@@ -125,7 +141,7 @@ func (s *Store) CheckAndUpdate(leaf *x509.Certificate, displayName string) error
 		}
 	}
 
-	unchanged := pinned &&
+	unchanged := pinned && !renamed &&
 		existing.SPKIFingerprint == fingerprint &&
 		existing.NotAfter == notAfter &&
 		existing.DisplayName == displayName

--- a/swift/WendyAgentCore/Sources/WendyAgent/Provisioning/ClientCertAuthorizer.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Provisioning/ClientCertAuthorizer.swift
@@ -16,19 +16,26 @@ import X509
 /// verified path to a trusted root; it never assumes the peer-presented
 /// certificates are valid. It fails closed: any parse or verification failure
 /// returns `false`.
+///
+/// "Organization" here means the tenant a certificate belongs to: the tenant
+/// SPIFFE principal pki-core stamps, or the legacy `urn:wendy:org` on an old
+/// chain. See `OrgIdentity.Scope`.
 enum ClientCertAuthorizer {
     /// How the org-equality gate treats the connecting client certificate,
     /// mirroring the Go agent's `interceptor.OrgMode`.
     enum OrgEnforcementMode: Sendable, Equatable {
         /// No org check: any client whose chain verifies is accepted.
         case off
-        /// Enforce org-equality for certs that carry an org identity, but allow
-        /// legacy certs that carry no org identity. This is the default and lets
-        /// today's `wendy` CLI user cert (`wendy/user/<uid>`, no org claim)
-        /// connect while cert rotation to org-bearing URNs completes.
+        /// Enforce tenant-equality for certs that carry an identity, but allow
+        /// legacy certs that carry none — and certs whose tenant this device has
+        /// no way to compare with its own, which is the state a fleet passes
+        /// through while its certificates rotate onto pki-core chains. This is
+        /// the default and lets today's `wendy` CLI user cert
+        /// (`wendy/user/<uid>`, no claim) connect meanwhile.
         case grace
-        /// Enforce org-equality AND require every client cert to carry an org
-        /// identity; a legacy no-org cert is rejected.
+        /// Enforce tenant-equality AND require every client cert to carry a
+        /// tenant this device can compare with its own; a legacy no-identity
+        /// cert, and one naming an incomparable tenant, are both rejected.
         case strict
 
         var name: String {
@@ -59,18 +66,18 @@ enum ClientCertAuthorizer {
     ///   - peerCertificatesDER: The peer-presented certificate chain, DER-encoded,
     ///     leaf first (the order NIOSSL delivers them in).
     ///   - trustRootsPEM: The device's CA chain (PEM), used as the trust anchors.
-    ///   - deviceOrg: This device's organization id, or `nil` if it could not be
+    ///   - deviceScope: This device's own tenant, or `nil` if it could not be
     ///     determined from the device's own certificate. When `nil` (and the mode
-    ///     is not `.off`), every client is rejected (fail closed): org-equality is
-    ///     the sole cross-org barrier and is never silently dropped.
+    ///     is not `.off`), every client is rejected (fail closed): tenant-equality
+    ///     is the sole cross-tenant barrier and is never silently dropped.
     ///   - mode: The org-enforcement mode (default `.grace`). See
     ///     ``OrgEnforcementMode``.
-    /// - Returns: `true` iff the chain verifies to a trusted root AND the org
+    /// - Returns: `true` iff the chain verifies to a trusted root AND the tenant
     ///   policy for `mode` is satisfied.
     static func isAuthorized(
         peerCertificatesDER: [[UInt8]],
         trustRootsPEM: String,
-        deviceOrg: Int32?,
+        deviceScope: OrgIdentity.Scope?,
         mode: OrgEnforcementMode = .grace
     ) async -> Bool {
         // Parse trust anchors from the device CA chain. Without any anchors we
@@ -93,44 +100,51 @@ enum ClientCertAuthorizer {
         )
         guard case .validCertificate = result else { return false }
 
-        // `.off` opts out of org enforcement entirely: any client whose chain
+        // `.off` opts out of tenant enforcement entirely: any client whose chain
         // verifies to a trusted root is accepted.
         if mode == .off { return true }
 
-        // Additional layer: org-equality. Because the PKI shares CA roots across
-        // organizations, chain verification alone would let a validly provisioned
-        // entity from another org connect — org-equality is the sole cross-org
-        // barrier. If the device's own org is unknown we reject every client (in
-        // grace and strict) rather than silently dropping that barrier: a device
-        // with an unparseable cert becomes unreachable over mTLS, the safe
-        // failure mode. Re-provision to recover.
-        guard let deviceOrg else { return false }
+        // Additional layer: tenant-equality. Because the PKI shares CA roots
+        // across organizations, chain verification alone would let a validly
+        // provisioned entity from another tenant connect — tenant-equality is
+        // the sole cross-tenant barrier. If the device's own tenant is unknown
+        // we reject every client (in grace and strict) rather than silently
+        // dropping that barrier: a device with an unparseable cert becomes
+        // unreachable over mTLS, the safe failure mode. Re-provision to recover.
+        guard let deviceScope else { return false }
 
-        // Extract the client's org claim. A present-but-malformed claim (thrown
+        // Extract the client's claim. A present-but-malformed claim (thrown
         // error) is anomalous and rejected under every mode.
-        let clientOrg: Int32?
+        let clientScope: OrgIdentity.Scope?
         do {
-            clientOrg = try OrgIdentity.organizationID(fromLeaf: leaf)
+            clientScope = try OrgIdentity.scope(fromLeaf: leaf)
         } catch {
             return false
         }
 
-        guard let clientOrg else {
-            // A legacy cert carrying no org identity (e.g. the CLI's user cert).
+        guard let clientScope else {
+            // A legacy cert carrying no identity (e.g. the CLI's user cert).
             // Allowed under grace, rejected under strict.
             return mode == .grace
         }
 
-        // Org claim present: it must equal the device's org.
-        return clientOrg == deviceOrg
+        if clientScope.matches(deviceScope) { return true }
+        // A different tenant, said in terms this device can check, is refused
+        // under grace as well as strict: grace forgives an identity it cannot
+        // read, never one it can read and that says someone else.
+        if clientScope.comparable(with: deviceScope) { return false }
+        // Otherwise the client named a tenant with no shared vocabulary — a
+        // SPIFFE-only caller reaching a device still on an old chain, or the
+        // reverse. Unprovable rather than wrong, and exactly the rotation
+        // window grace exists for.
+        return mode == .grace
     }
 
-    /// The organization id encoded in the common name of the leaf certificate of
-    /// the given PEM, or `nil` if it can't be parsed. Used to derive the device's
-    /// own org from its issued certificate when building the mTLS server.
-    static func organizationID(fromLeafPEM pem: String) -> Int32? {
+    /// This device's own tenant, read from the leaf certificate of the given
+    /// PEM, or `nil` if it can't be parsed. Used when building the mTLS server.
+    static func scope(fromLeafPEM pem: String) -> OrgIdentity.Scope? {
         guard let leaf = Self.parseCertificates(pem: pem).first else { return nil }
-        return (try? OrgIdentity.organizationID(fromLeaf: leaf)) ?? nil
+        return (try? OrgIdentity.scope(fromLeaf: leaf)) ?? nil
     }
 
     /// Parses zero or more PEM `CERTIFICATE` blocks into certificates, ignoring

--- a/swift/WendyAgentCore/Sources/WendyAgent/Provisioning/OrgIdentity.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Provisioning/OrgIdentity.swift
@@ -1,24 +1,74 @@
 import Foundation
 import X509
 
-/// Extracts the Wendy organization (and entity) identity carried by a
-/// certificate, mirroring the Go agent's `certs.IdentityFromCert`.
+/// Extracts the Wendy identity carried by a certificate, mirroring the Go
+/// agent's `certs.IdentityFromCert`.
 ///
-/// Resolution order:
-///  1. A SAN URI beginning with `urn:wendy:org:` (authoritative; at most one).
-///  2. The CommonName `sh/wendy/<org>/<asset>` (legacy device-cert fallback).
-///  3. Otherwise: no identity (a legacy cert that carries no org claim at all —
+/// Resolution order, SPIFFE first:
+///  1. The tenant SPIFFE principal SAN
+///     `spiffe://wendy.sh/tenant/<uuid>/<kind>/<name>` (authoritative; at most
+///     one). This is what pki-core stamps on everything it issues and
+///     re-stamps on everything it renews.
+///  2. A SAN URI beginning with `urn:wendy:org:` (legacy old-chain reading; at
+///     most one). On a transitional leaf carrying both, the principal decides
+///     who the caller is and the URN contributes only its organization.
+///  3. The CommonName `sh/wendy/<org>/<asset>` (legacy device-cert fallback).
+///  4. Otherwise: no identity (a legacy cert that carries no claim at all —
 ///     e.g. the `wendy` CLI's `wendy/user/<uid>` user certificate).
 ///
 /// The distinction between "no identity" (`nil`) and "malformed claim" (a thrown
-/// error) matters: the mTLS org-enforcement gate allows no-identity certs under
-/// grace mode but always rejects a cert whose org claim is present-but-broken.
+/// error) matters: the mTLS enforcement gate allows no-identity certs under
+/// grace mode but always rejects a cert whose claim is present-but-broken.
 enum OrgIdentity {
-    /// The org + entity identity carried by a certificate.
+    /// The tenant an identity belongs to.
+    ///
+    /// pki-core scopes everything it mints by tenant UUID; the `Int32` org
+    /// survives only on old-chain certificates. Both are carried because a
+    /// transitional leaf presents both SANs, and a comparison is only
+    /// meaningful between two scopes expressed in the same terms.
+    struct Scope: Equatable, Sendable {
+        var tenantUUID: String?
+        var orgID: Int32?
+
+        /// Whether this scope names anything at all.
+        var isKnown: Bool { tenantUUID != nil || orgID != nil }
+
+        /// Whether two scopes are expressed in a shared vocabulary, so that a
+        /// `matches` of `false` means "a different tenant" rather than "no way
+        /// to tell".
+        func comparable(with other: Scope) -> Bool {
+            (tenantUUID != nil && other.tenantUUID != nil) || (orgID != nil && other.orgID != nil)
+        }
+
+        /// Whether two scopes provably name the same tenant. Tenant UUIDs win
+        /// when both sides have one; otherwise the legacy org is compared when
+        /// both sides have one. A pair with no shared vocabulary is not a
+        /// match: no mapping exists between a tenant UUID and an `Int32` org.
+        func matches(_ other: Scope) -> Bool {
+            if let mine = tenantUUID, let theirs = other.tenantUUID { return mine == theirs }
+            if let mine = orgID, let theirs = other.orgID { return mine == theirs }
+            return false
+        }
+
+        var description: String {
+            switch (tenantUUID, orgID) {
+            case let (.some(tenant), .some(org)): return "tenant \(tenant) (org \(org))"
+            case let (.some(tenant), .none): return "tenant \(tenant)"
+            case let (.none, .some(org)): return "org \(org)"
+            case (.none, .none): return "no scope"
+            }
+        }
+    }
+
+    /// The identity carried by a certificate.
     struct WendyIdentity: Equatable, Sendable {
-        var orgID: Int32
-        var entityType: String  // "user" or "asset"
+        var orgID: Int32?
+        var entityType: String  // "user", "asset" or "signer"
         var entityID: String
+        var tenantUUID: String?
+        var principal: String?
+
+        var scope: Scope { Scope(tenantUUID: tenantUUID, orgID: orgID) }
     }
 
     /// A org claim was present but malformed, ambiguous, or non-positive. A
@@ -26,38 +76,64 @@ enum OrgIdentity {
     /// mode (it is anomalous, not merely legacy).
     enum OrgIdentityError: Error, Equatable {
         case multipleOrgURNs(Int)
+        case multiplePrincipals(Int)
         case invalidURN(String)
+        case invalidPrincipal(String)
         case invalidCommonName(String)
         case nonPositiveOrg(Int32)
     }
 
     private static let wendyOrgURNPrefix = "urn:wendy:org:"
+    private static let tenantSPIFFEPrefix = "spiffe://wendy.sh/tenant/"
 
     /// The full identity, or `nil` when the certificate carries no Wendy org
     /// identity at all. Throws `OrgIdentityError` when an org claim is present but
     /// cannot be parsed.
     static func identity(fromLeaf certificate: Certificate) throws -> WendyIdentity? {
-        // 1. SAN URI (authoritative). Decoding the SAN extension can throw for a
-        // malformed extension; treat that as "no URN present" and fall through to
-        // the CommonName, rather than failing the whole lookup.
+        // 1./2. SAN URIs. Decoding the SAN extension can throw for a malformed
+        // extension; treat that as "no SAN present" and fall through to the
+        // CommonName, rather than failing the whole lookup.
+        var principals: [String] = []
         var urns: [String] = []
         if let sans = try? certificate.extensions.subjectAlternativeNames {
             for name in sans {
-                if case .uniformResourceIdentifier(let uri) = name,
-                    uri.hasPrefix(Self.wendyOrgURNPrefix)
-                {
+                guard case .uniformResourceIdentifier(let uri) = name else { continue }
+                if uri.hasPrefix(Self.tenantSPIFFEPrefix) {
+                    principals.append(uri)
+                } else if uri.hasPrefix(Self.wendyOrgURNPrefix) {
                     urns.append(uri)
                 }
             }
         }
+        if principals.count > 1 {
+            throw OrgIdentityError.multiplePrincipals(principals.count)
+        }
         if urns.count > 1 {
             throw OrgIdentityError.multipleOrgURNs(urns.count)
         }
-        if let urn = urns.first {
-            return try Self.parseWendyOrgURN(urn)
+
+        let legacy = try urns.first.map(Self.parseWendyOrgURN)
+
+        if let principal = principals.first {
+            var identity = try Self.parsePrincipal(principal)
+            // The legacy URN survives only as the org it names, so a peer that
+            // can still only compare orgs keeps working against this leaf — but
+            // only when the two SANs agree about which entity this is. A leaf
+            // whose URN names a different entity than its principal is
+            // misissued; the principal is authoritative, so a contradictory
+            // legacy claim contributes nothing.
+            if let legacy,
+                legacy.entityType == identity.entityType, legacy.entityID == identity.entityID
+            {
+                identity.orgID = legacy.orgID
+            }
+            return identity
+        }
+        if let legacy {
+            return legacy
         }
 
-        // 2. CommonName legacy fallback.
+        // 3. CommonName legacy fallback.
         for relativeName in certificate.subject {
             for attribute in relativeName where attribute.type == .RDNAttributeType.commonName {
                 let cn = attribute.value.description
@@ -67,14 +143,85 @@ enum OrgIdentity {
             }
         }
 
-        // 3. No identity.
+        // 4. No identity.
         return nil
     }
 
+    /// The tenant scope only (entity dropped), or `nil` when the cert carries no
+    /// identity. Throws when a claim is present but unparseable.
+    static func scope(fromLeaf certificate: Certificate) throws -> Scope? {
+        guard let scope = try Self.identity(fromLeaf: certificate)?.scope, scope.isKnown else {
+            return nil
+        }
+        return scope
+    }
+
     /// The org id only (entity dropped), or `nil` when the cert carries no org
-    /// claim. Throws when an org claim is present but unparseable.
+    /// claim. Throws when a claim is present but unparseable. Retained for
+    /// callers that genuinely need the legacy int org rather than a tenant.
     static func organizationID(fromLeaf certificate: Certificate) throws -> Int32? {
         try Self.identity(fromLeaf: certificate)?.orgID
+    }
+
+    /// Parses `spiffe://wendy.sh/tenant/<uuid>/<kind>/<name>`.
+    ///
+    /// Every kind pki-core mints is accepted — `operator`, `service`, `device`,
+    /// `signer` — because a kind this refuses is an actor no gate can see.
+    /// Cloud's `service/user-<id>` and `service/asset-<id>` spellings are
+    /// unwrapped to the user/asset entity types the rest of the agent compares
+    /// on; a device principal's name is path-shaped and keeps its slashes.
+    static func parsePrincipal(_ principal: String) throws -> WendyIdentity {
+        guard principal.hasPrefix(Self.tenantSPIFFEPrefix) else {
+            throw OrgIdentityError.invalidPrincipal(principal)
+        }
+        let rest = String(principal.dropFirst(Self.tenantSPIFFEPrefix.count))
+        let segments = rest.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
+        guard segments.count >= 3 else { throw OrgIdentityError.invalidPrincipal(principal) }
+        let tenant = segments[0]
+        // pki-core routes by the tenant UUID and compares it canonically, so a
+        // non-canonical spelling of the same tenant is a different string to
+        // every downstream comparison. Reject it rather than let two spellings
+        // of one tenant fail to match each other.
+        guard let parsed = UUID(uuidString: tenant), parsed.uuidString.lowercased() == tenant else {
+            throw OrgIdentityError.invalidPrincipal(principal)
+        }
+        let kind = segments[1]
+        let name = segments.dropFirst(2).joined(separator: "/")
+        guard !name.isEmpty else { throw OrgIdentityError.invalidPrincipal(principal) }
+
+        var entityType: String
+        var entityID = name
+        switch kind {
+        case "operator":
+            entityType = "user"
+        case "device":
+            entityType = "asset"
+        case "signer":
+            entityType = "signer"
+        case "service":
+            // A service account is a machine user (AAA contract D17). Cloud
+            // encodes the entity it relayed in the name; anything else is a
+            // plain service account and reads as a user.
+            if name.hasPrefix("asset-") {
+                entityType = "asset"
+                entityID = String(name.dropFirst("asset-".count))
+            } else if name.hasPrefix("user-") {
+                entityType = "user"
+                entityID = String(name.dropFirst("user-".count))
+            } else {
+                entityType = "user"
+            }
+            guard !entityID.isEmpty else { throw OrgIdentityError.invalidPrincipal(principal) }
+        default:
+            throw OrgIdentityError.invalidPrincipal(principal)
+        }
+        return WendyIdentity(
+            orgID: nil,
+            entityType: entityType,
+            entityID: entityID,
+            tenantUUID: tenant,
+            principal: principal
+        )
     }
 
     /// The org id parsed out of a `sh/wendy/<org>/<asset>` common name, or `nil`
@@ -100,7 +247,8 @@ enum OrgIdentity {
             throw OrgIdentityError.invalidURN(uri)
         }
         guard !parts[5].isEmpty else { throw OrgIdentityError.invalidURN(uri) }
-        return WendyIdentity(orgID: org, entityType: entityType, entityID: parts[5])
+        return WendyIdentity(
+            orgID: org, entityType: entityType, entityID: parts[5], tenantUUID: nil, principal: nil)
     }
 
     /// Parses `sh/wendy/<org>/<asset>`. Caller verifies the `sh/wendy/` prefix.
@@ -110,6 +258,7 @@ enum OrgIdentity {
         guard let org = Int32(parts[2]) else { throw OrgIdentityError.invalidCommonName(cn) }
         guard org > 0 else { throw OrgIdentityError.nonPositiveOrg(org) }
         guard !parts[3].isEmpty else { throw OrgIdentityError.invalidCommonName(cn) }
-        return WendyIdentity(orgID: org, entityType: "asset", entityID: parts[3])
+        return WendyIdentity(
+            orgID: org, entityType: "asset", entityID: parts[3], tenantUUID: nil, principal: nil)
     }
 }

--- a/swift/WendyAgentCore/Sources/WendyAgent/Provisioning/OrgIdentity.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Provisioning/OrgIdentity.swift
@@ -52,9 +52,9 @@ enum OrgIdentity {
 
         var description: String {
             switch (tenantUUID, orgID) {
-            case let (.some(tenant), .some(org)): return "tenant \(tenant) (org \(org))"
-            case let (.some(tenant), .none): return "tenant \(tenant)"
-            case let (.none, .some(org)): return "org \(org)"
+            case (.some(let tenant), .some(let org)): return "tenant \(tenant) (org \(org))"
+            case (.some(let tenant), .none): return "tenant \(tenant)"
+            case (.none, .some(let org)): return "org \(org)"
             case (.none, .none): return "no scope"
             }
         }
@@ -248,7 +248,12 @@ enum OrgIdentity {
         }
         guard !parts[5].isEmpty else { throw OrgIdentityError.invalidURN(uri) }
         return WendyIdentity(
-            orgID: org, entityType: entityType, entityID: parts[5], tenantUUID: nil, principal: nil)
+            orgID: org,
+            entityType: entityType,
+            entityID: parts[5],
+            tenantUUID: nil,
+            principal: nil
+        )
     }
 
     /// Parses `sh/wendy/<org>/<asset>`. Caller verifies the `sh/wendy/` prefix.
@@ -259,6 +264,11 @@ enum OrgIdentity {
         guard org > 0 else { throw OrgIdentityError.nonPositiveOrg(org) }
         guard !parts[3].isEmpty else { throw OrgIdentityError.invalidCommonName(cn) }
         return WendyIdentity(
-            orgID: org, entityType: "asset", entityID: parts[3], tenantUUID: nil, principal: nil)
+            orgID: org,
+            entityType: "asset",
+            entityID: parts[3],
+            tenantUUID: nil,
+            principal: nil
+        )
     }
 }

--- a/swift/WendyAgentCore/Sources/WendyAgent/Registry/RegistryTLS.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Registry/RegistryTLS.swift
@@ -19,23 +19,23 @@ enum RegistryTLS {
         var chainPEM: String
         var keyBacking: ProvisioningStore.KeyBacking
         var seKey: SEPrivateKey?
-        var deviceOrg: Int32?
+        var deviceScope: OrgIdentity.Scope?
         var orgMode: ClientCertAuthorizer.OrgEnforcementMode
     }
 
     /// Derives the verification policy exactly like the gRPC server: the
-    /// device's org comes from its own leaf certificate (nil fails closed in
-    /// `ClientCertAuthorizer`), and the org-enforcement mode comes from
+    /// device's tenant comes from its own leaf certificate (nil fails closed in
+    /// `ClientCertAuthorizer`), and the enforcement mode comes from
     /// `WENDY_MTLS_ORG_ENFORCEMENT` (off|grace|strict, defaulting to grace).
     static func makeConfiguration(
         certs: ProvisioningService.ProvisioningCerts,
         environment: [String: String] = ProcessInfo.processInfo.environment,
         logger: Logger
     ) -> Configuration {
-        let deviceOrg = ClientCertAuthorizer.organizationID(fromLeafPEM: certs.certPEM)
-        if deviceOrg == nil {
+        let deviceScope = ClientCertAuthorizer.scope(fromLeafPEM: certs.certPEM)
+        if deviceScope == nil {
             logger.error(
-                "Could not determine device organization from its own certificate; the registry push listener will reject all clients (fail closed). Re-provision the device to recover."
+                "Could not determine device tenant from its own certificate; the registry push listener will reject all clients (fail closed). Re-provision the device to recover."
             )
         }
         let rawOrgEnforcement = environment["WENDY_MTLS_ORG_ENFORCEMENT"]
@@ -51,7 +51,7 @@ enum RegistryTLS {
             chainPEM: certs.chainPEM,
             keyBacking: certs.keyBacking,
             seKey: certs.seKey,
-            deviceOrg: deviceOrg,
+            deviceScope: deviceScope,
             orgMode: orgMode
         )
     }
@@ -94,7 +94,7 @@ enum RegistryTLS {
         tls.trustRoots = .certificates(chainCerts)
 
         let trustRootsPEM = config.chainPEM
-        let deviceOrg = config.deviceOrg
+        let deviceScope = config.deviceScope
         let orgMode = config.orgMode
         return TLSChannelConfiguration(
             tlsConfiguration: tls,
@@ -104,7 +104,7 @@ enum RegistryTLS {
                     let authorized = await ClientCertAuthorizer.isAuthorized(
                         peerCertificatesDER: ders,
                         trustRootsPEM: trustRootsPEM,
-                        deviceOrg: deviceOrg,
+                        deviceScope: deviceScope,
                         mode: orgMode
                     )
                     promise.succeed(authorized ? .certificateVerified : .failed)

--- a/swift/WendyAgentCore/Sources/WendyAgent/WendyAgent.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/WendyAgent.swift
@@ -498,16 +498,16 @@ public actor WendyAgent {
         let key = try tlsPrivateKeySource(certs.keyBacking, seKey: certs.seKey)
 
         let trustRootsPEM = certs.chainPEM
-        let deviceOrg = ClientCertAuthorizer.organizationID(fromLeafPEM: certs.certPEM)
-        if deviceOrg == nil {
+        let deviceScope = ClientCertAuthorizer.scope(fromLeafPEM: certs.certPEM)
+        if deviceScope == nil {
             self.logger.error(
-                "Could not determine device organization from its own certificate; mTLS will reject all clients (fail closed). Re-provision the device to recover."
+                "Could not determine device tenant from its own certificate; mTLS will reject all clients (fail closed). Re-provision the device to recover."
             )
         }
 
-        // Org-enforcement mode (WENDY_MTLS_ORG_ENFORCEMENT: off|grace|strict).
-        // Defaults to grace so today's CLI user certs — which carry no org claim
-        // — can connect while cert rotation to org-bearing URNs completes.
+        // Enforcement mode (WENDY_MTLS_ORG_ENFORCEMENT: off|grace|strict).
+        // Defaults to grace so today's CLI user certs — which carry no claim at
+        // all — can connect while certificates rotate onto pki-core chains.
         let rawOrgEnforcement = ProcessInfo.processInfo.environment["WENDY_MTLS_ORG_ENFORCEMENT"]
         let (orgMode, recognized) = ClientCertAuthorizer.OrgEnforcementMode.parse(rawOrgEnforcement)
         if !recognized {
@@ -536,7 +536,7 @@ public actor WendyAgent {
                 let authorized = await ClientCertAuthorizer.isAuthorized(
                     peerCertificatesDER: ders,
                     trustRootsPEM: trustRootsPEM,
-                    deviceOrg: deviceOrg,
+                    deviceScope: deviceScope,
                     mode: orgMode
                 )
                 promise.succeed(authorized ? .certificateVerified(.init(nil)) : .failed)

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/ClientCertAuthorizerTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/ClientCertAuthorizerTests.swift
@@ -118,7 +118,7 @@ struct ClientCertAuthorizerTests {
         let authorized = await ClientCertAuthorizer.isAuthorized(
             peerCertificatesDER: [try Self.der(client)],
             trustRootsPEM: ca.pem,
-            deviceOrg: 7
+            deviceScope: .init(tenantUUID: nil, orgID: 7)
         )
         #expect(authorized)
     }
@@ -131,7 +131,7 @@ struct ClientCertAuthorizerTests {
         let authorized = await ClientCertAuthorizer.isAuthorized(
             peerCertificatesDER: [try Self.der(client)],
             trustRootsPEM: ca.pem,
-            deviceOrg: 7,
+            deviceScope: .init(tenantUUID: nil, orgID: 7),
             mode: .strict
         )
         #expect(!authorized)
@@ -146,7 +146,7 @@ struct ClientCertAuthorizerTests {
             let authorized = await ClientCertAuthorizer.isAuthorized(
                 peerCertificatesDER: [try Self.der(client)],
                 trustRootsPEM: ca.pem,
-                deviceOrg: 7,
+                deviceScope: .init(tenantUUID: nil, orgID: 7),
                 mode: mode
             )
             #expect(authorized, "mode \(mode.name) should accept a matching org URN")
@@ -162,7 +162,7 @@ struct ClientCertAuthorizerTests {
             let authorized = await ClientCertAuthorizer.isAuthorized(
                 peerCertificatesDER: [try Self.der(client)],
                 trustRootsPEM: ca.pem,
-                deviceOrg: 7,
+                deviceScope: .init(tenantUUID: nil, orgID: 7),
                 mode: mode
             )
             #expect(!authorized, "mode \(mode.name) must reject a mismatched org URN")
@@ -179,7 +179,7 @@ struct ClientCertAuthorizerTests {
             let authorized = await ClientCertAuthorizer.isAuthorized(
                 peerCertificatesDER: [try Self.der(client)],
                 trustRootsPEM: ca.pem,
-                deviceOrg: 7,
+                deviceScope: .init(tenantUUID: nil, orgID: 7),
                 mode: .off
             )
             #expect(authorized)
@@ -195,7 +195,7 @@ struct ClientCertAuthorizerTests {
         let authorized = await ClientCertAuthorizer.isAuthorized(
             peerCertificatesDER: [try Self.der(client)],
             trustRootsPEM: deviceCA.pem,
-            deviceOrg: 7,
+            deviceScope: .init(tenantUUID: nil, orgID: 7),
             mode: .off
         )
         #expect(!authorized)
@@ -209,7 +209,7 @@ struct ClientCertAuthorizerTests {
         let authorized = await ClientCertAuthorizer.isAuthorized(
             peerCertificatesDER: [try Self.der(client)],
             trustRootsPEM: ca.pem,
-            deviceOrg: nil
+            deviceScope: nil
         )
         #expect(!authorized)
     }
@@ -222,7 +222,7 @@ struct ClientCertAuthorizerTests {
         let authorized = await ClientCertAuthorizer.isAuthorized(
             peerCertificatesDER: [try Self.der(client)],
             trustRootsPEM: ca.pem,
-            deviceOrg: 7
+            deviceScope: .init(tenantUUID: nil, orgID: 7)
         )
         #expect(authorized)
     }
@@ -235,7 +235,7 @@ struct ClientCertAuthorizerTests {
         let authorized = await ClientCertAuthorizer.isAuthorized(
             peerCertificatesDER: [try Self.der(client)],
             trustRootsPEM: ca.pem,
-            deviceOrg: 7
+            deviceScope: .init(tenantUUID: nil, orgID: 7)
         )
         #expect(!authorized)
     }
@@ -250,7 +250,7 @@ struct ClientCertAuthorizerTests {
         let authorized = await ClientCertAuthorizer.isAuthorized(
             peerCertificatesDER: [try Self.der(client)],
             trustRootsPEM: deviceCA.pem,
-            deviceOrg: 7
+            deviceScope: .init(tenantUUID: nil, orgID: 7)
         )
         #expect(!authorized)
     }
@@ -268,7 +268,7 @@ struct ClientCertAuthorizerTests {
         let authorized = await ClientCertAuthorizer.isAuthorized(
             peerCertificatesDER: [try Self.der(client), try Self.der(rogueCA.certificate)],
             trustRootsPEM: deviceCA.pem,
-            deviceOrg: 7
+            deviceScope: .init(tenantUUID: nil, orgID: 7)
         )
         #expect(!authorized)
     }
@@ -286,14 +286,14 @@ struct ClientCertAuthorizerTests {
         let rejectsTrusted = await ClientCertAuthorizer.isAuthorized(
             peerCertificatesDER: [try Self.der(trusted)],
             trustRootsPEM: ca.pem,
-            deviceOrg: nil
+            deviceScope: nil
         )
         #expect(!rejectsTrusted)
 
         let rejectsUntrusted = await ClientCertAuthorizer.isAuthorized(
             peerCertificatesDER: [try Self.der(untrusted)],
             trustRootsPEM: ca.pem,
-            deviceOrg: nil
+            deviceScope: nil
         )
         #expect(!rejectsUntrusted)
     }
@@ -304,7 +304,7 @@ struct ClientCertAuthorizerTests {
         let authorized = await ClientCertAuthorizer.isAuthorized(
             peerCertificatesDER: [],
             trustRootsPEM: ca.pem,
-            deviceOrg: 7
+            deviceScope: .init(tenantUUID: nil, orgID: 7)
         )
         #expect(!authorized)
     }
@@ -316,7 +316,7 @@ struct ClientCertAuthorizerTests {
         let authorized = await ClientCertAuthorizer.isAuthorized(
             peerCertificatesDER: [try Self.der(client)],
             trustRootsPEM: "",
-            deviceOrg: 7
+            deviceScope: .init(tenantUUID: nil, orgID: 7)
         )
         #expect(!authorized)
     }
@@ -326,6 +326,6 @@ struct ClientCertAuthorizerTests {
         let ca = try Self.makeCA()
         let leaf = try Self.makeLeaf(org: 12, asset: 34, ca: ca)
         let pem = try leaf.serializeAsPEM().pemString
-        #expect(ClientCertAuthorizer.organizationID(fromLeafPEM: pem) == 12)
+        #expect(ClientCertAuthorizer.scope(fromLeafPEM: pem) == .init(tenantUUID: nil, orgID: 12))
     }
 }

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/OrgIdentityTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/OrgIdentityTests.swift
@@ -108,7 +108,10 @@ struct OrgEnforcementModeParseTests {
     @Test("scopes match only in a shared vocabulary")
     func scopeMatching() {
         let tenantA = OrgIdentity.Scope(tenantUUID: Self.tenant, orgID: nil)
-        let tenantB = OrgIdentity.Scope(tenantUUID: "00000000-0000-4000-8000-000000000000", orgID: nil)
+        let tenantB = OrgIdentity.Scope(
+            tenantUUID: "00000000-0000-4000-8000-000000000000",
+            orgID: nil
+        )
         let org7 = OrgIdentity.Scope(tenantUUID: nil, orgID: 7)
         let both = OrgIdentity.Scope(tenantUUID: Self.tenant, orgID: 7)
 

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/OrgIdentityTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/OrgIdentityTests.swift
@@ -46,4 +46,83 @@ struct OrgEnforcementModeParseTests {
     func unknownFallsBack() {
         #expect(ClientCertAuthorizer.OrgEnforcementMode.parse("lenient") == (.grace, false))
     }
+
+    // MARK: - Tenant SPIFFE principals
+
+    private static let tenant = "6f1b7d3c-6b7e-4a2f-9c1e-2b4a8d5e0f31"
+
+    @Test("parses every principal kind pki-core mints")
+    func parsesPrincipalKinds() throws {
+        let base = "spiffe://wendy.sh/tenant/\(Self.tenant)"
+
+        let op = try OrgIdentity.parsePrincipal("\(base)/operator/auth0|abc")
+        #expect(op.entityType == "user")
+        #expect(op.entityID == "auth0|abc")
+        #expect(op.tenantUUID == Self.tenant)
+        #expect(op.orgID == nil)
+
+        // Cloud relays through the service-identity profile and encodes the
+        // entity in the name; both spellings unwrap to the legacy entity types.
+        let user = try OrgIdentity.parsePrincipal("\(base)/service/user-5")
+        #expect(user.entityType == "user")
+        #expect(user.entityID == "5")
+
+        let asset = try OrgIdentity.parsePrincipal("\(base)/service/asset-42")
+        #expect(asset.entityType == "asset")
+        #expect(asset.entityID == "42")
+
+        // A plain service account is a machine user (AAA contract D17).
+        let sa = try OrgIdentity.parsePrincipal("\(base)/service/ci-runner")
+        #expect(sa.entityType == "user")
+        #expect(sa.entityID == "ci-runner")
+
+        // A device id is path-shaped and keeps its slashes.
+        let device = try OrgIdentity.parsePrincipal("\(base)/device/fleet-a/box-01")
+        #expect(device.entityType == "asset")
+        #expect(device.entityID == "fleet-a/box-01")
+
+        let signer = try OrgIdentity.parsePrincipal("\(base)/signer/release")
+        #expect(signer.entityType == "signer")
+    }
+
+    @Test("rejects malformed principals")
+    func rejectsMalformedPrincipals() {
+        let bad = [
+            "spiffe://wendy.sh/tenant/not-a-uuid/operator/x",
+            // Non-canonical (upper-case) UUID: pki-core compares canonically,
+            // so two spellings of one tenant must not both parse.
+            "spiffe://wendy.sh/tenant/\(Self.tenant.uppercased())/operator/x",
+            "spiffe://wendy.sh/tenant/\(Self.tenant)/operator/",
+            "spiffe://wendy.sh/tenant/\(Self.tenant)/wizard/x",
+            "spiffe://wendy.sh/tenant/\(Self.tenant)",
+            "spiffe://other.example/tenant/\(Self.tenant)/operator/x",
+            "urn:wendy:org:7:user:5",
+        ]
+        for principal in bad {
+            #expect(throws: (any Error).self) {
+                _ = try OrgIdentity.parsePrincipal(principal)
+            }
+        }
+    }
+
+    @Test("scopes match only in a shared vocabulary")
+    func scopeMatching() {
+        let tenantA = OrgIdentity.Scope(tenantUUID: Self.tenant, orgID: nil)
+        let tenantB = OrgIdentity.Scope(tenantUUID: "00000000-0000-4000-8000-000000000000", orgID: nil)
+        let org7 = OrgIdentity.Scope(tenantUUID: nil, orgID: 7)
+        let both = OrgIdentity.Scope(tenantUUID: Self.tenant, orgID: 7)
+
+        #expect(tenantA.matches(tenantA))
+        #expect(!tenantA.matches(tenantB))
+        #expect(tenantA.comparable(with: tenantB))
+
+        #expect(org7.matches(org7))
+        #expect(tenantA.matches(both))
+
+        // No shared vocabulary: unprovable, and deliberately not a match.
+        #expect(!tenantA.matches(org7))
+        #expect(!tenantA.comparable(with: org7))
+
+        #expect(!OrgIdentity.Scope(tenantUUID: nil, orgID: nil).isKnown)
+    }
 }

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/RegistryTLSListenerTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/RegistryTLSListenerTests.swift
@@ -108,7 +108,7 @@ struct RegistryTLSListenerTests {
                     chainPEM: ca.pem,
                     keyBacking: .softwarePEM(device.keyPEM),
                     seKey: nil,
-                    deviceOrg: deviceOrg,
+                    deviceScope: .init(tenantUUID: nil, orgID: deviceOrg),
                     orgMode: .grace
                 ),
                 routes: .pushAndPull,

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/RegistryTLSTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/RegistryTLSTests.swift
@@ -24,7 +24,7 @@ struct RegistryTLSTests {
             environment: ["WENDY_MTLS_ORG_ENFORCEMENT": "strict"],
             logger: Self.logger
         )
-        #expect(config.deviceOrg == 7)
+        #expect(config.deviceScope == .init(tenantUUID: nil, orgID: 7))
         #expect(config.orgMode == .strict)
 
         let defaulted = RegistryTLS.makeConfiguration(
@@ -44,7 +44,7 @@ struct RegistryTLSTests {
             chainPEM: ca.pem,
             keyBacking: .softwarePEM(device.keyPEM),
             seKey: nil,
-            deviceOrg: 1,
+            deviceScope: .init(tenantUUID: nil, orgID: 1),
             orgMode: .grace
         )
         let channel = try RegistryTLS.channelConfiguration(config)
@@ -58,7 +58,7 @@ struct RegistryTLSTests {
             chainPEM: "not a chain",
             keyBacking: .softwarePEM("not a key"),
             seKey: nil,
-            deviceOrg: 1,
+            deviceScope: .init(tenantUUID: nil, orgID: 1),
             orgMode: .grace
         )
         #expect(throws: (any Error).self) {


### PR DESCRIPTION
- **Closes:** [WDY-2968 wendy-agent: read the tenant SPIFFE principal as an identity source — a pki-core-renewed leaf carries no urn:wendy SAN](https://linear.app/wendylabsinc/issue/WDY-2968/wendy-agent-read-the-tenant-spiffe-principal-as-an-identity-source-a)
- **Depends on:** [#1897 cli: renew refresh-certs against pki-core](https://github.com/wendylabsinc/WendyOS/pull/1897) (merged into this base)

> **In plain terms:** A certificate renewed by pki-core loses its `urn:wendy:org` SAN, and that urn was the only identity the CLI and agent could read. Renewed operator certs were answering `PermissionDenied` on every mTLS call, remote builds refused them outright, and an ACME-enrolled device's own urn-less leaf turned org enforcement off for its whole server. The tenant SPIFFE principal is now the identity, and the urn is read only as a legacy old-chain fallback.

## Summary

- `certs.IdentityFromCert` resolves the tenant SPIFFE principal first and accepts every kind pki-core mints — `operator/<sub>`, `service/user-<id>`, `service/asset-<id>`, `device/<id>`, `signer/<name>` — reconciled against the AAA contract (§4.2, D17). `urn:wendy:org` is second and the `sh/wendy/…` CN third. On a transitional leaf carrying both SANs the principal decides the entity and the urn lends only its org, so a peer that can still compare nothing but orgs keeps working.
- A new `certs.Scope` (tenant UUID, legacy org) replaces the bare `int32` in the agent's mTLS interceptor, `mtls.NewServer`, `MeshService`, and the mesh peer pin. Two scopes match only in a vocabulary both share; a pair with no shared vocabulary is *unprovable*, not equal, and is distinguished from a genuine tenant mismatch so grace mode can forgive the rotation window while strict does not. A different tenant is refused under grace as well as strict.
- The agent no longer disarms enforcement fleet-wide when its own leaf is pki-core-issued: `ScopeFromCertPEM` reads such a leaf as a known scope, so `main.go`'s fail-safe branch stops firing on exactly the devices it was meant to protect.
- `cloudrequest` accepted only the kind `operator` and therefore refused the `service/user-<id>` cloud actually mints. Both are operator identities under the contract; `certs.ParsePrincipal` is the single place that now decides so, and a `device`/`signer` principal is still refused.
- Device pins survive the identity change: the SPKI store keys a pki-core-issued device by its principal, and a leaf presenting both SANs is the one moment the two names are provably the same device, so the entry is carried over instead of silently re-TOFU'd. `DevicePin` records the principal so `wendy device unpin <hostname>` can still reach the SPKI entry, and `unpin` accepts a principal as an argument.
- The Swift agent (`OrgIdentity`, `ClientCertAuthorizer`, `RegistryTLS`) gets the same transformation — it enforces the same gate on the same certificates.

Known gap, unchanged by this PR: the mesh LAN path addresses peers by the int32 cloud asset id it reads from an mDNS TXT record, so a device named `device/<uuid>` still cannot be reached over it. Closing that means teaching discovery to advertise the principal, which is a wire-format change and a separate ticket.

## Boundary changes

- **CLI:** `wendy device unpin` additionally accepts a tenant SPIFFE principal (`spiffe://wendy.sh/tenant/<uuid>/device/<id>`) where it previously took only a hostname or a `urn:wendy:org:…` urn. Additive.
- **CLI config:** `devicePins` entries gain an optional `principal` field, backfilled on the next successful connect. Older CLIs ignore it; the pin still matches on (org, cloud, asset).
- **Agent:** `WENDY_MTLS_ORG_ENFORCEMENT` keeps its values and its strict default, but now gates on the tenant rather than the org. Under `strict`, a caller whose certificate names a tenant this device cannot compare with its own is refused; `grace` allows it. A fleet mid-rotation should sit on `grace` until its certificates have moved.
- **Agent, refusal text:** "certificate organization not permitted" → "certificate tenant not permitted", and the equivalents for the undeterminable and missing-identity cases.

## Tests

- `go build ./...`, `go vet ./...`, `gofmt -l .` — clean
- `go test ./... -count=1` — passes except the four `internal/agent/oci` GPU tests that fail on any branch on a machine with no NVIDIA device
- New: `certs` principal-parser and scope-matching tables, `devicepin` legacy→principal carry-over (including that the carried fingerprint still refuses a key change), interceptor tenant-enforcement table covering the strict/grace/off split
- Swift: **not run locally** — `WendyAgentCore` does not build on Linux (`no such module 'Security'`, pre-existing). The `Run WendyAgentCore Tests` and `Build WendyAgentMac app` checks are the verification for that half.