### PR TITLE
WDY-2907: apply CLI environment overrides to every selected service

### DIFF
--- a/Examples/ComposeEnv/README.md
+++ b/Examples/ComposeEnv/README.md
@@ -69,6 +69,17 @@ Expected output:
 
 ## Run locally with Docker Desktop
 
+To verify global CLI overrides on both services, including repeated keys and an
+explicit empty value (WDY-2907), deploy with:
+
+```sh
+wendy run --env CHECK_CLI_OVERRIDES=1 --env APP_MODE=first --env APP_MODE=cli --env GREETING= --env MAX_WORKERS=7
+```
+
+The client checks its own environment and the server response. It exits with
+an error if either service missed an override. The same resolved environment
+is used for build fingerprints and watch change detection.
+
 `docker-compose.yml` is unmodified, so it works as-is with Docker Desktop
 (environment vars are native Docker Compose behaviour):
 

--- a/Examples/ComposeEnv/client/main.py
+++ b/Examples/ComposeEnv/client/main.py
@@ -38,6 +38,13 @@ print("[client] server response:", flush=True)
 print(json.dumps(data, indent=2), flush=True)
 
 compose_env = data.get("from_compose_environment", {})
+if os.environ.get("CHECK_CLI_OVERRIDES") == "1":
+    expected = {"APP_MODE": "cli", "GREETING": "", "MAX_WORKERS": "7"}
+    local = {key: os.environ.get(key) for key in expected}
+    if local != expected or compose_env != expected:
+        print(f"[client] CLI overrides mismatch: client={local}, server={compose_env}", flush=True)
+        sys.exit(1)
+    print("[client] CLI overrides reached both services (last key wins, empty preserved)", flush=True)
 all_set = all(v != "<not set>" for v in compose_env.values())
 if all_set:
     print("[client] ✓ all compose environment: vars reached the server container", flush=True)

--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -1233,6 +1233,16 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 			return err
 		}
 	}
+	serviceEnvs := make(map[string][]string, len(cfg.Services))
+	for name, svc := range cfg.Services {
+		var serviceConfig *appconfig.ServiceConfig
+		if companion != nil {
+			serviceConfig = companion.Services[name]
+		}
+		// Compose supplies service values; the companion can override those,
+		// and global CLI values are applied last to every service.
+		serviceEnvs[name] = mergeEnvEntries(expandServiceEnv(companion, nil), composeEnv(svc), expandServiceEnv(nil, serviceConfig), opts.env)
+	}
 	svcLifecycleCfgs := composeServiceLifecycleConfigs(svcCfgs, companion)
 	portConfigs := []*appconfig.AppConfig{companion}
 	for _, svc := range svcCfgs {
@@ -1303,7 +1313,7 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 			if dockerfile, err = prepareDockerBuildFile(ctxDir, dockerfile, gpuArch, sfOpts...); err != nil {
 				return fmt.Errorf("service %s: %w", name, err)
 			}
-			imageIdentity, err = computeBuildInputHash(ctxDir, dockerfile, platform, allBuildArgs, composeEnv(svc))
+			imageIdentity, err = computeBuildInputHash(ctxDir, dockerfile, platform, allBuildArgs, serviceEnvs[name])
 			if err != nil {
 				return fmt.Errorf("hashing service %s build inputs: %w", name, err)
 			}
@@ -1322,7 +1332,7 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 			restartPolicy = composeRestartPolicy(svc.Restart)
 		}
 		cmd, extraArgs := composeArgv(svc)
-		desiredHash, hashErr := composeServiceWatchHash(imageIdentity, appCfg, cmd, extraArgs, restartPolicy, composeEnv(svc))
+		desiredHash, hashErr := composeServiceWatchHash(imageIdentity, appCfg, cmd, extraArgs, restartPolicy, serviceEnvs[name])
 		if hashErr == nil && contentPinned {
 			desiredHashes[name] = desiredHash
 			candidates[name] = watchServiceCandidate{appID: appCfg.AppID, containerName: appCfg.ContainerName(), desiredHash: desiredHash}
@@ -1450,7 +1460,7 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 			Cmd:           cmd,
 			RestartPolicy: restartPolicy,
 			UserArgs:      extraArgs,
-			Env:           composeEnv(svc),
+			Env:           serviceEnvs[name],
 		}
 
 		cliLogln("Creating container for service %s (%s)...", name, appCfg.ContainerName())

--- a/go/internal/cli/commands/effective_env_test.go
+++ b/go/internal/cli/commands/effective_env_test.go
@@ -1,0 +1,58 @@
+package commands
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+func TestEffectiveServiceEnvs(t *testing.T) {
+	t.Setenv("ENV_FIXTURE", "expanded")
+	app := &appconfig.AppConfig{Env: map[string]string{"DEFAULT": "$ENV_FIXTURE", "SHARED": "app", "EMPTY": "app"}}
+	services := map[string]*appconfig.ServiceConfig{
+		"api":    {Env: map[string]string{"SHARED": "api", "ONLY": "api"}},
+		"worker": {Env: map[string]string{"SHARED": "worker", "ONLY": "worker"}},
+	}
+	envs := effectiveServiceEnvs(app, services, []string{"SHARED=first", "SHARED=last", "EMPTY=", "LITERAL=$ENV_FIXTURE"})
+	for name := range services {
+		want := []string{"DEFAULT=expanded", "EMPTY=", "LITERAL=$ENV_FIXTURE", "ONLY=" + name, "SHARED=last"}
+		if !reflect.DeepEqual(envs[name], want) {
+			t.Fatalf("%s environment = %q, want %q", name, envs[name], want)
+		}
+	}
+	if app.Env["SHARED"] != "app" || services["api"].Env["SHARED"] != "api" {
+		t.Fatal("resolution mutated configuration")
+	}
+}
+
+func TestEnvironmentOnlyChangeInvalidatesWatchService(t *testing.T) {
+	cfg := &appconfig.AppConfig{AppID: "app"}
+	services := map[string]*appconfig.ServiceConfig{"api": {}, "worker": {}}
+	before := effectiveServiceEnvs(cfg, services, []string{"MODE=one"})
+	after := effectiveServiceEnvs(cfg, services, []string{"MODE=two"})
+	state := &watchDeployState{hashes: map[string]string{}}
+	for name := range services {
+		oldHash, err := multiServiceWatchHash("same-image", cfg, before[name], nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		newHash, err := multiServiceWatchHash("same-image", cfg, after[name], nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		key := watchServiceKey("device", cfg.AppID, name)
+		state.record(key, oldHash)
+		if state.matches(key, newHash) {
+			t.Fatalf("%s was preserved after environment changed", name)
+		}
+	}
+}
+
+func TestEnvironmentFingerprintIgnoresOverriddenValues(t *testing.T) {
+	one := mergeEnvEntries([]string{"KEY=ignored", "EMPTY=ignored"}, []string{"KEY=final", "EMPTY="})
+	two := mergeEnvEntries([]string{"EMPTY=", "KEY=final"})
+	if !reflect.DeepEqual(one, two) {
+		t.Fatalf("equivalent environments differ: %v, %v", one, two)
+	}
+}

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -158,7 +158,7 @@ type servicePlan struct {
 // plan as "don't skip this service, and don't reuse anything for it", so the
 // real error surfaces from the build path instead of aborting the whole group
 // during planning.
-func computeServicePlans(cwd, platform, gpuArch string, appCfg *appconfig.AppConfig, services map[string]*appconfig.ServiceConfig, buildArgs map[string]string, sfOpts ...stagefile.Option) map[string]servicePlan {
+func computeServicePlans(cwd, platform, gpuArch string, serviceEnvs map[string][]string, services map[string]*appconfig.ServiceConfig, buildArgs map[string]string, sfOpts ...stagefile.Option) map[string]servicePlan {
 	var mu sync.Mutex
 	plans := make(map[string]servicePlan, len(services))
 
@@ -174,7 +174,7 @@ func computeServicePlans(cwd, platform, gpuArch string, appCfg *appconfig.AppCon
 			if err != nil {
 				return
 			}
-			hash, err := computeBuildInputHash(contextDir, dockerfile, platform, buildArgs, expandServiceEnv(appCfg, svc))
+			hash, err := computeBuildInputHash(contextDir, dockerfile, platform, buildArgs, serviceEnvs[name])
 			if err != nil {
 				return
 			}
@@ -274,7 +274,7 @@ func deviceContainerNames(ctx context.Context, conn *grpcclient.AgentConnection)
 // that consult the device happen here. The resolved build files are returned
 // alongside so the build path can reuse them instead of resolving (and, for a
 // Stagefile, recompiling) every service a second time in the same run.
-func planServicePushSkips(ctx context.Context, conn *grpcclient.AgentConnection, cwd, appID, deviceKey, platform string, appCfg *appconfig.AppConfig, services map[string]*appconfig.ServiceConfig, buildArgs map[string]string, sfOpts ...stagefile.Option) (skip map[string]bool, hashes, dockerfiles map[string]string) {
+func planServicePushSkips(ctx context.Context, conn *grpcclient.AgentConnection, cwd, appID, deviceKey, platform string, serviceEnvs map[string][]string, services map[string]*appconfig.ServiceConfig, buildArgs map[string]string, sfOpts ...stagefile.Option) (skip map[string]bool, hashes, dockerfiles map[string]string) {
 	skip = map[string]bool{}
 	hashes = map[string]string{}
 	dockerfiles = map[string]string{}
@@ -282,7 +282,7 @@ func planServicePushSkips(ctx context.Context, conn *grpcclient.AgentConnection,
 		return skip, hashes, dockerfiles
 	}
 
-	plans := computeServicePlans(cwd, platform, serviceGPUArch(ctx, cwd, services, conn), appCfg, services, buildArgs, sfOpts...)
+	plans := computeServicePlans(cwd, platform, serviceGPUArch(ctx, cwd, services, conn), serviceEnvs, services, buildArgs, sfOpts...)
 	present := deviceContainerNames(ctx, conn)
 	type candidate struct {
 		name string
@@ -428,7 +428,8 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	// fail closed because they do not provide a verifiable content identity.
 	deviceKey := deviceFingerprintKey(versionResp)
 	sfOpts := debugStagefileOptions(opts.debug)
-	skip, hashes, dockerfiles := planServicePushSkips(ctx, conn, cwd, appCfg.AppID, deviceKey, platform, appCfg, services, buildArgs, sfOpts...)
+	serviceEnvs := effectiveServiceEnvs(appCfg, services, opts.env)
+	skip, hashes, dockerfiles := planServicePushSkips(ctx, conn, cwd, appCfg.AppID, deviceKey, platform, serviceEnvs, services, buildArgs, sfOpts...)
 
 	// Build the full per-service create configs before selecting watch work: a
 	// service is unchanged only when both its image inputs and its effective
@@ -445,12 +446,12 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	if opts.watchState != nil {
 		states := deviceContainerStates(ctx, conn)
 		candidates := map[string]watchServiceCandidate{}
-		for name, svc := range services {
+		for name := range services {
 			buildHash, planned := hashes[name]
 			if !planned {
 				continue
 			}
-			desiredHash, err := multiServiceWatchHash(buildHash, svcCfgs[name], expandServiceEnv(appCfg, svc), resolveRestartPolicy(opts))
+			desiredHash, err := multiServiceWatchHash(buildHash, svcCfgs[name], serviceEnvs[name], resolveRestartPolicy(opts))
 			if err != nil {
 				continue
 			}
@@ -540,7 +541,6 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	}
 
 	createService := func(name string) error {
-		svc := services[name]
 		deviceImage := fmt.Sprintf("localhost:%d/%s-%s:latest", regPort,
 			strings.ToLower(appCfg.AppID), strings.ToLower(name))
 
@@ -556,7 +556,7 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 			AppName:       serviceCfg.ContainerName(),
 			AppConfig:     appConfigData,
 			RestartPolicy: restartPolicy,
-			Env:           expandServiceEnv(appCfg, svc),
+			Env:           serviceEnvs[name],
 		}
 
 		cliLogln("Creating container for service %s...", name)

--- a/go/internal/cli/commands/multibuild_test.go
+++ b/go/internal/cli/commands/multibuild_test.go
@@ -95,7 +95,7 @@ func TestComputeServicePlansRunsServicesConcurrently(t *testing.T) {
 
 	done := make(chan map[string]servicePlan, 1)
 	go func() {
-		done <- computeServicePlans(root, "linux/arm64", "", &appconfig.AppConfig{AppID: "app"}, services, nil)
+		done <- computeServicePlans(root, "linux/arm64", "", nil, services, nil)
 	}()
 
 	select {
@@ -133,7 +133,7 @@ func TestComputeServicePlansOmitsServicesItCannotPlan(t *testing.T) {
 		return "Dockerfile", nil
 	}
 
-	plans := computeServicePlans(root, "linux/arm64", "", &appconfig.AppConfig{AppID: "app"}, services, nil)
+	plans := computeServicePlans(root, "linux/arm64", "", nil, services, nil)
 
 	if _, ok := plans["svc00"]; ok {
 		t.Error("svc00 could not be resolved; it must not get a plan")

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -1382,7 +1382,7 @@ func runSwiftWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cw
 		UserArgs:      userArgs,
 		// Service env from wendy.json (mesh: MESH_PEERS etc.) plus any fleet-injected
 		// env (discovery peers). Fleet env is appended last so it wins on key clash.
-		Env: append(resolveServiceEnv(appCfg), opts.env...),
+		Env: mergeEnvEntries(resolveServiceEnv(appCfg), opts.env),
 	}
 
 	return startAndStreamContainer(ctx, conn, appCfg, createReq, opts)
@@ -2030,7 +2030,7 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 	// wendy.json env plus --env and fleet-injected env, appended last so they win
 	// on key clash. Feeds the remote-build path below, the fingerprint, and
 	// whichever local deploy path runs.
-	deployEnv := append(resolveServiceEnv(appCfg), opts.env...)
+	deployEnv := mergeEnvEntries(resolveServiceEnv(appCfg), opts.env)
 
 	// Remote build: hand the build to another WendyOS device, which pushes the
 	// finished image straight into this device's registry over the mesh. Placed
@@ -2316,6 +2316,29 @@ func sortedEnvEntries(env map[string]string) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// mergeEnvEntries applies already-expanded environments in precedence order.
+// CLI values are literal, including empty values; repeated keys use the last
+// value. Sorting and deduplication make fingerprints describe the actual env.
+func mergeEnvEntries(layers ...[]string) []string {
+	merged := map[string]string{}
+	for _, entries := range layers {
+		for _, entry := range entries {
+			if key, value, ok := strings.Cut(entry, "="); ok {
+				merged[key] = value
+			}
+		}
+	}
+	return sortedEnvEntries(merged)
+}
+
+func effectiveServiceEnvs(appCfg *appconfig.AppConfig, services map[string]*appconfig.ServiceConfig, overrides []string) map[string][]string {
+	envs := make(map[string][]string, len(services))
+	for name, svc := range services {
+		envs[name] = mergeEnvEntries(expandServiceEnv(appCfg, svc), overrides)
+	}
+	return envs
 }
 
 // expandServiceEnv resolves the env for one service of a multi-service app:


### PR DESCRIPTION
Service deployments now compute app → service → CLI environment once and reuse it for creation, build/deployment fingerprints, and watch change detection. Repeated CLI keys take the last value, including an explicit empty value. The ComposeEnv integration fixture covers both services.

Validation: Go CLI environment/watch fixtures and package tests passed on the complete stack; Linux race tests passed.

Part of the WDY-2906–2913 stack. Merge in dependency order. [Final acceptance record and stack index](https://github.com/wendylabsinc/WendyOS/pull/1905). Hardware acceptance and the stable agent/CLI release are still pending; no issue closure is claimed.
