### PR TITLE
WDY-2906/2913: explain omitted networking and honor isolation removal

### DIFF
--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -419,12 +419,10 @@ func (c *Client) hydrateIsolationLocked(appID string, labels map[string]string) 
 	if c.appIsolation == nil {
 		c.appIsolation = make(map[string]string)
 	}
-	if c.appIsolation[appID] != "" {
+	if _, loaded := c.appIsolation[appID]; loaded {
 		return // already set (live create or earlier hydrate) — never override
 	}
-	if v := labels[labelKeyIsolation]; v != "" {
-		c.appIsolation[appID] = v
-	}
+	c.appIsolation[appID] = labels[labelKeyIsolation]
 }
 
 // recordServiceIP stores the CNI-assigned IP for a service. Caller must hold c.mu.
@@ -1675,12 +1673,12 @@ func (c *Client) CreateContainerWithProgress(ctx context.Context, req *agentpb.C
 		}
 		c.appServices[appID] = appCfg.Services
 	}
-	if appCfg.Isolation != "" {
-		if c.appIsolation == nil {
-			c.appIsolation = make(map[string]string)
-		}
-		c.appIsolation[appID] = appCfg.Isolation
+	if c.appIsolation == nil {
+		c.appIsolation = make(map[string]string)
 	}
+	// An empty value is authoritative too: a redeploy can remove isolation.
+	// Hydration must not revive old sibling labels during group replacement.
+	c.appIsolation[appID] = appCfg.Isolation
 
 	return nil
 }
@@ -2153,7 +2151,7 @@ func (c *Client) startContainer(ctx context.Context, appName string, stdin io.Re
 				// c.appIsolation[appID] during the window between CNI ADD and this
 				// re-lock. If the app is already gone, discard the IP silently rather
 				// than writing stale state (SOC2-CC6, NIST-SI-16, ISO27001-A.8).
-				if c.appIsolation[appID] == "" {
+				if _, loaded := c.appIsolation[appID]; !loaded {
 					c.mu.Unlock()
 					c.logger.Warn("CNI ADD: app already stopped before IP could be recorded, discarding IP",
 						zap.String(logfields.AppID, appID), zap.String("ip", ip))

--- a/go/internal/agent/containerd/isolation_hydrate_test.go
+++ b/go/internal/agent/containerd/isolation_hydrate_test.go
@@ -8,6 +8,23 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
 )
 
+func TestHydrateIsolationDoesNotRestoreRemovedIsolation(t *testing.T) {
+	c := &Client{logger: zap.NewNop(), appIsolation: map[string]string{"myapp": ""}}
+	c.hydrateIsolation("myapp", map[string]string{labelKeyIsolation: "shared-network"})
+	if got := c.appIsolation["myapp"]; got != "" {
+		t.Fatalf("old sibling restored removed isolation: %q", got)
+	}
+}
+
+func TestHydrateIsolationRecordsEmptyAsLoaded(t *testing.T) {
+	c := &Client{logger: zap.NewNop()}
+	c.hydrateIsolation("myapp", map[string]string{})
+	c.hydrateIsolation("myapp", map[string]string{labelKeyIsolation: "isolated"})
+	if value, loaded := c.appIsolation["myapp"]; !loaded || value != "" {
+		t.Fatalf("empty isolation was not authoritative: %q, loaded=%v", value, loaded)
+	}
+}
+
 // TestHydrateIsolation_SetsFromLabelWhenEmpty is the RED test for the reboot bug:
 // after a fresh process start (or right after ListBootContainers reads a
 // container's persisted labels), the in-memory appIsolation cache is empty for

--- a/go/internal/cli/assets/docs/device/entitlements.md
+++ b/go/internal/cli/assets/docs/device/entitlements.md
@@ -56,14 +56,18 @@ The network entitlement allows the container to access the device's network. If 
 
 A "network" type entitlement can have the following values:
 
-- **network**: A string representing the network type. Can be `host` (default) or `none`.
+- **mode**: `host` shares the device's network for LAN access; `bridge` provides
+  outbound DNS/downloads through NAT without LAN port publishing; `none` provides
+  only loopback. Declare a mode explicitly. Omitting the entire entitlement gives
+  an ordinary container only loopback, and `wendy run` warns before building.
+  In a shared-network group, secondaries inherit the primary service's namespace.
 
 > Note: NetworkMode `none` does not support remote debugging.
 
 ```json
 {
     "type": "network",
-    "network": "host"
+    "mode": "host"
 }
 ```
 

--- a/go/internal/cli/assets/docs/device/entitlements.mdx
+++ b/go/internal/cli/assets/docs/device/entitlements.mdx
@@ -60,7 +60,15 @@ The network entitlement controls how your application accesses the network.
 | Mode | Description |
 |------|-------------|
 | `host` | Application shares the host's network stack. The container uses the same network interfaces, IP addresses, and ports as the host device. Required for HTTP servers and any network services that need to accept incoming connections. |
+| `bridge` | Private network namespace with outbound connectivity, including DNS and downloads, through NAT. Ports are not published on the device's LAN address. |
 | `none` | Application runs in an isolated network namespace with no network access. Use this for applications that should be completely offline, such as data processing tasks that don't need external connectivity. |
+
+Omitting the network entitlement gives an ordinary container only loopback.
+Declare `none` explicitly when that is intentional; otherwise `wendy run` warns
+before building. Declaring a network entitlement with no `mode` currently means
+`host`; choose a mode explicitly. Isolated service groups receive their CNI bridge.
+With `shared-network` (or `shared-ipc`), secondary services inherit the primary
+service's network namespace, so set networking on the primary service or at app level.
 
 <Callout type="info">
   **Web Servers**: If you're building a web server or any application that accepts incoming connections, you need `"mode": "host"` to make your service accessible from other devices on the network.

--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -782,10 +782,10 @@ func composeAppConfig(projectName, serviceName string, svc composeService, numSe
 	var entitlements []appconfig.Entitlement
 
 	// Network entitlement.
-	if svc.NetworkMode == "host" {
+	if svc.NetworkMode == "host" || svc.NetworkMode == "none" || svc.NetworkMode == "bridge" {
 		entitlements = append(entitlements, appconfig.Entitlement{
 			Type: appconfig.EntitlementNetwork,
-			Mode: "host",
+			Mode: svc.NetworkMode,
 		})
 	} else if len(svc.Ports) > 0 {
 		var ports []appconfig.PortMapping
@@ -1233,6 +1233,15 @@ func runComposeWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, 
 			return err
 		}
 	}
+	networkOrder, err := serviceOrder(cfg)
+	if err != nil {
+		return err
+	}
+	networkConfigs := make([]*appconfig.AppConfig, 0, len(networkOrder))
+	for _, name := range networkOrder {
+		networkConfigs = append(networkConfigs, svcCfgs[name])
+	}
+	printMissingNetworkWarnings(networkConfigs...)
 	serviceEnvs := make(map[string][]string, len(cfg.Services))
 	for name, svc := range cfg.Services {
 		var serviceConfig *appconfig.ServiceConfig

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -369,6 +369,15 @@ func runMultiServiceWithAgent(ctx context.Context, conn *grpcclient.AgentConnect
 	if err != nil {
 		return err
 	}
+	networkOrder, err := serviceTopoOrder(services)
+	if err != nil {
+		return err
+	}
+	networkConfigs := make([]*appconfig.AppConfig, 0, len(networkOrder))
+	for _, name := range networkOrder {
+		networkConfigs = append(networkConfigs, multiServiceCreateConfig(appCfg, name, services[name]))
+	}
+	printMissingNetworkWarnings(networkConfigs...)
 	portConfigs := []*appconfig.AppConfig{appCfg}
 	for name, svc := range services {
 		portConfigs = append(portConfigs, multiServiceCreateConfig(appCfg, name, svc))

--- a/go/internal/cli/commands/network_warning.go
+++ b/go/internal/cli/commands/network_warning.go
@@ -1,0 +1,56 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+// missingNetworkWarnings receives the exact create configs in startup order.
+// A shared-namespace secondary uses the primary's network, even when its own
+// configuration declares different networking. Explicit none is intentional.
+func missingNetworkWarnings(configs []*appconfig.AppConfig) []string {
+	var warnings []string
+	for i, cfg := range configs {
+		if cfg == nil {
+			continue
+		}
+		effective := cfg
+		if i > 0 && appconfig.IsSharedNamespaceIsolation(cfg.Isolation) {
+			effective = configs[0]
+		}
+		if effective == nil {
+			continue
+		}
+		declared := false
+		for _, entitlement := range effective.Entitlements {
+			if entitlement.Type == appconfig.EntitlementNetwork {
+				declared = true
+				break
+			}
+		}
+		// Isolated service groups receive a CNI bridge even without a network
+		// entitlement. Report only services that actually get loopback alone.
+		if declared || (effective.Isolation == "isolated" && effective.ServiceName != "") {
+			continue
+		}
+		name := cfg.ContainerName()
+		inherited := ""
+		if effective != cfg {
+			inherited = fmt.Sprintf(" (inherits primary service %q's network namespace)", effective.ServiceName)
+		}
+		warnings = append(warnings, fmt.Sprintf("service %q has no network entitlement and will receive only loopback%s. Declare {\"type\":\"network\",\"mode\":\"host\"} for LAN access, \"bridge\" for outbound DNS/downloads without LAN port publishing, or \"none\" for intentional offline operation.", name, inherited))
+	}
+	return warnings
+}
+
+func printMissingNetworkWarnings(configs ...*appconfig.AppConfig) {
+	for _, warning := range missingNetworkWarnings(configs) {
+		cliLogln("Warning: %s", warning)
+	}
+}
+
+func isContainerPlatform(platform string) bool {
+	return strings.HasPrefix(platform, "linux") || strings.HasPrefix(platform, "wendyos")
+}

--- a/go/internal/cli/commands/network_warning_test.go
+++ b/go/internal/cli/commands/network_warning_test.go
@@ -1,0 +1,46 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+func TestMissingNetworkWarnings(t *testing.T) {
+	for _, mode := range []string{"host", "bridge", "none", ""} {
+		cfg := &appconfig.AppConfig{AppID: "app", Entitlements: []appconfig.Entitlement{{Type: "network", Mode: mode}}}
+		if got := missingNetworkWarnings([]*appconfig.AppConfig{cfg}); len(got) != 0 {
+			t.Errorf("explicit %q: %v", mode, got)
+		}
+	}
+	cfg := &appconfig.AppConfig{AppID: "app", ServiceName: "api"}
+	warnings := missingNetworkWarnings([]*appconfig.AppConfig{cfg})
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %v", warnings)
+	}
+	for _, text := range []string{"app_api", "loopback", "host", "bridge", "none", "LAN"} {
+		if !strings.Contains(warnings[0], text) {
+			t.Errorf("missing %q: %s", text, warnings[0])
+		}
+	}
+	cfg.Isolation = "isolated"
+	if got := missingNetworkWarnings([]*appconfig.AppConfig{cfg}); len(got) != 0 {
+		t.Fatalf("isolated CNI group: %v", got)
+	}
+}
+
+func TestMissingNetworkWarningsSharedPrimary(t *testing.T) {
+	app := &appconfig.AppConfig{AppID: "app", Isolation: "shared-network"}
+	primary := multiServiceCreateConfig(app, "primary", &appconfig.ServiceConfig{})
+	secondary := multiServiceCreateConfig(app, "secondary", &appconfig.ServiceConfig{Entitlements: []appconfig.Entitlement{{Type: "network", Mode: "host"}}})
+	warnings := missingNetworkWarnings([]*appconfig.AppConfig{primary, secondary})
+	if len(warnings) != 2 || !strings.Contains(warnings[1], "inherits primary") {
+		t.Fatalf("warnings = %v", warnings)
+	}
+	app.Entitlements = []appconfig.Entitlement{{Type: "network", Mode: "none"}}
+	primary = multiServiceCreateConfig(app, "primary", &appconfig.ServiceConfig{})
+	if got := missingNetworkWarnings([]*appconfig.AppConfig{primary, secondary}); len(got) != 0 {
+		t.Fatalf("explicit primary none: %v", got)
+	}
+}

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -1941,6 +1941,10 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 		}
 	}
 
+	if isContainerPlatform(platform) && projectType != "compose" {
+		printMissingNetworkWarnings(appCfg)
+	}
+
 	// Xcode projects: always use the local-build + file-sync path (darwin only).
 	if projectType == "xcode" {
 		if err := rejectUnsupportedBuildHostProject(opts.buildHost, "Xcode projects"); err != nil {


### PR DESCRIPTION
Warn before building when effective networking leaves a service with only loopback, accounting for shared primary namespaces and explicit none. Explicit bridge/none remain selected. Successful creation records empty isolation authoritatively, preserving old persisted CNI cleanup. Networking documentation explains host LAN access and bridge outbound connectivity.

Previous component: https://github.com/wendylabsinc/WendyOS/pull/1906.

Validation: Warning/cache fixtures and Linux container lifecycle race tests passed. Physical LAN/DNS and deployed-group CNI acceptance remain recorded hardware gates.

Part of the WDY-2906–2913 stack. Merge in dependency order. [Final acceptance record and stack index](https://github.com/wendylabsinc/WendyOS/pull/1905). Hardware acceptance and the stable agent/CLI release are still pending; no issue closure is claimed.
