### PR TITLE
WDY-2908/2909: report container storage and explicit GPU backends

### DIFF
--- a/go/internal/agent/gpudiscovery/discovery.go
+++ b/go/internal/agent/gpudiscovery/discovery.go
@@ -80,6 +80,15 @@ func Discover(root string) []Device {
 	for _, pattern := range []string{"/usr/lib*/libcuda.so*", "/usr/lib/*/libcuda.so*", "/usr/lib/*/tegra/libcuda.so*", "/usr/lib/*/nvidia*/libcuda.so*"} {
 		cuda = cuda || len(glob(pattern)) > 0
 	}
+	// The Qualcomm Hexagon NPU (Dragonwing) is reached over FastRPC, and its
+	// non-secure nodes are the app-usable transport: that is the driver-level
+	// evidence for the qnn backend, the same bar /dev/nvidiactl sets for CUDA.
+	// The root-only "-secure" nodes are the signed-PD path and prove nothing
+	// about what an app can reach. The QNN runtime itself ships in the app
+	// image, so no host library is required.
+	qnn := slices.ContainsFunc(glob("/dev/fastrpc-*"), func(node string) bool {
+		return !strings.HasSuffix(node, "-secure")
+	})
 	for i := range devices {
 		switch devices[i].Vendor {
 		case "nvidia":
@@ -89,6 +98,10 @@ func Discover(root string) []Device {
 		case "amd":
 			if exists("/dev/kfd") {
 				devices[i].ComputeBackends = []string{"rocm"}
+			}
+		case "qualcomm":
+			if qnn {
+				devices[i].ComputeBackends = []string{"qnn"}
 			}
 		}
 	}

--- a/go/internal/agent/gpudiscovery/discovery.go
+++ b/go/internal/agent/gpudiscovery/discovery.go
@@ -1,0 +1,144 @@
+// Package gpudiscovery shares host GPU evidence between metadata and inventory.
+package gpudiscovery
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+)
+
+type Device struct {
+	Path, Vendor, Driver string
+	ComputeBackends      []string
+}
+
+func Host() []Device { return Discover("/") }
+
+// Discover reads a supplied filesystem root, allowing deterministic sysfs/devfs
+// fixtures. Device presence and supported host compute backends are independent.
+func Discover(root string) []Device {
+	path := func(p string) string { return filepath.Join(root, p) }
+	exists := func(p string) bool { _, err := os.Stat(path(p)); return err == nil }
+	read := func(p string) string { data, _ := os.ReadFile(path(p)); return strings.TrimSpace(string(data)) }
+	glob := func(p string) []string { matches, _ := filepath.Glob(path(p)); return matches }
+	var devices []Device
+	seen := map[string]bool{}
+	add := func(sysPath, devPath string) {
+		identity, err := filepath.EvalSymlinks(path(sysPath))
+		if err != nil {
+			identity = path(sysPath)
+		}
+		if seen[identity] {
+			return
+		}
+		seen[identity] = true
+		driverPath, _ := os.Readlink(path(filepath.Join(sysPath, "driver")))
+		driver := filepath.Base(driverPath)
+		if driverPath == "" {
+			driver = ""
+		}
+		vendor := vendorID(read(filepath.Join(sysPath, "vendor")))
+		if vendor == "" {
+			vendor = driverVendor(driver)
+		}
+		devices = append(devices, Device{Path: devPath, Vendor: vendor, Driver: driver})
+	}
+	entries, _ := os.ReadDir(path("/sys/class/drm"))
+	for _, entry := range entries {
+		name := entry.Name()
+		if (strings.HasPrefix(name, "card") || strings.HasPrefix(name, "renderD")) && !strings.Contains(name, "-") {
+			add("/sys/class/drm/"+name+"/device", "/dev/dri/"+name)
+		}
+	}
+	entries, _ = os.ReadDir(path("/sys/bus/pci/devices"))
+	for _, entry := range entries {
+		sysPath := "/sys/bus/pci/devices/" + entry.Name()
+		if strings.HasPrefix(read(sysPath+"/class"), "0x03") {
+			add(sysPath, sysPath)
+		}
+	}
+	hasVendor := func(vendor string) bool {
+		return slices.ContainsFunc(devices, func(d Device) bool { return d.Vendor == vendor })
+	}
+	if !hasVendor("nvidia") && (exists("/etc/nv_tegra_release") || exists("/dev/nvidia0")) {
+		devices = append(devices, Device{Path: "/dev/nvidia0", Vendor: "nvidia"})
+	}
+	if !hasVendor("amd") && exists("/dev/kfd") {
+		devices = append(devices, Device{Path: "/dev/kfd", Vendor: "amd"})
+	}
+	if len(devices) == 0 {
+		for _, node := range glob("/dev/dri/*") {
+			if strings.HasPrefix(filepath.Base(node), "card") || strings.HasPrefix(filepath.Base(node), "renderD") {
+				devices = append(devices, Device{Path: "/dev/dri/" + filepath.Base(node)})
+			}
+		}
+	}
+	// CUDA requires host driver evidence, not just a PCI vendor or toolkit.
+	cuda := exists("/dev/nvidiactl") || exists("/dev/nvhost-gpu") || exists("/dev/nvhost-ctrl-gpu")
+	for _, pattern := range []string{"/usr/lib*/libcuda.so*", "/usr/lib/*/libcuda.so*", "/usr/lib/*/tegra/libcuda.so*", "/usr/lib/*/nvidia*/libcuda.so*"} {
+		cuda = cuda || len(glob(pattern)) > 0
+	}
+	for i := range devices {
+		switch devices[i].Vendor {
+		case "nvidia":
+			if cuda {
+				devices[i].ComputeBackends = []string{"cuda"}
+			}
+		case "amd":
+			if exists("/dev/kfd") {
+				devices[i].ComputeBackends = []string{"rocm"}
+			}
+		}
+	}
+	return devices
+}
+
+func vendorID(id string) string {
+	return map[string]string{"0x10de": "nvidia", "0x1002": "amd", "0x1022": "amd", "0x8086": "intel", "0x14e4": "broadcom", "0x13b5": "arm", "0x5143": "qualcomm"}[strings.ToLower(id)]
+}
+
+func driverVendor(driver string) string {
+	switch strings.ToLower(driver) {
+	case "nvidia", "nouveau", "nvgpu", "tegra":
+		return "nvidia"
+	case "amdgpu", "radeon":
+		return "amd"
+	case "i915", "xe":
+		return "intel"
+	case "vc4", "v3d":
+		return "broadcom"
+	case "panfrost", "panthor", "mali", "mali_kbase", "lima":
+		return "arm"
+	case "msm", "msm_dpu", "adreno", "kgsl":
+		// Dragonwing IQ-8275 (CONFIG_DRM_MSM): display and GPU are one msm DRM
+		// device, and the live board binds both nodes to msm_dpu.
+		return "qualcomm"
+	case "etnaviv", "galcore", "vivante":
+		return "vivante"
+	case "virtio_gpu":
+		// QEMU ARM64 and both VM targets, whose virtual GPU is virtio. Named so
+		// a VM reports what it has instead of an unknown vendor.
+		return "virtio"
+	}
+	return ""
+}
+
+// Summary uses a compute-capable device as the legacy singular vendor hint,
+// while retaining all detected backends for hosts with more than one GPU.
+func Summary(devices []Device) (vendor string, backends []string) {
+	backends = []string{}
+	for _, d := range devices {
+		if vendor == "" || len(d.ComputeBackends) > 0 {
+			vendor = d.Vendor
+		}
+		for _, backend := range d.ComputeBackends {
+			if !slices.Contains(backends, backend) {
+				backends = append(backends, backend)
+			}
+		}
+	}
+	sort.Strings(backends)
+	return vendor, backends
+}

--- a/go/internal/agent/gpudiscovery/discovery_test.go
+++ b/go/internal/agent/gpudiscovery/discovery_test.go
@@ -27,6 +27,10 @@ func TestDiscoverVendorsAndCompute(t *testing.T) {
 		{"broadcom", "", "vc4", "", []string{}},
 		{"arm", "", "panfrost", "", []string{}},
 		{"qualcomm", "", "msm", "", []string{}},
+		// Dragonwing: the Hexagon NPU is reachable once a non-secure FastRPC
+		// node exists; the root-only -secure node alone proves nothing.
+		{"qualcomm", "", "msm_dpu", "/dev/fastrpc-cdsp", []string{"qnn"}},
+		{"qualcomm", "", "kgsl", "/dev/fastrpc-cdsp-secure", []string{}},
 		{"vivante", "", "etnaviv", "", []string{}},
 		{"intel", "0x8086", "i915", "", []string{}},
 		{"nvidia", "0x10de", "nvidia", "/dev/nvidiactl", []string{"cuda"}},

--- a/go/internal/agent/gpudiscovery/discovery_test.go
+++ b/go/internal/agent/gpudiscovery/discovery_test.go
@@ -1,0 +1,132 @@
+package gpudiscovery
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func writeFixture(t *testing.T, root, path, text string) {
+	t.Helper()
+	p := filepath.Join(root, path)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(text), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDiscoverVendorsAndCompute(t *testing.T) {
+	for _, tc := range []struct {
+		vendor, id, driver, evidence string
+		backends                     []string
+	}{
+		{"broadcom", "", "v3d", "", []string{}},
+		{"broadcom", "", "vc4", "", []string{}},
+		{"arm", "", "panfrost", "", []string{}},
+		{"qualcomm", "", "msm", "", []string{}},
+		{"vivante", "", "etnaviv", "", []string{}},
+		{"intel", "0x8086", "i915", "", []string{}},
+		{"nvidia", "0x10de", "nvidia", "/dev/nvidiactl", []string{"cuda"}},
+		{"nvidia", "0x10de", "nouveau", "", []string{}},
+		{"amd", "0x1002", "amdgpu", "/dev/kfd", []string{"rocm"}},
+	} {
+		t.Run(tc.driver, func(t *testing.T) {
+			root := t.TempDir()
+			writeFixture(t, root, "/sys/class/drm/card0/device/vendor", tc.id)
+			if err := os.Symlink("/sys/bus/platform/drivers/"+tc.driver, filepath.Join(root, "sys/class/drm/card0/device/driver")); err != nil {
+				t.Fatal(err)
+			}
+			if tc.evidence != "" {
+				writeFixture(t, root, tc.evidence, "")
+			}
+			devices := Discover(root)
+			vendor, backends := Summary(devices)
+			if len(devices) != 1 || vendor != tc.vendor || !reflect.DeepEqual(backends, tc.backends) {
+				t.Fatalf("discovered %+v, summary %s %v; want %s %v", devices, vendor, backends, tc.vendor, tc.backends)
+			}
+		})
+	}
+}
+
+func TestDiscoverPCIWithoutDRMAndNoFalseCUDA(t *testing.T) {
+	root := t.TempDir()
+	writeFixture(t, root, "/sys/bus/pci/devices/0000:01:00.0/class", "0x030200")
+	writeFixture(t, root, "/sys/bus/pci/devices/0000:01:00.0/vendor", "0x10de")
+	writeFixture(t, root, "/usr/local/cuda/version.txt", "CUDA 13.0")
+	devices := Discover(root)
+	if len(devices) != 1 || devices[0].Vendor != "nvidia" || len(devices[0].ComputeBackends) != 0 {
+		t.Fatalf("PCI hardware/toolkit should not imply a working CUDA driver: %+v", devices)
+	}
+	if devices := Discover(t.TempDir()); len(devices) != 0 {
+		t.Fatalf("empty host: %+v", devices)
+	}
+}
+
+// drmTree lays out /sys/class/drm-shaped nodes under root: node name -> driver
+// name. An empty driver means the node has no driver symlink, like a connector
+// child. Each node gets its own device directory, as sysfs presents them.
+func drmTree(t *testing.T, root string, nodes map[string]string) {
+	t.Helper()
+	for node, driver := range nodes {
+		dev := filepath.Join(root, "sys/class/drm", node, "device")
+		if err := os.MkdirAll(dev, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if driver == "" {
+			continue
+		}
+		target := filepath.Join(root, "sys/bus/platform/drivers", driver)
+		if err := os.MkdirAll(target, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(target, filepath.Join(dev, "driver")); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestDiscoverDRMDriverVendors covers the boards WendyOS ships, laid out as
+// their live sysfs trees. An untested driver reports a present device with an
+// honest empty vendor rather than a guess.
+func TestDiscoverDRMDriverVendors(t *testing.T) {
+	for name, tc := range map[string]struct {
+		nodes   map[string]string
+		vendor  string
+		devices int
+	}{
+		// The real Dragonwing IQ-8275: display and GPU are one msm DRM device,
+		// both nodes bind to msm_dpu, and the connector children carry no
+		// driver of their own.
+		"dragonwing": {
+			nodes: map[string]string{
+				"card0":             "msm_dpu",
+				"renderD128":        "msm_dpu",
+				"card0-DP-1":        "",
+				"card0-Writeback-1": "",
+			},
+			vendor: "qualcomm", devices: 2,
+		},
+		// A Raspberry Pi splits them: vc4 drives the display, v3d the GPU.
+		"raspberry pi": {nodes: map[string]string{"card0": "vc4", "renderD128": "v3d"}, vendor: "broadcom", devices: 2},
+		"display only": {nodes: map[string]string{"card0": "vc4"}, vendor: "broadcom", devices: 1},
+		"amd":          {nodes: map[string]string{"card0": "amdgpu", "renderD128": "amdgpu"}, vendor: "amd", devices: 2},
+		"intel":        {nodes: map[string]string{"card0": "i915", "renderD128": "i915"}, vendor: "intel", devices: 2},
+		// QEMU ARM64 and both VM targets, whose virtual GPU is virtio.
+		"vm":           {nodes: map[string]string{"card0": "virtio_gpu", "renderD128": "virtio_gpu"}, vendor: "virtio", devices: 2},
+		"untested gpu": {nodes: map[string]string{"card0": "vmwgfx"}, vendor: "", devices: 1},
+		"no driver":    {nodes: map[string]string{"card0": ""}, vendor: "", devices: 1},
+	} {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			drmTree(t, root, tc.nodes)
+			devices := Discover(root)
+			vendor, backends := Summary(devices)
+			if len(devices) != tc.devices || vendor != tc.vendor || len(backends) != 0 {
+				t.Fatalf("discovered %+v, summary %q %v; want %d devices, vendor %q, no backends", devices, vendor, backends, tc.devices, tc.vendor)
+			}
+		})
+	}
+}

--- a/go/internal/agent/hardware/discoverer.go
+++ b/go/internal/agent/hardware/discoverer.go
@@ -13,12 +13,14 @@ import (
 
 	"github.com/wendylabsinc/wendy/go/internal/agent/audio"
 	"github.com/wendylabsinc/wendy/go/internal/agent/camera"
+	"github.com/wendylabsinc/wendy/go/internal/agent/gpudiscovery"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
 
 // SystemHardwareDiscoverer discovers hardware by probing the Linux sysfs/devfs/procfs.
 type SystemHardwareDiscoverer struct {
 	logger             *zap.Logger
+	discoverGPUs       func() []gpudiscovery.Device
 	classifyTransport  func(base string) (camera.Transport, string)
 	enumerateLibcamera func(ctx context.Context) (map[string]string, error)
 }
@@ -62,46 +64,19 @@ func (d *SystemHardwareDiscoverer) Discover(ctx context.Context, categoryFilter 
 	return caps, nil
 }
 
-// discoverGPU checks for NVIDIA and DRM GPU devices.
+// discoverGPU uses the same injectable discovery as device metadata.
 func (d *SystemHardwareDiscoverer) discoverGPU() []*agentpb.ListHardwareCapabilitiesResponse_HardwareCapability {
+	probe := d.discoverGPUs
+	if probe == nil {
+		probe = gpudiscovery.Host
+	}
 	var caps []*agentpb.ListHardwareCapabilitiesResponse_HardwareCapability
-
-	// NVIDIA devices.
-	for i := 0; i < 16; i++ {
-		path := fmt.Sprintf("/dev/nvidia%d", i)
-		if _, err := os.Stat(path); err == nil {
-			caps = append(caps, &agentpb.ListHardwareCapabilitiesResponse_HardwareCapability{
-				Category:    "gpu",
-				DevicePath:  path,
-				Description: fmt.Sprintf("NVIDIA GPU %d", i),
-			})
-		}
+	for _, gpu := range probe() {
+		caps = append(caps, &agentpb.ListHardwareCapabilitiesResponse_HardwareCapability{
+			Category: "gpu", DevicePath: gpu.Path, Description: strings.TrimSpace(gpu.Vendor + " GPU " + gpu.Driver),
+			Properties: map[string]string{"vendor": gpu.Vendor, "driver": gpu.Driver, "compute_backends": strings.Join(gpu.ComputeBackends, ",")},
+		})
 	}
-
-	// DRM devices.
-	drmPath := "/sys/class/drm"
-	entries, err := os.ReadDir(drmPath)
-	if err == nil {
-		for _, entry := range entries {
-			if strings.HasPrefix(entry.Name(), "card") && !strings.Contains(entry.Name(), "-") {
-				devPath := filepath.Join("/dev/dri", entry.Name())
-				name := entry.Name()
-
-				// Try to read device model.
-				labelPath := filepath.Join(drmPath, entry.Name(), "device", "label")
-				if data, err := os.ReadFile(labelPath); err == nil {
-					name = strings.TrimSpace(string(data))
-				}
-
-				caps = append(caps, &agentpb.ListHardwareCapabilitiesResponse_HardwareCapability{
-					Category:    "gpu",
-					DevicePath:  devPath,
-					Description: name,
-				})
-			}
-		}
-	}
-
 	return caps
 }
 

--- a/go/internal/agent/oci/entitlements.go
+++ b/go/internal/agent/oci/entitlements.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -15,6 +16,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/wendylabsinc/wendy/go/internal/agent/board"
+	"github.com/wendylabsinc/wendy/go/internal/agent/gpudiscovery"
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
 )
 
@@ -194,6 +196,14 @@ func applyGPU(spec *Spec) {
 		applyAMDGPU(spec)
 		return
 	}
+	// A Qualcomm SoC (Dragonwing) has neither /dev/kfd nor /dev/nvidia*, so it
+	// would otherwise fall into the NVIDIA static fallback below and receive
+	// bogus major-195 nodes while the render node its GPU userspace needs is
+	// never granted. Branch on the live DRM driver instead.
+	if qualcommGPUPresent() {
+		applyQualcommGPU(spec)
+		return
+	}
 
 	// Add the nvidia group GID for device access.
 	spec.Process.User.AdditionalGids = appendUnique(spec.Process.User.AdditionalGids, nvidiaGroupGID)
@@ -310,6 +320,33 @@ func applyAMDGPU(spec *Spec) {
 
 	// The GPU is the DRM render node. Grant renderD* exactly (mknod'd into the
 	// container from the live major:minor), the same mechanism as the Jetson iGPU.
+	addExactDeviceNodes(spec, discoverRenderDeviceNodes())
+}
+
+// qualcommGPUPresent reports whether the host GPU is a Qualcomm Adreno behind
+// the msm DRM driver (the Dragonwing IQ-8275 and its kin), using the same
+// discovery device metadata reports from. Behind a var so tests can pin the
+// answer without a Qualcomm sysfs tree.
+var qualcommGPUPresent = func() bool {
+	return slices.ContainsFunc(gpudiscovery.Host(), func(d gpudiscovery.Device) bool {
+		return d.Vendor == "qualcomm"
+	})
+}
+
+// applyQualcommGPU wires up Adreno GPU access on a Qualcomm SoC. The GPU
+// userspace (mesa freedreno/turnip, OpenCL, Vulkan) opens the DRM render node;
+// there is no vendor control node like /dev/nvidiactl or /dev/kfd. card* stays
+// behind the display entitlement, matching the AMD and Jetson paths. The
+// Hexagon NPU is a separate accelerator reached over FastRPC and belongs to
+// the npu entitlement, not this one.
+func applyQualcommGPU(spec *Spec) {
+	// renderD* is group-owned by "render" (and "video" on some images). Add
+	// both; the exact device node and cgroup rule below remain the real access
+	// boundary, so group membership alone reaches nothing.
+	spec.Process.User.AdditionalGids = appendUnique(spec.Process.User.AdditionalGids, videoGroupGID)
+	if gid, ok := lookupRenderGID(); ok {
+		spec.Process.User.AdditionalGids = appendUnique(spec.Process.User.AdditionalGids, gid)
+	}
 	addExactDeviceNodes(spec, discoverRenderDeviceNodes())
 }
 

--- a/go/internal/agent/oci/entitlements_test.go
+++ b/go/internal/agent/oci/entitlements_test.go
@@ -2834,3 +2834,108 @@ func TestApplyNPU_LeavesFirmwareMasked(t *testing.T) {
 		})
 	}
 }
+
+// installFakeQualcommDevTree stands in for a Qualcomm SoC such as the Dragonwing
+// IQ-8275: an Adreno GPU behind the msm DRM driver, so a render node and no
+// vendor control node (no /dev/kfd, no /dev/nvidia*). It pins the Qualcomm
+// probe so the suite needs no Qualcomm sysfs tree.
+func installFakeQualcommDevTree(t *testing.T, renderNodes map[string][2]int64) string {
+	t.Helper()
+	dev := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dev, "dri"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	renderNums := map[string][2]int64{}
+	for name, nums := range renderNodes {
+		p := filepath.Join(dev, "dri", name)
+		if err := os.WriteFile(p, nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		renderNums[p] = nums
+	}
+
+	origKFD := kfdDevicePath
+	origQualcomm := qualcommGPUPresent
+	origRenderGlobs := renderDeviceGlobs
+	origStatChar := statCharDevice
+	origRender := lookupRenderGID
+	t.Cleanup(func() {
+		kfdDevicePath = origKFD
+		qualcommGPUPresent = origQualcomm
+		renderDeviceGlobs = origRenderGlobs
+		statCharDevice = origStatChar
+		lookupRenderGID = origRender
+	})
+
+	kfdDevicePath = filepath.Join(dev, "absent-kfd")
+	qualcommGPUPresent = func() bool { return true }
+	renderDeviceGlobs = []string{filepath.Join(dev, "dri", "renderD*")}
+	statCharDevice = func(p string) (int64, int64, error) {
+		if nums, ok := renderNums[p]; ok {
+			return nums[0], nums[1], nil
+		}
+		return 0, 0, fmt.Errorf("%s is not a character device node", p)
+	}
+	lookupRenderGID = func() (uint32, bool) { return 107, true }
+	return dev
+}
+
+// TestApplyGPU_QualcommExposesRenderNodeOnly is the load-bearing Dragonwing
+// test: on a Qualcomm host the gpu entitlement must grant the Adreno render
+// node (what mesa, OpenCL and Vulkan open) with an exact major:minor rule and
+// the render/video groups, keep the display card node behind the display
+// entitlement, and NOT fall through to the NVIDIA static-node fallback, which
+// would mknod bogus major-195 nodes into the container.
+func TestApplyGPU_QualcommExposesRenderNodeOnly(t *testing.T) {
+	dev := installFakeQualcommDevTree(t, map[string][2]int64{"renderD128": {226, 128}, "card0": {226, 0}})
+
+	spec := gpuSpec(t)
+
+	if _, ok := deviceForPath(spec, filepath.Join(dev, "dri", "renderD128")); !ok {
+		t.Error("Qualcomm GPU entitlement did not add the DRM render node")
+	}
+	if !hasExactDeviceRule(spec, 226, 128) {
+		t.Error("Qualcomm GPU entitlement did not allow the render node major:minor")
+	}
+	if _, ok := deviceForPath(spec, filepath.Join(dev, "dri", "card0")); ok {
+		t.Error("Qualcomm GPU entitlement granted the display card node")
+	}
+
+	if !hasGID(spec, 107) {
+		t.Error("Qualcomm GPU entitlement did not add the render GID")
+	}
+	if !hasGID(spec, videoGroupGID) {
+		t.Error("Qualcomm GPU entitlement did not add the video GID")
+	}
+
+	if hasMajorRule(spec, 195) {
+		t.Error("Qualcomm host must not get the NVIDIA major-195 fallback rule")
+	}
+	for _, d := range spec.Linux.Devices {
+		if strings.Contains(d.Path, "nvidia") {
+			t.Errorf("Qualcomm host must not get NVIDIA device nodes, got %q", d.Path)
+		}
+	}
+	for _, e := range spec.Process.Env {
+		if strings.HasPrefix(e, "NVIDIA_") {
+			t.Errorf("Qualcomm host must not get NVIDIA env vars, got %q", e)
+		}
+	}
+}
+
+// TestApplyGPU_QualcommWithoutRenderNodeAddsNoDevices keeps the entitlement
+// inert on a Qualcomm host whose render node has not appeared yet: no device
+// grants, and still no NVIDIA fallback.
+func TestApplyGPU_QualcommWithoutRenderNodeAddsNoDevices(t *testing.T) {
+	installFakeQualcommDevTree(t, nil)
+
+	base := DefaultSpec("/rootfs", []string{"/bin/sh"})
+	spec := gpuSpec(t)
+
+	if len(spec.Linux.Devices) != len(base.Linux.Devices) {
+		t.Errorf("devices changed with no render node: %d -> %d", len(base.Linux.Devices), len(spec.Linux.Devices))
+	}
+	if hasMajorRule(spec, 195) {
+		t.Error("Qualcomm host must not get the NVIDIA major-195 fallback rule")
+	}
+}

--- a/go/internal/agent/services/agent_service.go
+++ b/go/internal/agent/services/agent_service.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/wendylabsinc/wendy/go/internal/agent/gpudiscovery"
 	"github.com/wendylabsinc/wendy/go/internal/agent/hoststats"
 	"github.com/wendylabsinc/wendy/go/internal/agent/oshealth"
 	"github.com/wendylabsinc/wendy/go/internal/shared/sigverify"
@@ -30,13 +31,15 @@ import (
 
 type AgentService struct {
 	agentpb.UnimplementedWendyAgentServiceServer
-	logger             *zap.Logger
-	networkManager     NetworkManager
-	hardwareDiscoverer HardwareDiscoverer
-	bluetoothManager   BluetoothManager
-	installer          *AgentInstaller
-	isWendyOSHost      func() bool
-	osUpdateStateDir   string
+	logger                   *zap.Logger
+	networkManager           NetworkManager
+	hardwareDiscoverer       HardwareDiscoverer
+	discoverGPUs             func() []gpudiscovery.Device
+	discoverContainerStorage func() (partitionUsage, bool)
+	bluetoothManager         BluetoothManager
+	installer                *AgentInstaller
+	isWendyOSHost            func() bool
+	osUpdateStateDir         string
 
 	// verifier checks the update binary's signature before install. Defaults
 	// to sigverify.DefaultVerifier (disabled until a real pinned key is
@@ -109,7 +112,12 @@ func (s *AgentService) GetAgentVersion(_ context.Context, _ *agentpb.GetAgentVer
 		}
 	}
 
-	gpuInfo := detectGPUInfo()
+	gpuProbe := s.discoverGPUs
+	if gpuProbe == nil {
+		gpuProbe = gpudiscovery.Host
+	}
+	gpuInfo := detectGPUInfoFrom(gpuProbe())
+	resp.GpuCapabilities = gpuCapabilitiesV1(gpuInfo.devices)
 	resp.HasGpu = &gpuInfo.hasGPU
 	if gpuInfo.vendor != "" {
 		resp.GpuVendor = &gpuInfo.vendor
@@ -133,6 +141,14 @@ func (s *AgentService) GetAgentVersion(_ context.Context, _ *agentpb.GetAgentVer
 	if usage, ok := rootDiskUsage(); ok {
 		resp.DiskUsedBytes = &usage.usedBytes
 		resp.DiskTotalBytes = &usage.totalBytes
+	}
+
+	storageProbe := s.discoverContainerStorage
+	if storageProbe == nil {
+		storageProbe = containerStorageUsage
+	}
+	if p, ok := storageProbe(); ok {
+		resp.ContainerStorage = &agentpb.DiskPartition{Mountpoint: p.mountpoint, Filesystem: p.filesystem, Device: p.device, UsedBytes: p.usedBytes, TotalBytes: p.totalBytes}
 	}
 
 	resp.MemTotalBytes, resp.CpuCount = hostMemAndCPUCount()
@@ -224,6 +240,7 @@ type gpuInfo struct {
 	jetpackVersion string
 	cudaVersion    string
 	gpuArch        string
+	devices        []gpudiscovery.Device
 }
 
 // detectGPUInfo probes on every call rather than caching. /dev/dri and the DRM
@@ -231,31 +248,11 @@ type gpuInfo struct {
 // and installing a driver add-on makes a GPU appear without restarting the
 // agent — so a cached "no GPU" would never heal, and would contradict
 // detectFeatureset, which re-probes.
-func detectGPUInfo() gpuInfo {
-	info := gpuInfo{}
+func detectGPUInfo() gpuInfo { return detectGPUInfoFrom(gpudiscovery.Host()) }
 
-	// /etc/nv_tegra_release is the definitive indicator of an NVIDIA Tegra/Jetson
-	// device. Check it first because /dev/nvidia0 is absent on many Jetson configs
-	// where the GPU is an integrated Tegra (e.g. JetPack 5/6 on Orin).
-	if _, err := os.Stat("/etc/nv_tegra_release"); err == nil {
-		info.hasGPU = true
-		info.vendor = "nvidia"
-	} else if _, err := os.Stat("/dev/nvidia0"); err == nil {
-		// Discrete NVIDIA GPU (no Tegra release file).
-		info.hasGPU = true
-		info.vendor = "nvidia"
-	} else if _, err := os.Stat("/dev/kfd"); err == nil {
-		// AMD ROCm: /dev/kfd (the compute device) is the definitive signal, and
-		// unlike a bare /dev/dri it names the vendor. Checked before the generic
-		// DRM branch so an AMD box reports "amd" rather than an unknown vendor.
-		info.hasGPU = true
-		info.vendor = "amd"
-	} else if entries, _ := os.ReadDir(devDRIPath); len(entries) > 0 {
-		// Name the vendor from the kernel driver: an SoC GPU has no PCI
-		// vendor id, so that is the only signal available.
-		info.hasGPU = true
-		info.vendor = drmVendor()
-	}
+func detectGPUInfoFrom(devices []gpudiscovery.Device) gpuInfo {
+	vendor, _ := gpudiscovery.Summary(devices)
+	info := gpuInfo{hasGPU: len(devices) > 0, vendor: vendor, devices: devices}
 
 	switch info.vendor {
 	case "nvidia":
@@ -269,70 +266,13 @@ func detectGPUInfo() gpuInfo {
 	return info
 }
 
-// drmDriverVendors maps a DRM kernel driver to the GPU vendor behind it. Every
-// entry is a driver a WendyOS image actually ships, so an untested GPU reports
-// an honest "unknown" rather than a guess.
-//
-// Never map a driver to "nvidia": an NVIDIA GPU is identified by the branches
-// above, and reaching this one means the proprietary stack is absent — so the
-// JetPack/CUDA/nvidia-smi probes would report a runtime that is not there.
-var drmDriverVendors = map[string]string{
-	// Dragonwing IQ-8275 (CONFIG_DRM_MSM).
-	"msm":     "qualcomm",
-	"msm_dpu": "qualcomm",
-	// Raspberry Pi 3/4/5: vc4 drives the display, v3d the GPU.
-	"v3d": "broadcom",
-	"vc4": "broadcom",
-	// Generic x86: the builder's x86-nuc-drivers.cfg enables all four for
-	// "integrated and discrete GPU coverage for commodity x86 PCs".
-	"i915":   "intel",
-	"xe":     "intel",
-	"amdgpu": "amd",
-	"radeon": "amd",
-	// QEMU ARM64 and both VM targets, whose virtual GPU is virtio.
-	"virtio_gpu": "virtio",
-}
-
-// These paths are behind vars so tests can point them at a fixture tree.
+// FastRPC transport nodes; the "-secure" ones are the root-only signed-PD path.
+// Kept in step with the npu entitlement in agent/oci, which grants the same set.
+// Behind vars so tests can point them at a fixture tree.
 var (
-	drmSysfsRoot = "/sys/class/drm"
-	devDRIPath   = "/dev/dri"
-	// FastRPC transport nodes; the "-secure" ones are the root-only signed-PD path.
-	// Kept in step with the npu entitlement in agent/oci, which grants the same set.
 	fastrpcDeviceGlob   = "/dev/fastrpc-*"
 	fastrpcSecureSuffix = "-secure"
 )
-
-// drmVendor names the GPU vendor from the DRM driver bound to it. The render
-// node wins over the card node: on a board that splits them (an RPi exposes
-// vc4 for display and v3d for the GPU) the render node is the GPU.
-func drmVendor() string {
-	entries, err := os.ReadDir(drmSysfsRoot)
-	if err != nil {
-		return ""
-	}
-	// Render nodes first: on a split display/GPU SoC that is the GPU.
-	for _, prefix := range []string{"renderD", "card"} {
-		for _, e := range entries {
-			name := e.Name()
-			if !strings.HasPrefix(name, prefix) {
-				continue
-			}
-			// Skip per-connector children ("card0-DP-1"): no driver.
-			if prefix == "card" && strings.Contains(name, "-") {
-				continue
-			}
-			link, err := os.Readlink(filepath.Join(drmSysfsRoot, name, "device", "driver"))
-			if err != nil {
-				continue
-			}
-			if vendor, ok := drmDriverVendors[filepath.Base(link)]; ok {
-				return vendor
-			}
-		}
-	}
-	return ""
-}
 
 // adrenoCompatibleRe pulls the model out of "qcom,adreno-623.0" -> "623".
 var adrenoCompatibleRe = regexp.MustCompile(`qcom,adreno-(\d+)\.\d+`)
@@ -1127,4 +1067,19 @@ func CleanupOldBackups(logger *zap.Logger) {
 		}
 		logger.Info("Removed old backup", zap.String("path", backupPath))
 	}
+}
+
+// gpuCapabilitiesV1 lists one entry per detected GPU. A GPU without a supported
+// backend is still listed with an empty backend list, so a client can tell "no
+// compute on this GPU" from "older agent that never sent the list".
+func gpuCapabilitiesV1(devices []gpudiscovery.Device) []*agentpb.GpuCapabilities {
+	out := make([]*agentpb.GpuCapabilities, 0, len(devices))
+	for _, d := range devices {
+		out = append(out, &agentpb.GpuCapabilities{
+			Vendor:          d.Vendor,
+			Path:            d.Path,
+			ComputeBackends: append([]string{}, d.ComputeBackends...),
+		})
+	}
+	return out
 }

--- a/go/internal/agent/services/container_storage.go
+++ b/go/internal/agent/services/container_storage.go
@@ -1,0 +1,51 @@
+package services
+
+import "strings"
+
+// discoverContainerStorage matches the path's device identity against mountinfo,
+// including bind mounts whose mount root is a subdirectory of the filesystem.
+// Prefer the filesystem's root mount so the result identifies the same partition
+// as the ordinary partition list. All host inspection is supplied by the caller.
+func discoverContainerStorage(mountinfo, path, deviceID string, usage func(string) (diskUsage, bool)) (partitionUsage, bool) {
+	type mount struct {
+		mountEntry
+		id, root string
+	}
+	var mounts []mount
+	var containing *mount
+	for line := range strings.SplitSeq(mountinfo, "\n") {
+		left, right, ok := strings.Cut(line, " - ")
+		if !ok {
+			continue
+		}
+		fields, fs := strings.Fields(left), strings.Fields(right)
+		if len(fields) < 6 || len(fs) < 3 || fields[2] != deviceID {
+			continue
+		}
+		m := mount{mountEntry{device: unescapeMountField(fs[1]), mountpoint: unescapeMountField(fields[4]), filesystem: fs[0]}, fields[2], unescapeMountField(fields[3])}
+		mounts = append(mounts, m)
+		if path == m.mountpoint || strings.HasPrefix(path, strings.TrimSuffix(m.mountpoint, "/")+"/") {
+			if containing == nil || len(m.mountpoint) > len(containing.mountpoint) {
+				copy := m
+				containing = &copy
+			}
+		}
+	}
+	if containing == nil {
+		return partitionUsage{}, false
+	}
+	chosen := *containing
+	for _, m := range mounts {
+		if m.root == "/" && (chosen.root != "/" || len(m.mountpoint) < len(chosen.mountpoint)) {
+			chosen = m
+		}
+	}
+	if !strings.HasPrefix(chosen.device, "/dev/") {
+		return partitionUsage{}, false
+	}
+	u, ok := usage(path)
+	if !ok {
+		return partitionUsage{}, false
+	}
+	return partitionUsage{mountpoint: chosen.mountpoint, filesystem: chosen.filesystem, device: chosen.device, usedBytes: u.usedBytes, totalBytes: u.totalBytes}, true
+}

--- a/go/internal/agent/services/container_storage_linux.go
+++ b/go/internal/agent/services/container_storage_linux.go
@@ -1,0 +1,28 @@
+//go:build linux
+
+package services
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+func containerStorageUsage() (partitionUsage, bool) {
+	path, err := filepath.EvalSymlinks("/var/lib/containerd")
+	if err != nil {
+		return partitionUsage{}, false
+	}
+	var stat unix.Stat_t
+	if err := unix.Stat(path, &stat); err != nil {
+		return partitionUsage{}, false
+	}
+	data, err := os.ReadFile("/proc/self/mountinfo")
+	if err != nil {
+		return partitionUsage{}, false
+	}
+	id := fmt.Sprintf("%d:%d", unix.Major(uint64(stat.Dev)), unix.Minor(uint64(stat.Dev)))
+	return discoverContainerStorage(string(data), path, id, statfsUsage)
+}

--- a/go/internal/agent/services/container_storage_other.go
+++ b/go/internal/agent/services/container_storage_other.go
@@ -1,0 +1,5 @@
+//go:build !linux
+
+package services
+
+func containerStorageUsage() (partitionUsage, bool) { return partitionUsage{}, false }

--- a/go/internal/agent/services/container_storage_test.go
+++ b/go/internal/agent/services/container_storage_test.go
@@ -1,0 +1,103 @@
+package services
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/gpudiscovery"
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
+)
+
+func TestContainerStorageMountIdentity(t *testing.T) {
+	info := `24 1 8:1 / / rw - ext4 /dev/sda1 rw
+25 24 259:1 / /data rw - ext4 /dev/nvme0n1p1 rw
+26 24 259:1 /containerd /var/lib/containerd rw - ext4 /dev/disk/by-uuid/data rw
+27 24 8:2 / /var/lib/containerd-other rw - ext4 /dev/sda2 rw
+`
+	usage := func(path string) (diskUsage, bool) {
+		if path != "/var/lib/containerd" {
+			t.Fatalf("statfs queried %q", path)
+		}
+		return diskUsage{usedBytes: 150, totalBytes: 1000}, true
+	}
+	p, ok := discoverContainerStorage(info, "/var/lib/containerd", "259:1", usage)
+	if !ok || p.mountpoint != "/data" || p.device != "/dev/nvme0n1p1" || p.totalBytes != 1000 {
+		t.Fatalf("storage = %+v, %v", p, ok)
+	}
+	if _, ok := discoverContainerStorage(info, "/var/lib/containerd", "8:2", usage); ok {
+		t.Fatal("matched a path prefix without containment")
+	}
+	if _, ok := discoverContainerStorage(info, "/var/lib/containerd", "259:1", func(string) (diskUsage, bool) { return diskUsage{}, false }); ok {
+		t.Fatal("reported failed statfs")
+	}
+}
+
+func TestDeviceMetadataStorageAndGPUParity(t *testing.T) {
+	storage := func() (partitionUsage, bool) {
+		return partitionUsage{mountpoint: "/data", device: "/dev/nvme0n1p1", totalBytes: 1000, usedBytes: 150}, true
+	}
+	gpu := func() []gpudiscovery.Device {
+		return []gpudiscovery.Device{{Path: "/dev/dri/card0", Vendor: "broadcom"}}
+	}
+	v1, err := (&AgentService{discoverContainerStorage: storage, discoverGPUs: gpu}).GetAgentVersion(context.Background(), &agentpb.GetAgentVersionRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	v2, err := (&DeviceInfoService{discoverContainerStorage: storage, discoverGPUs: gpu}).GetDeviceInfo(context.Background(), &agentpbv2.GetDeviceInfoRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v1.GetContainerStorage().GetTotalBytes() != v2.GetContainerStorage().GetTotalBytes() || v1.GetContainerStorage().GetMountpoint() != "/data" {
+		t.Fatal("storage metadata mismatch")
+	}
+	if !v1.GetHasGpu() || v1.GetGpuVendor() != "broadcom" {
+		t.Fatalf("v1 has_gpu=%v vendor=%q; want a broadcom GPU", v1.GetHasGpu(), v1.GetGpuVendor())
+	}
+	// A GPU without a supported backend is still listed, with an empty backend
+	// list, so callers can tell "no compute" from "older agent".
+	v1GPUs, v2GPUs := v1.GetGpuCapabilities(), v2.GetGpuCapabilities()
+	if len(v1GPUs) != 1 || v1GPUs[0].GetVendor() != "broadcom" || v1GPUs[0].GetPath() != "/dev/dri/card0" || len(v1GPUs[0].GetComputeBackends()) != 0 {
+		t.Fatalf("v1 gpu entries = %+v; want one broadcom entry without backends", v1GPUs)
+	}
+	if len(v2GPUs) != 1 || v2GPUs[0].GetVendor() != "broadcom" || v2GPUs[0].GetPath() != "/dev/dri/card0" || len(v2GPUs[0].GetComputeBackends()) != 0 {
+		t.Fatalf("v2 gpu entries = %+v; want one broadcom entry without backends", v2GPUs)
+	}
+}
+
+func TestDeviceMetadataListsEveryGPU(t *testing.T) {
+	gpu := func() []gpudiscovery.Device {
+		return []gpudiscovery.Device{
+			{Path: "/dev/dri/card0", Vendor: "amd", ComputeBackends: []string{"rocm"}},
+			{Path: "/dev/dri/card1", Vendor: "nvidia", ComputeBackends: []string{"cuda"}},
+		}
+	}
+	v1, err := (&AgentService{discoverGPUs: gpu}).GetAgentVersion(context.Background(), &agentpb.GetAgentVersionRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	v2, err := (&DeviceInfoService{discoverGPUs: gpu}).GetDeviceInfo(context.Background(), &agentpbv2.GetDeviceInfoRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []struct{ vendor, path, backend string }{
+		{"amd", "/dev/dri/card0", "rocm"},
+		{"nvidia", "/dev/dri/card1", "cuda"},
+	}
+	v1GPUs, v2GPUs := v1.GetGpuCapabilities(), v2.GetGpuCapabilities()
+	if len(v1GPUs) != len(want) || len(v2GPUs) != len(want) {
+		t.Fatalf("v1 %d entries, v2 %d entries; want %d each", len(v1GPUs), len(v2GPUs), len(want))
+	}
+	for i, w := range want {
+		if v1GPUs[i].GetVendor() != w.vendor || v1GPUs[i].GetPath() != w.path || !reflect.DeepEqual(v1GPUs[i].GetComputeBackends(), []string{w.backend}) {
+			t.Fatalf("v1 entry %d = %+v; want %+v", i, v1GPUs[i], w)
+		}
+		if v2GPUs[i].GetVendor() != w.vendor || v2GPUs[i].GetPath() != w.path || !reflect.DeepEqual(v2GPUs[i].GetComputeBackends(), []string{w.backend}) {
+			t.Fatalf("v2 entry %d = %+v; want %+v", i, v2GPUs[i], w)
+		}
+	}
+	if !v1.GetHasGpu() || v1.GetGpuVendor() == "" {
+		t.Fatalf("legacy singular fields dropped: has_gpu=%v vendor=%q", v1.GetHasGpu(), v1.GetGpuVendor())
+	}
+}

--- a/go/internal/agent/services/device_info_service.go
+++ b/go/internal/agent/services/device_info_service.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/wendylabsinc/wendy/go/internal/agent/gpudiscovery"
 	"github.com/wendylabsinc/wendy/go/internal/agent/hoststats"
 	"github.com/wendylabsinc/wendy/go/internal/shared/version"
 	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
@@ -17,8 +18,10 @@ import (
 
 type DeviceInfoService struct {
 	agentpbv2.UnimplementedWendyDeviceInfoServiceServer
-	logger             *zap.Logger
-	hardwareDiscoverer HardwareDiscoverer
+	logger                   *zap.Logger
+	hardwareDiscoverer       HardwareDiscoverer
+	discoverGPUs             func() []gpudiscovery.Device
+	discoverContainerStorage func() (partitionUsage, bool)
 }
 
 func NewDeviceInfoService(logger *zap.Logger, hd HardwareDiscoverer) *DeviceInfoService {
@@ -44,7 +47,12 @@ func (s *DeviceInfoService) GetDeviceInfo(_ context.Context, _ *agentpbv2.GetDev
 		resp.DeviceType = &v
 	}
 
-	gpuInfo := detectGPUInfo()
+	gpuProbe := s.discoverGPUs
+	if gpuProbe == nil {
+		gpuProbe = gpudiscovery.Host
+	}
+	gpuInfo := detectGPUInfoFrom(gpuProbe())
+	resp.GpuCapabilities = gpuCapabilitiesV2(gpuInfo.devices)
 	resp.HasGpu = &gpuInfo.hasGPU
 	if gpuInfo.vendor != "" {
 		resp.GpuVendor = &gpuInfo.vendor
@@ -68,6 +76,14 @@ func (s *DeviceInfoService) GetDeviceInfo(_ context.Context, _ *agentpbv2.GetDev
 	if usage, ok := rootDiskUsage(); ok {
 		resp.DiskUsedBytes = &usage.usedBytes
 		resp.DiskTotalBytes = &usage.totalBytes
+	}
+
+	storageProbe := s.discoverContainerStorage
+	if storageProbe == nil {
+		storageProbe = containerStorageUsage
+	}
+	if p, ok := storageProbe(); ok {
+		resp.ContainerStorage = &agentpbv2.DiskPartition{Mountpoint: p.mountpoint, Filesystem: p.filesystem, Device: p.device, UsedBytes: p.usedBytes, TotalBytes: p.totalBytes}
 	}
 
 	resp.MemTotalBytes, resp.CpuCount = hostMemAndCPUCount()
@@ -117,4 +133,17 @@ func (s *DeviceInfoService) ListHardwareCapabilities(ctx context.Context, req *a
 		}
 	}
 	return &agentpbv2.ListHardwareCapabilitiesResponse{Capabilities: v2caps}, nil
+}
+
+// gpuCapabilitiesV2 is the v2 twin of gpuCapabilitiesV1.
+func gpuCapabilitiesV2(devices []gpudiscovery.Device) []*agentpbv2.GpuCapabilities {
+	out := make([]*agentpbv2.GpuCapabilities, 0, len(devices))
+	for _, d := range devices {
+		out = append(out, &agentpbv2.GpuCapabilities{
+			Vendor:          d.Vendor,
+			Path:            d.Path,
+			ComputeBackends: append([]string{}, d.ComputeBackends...),
+		})
+	}
+	return out
 }

--- a/go/internal/agent/services/gpu_drm_test.go
+++ b/go/internal/agent/services/gpu_drm_test.go
@@ -1,3 +1,5 @@
+// DRM vendor naming moved to gpudiscovery (see discovery_test.go); the Adreno
+// arch probe stays here because it reads platform devices, not DRM nodes.
 package services
 
 import (
@@ -5,81 +7,6 @@ import (
 	"path/filepath"
 	"testing"
 )
-
-// drmTree builds a /sys/class/drm-shaped fixture: node name -> driver name.
-// An empty driver means the node has no driver symlink, like a connector child.
-func drmTree(t *testing.T, nodes map[string]string) string {
-	t.Helper()
-	root := t.TempDir()
-	for node, driver := range nodes {
-		dev := filepath.Join(root, node, "device")
-		if err := os.MkdirAll(dev, 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if driver == "" {
-			continue
-		}
-		target := filepath.Join(root, "drivers", driver)
-		if err := os.MkdirAll(target, 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Symlink(target, filepath.Join(dev, "driver")); err != nil {
-			t.Fatal(err)
-		}
-	}
-	return root
-}
-
-func TestDRMVendor(t *testing.T) {
-	for name, tc := range map[string]struct {
-		nodes map[string]string
-		want  string
-	}{
-		// The real Dragonwing: display and GPU are one msm DRM device, and the
-		// connector children carry no driver of their own.
-		"dragonwing": {
-			nodes: map[string]string{
-				"card0":             "msm_dpu",
-				"renderD128":        "msm_dpu",
-				"card0-DP-1":        "",
-				"card0-Writeback-1": "",
-			},
-			want: "qualcomm",
-		},
-		// A Raspberry Pi splits them: vc4 drives the display, v3d the GPU.
-		// The render node must win, or the vendor would come from the display.
-		"raspberry pi": {
-			nodes: map[string]string{"card0": "vc4", "renderD128": "v3d"},
-			want:  "broadcom",
-		},
-		"amd":          {nodes: map[string]string{"card0": "amdgpu", "renderD128": "amdgpu"}, want: "amd"},
-		"intel":        {nodes: map[string]string{"card0": "i915", "renderD128": "i915"}, want: "intel"},
-		"vm":           {nodes: map[string]string{"card0": "virtio_gpu", "renderD128": "virtio_gpu"}, want: "virtio"},
-		"untested gpu": {nodes: map[string]string{"card0": "vmwgfx"}, want: ""},
-		"unknown":      {nodes: map[string]string{"card0": "somethingnew"}, want: ""},
-		"no driver":    {nodes: map[string]string{"card0": ""}, want: ""},
-		"display only": {nodes: map[string]string{"card0": "vc4"}, want: "broadcom"},
-	} {
-		t.Run(name, func(t *testing.T) {
-			old := drmSysfsRoot
-			drmSysfsRoot = drmTree(t, tc.nodes)
-			defer func() { drmSysfsRoot = old }()
-
-			if got := drmVendor(); got != tc.want {
-				t.Errorf("drmVendor() = %q, want %q", got, tc.want)
-			}
-		})
-	}
-}
-
-func TestDRMVendorMissingSysfs(t *testing.T) {
-	old := drmSysfsRoot
-	drmSysfsRoot = filepath.Join(t.TempDir(), "absent")
-	defer func() { drmSysfsRoot = old }()
-	if got := drmVendor(); got != "" {
-		t.Errorf("drmVendor() = %q on a host with no DRM, want empty", got)
-	}
-}
 
 func TestDetectAdrenoArch(t *testing.T) {
 	// The device-tree property is a NUL-separated string list, exactly as the
@@ -121,17 +48,6 @@ func TestDetectAdrenoArchMissingSysfs(t *testing.T) {
 	defer func() { platformDevicesRoot = old }()
 	if got := detectAdrenoArch(); got != "" {
 		t.Errorf("detectAdrenoArch() = %q, want empty", got)
-	}
-}
-
-func TestDRMDriverVendorsNeverNameNvidia(t *testing.T) {
-	// Reaching the DRM branch means neither /etc/nv_tegra_release nor
-	// /dev/nvidia0 exists, so the JetPack/CUDA/nvidia-smi probes keyed on
-	// vendor=="nvidia" would report a runtime that is not installed.
-	for driver, vendor := range drmDriverVendors {
-		if vendor == "nvidia" {
-			t.Errorf("%q maps to nvidia; the probes assume the proprietary stack", driver)
-		}
 	}
 }
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/build.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/build.md
@@ -140,7 +140,8 @@ Docker for local provider runs.
 | `WENDY_PLATFORM` | `nvidia-jetson` \| `generic` | Platform tier derived from the device type |
 | `WENDY_DEBUG` | `true` \| `false` | Set when `--debug` is passed. [`wendy project optimize`](project/optimize.md) flags it when it's declared (`ARG`/`ENV`) but no `RUN` step branches on it — gate your optimization level on it so debug builds aren't shipped to release. |
 | `WENDY_DEVICE_TYPE` | e.g. `jetson-agx-orin` | Raw device type; absent when unknown |
-| `WENDY_HAS_GPU` | `true` \| `false` | Absent on older agents |
+| `WENDY_HAS_GPU` | `true` \| `false` (hardware presence) | Absent on older agents |
+| `WENDY_HAS_CUDA` | `true` \| `false` (host CUDA support) | Falls back only to an explicit NVIDIA vendor on older agents |
 | `WENDY_GPU_VENDOR` | e.g. `nvidia`, `qualcomm` | Absent when no GPU is reported |
 | `WENDY_JETPACK_VERSION` | e.g. `6.0` | Jetson only |
 | `WENDY_JETPACK_MAJOR` | e.g. `6`, `7` | Jetson only; JetPack major for per-generation base-image selection |
@@ -200,3 +201,11 @@ Delegating a build to another device is a [`wendy run`](run.md#remote-build-host
 The reason is that the two commands mean different things by "build". `wendy run --build-host` has a target device: the build host builds the image and pushes it straight into *that* device's registry over the mesh. `wendy build` has no target — it leaves an image behind on the machine that built it — so a remote build would deposit the image on the build host and nowhere useful, which is worse than not offering the flag.
 
 Use `wendy run --build-host <device>` instead. To make a device willing to accept builds in the first place, see [`wendy device build-host`](device/build-host.md).
+
+CUDA-selecting Dockerfiles must use `WENDY_HAS_CUDA`. `WENDY_HAS_GPU`
+reports hardware presence, including Broadcom and other GPUs without CUDA.
+Device info exposes `gpuCapabilities`, one entry per detected GPU with its
+`vendor`, `path`, and `computeBackends` (`cuda`, `rocm`, `metal`). A GPU whose
+backend list is empty has no supported backend; no entries at all on a device
+that reports a GPU means an older agent. `containerStorage` identifies the filesystem used by
+containerd; the existing disk scalar fields continue to describe the root filesystem.

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/build.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/build.md
@@ -205,7 +205,7 @@ Use `wendy run --build-host <device>` instead. To make a device willing to accep
 CUDA-selecting Dockerfiles must use `WENDY_HAS_CUDA`. `WENDY_HAS_GPU`
 reports hardware presence, including Broadcom and other GPUs without CUDA.
 Device info exposes `gpuCapabilities`, one entry per detected GPU with its
-`vendor`, `path`, and `computeBackends` (`cuda`, `rocm`, `metal`). A GPU whose
-backend list is empty has no supported backend; no entries at all on a device
-that reports a GPU means an older agent. `containerStorage` identifies the filesystem used by
+`vendor`, `path`, and `computeBackends` (`cuda`, `rocm`, `metal`, `qnn`). A GPU
+whose backend list is empty has no supported backend; no entries at all on a
+device that reports a GPU means an older agent. `containerStorage` identifies the filesystem used by
 containerd; the existing disk scalar fields continue to describe the root filesystem.

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/info.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/info.md
@@ -34,7 +34,8 @@ On GPU-capable devices, the following GPU fields are included. Each is omitted f
 | `gpuVendor` | `GPU:` | GPU vendor (e.g. `nvidia`, `qualcomm`); shown as `unknown` in human-readable output when a GPU is present but the vendor is unreported. |
 | `jetpackVersion` | `JetPack:` | JetPack/L4T version string (Jetson only). |
 | `cudaVersion` | `CUDA:` | CUDA toolkit version (e.g. `12.6`). |
-| `gpuArch` | `GPU Arch:` | GPU architecture identifier. Format is vendor-specific (e.g. `sm_87` for NVIDIA). |
+| `gpuArch` | `GPU Arch:` | GPU architecture identifier. Format is vendor-specific (e.g. `sm_87` for NVIDIA, `a623` for a Qualcomm Adreno). |
+| `gpuCapabilities[]` | `GPU Compute:` | One entry per detected GPU: `vendor`, `path` (the device node that identified it, e.g. `/dev/dri/card0`), and `computeBackends` (`cuda`, `rocm`, `metal`, or `qnn`, the Qualcomm Hexagon NPU over FastRPC on Dragonwing). A single GPU prints its backends, or `none detected`; several GPUs print each one with its vendor and path. No entries means an older agent. |
 
 ### NPU output fields
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/info.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/info.md
@@ -25,6 +25,14 @@ Two headline hardware specs are included when the agent reports them. Both are o
 
 For **live** CPU and memory utilization, use [`wendy device top`](top.md).
 
+### Storage output fields
+
+When the agent can identify the filesystem that holds `/var/lib/containerd`, it is reported alongside the mounted partitions. The field is omitted from the JSON map when inspection fails or the agent predates it.
+
+| Field (JSON) | Human-readable label | Description |
+|---|---|---|
+| `containerStorage` | `(container storage)` suffix on the matching partition row | The mounted filesystem backing `/var/lib/containerd`: `mountpoint`, `filesystem`, `device`, `usedBytes`, and `totalBytes`. Image pulls and container layers consume this filesystem, so its usage feeds the disk-usage warning. |
+
 ### GPU output fields
 
 On GPU-capable devices, the following GPU fields are included. Each is omitted from both the human-readable output and the JSON map when the agent does not report it (e.g. non-GPU devices or older agents), so consumers should treat every field as optional.

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
@@ -418,7 +418,7 @@ Set `WENDY_IMAGE_SIGNATURE_PATH` to the path of the detached signature file; whe
 CUDA-selecting Dockerfiles must use `WENDY_HAS_CUDA`. `WENDY_HAS_GPU`
 reports hardware presence, including Broadcom and other GPUs without CUDA.
 Device info exposes `gpuCapabilities`, one entry per detected GPU with its
-`vendor`, `path`, and `computeBackends` (`cuda`, `rocm`, `metal`). A GPU whose
-backend list is empty has no supported backend; no entries at all on a device
-that reports a GPU means an older agent. `containerStorage` identifies the filesystem used by
+`vendor`, `path`, and `computeBackends` (`cuda`, `rocm`, `metal`, `qnn`). A GPU
+whose backend list is empty has no supported backend; no entries at all on a
+device that reports a GPU means an older agent. `containerStorage` identifies the filesystem used by
 containerd; the existing disk scalar fields continue to describe the root filesystem.

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
@@ -90,7 +90,8 @@ devices first. Select one explicitly with `--device` (as above), or set
 | `WENDY_PLATFORM` | `nvidia-jetson` \| `generic` | Platform tier derived from the device type |
 | `WENDY_DEBUG` | `true` \| `false` | Set when `--debug` is passed |
 | `WENDY_DEVICE_TYPE` | e.g. `jetson-agx-orin` | Raw device type; absent when unknown |
-| `WENDY_HAS_GPU` | `true` \| `false` | Absent on older agents |
+| `WENDY_HAS_GPU` | `true` \| `false` (hardware presence) | Absent on older agents |
+| `WENDY_HAS_CUDA` | `true` \| `false` (host CUDA support) | Falls back only to an explicit NVIDIA vendor on older agents |
 | `WENDY_GPU_VENDOR` | e.g. `nvidia`, `qualcomm` | Absent when no GPU is reported |
 | `WENDY_JETPACK_VERSION` | e.g. `6.0` | Jetson only |
 | `WENDY_JETPACK_MAJOR` | e.g. `6`, `7` | Jetson only; JetPack major for per-generation base-image selection |
@@ -413,3 +414,11 @@ process to reap. Attached watch hooks are owned and reaped by the watch session.
 `wendy run` optionally includes a detached **ML-DSA65** signature with every `RunContainer` call. The agent verifies the signature over the SHA256 digest of the OCI image config before assembling or starting the container.
 
 Set `WENDY_IMAGE_SIGNATURE_PATH` to the path of the detached signature file; when the variable is unset or points to an empty file, no signature is sent. Verification is currently dormant on the agent side (the per-org publisher key is not yet wired in), so omitting the signature does not block container creation today. Once the publisher key is provisioned, sending an unsigned or tampered image causes the agent to refuse the run.
+
+CUDA-selecting Dockerfiles must use `WENDY_HAS_CUDA`. `WENDY_HAS_GPU`
+reports hardware presence, including Broadcom and other GPUs without CUDA.
+Device info exposes `gpuCapabilities`, one entry per detected GPU with its
+`vendor`, `path`, and `computeBackends` (`cuda`, `rocm`, `metal`). A GPU whose
+backend list is empty has no supported backend; no entries at all on a device
+that reports a GPU means an older agent. `containerStorage` identifies the filesystem used by
+containerd; the existing disk scalar fields continue to describe the root filesystem.

--- a/go/internal/cli/assets/docs/guides/tutorials/python/yolov8-webcam-detection.mdx
+++ b/go/internal/cli/assets/docs/guides/tutorials/python/yolov8-webcam-detection.mdx
@@ -165,10 +165,10 @@ Frames flow through the app like this:
 
     The FastAPI backend (`app.py`) captures frames with GStreamer, runs YOLOv8 inference on a **separate background thread**, and ships raw JPEG frames plus JSON detection metadata to the browser over a WebSocket. Capturing and inference are decoupled so a slow inference pass never stalls the video.
 
-    The base-image selection at build time is mirrored at runtime: the app reads the `WENDY_HAS_GPU` / `WENDY_GPU_VENDOR` hints the CLI baked in, and chooses CUDA vs CPU (and a sensible inference FPS/image size) accordingly:
+    The base-image selection at build time is mirrored at runtime: the app reads the `WENDY_HAS_CUDA` / `WENDY_GPU_VENDOR` hints the CLI baked in, and chooses CUDA vs CPU (and a sensible inference FPS/image size) accordingly:
 
     ```python
-    _HAS_CUDA = _has_cuda()  # uses WENDY_HAS_GPU hint, then torch.cuda.is_available()
+    _HAS_CUDA = _has_cuda()  # uses WENDY_HAS_CUDA hint, then torch.cuda.is_available()
     _MAX_INFERENCE_FPS = float(os.environ.get("YOLO_MAX_FPS", "15" if _HAS_CUDA else "3"))
     _INFERENCE_IMGSZ = 320 if _HAS_CUDA else 224
     # RPi5 / CPU devices idle lighter on OpenCV than GStreamer + inference.

--- a/go/internal/cli/assets/docs/hardware/gpu.mdx
+++ b/go/internal/cli/assets/docs/hardware/gpu.mdx
@@ -11,6 +11,8 @@ This covers **NVIDIA GPUs (CUDA)** on Jetson and x86 systems, and **AMD GPUs (RO
 
 For a complete AMD example, follow [Run PyTorch on an AMD GPU](/docs/guides/tutorials/python/amd-rocm-pytorch). Stagefile's `cuda: true` option remains NVIDIA-only; the ROCm example selects its wheel index explicitly.
 
+On **Qualcomm Dragonwing** boards (such as the IQ-8275), the entitlement exposes the Adreno GPU's DRM render node, which the mesa freedreno/turnip, OpenCL, and Vulkan userspace in your image opens. The on-SoC Hexagon NPU is a separate accelerator: `wendy device info` reports it as the `qnn` compute backend when its FastRPC nodes are present, and apps reach it through the `npu` entitlement rather than `gpu`.
+
 On NVIDIA Jetson, the latest WendyOS is built on **JetPack 7.2** (L4T R39.2.0, CUDA 13). Target JetPack 7.2 or later when selecting CUDA wheels or base images for your app.
 
 Add the entitlement from your project directory:

--- a/go/internal/cli/commands/bytes_format.go
+++ b/go/internal/cli/commands/bytes_format.go
@@ -37,15 +37,30 @@ func formatGigabytes(n int64) string {
 // formatPartitionTable renders an aligned, human-readable table of per-partition
 // disk usage suitable for printing under the device info output. The returned
 // string ends with a trailing newline.
-func formatPartitionTable(partitions []*agentpb.DiskPartition) string {
+func formatPartitionTable(partitions []*agentpb.DiskPartition, storage ...*agentpb.DiskPartition) string {
 	var b strings.Builder
 	b.WriteString("Disk Usage:\n")
+	var containerStorage *agentpb.DiskPartition
+	if len(storage) > 0 && storage[0] != nil {
+		containerStorage = storage[0]
+		ordered := []*agentpb.DiskPartition{containerStorage}
+		for _, p := range partitions {
+			if !samePartition(p, containerStorage) {
+				ordered = append(ordered, p)
+			}
+		}
+		partitions = ordered
+	}
 
 	tw := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(tw, "  MOUNTPOINT\tFILESYSTEM\tUSED\tTOTAL\tUSE%")
 	for _, p := range partitions {
+		name := p.GetMountpoint()
+		if samePartition(p, containerStorage) {
+			name += " (container storage)"
+		}
 		fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\t%s\n",
-			p.GetMountpoint(),
+			name,
 			p.GetFilesystem(),
 			formatGigabytes(p.GetUsedBytes()),
 			formatGigabytes(p.GetTotalBytes()),

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -232,6 +232,8 @@ func newDeviceInfoLikeCmd(use string, deprecated bool) *cobra.Command {
 			var memTotalBytes int64
 			var cpuCount uint32
 			var partitions []*agentpb.DiskPartition
+			var containerStorage *agentpb.DiskPartition
+			var gpuCapabilities []*agentpb.GpuCapabilities
 			var netInterfaces []*agentpb.NetworkInterface
 			var hasGPU, hasNPU bool
 			var providerInfo *providers.ProviderDeviceInfo
@@ -277,6 +279,8 @@ func newDeviceInfoLikeCmd(use string, deprecated bool) *cobra.Command {
 				memTotalBytes = resp.GetMemTotalBytes()
 				cpuCount = resp.GetCpuCount()
 				partitions = resp.GetPartitions()
+				containerStorage = resp.GetContainerStorage()
+				gpuCapabilities = resp.GetGpuCapabilities()
 				netInterfaces = resp.GetNetworkInterfaces()
 				battery = resp.GetBattery()
 			} else if target.External != nil && target.Provider != nil {
@@ -343,6 +347,12 @@ func newDeviceInfoLikeCmd(use string, deprecated bool) *cobra.Command {
 				if cpuCount > 0 {
 					out["cpuCount"] = cpuCount
 				}
+				if containerStorage != nil {
+					out["containerStorage"] = map[string]any{"mountpoint": containerStorage.GetMountpoint(), "filesystem": containerStorage.GetFilesystem(), "device": containerStorage.GetDevice(), "usedBytes": containerStorage.GetUsedBytes(), "totalBytes": containerStorage.GetTotalBytes()}
+				}
+				if len(gpuCapabilities) > 0 {
+					out["gpuCapabilities"] = gpuCapabilitiesJSON(gpuCapabilities)
+				}
 				if len(partitions) > 0 {
 					parts := make([]map[string]any, len(partitions))
 					for i, p := range partitions {
@@ -356,7 +366,7 @@ func newDeviceInfoLikeCmd(use string, deprecated bool) *cobra.Command {
 					}
 					out["partitions"] = parts
 				}
-				if alert, ok := highDiskUsage(partitions, diskUsedBytes, diskTotalBytes); ok {
+				if alert, ok := highDiskUsage(partitions, diskUsedBytes, diskTotalBytes, containerStorage); ok {
 					out["diskWarning"] = map[string]any{
 						"mountpoint":       alert.Mountpoint,
 						"usedPercent":      alert.UsedPercent,
@@ -429,12 +439,12 @@ func newDeviceInfoLikeCmd(use string, deprecated bool) *cobra.Command {
 			if storageMedium != "" {
 				fmt.Printf("%s %s\n", tui.Dim("Storage:"), tui.Value(storageMedium))
 			}
-			if len(partitions) > 0 {
-				fmt.Print(formatPartitionTable(partitions))
+			if len(partitions) > 0 || containerStorage != nil {
+				fmt.Print(formatPartitionTable(partitions, containerStorage))
 			} else if diskUsedBytes != nil && diskTotalBytes != nil {
 				fmt.Printf("%s %s\n", tui.Dim("Disk Usage:"), tui.Value(formatDiskUsage(*diskUsedBytes, *diskTotalBytes)))
 			}
-			if alert, ok := highDiskUsage(partitions, diskUsedBytes, diskTotalBytes); ok {
+			if alert, ok := highDiskUsage(partitions, diskUsedBytes, diskTotalBytes, containerStorage); ok {
 				fmt.Println(tui.WarningMessage(diskUsageWarningText(alert)))
 			}
 			if len(netInterfaces) > 0 {
@@ -446,6 +456,9 @@ func newDeviceInfoLikeCmd(use string, deprecated bool) *cobra.Command {
 					vendor = "unknown"
 				}
 				fmt.Printf("%s %s\n", tui.Dim("GPU:"), tui.Value(vendor))
+				if compute := formatGPUCompute(gpuCapabilities); compute != "" {
+					fmt.Printf("%s %s\n", tui.Dim("GPU Compute:"), tui.Value(compute))
+				}
 				if jetpackVersion != "" {
 					fmt.Printf("%s %s\n", tui.Dim("JetPack:"), tui.Value(jetpackVersion))
 				}

--- a/go/internal/cli/commands/device_build_args_test.go
+++ b/go/internal/cli/commands/device_build_args_test.go
@@ -73,8 +73,37 @@ func TestApplyDeviceBuildArgHints_DerivesJetpackMajor(t *testing.T) {
 func TestApplyDeviceBuildArgHints_OmitsUnreportedHints(t *testing.T) {
 	buildArgs := map[string]string{}
 	applyDeviceBuildArgHints(buildArgs, &agentpb.GetAgentVersionResponse{})
-	if len(buildArgs) != 0 {
-		t.Fatalf("expected no hints set for empty response, got %v", buildArgs)
+	if len(buildArgs) != 1 || buildArgs["WENDY_HAS_CUDA"] != "false" {
+		t.Fatalf("expected conservative CUDA hint for empty response, got %v", buildArgs)
+	}
+}
+
+func TestCUDAHintCapabilitiesAndLegacyFallback(t *testing.T) {
+	nvidiaCUDA := &agentpb.GpuCapabilities{Vendor: "nvidia", Path: "/dev/dri/card1", ComputeBackends: []string{"cuda"}}
+	amdROCm := &agentpb.GpuCapabilities{Vendor: "amd", Path: "/dev/dri/card0", ComputeBackends: []string{"rocm"}}
+	for _, tc := range []struct {
+		name   string
+		vendor string
+		gpus   []*agentpb.GpuCapabilities
+		want   string
+	}{
+		{"gpu without compute", "broadcom", []*agentpb.GpuCapabilities{{Vendor: "broadcom"}}, "false"},
+		{"nvidia without driver evidence", "nvidia", []*agentpb.GpuCapabilities{{Vendor: "nvidia"}}, "false"},
+		{"nvidia with cuda", "nvidia", []*agentpb.GpuCapabilities{nvidiaCUDA}, "true"},
+		{"amd with rocm", "amd", []*agentpb.GpuCapabilities{amdROCm}, "false"},
+		{"apple with metal", "apple", []*agentpb.GpuCapabilities{{Vendor: "apple", ComputeBackends: []string{"metal"}}}, "false"},
+		// The legacy vendor names the AMD card; cuda on the second GPU still counts.
+		{"amd and nvidia", "amd", []*agentpb.GpuCapabilities{amdROCm, nvidiaCUDA}, "true"},
+		{"older agent, nvidia", "nvidia", nil, "true"},
+		{"older agent, no vendor", "", nil, "false"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			args := map[string]string{}
+			applyDeviceBuildArgHints(args, &agentpb.GetAgentVersionResponse{GpuVendor: &tc.vendor, GpuCapabilities: tc.gpus})
+			if args["WENDY_HAS_CUDA"] != tc.want {
+				t.Fatalf("WENDY_HAS_CUDA = %q, want %q (%v)", args["WENDY_HAS_CUDA"], tc.want, args)
+			}
+		})
 	}
 }
 

--- a/go/internal/cli/commands/device_gpu_format.go
+++ b/go/internal/cli/commands/device_gpu_format.go
@@ -1,0 +1,53 @@
+package commands
+
+import (
+	"strings"
+
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+// formatGPUCompute renders the per-GPU compute backends for `device info`.
+// One GPU prints just its backends ("cuda", or "none detected"); more than one
+// prints each GPU with its vendor and path so a mixed AMD+NVIDIA host reads
+// unambiguously. Empty when the agent sent no entries (an older agent).
+func formatGPUCompute(gpus []*agentpb.GpuCapabilities) string {
+	switch len(gpus) {
+	case 0:
+		return ""
+	case 1:
+		if backends := strings.Join(gpus[0].GetComputeBackends(), ", "); backends != "" {
+			return backends
+		}
+		return "none detected"
+	}
+	parts := make([]string, 0, len(gpus))
+	for _, gpu := range gpus {
+		backends := strings.Join(gpu.GetComputeBackends(), ", ")
+		if backends == "" {
+			backends = "none"
+		}
+		ident := gpu.GetVendor()
+		if ident == "" {
+			ident = "unknown"
+		}
+		if path := gpu.GetPath(); path != "" {
+			ident += " " + path
+		}
+		parts = append(parts, backends+" ("+ident+")")
+	}
+	return strings.Join(parts, "; ")
+}
+
+// gpuCapabilitiesJSON is the `device info --json` shape of the GPU list: one
+// object per GPU with a non-null computeBackends array.
+func gpuCapabilitiesJSON(gpus []*agentpb.GpuCapabilities) []map[string]any {
+	out := make([]map[string]any, 0, len(gpus))
+	for _, gpu := range gpus {
+		out = append(out, map[string]any{
+			"vendor":          gpu.GetVendor(),
+			"path":            gpu.GetPath(),
+			"computeBackends": append([]string{}, gpu.GetComputeBackends()...),
+		})
+	}
+	return out
+}

--- a/go/internal/cli/commands/device_gpu_format_test.go
+++ b/go/internal/cli/commands/device_gpu_format_test.go
@@ -1,0 +1,48 @@
+package commands
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+func TestFormatGPUCompute(t *testing.T) {
+	for name, tc := range map[string]struct {
+		gpus []*agentpb.GpuCapabilities
+		want string
+	}{
+		"older agent":      {nil, ""},
+		"single with cuda": {[]*agentpb.GpuCapabilities{{Vendor: "nvidia", Path: "/dev/nvidia0", ComputeBackends: []string{"cuda"}}}, "cuda"},
+		"single without":   {[]*agentpb.GpuCapabilities{{Vendor: "broadcom", Path: "/dev/dri/card0"}}, "none detected"},
+		"two vendors": {[]*agentpb.GpuCapabilities{
+			{Vendor: "nvidia", Path: "/dev/dri/card0", ComputeBackends: []string{"cuda"}},
+			{Vendor: "amd", Path: "/dev/dri/card1", ComputeBackends: []string{"rocm"}},
+		}, "cuda (nvidia /dev/dri/card0); rocm (amd /dev/dri/card1)"},
+		"two with one bare": {[]*agentpb.GpuCapabilities{
+			{Vendor: "intel", Path: "/dev/dri/card0"},
+			{Vendor: "nvidia", Path: "/dev/dri/card1", ComputeBackends: []string{"cuda"}},
+		}, "none (intel /dev/dri/card0); cuda (nvidia /dev/dri/card1)"},
+		"unknown vendor and no path": {[]*agentpb.GpuCapabilities{{}, {Vendor: "amd", ComputeBackends: []string{"rocm"}}}, "none (unknown); rocm (amd)"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := formatGPUCompute(tc.gpus); got != tc.want {
+				t.Fatalf("formatGPUCompute() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGPUCapabilitiesJSON(t *testing.T) {
+	got := gpuCapabilitiesJSON([]*agentpb.GpuCapabilities{
+		{Vendor: "nvidia", Path: "/dev/dri/card0", ComputeBackends: []string{"cuda"}},
+		{Vendor: "broadcom", Path: "/dev/dri/card1"},
+	})
+	want := []map[string]any{
+		{"vendor": "nvidia", "path": "/dev/dri/card0", "computeBackends": []string{"cuda"}},
+		{"vendor": "broadcom", "path": "/dev/dri/card1", "computeBackends": []string{}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("gpuCapabilitiesJSON() = %#v, want %#v", got, want)
+	}
+}

--- a/go/internal/cli/commands/disk_warning.go
+++ b/go/internal/cli/commands/disk_warning.go
@@ -9,17 +9,24 @@ import (
 const diskWarningThresholdPercent int64 = 85
 
 type diskUsageAlert struct {
-	Mountpoint  string
-	UsedPercent int64
+	Mountpoint       string
+	UsedPercent      int64
+	Device           string
+	ContainerStorage bool
 }
 
 // highDiskUsage returns the fullest partition above the warning threshold.
 // Partition data takes precedence over the legacy root-only fields.
-func highDiskUsage(partitions []*agentpb.DiskPartition, legacyUsed, legacyTotal *int64) (diskUsageAlert, bool) {
+func highDiskUsage(partitions []*agentpb.DiskPartition, legacyUsed, legacyTotal *int64, storage ...*agentpb.DiskPartition) (diskUsageAlert, bool) {
 	var (
 		best      diskUsageAlert
 		bestRatio float64
 	)
+	var containerStorage *agentpb.DiskPartition
+	if len(storage) > 0 && storage[0] != nil {
+		containerStorage = storage[0]
+		partitions = append(append([]*agentpb.DiskPartition{}, partitions...), containerStorage)
+	}
 	for _, p := range partitions {
 		if p == nil || p.GetTotalBytes() <= 0 || p.GetUsedBytes() < 0 || p.GetUsedBytes() > p.GetTotalBytes() {
 			continue
@@ -27,7 +34,7 @@ func highDiskUsage(partitions []*agentpb.DiskPartition, legacyUsed, legacyTotal 
 		ratio := float64(p.GetUsedBytes()) / float64(p.GetTotalBytes())
 		if ratio > float64(diskWarningThresholdPercent)/100 && ratio > bestRatio {
 			bestRatio = ratio
-			best = diskUsageAlert{Mountpoint: p.GetMountpoint(), UsedPercent: int64(ratio * 100)}
+			best = diskUsageAlert{Mountpoint: p.GetMountpoint(), Device: p.GetDevice(), UsedPercent: int64(ratio * 100), ContainerStorage: samePartition(p, containerStorage)}
 		}
 	}
 	if bestRatio > 0 {
@@ -49,14 +56,25 @@ func diskUsageWarningText(alert diskUsageAlert) string {
 	} else {
 		mountpoint = fmt.Sprintf("disk %s", mountpoint)
 	}
-	return fmt.Sprintf("%s is %d%% full. Free cached container data with 'wendy device cache prune'.", mountpoint, alert.UsedPercent)
+	text := fmt.Sprintf("%s is %d%% full.", mountpoint, alert.UsedPercent)
+	if alert.ContainerStorage {
+		return text + " Free cached container data with 'wendy device cache prune'."
+	}
+	return text + " Free space on this filesystem."
+}
+
+func samePartition(a, b *agentpb.DiskPartition) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	return (a.GetDevice() != "" && a.GetDevice() == b.GetDevice()) || (a.GetMountpoint() != "" && a.GetMountpoint() == b.GetMountpoint())
 }
 
 func printRunDiskUsageWarning(resp *agentpb.GetAgentVersionResponse) {
 	if resp == nil {
 		return
 	}
-	if alert, ok := highDiskUsage(resp.GetPartitions(), resp.DiskUsedBytes, resp.DiskTotalBytes); ok {
+	if alert, ok := highDiskUsage(resp.GetPartitions(), resp.DiskUsedBytes, resp.DiskTotalBytes, resp.GetContainerStorage()); ok {
 		cliNotice("Warning: %s", diskUsageWarningText(alert))
 	}
 }

--- a/go/internal/cli/commands/disk_warning_test.go
+++ b/go/internal/cli/commands/disk_warning_test.go
@@ -17,8 +17,26 @@ func TestHighDiskUsageThresholdAndFullestPartition(t *testing.T) {
 	if !ok || alert.Mountpoint != "/data" || alert.UsedPercent != 96 {
 		t.Fatalf("alert = %+v, ok=%v", alert, ok)
 	}
-	if !strings.Contains(diskUsageWarningText(alert), "wendy device cache prune") {
-		t.Fatal("warning does not include remediation command")
+	if strings.Contains(diskUsageWarningText(alert), "cache prune") {
+		t.Fatal("unconfirmed storage must not recommend container pruning")
+	}
+}
+
+func TestContainerStoragePruningAdvice(t *testing.T) {
+	root := &agentpb.DiskPartition{Mountpoint: "/", Device: "/dev/root", UsedBytes: 99, TotalBytes: 100}
+	storage := &agentpb.DiskPartition{Mountpoint: "/data", Device: "/dev/nvme0n1p1", UsedBytes: 10, TotalBytes: 100}
+	alert, _ := highDiskUsage([]*agentpb.DiskPartition{root, storage}, nil, nil, storage)
+	if strings.Contains(diskUsageWarningText(alert), "cache prune") {
+		t.Fatal("root pressure recommended pruning container storage on a different filesystem")
+	}
+	root.UsedBytes, storage.UsedBytes = 10, 99
+	alert, _ = highDiskUsage([]*agentpb.DiskPartition{root, storage}, nil, nil, storage)
+	if !strings.Contains(diskUsageWarningText(alert), "cache prune") {
+		t.Fatal("confirmed container pressure missing pruning advice")
+	}
+	table := formatPartitionTable([]*agentpb.DiskPartition{root, storage}, storage)
+	if strings.Count(table, "/data") != 1 || !strings.Contains(table, "/data (container storage)") || strings.Index(table, "/data") > strings.Index(table, "/ ") {
+		t.Fatalf("storage ordering/label/deduplication: %s", table)
 	}
 }
 

--- a/go/internal/cli/commands/docker.go
+++ b/go/internal/cli/commands/docker.go
@@ -459,6 +459,21 @@ func applyDeviceBuildArgHints(buildArgs map[string]string, versionResp *agentpb.
 	if versionResp.HasGpu != nil {
 		buildArgs["WENDY_HAS_GPU"] = fmt.Sprintf("%t", versionResp.GetHasGpu())
 	}
+	// A new agent lists every GPU, so a non-empty list without a cuda backend
+	// suppresses the legacy vendor hint. An empty list is an older agent (or a
+	// host with no GPU, where the vendor hint is empty anyway).
+	hasCUDA := strings.EqualFold(versionResp.GetGpuVendor(), "nvidia")
+	if gpus := versionResp.GetGpuCapabilities(); len(gpus) > 0 {
+		hasCUDA = false
+		for _, gpu := range gpus {
+			for _, backend := range gpu.GetComputeBackends() {
+				if backend == "cuda" {
+					hasCUDA = true
+				}
+			}
+		}
+	}
+	buildArgs["WENDY_HAS_CUDA"] = fmt.Sprintf("%t", hasCUDA)
 	setHint("WENDY_GPU_VENDOR", versionResp.GetGpuVendor())
 	setHint("WENDY_JETPACK_VERSION", versionResp.GetJetpackVersion())
 	// Coarse major ("7" from "7.2") to aid in per-generation image selection

--- a/go/internal/cli/mcp/tools_device.go
+++ b/go/internal/cli/mcp/tools_device.go
@@ -164,6 +164,16 @@ func (s *mcpServer) handleDeviceInfo(ctx context.Context, _ mcpgo.CallToolReques
 		}
 		info["partitions"] = parts
 	}
+	if p := resp.GetContainerStorage(); p != nil {
+		info["container_storage"] = map[string]any{"mountpoint": p.GetMountpoint(), "filesystem": p.GetFilesystem(), "device": p.GetDevice(), "used_bytes": p.GetUsedBytes(), "total_bytes": p.GetTotalBytes()}
+	}
+	if gpus := resp.GetGpuCapabilities(); len(gpus) > 0 {
+		entries := make([]map[string]any, 0, len(gpus))
+		for _, gpu := range gpus {
+			entries = append(entries, map[string]any{"vendor": gpu.GetVendor(), "path": gpu.GetPath(), "compute_backends": append([]string{}, gpu.GetComputeBackends()...)})
+		}
+		info["gpu_capabilities"] = entries
+	}
 	if resp.HasGpu != nil {
 		info["has_gpu"] = resp.GetHasGpu()
 	}

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentService.swift
@@ -5,6 +5,8 @@ import WendyAgentGRPC
 
 struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     var hardware: any HardwareDiscovering = HardwareInventory()
+    var gpuDiscovery = GPUDiscovery()
+    var reportedVersion: @Sendable () -> String = { WendyAgent.version }
     var hostname: any HostnameSetting = ScutilHostname()
     var wifi: any WiFiManaging = WiFiController()
     var bluetooth: any BluetoothManaging = BluetoothScanner()
@@ -84,7 +86,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
     ) async throws -> ServerResponse<Wendy_Agent_Services_V1_GetAgentVersionResponse> {
         let osVersion = ProcessInfo.processInfo.operatingSystemVersion
         var response = Wendy_Agent_Services_V1_GetAgentVersionResponse()
-        response.version = WendyAgent.version
+        response.version = reportedVersion()
         response.os = "darwin"
         response.osVersion =
             "\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)"
@@ -96,6 +98,16 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
         response.memTotalBytes = Int64(clamping: ProcessInfo.processInfo.physicalMemory)
         response.cpuCount = UInt32(clamping: ProcessInfo.processInfo.activeProcessorCount)
         response.binarySha256 = self.binarySHA256
+        let devices = gpuDiscovery.devices()
+        response.hasGpu_p = !devices.isEmpty
+        if let device = devices.first { response.gpuVendor = device.vendor }
+        // One entry per Metal device. macOS has no device node, so path stays empty.
+        response.gpuCapabilities = devices.map { device in
+            var capabilities = Wendy_Agent_Services_V1_GpuCapabilities()
+            capabilities.vendor = device.vendor
+            capabilities.computeBackends = device.computeBackends
+            return capabilities
+        }
         return ServerResponse(message: response)
     }
 

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/Platform/GPUDiscovery.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/Platform/GPUDiscovery.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+#if canImport(Metal)
+    import Metal
+#endif
+
+/// Shared, injectable GPU evidence for device metadata and hardware inventory.
+struct GPUDiscovery: Sendable {
+    struct Device: Sendable {
+        var name: String
+        var vendor: String
+        var computeBackends: [String]
+    }
+
+    var devices: @Sendable () -> [Device] = {
+        #if canImport(Metal)
+            MTLCopyAllDevices().map { device in
+                let name = device.name.lowercased()
+                let vendor =
+                    name.contains("apple")
+                    ? "apple"
+                    : name.contains("amd")
+                        ? "amd"
+                        : name.contains("intel")
+                            ? "intel"
+                            : name.contains("nvidia") ? "nvidia" : "unknown"
+                return Device(name: device.name, vendor: vendor, computeBackends: ["metal"])
+            }
+        #else
+            []
+        #endif
+    }
+}

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/Platform/HardwareInventory.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/Platform/HardwareInventory.swift
@@ -22,6 +22,7 @@ protocol HardwareDiscovering: Sendable {
 /// intentionally omitted.
 struct HardwareInventory: HardwareDiscovering {
     private let systemProfilerPath = "/usr/sbin/system_profiler"
+    var gpuDiscovery = GPUDiscovery()
 
     func discover(categoryFilter: String?) async throws -> [HardwareCapability] {
         async let displays = dataType("SPDisplaysDataType")
@@ -37,6 +38,23 @@ struct HardwareInventory: HardwareDiscovering {
             audio: await audio,
             storage: await storage
         )
+        let gpus = gpuDiscovery.devices()
+        if !gpus.isEmpty {
+            caps.removeAll { $0.category == "gpu" }
+            caps.append(
+                contentsOf: gpus.map { gpu in
+                    HardwareCapability(
+                        category: "gpu",
+                        devicePath: "",
+                        description: gpu.name,
+                        properties: [
+                            "vendor": gpu.vendor,
+                            "compute_backends": gpu.computeBackends.joined(separator: ","),
+                        ]
+                    )
+                }
+            )
+        }
         caps.append(contentsOf: Self.networkCapabilities())
 
         if let categoryFilter, !categoryFilter.isEmpty {

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/HardwareInventoryTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/HardwareInventoryTests.swift
@@ -7,6 +7,44 @@ import WendyAgentGRPC
 
 @Suite("HardwareInventory parsing")
 struct HardwareInventoryParsingTests {
+    @Test("device metadata distinguishes Metal capability from legacy absence")
+    func metalMetadata() async throws {
+        let service = AgentService(
+            gpuDiscovery: GPUDiscovery(devices: {
+                [.init(name: "Apple GPU", vendor: "apple", computeBackends: ["metal"])]
+            }),
+            reportedVersion: { "test" }
+        )
+        let response = try await service.getAgentVersion(
+            request: ServerRequest(
+                metadata: [:],
+                message: Wendy_Agent_Services_V1_GetAgentVersionRequest()
+            ),
+            context: makeHardwareContext()
+        ).message
+        #expect(response.hasGpu_p)
+        #expect(response.gpuVendor == "apple")
+        #expect(response.gpuCapabilities.map(\.vendor) == ["apple"])
+        #expect(response.gpuCapabilities.map(\.computeBackends) == [["metal"]])
+    }
+
+    @Test("device metadata lists no GPU entries when Metal finds no device")
+    func noMetalDevices() async throws {
+        let service = AgentService(
+            gpuDiscovery: GPUDiscovery(devices: { [] }),
+            reportedVersion: { "test" }
+        )
+        let response = try await service.getAgentVersion(
+            request: ServerRequest(
+                metadata: [:],
+                message: Wendy_Agent_Services_V1_GetAgentVersionRequest()
+            ),
+            context: makeHardwareContext()
+        ).message
+        #expect(!response.hasGpu_p)
+        #expect(response.gpuCapabilities.isEmpty)
+    }
+
     @Test("parses GPU from SPDisplaysDataType")
     func parsesGPU() {
         let json = Data(


### PR DESCRIPTION
Identify /var/lib/containerd storage by filesystem/mount device identity, including bind mounts, and recommend pruning only for confirmed container-storage pressure. Share injectable hardware discovery across metadata and GPU enumeration; expose cuda/rocm/metal capabilities in CLI and MCP, and provide WENDY_HAS_CUDA with conservative legacy NVIDIA fallback. Native Mac reports Metal.

Previous component: https://github.com/wendylabsinc/WendyOS/pull/1908.

Validation: Deterministic mount/vendor/backend fixtures, CLI/MCP tests, Linux race tests, and Swift tests passed on the complete stack. Real Apple M4 Max metadata reports Metal. Thor df and physical Pi/NVIDIA/AMD acceptance remain open; templates PR #103 migrates CUDA consumers.

Part of the WDY-2906–2913 stack. Merge in dependency order. [Final acceptance record and stack index](https://github.com/wendylabsinc/WendyOS/pull/1905). Hardware acceptance and the stable agent/CLI release are still pending; no issue closure is claimed.
