### PR TITLE
WDY-2910: continue observing slow startup and defer readiness hooks

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
@@ -422,3 +422,10 @@ Device info exposes `gpuCapabilities`, one entry per detected GPU with its
 whose backend list is empty has no supported backend; no entries at all on a
 device that reports a GPU means an older agent. `containerStorage` identifies the filesystem used by
 containerd; the existing disk scalar fields continue to describe the root filesystem.
+
+Attached runs keep observing slow startup after the initial readiness budget.
+If the relevant service is still running, the CLI reports “still starting” and
+checks every five seconds while streaming logs. Browser opening and host
+`postStart` commands run once readiness succeeds. Stopping the service,
+canceling the session, or replacing a watch deployment cancels its probes.
+Detached and create-only runs continue to skip host readiness and hooks.

--- a/go/internal/cli/commands/compose.go
+++ b/go/internal/cli/commands/compose.go
@@ -1639,6 +1639,8 @@ func composeStartWatch(ctx context.Context, conn *grpcclient.AgentConnection, or
 // owns Ctrl+C handling and cancels runCtx after stopping the services.
 func composeStartAndStream(runCtx context.Context, runCancel context.CancelFunc, conn *grpcclient.AgentConnection, ordered []string, svcCfgs, svcLifecycleCfgs map[string]*appconfig.AppConfig, appLevelCfg *appconfig.AppConfig, stdoutWriters, stderrWriters map[string]*serviceLogWriter, opts runOptions) error {
 	runner := &serviceHookRunner{conn: conn, opts: opts}
+	appHookCtx, appHookCancel := context.WithCancel(runCtx)
+	defer appHookCancel()
 	var appName string
 	if len(ordered) > 0 && svcCfgs[ordered[0]] != nil {
 		appName = svcCfgs[ordered[0]].AppID
@@ -1662,6 +1664,9 @@ func composeStartAndStream(runCtx context.Context, runCancel context.CancelFunc,
 		wg.Add(1)
 		go func(serviceName, containerID string, svcCfg, lifecycleCfg *appconfig.AppConfig) {
 			defer wg.Done()
+			serviceCtx, serviceCancel := context.WithCancel(runCtx)
+			defer serviceCancel()
+			defer appHookCancel()
 			markStarted := sync.OnceFunc(startedWg.Done)
 			defer markStarted()
 			outW := stdoutWriters[serviceName]
@@ -1743,7 +1748,7 @@ func composeStartAndStream(runCtx context.Context, runCancel context.CancelFunc,
 					// slow or failing probe never stalls this log loop.
 					hookFired = true
 					markStarted()
-					runner.startAsync(runCtx, lifecycleCfg)
+					runner.startAsync(serviceCtx, lifecycleCfg)
 				}
 				if out := resp.GetStdoutOutput(); out != nil {
 					outW.Write(out.GetData())
@@ -1768,7 +1773,7 @@ func composeStartAndStream(runCtx context.Context, runCancel context.CancelFunc,
 	runner.spawn(func() {
 		startedWg.Wait()
 		if runCtx.Err() == nil {
-			runner.runOne(runCtx, runCtx, appLevelCfg)
+			runner.runOne(appHookCtx, runCtx, appLevelCfg)
 		}
 	})
 

--- a/go/internal/cli/commands/multibuild.go
+++ b/go/internal/cli/commands/multibuild.go
@@ -1136,6 +1136,9 @@ func startAndStreamServices(ctx context.Context, conn *grpcclient.AgentConnectio
 	defer runCancel()
 
 	runner := &serviceHookRunner{conn: conn, opts: opts}
+	defer func() { runCancel(); runner.reap() }()
+	appHookCtx, appHookCancel := context.WithCancel(runCtx)
+	defer appHookCancel()
 
 	// Ctrl+C stops all services. The watch loop owns the signal for the whole
 	// session and leaves the group running when it stops, so a watch cycle must
@@ -1218,7 +1221,7 @@ func startAndStreamServices(ctx context.Context, conn *grpcclient.AgentConnectio
 		for _, name := range preservedLifecycle {
 			runner.startAsync(runCtx, svcLifecycleCfgs[name])
 		}
-		runner.startAsync(runCtx, appLevelCfg)
+		runner.startAsync(appHookCtx, appLevelCfg)
 		if len(ordered) > 0 {
 			cliLogln("App group %s started (%d services).", appID, len(ordered))
 		}
@@ -1269,10 +1272,13 @@ func startAndStreamServices(ctx context.Context, conn *grpcclient.AgentConnectio
 		// failing probe never delays creating/starting the next service — the
 		// sequential Started-ack ordering above is load-bearing for
 		// shared-ipc/shared-network joins and must not be disturbed (WDY-1271).
-		runner.startAsync(runCtx, svcLifecycleCfgs[name])
+		serviceCtx, serviceCancel := context.WithCancel(runCtx)
+		runner.startAsync(serviceCtx, svcLifecycleCfgs[name])
 		wg.Add(1)
 		go func(name string, stream agentpb.WendyContainerService_StartContainerClient) {
 			defer wg.Done()
+			defer serviceCancel()
+			defer appHookCancel()
 			for {
 				resp, recvErr := stream.Recv()
 				if recvErr == io.EOF {
@@ -1304,7 +1310,7 @@ func startAndStreamServices(ctx context.Context, conn *grpcclient.AgentConnectio
 
 	// Every service has started: fire the app-level fallback (nil on subset
 	// runs). Async, for the same non-blocking reason as the per-service hooks.
-	runner.startAsync(runCtx, appLevelCfg)
+	runner.startAsync(appHookCtx, appLevelCfg)
 
 	go func() {
 		wg.Wait()

--- a/go/internal/cli/commands/readiness_observer.go
+++ b/go/internal/cli/commands/readiness_observer.go
@@ -1,0 +1,135 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+// readinessState reads the relevant service, never the group's any-running
+// aggregate. App-level probes require every service to remain running.
+func readinessState(ctx context.Context, conn *grpcclient.AgentConnection, cfg *appconfig.AppConfig) (bool, error) {
+	if conn == nil || conn.ContainerService == nil {
+		return false, fmt.Errorf("container status unavailable")
+	}
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	stream, err := conn.ContainerService.ListContainers(ctx, &agentpb.ListContainersRequest{})
+	if err != nil {
+		return false, fmt.Errorf("container status unavailable: %w", err)
+	}
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			return false, fmt.Errorf("container status unavailable: %s was not reported", cfg.ContainerName())
+		}
+		if err != nil {
+			return false, fmt.Errorf("container status unavailable: %w", err)
+		}
+		app := resp.GetContainer()
+		if app == nil || !strings.EqualFold(app.GetAppName(), cfg.AppID) {
+			continue
+		}
+		if len(app.GetServices()) == 0 {
+			if cfg.ServiceName != "" {
+				return false, fmt.Errorf("service status unavailable: %s was not reported", cfg.ContainerName())
+			}
+			return app.GetRunningState() == agentpb.AppRunningState_RUNNING, nil
+		}
+		for _, service := range app.GetServices() {
+			if cfg.ServiceName != "" && service.GetName() != cfg.ServiceName {
+				continue
+			}
+			if service.GetRunningState() != agentpb.AppRunningState_RUNNING {
+				return false, nil
+			}
+			if cfg.ServiceName != "" {
+				return true, nil
+			}
+		}
+		if cfg.ServiceName != "" {
+			return false, fmt.Errorf("service status unavailable: %s was not reported", cfg.ContainerName())
+		}
+		return true, nil
+	}
+}
+
+// continueReadiness is clock/probe/status injectable so slow-start and
+// cancellation races can be tested without sleeping through real deadlines.
+func continueReadiness(ctx context.Context, tick <-chan time.Time, probe func(context.Context) bool, running func(context.Context) (bool, error), unavailable func(error)) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-tick:
+		}
+		alive, err := running(ctx)
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if err != nil {
+			unavailable(err)
+			continue
+		}
+		if !alive {
+			return fmt.Errorf("service stopped before readiness succeeded")
+		}
+		if probe(ctx) {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return nil
+		}
+	}
+}
+
+func waitForAttachedReadiness(ctx context.Context, conn *grpcclient.AgentConnection, cfg *appconfig.AppConfig, hostname string) error {
+	started := time.Now()
+	readiness := effectiveReadiness(cfg)
+	err := waitForReadiness(ctx, readiness, hostname)
+	if err == nil || ctx.Err() != nil {
+		return err
+	}
+	running := func(ctx context.Context) (bool, error) { return readinessState(ctx, conn, cfg) }
+	alive, stateErr := running(ctx)
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if stateErr != nil {
+		return fmt.Errorf("%w; %v", err, stateErr)
+	}
+	if !alive {
+		return fmt.Errorf("%w; %s stopped before readiness succeeded", err, cfg.ContainerName())
+	}
+	cliLogln("Application %s is still starting after %s; continuing readiness checks every 5 seconds.", cfg.ContainerName(), time.Since(started).Round(time.Second))
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	addr := net.JoinHostPort(hostname, fmt.Sprint(readiness.TCPSocket.Port))
+	dialer := net.Dialer{Timeout: 2 * time.Second}
+	probe := func(ctx context.Context) bool {
+		connection, err := dialer.DialContext(ctx, "tcp", addr)
+		if err != nil {
+			return false
+		}
+		_ = connection.Close()
+		return true
+	}
+	warned := false
+	err = continueReadiness(ctx, ticker.C, probe, running, func(err error) {
+		if !warned {
+			cliLogln("Warning: %v; continuing to observe startup.", err)
+			warned = true
+		}
+	})
+	if err == nil {
+		cliLogln("Application %s ready after %s.", cfg.ContainerName(), time.Since(started).Round(time.Second))
+	}
+	return err
+}

--- a/go/internal/cli/commands/readiness_observer_test.go
+++ b/go/internal/cli/commands/readiness_observer_test.go
@@ -1,0 +1,64 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+func TestContinuedReadinessWithDeterministicTicks(t *testing.T) {
+	ticks := make(chan time.Time, 4)
+	for range 4 {
+		ticks <- time.Time{}
+	}
+	probes, states, warnings := 0, 0, 0
+	err := continueReadiness(context.Background(), ticks, func(context.Context) bool { probes++; return probes == 3 }, func(context.Context) (bool, error) {
+		states++
+		if states == 2 {
+			return false, errors.New("status temporarily unavailable")
+		}
+		return true, nil
+	}, func(error) { warnings++ })
+	if err != nil || probes != 3 || states != 4 || warnings != 1 {
+		t.Fatalf("result=%v probes=%d states=%d warnings=%d", err, probes, states, warnings)
+	}
+}
+
+func TestContinuedReadinessCancelsObsoleteProbe(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	ticks := make(chan time.Time, 1)
+	ticks <- time.Time{}
+	err := continueReadiness(ctx, ticks, func(context.Context) bool { cancel(); return true }, func(context.Context) (bool, error) { return true, nil }, func(error) {})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("stale successful probe survived cancellation: %v", err)
+	}
+}
+
+func TestContinuedReadinessStopsOnTerminalService(t *testing.T) {
+	ticks := make(chan time.Time, 1)
+	ticks <- time.Time{}
+	err := continueReadiness(context.Background(), ticks, func(context.Context) bool { t.Fatal("probed a stopped service"); return true }, func(context.Context) (bool, error) { return false, nil }, func(error) {})
+	if err == nil {
+		t.Fatal("stopped service reported ready")
+	}
+}
+
+func TestReadinessStateUsesServiceNotGroupAggregate(t *testing.T) {
+	fake := &lifecycleFakeContainerClient{container: &agentpb.AppContainer{AppName: "app", RunningState: agentpb.AppRunningState_RUNNING,
+		Services: []*agentpb.ServiceEntry{{Name: "api", RunningState: agentpb.AppRunningState_RUNNING}, {Name: "model", RunningState: agentpb.AppRunningState_STOPPED}},
+	}}
+	conn := newLifecycleTestConn("127.0.0.1", fake)
+	for _, tc := range []struct {
+		service string
+		running bool
+	}{{"api", true}, {"model", false}, {"", false}} {
+		running, err := readinessState(context.Background(), conn, &appconfig.AppConfig{AppID: "app", ServiceName: tc.service})
+		if err != nil || running != tc.running {
+			t.Fatalf("%q: %v, %v", tc.service, running, err)
+		}
+	}
+}

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -1246,8 +1246,13 @@ func runMacOSNativeContainer(ctx context.Context, conn *grpcclient.AgentConnecti
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt)
+	defer signal.Stop(sigCh)
 	go func() {
-		<-sigCh
+		select {
+		case <-sigCh:
+		case <-runCtx.Done():
+			return
+		}
 		cliLogln("\nStopping container...")
 		_, _ = conn.ContainerService.StopContainer(context.Background(), &agentpb.StopContainerRequest{
 			AppName: appCfg.ContainerName(),
@@ -1255,6 +1260,9 @@ func runMacOSNativeContainer(ctx context.Context, conn *grpcclient.AgentConnecti
 		runCancel()
 	}()
 
+	runner := &serviceHookRunner{conn: conn, opts: opts}
+	defer func() { runCancel(); runner.reap() }()
+	hookFired := false
 	for {
 		resp, recvErr := stream.Recv()
 		if recvErr == io.EOF {
@@ -1265,6 +1273,10 @@ func runMacOSNativeContainer(ctx context.Context, conn *grpcclient.AgentConnecti
 				break
 			}
 			return fmt.Errorf("receiving container output: %w", recvErr)
+		}
+		if resp.GetStarted() != nil && !hookFired {
+			hookFired = true
+			runner.startAsync(runCtx, appCfg)
 		}
 		if out := resp.GetStdoutOutput(); out != nil {
 			_, _ = os.Stdout.Write(out.GetData())
@@ -2474,8 +2486,9 @@ func startAndStreamContainer(ctx context.Context, conn *grpcclient.AgentConnecti
 
 	// Announce + post-start hook, gated on readiness; the hook is tied to runCtx
 	// so Ctrl+C kills it.
-	var postStartCmd *exec.Cmd
-	postStartCmd = runPostStartIfReady(runCtx, runCtx, conn, appCfg, runOptions{})
+	runner := &serviceHookRunner{conn: conn, opts: opts}
+	defer func() { runCancel(); runner.reap() }()
+	hookFired := false
 
 	gotFirstResponse := false
 	// Set when the stream ends on a genuine failure (as opposed to a clean
@@ -2518,6 +2531,10 @@ func startAndStreamContainer(ctx context.Context, conn *grpcclient.AgentConnecti
 			break
 		}
 		gotFirstResponse = true
+		if resp.GetStarted() != nil && !hookFired {
+			hookFired = true
+			runner.startAsync(runCtx, appCfg)
+		}
 		if out := resp.GetStdoutOutput(); out != nil {
 			_, _ = os.Stdout.Write(out.GetData())
 		}
@@ -2529,9 +2546,7 @@ func startAndStreamContainer(ctx context.Context, conn *grpcclient.AgentConnecti
 	// Cancel runCtx to terminate the postStart hook if it's still running,
 	// then wait for it to exit so we don't leave orphan processes.
 	runCancel()
-	if postStartCmd != nil {
-		_ = postStartCmd.Wait()
-	}
+	runner.reap()
 	if runErr != nil {
 		return runErr
 	}
@@ -2769,7 +2784,7 @@ func runPostStartIfReady(ctx, hookCtx context.Context, conn *grpcclient.AgentCon
 		return nil
 	}
 
-	err := waitForReadiness(ctx, readiness, hookHost)
+	err := waitForAttachedReadiness(ctx, conn, appCfg, hookHost)
 	rp("  ↳ runcontainer: readiness wait")
 	if err != nil {
 		if ctx.Err() == nil {
@@ -2813,6 +2828,9 @@ func runPostStartIfReady(ctx, hookCtx context.Context, conn *grpcclient.AgentCon
 // wait on or kill. Returns nil when no cli command is configured (regardless
 // of whether openURL was fired).
 func startPostStartHook(ctx context.Context, appCfg *appconfig.AppConfig, hostname, serviceName string) *exec.Cmd {
+	if ctx.Err() != nil {
+		return nil
+	}
 	if appCfg.Hooks == nil || appCfg.Hooks.PostStart == nil {
 		return nil
 	}
@@ -2830,6 +2848,9 @@ func startPostStartHook(ctx context.Context, appCfg *appconfig.AppConfig, hostna
 	}
 
 	if hook.CLI == "" {
+		return nil
+	}
+	if ctx.Err() != nil {
 		return nil
 	}
 
@@ -2917,13 +2938,8 @@ func streamRunContainer(ctx context.Context, conn *grpcclient.AgentConnection, s
 	// hooks. They have completely different causes when one is slow.
 	rc := phaseTimer()
 	hookCtx, hookCancel := context.WithCancel(ctx)
-	var postStartCmd *exec.Cmd
-	defer func() {
-		hookCancel()
-		if postStartCmd != nil {
-			_ = postStartCmd.Wait()
-		}
-	}()
+	runner := &serviceHookRunner{conn: conn, opts: opts}
+	defer func() { hookCancel(); runner.reap() }()
 	hookFired := false
 	for {
 		resp, err := stream.Recv()
@@ -2957,7 +2973,7 @@ func streamRunContainer(ctx context.Context, conn *grpcclient.AgentConnection, s
 					opts.watchState.reapCommand(cmd)
 					return nil
 				}
-				postStartCmd = runPostStartIfReady(ctx, hookCtx, conn, appCfg, runOptions{})
+				runner.startAsync(hookCtx, appCfg)
 			}
 			continue
 		}

--- a/go/internal/cli/commands/service_lifecycle.go
+++ b/go/internal/cli/commands/service_lifecycle.go
@@ -11,9 +11,8 @@ import (
 
 // serviceHookRunner runs the per-service "wait for readiness → announce URL →
 // fire postStart" sequence for multi-service runs (compose + services map).
-// A readiness failure warns and still fires explicitly configured hooks, but
-// suppresses the success announcement and HTTP-entitlement-synthesized browser
-// open. Context cancellation suppresses every side effect, as does a watch
+// Readiness gates all explicit and synthesized host actions. A slow running
+// service remains under observation until ready, stopped, or canceled. Context cancellation suppresses every side effect, as does a watch
 // session that has already completed the sequence for this container.
 //
 // Zero-value-ready except conn: construct with
@@ -92,34 +91,17 @@ func (r *serviceHookRunner) runOne(ctx, hookCtx context.Context, cfg *appconfig.
 		return
 	}
 
-	readinessSucceeded := true
-	if err := waitForReadiness(ctx, readiness, hookHost); err != nil {
-		if ctx.Err() != nil {
-			// Canceled (e.g. Ctrl+C, or the run ending) — stay silent and skip
-			// the hook entirely; this is not a readiness failure to report.
-			return
+	if err := waitForAttachedReadiness(ctx, r.conn, cfg, hookHost); err != nil {
+		if ctx.Err() == nil {
+			warnReadiness(ctx, r.conn, cfg.AppID, err)
 		}
-		// containerExitDetail (invoked by warnReadiness) matches on the GROUP
-		// appID: the agent's ListContainers groups per-service containers under
-		// the group app-ID label, reports AppContainer.AppName as the bare
-		// group appID, and aggregates exit code/reason onto that group entry —
-		// so pass cfg.AppID, never cfg.ContainerName().
-		warnReadiness(ctx, r.conn, cfg.AppID, err)
-		readinessSucceeded = false
+		return
 	}
 	if ctx.Err() != nil {
 		return
 	}
-	// Watch claims host-side actions only after readiness succeeds. A failed
-	// attempt releases the claim so a later deploy can try again.
-	if r.opts.isWatch() && !readinessSucceeded {
-		return
-	}
-
 	effectiveCfg := cfg
-	// A failed probe must not synthesize an automatic browser open from an HTTP
-	// entitlement. Explicit hooks still run after a non-cancellation timeout.
-	if readinessSucceeded && hooks != cfg.Hooks {
+	if hooks != cfg.Hooks {
 		clone := *cfg
 		clone.Hooks = hooks
 		effectiveCfg = &clone

--- a/go/internal/cli/commands/service_lifecycle_test.go
+++ b/go/internal/cli/commands/service_lifecycle_test.go
@@ -384,8 +384,7 @@ func TestServiceHookRunner_CloudNoReportedIPSkipsHookAndReadiness(t *testing.T) 
 
 // TestServiceHookRunner_ReadinessTimeoutSuppressesAutomaticHTTPSideEffects
 // verifies that a timed-out HTTP readiness gate warns without claiming success
-// or opening a synthesized browser URL, while an explicitly configured hook
-// retains the established multi-service non-fatal behavior and still runs.
+// or running explicit host hooks before readiness succeeds.
 func TestServiceHookRunner_ReadinessTimeoutSuppressesAutomaticHTTPSideEffects(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("host-side postStart cli hook uses `touch`, unavailable on Windows")
@@ -429,7 +428,9 @@ func TestServiceHookRunner_ReadinessTimeoutSuppressesAutomaticHTTPSideEffects(t 
 	if len(*calls) != 0 {
 		t.Fatalf("browserOpen calls = %v, want none after readiness timeout", *calls)
 	}
-	waitForFile(t, sentinel, 5*time.Second)
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Fatal("postStart hook ran before readiness succeeded")
+	}
 	if containerFake.listContainersCalls == 0 {
 		t.Errorf("ListContainers never called; expected warnReadiness's exit-detail lookup to run")
 	}
@@ -1285,8 +1286,7 @@ func TestStartAndStreamServices_Detached_NoHostSideWork(t *testing.T) {
 
 // TestStartAndStreamServices_Attached_ReadinessTimeoutNonFatal keeps the
 // documented contract that a non-cancellation readiness timeout warns without
-// failing the command: the run still returns nil and the explicitly configured
-// cli hook still fires. Detached runs do not probe, so attached is the only
+// failing the command: the run still returns nil and host hooks remain gated. Detached runs do not probe, so attached is the only
 // mode this applies to.
 func TestStartAndStreamServices_Attached_ReadinessTimeoutNonFatal(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -1311,9 +1311,9 @@ func TestStartAndStreamServices_Attached_ReadinessTimeoutNonFatal(t *testing.T) 
 			Hooks:       &appconfig.HooksConfig{PostStart: &appconfig.HookCommand{CLI: fmt.Sprintf("touch %q", sentinel)}},
 		},
 	}
-	// Hold the log stream open until the hook has run, so the teardown
-	// (runCancel then reap) cannot suppress it first.
-	fake := &hookSvcContainerClient{deadline: time.Now().Add(20 * time.Second)}
+	// Hold the log stream past the initial deadline to verify the warning
+	// without running a host hook for a service that never becomes ready.
+	fake := &hookSvcContainerClient{deadline: time.Now().Add(2 * time.Second)}
 	fake.shouldEOF = func() bool { _, statErr := os.Stat(sentinel); return statErr == nil }
 	conn := newLifecycleTestConn("127.0.0.1", nil)
 	conn.ContainerService = fake
@@ -1322,7 +1322,9 @@ func TestStartAndStreamServices_Attached_ReadinessTimeoutNonFatal(t *testing.T) 
 		func(string) error { return nil }, svcCfgs, svcCfgs, nil); err != nil {
 		t.Fatalf("startAndStreamServices returned %v, want nil (readiness timeout must be non-fatal)", err)
 	}
-	waitForFile(t, sentinel, 5*time.Second)
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Fatal("postStart hook ran before readiness succeeded")
+	}
 	if fake.listContainersCalls() == 0 {
 		t.Error("no ListContainers call: the readiness failure was never reported through warnReadiness")
 	}

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -991,6 +991,7 @@ func ValidateJSON(data []byte) []string {
 	}
 	warnings = append(warnings, validateEntitlementsJSON(raw["entitlements"], "entitlement")...)
 	warnings = append(warnings, validateHooksJSON(raw["hooks"], "hooks")...)
+	warnings = append(warnings, validateReadinessJSON(raw["readiness"], "readiness")...)
 	warnings = append(warnings, validateFrameworksJSON(raw["frameworks"], "frameworks")...)
 
 	// Validate service-level entitlements, frameworks, and hooks when a
@@ -1011,6 +1012,7 @@ func ValidateJSON(data []byte) []string {
 				warnings = append(warnings, validateEntitlementsJSON(svc["entitlements"], prefix)...)
 				warnings = append(warnings, validateFrameworksJSON(svc["frameworks"], fmt.Sprintf("services[%q].frameworks", name))...)
 				warnings = append(warnings, validateHooksJSON(svc["hooks"], fmt.Sprintf("services[%q].hooks", name))...)
+				warnings = append(warnings, validateReadinessJSON(svc["readiness"], fmt.Sprintf("services[%q].readiness", name))...)
 			}
 
 			// A top-level hooks.postStart.agent has no app-level container to
@@ -1280,4 +1282,17 @@ func (a *AppConfig) GetROS2Config() *ROS2Config {
 		return nil
 	}
 	return a.Frameworks.ROS2
+}
+
+func validateReadinessJSON(data json.RawMessage, prefix string) []string {
+	var raw map[string]json.RawMessage
+	if json.Unmarshal(data, &raw) != nil {
+		return nil
+	}
+	warnings := unknownKeyWarnings(raw, prefix, jsonFieldNames(reflect.TypeOf(ReadinessConfig{})))
+	var tcp map[string]json.RawMessage
+	if json.Unmarshal(raw["tcpSocket"], &tcp) == nil {
+		warnings = append(warnings, unknownKeyWarnings(tcp, prefix+".tcpSocket", jsonFieldNames(reflect.TypeOf(TCPSocketProbe{})))...)
+	}
+	return warnings
 }

--- a/go/internal/shared/appconfig/readiness_keys_test.go
+++ b/go/internal/shared/appconfig/readiness_keys_test.go
@@ -1,0 +1,16 @@
+package appconfig
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWarnUnknownReadinessKeysAtEveryScope(t *testing.T) {
+	warnings := ValidateJSON([]byte(`{"appId":"app","readiness":{"initialDelaySeconds":10},"services":{"api":{"context":".","readiness":{"timeout":10,"tcpSocket":{"port":8080,"host":"wrong"}}}}}`))
+	text := strings.Join(warnings, "\n")
+	for _, key := range []string{"readiness", "initialDelaySeconds", `services["api"].readiness`, "timeout", "host"} {
+		if !strings.Contains(text, key) {
+			t.Fatalf("missing %q in %s", key, text)
+		}
+	}
+}


### PR DESCRIPTION
After the existing initial deadline, inspect each relevant service and continue probing running services every five seconds while attached logs stream. Readiness owns browser/postStart actions and runs them once; cancellation, replacement, and terminal failure cancel obsolete probes. Unknown readiness keys warn at app and service levels.

Previous component: https://github.com/wendylabsinc/WendyOS/pull/1909.

Validation: Deterministic clock/state/cancellation fixtures and Linux CLI race tests passed. Real Mac fixture reported still starting at a one-second deadline, became ready at 11 seconds, and ran exactly one hook.

Part of the WDY-2906–2913 stack. Merge in dependency order. [Final acceptance record and stack index](https://github.com/wendylabsinc/WendyOS/pull/1905). Hardware acceptance and the stable agent/CLI release are still pending; no issue closure is claimed.
