### PR TITLE
WDY-2911: support durable native Mac command deployments

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
@@ -429,3 +429,38 @@ checks every five seconds while streaming logs. Browser opening and host
 `postStart` commands run once readiness succeeds. Stopping the service,
 canceling the session, or replacing a watch deployment cancels its probes.
 Detached and create-only runs continue to skip host readiness and hooks.
+
+
+## Native commands on Mac
+
+A single native Darwin app can name a target executable directly:
+
+```json
+{
+  "appId": "sh.example.chat",
+  "platform": "darwin",
+  "files": [{"path": "launcher.py"}, {"path": "data"}],
+  "run": {"command": "/usr/bin/python3", "args": ["../launcher.py"], "cwd": "data"},
+  "env": {"MAX_MODEL": "HuggingFaceTB/SmolLM2-135M-Instruct"}
+}
+```
+
+`run.command` is an absolute executable on the target or an executable relative
+ to the synced app directory. Relative scripts must have executable permission.
+`run.cwd` defaults to the app directory and must stay inside it, including after
+symlink resolution. Arguments are passed directly; shell expressions are literal
+unless you explicitly choose a shell executable. The CLI selects this mode before
+project detection and rejects conflicting build flags and non-Darwin targets.
+
+The target must advertise `native-process-v1`; update Wendy Agent for Mac if the
+CLI requests it. Declared files, `wendy.json`, an optional `sandbox.sb`, and the
+configured Brewfile (or auto-detected `Brewfile.wendy`) use native file sync.
+Homebrew installation completes before the agent validates the executable.
+Request environment values apply to native command, SwiftPM, and Xcode launches;
+agent identity and telemetry settings take precedence. `WENDY_APP_ID` identifies
+the app. Keep runtime data outside the synced source directory, for example under
+`~/Library/Application Support/<appId>/runtime/`, to retain it across file sync.
+
+Attached watch compares the command, working directory, arguments, effective
+environment, files, configuration, and restart policy. Unchanged running commands
+remain running. Host hooks and browser opening wait for readiness.

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
@@ -452,7 +452,7 @@ symlink resolution. Arguments are passed directly; shell expressions are literal
 unless you explicitly choose a shell executable. The CLI selects this mode before
 project detection and rejects conflicting build flags and non-Darwin targets.
 
-The target must advertise `native-process-v1`; update Wendy Agent for Mac if the
+The target must advertise `native-process`; update Wendy Agent for Mac if the
 CLI requests it. Declared files, `wendy.json`, an optional `sandbox.sb`, and the
 configured Brewfile (or auto-detected `Brewfile.wendy`) use native file sync.
 Homebrew installation completes before the agent validates the executable.

--- a/go/internal/cli/commands/native_command.go
+++ b/go/internal/cli/commands/native_command.go
@@ -1,0 +1,130 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+func runNativeCommandWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd string, cfg *appconfig.AppConfig, opts runOptions, version *agentpb.GetAgentVersionResponse) error {
+	if err := validateNativeCommandOptions(cfg, opts, version); err != nil {
+		return err
+	}
+	// The agent uses platform to select its native runtime, including when the
+	// manifest omitted it and the target supplied the default.
+	cfg.Platform = appconfig.PlatformDarwin
+	entries, err := assembleNativeCommandSyncEntries(cwd, cfg)
+	if err != nil {
+		return err
+	}
+	manifest, _, err := buildCombinedManifest(entries)
+	if err != nil {
+		return err
+	}
+	if !path.IsAbs(cfg.Run.Command) {
+		command := path.Clean(cfg.Run.Command)
+		if !slices.ContainsFunc(manifest.Files, func(f *agentpb.FileSyncEntry) bool { return path.Clean(f.Path) == command && f.Mode&0111 != 0 }) {
+			return fmt.Errorf("run.command %q must be an executable in the synced files (use chmod +x for a script)", cfg.Run.Command)
+		}
+	}
+	req := &agentpb.CreateContainerRequest{
+		AppName: cfg.AppID, Cmd: cfg.Run.Command, WorkingDir: cfg.Run.Cwd,
+		UserArgs: cfg.Run.Args, Env: mergeEnvEntries(resolveServiceEnv(cfg), opts.env), RestartPolicy: resolveRestartPolicy(opts),
+	}
+	if len(opts.userArgs) > 0 {
+		req.UserArgs = opts.userArgs
+	}
+	hash, err := watchDesiredHash(struct {
+		Request *agentpb.CreateContainerRequest
+		Config  *appconfig.AppConfig
+		Files   *agentpb.FileSyncManifest
+	}{req, cfg, manifest})
+	if err != nil {
+		return err
+	}
+	key := watchServiceKey(deviceFingerprintKey(version), cfg.AppID, "")
+	if opts.isWatch() && opts.watchState.matches(key, hash) && deviceContainerStates(ctx, conn)[strings.ToLower(cfg.ContainerName())] == agentpb.AppRunningState_RUNNING {
+		cliLogln("Application %s is unchanged and running.", containerDisplayName(cfg))
+		if !opts.detach && !opts.deploy {
+			opts.watchState.reapCommand(runPostStartIfReady(ctx, opts.watchState.hookContext(ctx), conn, cfg, opts))
+		}
+		return nil
+	}
+	if err := syncFiles(ctx, conn, cfg.AppID, entries); err != nil {
+		return fmt.Errorf("syncing native app files: %w", err)
+	}
+	if err := runMacOSNativeContainer(ctx, conn, cfg, req, opts); err != nil {
+		return err
+	}
+	opts.watchState.record(key, hash)
+	return nil
+}
+
+func validateNativeCommandOptions(cfg *appconfig.AppConfig, opts runOptions, version *agentpb.GetAgentVersionResponse) error {
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+	if version.GetOs() != "darwin" {
+		return fmt.Errorf("run.command requires a native Darwin agent target")
+	}
+	if !slices.Contains(version.GetFeatureset(), "native-process-v1") {
+		return fmt.Errorf("this Mac agent does not support run.command; update Wendy Agent on the target Mac to a version advertising native-process-v1, then run again")
+	}
+	if opts.buildType != "" || opts.dockerfile != "" || opts.builder != "" || opts.buildHost != "" || opts.product != "" || opts.debug || opts.gpuArch != "" {
+		return fmt.Errorf("run.command cannot be combined with build selections (--build-type, --dockerfile, --builder, --build-host, --product, --debug, or --gpu-arch)")
+	}
+	return nil
+}
+
+func assembleNativeCommandSyncEntries(cwd string, cfg *appconfig.AppConfig) ([]fileSyncEntry, error) {
+	var entries []fileSyncEntry
+	for _, f := range cfg.Files {
+		remote := effectiveRemotePath(f.Path, f.To)
+		if !appconfig.SafeNativeRelativePath(remote, true) {
+			return nil, fmt.Errorf("synced destination %q must remain inside the app directory", remote)
+		}
+		entries = append(entries, fileSyncEntry{localPath: filepath.Join(cwd, f.Path), remotePath: remote})
+	}
+	// Preserve declared mappings. Only add an implicit support file when the
+	// same destination isn't already supplied by its file/directory entry.
+	add := func(name string, required bool) error {
+		candidate := fileSyncEntry{localPath: filepath.Join(cwd, name), remotePath: path.Clean(name)}
+		for _, e := range entries {
+			coverage, err := syncEntryCoversBrewfile(e, candidate)
+			if err != nil {
+				return err
+			}
+			if coverage.covered {
+				return nil
+			}
+		}
+		if _, err := os.Stat(candidate.localPath); err != nil {
+			if !required && os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		entries = append(entries, candidate)
+		return nil
+	}
+	if err := add("wendy.json", true); err != nil {
+		return nil, err
+	}
+	if err := add("sandbox.sb", false); err != nil {
+		return nil, err
+	}
+	if !path.IsAbs(cfg.Run.Command) {
+		if err := add(cfg.Run.Command, true); err != nil {
+			return nil, fmt.Errorf("run.command: %w", err)
+		}
+	}
+	return appendNativeBrewfileSyncEntry(entries, cwd, cfg)
+}

--- a/go/internal/cli/commands/native_command.go
+++ b/go/internal/cli/commands/native_command.go
@@ -75,8 +75,8 @@ func validateNativeCommandOptions(cfg *appconfig.AppConfig, opts runOptions, ver
 	if version.GetOs() != "darwin" {
 		return fmt.Errorf("run.command requires a native Darwin agent target")
 	}
-	if !slices.Contains(version.GetFeatureset(), "native-process-v1") {
-		return fmt.Errorf("this Mac agent does not support run.command; update Wendy Agent on the target Mac to a version advertising native-process-v1, then run again")
+	if !slices.Contains(version.GetFeatureset(), "native-process") {
+		return fmt.Errorf("this Mac agent does not support run.command; update Wendy Agent on the target Mac to a version advertising native-process, then run again")
 	}
 	if opts.buildType != "" || opts.dockerfile != "" || opts.builder != "" || opts.buildHost != "" || opts.product != "" || opts.debug || opts.gpuArch != "" {
 		return fmt.Errorf("run.command cannot be combined with build selections (--build-type, --dockerfile, --builder, --build-host, --product, --debug, or --gpu-arch)")

--- a/go/internal/cli/commands/native_command_test.go
+++ b/go/internal/cli/commands/native_command_test.go
@@ -1,0 +1,113 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+)
+
+func TestNativeCommandDeployment(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "launch.py"), []byte("#!/usr/bin/python3\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "Brewfile.wendy"), []byte("brew \"uv\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &appconfig.AppConfig{AppID: "sh.wendy.NativeTest", Platform: "darwin", Run: &appconfig.RunConfig{Command: "launch.py", Cwd: ".", Args: []string{"hello world", "$(literal)"}}, Env: map[string]string{"MODE": "app", "EMPTY": "app"}}
+	data, _ := json.Marshal(cfg)
+	if err := os.WriteFile(filepath.Join(dir, "wendy.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	// The explicit command takes precedence even with a Docker project marker.
+	if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if project, err := resolveRunProjectType(dir, ""); err != nil || project != "native-process" {
+		t.Fatalf("project=%q err=%v", project, err)
+	}
+	state := &fakeMacRunState{}
+	conn, cleanup := startFakeMacRunServer(t, state)
+	defer cleanup()
+	version := &agentpb.GetAgentVersionResponse{Os: "darwin", Featureset: []string{"native-process-v1"}}
+	opts := runOptions{deploy: true, env: []string{"MODE=first", "MODE=cli", "EMPTY="}, noRestart: true}
+	if err := runNativeCommandWithAgent(context.Background(), conn, dir, cfg, opts, version); err != nil {
+		t.Fatal(err)
+	}
+	if len(state.createReqs) != 1 {
+		t.Fatalf("creates=%d", len(state.createReqs))
+	}
+	req := state.createReqs[0]
+	if req.Cmd != "launch.py" || req.WorkingDir != "." || !reflect.DeepEqual(req.UserArgs, cfg.Run.Args) {
+		t.Fatalf("request: %v", req)
+	}
+	slices.Sort(req.Env)
+	if !reflect.DeepEqual(req.Env, []string{"EMPTY=", "MODE=cli"}) {
+		t.Fatalf("env=%v", req.Env)
+	}
+	if req.RestartPolicy.GetMode() != agentpb.RestartPolicyMode_NO {
+		t.Fatalf("restart=%v", req.RestartPolicy)
+	}
+	if cfg.Brewfile != "Brewfile.wendy" {
+		t.Fatal("Brewfile not synced")
+	}
+}
+
+func TestNativeCommandWatchDetectsLaunchAndFileChanges(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "launch.py"), []byte("#!/usr/bin/python3\n"), 0755)
+	os.WriteFile(filepath.Join(dir, "wendy.json"), []byte(`{"appId":"sh.wendy.Watch"}`), 0644)
+	cfg := &appconfig.AppConfig{AppID: "sh.wendy.Watch", Platform: "darwin", Run: &appconfig.RunConfig{Command: "launch.py"}}
+	state := &fakeMacRunState{}
+	conn, cleanup := startFakeMacRunServer(t, state)
+	defer cleanup()
+	version := &agentpb.GetAgentVersionResponse{Os: "darwin", Featureset: []string{"native-process-v1"}}
+	opts := runOptions{detach: true, watchState: &watchDeployState{hashes: map[string]string{}}}
+	run := func(want int) {
+		t.Helper()
+		if err := runNativeCommandWithAgent(context.Background(), conn, dir, cfg, opts, version); err != nil {
+			t.Fatal(err)
+		}
+		if len(state.createReqs) != want {
+			t.Fatalf("creates=%d want=%d", len(state.createReqs), want)
+		}
+	}
+	run(1)
+	run(1)
+	opts.env = []string{"MODE=changed"}
+	run(2)
+	cfg.Run.Cwd = "."
+	run(3)
+	cfg.Run.Args = []string{"literal arg"}
+	run(4)
+	opts.noRestart = true
+	run(5)
+	os.WriteFile(filepath.Join(dir, "launch.py"), []byte("#!/usr/bin/python3\nprint('new')\n"), 0755)
+	run(6)
+	cfg.Run.Command = "./launch.py"
+	run(7)
+}
+
+func TestNativeCommandRequiresCapabilityAndRejectsBuildOptions(t *testing.T) {
+	cfg := &appconfig.AppConfig{AppID: "sh.wendy.Test", Run: &appconfig.RunConfig{Command: "/usr/bin/python3"}}
+	version := &agentpb.GetAgentVersionResponse{Os: "darwin"}
+	if err := validateNativeCommandOptions(cfg, runOptions{}, version); err == nil {
+		t.Fatal("older agent accepted")
+	}
+	version.Featureset = []string{"native-process-v1"}
+	for _, opts := range []runOptions{{buildType: "docker"}, {dockerfile: "Dockerfile"}, {product: "App"}, {buildHost: "device"}, {debug: true}} {
+		if err := validateNativeCommandOptions(cfg, opts, version); err == nil {
+			t.Fatalf("accepted %+v", opts)
+		}
+	}
+	if err := validateNativeCommandOptions(cfg, runOptions{}, version); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/go/internal/cli/commands/native_command_test.go
+++ b/go/internal/cli/commands/native_command_test.go
@@ -36,7 +36,7 @@ func TestNativeCommandDeployment(t *testing.T) {
 	state := &fakeMacRunState{}
 	conn, cleanup := startFakeMacRunServer(t, state)
 	defer cleanup()
-	version := &agentpb.GetAgentVersionResponse{Os: "darwin", Featureset: []string{"native-process-v1"}}
+	version := &agentpb.GetAgentVersionResponse{Os: "darwin", Featureset: []string{"native-process"}}
 	opts := runOptions{deploy: true, env: []string{"MODE=first", "MODE=cli", "EMPTY="}, noRestart: true}
 	if err := runNativeCommandWithAgent(context.Background(), conn, dir, cfg, opts, version); err != nil {
 		t.Fatal(err)
@@ -68,7 +68,7 @@ func TestNativeCommandWatchDetectsLaunchAndFileChanges(t *testing.T) {
 	state := &fakeMacRunState{}
 	conn, cleanup := startFakeMacRunServer(t, state)
 	defer cleanup()
-	version := &agentpb.GetAgentVersionResponse{Os: "darwin", Featureset: []string{"native-process-v1"}}
+	version := &agentpb.GetAgentVersionResponse{Os: "darwin", Featureset: []string{"native-process"}}
 	opts := runOptions{detach: true, watchState: &watchDeployState{hashes: map[string]string{}}}
 	run := func(want int) {
 		t.Helper()
@@ -101,7 +101,7 @@ func TestNativeCommandRequiresCapabilityAndRejectsBuildOptions(t *testing.T) {
 	if err := validateNativeCommandOptions(cfg, runOptions{}, version); err == nil {
 		t.Fatal("older agent accepted")
 	}
-	version.Featureset = []string{"native-process-v1"}
+	version.Featureset = []string{"native-process"}
 	for _, opts := range []runOptions{{buildType: "docker"}, {dockerfile: "Dockerfile"}, {product: "App"}, {buildHost: "device"}, {debug: true}} {
 		if err := validateNativeCommandOptions(cfg, opts, version); err == nil {
 			t.Fatalf("accepted %+v", opts)

--- a/go/internal/cli/commands/run.go
+++ b/go/internal/cli/commands/run.go
@@ -59,7 +59,7 @@ func rejectUnsupportedMacRunProject(projectType, platform string) error {
 		return errors.New(macPlatformMismatchMessage(platform))
 	}
 	switch projectType {
-	case "swift", "xcode", "docker", "python", "compose", "multi-service":
+	case "swift", "xcode", "docker", "python", "compose", "multi-service", "native-process":
 		return nil
 	default:
 		return fmt.Errorf("unable to detect project type for a Mac target: %q", projectType)
@@ -1019,6 +1019,10 @@ func runCommand(ctx context.Context, opts runOptions) error {
 		}
 	}
 
+	if projectType == "native-process" && target.Agent == nil {
+		return fmt.Errorf("run.command requires a native Darwin agent target")
+	}
+
 	// Provider-based run path.
 	if target.External != nil && target.Provider != nil {
 		if err := rejectUnsupportedBuildHostProject(opts.buildHost, "provider targets"); err != nil {
@@ -1171,6 +1175,13 @@ func runMacOSNativeContainer(ctx context.Context, conn *grpcclient.AgentConnecti
 		return fmt.Errorf("marshaling app config: %w", err)
 	}
 	createReq.AppConfig = appConfigData
+	if createReq.Env == nil {
+		createReq.Env = mergeEnvEntries(resolveServiceEnv(appCfg), opts.env)
+	}
+	createReq.RestartPolicy = resolveRestartPolicy(opts)
+	if appCfg.Run != nil && appCfg.Run.Cwd != "" {
+		createReq.WorkingDir = appCfg.Run.Cwd
+	}
 
 	if appCfg.Brewfile != "" {
 		cliLogln("Will apply Brewfile on target Mac.")
@@ -1532,6 +1543,12 @@ func assembleSwiftPMSyncEntries(binaryPath, cwd string, appCfg *appconfig.AppCon
 }
 
 func resolveRunProjectType(dir, requestedType string) (string, error) {
+	if cfg, err := appconfig.LoadFromFile(filepath.Join(dir, "wendy.json")); err == nil && cfg.Run != nil && cfg.Run.Command != "" {
+		if requestedType != "" {
+			return "", fmt.Errorf("run.command cannot be combined with --build-type")
+		}
+		return "native-process", nil
+	}
 	if strings.TrimSpace(requestedType) == "" {
 		return detectProjectType(dir)
 	}
@@ -1955,6 +1972,13 @@ func runWithAgent(ctx context.Context, conn *grpcclient.AgentConnection, cwd str
 
 	if isContainerPlatform(platform) && projectType != "compose" {
 		printMissingNetworkWarnings(appCfg)
+	}
+
+	if appCfg.Run != nil && appCfg.Run.Command != "" {
+		if !strings.EqualFold(agentOS, "darwin") || platformOS(platform) != "darwin" {
+			return fmt.Errorf("run.command requires a native Darwin agent target")
+		}
+		return runNativeCommandWithAgent(ctx, conn, cwd, appCfg, opts, versionResp)
 	}
 
 	// Xcode projects: always use the local-build + file-sync path (darwin only).

--- a/go/internal/cli/commands/run_macos_test.go
+++ b/go/internal/cli/commands/run_macos_test.go
@@ -58,6 +58,15 @@ func (s *fakeMacContainerServer) CreateContainer(_ context.Context, req *agentpb
 	return &agentpb.CreateContainerResponse{}, nil
 }
 
+func (s *fakeMacContainerServer) ListContainers(_ *agentpb.ListContainersRequest, stream grpc.ServerStreamingServer[agentpb.ListContainersResponse]) error {
+	for _, req := range s.state.createReqs {
+		if err := stream.Send(&agentpb.ListContainersResponse{Container: &agentpb.AppContainer{AppName: req.AppName, RunningState: agentpb.AppRunningState_RUNNING}}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (s *fakeMacContainerServer) StartContainer(req *agentpb.StartContainerRequest, _ grpc.ServerStreamingServer[agentpb.RunContainerLayersResponse]) error {
 	s.state.startReqs = append(s.state.startReqs, proto.Clone(req).(*agentpb.StartContainerRequest))
 	return nil

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -147,7 +147,9 @@ type FileSyncEntry struct {
 
 // RunConfig holds runtime configuration applied when the app is started.
 type RunConfig struct {
-	Args []string `json:"args,omitempty"`
+	Command string   `json:"command,omitempty"`
+	Cwd     string   `json:"cwd,omitempty"`
+	Args    []string `json:"args,omitempty"`
 }
 
 // ROS2Config holds ROS 2 runtime configuration for a container.
@@ -620,6 +622,11 @@ func ValidateReadiness(prefix string, r *ReadinessConfig) error {
 
 // Validate checks the AppConfig for required fields and valid entitlement types.
 func (c *AppConfig) Validate() error {
+	if c.Run != nil {
+		if err := c.validateNativeRun(); err != nil {
+			return err
+		}
+	}
 	if err := ValidateAppID(c.AppID); err != nil {
 		return err
 	}

--- a/go/internal/shared/appconfig/native_run.go
+++ b/go/internal/shared/appconfig/native_run.go
@@ -1,0 +1,42 @@
+package appconfig
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+func (c *AppConfig) validateNativeRun() error {
+	r := c.Run
+	if r.Cwd != "" && !SafeNativeRelativePath(r.Cwd, true) {
+		return fmt.Errorf("run.cwd must be a relative directory inside the app directory")
+	}
+	if r.Command == "" {
+		return nil
+	}
+	if strings.ContainsAny(r.Command, "\x00\r\n\\") || (!path.IsAbs(r.Command) && !SafeNativeRelativePath(r.Command, false)) {
+		return fmt.Errorf("run.command must name an absolute target executable or a synced executable inside the app directory")
+	}
+	if len(c.Services) != 0 {
+		return fmt.Errorf("run.command supports only a single native Darwin app")
+	}
+	if c.Platform != "" && c.Platform != PlatformDarwin && !strings.HasPrefix(c.Platform, PlatformDarwin+"/") {
+		return fmt.Errorf("run.command requires a Darwin target")
+	}
+	if c.Xcode != nil {
+		return fmt.Errorf("run.command cannot be combined with xcode build configuration")
+	}
+	return nil
+}
+
+func SafeNativeRelativePath(value string, allowCurrent bool) bool {
+	if value == "" || path.IsAbs(value) || strings.ContainsAny(value, "\x00\r\n\\") {
+		return false
+	}
+	for _, component := range strings.Split(value, "/") {
+		if component == ".." {
+			return false
+		}
+	}
+	return allowCurrent || path.Clean(value) != "."
+}

--- a/go/internal/shared/appconfig/native_run_test.go
+++ b/go/internal/shared/appconfig/native_run_test.go
@@ -1,0 +1,20 @@
+package appconfig
+
+import "testing"
+
+func TestNativeRunValidation(t *testing.T) {
+	for _, tc := range []struct {
+		command, cwd, platform string
+		valid                  bool
+	}{
+		{"./serve.py", "", "darwin", true}, {"/opt/homebrew/bin/python3", "data", "darwin/arm64", true},
+		{"serve.py", ".", "", true}, {"../serve.py", "", "darwin", false},
+		{"serve.py", "../other", "darwin", false}, {"serve.py", "/tmp", "darwin", false},
+		{"serve.py", "", "linux/arm64", false}, {".", "", "darwin", false},
+	} {
+		cfg := &AppConfig{AppID: "sh.wendy.test", Platform: tc.platform, Run: &RunConfig{Command: tc.command, Cwd: tc.cwd}}
+		if err := cfg.Validate(); (err == nil) != tc.valid {
+			t.Errorf("%+v: %v", tc, err)
+		}
+	}
+}

--- a/go/internal/shared/appconfig/wendy.schema.json
+++ b/go/internal/shared/appconfig/wendy.schema.json
@@ -476,6 +476,14 @@
       "description": "Runtime configuration applied when the app is started.",
       "additionalProperties": false,
       "properties": {
+        "command": {
+          "type": "string", "minLength": 1,
+          "description": "Single native Darwin app: a synced executable relative to the app directory, or an absolute executable on the target. Arguments are executed directly without shell parsing. Requires agent feature native-process-v1."
+        },
+        "cwd": {
+          "type": "string", "minLength": 1,
+          "description": "Native working directory relative to the app directory (default .). Must stay inside the app directory, including through symlinks."
+        },
         "args": {
           "type": "array",
           "description": "Command-line arguments passed directly to the app executable.",

--- a/go/internal/shared/appconfig/wendy.schema.json
+++ b/go/internal/shared/appconfig/wendy.schema.json
@@ -478,7 +478,7 @@
       "properties": {
         "command": {
           "type": "string", "minLength": 1,
-          "description": "Single native Darwin app: a synced executable relative to the app directory, or an absolute executable on the target. Arguments are executed directly without shell parsing. Requires agent feature native-process-v1."
+          "description": "Single native Darwin app: a synced executable relative to the app directory, or an absolute executable on the target. Arguments are executed directly without shell parsing. Requires agent feature native-process."
         },
         "cwd": {
           "type": "string", "minLength": 1,

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentService.swift
@@ -88,6 +88,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
         var response = Wendy_Agent_Services_V1_GetAgentVersionResponse()
         response.version = reportedVersion()
         response.os = "darwin"
+        response.featureset.append("native-process-v1")
         response.osVersion =
             "\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)"
         #if arch(arm64)

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/AgentService.swift
@@ -88,7 +88,7 @@ struct AgentService: Wendy_Agent_Services_V1_WendyAgentService.ServiceProtocol {
         var response = Wendy_Agent_Services_V1_GetAgentVersionResponse()
         response.version = reportedVersion()
         response.os = "darwin"
-        response.featureset.append("native-process-v1")
+        response.featureset.append("native-process")
         response.osVersion =
             "\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)"
         #if arch(arm64)

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/ContainerService.swift
@@ -79,6 +79,7 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
     /// the Linux monitor's 10 s floor (`planRestarts`).
     private let restartFloorSeconds: TimeInterval
     private let pidExecutablePath: PIDExecutablePathLookup
+    private let pidBirthTime: PIDBirthTimeLookup
     private let sendSignal: PIDSignalSender
 
     init(
@@ -96,6 +97,9 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
         pidExecutablePath: @escaping PIDExecutablePathLookup = {
             ContainerService.executablePath(forPID: $0)
         },
+        pidBirthTime: @escaping PIDBirthTimeLookup = {
+            NativeProcessConfiguration.birthTime(forPID: $0)
+        },
         sendSignal: @escaping PIDSignalSender = { pid, signal in _ = Darwin.kill(pid, signal) },
         onAppsChanged: @escaping @Sendable ([WendyAppInfo]) async -> Void = { _ in }
     ) {
@@ -109,6 +113,7 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
         self.supervisorInterval = supervisorInterval
         self.restartFloorSeconds = Self.seconds(restartFloor)
         self.pidExecutablePath = pidExecutablePath
+        self.pidBirthTime = pidBirthTime
         self.sendSignal = sendSignal
 
         let defaultStateDirectory = WendyAgentPaths.stateDirectory
@@ -337,6 +342,7 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
         )
         app.process = process
         app.launchToken = launchToken
+        app.pidBirthTime = self.pidBirthTime(process.processIdentifier)
         self.appsByID[id] = app
         try self.saveApps()
         await self.publishApps()
@@ -834,21 +840,20 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
     /// a pid that has already exited (and possibly been recycled) is marked
     /// stopped without anything being signalled.
     private func stopAdoptedNativeApp(id: String, pid: Int32, app: WendyApp) async {
-        guard let binaryPath = Self.nativeBinaryPath(app), self.isPIDRunningApp(pid, app: app)
+        guard self.isPIDRunningApp(pid, app: app)
         else {
             await self.markAppStopped(id: id)
             return
         }
 
         self.sendSignal(pid, SIGTERM)
-        if !(await self.waitForPIDToExit(pid, matching: binaryPath, timeout: self.nativeStopTimeout))
-        {
+        if !(await self.waitForPIDToExit(pid, matching: app, timeout: self.nativeStopTimeout)) {
             self.logger.warning(
                 "Adopted native app did not exit after SIGTERM, force killing",
                 metadata: ["app_name": "\(id)", "pid": "\(pid)"]
             )
-            self.sendSignal(pid, SIGKILL)
-            _ = await self.waitForPIDToExit(pid, matching: binaryPath, timeout: .seconds(1))
+            if self.isPIDRunningApp(pid, app: app) { self.sendSignal(pid, SIGKILL) }
+            _ = await self.waitForPIDToExit(pid, matching: app, timeout: .seconds(1))
         }
 
         await self.markAppStopped(id: id)
@@ -860,13 +865,18 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
     /// recycled is never mistaken for the app.
     private func isPIDRunningApp(_ pid: Int32, app: WendyApp) -> Bool {
         guard pid > 0, let binaryPath = Self.nativeBinaryPath(app) else { return false }
+        if let expected = app.pidBirthTime {
+            return self.pidBirthTime(pid) == expected
+        }
         guard let actualPath = self.pidExecutablePath(pid) else { return false }
         return Self.pathsMatch(actualPath, binaryPath)
     }
 
     nonisolated private static func nativeBinaryPath(_ app: WendyApp) -> String? {
         guard let native = app.native else { return nil }
-        return "\(native.directory)/\(native.binaryName)"
+        return native.executablePath
+            ?? (native.binaryName.hasPrefix("/")
+                ? native.binaryName : "\(native.directory)/\(native.binaryName)")
     }
 
     /// Marks an app running without a `Foundation.Process`: it is alive but
@@ -960,11 +970,9 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
     /// and only then is it terminated, so the relaunch that follows leaves
     /// exactly one copy that the agent owns.
     ///
-    /// A mismatch is never signalled. That deliberately means apps launched
-    /// through `/usr/bin/sandbox-exec`, or whose "binary" is a script (where the
-    /// pid's executable is the interpreter), are not recognized as survivors and
-    /// are left alone: starting a second copy is a far cheaper mistake than
-    /// killing an unrelated process that merely reused the pid.
+    /// The persisted birth time identifies scripts, interpreters and sandboxed
+    /// launches across exec(). A recycled PID with a different birth time is
+    /// never adopted or signalled. Legacy snapshots use the executable check.
     ///
     /// Terminating is right here and wrong in `syncAdoptedNativeStates`, which
     /// adopts instead, because of who owns the process: reconcile runs on a
@@ -974,7 +982,7 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
     /// a live `ContainerService` in this same process.
     private func terminateNativeSurvivorIfAny(_ app: WendyApp) async {
         guard let pid = app.persistedPID, pid > 0,
-            let binaryPath = Self.nativeBinaryPath(app)
+            Self.nativeBinaryPath(app) != nil
         else {
             return
         }
@@ -1002,7 +1010,7 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
             metadata: ["app_name": "\(app.info.id)", "pid": "\(pid)"]
         )
         self.sendSignal(pid, SIGTERM)
-        if await self.waitForPIDToExit(pid, matching: binaryPath, timeout: self.nativeStopTimeout) {
+        if await self.waitForPIDToExit(pid, matching: app, timeout: self.nativeStopTimeout) {
             return
         }
 
@@ -1010,10 +1018,10 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
             "Surviving app process ignored SIGTERM, force killing",
             metadata: ["app_name": "\(app.info.id)", "pid": "\(pid)"]
         )
-        self.sendSignal(pid, SIGKILL)
+        if self.isPIDRunningApp(pid, app: app) { self.sendSignal(pid, SIGKILL) }
         let didExit = await self.waitForPIDToExit(
             pid,
-            matching: binaryPath,
+            matching: app,
             timeout: .seconds(1)
         )
         if !didExit {
@@ -1029,13 +1037,13 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
     /// costs nothing.
     private func waitForPIDToExit(
         _ pid: Int32,
-        matching binaryPath: String,
+        matching app: WendyApp,
         timeout: Duration
     ) async -> Bool {
         let clock = ContinuousClock()
         let deadline = clock.now + timeout
         while true {
-            guard let path = self.pidExecutablePath(pid), Self.pathsMatch(path, binaryPath) else {
+            guard self.isPIDRunningApp(pid, app: app) else {
                 return true
             }
             if clock.now >= deadline { return false }
@@ -1183,6 +1191,7 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
 
     nonisolated static func brewBundleEnvironment(
         source: [String: String] = ProcessInfo.processInfo.environment,
+        overrides: [String: String] = [:],
         realUserName: String? = realUserName()
     ) -> [String: String] {
         var environment: [String: String] = [:]
@@ -1219,9 +1228,11 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
     nonisolated static func nativeAppEnvironment(
         appName: String,
         otelPort: Int,
-        source: [String: String] = ProcessInfo.processInfo.environment
+        source: [String: String] = ProcessInfo.processInfo.environment,
+        overrides: [String: String] = [:]
     ) -> [String: String] {
-        var environment = source
+        var environment = source.merging(overrides) { _, userValue in userValue }
+        environment["WENDY_APP_ID"] = appName
         environment["NSUnbufferedIO"] = "YES"
         environment["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://127.0.0.1:\(otelPort)"
         environment["OTEL_EXPORTER_OTLP_PROTOCOL"] = "grpc"
@@ -1512,7 +1523,7 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
             } ?? false
         let brewfile = appConfig?.brewfile?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
-        if !brewfile.isEmpty, appConfig?.platform != "darwin" {
+        if !brewfile.isEmpty, isLinux {
             throw RPCError(
                 code: .invalidArgument,
                 message: "Brewfile is only supported for native Darwin apps"
@@ -1538,10 +1549,13 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
 
         // Native darwin path (existing behavior).
 
-        let nativeLaunchInfo: NativeLaunchInfo
+        var nativeLaunchInfo: NativeLaunchInfo
         if imageName.hasPrefix("sha256:") {
             // OCI image: parse manifest → config → extract layer.
-            let appDirectory = try validateContainedPath(base: appsBase, relative: appName).path
+            let appDirectory = try NativeProcessConfiguration.contained(
+                appName,
+                directory: appsBase.path
+            )
             try FileManager.default.createDirectory(
                 atPath: appDirectory,
                 withIntermediateDirectories: true
@@ -1569,14 +1583,6 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
             }
             try await extractTarGz(blobDigest: layerDesc.digest, to: appDirectory)
 
-            let binaryPath = "\(appDirectory)/\(binaryName)"
-            guard FileManager.default.fileExists(atPath: binaryPath) else {
-                throw RPCError(
-                    code: .notFound,
-                    message: "Binary not found at \(binaryPath) after extraction"
-                )
-            }
-
             nativeLaunchInfo = NativeLaunchInfo(
                 directory: appDirectory,
                 binaryName: binaryName,
@@ -1589,11 +1595,11 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
             )
         } else if !imageName.isEmpty {
             // Legacy: imageName is the binary name directly.
-            let appDirectory = try validateContainedPath(base: appsBase, relative: appName).path
+            let appDirectory = try NativeProcessConfiguration.contained(
+                appName,
+                directory: appsBase.path
+            )
             let binaryPath = "\(appDirectory)/\(imageName)"
-            guard FileManager.default.fileExists(atPath: binaryPath) else {
-                throw RPCError(code: .notFound, message: "Binary not found at \(binaryPath)")
-            }
             nativeLaunchInfo = NativeLaunchInfo(
                 directory: appDirectory,
                 binaryName: imageName,
@@ -1611,16 +1617,11 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
                 // Nothing to register — container will fall back to --appPath.
                 return ServerResponse(message: Wendy_Agent_Services_V1_CreateContainerResponse())
             }
-            let appDirectory = try validateContainedPath(base: appsBase, relative: appName).path
+            let appDirectory = try NativeProcessConfiguration.contained(
+                appName,
+                directory: appsBase.path
+            )
             let binaryPath = "\(appDirectory)/\(cmd)"
-
-            guard FileManager.default.fileExists(atPath: binaryPath) else {
-                throw RPCError(
-                    code: .notFound,
-                    message:
-                        "Binary not found at \(binaryPath). Run 'wendy run' to sync files first."
-                )
-            }
 
             nativeLaunchInfo = NativeLaunchInfo(
                 directory: appDirectory,
@@ -1640,6 +1641,18 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
             appName: appName,
             appDirectory: nativeLaunchInfo.directory
         )
+        nativeLaunchInfo.executablePath = try NativeProcessConfiguration.executable(
+            nativeLaunchInfo.binaryName,
+            directory: nativeLaunchInfo.directory
+        )
+        nativeLaunchInfo.currentDirectory = try NativeProcessConfiguration.workingDirectory(
+            request.message.workingDir,
+            directory: nativeLaunchInfo.directory
+        )
+        nativeLaunchInfo.environment = try NativeProcessConfiguration.environment(
+            Array(request.message.env)
+        )
+        nativeLaunchInfo.args = Array(request.message.userArgs)
         try await self.registerApp(
             id: appName,
             kind: .native,
@@ -1783,12 +1796,23 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
         let processArgs: [String]
         let currentDirectory: String?
         if let entry = app.native {
-            binaryPath = "\(entry.directory)/\(entry.binaryName)"
+            let directory = try NativeProcessConfiguration.contained(
+                entry.directory,
+                directory: appsBase.path
+            )
+            binaryPath = try NativeProcessConfiguration.executable(
+                entry.binaryName,
+                directory: directory
+            )
             let candidateProfile = "\(entry.directory)/sandbox.sb"
             profilePath =
-                FileManager.default.fileExists(atPath: candidateProfile) ? candidateProfile : nil
+                FileManager.default.fileExists(atPath: candidateProfile)
+                ? try NativeProcessConfiguration.contained("sandbox.sb", directory: directory) : nil
             processArgs = entry.args
-            currentDirectory = entry.currentDirectory
+            currentDirectory = try NativeProcessConfiguration.workingDirectory(
+                entry.currentDirectory ?? "",
+                directory: entry.directory
+            )
         } else {
             binaryPath = executablePath
             profilePath = sandboxProfilePath
@@ -1803,7 +1827,8 @@ actor ContainerService: Wendy_Agent_Services_V1_WendyContainerService.ServicePro
         // for long-running native macOS apps like HelloMLX.
         process.environment = Self.nativeAppEnvironment(
             appName: appName,
-            otelPort: self.otelPort
+            otelPort: self.otelPort,
+            overrides: app.native?.environment ?? [:]
         )
         if let profilePath {
             process.executableURL = URL(fileURLWithPath: "/usr/bin/sandbox-exec")

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/NativeProcessConfiguration.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/NativeProcessConfiguration.swift
@@ -1,0 +1,95 @@
+import Darwin
+import Foundation
+import GRPCCore
+
+typealias PIDBirthTimeLookup = @Sendable (Int32) -> UInt64?
+
+/// Resolution is repeated before launch, so saved configuration cannot bypass
+/// containment if a synced directory has since become a symlink.
+enum NativeProcessConfiguration {
+    static func contained(_ value: String, directory: String) throws -> String {
+        guard !value.contains("\0"), !value.contains("\\"),
+            !value.split(separator: "/").contains("..")
+        else {
+            throw RPCError(
+                code: .invalidArgument,
+                message: "Native path must remain inside the app directory: \(value)"
+            )
+        }
+        let base = URL(fileURLWithPath: directory).resolvingSymlinksInPath().standardizedFileURL
+        let candidate =
+            (value.hasPrefix("/")
+            ? URL(fileURLWithPath: value)
+            : base.appendingPathComponent(value.isEmpty ? "." : value))
+            .resolvingSymlinksInPath().standardizedFileURL
+        guard candidate.path == base.path || candidate.path.hasPrefix(base.path + "/") else {
+            throw RPCError(
+                code: .invalidArgument,
+                message: "Native path escapes the app directory: \(value)"
+            )
+        }
+        return candidate.path
+    }
+
+    static func executable(_ command: String, directory: String) throws -> String {
+        guard !command.isEmpty, !command.contains("\0") else {
+            throw RPCError(
+                code: .invalidArgument,
+                message: "Native command must name an executable"
+            )
+        }
+        let executable =
+            command.hasPrefix("/")
+            ? URL(fileURLWithPath: command).resolvingSymlinksInPath().path
+            : try contained(command, directory: directory)
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: executable, isDirectory: &isDirectory),
+            !isDirectory.boolValue, FileManager.default.isExecutableFile(atPath: executable)
+        else {
+            throw RPCError(
+                code: .notFound,
+                message:
+                    "Native executable is unavailable at \(executable) after installing the Brewfile. Check run.command and synced file permissions."
+            )
+        }
+        return executable
+    }
+
+    static func workingDirectory(_ value: String, directory: String) throws -> String {
+        let resolved = try contained(value, directory: directory)
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: resolved, isDirectory: &isDirectory),
+            isDirectory.boolValue
+        else {
+            throw RPCError(
+                code: .notFound,
+                message: "Native working directory does not exist: \(resolved)"
+            )
+        }
+        return resolved
+    }
+
+    static func environment(_ entries: [String]) throws -> [String: String] {
+        var result: [String: String] = [:]
+        for entry in entries {
+            guard let separator = entry.firstIndex(of: "="), separator != entry.startIndex,
+                !entry.contains("\0")
+            else {
+                throw RPCError(
+                    code: .invalidArgument,
+                    message: "Native environment entries must use KEY=VALUE"
+                )
+            }
+            result[String(entry[..<separator])] = String(entry[entry.index(after: separator)...])
+        }
+        return result
+    }
+
+    static func birthTime(forPID pid: Int32) -> UInt64? {
+        guard pid > 0 else { return nil }
+        var info = proc_bsdinfo()
+        let size = Int32(MemoryLayout<proc_bsdinfo>.stride)
+        guard proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &info, size) == size else { return nil }
+        return info.pbi_start_tvsec * 1_000_000 + info.pbi_start_tvusec
+    }
+}

--- a/swift/WendyAgentCore/Sources/WendyAgent/WendyApp.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/WendyApp.swift
@@ -6,6 +6,9 @@ struct WendyApp: Codable {
         var binaryName: String
         var args: [String]
         var currentDirectory: String?
+        /// Optional for compatibility with applications saved by older agents.
+        var executablePath: String? = nil
+        var environment: [String: String]? = nil
     }
 
     struct ContainerMetadata: Codable, Equatable {
@@ -45,6 +48,9 @@ struct WendyApp: Codable {
     /// survived a disorderly agent exit. Set only by `ContainerService.loadApps`
     /// and cleared once reconcile has considered it.
     var persistedPID: Int32? = nil
+    /// Kernel process birth time (microseconds since epoch). Unlike a PID or
+    /// executable path this also identifies scripts and survives exec().
+    var pidBirthTime: UInt64? = nil
 
     enum CodingKeys: String, CodingKey {
         case info
@@ -52,6 +58,7 @@ struct WendyApp: Codable {
         case container
         case restartPolicy
         case stoppedByUser
+        case pidBirthTime
     }
 
     init(
@@ -65,7 +72,8 @@ struct WendyApp: Codable {
         failureCount: Int = 0,
         lastRestart: Date? = nil,
         lastExitCode: Int32? = nil,
-        persistedPID: Int32? = nil
+        persistedPID: Int32? = nil,
+        pidBirthTime: UInt64? = nil
     ) {
         self.info = info
         self.native = native
@@ -78,6 +86,7 @@ struct WendyApp: Codable {
         self.lastRestart = lastRestart
         self.lastExitCode = lastExitCode
         self.persistedPID = persistedPID
+        self.pidBirthTime = pidBirthTime
     }
 
     /// Custom decode so `restartPolicy`/`stoppedByUser` default sensibly when
@@ -122,5 +131,6 @@ struct WendyApp: Codable {
         self.lastRestart = nil
         self.lastExitCode = nil
         self.persistedPID = nil
+        self.pidBirthTime = try values.decodeIfPresent(UInt64.self, forKey: .pidBirthTime)
     }
 }

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/ContainerServiceSupervisorTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/ContainerServiceSupervisorTests.swift
@@ -102,6 +102,7 @@ actor StubLinuxBackend: LinuxContainerBackend {
 final class PIDStub: @unchecked Sendable {
     private let queue = DispatchQueue(label: "wendy.tests.pid-stub")
     private var paths: [Int32: String]
+    private var births: [Int32: UInt64] = [:]
     private var signals: [(pid: Int32, signal: Int32)] = []
     /// When true, a pid is dropped from `paths` the moment it is signalled, so
     /// the survivor wait returns immediately instead of polling for real time.
@@ -114,6 +115,27 @@ final class PIDStub: @unchecked Sendable {
 
     var lookup: PIDExecutablePathLookup {
         { [self] pid in queue.sync { paths[pid] } }
+    }
+
+    var birthLookup: PIDBirthTimeLookup {
+        { [self] pid in queue.sync { paths[pid] == nil ? nil : births[pid] } }
+    }
+
+    func restoreBirths(_ apps: [WendyApp]) {
+        queue.sync {
+            for app in apps {
+                guard let pid = app.info.pid, let birth = app.pidBirthTime, let path = paths[pid]
+                else { continue }
+                if births[pid] == nil {
+                    births[pid] =
+                        path == app.native?.executablePath || path == "/bin/sh" ? birth : birth + 1
+                }
+            }
+        }
+    }
+
+    func setBirth(_ pid: Int32, _ birth: UInt64) {
+        queue.sync { births[pid] = birth }
     }
 
     var send: PIDSignalSender {
@@ -885,7 +907,9 @@ struct ContainerServiceSupervisorTests {
         await restarted.stopAllApps()
     }
 
-    @Test("reconcile terminates a surviving process whose executable matches the app binary")
+    @Test(
+        "reconcile identifies a surviving script by birth time despite its interpreter executable"
+    )
     func reconcileTerminatesMatchingSurvivor() async throws {
         let appsBase = try makeSupervisorTempDir()
         defer { cleanupSupervisorPath(appsBase) }
@@ -898,7 +922,7 @@ struct ContainerServiceSupervisorTests {
         let persistedPID = try await simulateDisorderlyExit(service: service, appID: appID)
 
         // The pid is still running this app's binary: it is ours.
-        let binaryPath = "\(appsBase)/\(appID)/sleep.sh"
+        let binaryPath = "/bin/sh"
         let pids = PIDStub(paths: [persistedPID: binaryPath])
         let restarted = makeService(appsBase: appsBase, pids: pids)
 
@@ -907,6 +931,24 @@ struct ContainerServiceSupervisorTests {
         #expect(pids.sentSignals().map(\.pid) == [persistedPID])
         #expect(pids.sentSignals().map(\.signal) == [SIGTERM])
         #expect(await restarted.appInfo(forAppID: appID)?.status == .running)
+        await restarted.stopAllApps()
+    }
+
+    @Test("a reused PID running the same executable is never signalled or adopted")
+    func reusedPIDWithDifferentBirthIsNotOurs() async throws {
+        let appsBase = try makeSupervisorTempDir()
+        defer { cleanupSupervisorPath(appsBase) }
+        let appID = "sh.wendy.tests.ReusedPID"
+        try writeSupervisorSleepScript(appsBase: appsBase, appID: appID, name: "sleep.sh")
+        let original = makeService(appsBase: appsBase)
+        try await createNativeApp(service: original, appID: appID, cmd: "sleep.sh")
+        let pid = try await simulateDisorderlyExit(service: original, appID: appID)
+        let pids = PIDStub(paths: [pid: "\(appsBase)/\(appID)/sleep.sh"])
+        pids.setBirth(pid, 1)
+        let restarted = makeService(appsBase: appsBase, pids: pids)
+        await restarted.reconcileApps()
+        #expect(pids.sentSignals().isEmpty)
+        #expect(await restarted.appInfo(forAppID: appID)?.pid != pid)
         await restarted.stopAllApps()
     }
 
@@ -977,10 +1019,20 @@ private func makeService(
 ) -> ContainerService {
     let lookup: PIDExecutablePathLookup
     let send: PIDSignalSender
+    let birthLookup: PIDBirthTimeLookup
     if let pids {
+        if let data = try? Data(
+            contentsOf: URL(fileURLWithPath: appsBase).appendingPathComponent("info.json")
+        ),
+            let apps = try? JSONDecoder().decode([WendyApp].self, from: data)
+        {
+            pids.restoreBirths(apps)
+        }
+        birthLookup = pids.birthLookup
         lookup = pids.lookup
         send = pids.send
     } else {
+        birthLookup = { NativeProcessConfiguration.birthTime(forPID: $0) }
         lookup = { ContainerService.executablePath(forPID: $0) }
         send = { pid, signal in _ = Darwin.kill(pid, signal) }
     }
@@ -993,6 +1045,7 @@ private func makeService(
         supervisorInterval: supervisorInterval,
         restartFloor: restartFloor,
         pidExecutablePath: lookup,
+        pidBirthTime: birthLookup,
         sendSignal: send
     )
 }

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/ContainerServiceTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/ContainerServiceTests.swift
@@ -440,7 +440,9 @@ struct ContainerServiceTests {
                     directory: appDirectory.path,
                     binaryName: "sleep.sh",
                     args: [],
-                    currentDirectory: appDirectory.path
+                    currentDirectory: appDirectory.path,
+                    executablePath: appDirectory.appendingPathComponent("sleep.sh").path,
+                    environment: [:]
                 )
         )
 

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/HardwareInventoryTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/HardwareInventoryTests.swift
@@ -28,6 +28,23 @@ struct HardwareInventoryParsingTests {
         #expect(response.gpuCapabilities.map(\.computeBackends) == [["metal"]])
     }
 
+    @Test("advertises the native-process feature without a version suffix")
+    func advertisesNativeProcessFeature() async throws {
+        let service = AgentService(
+            gpuDiscovery: GPUDiscovery(devices: { [] }),
+            reportedVersion: { "test" }
+        )
+        let response = try await service.getAgentVersion(
+            request: ServerRequest(
+                metadata: [:],
+                message: Wendy_Agent_Services_V1_GetAgentVersionRequest()
+            ),
+            context: makeHardwareContext()
+        ).message
+        #expect(response.featureset.contains("native-process"))
+        #expect(!response.featureset.contains { $0.hasSuffix("-v1") })
+    }
+
     @Test("device metadata lists no GPU entries when Metal finds no device")
     func noMetalDevices() async throws {
         let service = AgentService(

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/NativeProcessConfigurationTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/NativeProcessConfigurationTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import GRPCCore
+import Testing
+
+@testable import WendyAgentCore
+
+@Suite("Native process configuration")
+struct NativeProcessConfigurationTests {
+    @Test("relative commands and working directories reject traversal and symlink escapes")
+    func paths() throws {
+        let base = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: base) }
+        let sub = base.appendingPathComponent("sub")
+        try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(
+            atPath: base.appendingPathComponent("escape").path,
+            withDestinationPath: "/usr/bin"
+        )
+        #expect(throws: RPCError.self) {
+            try NativeProcessConfiguration.executable("escape/true", directory: base.path)
+        }
+        #expect(throws: RPCError.self) {
+            try NativeProcessConfiguration.workingDirectory("escape", directory: base.path)
+        }
+        #expect(throws: RPCError.self) {
+            try NativeProcessConfiguration.workingDirectory("../outside", directory: base.path)
+        }
+        #expect(
+            try NativeProcessConfiguration.workingDirectory("sub", directory: base.path)
+                == sub.resolvingSymlinksInPath().path
+        )
+        #expect(
+            try NativeProcessConfiguration.executable("/usr/bin/true", directory: base.path)
+                == "/usr/bin/true"
+        )
+        #expect(throws: RPCError.self) {
+            try NativeProcessConfiguration.executable("missing", directory: base.path)
+        }
+    }
+
+    @Test("request environment wins over the host before agent identity and telemetry")
+    func environment() throws {
+        let overrides = try NativeProcessConfiguration.environment([
+            "MODE=first", "MODE=last", "EMPTY=", "VALUE=a=b", "WENDY_APP_ID=wrong",
+            "OTEL_SERVICE_NAME=wrong",
+        ])
+        let env = ContainerService.nativeAppEnvironment(
+            appName: "my.app",
+            otelPort: 4321,
+            source: ["MODE": "host", "PATH": "/bin"],
+            overrides: overrides
+        )
+        #expect(env["MODE"] == "last")
+        #expect(env["EMPTY"] == "")
+        #expect(env["VALUE"] == "a=b")
+        #expect(env["PATH"] == "/bin")
+        #expect(env["WENDY_APP_ID"] == "my.app")
+        #expect(env["OTEL_SERVICE_NAME"] == "my.app")
+        #expect(env["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://127.0.0.1:4321")
+    }
+
+    @Test("old native launch metadata decodes without the new optional fields")
+    func legacy() throws {
+        let data = Data(#"{"directory":"/tmp/app","binaryName":"app","args":[]}"#.utf8)
+        let native = try JSONDecoder().decode(WendyApp.NativeMetadata.self, from: data)
+        #expect(native.environment == nil)
+        #expect(native.executablePath == nil)
+    }
+
+    @Test("kernel birth identity is stable for a live process")
+    func processIdentity() throws {
+        let pid = ProcessInfo.processInfo.processIdentifier
+        let birth = try #require(NativeProcessConfiguration.birthTime(forPID: pid))
+        #expect(birth > 0)
+        #expect(NativeProcessConfiguration.birthTime(forPID: pid) == birth)
+        #expect(NativeProcessConfiguration.birthTime(forPID: -1) == nil)
+    }
+}


### PR DESCRIPTION
Add single-app Darwin run.command/run.cwd with direct argument execution, target file/config/Brewfile sync, `native-process` capability negotiation, and complete native watch fingerprints. Resolve and contain relative paths including symlinks, apply user environment before agent-owned identity/telemetry, persist resolved launch settings compatibly, and verify PID birth identity before signalling or adopting processes.

Previous component: https://github.com/wendylabsinc/WendyOS/pull/1910.

Validation: Go path/config/watch tests, the Swift agent tests, Linux race tests, and build/vet checks passed on the complete stack. Apple Silicon acceptance covers fresh and warm browser chat, environment/cwd, persistence, agent restart, supervised-child failure/cleanup, and deterministic PID reuse protection. Templates PR #103 and final stack PR #1905 add the catalog/scaffold flow.

Part of the WDY-2906–2913 stack. Merge in dependency order. [Final acceptance record and stack index](https://github.com/wendylabsinc/WendyOS/pull/1905). Hardware acceptance and the stable agent/CLI release are still pending; no issue closure is claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBvDQzSwH3b1XHMhiH69fa
