### PR TITLE
WDY-2912: keep quiet log subscriptions active

### DIFF
--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -857,7 +857,7 @@ func main() {
 			grpc.KeepaliveParams(keepalive.ServerParameters{
 				MaxConnectionIdle: 5 * time.Minute,
 				Time:              30 * time.Second,
-				Timeout:           10 * time.Second,
+				Timeout:           20 * time.Second,
 			}),
 			grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 				MinTime:             10 * time.Second,
@@ -1001,7 +1001,7 @@ func main() {
 		grpc.KeepaliveParams(keepalive.ServerParameters{
 			MaxConnectionIdle: 5 * time.Minute,
 			Time:              30 * time.Second,
-			Timeout:           10 * time.Second,
+			Timeout:           20 * time.Second,
 		}),
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 			MinTime:             10 * time.Second,

--- a/go/internal/agent/mtls/server.go
+++ b/go/internal/agent/mtls/server.go
@@ -102,7 +102,7 @@ func NewServer(certPEM, chainPEM, keyPEM string, logger *zap.Logger, notBeforeFl
 		grpc.InitialConnWindowSize(16 * 1024 * 1024),
 		grpc.KeepaliveParams(keepalive.ServerParameters{
 			Time:    30 * time.Second,
-			Timeout: 10 * time.Second,
+			Timeout: 20 * time.Second,
 		}),
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 			MinTime:             10 * time.Second,

--- a/go/internal/agent/services/log_heartbeat_test.go
+++ b/go/internal/agent/services/log_heartbeat_test.go
@@ -1,0 +1,92 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	v2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
+	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+)
+
+type heartbeatTestStream[T any] struct {
+	grpc.ServerStream
+	ctx       context.Context
+	sent      chan *T
+	sendError error
+}
+
+func (s *heartbeatTestStream[T]) Context() context.Context { return s.ctx }
+func (s *heartbeatTestStream[T]) Send(value *T) error {
+	if s.sendError != nil {
+		return s.sendError
+	}
+	s.sent <- value
+	return nil
+}
+
+func testLogHeartbeats[T any](t *testing.T, serve func(*TelemetryBroadcaster, *heartbeatTestStream[T]) error, isHeartbeat func(*T) bool) {
+	t.Helper()
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		b := NewTelemetryBroadcaster()
+		s := &heartbeatTestStream[T]{ctx: ctx, sent: make(chan *T, 8)}
+		done := make(chan error, 1)
+		go func() { done <- serve(b, s) }()
+		synctest.Wait()
+		time.Sleep(15 * time.Second)
+		synctest.Wait()
+		if len(s.sent) != 1 || !isHeartbeat(<-s.sent) {
+			t.Fatal("quiet stream did not send an empty heartbeat at 15 seconds")
+		}
+		b.PublishLogs(&collogspb.ExportLogsServiceRequest{})
+		synctest.Wait()
+		if len(s.sent) != 1 || isHeartbeat(<-s.sent) {
+			t.Fatal("data after silence was lost")
+		}
+		time.Sleep(14 * time.Second)
+		synctest.Wait()
+		if len(s.sent) != 0 {
+			t.Fatal("heartbeat sent before the quiet deadline")
+		}
+		time.Sleep(time.Second)
+		synctest.Wait()
+		if len(s.sent) != 1 || !isHeartbeat(<-s.sent) {
+			t.Fatal("second quiet heartbeat missing")
+		}
+		cancel()
+		synctest.Wait()
+		if !errors.Is(<-done, context.Canceled) || len(b.logSubs) != 0 {
+			t.Fatal("cancellation leaked the stream subscription")
+		}
+	})
+	synctest.Test(t, func(t *testing.T) {
+		b := NewTelemetryBroadcaster()
+		failure := errors.New("connection lost")
+		s := &heartbeatTestStream[T]{ctx: context.Background(), sendError: failure}
+		done := make(chan error, 1)
+		go func() { done <- serve(b, s) }()
+		time.Sleep(15 * time.Second)
+		synctest.Wait()
+		if !errors.Is(<-done, failure) || len(b.logSubs) != 0 {
+			t.Fatal("heartbeat send failure was hidden or leaked subscription")
+		}
+	})
+}
+
+func TestLogHeartbeatsV1(t *testing.T) {
+	testLogHeartbeats(t, func(b *TelemetryBroadcaster, s *heartbeatTestStream[agentpb.StreamLogsResponse]) error {
+		return NewTelemetryService(zap.NewNop(), b, nil).StreamLogs(&agentpb.StreamLogsRequest{}, s)
+	}, func(r *agentpb.StreamLogsResponse) bool { return r.Logs == nil && !r.IsHistory })
+}
+func TestLogHeartbeatsV2(t *testing.T) {
+	testLogHeartbeats(t, func(b *TelemetryBroadcaster, s *heartbeatTestStream[v2.StreamLogsResponse]) error {
+		return NewTelemetryServiceV2(zap.NewNop(), b, nil).StreamLogs(&v2.StreamLogsRequest{}, s)
+	}, func(r *v2.StreamLogsResponse) bool { return r.Logs == nil && !r.IsHistory })
+}

--- a/go/internal/agent/services/telemetry_service.go
+++ b/go/internal/agent/services/telemetry_service.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -406,8 +407,18 @@ func (s *TelemetryService) StreamLogs(req *agentpb.StreamLogsRequest, stream grp
 
 	s.logger.Info("StreamLogs client connected", zap.String("sub_id", id))
 
+	// A single sender owns both logs and empty application heartbeats. Reset
+	// after each successful write so busy streams don't emit extra messages.
+	heartbeat := time.NewTimer(15 * time.Second)
+	defer heartbeat.Stop()
+
 	for {
 		select {
+		case <-heartbeat.C:
+			if err := stream.Send(&agentpb.StreamLogsResponse{}); err != nil {
+				return err
+			}
+			heartbeat.Reset(15 * time.Second)
 		case <-ctx.Done():
 			return ctx.Err()
 		case logReq, ok := <-ch:
@@ -428,6 +439,7 @@ func (s *TelemetryService) StreamLogs(req *agentpb.StreamLogsRequest, stream grp
 			}); err != nil {
 				return err
 			}
+			heartbeat.Reset(15 * time.Second)
 		}
 	}
 }

--- a/go/internal/agent/services/telemetry_service_v2.go
+++ b/go/internal/agent/services/telemetry_service_v2.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"strings"
+	"time"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -83,8 +84,18 @@ func (s *TelemetryServiceV2) StreamLogs(req *agentpbv2.StreamLogsRequest, stream
 		}
 	}
 
+	// A single sender owns both logs and empty application heartbeats. Reset
+	// after each successful write so busy streams don't emit extra messages.
+	heartbeat := time.NewTimer(15 * time.Second)
+	defer heartbeat.Stop()
+
 	for {
 		select {
+		case <-heartbeat.C:
+			if err := stream.Send(&agentpbv2.StreamLogsResponse{}); err != nil {
+				return err
+			}
+			heartbeat.Reset(15 * time.Second)
 		case <-stream.Context().Done():
 			return stream.Context().Err()
 		case item, ok := <-ch:
@@ -101,6 +112,7 @@ func (s *TelemetryServiceV2) StreamLogs(req *agentpbv2.StreamLogsRequest, stream
 			if err := stream.Send(&agentpbv2.StreamLogsResponse{Logs: item}); err != nil {
 				return err
 			}
+			heartbeat.Reset(15 * time.Second)
 		}
 	}
 }

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/run.md
@@ -464,3 +464,18 @@ the app. Keep runtime data outside the synced source directory, for example unde
 Attached watch compares the command, working directory, arguments, effective
 environment, files, configuration, and restart policy. Unchanged running commands
 remain running. Host hooks and browser opening wait for readiness.
+
+
+## Diagnosing an interrupted log stream
+
+Quiet log subscriptions receive an empty transport heartbeat every 15 seconds.
+The CLI and MCP omit these messages from logs, history transitions, and batch
+counts. Go agent gRPC keepalive acknowledgements allow 20 seconds. A stream that
+ends with a connection error still reports that error.
+
+For a recurrence, record the CLI, agent, and OS versions, timestamps, device
+address, direct WiFi or cloud route, and the exact gRPC error. Capture agent and
+cloud tunnel logs for the same interval; compare an idle subscription with one
+that emits a new log after ten minutes. Check WiFi roaming, link loss, NAT/proxy
+idle limits, and HTTP/2 GOAWAY/keepalive diagnostics before assigning a cause.
+The original direct-WiFi failure has no confirmed transport root cause.

--- a/go/internal/cli/mcp/tools_telemetry.go
+++ b/go/internal/cli/mcp/tools_telemetry.go
@@ -144,7 +144,12 @@ func (s *mcpServer) handleTelemetryLogs(ctx context.Context, req mcpgo.CallToolR
 		return errResult(codeFromGRPC(err), grpcErrString(err)), nil
 	}
 	result, err := collectProtoStream(ctx, func() (*agentpb.StreamLogsResponse, error) {
-		return stream.Recv()
+		for {
+			response, err := stream.Recv()
+			if err != nil || response.GetLogs() != nil {
+				return response, err
+			}
+		}
 	}, maxBatches)
 	if err != nil {
 		return errResult(codeFromGRPC(err), grpcErrString(err)), nil

--- a/go/internal/cli/mcp/tools_telemetry_test.go
+++ b/go/internal/cli/mcp/tools_telemetry_test.go
@@ -85,14 +85,14 @@ func TestTelemetryLogs_NotConnected(t *testing.T) {
 func TestTelemetryLogs_ReturnsJSON(t *testing.T) {
 	fake := &fakeTelemetryServer{
 		logBatches: []*agentpb.StreamLogsResponse{
-			{Logs: &collogspb.ExportLogsServiceRequest{}},
+			{}, {}, {Logs: &collogspb.ExportLogsServiceRequest{}}, {},
 		},
 	}
 	conn := startFakeTelemetryServer(t, fake)
 	srv := New(&config.Config{}, nil)
 	srv.SetConn(conn)
 
-	result, err := srv.callTool(context.Background(), "telemetry_logs", nil)
+	result, err := srv.callTool(context.Background(), "telemetry_logs", map[string]any{"max_batches": 1})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/LogHeartbeatStream.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/LogHeartbeatStream.swift
@@ -1,0 +1,36 @@
+import Foundation
+import OpenTelemetryGRPC
+
+/// Merge data and timer events into one stream consumed by one RPC writer.
+/// The bounded buffer follows TelemetryBroadcaster's existing buffering policy.
+enum LogHeartbeatEvent: Sendable {
+    case logs(TelemetryBroadcaster.LogsRequest)
+    case tick
+}
+
+func withLogHeartbeatStream(
+    _ logs: AsyncStream<TelemetryBroadcaster.LogsRequest>,
+    interval: Duration,
+    body: (AsyncStream<LogHeartbeatEvent>) async throws -> Void
+) async throws {
+    let (events, continuation) = AsyncStream<LogHeartbeatEvent>.makeStream(
+        bufferingPolicy: .bufferingNewest(100)
+    )
+    try await withThrowingTaskGroup(of: Void.self) { group in
+        group.addTask {
+            for await log in logs { continuation.yield(.logs(log)) }
+            continuation.finish()
+        }
+        group.addTask {
+            while !Task.isCancelled {
+                try await Task.sleep(for: interval)
+                continuation.yield(.tick)
+            }
+        }
+        defer {
+            group.cancelAll()
+            continuation.finish()
+        }
+        try await body(events)
+    }
+}

--- a/swift/WendyAgentCore/Sources/WendyAgent/Services/TelemetryService.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/Services/TelemetryService.swift
@@ -10,7 +10,10 @@ actor TelemetryService: Wendy_Agent_Services_V1_WendyTelemetryService.SimpleServ
     let broadcaster: TelemetryBroadcaster
     let logger = Logger(label: "sh.wendy.agent.telemetry-streaming")
 
-    init(broadcaster: TelemetryBroadcaster) {
+    let logHeartbeatInterval: Duration
+
+    init(broadcaster: TelemetryBroadcaster, logHeartbeatInterval: Duration = .seconds(15)) {
+        self.logHeartbeatInterval = logHeartbeatInterval
         self.broadcaster = broadcaster
     }
 
@@ -49,22 +52,34 @@ actor TelemetryService: Wendy_Agent_Services_V1_WendyTelemetryService.SimpleServ
                 }
             }
 
-            for await logsRequest in stream {
-                // Apply filters if specified
-                let filteredRequest = filterLogs(
-                    logsRequest,
-                    serviceName: request.hasServiceName ? request.serviceName : nil,
-                    minSeverity: request.hasMinSeverity ? request.minSeverity : nil,
-                    appName: request.hasAppName ? request.appName : nil
-                )
+            try await withLogHeartbeatStream(stream, interval: self.logHeartbeatInterval) {
+                events in
+                for await event in events {
+                    guard !Task.isCancelled else { break }
+                    let logsRequest: TelemetryBroadcaster.LogsRequest
+                    switch event {
+                    case .tick:
+                        try await response.write(Wendy_Agent_Services_V1_StreamLogsResponse())
+                        continue
+                    case .logs(let logs): logsRequest = logs
+                    }
 
-                // Only send if there are logs after filtering
-                if !filteredRequest.resourceLogs.isEmpty {
-                    try await response.write(
-                        Wendy_Agent_Services_V1_StreamLogsResponse.with {
-                            $0.logs = filteredRequest
-                        }
+                    // Apply filters if specified
+                    let filteredRequest = filterLogs(
+                        logsRequest,
+                        serviceName: request.hasServiceName ? request.serviceName : nil,
+                        minSeverity: request.hasMinSeverity ? request.minSeverity : nil,
+                        appName: request.hasAppName ? request.appName : nil
                     )
+
+                    // Only send if there are logs after filtering
+                    if !filteredRequest.resourceLogs.isEmpty {
+                        try await response.write(
+                            Wendy_Agent_Services_V1_StreamLogsResponse.with {
+                                $0.logs = filteredRequest
+                            }
+                        )
+                    }
                 }
             }
         } catch {

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/TelemetryBroadcasterTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/TelemetryBroadcasterTests.swift
@@ -45,6 +45,61 @@ struct TelemetryBroadcasterTests {
         #expect(await broadcaster.logSubscriberCountForTesting() == 0)
     }
 
+    @Test(
+        "a quiet stream sends empty heartbeats, then delivers data and cleans up",
+        .timeLimit(.minutes(1))
+    )
+    func quietHeartbeats() async throws {
+        let broadcaster = TelemetryBroadcaster()
+        let service = TelemetryService(
+            broadcaster: broadcaster,
+            logHeartbeatInterval: .milliseconds(10)
+        )
+        let writer = SignalingTelemetryWriter()
+        var responses = writer.events.makeAsyncIterator()
+        let task = Task {
+            try await service.streamLogs(
+                request: Wendy_Agent_Services_V1_StreamLogsRequest(),
+                response: RPCWriter(wrapping: writer),
+                context: makeTelemetryServerContext(method: "StreamLogs")
+            )
+        }
+        let heartbeat = try #require(await responses.next())
+        #expect(!heartbeat.hasLogs)
+        #expect(!heartbeat.isHistory)
+        await broadcaster.broadcastLogs(logRequest(marker: "after-silence"))
+        while let response = await responses.next() {
+            if response.hasLogs {
+                #expect(response.logs.resourceLogs.first?.schemaURL == "after-silence")
+                #expect(!response.isHistory)
+                break
+            }
+        }
+        task.cancel()
+        try await task.value
+        #expect(await broadcaster.logSubscriberCountForTesting() == 0)
+    }
+
+    @Test("heartbeat write failure propagates and unsubscribes", .timeLimit(.minutes(1)))
+    func heartbeatFailure() async {
+        let broadcaster = TelemetryBroadcaster()
+        let service = TelemetryService(
+            broadcaster: broadcaster,
+            logHeartbeatInterval: .milliseconds(10)
+        )
+        do {
+            try await service.streamLogs(
+                request: Wendy_Agent_Services_V1_StreamLogsRequest(),
+                response: RPCWriter(wrapping: FailingTelemetryWriter()),
+                context: makeTelemetryServerContext(method: "StreamLogs")
+            )
+            Issue.record("expected write failure")
+        } catch {
+            #expect(error is RPCError)
+        }
+        #expect(await broadcaster.logSubscriberCountForTesting() == 0)
+    }
+
     private func logRequest(
         marker: String
     ) -> Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceRequest {
@@ -90,4 +145,14 @@ private func makeTelemetryServerContext(method: String) -> ServerContext {
         localPeer: "in-process:test",
         cancellation: .init()
     )
+}
+
+private struct FailingTelemetryWriter: RPCWriterProtocol {
+    typealias Element = Wendy_Agent_Services_V1_StreamLogsResponse
+    func write(_ element: Element) async throws {
+        throw RPCError(code: .unavailable, message: "connection lost")
+    }
+    func write(contentsOf elements: some Sequence<Element>) async throws {
+        throw RPCError(code: .unavailable, message: "connection lost")
+    }
 }


### PR DESCRIPTION
Send empty log responses every 15 seconds from Go v1/v2 and Swift through serialized writers, cleaning up timers and subscriptions on cancellation/send failure. MCP excludes heartbeat data from batches; CLI keeps heartbeats out of output/history transitions. Raise Go server keepalive ACK timeouts from 10 to 20 seconds and document transport diagnostics.

Previous component: https://github.com/wendylabsinc/WendyOS/pull/1911.

Validation: Go/Swift heartbeat cancellation/failure fixtures and Linux race tests passed. One real Mac loopback subscription ran 625 seconds and received the message emitted after 605 seconds of silence, with one output line and no heartbeat data. Real direct-WiFi/cloud acceptance remains required; the original WiFi cause is unconfirmed.

Part of the WDY-2906–2913 stack. Merge in dependency order. [Final acceptance record and stack index](https://github.com/wendylabsinc/WendyOS/pull/1905). Hardware acceptance and the stable agent/CLI release are still pending; no issue closure is claimed.
