### PR TITLE
Use a private DNS namespace for Wendy Mesh

### DIFF
--- a/Proto/cloud/mesh.proto
+++ b/Proto/cloud/mesh.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package wendycloud.v1;
 
 // MeshRosterService serves the minimal name directory the WendyOS mesh needs
-// to resolve <devicename>.<org-slug>.cloud.wendy.dev to a cloud asset id. It is
+// to resolve <devicename>.<org-slug>.mesh.wendy.internal to a cloud asset id. It is
 // deliberately narrower than AssetService: only {name, asset_id} pairs plus the
 // caller's own org slug, scoped by the caller's asset-certificate identity.
 service MeshRosterService {

--- a/go/internal/agent/mesh/dns.go
+++ b/go/internal/agent/mesh/dns.go
@@ -10,17 +10,19 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
+	"github.com/wendylabsinc/wendy/go/internal/shared/meshname"
 	"go.uber.org/zap"
 )
 
-// meshNameRE matches the only names this server is authoritative for.
-var meshNameRE = regexp.MustCompile(`^device-([0-9]{1,5})\.cloud\.wendy\.dev\.$`)
+var meshDNSSuffixRE = `(?:` + regexp.QuoteMeta(meshname.Suffix) + `|` + regexp.QuoteMeta(meshname.LegacySuffix) + `)`
 
-// friendlyNameRE matches <devicename>.<org-slug>.cloud.wendy.dev. — the
-// human-readable mesh name resolved via the injected Resolver. It never
-// overlaps meshNameRE: the numeric form has one label before ".cloud", this
-// form has two.
-var friendlyNameRE = regexp.MustCompile(`^([a-z0-9-]+)\.([a-z0-9-]+)\.cloud\.wendy\.dev\.$`)
+// meshNameRE accepts the private mesh namespace and its legacy public alias.
+var meshNameRE = regexp.MustCompile(`^device-([0-9]{1,5})\.` + meshDNSSuffixRE + `\.$`)
+
+// friendlyNameRE matches <devicename>.<org-slug>.mesh.wendy.internal. and its
+// legacy alias. It never overlaps meshNameRE: the numeric form has one label
+// before the suffix, while this form has two.
+var friendlyNameRE = regexp.MustCompile(`^([a-z0-9-]+)\.([a-z0-9-]+)\.` + meshDNSSuffixRE + `\.$`)
 
 // Resolver maps a normalized device name to a cloud asset ID within this
 // device's own org, and reports this device's own org slug. It is implemented
@@ -31,7 +33,7 @@ type Resolver interface {
 	OrgSlug() string
 }
 
-// DNSServer answers device-N.cloud.wendy.dev with the device's mesh VIP and
+// DNSServer answers device-N.mesh.wendy.internal with the device's mesh VIP and
 // forwards every other query to the host's upstream resolver. One UDP
 // listener is bound per app bridge gateway address, refcounted by the number
 // of running meshed containers behind that bridge.

--- a/go/internal/agent/mesh/dns_test.go
+++ b/go/internal/agent/mesh/dns_test.go
@@ -37,7 +37,7 @@ func query(t *testing.T, addr, name string, qtype uint16) *dns.Msg {
 
 func TestDNSAnswersMeshName(t *testing.T) {
 	_, addr := startTestDNS(t, "")
-	resp := query(t, addr, "device-215.cloud.wendy.dev.", dns.TypeA)
+	resp := query(t, addr, "device-215.mesh.wendy.internal.", dns.TypeA)
 	if resp.Rcode != dns.RcodeSuccess || len(resp.Answer) != 1 {
 		t.Fatalf("rcode=%d answers=%d, want NOERROR with 1 answer", resp.Rcode, len(resp.Answer))
 	}
@@ -47,9 +47,17 @@ func TestDNSAnswersMeshName(t *testing.T) {
 	}
 }
 
+func TestDNSAnswersLegacyMeshAlias(t *testing.T) {
+	_, addr := startTestDNS(t, "")
+	resp := query(t, addr, "device-215.cloud.wendy.dev.", dns.TypeA)
+	if resp.Rcode != dns.RcodeSuccess || len(resp.Answer) != 1 {
+		t.Fatalf("rcode=%d answers=%d, want legacy alias to remain resolvable", resp.Rcode, len(resp.Answer))
+	}
+}
+
 func TestDNSMeshNameAAAAEmptyNoError(t *testing.T) {
 	_, addr := startTestDNS(t, "")
-	resp := query(t, addr, "device-215.cloud.wendy.dev.", dns.TypeAAAA)
+	resp := query(t, addr, "device-215.mesh.wendy.internal.", dns.TypeAAAA)
 	if resp.Rcode != dns.RcodeSuccess || len(resp.Answer) != 0 {
 		t.Fatalf("rcode=%d answers=%d, want NOERROR with 0 answers", resp.Rcode, len(resp.Answer))
 	}
@@ -57,7 +65,7 @@ func TestDNSMeshNameAAAAEmptyNoError(t *testing.T) {
 
 func TestDNSOutOfRangeIsNXDOMAIN(t *testing.T) {
 	_, addr := startTestDNS(t, "")
-	for _, name := range []string{"device-0.cloud.wendy.dev.", "device-70000.cloud.wendy.dev."} {
+	for _, name := range []string{"device-0.mesh.wendy.internal.", "device-70000.mesh.wendy.internal."} {
 		resp := query(t, addr, name, dns.TypeA)
 		if resp.Rcode != dns.RcodeNameError {
 			t.Fatalf("%s: rcode=%d, want NXDOMAIN", name, resp.Rcode)
@@ -159,9 +167,19 @@ func TestFriendlyNameResolves(t *testing.T) {
 	s := NewDNSServer(zaptest.NewLogger(t), "")
 	s.SetResolver(fakeResolver{slug: "acme", byName: map[string]int32{"brave-dolphin": 215}})
 
-	rcode, ip := answerA(t, s, "brave-dolphin.acme.cloud.wendy.dev.")
+	rcode, ip := answerA(t, s, "brave-dolphin.acme.mesh.wendy.internal.")
 	if rcode != dns.RcodeSuccess || ip != "10.99.0.215" {
 		t.Fatalf("got rcode=%d ip=%q, want SUCCESS 10.99.0.215", rcode, ip)
+	}
+}
+
+func TestLegacyFriendlyNameResolves(t *testing.T) {
+	s := NewDNSServer(zaptest.NewLogger(t), "")
+	s.SetResolver(fakeResolver{slug: "acme", byName: map[string]int32{"brave-dolphin": 215}})
+
+	rcode, ip := answerA(t, s, "brave-dolphin.acme.cloud.wendy.dev.")
+	if rcode != dns.RcodeSuccess || ip != "10.99.0.215" {
+		t.Fatalf("legacy friendly alias: got rcode=%d ip=%q, want SUCCESS 10.99.0.215", rcode, ip)
 	}
 }
 
@@ -169,7 +187,7 @@ func TestFriendlyNameWrongOrgIsNXDOMAIN(t *testing.T) {
 	s := NewDNSServer(zaptest.NewLogger(t), "")
 	s.SetResolver(fakeResolver{slug: "acme", byName: map[string]int32{"brave-dolphin": 215}})
 
-	rcode, _ := answerA(t, s, "brave-dolphin.other-org.cloud.wendy.dev.")
+	rcode, _ := answerA(t, s, "brave-dolphin.other-org.mesh.wendy.internal.")
 	if rcode != dns.RcodeNameError {
 		t.Fatalf("wrong-org: got rcode=%d, want NXDOMAIN", rcode)
 	}
@@ -179,7 +197,7 @@ func TestFriendlyNameUnknownDeviceIsNXDOMAIN(t *testing.T) {
 	s := NewDNSServer(zaptest.NewLogger(t), "")
 	s.SetResolver(fakeResolver{slug: "acme", byName: map[string]int32{}})
 
-	rcode, _ := answerA(t, s, "ghost.acme.cloud.wendy.dev.")
+	rcode, _ := answerA(t, s, "ghost.acme.mesh.wendy.internal.")
 	if rcode != dns.RcodeNameError {
 		t.Fatalf("unknown device: got rcode=%d, want NXDOMAIN", rcode)
 	}
@@ -187,7 +205,7 @@ func TestFriendlyNameUnknownDeviceIsNXDOMAIN(t *testing.T) {
 
 func TestFriendlyNameNoResolverIsNXDOMAIN(t *testing.T) {
 	s := NewDNSServer(zaptest.NewLogger(t), "")
-	rcode, _ := answerA(t, s, "brave-dolphin.acme.cloud.wendy.dev.")
+	rcode, _ := answerA(t, s, "brave-dolphin.acme.mesh.wendy.internal.")
 	if rcode != dns.RcodeNameError {
 		t.Fatalf("no resolver: got rcode=%d, want NXDOMAIN", rcode)
 	}
@@ -196,7 +214,7 @@ func TestFriendlyNameNoResolverIsNXDOMAIN(t *testing.T) {
 func TestNumericNamePathUnchanged(t *testing.T) {
 	s := NewDNSServer(zaptest.NewLogger(t), "")
 	s.SetResolver(fakeResolver{slug: "acme"})
-	rcode, ip := answerA(t, s, "device-215.cloud.wendy.dev.")
+	rcode, ip := answerA(t, s, "device-215.mesh.wendy.internal.")
 	if rcode != dns.RcodeSuccess || ip != "10.99.0.215" {
 		t.Fatalf("numeric: got rcode=%d ip=%q, want SUCCESS 10.99.0.215", rcode, ip)
 	}
@@ -210,7 +228,7 @@ func TestFriendlyNameDoubledHyphenNormalizes(t *testing.T) {
 	s := NewDNSServer(zaptest.NewLogger(t), "")
 	s.SetResolver(fakeResolver{slug: "acme", byName: map[string]int32{"a-b": 215}})
 
-	rcode, ip := answerA(t, s, "a--b.acme.cloud.wendy.dev.")
+	rcode, ip := answerA(t, s, "a--b.acme.mesh.wendy.internal.")
 	if rcode != dns.RcodeSuccess || ip != "10.99.0.215" {
 		t.Fatalf("doubled hyphen: got rcode=%d ip=%q, want SUCCESS 10.99.0.215", rcode, ip)
 	}

--- a/go/internal/agent/mesh/vip.go
+++ b/go/internal/agent/mesh/vip.go
@@ -1,6 +1,6 @@
 // Package mesh implements the WendyOS mesh data plane: the deterministic
 // device-ID↔VIP mapping, the per-app DNS server that answers
-// device-n.cloud.wendy.dev names, and the transparent TCP proxy that carries
+// device-n.mesh.wendy.internal names, and the transparent TCP proxy that carries
 // mesh VIP connections to peer devices.
 package mesh
 

--- a/go/internal/cli/commands/fleet_lan_test.go
+++ b/go/internal/cli/commands/fleet_lan_test.go
@@ -73,7 +73,7 @@ func TestComputePeers(t *testing.T) {
 		t.Fatalf("computePeers returned %d peers, want 2", len(peers))
 	}
 	// Known asset id -> mesh name (asset id wins over the LAN host).
-	if peers[0].URL != "http://device-42.cloud.wendy.dev:8000" {
+	if peers[0].URL != "http://device-42.mesh.wendy.internal:8000" {
 		t.Errorf("peer[0].URL = %q", peers[0].URL)
 	}
 	// Unknown asset id -> direct-LAN host fallback.
@@ -119,7 +119,7 @@ func TestDiscoveryEnv(t *testing.T) {
 	if err := json.Unmarshal([]byte(env[0][len(prefix):]), &peers); err != nil {
 		t.Fatalf("env value is not valid JSON: %v", err)
 	}
-	if len(peers) != 1 || peers[0].URL != "http://device-42.cloud.wendy.dev:8000" {
+	if len(peers) != 1 || peers[0].URL != "http://device-42.mesh.wendy.internal:8000" {
 		t.Errorf("peers = %+v", peers)
 	}
 }

--- a/go/internal/cli/commands/fleet_manifest.go
+++ b/go/internal/cli/commands/fleet_manifest.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+	"github.com/wendylabsinc/wendy/go/internal/shared/meshname"
 	"github.com/wendylabsinc/wendy/go/internal/shared/models"
 )
 
@@ -26,7 +27,7 @@ type fleetPeer struct {
 }
 
 // meshPeer is a discovered peer device for a component. When AssetID is known it
-// is addressed over the mesh as device-<AssetID>.cloud.wendy.dev (reachable
+// is addressed over the mesh as device-<AssetID>.mesh.wendy.internal (reachable
 // LAN-direct or cloud-relay); Host is a direct-LAN fallback for older agents
 // that don't advertise an asset id over mDNS.
 type meshPeer struct {
@@ -42,7 +43,7 @@ type meshPeer struct {
 // 'wendy fleet group add') and deployed over the cloud tunnel; with --lan they
 // are placed by matching device names over mDNS. Cross-component discovery
 // (discovers -> WENDY_FLEET_PEERS) resolves peers to their mesh names
-// (device-<assetID>.cloud.wendy.dev), reachable LAN-direct or via cloud-relay by
+// (device-<assetID>.mesh.wendy.internal), reachable LAN-direct or via cloud-relay by
 // Joannis's mesh — so discovery now works in both cloud and LAN mode. The
 // consuming component must run with a "mesh" network entitlement to reach them.
 func runFleetManifest(ctx context.Context, opts runOptions, projectCwd string, manifest *appconfig.FleetManifest, lan bool, central, cloudGRPC, brokerURL string, timeout time.Duration) error {
@@ -197,7 +198,7 @@ func discoveryEnv(consumer *appconfig.ComponentConfig, manifest *appconfig.Fleet
 
 // computePeers turns a component's discovered peers into endpoint URLs using its
 // exposed port. A peer with a known asset id is addressed over the mesh
-// (device-<id>.cloud.wendy.dev), reachable LAN-direct or via cloud-relay;
+// (device-<id>.mesh.wendy.internal), reachable LAN-direct or via cloud-relay;
 // otherwise it falls back to a direct-LAN host. url is the endpoint's base
 // origin; consumers append their own path (the discover contract — see the
 // template dashboard's serve.py).
@@ -211,7 +212,7 @@ func computePeers(comp *appconfig.ComponentConfig, peers []meshPeer) []fleetPeer
 		var url string
 		switch {
 		case p.AssetID > 0:
-			url = fmt.Sprintf("http://device-%d.cloud.wendy.dev:%d", p.AssetID, comp.Expose.Port)
+			url = fmt.Sprintf("http://%s:%d", meshname.Device(p.AssetID), comp.Expose.Port)
 		case p.Host != "":
 			url = fmt.Sprintf("http://%s:%d", p.Host, comp.Expose.Port)
 		default:

--- a/go/internal/shared/meshname/meshname.go
+++ b/go/internal/shared/meshname/meshname.go
@@ -1,0 +1,19 @@
+// Package meshname defines the private DNS namespace used by Wendy's mesh.
+package meshname
+
+import "fmt"
+
+const (
+	// Suffix is reserved for Wendy mesh routing. The .internal TLD is reserved
+	// for private-use DNS and, unlike .dev, does not force browsers onto HTTPS.
+	Suffix = "mesh.wendy.internal"
+
+	// LegacySuffix remains resolvable so deployed apps and older CLIs using the
+	// original public/HSTS-preloaded namespace continue to route.
+	LegacySuffix = "cloud.wendy.dev"
+)
+
+// Device returns the stable private mesh hostname for a cloud asset.
+func Device(assetID int32) string {
+	return fmt.Sprintf("device-%d.%s", assetID, Suffix)
+}

--- a/go/internal/shared/meshname/meshname_test.go
+++ b/go/internal/shared/meshname/meshname_test.go
@@ -1,0 +1,9 @@
+package meshname
+
+import "testing"
+
+func TestDevice(t *testing.T) {
+	if got, want := Device(216), "device-216.mesh.wendy.internal"; got != want {
+		t.Fatalf("Device(216) = %q, want %q", got, want)
+	}
+}

--- a/go/proto/gen/cloudpb/mesh_grpc.pb.go
+++ b/go/proto/gen/cloudpb/mesh_grpc.pb.go
@@ -27,7 +27,7 @@ const (
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 //
 // MeshRosterService serves the minimal name directory the WendyOS mesh needs
-// to resolve <devicename>.<org-slug>.cloud.wendy.dev to a cloud asset id. It is
+// to resolve <devicename>.<org-slug>.mesh.wendy.internal to a cloud asset id. It is
 // deliberately narrower than AssetService: only {name, asset_id} pairs plus the
 // caller's own org slug, scoped by the caller's asset-certificate identity.
 type MeshRosterServiceClient interface {
@@ -57,7 +57,7 @@ func (c *meshRosterServiceClient) GetMeshRoster(ctx context.Context, in *GetMesh
 // for forward compatibility.
 //
 // MeshRosterService serves the minimal name directory the WendyOS mesh needs
-// to resolve <devicename>.<org-slug>.cloud.wendy.dev to a cloud asset id. It is
+// to resolve <devicename>.<org-slug>.mesh.wendy.internal to a cloud asset id. It is
 // deliberately narrower than AssetService: only {name, asset_id} pairs plus the
 // caller's own org slug, scoped by the caller's asset-certificate identity.
 type MeshRosterServiceServer interface {


### PR DESCRIPTION
- **Related:** [WendyOS #1819 — Add macOS BuildKit runtime and Wendy Mesh VPN](https://github.com/wendylabsinc/WendyOS/pull/1819)
- **Followed by:** [WendyOS #1914 — Add the macOS Wendy Mesh transport core](https://github.com/wendylabsinc/WendyOS/pull/1914)

> **In plain terms:** Wendy Mesh device addresses now use a private DNS namespace that cannot collide with public websites. Existing `cloud.wendy.dev` names continue to work during the transition.

## Summary
- Make `*.mesh.wendy.internal` canonical and retain `*.cloud.wendy.dev` as a compatibility alias.
- Centralize canonical numeric device-name generation for Go callers.
- Extracted from [`f4020ae`](https://github.com/wendylabsinc/WendyOS/commit/f4020ae154809f5ffc95cd11aa6cb042044c6701) with Joannis Orlandos retained as commit author.

## Boundary changes
- **DNS:** Canonical mesh names move from the public `cloud.wendy.dev` suffix to the private `mesh.wendy.internal` suffix; the former remains a compatible alias.
- **gRPC:** The mesh protocol documentation advertises the new canonical suffix without changing wire fields or field numbers.

## Tests
- `go test ./internal/agent/mesh ./internal/shared/meshname`
- `go vet ./internal/agent/mesh ./internal/shared/meshname ./internal/cli/commands`
- GitHub Actions: all checks passed
