### PR TITLE
shared/ble 1/4: bluez and permission packages

### DIFF
--- a/go/internal/shared/ble/README.md
+++ b/go/internal/shared/ble/README.md
@@ -1,0 +1,388 @@
+# `internal/shared/ble` — generic BLE central (client)
+
+A **cross-platform BLE central**: connect to a peripheral, talk GATT, and open an L2CAP channel that
+can carry TLS. It runs on the machine acting as the BLE *central* and talks to whatever is acting as
+the *peripheral*.
+
+Four subpackages, each free of any Wendy identifier:
+
+1. [`central`](central/) — the connection API (`Connection`), covering GATT and L2CAP, plus the
+   L2CAP-to-`net.Conn` adapter TLS runs over.
+2. [`scan`](scan/) — a continuously-streaming scanner that finds peripherals and yields the
+   addresses `central.Connect` takes.
+3. [`bluez`](bluez/) — the BlueZ D-Bus plumbing both use on Linux (object enumeration, adapter and
+   device resolution, property readers, D-Bus error mapping).
+4. [`permission`](permission/) — checks OS Bluetooth permission before a scan or connection touches
+   the platform BLE stack for the first time.
+
+Everything Wendy-specific lives in [`internal/cli/ble`](../../cli/ble/) — the Wendy Lite and WendyOS
+agent protocol clients, their UUIDs, PSMs and framing. **Adding a Wendy identifier to `central`,
+`scan` or `bluez` is the change to push back on**; a `shared/models` or `shared/certs` import into
+one of them would be the first sign of it. (`WENDY_BT_ADAPTER`, the controller override `bluez`
+honors, is the single deliberate exception — it has to match the name the agent already reads.)
+
+There is one Wendy file at the root of this directory: `lite_info.go`, the Wendy Lite GATT info
+service. It lives here rather than with its siblings in `cli/ble` because `shared/discovery` reads a
+board's L2CAP PSM from it, and a `shared/` package importing a `cli/` one is an upward edge. It is
+outside `central/` and `scan/` for the reason above, and nothing else should join it.
+
+**This package must never import `shared/discovery`**, which imports it.
+
+## Files
+
+**`central/`** — the connection:
+
+| File | Role |
+| --- | --- |
+| `ble_darwin.go` / `.h` / `.m` | macOS backend. cgo bridge to a CoreBluetooth implementation in Objective-C. |
+| `ble_linux.go` | Linux backend. Raw `AF_BLUETOOTH` / `BTPROTO_L2CAP` socket via `golang.org/x/sys/unix`. |
+| `bluez_linux.go` / `gatt_linux.go` | Linux GATT client over BlueZ D-Bus — session, device resolution, characteristic index, notification router. |
+| `ble_windows.go` | Windows stub. Every method returns "not implemented". |
+| `conn.go` | Adapts an L2CAP channel to `net.Conn` so Go's `crypto/tls` can run over it (`NewL2CAPStream`), plus `ErrRecvTimeout`, `ErrGATTNotFound`, `ErrGATTDisconnected` and `TimeoutSeconds`. |
+| `uuid.go`, `gatt_errors.go` | Untagged, so their tests run on every platform. |
+
+**`scan/`** — finding peripherals. Its own cgo bridge on macOS, BlueZ D-Bus on Linux, a WinRT
+advertisement watcher on Windows. See [its section](#scanning-the-scan-subpackage).
+
+**`bluez/`** — Linux-only helpers plus an untagged `errors.go`, so the D-Bus error table is testable
+without a bus. `central` and `scan` are its only callers; `internal/agent/bluetooth` still carries
+its own older copies of some of these.
+
+`scan/` and `bluez/` have tests that run without a radio; `central`'s pure pieces (UUID
+canonicalization, the characteristic index build, the notification router, address parsing, error
+mapping) do too. The parts that need hardware are gated behind `WENDY_BLE_LIVE_*` (see below).
+
+## The `Connection` API ([`central`](central/))
+
+Each platform file in `central/` defines the same `Connection` type and method set, selected by build
+tag — there is no Go interface, so the build tags are the contract. The API is blocking, with
+integer-second timeouts.
+
+```go
+conn, err := central.Connect(address, 10)   // address semantics differ per platform, see below
+defer conn.Close()
+
+// GATT
+err  = conn.DiscoverServices(10)
+ok  := conn.HasService(serviceUUID)
+s   := conn.ListServices()                                  // comma-separated discovered UUIDs
+data, err := conn.ReadCharacteristic(svcUUID, chrUUID)
+err  = conn.WriteCharacteristic(svcUUID, chrUUID, data)             // write with response
+err  = conn.WriteCharacteristicNoResponse(svcUUID, chrUUID, data)   // write without response
+err  = conn.Subscribe(svcUUID, chrUUID)                             // enable notifications
+data, err = conn.WaitNotification(svcUUID, chrUUID, 5)              // pull one queued notification
+
+// L2CAP (connection-oriented channel)
+err  = conn.OpenL2CAP(psm, 10)
+err  = conn.L2CAPSend(payload)
+data, err = conn.L2CAPRecv(30)
+```
+
+### Capability matrix
+
+| Capability | macOS | Linux | Windows |
+| --- | :---: | :---: | :---: |
+| Connect to peripheral | ✅ CoreBluetooth | ✅ (socket created; the link comes up in `OpenL2CAP` or `DiscoverServices`) | ❌ |
+| Service / characteristic discovery | ✅ | ✅ BlueZ D-Bus | ❌ |
+| Read / write characteristic | ✅ | ✅ | ❌ |
+| Write without response | ✅ | ✅ | ❌ |
+| Notifications (subscribe + wait) | ✅ | ✅ (per-characteristic queues) | ❌ |
+| L2CAP channel (open / send / recv) | ✅ | ✅ | ❌ |
+| `net.Conn` + TLS over L2CAP | ✅ | ✅ | ❌ |
+
+On Windows the GATT methods exist only to satisfy the shared method set; they return
+`"not implemented"`.
+
+**The Linux L2CAP path was broken in four ways at once**, and all four are fixed. They are recorded
+because each masked the others: every one presented as the same uniform connect timeout or
+mid-handshake disconnect, and none pointed at its own cause. Two of them also invalidated the
+experiments that would have found the others, so the order they were fixed in mattered.
+
+1. `parseBTAddr` guarded its separator check on the loop index rather than the byte offset, so it
+   indexed `s[-1]` and **panicked on every valid address**. `central.Connect` could never return.
+2. `parseBTAddr` then returned the address least-significant-byte first, but `x/sys/unix` reverses
+   `SockaddrL2.Addr` while marshalling — it wants the human order and does the conversion itself.
+   Pre-reversing cancelled that out and aimed every connect at a byte-reversed peer, so nothing
+   answered. Every PSM timed out identically, including ones nothing listens on, which a reachable
+   peer would have *refused*.
+3. **The socket was never bound**, so the channel ran in basic L2CAP mode rather than LE
+   credit-based flow control. `l2cap_sock_connect` only switches mode when the channel's source
+   address type is LE, and only `bind` sets that. In basic mode the kernel writes each payload as a
+   bare PDU **with no 2-byte SDU-length header**, so the peer reads the first two bytes of the data
+   as the SDU length. A TLS ClientHello begins `0x16 0x03`, which reads as an SDU of 790 bytes —
+   past the peer's MTU, so it dropped the channel immediately. This is why the failure looked
+   content-dependent: a payload of `00 00` reads as a legal empty SDU and is accepted, while three
+   zero bytes read as an empty SDU with a stray byte after it and are not.
+4. `L2CAPSend` looped over the unwritten remainder, which cannot chunk anything: the socket is
+   `SOCK_SEQPACKET`, so one write is one SDU and the kernel fails with `EMSGSIZE` rather than
+   writing part of it. The first TLS record was larger than the negotiated MTU and simply failed.
+   It now splits at the MTU read back from `BT_SNDMTU` once the channel is up.
+
+A fifth, separate bug: `poll(2)` returning `EINTR` was reported as a failure. The Go runtime
+preempts goroutines with `SIGURG`, so a long idle wait is interrupted routinely — an idle channel
+would surface "interrupted system call" instead of the timeout sentinel `l2capNetConn.Read` knows to
+retry, which breaks any connection that goes quiet. Poll, read and write now retry on `EINTR`.
+
+Verified against a Wendy Lite board end to end: channel open, TLS handshake, WendyCom handshake and
+round-tripping pings.
+
+Note for anyone debugging this layer again: the socket API gives almost no visibility here — a
+malformed K-frame is indistinguishable from an unreachable peer, because both simply fail to get a
+reply. `btmon` is the tool that settles it, since the missing SDU-length header and the peer's
+`Disconnection Request` are both plainly visible on the wire and neither is inferable from `errno`.
+
+### Addressing is platform-dependent
+
+`Connect` takes a *string*, but its meaning is not the same everywhere:
+
+* **macOS** — a CoreBluetooth peripheral UUID (`"XXXXXXXX-XXXX-…"`). CoreBluetooth never exposes
+  the hardware MAC address.
+* **Linux** — a Bluetooth MAC address, `"AA:BB:CC:DD:EE:FF"` (parsed to a `[6]byte` in written
+  order, which is what `unix.SockaddrL2` takes — see the note below). The LE
+  address type is read from BlueZ's `Device1.AddressType` where the device is known, so
+  random-static and resolvable-private addresses work; when BlueZ has never seen the device,
+  `OpenL2CAP` tries public then random.
+
+Either source of addresses hands you the right kind of value per platform: the [`scan`](scan/)
+subpackage in `BLEDeviceInfo.Address`, or [`shared/discovery`](../discovery/) in
+`models.BluetoothDevice.Address`. Windows is the gap — `scan` can find peripherals there, but
+`central.Connect` cannot reach them.
+
+### L2CAP-over-TLS bridge (`central/conn.go`)
+
+`NewL2CAPStream(conn)` wraps a `*Connection` as a `net.Conn`. Call it after `OpenL2CAP`; closing the
+returned conn closes the underlying BLE connection.
+
+* `Read` polls `L2CAPRecv` in `recvChunkSeconds` (2 s) slices and retries `ErrRecvTimeout`, so one
+  `Read` may span many `L2CAPRecv` calls. Leftovers from an oversized read are buffered for later
+  reads — needed because macOS coalesces incoming bytes into a stream buffer while Linux
+  `SOCK_SEQPACKET` preserves SDU boundaries.
+* **With no read deadline set, `Read` blocks indefinitely**, as `net.Conn` requires. The 2 s slice is
+  polling granularity, not a timeout callers see. With a deadline it returns a `net.Error` whose
+  `Timeout()` is true, which is what stops `crypto/tls` treating a deadline as a broken connection.
+  Write deadlines are ignored.
+* `Close` takes the same lock `Read` holds across `L2CAPRecv`, so it waits out an in-flight read (at
+  most 2 s). That matters on macOS, where `wendy_ble_disconnect` hands the CoreBluetooth wrapper to
+  ARC while a blocked reader still holds a bare pointer to it. Its idempotency flag is now belt and
+  braces — `Connection.Close` is idempotent on both backends.
+* `LocalAddr`/`RemoteAddr` are placeholders (`"ble-l2cap"` / `"ble"`).
+
+The TLS config that runs over this is the caller's business. Wendy's is
+`ble.NewClientTLSConfig` in [`internal/cli/ble`](../../cli/ble/): it sets `InsecureSkipVerify: true`
+— there is no hostname to verify over L2CAP, and ML-DSA chain certs don't parse in Go's built-in
+verifier — and performs real validation in a `VerifyConnection` callback from `shared/certs`. That
+function depends on the Wendy PKI, which is exactly why it is not here.
+
+## Scanning (the [`scan`](scan/) subpackage)
+
+`central.Connect` needs an address, and this is where addresses come from. It is as protocol-free as
+`Connection` is — the services to look for are an argument, and a result carries only what a BLE
+advertisement can actually supply.
+
+```go
+devices, err := scan.DiscoverBluetoothContinuous(ctx, scan.Options{
+    Services: []string{"7565E9EB-4C20-4B67-9272-D708B397B631"}, // empty = every device in range
+})
+if err != nil {
+    return err // the scan could not start at all; a mid-stream failure closes the channel instead
+}
+for set := range devices {
+    // set is the COMPLETE list, sorted by RSSI descending — replace, don't merge.
+    // set[i].Address feeds straight into central.Connect.
+}
+```
+
+A stream re-emits the whole array whenever it changes and closes when `ctx` is cancelled. Devices
+accumulate and are never dropped: BLE has no "device went away" signal, and a disappearance timeout
+would make a peripheral blink out of a picker between advertisements. Emits are coalesced on
+`Options.Interval` (1 s by default), which is what stops RSSI churn — it changes on nearly every
+advertising packet — from spinning the channel.
+
+Two things it deliberately does *not* report:
+
+* **No L2CAP PSM.** A PSM is not in an advertisement. Read it from the peripheral over GATT after
+  connecting, or fall back to a per-protocol default the caller owns.
+* **No stable cross-platform identity.** `Address` is a CoreBluetooth UUID on macOS and a MAC on
+  Linux and Windows, exactly as `central.Connect` requires, so it cannot be compared across
+  machines.
+
+`Name` is the advertised local name, and it is a display label rather than an identity: macOS falls
+back to CoreBluetooth's cached name and Linux to BlueZ's persisted one, so it can outlive the
+advertisement it came from. Windows has no cache to fall back on and reports `""` instead.
+
+Service UUIDs are normalized through `scan.CanonicalUUID`, which matters more than it looks:
+CoreBluetooth renders a 16-bit UUID as four hex characters (`"180F"`) where BlueZ and WinRT give the
+full 128-bit form, so comparing raw strings across platforms silently misses matches. `central` has
+its own copy of that function — it must not import `scan` — and the two must stay identical.
+
+| Capability | macOS | Linux | Windows |
+| --- | :---: | :---: | :---: |
+| Continuous scan | ✅ CoreBluetooth | ✅ BlueZ D-Bus | ✅ WinRT advertisement watcher |
+| Filter by service UUID | ✅ (in Go) | ✅ (BlueZ + Go) | ✅ (WinRT + Go) |
+| RSSI | ✅ | ✅ | ✅ |
+| Advertised name | ✅ | ✅ | ✅ (no cache fallback) |
+| `RunBLECheck` is meaningful | ✅ | ❌ returns 0 | ❌ returns 0 |
+
+**The Windows column is unverified on hardware.** It compiles and its JSON parsing is covered by
+tests, but no one has run it against a real radio, and the WinRT event binding is the part most
+likely to need work — `Register-ObjectEvent` binds WinRT `TypedEventHandler` events unevenly, so the
+script may need an `Add-Type` inline-C# shim instead. Treat it as a first cut. Windows also has no
+`central` backend, so nothing it finds can be connected to yet.
+
+The macOS backend keeps a long-lived `CBCentralManager` and lets Go poll a snapshot, so there are no
+cgo→Go callbacks and nothing ever calls into Go from a CoreBluetooth thread. It scans with
+`AllowDuplicates: YES` and **no** native service filter — CoreBluetooth's own filter drops
+peripherals whose advertisement omits the UUID, which is exactly the case a name-based fallback
+exists to catch — and filters in Go instead. The Windows backend runs one long-lived Windows
+PowerShell 5.1 process (the WinRT-projecting host) driving a `BluetoothLEAdvertisementWatcher` and
+streaming JSON lines back.
+
+Because CI has no radio and no macOS job compiles this cgo at all, the only thing that exercises the
+real bridges is the hardware-gated test:
+
+```sh
+WENDY_BLE_LIVE_SCAN=1 go test ./internal/shared/ble/scan -run TestLiveScan -v
+# WENDY_BLE_LIVE_SERVICES=<uuid>[,<uuid>] to exercise filtering
+```
+
+## Permission preflight (the [`permission`](permission/) subpackage)
+
+`permission.Preflight(ctx)` is meant to be wired into `scan.Options.Preflight` (or run before any
+other first touch of the platform BLE stack) by a caller that wants a clean error instead of a
+crash on macOS. It re-execs the running binary as the hidden `__ble-check` subcommand
+(`permission.CheckArg`) — `cmd/wendy` registers that subcommand to run `scan.RunBLECheck()` and
+exit with its result — so the CoreBluetooth touch that can `SIGABRT` a process with no Bluetooth
+TCC permission kills a disposable child instead of the caller. The result is cached with
+`sync.Once` for the life of the process, since terminal Bluetooth permission cannot change while a
+`wendy` invocation is running.
+
+It has no platform build tags and no dependency on `scan` or `central` — it only knows how to
+re-exec itself and interpret an exit code, so it is safe for any caller in this module to import.
+
+## Platform implementation notes
+
+### macOS (`central/ble_darwin.m`)
+
+The interesting part is that this runs inside a **CLI binary with no main run loop**, which
+CoreBluetooth normally assumes exists.
+
+* The `CBCentralManager` gets its own serial dispatch queue; every C entry point blocks on a
+  `dispatch_semaphore_t` signalled from the delegate callbacks.
+* `Connect` first tries `retrievePeripheralsWithIdentifiers:` (CoreBluetooth shares its peripheral
+  cache process-wide, so a peripheral already seen during discovery needs no re-scan) and only
+  falls back to scanning. This avoids a 10 s stall when the device stops advertising between
+  discovery and connect.
+* L2CAP streams get a **dedicated `NSThread` running a real `NSRunLoop`**, because
+  `NSStreamDelegate` events are otherwise never delivered. Writes are marshalled onto that thread
+  with `performSelector:onThread:waitUntilDone:YES` — a `CBL2CAPChannel` output stream returns `-1`
+  when written from a foreign thread (e.g. Go's TLS goroutine), even when the stream reports open.
+  Channel setup waits for `NSStreamEventHasSpaceAvailable` (5 s cap) before declaring the channel
+  usable.
+* Incoming L2CAP bytes accumulate in an `NSMutableData` behind a lock; `L2CAPRecv` drains the whole
+  buffer at once. Reads use a 4096-byte chunk.
+* Requires cgo, `-framework CoreBluetooth`, and the macOS Bluetooth TCC permission. Sandboxed
+  terminals can `SIGABRT` on CoreBluetooth init rather than returning an error, which is why the
+  probe runs in a throwaway subprocess: [`permission.Preflight`](permission/) re-execs the CLI as
+  `__ble-check`, and `scan.RunBLECheck` is the same probe for a caller to wire into
+  `scan.Options.Preflight`.
+* This file and `../scan/scan_darwin.m` both link into one binary, so their C symbols and
+  Objective-C class names must not collide — ObjC class names are process-global and a duplicate
+  makes the runtime pick one arbitrarily. Hence `wendy_ble_*` / `WendyBLEConnection` here versus
+  `wendy_blescan_*` / `WendyBLEScanSession` there.
+* Error codes are a small C enum (`timeout`, `not found`, `connect failed`, `discover failed`,
+  `write failed`, `read failed`, `L2CAP failed`, `disconnected`) mapped to Go `error` strings by
+  `bleError`. The one exception is `L2CAPRecv`, which returns the `ErrRecvTimeout` sentinel instead
+  of routing a timeout through `bleError`, so a caller can tell an idle channel from a dead one and
+  retry. Everything else surfaces as an opaque string.
+
+### Linux (`central/ble_linux.go`, `bluez_linux.go`, `gatt_linux.go`)
+
+Two halves that share only the peer's address, and the split is deliberate.
+
+**L2CAP** is a raw socket, no cgo and no D-Bus. `Connect` only creates the socket; `OpenL2CAP` does
+a best-effort, non-fatal BlueZ lookup for the peer's LE address type, then the non-blocking
+`connect(2)` + `Poll` (so the timeout is respected) + `SO_ERROR` check, then switches back to
+blocking mode. Receive is `Poll` + one `read(2)` into a 64 KiB buffer, one SDU per call. When BlueZ
+has no object for the device its address type is unknown, so the caller's timeout is split and
+public is tried before random — a wrong type times out rather than failing fast, because the
+controller ends up paging an address nobody answers.
+
+Three things are easy to get wrong here and were. The socket must be **bound** before connect, with
+an LE source address type — that, and nothing else, is what puts the channel into LE credit-based
+flow control instead of basic mode; the bound address itself is irrelevant, `BDADDR_ANY` is fine.
+`SockaddrL2.Addr` takes the address in the order it is written, most significant byte first:
+`x/sys/unix` reverses it into the kernel's little-endian `bdaddr_t` itself, so handing it a
+pre-reversed address silently targets the wrong peer. And sends must be split at the negotiated SDU
+size — `SOCK_SEQPACKET` means one write is one SDU, so an
+oversized buffer fails with `EMSGSIZE` and a write loop never gets the chance to chunk it. The size
+comes from `BT_SNDMTU`, which is only meaningful once the channel is open.
+
+`Connect` stays lazy on purpose: the kernel's L2CAP connect does its own scan-and-connect and reaches
+a device BlueZ has no object for at all, which is the normal case some seconds after a scan stops.
+Making `Connect` establish a link through BlueZ would break that, and the pure-L2CAP callers never
+ask for GATT anyway.
+
+**GATT** goes through BlueZ over D-Bus, because there is no reasonable alternative — an ATT client on
+a raw socket would mean implementing the protocol by hand, and BlueZ owns the link anyway.
+`DiscoverServices` resolves the device object by matching its `Address` property (never by
+synthesizing `/org/bluez/hciX/dev_AA_BB_…`), calls `Device1.Connect()`, waits for `ServicesResolved`,
+then walks `GattService1` / `GattCharacteristic1` objects under the device path into a
+`(service UUID, characteristic UUID) → object path` index. BlueZ reports UUIDs lowercase and 128-bit
+where callers pass uppercase, so both sides go through `canonicalUUID`.
+
+BlueZ evicts unpaired devices from its object tree roughly 30 s after discovery stops, so a MAC that
+a scan produced often has no D-Bus object left by the time GATT runs. On that miss `DiscoverServices`
+runs a short `StartDiscovery`, polls until the device appears, and **stops discovery before
+connecting** — an outgoing LE connect while the controller is scanning fails on older kernels.
+
+Notifications arrive as `PropertiesChanged` signals carrying `Value`. One match rule on the device's
+path namespace covers the device object and every characteristic under it; a single router goroutine
+fans those into **one bounded queue per characteristic**, which is why `WaitNotification` is
+per-characteristic here and not per-connection as it is on macOS. The router never blocks — godbus
+spawns a goroutine per signal rather than dropping when a registered channel is full, so a stuck
+router would leak unboundedly — and drops the oldest value when a queue fills.
+
+Two BlueZ behaviors to know: `ReadValue` also updates `Value` and emits `PropertiesChanged`, so a
+read on a subscribed characteristic enqueues a phantom notification; and gdbus batches property
+changes per main-loop iteration, so two notifications in the same iteration can collapse into one.
+Neither is worth working around for a rate-limited status characteristic, and the escape hatch if a
+streaming one ever appears is `AcquireNotify`, which hands back a seqpacket fd and bypasses D-Bus.
+
+`Close` tears the ACL link down only if this connection brought it up *and* no L2CAP channel is
+riding on it — `Device1.Disconnect()` drops the HCI link, which would kill a channel belonging to us
+or to another process.
+
+Pairing/bonding is assumed to already exist; this package never initiates it and registers no
+`org.bluez.Agent1`. A peripheral that demands encryption surfaces `NotPermitted` / `NotAuthorized`,
+mapped to a message telling the user to pair with `bluetoothctl` first.
+
+## Known limitations
+
+These are all about `central`'s `Connection` API; `scan`'s own caveats are in its section above.
+
+* **GATT is not goroutine-safe**, on either backend. At most one outstanding GATT operation per
+  connection. The L2CAP data path is the exception: one concurrent sender plus one concurrent
+  receiver is supported and relied on (`liteclient`'s framing writes from command goroutines while
+  its read loop blocks in `Read`). On macOS that holds because sends are dispatched onto the I/O
+  thread and never touch the recv buffer or its semaphore; on Linux because `write(2)` and `read(2)`
+  on one socket are independent. Two concurrent *senders* are still unsafe — on macOS they race on
+  the shared write result, and on Linux `L2CAPSend`'s write loop would interleave and corrupt the
+  stream — so callers must serialize writes, as `liteclient` does.
+* **macOS only: `WaitNotification` is per-connection, not per-characteristic.** All subscriptions
+  share one semaphore; a notification on characteristic *A* wakes a waiter on *B*, which then finds
+  its own queue empty and reports a timeout. Fine with one subscription, fragile with several. Linux
+  gives each characteristic its own queue.
+* **macOS only: a read on a subscribed characteristic lands in the notification queue.** The
+  `didUpdateValueForCharacteristic:` handler checks the notify queues first, so `ReadCharacteristic`
+  on a characteristic you've subscribed to never gets its response and times out after 10 s. On
+  Linux a read is a D-Bus method call with its own reply and cannot be confused with a notification.
+* **No `context.Context`**, no cancellation; timeouts are whole seconds only, and several
+  (GATT read/write/subscribe: 10 s) are hard-coded.
+* **No MTU or max-SDU negotiation** is exposed. Linux reads `GattCharacteristic1.MTU` where BlueZ
+  publishes it, but only to decide whether a read may have been truncated.
+* **No descriptor access, no indications** (only notifications), no characteristic-property
+  inspection beyond the `Flags` Linux puts in error messages.
+* **Central role only** — no advertising, no GATT server, no peripheral role.
+* **No reconnect or retry logic**; a disconnect surfaces as an error on the next call.
+* On macOS, a disconnect wakes blocked waiters but `L2CAPRecv` may report `disconnected` rather
+  than a clean EOF.

--- a/go/internal/shared/ble/bluez/bluez_linux.go
+++ b/go/internal/shared/ble/bluez/bluez_linux.go
@@ -1,0 +1,301 @@
+//go:build linux
+
+package bluez
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/godbus/dbus/v5"
+)
+
+// BlueZ D-Bus names.
+const (
+	Service      = "org.bluez"
+	AdapterIface = "org.bluez.Adapter1"
+	DeviceIface  = "org.bluez.Device1"
+
+	GattServiceIface = "org.bluez.GattService1"
+	GattCharIface    = "org.bluez.GattCharacteristic1"
+
+	PropsIface       = "org.freedesktop.DBus.Properties"
+	PropsChangedName = PropsIface + ".PropertiesChanged"
+	ObjectManagerGet = "org.freedesktop.DBus.ObjectManager.GetManagedObjects"
+)
+
+// AdapterEnvVar pins a controller when a host has several. It is the one
+// product-specific name in this package, and has to match what the agent reads.
+const AdapterEnvVar = "WENDY_BT_ADAPTER"
+
+// ManagedObjects is the shape org.freedesktop.DBus.ObjectManager returns.
+type ManagedObjects = map[dbus.ObjectPath]map[string]map[string]dbus.Variant
+
+// GetManagedObjects enumerates BlueZ's whole object tree: adapters, devices,
+// and — once a device's services are resolved — its GATT services,
+// characteristics and descriptors.
+func GetManagedObjects(ctx context.Context, conn *dbus.Conn) (ManagedObjects, error) {
+	var managed ManagedObjects
+	root := conn.Object(Service, "/")
+	if err := root.CallWithContext(ctx, ObjectManagerGet, 0).Store(&managed); err != nil {
+		return nil, fmt.Errorf("enumerating BlueZ objects: %w", err)
+	}
+	return managed, nil
+}
+
+// ResolveAdapterPath selects the adapter to operate on. The onboard radio is
+// not always hci0 — it can enumerate higher, or a USB dongle may be the only
+// controller — so the path is discovered rather than assumed, and the lowest
+// one wins so repeated runs pick the same controller on a host with several.
+//
+// AdapterEnvVar pins a specific controller, by full object path or by bare name
+// ("hci1"). Unlike the agent's older copy, an override naming an adapter that
+// does not exist is an error rather than a path that will fail later with a
+// worse message.
+func ResolveAdapterPath(managed ManagedObjects) (string, error) {
+	if want := os.Getenv(AdapterEnvVar); want != "" {
+		for path, ifaces := range managed {
+			if _, ok := ifaces[AdapterIface]; !ok {
+				continue
+			}
+			if string(path) == want || strings.HasSuffix(string(path), "/"+want) {
+				return string(path), nil
+			}
+		}
+		return "", fmt.Errorf("no Bluetooth adapter matching %s=%q", AdapterEnvVar, want)
+	}
+	if p := FindAdapterByInterface(managed, AdapterIface); p != "" {
+		return p, nil
+	}
+	return "", fmt.Errorf("no Bluetooth adapter found (no object implements %s)", AdapterIface)
+}
+
+// FindAdapterByInterface returns the lowest object path implementing iface, or
+// "" when none does. Taking the interface as an argument matters because an
+// adapter that can scan is not necessarily one that can advertise or serve
+// GATT — those are separate interfaces on the same object.
+func FindAdapterByInterface(managed ManagedObjects, iface string) string {
+	var best string
+	for path, ifaces := range managed {
+		if _, ok := ifaces[iface]; !ok {
+			continue
+		}
+		if s := string(path); best == "" || s < best {
+			best = s
+		}
+	}
+	return best
+}
+
+// FindDeviceByAddress locates a device object by its Bluetooth address. The
+// adapter comes from the device's own Adapter property rather than from the
+// parent path, which is only a convention; the path prefix is the fallback.
+// Lowest path wins so the choice is stable under Go's randomized map order.
+func FindDeviceByAddress(managed ManagedObjects, address string) (devicePath dbus.ObjectPath, adapterPath string, props map[string]dbus.Variant, found bool) {
+	var (
+		bestPath  dbus.ObjectPath
+		bestProps map[string]dbus.Variant
+	)
+	for path, ifaces := range managed {
+		devProps, ok := ifaces[DeviceIface]
+		if !ok {
+			continue
+		}
+		addr, ok := StringProp(devProps, "Address")
+		if !ok || !strings.EqualFold(addr, address) {
+			continue
+		}
+		if bestPath == "" || path < bestPath {
+			bestPath, bestProps = path, devProps
+		}
+	}
+	if bestPath == "" {
+		return "", "", nil, false
+	}
+
+	adapter := string(ObjectPathProp(bestProps, "Adapter"))
+	if adapter == "" {
+		if i := strings.LastIndex(string(bestPath), "/"); i > 0 {
+			adapter = string(bestPath)[:i]
+		}
+	}
+	return bestPath, adapter, bestProps, true
+}
+
+// RestrictToAdapter narrows a managed-objects map to the adapter at adapterPath
+// and the objects nested under it, so an AdapterEnvVar override pins device
+// lookups to the chosen controller. An empty adapterPath returns the input
+// unchanged.
+func RestrictToAdapter(managed ManagedObjects, adapterPath string) ManagedObjects {
+	if adapterPath == "" {
+		return managed
+	}
+	prefix := adapterPath + "/"
+	restricted := ManagedObjects{}
+	for path, ifaces := range managed {
+		if string(path) == adapterPath || strings.HasPrefix(string(path), prefix) {
+			restricted[path] = ifaces
+		}
+	}
+	return restricted
+}
+
+// PowerOn powers the adapter on. The call is a no-op if it is already on, but
+// it also clears Command Disallowed state left over from a previous BLE
+// connection that wasn't fully torn down at the HCI level.
+func PowerOn(ctx context.Context, conn *dbus.Conn, adapterPath string) error {
+	adapter := conn.Object(Service, dbus.ObjectPath(adapterPath))
+	return adapter.CallWithContext(ctx, PropsIface+".Set", 0,
+		AdapterIface, "Powered", dbus.MakeVariant(true)).Err
+}
+
+// Caller is the slice of dbus.BusObject these helpers need. Narrowing it lets a
+// caller substitute a fake and test its D-Bus interaction with no bus present;
+// *dbus.Object satisfies it as-is.
+type Caller interface {
+	CallWithContext(ctx context.Context, method string, flags dbus.Flags, args ...any) *dbus.Call
+}
+
+// LiveBoolProp reads one boolean property straight off the bus rather than from
+// a cached GetManagedObjects snapshot. ok is false when the read failed or the
+// property is not a bool, which callers polling for a state change should treat
+// as "not yet" rather than as false.
+func LiveBoolProp(ctx context.Context, obj Caller, iface, prop string) (value, ok bool) {
+	call := obj.CallWithContext(ctx, PropsIface+".Get", 0, iface, prop)
+	if call.Err != nil {
+		return false, false
+	}
+	var v dbus.Variant
+	if call.Store(&v) != nil {
+		return false, false
+	}
+	b, isBool := v.Value().(bool)
+	return b, isBool
+}
+
+// ErrorInfo pulls the D-Bus error name and message out of a godbus error,
+// through any wrapping. ok is false for an error that did not come from the
+// bus at all.
+func ErrorInfo(err error) (name, message string, ok bool) {
+	var val dbus.Error
+	if errors.As(err, &val) {
+		return val.Name, firstStringBody(val.Body), true
+	}
+	var ptr *dbus.Error
+	if errors.As(err, &ptr) && ptr != nil {
+		return ptr.Name, firstStringBody(ptr.Body), true
+	}
+	return "", "", false
+}
+
+// IsErrorName reports whether err is a D-Bus error with one of the given names.
+func IsErrorName(err error, names ...string) bool {
+	got, _, ok := ErrorInfo(err)
+	if !ok {
+		return false
+	}
+	for _, want := range names {
+		if got == want {
+			return true
+		}
+	}
+	return false
+}
+
+func firstStringBody(body []any) string {
+	if len(body) > 0 {
+		if s, ok := body[0].(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+// ── Property readers ─────────────────────────────────────────────────────────
+//
+// Each yields the zero value for a missing property or a type mismatch, so a
+// caller never has to distinguish "absent" from "wrong shape" — for BlueZ they
+// mean the same thing, and StringProp's second result covers the one case
+// (an empty-but-present name) where it matters.
+
+func StringProp(props map[string]dbus.Variant, key string) (string, bool) {
+	v, ok := props[key]
+	if !ok {
+		return "", false
+	}
+	s, ok := v.Value().(string)
+	return s, ok
+}
+
+func BoolProp(props map[string]dbus.Variant, key string) bool {
+	v, ok := props[key]
+	if !ok {
+		return false
+	}
+	b, _ := v.Value().(bool)
+	return b
+}
+
+func StringsProp(props map[string]dbus.Variant, key string) []string {
+	v, ok := props[key]
+	if !ok {
+		return nil
+	}
+	ss, _ := v.Value().([]string)
+	return ss
+}
+
+func ObjectPathProp(props map[string]dbus.Variant, key string) dbus.ObjectPath {
+	v, ok := props[key]
+	if !ok {
+		return ""
+	}
+	p, _ := v.Value().(dbus.ObjectPath)
+	return p
+}
+
+func BytesProp(props map[string]dbus.Variant, key string) []byte {
+	v, ok := props[key]
+	if !ok {
+		return nil
+	}
+	b, _ := v.Value().([]byte)
+	return b
+}
+
+// Uint16Prop reads a uint16 property. BlueZ types GattCharacteristic1.MTU this
+// way, and omits it entirely before 5.62.
+func Uint16Prop(props map[string]dbus.Variant, key string) uint16 {
+	v, ok := props[key]
+	if !ok {
+		return 0
+	}
+	n, _ := v.Value().(uint16)
+	return n
+}
+
+// RSSIProp reads the RSSI property, which BlueZ types as int16 and omits
+// entirely for a device it is not currently seeing.
+func RSSIProp(props map[string]dbus.Variant) int {
+	v, ok := props["RSSI"]
+	if !ok {
+		return 0
+	}
+	rssi, ok := v.Value().(int16)
+	if !ok {
+		return 0
+	}
+	return int(rssi)
+}
+
+// IsDefaultAlias reports whether an Alias is the placeholder BlueZ synthesizes
+// for a device advertising no name — the address with ':' replaced by '-'.
+// Without this check every anonymous device would appear named.
+func IsDefaultAlias(alias, address string) bool {
+	if address == "" {
+		return false
+	}
+	return strings.EqualFold(alias, strings.ReplaceAll(address, ":", "-"))
+}

--- a/go/internal/shared/ble/bluez/bluez_linux_test.go
+++ b/go/internal/shared/ble/bluez/bluez_linux_test.go
@@ -1,0 +1,355 @@
+//go:build linux
+
+package bluez
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/godbus/dbus/v5"
+)
+
+// tree builds a ManagedObjects fixture from a compact description.
+func tree(entries ...objectEntry) ManagedObjects {
+	managed := ManagedObjects{}
+	for _, e := range entries {
+		if managed[e.path] == nil {
+			managed[e.path] = map[string]map[string]dbus.Variant{}
+		}
+		managed[e.path][e.iface] = e.props
+	}
+	return managed
+}
+
+type objectEntry struct {
+	path  dbus.ObjectPath
+	iface string
+	props map[string]dbus.Variant
+}
+
+func adapter(path string) objectEntry {
+	return objectEntry{dbus.ObjectPath(path), AdapterIface, map[string]dbus.Variant{}}
+}
+
+func device(path, address string, extra ...map[string]dbus.Variant) objectEntry {
+	props := map[string]dbus.Variant{"Address": dbus.MakeVariant(address)}
+	for _, m := range extra {
+		for k, v := range m {
+			props[k] = v
+		}
+	}
+	return objectEntry{dbus.ObjectPath(path), DeviceIface, props}
+}
+
+func TestResolveAdapterPath(t *testing.T) {
+	t.Run("lowest path wins", func(t *testing.T) {
+		// Map order is randomized, so an unstable choice would show up as a
+		// flake rather than a consistent failure. Run it enough to catch that.
+		managed := tree(adapter("/org/bluez/hci1"), adapter("/org/bluez/hci0"), adapter("/org/bluez/hci2"))
+		for i := 0; i < 50; i++ {
+			got, err := ResolveAdapterPath(managed)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != "/org/bluez/hci0" {
+				t.Fatalf("ResolveAdapterPath = %q, want /org/bluez/hci0", got)
+			}
+		}
+	})
+
+	t.Run("no adapter is an error", func(t *testing.T) {
+		if _, err := ResolveAdapterPath(tree(device("/org/bluez/hci0/dev_AA", "AA:BB:CC:DD:EE:FF"))); err == nil {
+			t.Fatal("expected an error when no object implements Adapter1")
+		}
+	})
+
+	t.Run("env override by bare name", func(t *testing.T) {
+		t.Setenv(AdapterEnvVar, "hci1")
+		managed := tree(adapter("/org/bluez/hci0"), adapter("/org/bluez/hci1"))
+		got, err := ResolveAdapterPath(managed)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "/org/bluez/hci1" {
+			t.Fatalf("ResolveAdapterPath = %q, want /org/bluez/hci1", got)
+		}
+	})
+
+	t.Run("env override by full path", func(t *testing.T) {
+		t.Setenv(AdapterEnvVar, "/org/bluez/hci1")
+		managed := tree(adapter("/org/bluez/hci0"), adapter("/org/bluez/hci1"))
+		got, err := ResolveAdapterPath(managed)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "/org/bluez/hci1" {
+			t.Fatalf("ResolveAdapterPath = %q, want /org/bluez/hci1", got)
+		}
+	})
+
+	t.Run("env override naming a missing adapter is an error", func(t *testing.T) {
+		// The agent's older copy returns the override verbatim here, which
+		// defers the failure to a worse message later.
+		t.Setenv(AdapterEnvVar, "hci9")
+		if _, err := ResolveAdapterPath(tree(adapter("/org/bluez/hci0"))); err == nil {
+			t.Fatal("expected an error for an override that matches no adapter")
+		}
+	})
+
+	t.Run("env override does not match a non-adapter object", func(t *testing.T) {
+		t.Setenv(AdapterEnvVar, "dev_AA")
+		managed := tree(adapter("/org/bluez/hci0"), device("/org/bluez/hci0/dev_AA", "AA:BB:CC:DD:EE:FF"))
+		if _, err := ResolveAdapterPath(managed); err == nil {
+			t.Fatal("expected an error: the override names a device, not an adapter")
+		}
+	})
+}
+
+func TestFindAdapterByInterface(t *testing.T) {
+	managed := tree(
+		adapter("/org/bluez/hci0"),
+		objectEntry{"/org/bluez/hci1", AdapterIface, map[string]dbus.Variant{}},
+		objectEntry{"/org/bluez/hci1", "org.bluez.GattManager1", map[string]dbus.Variant{}},
+	)
+	// An adapter that can scan is not necessarily one that can serve GATT.
+	if got := FindAdapterByInterface(managed, "org.bluez.GattManager1"); got != "/org/bluez/hci1" {
+		t.Errorf("GattManager1 lookup = %q, want /org/bluez/hci1", got)
+	}
+	if got := FindAdapterByInterface(managed, AdapterIface); got != "/org/bluez/hci0" {
+		t.Errorf("Adapter1 lookup = %q, want /org/bluez/hci0 (lowest)", got)
+	}
+	if got := FindAdapterByInterface(managed, "org.bluez.LEAdvertisingManager1"); got != "" {
+		t.Errorf("missing interface = %q, want empty", got)
+	}
+}
+
+func TestFindDeviceByAddress(t *testing.T) {
+	t.Run("case-insensitive match, adapter from the Adapter property", func(t *testing.T) {
+		managed := tree(
+			adapter("/org/bluez/hci0"),
+			device("/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF", "AA:BB:CC:DD:EE:FF", map[string]dbus.Variant{
+				"Adapter": dbus.MakeVariant(dbus.ObjectPath("/org/bluez/hci0")),
+			}),
+		)
+		path, adapterPath, props, found := FindDeviceByAddress(managed, "aa:bb:cc:dd:ee:ff")
+		if !found {
+			t.Fatal("device not found for a lowercase address")
+		}
+		if path != "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF" {
+			t.Errorf("path = %q", path)
+		}
+		if adapterPath != "/org/bluez/hci0" {
+			t.Errorf("adapter = %q", adapterPath)
+		}
+		if addr, _ := StringProp(props, "Address"); addr != "AA:BB:CC:DD:EE:FF" {
+			t.Errorf("props carried Address %q", addr)
+		}
+	})
+
+	t.Run("adapter falls back to the parent path", func(t *testing.T) {
+		managed := tree(device("/org/bluez/hci2/dev_AA_BB_CC_DD_EE_FF", "AA:BB:CC:DD:EE:FF"))
+		_, adapterPath, _, found := FindDeviceByAddress(managed, "AA:BB:CC:DD:EE:FF")
+		if !found {
+			t.Fatal("device not found")
+		}
+		if adapterPath != "/org/bluez/hci2" {
+			t.Errorf("adapter = %q, want the parent path /org/bluez/hci2", adapterPath)
+		}
+	})
+
+	t.Run("lowest path wins when two adapters see one device", func(t *testing.T) {
+		managed := tree(
+			device("/org/bluez/hci1/dev_AA_BB_CC_DD_EE_FF", "AA:BB:CC:DD:EE:FF"),
+			device("/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF", "AA:BB:CC:DD:EE:FF"),
+		)
+		for i := 0; i < 50; i++ {
+			path, _, _, found := FindDeviceByAddress(managed, "AA:BB:CC:DD:EE:FF")
+			if !found || path != "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF" {
+				t.Fatalf("path = %q (found=%v), want the hci0 one every time", path, found)
+			}
+		}
+	})
+
+	t.Run("absent device", func(t *testing.T) {
+		managed := tree(device("/org/bluez/hci0/dev_11", "11:22:33:44:55:66"))
+		if _, _, _, found := FindDeviceByAddress(managed, "AA:BB:CC:DD:EE:FF"); found {
+			t.Error("found a device that is not in the tree")
+		}
+	})
+}
+
+func TestRestrictToAdapter(t *testing.T) {
+	managed := tree(
+		adapter("/org/bluez/hci0"),
+		device("/org/bluez/hci0/dev_AA", "AA:BB:CC:DD:EE:FF"),
+		adapter("/org/bluez/hci1"),
+		device("/org/bluez/hci1/dev_BB", "BB:BB:CC:DD:EE:FF"),
+	)
+
+	got := RestrictToAdapter(managed, "/org/bluez/hci0")
+	if len(got) != 2 {
+		t.Fatalf("restricted tree has %d objects, want 2", len(got))
+	}
+	if _, ok := got["/org/bluez/hci1/dev_BB"]; ok {
+		t.Error("restricted tree leaked an object from the other adapter")
+	}
+	if _, _, _, found := FindDeviceByAddress(got, "BB:BB:CC:DD:EE:FF"); found {
+		t.Error("a device on the other adapter is still findable")
+	}
+
+	// An empty adapter path means "no override", not "match nothing".
+	if len(RestrictToAdapter(managed, "")) != len(managed) {
+		t.Error("an empty adapter path should pass the tree through unchanged")
+	}
+
+	// hci1 must not match by prefix against hci10.
+	wide := tree(adapter("/org/bluez/hci1"), device("/org/bluez/hci10/dev_CC", "CC:BB:CC:DD:EE:FF"))
+	if len(RestrictToAdapter(wide, "/org/bluez/hci1")) != 1 {
+		t.Error("hci1 matched an object under hci10")
+	}
+}
+
+func TestErrorInfo(t *testing.T) {
+	const name = "org.bluez.Error.NotPermitted"
+
+	t.Run("value", func(t *testing.T) {
+		err := dbus.Error{Name: name, Body: []any{"nope"}}
+		gotName, gotMsg, ok := ErrorInfo(err)
+		if !ok || gotName != name || gotMsg != "nope" {
+			t.Fatalf("ErrorInfo = (%q, %q, %v)", gotName, gotMsg, ok)
+		}
+	})
+
+	t.Run("pointer", func(t *testing.T) {
+		err := &dbus.Error{Name: name, Body: []any{"nope"}}
+		gotName, _, ok := ErrorInfo(err)
+		if !ok || gotName != name {
+			t.Fatalf("ErrorInfo = (%q, _, %v)", gotName, ok)
+		}
+	})
+
+	t.Run("wrapped", func(t *testing.T) {
+		err := fmt.Errorf("reading characteristic: %w", dbus.Error{Name: name})
+		gotName, _, ok := ErrorInfo(err)
+		if !ok || gotName != name {
+			t.Fatalf("ErrorInfo through a wrap = (%q, _, %v)", gotName, ok)
+		}
+	})
+
+	t.Run("non-bus error", func(t *testing.T) {
+		if _, _, ok := ErrorInfo(errors.New("plain")); ok {
+			t.Error("a plain error was reported as a bus error")
+		}
+	})
+
+	t.Run("body without a string", func(t *testing.T) {
+		_, gotMsg, ok := ErrorInfo(dbus.Error{Name: name, Body: []any{42}})
+		if !ok || gotMsg != "" {
+			t.Fatalf("message = %q, want empty for a non-string body", gotMsg)
+		}
+	})
+}
+
+func TestIsErrorName(t *testing.T) {
+	err := fmt.Errorf("wrapped: %w", dbus.Error{Name: "org.bluez.Error.InProgress"})
+	if !IsErrorName(err, "org.bluez.Error.AlreadyConnected", "org.bluez.Error.InProgress") {
+		t.Error("IsErrorName missed a name in the list")
+	}
+	if IsErrorName(err, "org.bluez.Error.Failed") {
+		t.Error("IsErrorName matched the wrong name")
+	}
+	if IsErrorName(errors.New("plain"), "org.bluez.Error.Failed") {
+		t.Error("IsErrorName matched a non-bus error")
+	}
+}
+
+func TestPropReaders(t *testing.T) {
+	props := map[string]dbus.Variant{
+		"Address":     dbus.MakeVariant("AA:BB:CC:DD:EE:FF"),
+		"Connected":   dbus.MakeVariant(true),
+		"UUIDs":       dbus.MakeVariant([]string{"a", "b"}),
+		"Adapter":     dbus.MakeVariant(dbus.ObjectPath("/org/bluez/hci0")),
+		"Value":       dbus.MakeVariant([]byte{1, 2, 3}),
+		"MTU":         dbus.MakeVariant(uint16(517)),
+		"RSSI":        dbus.MakeVariant(int16(-42)),
+		"WrongType":   dbus.MakeVariant(int32(7)),
+		"EmptyString": dbus.MakeVariant(""),
+	}
+
+	if s, ok := StringProp(props, "Address"); !ok || s != "AA:BB:CC:DD:EE:FF" {
+		t.Errorf("StringProp = (%q, %v)", s, ok)
+	}
+	// A present-but-empty string is distinguishable from an absent one, which
+	// is the whole reason StringProp returns two values.
+	if s, ok := StringProp(props, "EmptyString"); !ok || s != "" {
+		t.Errorf("StringProp(EmptyString) = (%q, %v), want (\"\", true)", s, ok)
+	}
+	if _, ok := StringProp(props, "Missing"); ok {
+		t.Error("StringProp reported a missing key as present")
+	}
+	if _, ok := StringProp(props, "WrongType"); ok {
+		t.Error("StringProp reported a type mismatch as present")
+	}
+
+	if !BoolProp(props, "Connected") {
+		t.Error("BoolProp(Connected) = false")
+	}
+	if BoolProp(props, "Missing") || BoolProp(props, "WrongType") {
+		t.Error("BoolProp should be false for a missing key or a type mismatch")
+	}
+
+	if got := StringsProp(props, "UUIDs"); len(got) != 2 || got[0] != "a" {
+		t.Errorf("StringsProp = %v", got)
+	}
+	if StringsProp(props, "Missing") != nil || StringsProp(props, "WrongType") != nil {
+		t.Error("StringsProp should be nil for a missing key or a type mismatch")
+	}
+
+	if got := ObjectPathProp(props, "Adapter"); got != "/org/bluez/hci0" {
+		t.Errorf("ObjectPathProp = %q", got)
+	}
+	if ObjectPathProp(props, "Missing") != "" || ObjectPathProp(props, "WrongType") != "" {
+		t.Error("ObjectPathProp should be empty for a missing key or a type mismatch")
+	}
+
+	if got := BytesProp(props, "Value"); len(got) != 3 || got[2] != 3 {
+		t.Errorf("BytesProp = %v", got)
+	}
+	if BytesProp(props, "Missing") != nil {
+		t.Error("BytesProp should be nil for a missing key")
+	}
+
+	if got := Uint16Prop(props, "MTU"); got != 517 {
+		t.Errorf("Uint16Prop = %d", got)
+	}
+	// BlueZ before 5.62 omits MTU entirely, and 0 is how callers detect that.
+	if Uint16Prop(props, "Missing") != 0 || Uint16Prop(props, "WrongType") != 0 {
+		t.Error("Uint16Prop should be 0 for a missing key or a type mismatch")
+	}
+
+	if got := RSSIProp(props); got != -42 {
+		t.Errorf("RSSIProp = %d", got)
+	}
+	if RSSIProp(map[string]dbus.Variant{}) != 0 {
+		t.Error("RSSIProp should be 0 when BlueZ omits it")
+	}
+}
+
+func TestIsDefaultAlias(t *testing.T) {
+	tests := []struct {
+		alias, address string
+		want           bool
+	}{
+		{"AA-BB-CC-DD-EE-FF", "AA:BB:CC:DD:EE:FF", true},
+		{"aa-bb-cc-dd-ee-ff", "AA:BB:CC:DD:EE:FF", true},
+		{"wendy-5f2c", "AA:BB:CC:DD:EE:FF", false},
+		{"AA-BB-CC-DD-EE-FF", "", false},
+		{"", "", false},
+	}
+	for _, tc := range tests {
+		if got := IsDefaultAlias(tc.alias, tc.address); got != tc.want {
+			t.Errorf("IsDefaultAlias(%q, %q) = %v, want %v", tc.alias, tc.address, got, tc.want)
+		}
+	}
+}

--- a/go/internal/shared/ble/bluez/doc.go
+++ b/go/internal/shared/ble/bluez/doc.go
@@ -1,0 +1,17 @@
+// Package bluez is the BlueZ D-Bus plumbing shared by the BLE scanner and the
+// BLE central: enumerating the object tree, resolving an adapter and a device,
+// reading typed properties off a variant map, and turning a raw D-Bus failure
+// into something a user can act on.
+//
+// Nothing here is specific to any device or protocol. The one product-specific
+// concession is the WENDY_BT_ADAPTER environment variable, which pins a
+// controller — it has to spell the same thing the agent already reads.
+//
+// Everything but the error table is Linux-only, and lives in bluez_linux.go.
+// This file carries no build tag so that `go build ./...` on darwin and windows
+// finds a package rather than "build constraints exclude all Go files".
+//
+// internal/agent/bluetooth still has its own older copies of several of these
+// helpers. Converging them is a separate change on device-side code; the
+// versions here are the merged best of that copy and the scanner's.
+package bluez

--- a/go/internal/shared/ble/bluez/errors.go
+++ b/go/internal/shared/ble/bluez/errors.go
@@ -1,0 +1,140 @@
+package bluez
+
+import (
+	"errors"
+	"strings"
+)
+
+// ErrDeviceNotFound reports that a peripheral is not known to BlueZ and was not
+// seen during on-demand discovery. It is a sentinel so a caller can tell
+// "rescan" apart from a genuine connection failure.
+var ErrDeviceNotFound = errors.New("bluetooth device not found")
+
+// FriendlyError converts a D-Bus/BlueZ error, identified by its D-Bus error
+// name and message body, into user-facing text. notFound reports that the error
+// means the object does not exist in BlueZ; ok=false means the name was not
+// recognized and the caller should keep the raw error.
+//
+// This file carries no build tag, and must stay free of godbus imports, so the
+// table is testable on every platform. Use ErrorInfo (Linux only) to pull the
+// name and message out of a godbus error first.
+//
+// It is a superset of the table in internal/agent/bluetooth/errors.go: the
+// agent connects to peripherals, while a central also reads and writes
+// characteristics and can be denied bus access outright.
+func FriendlyError(name, message string) (text string, notFound, ok bool) {
+	switch name {
+	case "org.freedesktop.DBus.Error.UnknownMethod",
+		"org.freedesktop.DBus.Error.UnknownObject",
+		"org.freedesktop.DBus.Error.UnknownInterface",
+		"org.bluez.Error.DoesNotExist":
+		return "device is no longer known to the Bluetooth adapter — make sure it is powered on and in range, then rescan", true, true
+
+	case "org.bluez.Error.Failed":
+		return FriendlyBearerFailure(message), false, true
+
+	case "org.bluez.Error.AuthenticationFailed":
+		return "pairing authentication failed — put the device in pairing mode and retry", false, true
+	case "org.bluez.Error.AuthenticationRejected":
+		return "the device rejected pairing — it may be bonded to another host; unpair it there, or forget it here and retry", false, true
+	case "org.bluez.Error.AuthenticationCanceled":
+		return "pairing was canceled by the device", false, true
+	case "org.bluez.Error.AuthenticationTimeout":
+		return "pairing timed out — make sure the device is in pairing mode and in range", false, true
+	case "org.bluez.Error.ConnectionAttemptFailed":
+		return "could not reach the device to pair — make sure it is powered on and in range", false, true
+	case "org.bluez.Error.InProgress":
+		return "another Bluetooth operation is in progress — retry in a few seconds", false, true
+	case "org.bluez.Error.NotReady":
+		return "the Bluetooth adapter is not ready — check that it is powered on", false, true
+
+	// Central-side additions. A GATT client touches attributes the agent never
+	// does, and runs as whatever user invoked the CLI rather than as a service.
+	case "org.bluez.Error.NotConnected":
+		return "the link to the device dropped — reconnect and retry", false, true
+	case "org.bluez.Error.NotPermitted", "org.bluez.Error.NotAuthorized":
+		return "the device requires pairing for this attribute — pair it with `bluetoothctl` first", false, true
+	case "org.bluez.Error.NotSupported":
+		return "the device does not support this operation on that characteristic", false, true
+
+	case "org.freedesktop.DBus.Error.NoReply":
+		return "the Bluetooth service did not respond in time — retry", false, true
+	case "org.freedesktop.DBus.Error.ServiceUnknown":
+		return "the Bluetooth service (bluetoothd) is not running", false, true
+	case "org.freedesktop.DBus.Error.AccessDenied":
+		// The failure a headless CI job or a non-console SSH session actually
+		// hits: BlueZ's D-Bus policy grants at-console users by default, and
+		// nothing else. Worth naming, because the raw error says only
+		// "Rejected send message".
+		return "the D-Bus policy denies BlueZ access to this user — run as root, or add the user to the `bluetooth` group", false, true
+	}
+	return "", false, false
+}
+
+// IsTransientError reports whether a D-Bus/BlueZ failure, identified by its
+// error name and message body, is worth retrying rather than surfacing
+// immediately. BlueZ's "unknown" bearer reason (br-connection-unknown /
+// le-connection-unknown) is its catch-all for an HCI-level disconnect status it
+// could not classify, and in practice this often fires as a momentary race —
+// e.g. a peripheral still tearing down its previous connection — rather than a
+// permanent rejection, so a short retry frequently succeeds.
+// org.bluez.Error.InProgress and a bus-level NoReply are likewise transient by
+// definition. A canceled attempt (br-connection-canceled /
+// le-connection-abort-by-local) is a collision with another connect on the same
+// device — bluetoothd's own background auto-connect races an explicit one every
+// ~2s — and retrying lets the explicit attempt run to completion and observe
+// the real error. Every other classified reason (refused, timeout,
+// adapter-not-powered, authentication rejected, device not found, ...) reflects
+// a real condition that a bare retry will not fix.
+func IsTransientError(name, message string) bool {
+	switch name {
+	case "org.bluez.Error.InProgress", "org.freedesktop.DBus.Error.NoReply":
+		return true
+	case "org.bluez.Error.Failed":
+		return strings.Contains(message, "br-connection-unknown") ||
+			strings.Contains(message, "le-connection-unknown") ||
+			strings.Contains(message, "br-connection-busy") ||
+			strings.Contains(message, "le-connection-busy") ||
+			strings.Contains(message, "br-connection-canceled") ||
+			strings.Contains(message, "le-connection-abort-by-local")
+	}
+	return false
+}
+
+// FriendlyBearerFailure maps the reason strings BlueZ places in
+// org.bluez.Error.Failed messages (src/error.c, e.g. "br-connection-refused")
+// to actionable text. Unrecognized bearer reasons get a generic hint that
+// embeds the raw reason; messages without a bearer reason pass through
+// unchanged (older BlueZ reports plain strerror text there).
+func FriendlyBearerFailure(message string) string {
+	has := func(reasons ...string) bool {
+		for _, r := range reasons {
+			if strings.Contains(message, r) {
+				return true
+			}
+		}
+		return false
+	}
+
+	switch {
+	case has("br-connection-page-timeout", "br-connection-timeout", "le-connection-timeout"):
+		return "the device did not respond — make sure it is powered on and in range"
+	case has("br-connection-refused", "br-connection-aborted-by-remote", "le-connection-refused"):
+		return "the device refused the connection — put it in pairing mode; if it is paired to another host, disconnect or unpair it there first"
+	case has("br-connection-unknown", "le-connection-unknown"):
+		return "the device rejected or dropped the connection — put it in pairing mode and retry; if it is bonded to another device, unpair it there first"
+	case has("br-connection-adapter-not-powered", "le-connection-adapter-not-powered"):
+		return "the Bluetooth adapter is powered off"
+	case has("br-connection-busy", "le-connection-busy"):
+		return "the Bluetooth adapter is busy — wait a few seconds and retry"
+	case has("br-connection-key-missing"):
+		return "stored pairing keys are stale — forget the device and pair again"
+	case has("br-connection-profile-unavailable", "br-connection-sdp-search"):
+		return "no usable service profile found on the device — put it in pairing mode and retry"
+	case has("br-connection-canceled", "le-connection-abort-by-local"):
+		return "the connection attempt was canceled"
+	case has("br-connection-", "le-connection-"):
+		return "connection failed (" + message + ") — make sure the device is in pairing mode and in range"
+	}
+	return message
+}

--- a/go/internal/shared/ble/bluez/errors_test.go
+++ b/go/internal/shared/ble/bluez/errors_test.go
@@ -1,0 +1,169 @@
+package bluez
+
+import "testing"
+
+func TestFriendlyError(t *testing.T) {
+	tests := []struct {
+		name     string
+		errName  string
+		message  string
+		wantOK   bool
+		notFound bool
+		contains string
+	}{
+		{
+			name:     "unknown object means rescan",
+			errName:  "org.freedesktop.DBus.Error.UnknownObject",
+			wantOK:   true,
+			notFound: true,
+			contains: "rescan",
+		},
+		{
+			name:     "DoesNotExist also means rescan",
+			errName:  "org.bluez.Error.DoesNotExist",
+			wantOK:   true,
+			notFound: true,
+			contains: "rescan",
+		},
+		{
+			name:     "Failed defers to the bearer reason",
+			errName:  "org.bluez.Error.Failed",
+			message:  "le-connection-timeout",
+			wantOK:   true,
+			contains: "did not respond",
+		},
+		{
+			name:     "access denied names the group",
+			errName:  "org.freedesktop.DBus.Error.AccessDenied",
+			wantOK:   true,
+			contains: "bluetooth` group",
+		},
+		{
+			name:     "not permitted suggests pairing",
+			errName:  "org.bluez.Error.NotPermitted",
+			wantOK:   true,
+			contains: "bluetoothctl",
+		},
+		{
+			name:     "not authorized suggests pairing",
+			errName:  "org.bluez.Error.NotAuthorized",
+			wantOK:   true,
+			contains: "bluetoothctl",
+		},
+		{
+			name:     "not supported blames the characteristic",
+			errName:  "org.bluez.Error.NotSupported",
+			wantOK:   true,
+			contains: "characteristic",
+		},
+		{
+			name:     "not connected suggests reconnecting",
+			errName:  "org.bluez.Error.NotConnected",
+			wantOK:   true,
+			contains: "reconnect",
+		},
+		{
+			name:     "service unknown names bluetoothd",
+			errName:  "org.freedesktop.DBus.Error.ServiceUnknown",
+			wantOK:   true,
+			contains: "bluetoothd",
+		},
+		{
+			name:    "an unrecognized name is left to the caller",
+			errName: "org.example.Whatever",
+			wantOK:  false,
+		},
+		{
+			name:    "an empty name is left to the caller",
+			errName: "",
+			wantOK:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			text, notFound, ok := FriendlyError(tc.errName, tc.message)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (text %q)", ok, tc.wantOK, text)
+			}
+			if !ok {
+				if text != "" {
+					t.Errorf("unrecognized name yielded text %q, want empty", text)
+				}
+				return
+			}
+			if notFound != tc.notFound {
+				t.Errorf("notFound = %v, want %v", notFound, tc.notFound)
+			}
+			if !contains(text, tc.contains) {
+				t.Errorf("text = %q, want it to contain %q", text, tc.contains)
+			}
+		})
+	}
+}
+
+func TestIsTransientError(t *testing.T) {
+	tests := []struct {
+		errName string
+		message string
+		want    bool
+	}{
+		{"org.bluez.Error.InProgress", "", true},
+		{"org.freedesktop.DBus.Error.NoReply", "", true},
+		{"org.bluez.Error.Failed", "le-connection-unknown", true},
+		{"org.bluez.Error.Failed", "br-connection-busy", true},
+		{"org.bluez.Error.Failed", "le-connection-abort-by-local", true},
+		// A refused or timed-out connection reflects a real condition; a bare
+		// retry will not fix it.
+		{"org.bluez.Error.Failed", "le-connection-refused", false},
+		{"org.bluez.Error.Failed", "le-connection-timeout", false},
+		{"org.bluez.Error.AuthenticationFailed", "", false},
+		{"org.freedesktop.DBus.Error.AccessDenied", "", false},
+		{"", "", false},
+	}
+	for _, tc := range tests {
+		if got := IsTransientError(tc.errName, tc.message); got != tc.want {
+			t.Errorf("IsTransientError(%q, %q) = %v, want %v", tc.errName, tc.message, got, tc.want)
+		}
+	}
+}
+
+func TestFriendlyBearerFailure(t *testing.T) {
+	tests := []struct {
+		message  string
+		contains string
+	}{
+		{"le-connection-timeout", "did not respond"},
+		{"br-connection-page-timeout", "did not respond"},
+		{"le-connection-refused", "refused the connection"},
+		{"le-connection-adapter-not-powered", "powered off"},
+		{"br-connection-key-missing", "stale"},
+		{"le-connection-abort-by-local", "canceled"},
+		// An unclassified bearer reason still gets a hint, with the raw reason
+		// embedded so a bug report carries it.
+		{"le-connection-something-new", "le-connection-something-new"},
+		// Older BlueZ puts plain strerror text here, which passes through.
+		{"Input/output error", "Input/output error"},
+	}
+	for _, tc := range tests {
+		if got := FriendlyBearerFailure(tc.message); !contains(got, tc.contains) {
+			t.Errorf("FriendlyBearerFailure(%q) = %q, want it to contain %q", tc.message, got, tc.contains)
+		}
+	}
+}
+
+func contains(haystack, needle string) bool {
+	if needle == "" {
+		return true
+	}
+	return len(haystack) >= len(needle) && indexOf(haystack, needle) >= 0
+}
+
+func indexOf(haystack, needle string) int {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	return -1
+}

--- a/go/internal/shared/ble/permission/preflight.go
+++ b/go/internal/shared/ble/permission/preflight.go
@@ -1,0 +1,98 @@
+// Package permission checks whether this process has OS permission to use
+// Bluetooth Low Energy, before any scan or connection touches the platform's
+// BLE stack for the first time.
+package permission
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"sync"
+)
+
+// CheckArg is the hidden CLI subcommand a caller re-execs itself as to run
+// the actual platform probe (scan.RunBLECheck) in a disposable child
+// process. cmd/wendy registers the other half of this contract: a hidden
+// command named CheckArg that runs the probe and exits with its result.
+const CheckArg = "__ble-check"
+
+// mu guards resolved/resolvedErr: the CheckArg subprocess canary result,
+// cached for the life of the process once it is genuinely known — terminal
+// Bluetooth permission cannot change while wendy is running, so a real
+// success or a real subprocess failure is worth never re-probing.
+//
+// A result is deliberately NOT cached, and the next call re-probes from
+// scratch, when the probe subprocess died only because the CALLER's ctx was
+// canceled or timed out while it was starting or still running: that proves
+// nothing about Bluetooth permission, only that this particular caller
+// stopped waiting. Preflight always execs with the caller's ctx (rather than
+// one scoped to itself) so a caller can still kill an in-flight probe
+// promptly on shutdown — trading that responsiveness away to get
+// unconditional caching is not this package's call to make.
+var (
+	mu          sync.Mutex
+	resolved    bool
+	resolvedErr error
+)
+
+// runCheck execs exe as CheckArg and reports the probe's outcome. A package
+// var, following this codebase's seam convention (see blePreflightFn et al.
+// in shared/discovery/ble_lite_discovery.go), so a test can replace it
+// without a real subprocess, cgo, or CoreBluetooth. Production never
+// reassigns it.
+var runCheck = func(ctx context.Context, exe string) error {
+	cmd := exec.CommandContext(ctx, exe, CheckArg)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	return cmd.Run()
+}
+
+// Preflight verifies BLE access is available before any scanner or GATT
+// connection touches the platform Bluetooth stack. Touching CoreBluetooth
+// for the first time in a process without Bluetooth TCC permission can
+// SIGABRT the whole process instead of returning an error; running that
+// first touch in a disposable child re-exec'd with CheckArg means only the
+// child dies, and this process gets back a clean error instead.
+//
+// A genuinely determined result is cached for the process's lifetime (see
+// the resolved/-Err doc comment). A probe interrupted only by the caller's
+// own ctx ending is inconclusive: this call returns an error, but nothing is
+// cached, so the next call — presumably with a live context — gets a real
+// answer instead of being stuck with a false "unavailable" forever.
+func Preflight(ctx context.Context) error {
+	mu.Lock()
+	defer mu.Unlock()
+	if resolved {
+		return resolvedErr
+	}
+
+	exe, exeErr := os.Executable()
+	if exeErr != nil {
+		resolved = true // can't locate self, assume BLE is available
+		return nil
+	}
+
+	if runErr := runCheck(ctx, exe); runErr != nil {
+		// A subprocess killed by exec.CommandContext's Cancel because ctx
+		// ended does NOT return context.Canceled/DeadlineExceeded from
+		// Run(): os/exec's Wait() prefers the child's own exit error (e.g.
+		// "signal: killed") over the context error whenever the process
+		// actually exited non-zero, which is exactly what a killed process
+		// does. So errors.Is(runErr, context.Canceled) would miss this, the
+		// common, case — checking ctx.Err() after the fact is the only
+		// reliable signal. (A genuine failure that happens to coincide with
+		// an unrelated ctx cancellation is misclassified as inconclusive
+		// too, but that only costs one harmless extra retry later — never a
+		// stuck false negative, which is the failure mode being fixed here.)
+		if ctx.Err() != nil {
+			return fmt.Errorf("Bluetooth preflight interrupted: %w", ctx.Err())
+		}
+		resolvedErr = fmt.Errorf("Bluetooth unavailable - your terminal may not have Bluetooth permission")
+		resolved = true
+		return resolvedErr
+	}
+
+	resolved = true
+	return nil
+}

--- a/go/internal/shared/ble/permission/preflight_test.go
+++ b/go/internal/shared/ble/permission/preflight_test.go
@@ -1,0 +1,160 @@
+package permission
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+)
+
+// resetPreflight clears the cached result and installs fakeRun as runCheck
+// for the duration of the test, restoring both afterwards — resolved and
+// resolvedErr otherwise persist across tests in the same binary the same way
+// they persist across calls in production.
+func resetPreflight(t *testing.T, fakeRun func(ctx context.Context, exe string) error) {
+	t.Helper()
+	origResolved, origErr, origRun := resolved, resolvedErr, runCheck
+	resolved, resolvedErr = false, nil
+	runCheck = fakeRun
+	t.Cleanup(func() {
+		resolved, resolvedErr, runCheck = origResolved, origErr, origRun
+	})
+}
+
+func TestPreflightCachesSuccess(t *testing.T) {
+	calls := 0
+	resetPreflight(t, func(context.Context, string) error {
+		calls++
+		return nil
+	})
+
+	if err := Preflight(context.Background()); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if err := Preflight(context.Background()); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("runCheck called %d times, want 1", calls)
+	}
+}
+
+// TestPreflightCachesGenuineFailure proves a real probe failure — e.g. the
+// subprocess exiting non-zero because the platform actually denied
+// Bluetooth TCC access — is cached forever, matching the original
+// sync.Once behavior for this case.
+func TestPreflightCachesGenuineFailure(t *testing.T) {
+	calls := 0
+	resetPreflight(t, func(context.Context, string) error {
+		calls++
+		return errors.New("exit status 1")
+	})
+
+	err1 := Preflight(context.Background())
+	if err1 == nil {
+		t.Fatal("first call: want an error, got nil")
+	}
+	err2 := Preflight(context.Background())
+	if err2 != err1 {
+		t.Errorf("second call returned %v, want the same cached error %v", err2, err1)
+	}
+	if calls != 1 {
+		t.Errorf("runCheck called %d times, want 1", calls)
+	}
+}
+
+// TestPreflightDoesNotCacheContextCancellation is the regression test for
+// the bug: a probe killed by the CALLER's context ending must not poison the
+// cache forever. The fake mirrors what exec.Cmd actually returns when
+// CommandContext's Cancel kills a running child (see os/exec's watchCtx and
+// Wait): a plain non-context error, NOT context.Canceled — proving Preflight
+// distinguishes this case via ctx.Err() rather than errors.Is on the
+// underlying error.
+func TestPreflightDoesNotCacheContextCancellation(t *testing.T) {
+	calls := 0
+	started := make(chan struct{})
+	resetPreflight(t, func(ctx context.Context, _ string) error {
+		calls++
+		close(started)
+		<-ctx.Done() // simulate the probe still running when ctx ends
+		return errors.New("signal: killed")
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-started
+		cancel()
+	}()
+
+	if err := Preflight(ctx); err == nil {
+		t.Fatal("want a non-nil error for an interrupted probe")
+	}
+	if resolved {
+		t.Fatal("an interrupted probe must not be cached")
+	}
+
+	// The next call, with a live context, gets a real probe and IS cached.
+	// Swap in a fake that succeeds instead of blocking on ctx.Done(), since
+	// context.Background() here never closes.
+	runCheck = func(context.Context, string) error {
+		calls++
+		return nil
+	}
+	if err := Preflight(context.Background()); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if !resolved || calls != 2 {
+		t.Errorf("resolved=%v calls=%d, want resolved=true calls=2", resolved, calls)
+	}
+}
+
+// TestPreflightAlreadyCanceledContext covers the other ctx-cancellation
+// path: ctx already done before Preflight is even called (mirrors
+// exec.Cmd.Start's own early-return-without-spawning behavior).
+func TestPreflightAlreadyCanceledContext(t *testing.T) {
+	resetPreflight(t, func(ctx context.Context, _ string) error {
+		return ctx.Err()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := Preflight(ctx); err == nil {
+		t.Fatal("want a non-nil error")
+	}
+	if resolved {
+		t.Fatal("must not cache when ctx was already canceled")
+	}
+}
+
+// TestPreflightSerializesConcurrentCallers proves concurrent callers still
+// share one probe, matching sync.Once's original guarantee.
+func TestPreflightSerializesConcurrentCallers(t *testing.T) {
+	var calls int
+	var countMu sync.Mutex
+	release := make(chan struct{})
+	resetPreflight(t, func(context.Context, string) error {
+		countMu.Lock()
+		calls++
+		countMu.Unlock()
+		<-release
+		return nil
+	})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = Preflight(context.Background())
+		}()
+	}
+	close(release)
+	wg.Wait()
+
+	countMu.Lock()
+	defer countMu.Unlock()
+	if calls != 1 {
+		t.Errorf("runCheck called %d times concurrently, want 1", calls)
+	}
+}


### PR DESCRIPTION
**1 of 4.** Splits #1926, which had to be broken up because its 291,218-byte diff exceeded the AI security review's 140,000-byte limit. Each part is disjoint — every file appears in exactly one PR, and merging all four reproduces #1926's tree byte-for-byte.

**This code is not used by anything yet.** Nothing in the tree imports it and it is not reachable from any binary. It is the BLE stack developed on `gab/ble`, landed on main so it is under review and CI going forward.

## Contents (8 files)

| Path | What |
|---|---|
| `go/internal/shared/ble/bluez/` | Linux BlueZ D-Bus helpers and error mapping |
| `go/internal/shared/ble/permission/` | Platform permission preflight checks |
| `go/internal/shared/ble/README.md` | Design doc for the whole stack — worth reading first |

## Notes

- **No dependency changes.** `go.mod` and `go.sum` are untouched. The only external import is `github.com/godbus/dbus/v5`, already a direct require on main.
- **Merge this first.** Both `scan` (#2) and `central` (#3) import `bluez`, so they cannot compile until this lands.
- Builds and vets clean on darwin, `GOOS=linux`, and `GOOS=windows`; `go test` passes.

## Sequence

1. **this PR** — bluez + permission + README
2. `scan` — needs this
3. `central` production files — needs this
4. #1926 — `central` tests; needs 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)