### PR TITLE
shared/ble 2/4: scan package

### DIFF
--- a/go/internal/shared/ble/scan/live_test.go
+++ b/go/internal/shared/ble/scan/live_test.go
@@ -1,0 +1,77 @@
+package scan
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestLiveScan drives the real platform backend against real hardware. It is
+// skipped unless WENDY_BLE_LIVE_SCAN is set, because CI has no radio — and on
+// macOS no CI job compiles this package's cgo at all, so this is the only thing
+// that exercises the CoreBluetooth bridge.
+//
+//	WENDY_BLE_LIVE_SCAN=1 go test ./internal/shared/ble/scan -run TestLiveScan -v
+//
+// Set WENDY_BLE_LIVE_SERVICES to a comma-separated UUID list to exercise
+// filtering; leave it unset to report every device in range.
+func TestLiveScan(t *testing.T) {
+	if os.Getenv("WENDY_BLE_LIVE_SCAN") == "" {
+		t.Skip("set WENDY_BLE_LIVE_SCAN=1 to run a real BLE scan")
+	}
+
+	var services []string
+	if raw := os.Getenv("WENDY_BLE_LIVE_SERVICES"); raw != "" {
+		services = splitCommaList(raw)
+		t.Logf("filtering on %v", services)
+	} else {
+		t.Log("no filter: reporting every device in range")
+	}
+
+	duration := 15 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), duration)
+	defer cancel()
+
+	ch, err := DiscoverBluetoothContinuous(ctx, Options{Services: services})
+	if err != nil {
+		t.Fatalf("DiscoverBluetoothContinuous: %v", err)
+	}
+
+	emits := 0
+	var last []BLEDeviceInfo
+	for devices := range ch {
+		emits++
+		last = devices
+		t.Logf("emit %d: %d device(s)", emits, len(devices))
+		for _, d := range devices {
+			t.Logf("    %-38s rssi=%-5d name=%-24q services=%v",
+				d.Address, d.RSSI, d.Name, d.ServiceUUIDs)
+		}
+	}
+
+	// Not a failure: an empty room is a legitimate result. Say so plainly
+	// rather than reporting a pass that proves nothing.
+	if emits == 0 {
+		t.Logf("no devices seen in %s — nothing was advertising, or the radio is off", duration)
+		return
+	}
+	t.Logf("%d emit(s), %d device(s) at the end", emits, len(last))
+}
+
+// splitCommaList is a test-only reader for WENDY_BLE_LIVE_SERVICES. The
+// production comma parser lives in the darwin file, which is not built
+// everywhere.
+func splitCommaList(s string) []string {
+	var out []string
+	start := 0
+	for i := 0; i <= len(s); i++ {
+		if i == len(s) || s[i] == ',' {
+			if part := s[start:i]; part != "" {
+				out = append(out, part)
+			}
+			start = i + 1
+		}
+	}
+	return out
+}

--- a/go/internal/shared/ble/scan/scan.go
+++ b/go/internal/shared/ble/scan/scan.go
@@ -1,0 +1,284 @@
+// Package scan is a generic, continuously-streaming BLE scanner for the
+// central (client) side. It complements the sibling central package, which
+// connects to a peripheral but, as the README says, "does no scanning or
+// discovery of its own".
+//
+// Nothing here knows about any particular device or protocol: the service UUIDs
+// to look for are an argument, and the results carry only what a BLE
+// advertisement can actually supply. An L2CAP PSM is deliberately absent — it
+// is not advertised, and can only be learned from a GATT read after connecting.
+//
+// The Address a scan reports is the string central.Connect expects on the same
+// platform, so results feed straight into a connection.
+package scan
+
+import (
+	"context"
+	"sort"
+	"time"
+)
+
+// BLEDeviceInfo is one device seen during a scan.
+type BLEDeviceInfo struct {
+	// Address identifies the device to ble.Connect. Its meaning is
+	// platform-dependent: a CoreBluetooth peripheral UUID on macOS (the OS
+	// never exposes the hardware MAC), an "AA:BB:CC:DD:EE:FF" MAC on Linux and
+	// Windows.
+	Address string
+
+	// Name is the advertised local name, "" when none is available. It is a
+	// display label, not an identity: macOS and Linux fall back to an
+	// OS-cached name, so it may outlive the advertisement it came from.
+	Name string
+
+	// ServiceUUIDs are the advertised service UUIDs, canonicalized to
+	// uppercase 128-bit form.
+	ServiceUUIDs []string
+
+	// RSSI is signal strength in dBm from the most recent sighting; 0 when the
+	// platform does not report it.
+	RSSI int
+}
+
+// Options configures a continuous scan.
+type Options struct {
+	// Services filters results: a device is reported when it advertises at
+	// least one of these. Empty reports every device seen. Any spelling is
+	// accepted — 16-bit, 32-bit or full 128-bit, either case.
+	Services []string
+
+	// Interval bounds how often the stream emits, and how often the platform
+	// backend is sampled. Zero uses DefaultInterval.
+	Interval time.Duration
+
+	// Preflight optionally gates the scan before the radio is touched, for a
+	// caller that has its own way of testing BLE availability. A non-nil error
+	// fails DiscoverBluetoothContinuous. Nil skips the check.
+	//
+	// This is a func rather than a built-in probe so that a caller needing to
+	// run RunBLECheck in a subprocess (see its doc comment) owns that policy —
+	// how to re-invoke itself is not something this package can know.
+	Preflight func(context.Context) error
+}
+
+// DefaultInterval is the emit and sampling cadence when Options.Interval is
+// zero. One second keeps a device picker feeling live without resampling the
+// backend more often than advertisements typically arrive.
+const DefaultInterval = time.Second
+
+// streamBuffer decouples the scan loop from a consumer that renders between
+// reads. Snapshots are coalesced rather than queued, so a small buffer is
+// enough; a full buffer simply makes the loop skip an emit and try again on the
+// next tick with even fresher data.
+const streamBuffer = 4
+
+// newScannerFn opens the platform backend. A package seam, not a const, so the
+// engine below can be tested with no radio present — mirroring bleScanFn in
+// shared/discovery/bluetooth_darwin.go. Production never reassigns it.
+var newScannerFn = newScanner
+
+// scanner is what each platform file implements. Backends report whatever they
+// can currently see; accumulating across samples is the engine's job, so a
+// backend that forgets a device (BlueZ evicting a stale entry, a watcher
+// restarting) cannot shrink the emitted array.
+type scanner interface {
+	// Snapshot returns the devices visible now. A non-nil error ends the scan
+	// after this call's devices, if any, are merged and emitted — a backend
+	// may report something new in the same call that it reports a fatal error.
+	// ctx is the scan's own lifetime context, so a backend whose read can block
+	// (a D-Bus round trip, say) can return promptly once the caller cancels
+	// instead of wedging the sampling loop.
+	Snapshot(ctx context.Context) ([]BLEDeviceInfo, error)
+	// Close stops scanning and releases the backend. Safe to call once.
+	Close()
+}
+
+// DiscoverBluetoothContinuous streams the full set of matching devices seen so
+// far, re-emitted whenever it changes, until ctx is cancelled. The channel is
+// closed when the session ends.
+//
+// Each emitted slice is complete and sorted by RSSI descending (strongest
+// first) — a consumer replaces its whole list rather than applying a delta.
+// Devices accumulate for the life of the stream and are never removed: BLE
+// offers no "device went away" signal, and a disappearance timeout would make
+// a device blink out of a picker between advertisements.
+//
+// The returned error reports only that the scan could not be started at all
+// (Preflight said no, or the platform has no BLE support). A backend that fails
+// mid-stream ends the stream by closing the channel.
+func DiscoverBluetoothContinuous(ctx context.Context, opts Options) (<-chan []BLEDeviceInfo, error) {
+	if opts.Preflight != nil {
+		if err := opts.Preflight(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	interval := opts.Interval
+	if interval <= 0 {
+		interval = DefaultInterval
+	}
+	want := canonicalUUIDs(opts.Services)
+
+	sc, err := newScannerFn(ctx, want)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(chan []BLEDeviceInfo, streamBuffer)
+	go func() {
+		defer close(out)
+		defer sc.Close()
+		runScan(ctx, sc, want, interval, out)
+	}()
+	return out, nil
+}
+
+// runScan samples the backend on every tick and emits the accumulated set
+// whenever it differs from what was last sent. Coalescing on the tick is what
+// keeps RSSI churn — which changes on nearly every advertising packet — from
+// spinning the channel.
+func runScan(ctx context.Context, sc scanner, want []string, interval time.Duration, out chan<- []BLEDeviceInfo) {
+	store := newDeviceStore()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	// Sample once up front so a caller sees whatever the backend already knows
+	// (CoreBluetooth and BlueZ both hold a cache) without waiting a full tick.
+	if !sample(ctx, sc, want, store, out) {
+		return
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if !sample(ctx, sc, want, store, out) {
+				return
+			}
+		}
+	}
+}
+
+// sample takes one backend reading and emits if anything is pending. It reports
+// whether the scan should continue.
+func sample(ctx context.Context, sc scanner, want []string, store *deviceStore, out chan<- []BLEDeviceInfo) bool {
+	devices, err := sc.Snapshot(ctx)
+
+	// Merge and try to emit whatever the backend returned even when err is
+	// non-nil: a backend that just died may still report something new in this
+	// same call (windowsScanner's accumulated map, say), and dropping it on the
+	// floor would lose it for good — the stream is ending either way, so this
+	// is the last chance to flush it.
+	for _, d := range devices {
+		if d.Address == "" {
+			continue
+		}
+		d.ServiceUUIDs = canonicalUUIDs(d.ServiceUUIDs)
+		if !matchesServices(d.ServiceUUIDs, want) {
+			continue
+		}
+		store.merge(d)
+	}
+	if store.pending {
+		// Non-blocking send: a consumer that is behind simply misses this emit
+		// and gets a superset on the next tick, with pending still set so the
+		// retry happens even if no new advertisement arrives in the meantime.
+		// Blocking here instead would stall sampling behind rendering.
+		snapshot := store.snapshot()
+		select {
+		case <-ctx.Done():
+			return false
+		case out <- snapshot:
+			store.pending = false
+		default:
+		}
+	}
+
+	return err == nil
+}
+
+// deviceStore accumulates sightings across samples, keyed by address.
+type deviceStore struct {
+	byAddress map[string]BLEDeviceInfo
+	// pending is set when the store changed since the last delivered emit, so a
+	// dropped emit is retried on the following tick.
+	pending bool
+}
+
+func newDeviceStore() *deviceStore {
+	return &deviceStore{byAddress: make(map[string]BLEDeviceInfo)}
+}
+
+// merge folds one sighting in and reports whether it changed the store.
+// Later readings win: under an accumulate-forever policy, keeping the strongest
+// RSSI ever seen (as the one-shot macOS scan does) would pin a device to its
+// best-ever reading for the whole session, so a stale value could never
+// recover.
+func (s *deviceStore) merge(d BLEDeviceInfo) bool {
+	prev, existed := s.byAddress[d.Address]
+	if existed && !deviceChanged(prev, d) {
+		return false
+	}
+	// Never let a sighting that omits a field erase what an earlier one
+	// established: macOS reports a name only once the local-name AD field or
+	// the OS cache supplies it, and BlueZ populates UUIDs asynchronously after
+	// a device first appears.
+	if d.Name == "" {
+		d.Name = prev.Name
+	}
+	if len(d.ServiceUUIDs) == 0 {
+		d.ServiceUUIDs = prev.ServiceUUIDs
+	}
+	if d.RSSI == 0 {
+		d.RSSI = prev.RSSI
+	}
+	s.byAddress[d.Address] = d
+	s.pending = true
+	return true
+}
+
+// snapshot returns the accumulated set, sorted strongest signal first.
+func (s *deviceStore) snapshot() []BLEDeviceInfo {
+	out := make([]BLEDeviceInfo, 0, len(s.byAddress))
+	for _, d := range s.byAddress {
+		out = append(out, d)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].RSSI != out[j].RSSI {
+			return out[i].RSSI > out[j].RSSI
+		}
+		// Stable tiebreak so an unchanged set never reorders between emits —
+		// map iteration order alone would shuffle equal-RSSI devices.
+		return out[i].Address < out[j].Address
+	})
+	return out
+}
+
+// deviceChanged reports whether an incoming sighting carries anything new,
+// treating an empty field as "no news" to match merge's field-preserving
+// behavior.
+func deviceChanged(prev, next BLEDeviceInfo) bool {
+	if next.Name != "" && next.Name != prev.Name {
+		return true
+	}
+	if next.RSSI != 0 && next.RSSI != prev.RSSI {
+		return true
+	}
+	if len(next.ServiceUUIDs) != 0 && !sameUUIDs(prev.ServiceUUIDs, next.ServiceUUIDs) {
+		return true
+	}
+	return false
+}
+
+func sameUUIDs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/go/internal/shared/ble/scan/scan_darwin.go
+++ b/go/internal/shared/ble/scan/scan_darwin.go
@@ -1,0 +1,115 @@
+//go:build darwin
+
+package scan
+
+/*
+#cgo CFLAGS: -fobjc-arc
+#cgo LDFLAGS: -framework CoreBluetooth -framework Foundation
+#include "scan_darwin.h"
+*/
+import "C"
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"unsafe"
+)
+
+// readyTimeoutSeconds is how long wendy_blescan_start waits for the adapter to
+// report powered-on before giving up.
+const readyTimeoutSeconds = 5
+
+// RunBLECheck reports whether BLE is usable on this host: 0 if available, 1 if
+// denied or restricted.
+//
+// On macOS this touches CoreBluetooth, which can SIGABRT rather than return an
+// error when the terminal has no Bluetooth TCC permission. Run it in a
+// subprocess — a long-lived process cannot survive that abort — and wire the
+// result back through Options.Preflight.
+func RunBLECheck() int {
+	return int(C.wendy_blescan_check())
+}
+
+// darwinScanner holds a running CoreBluetooth scan session.
+type darwinScanner struct {
+	mu     sync.Mutex
+	handle C.WendyBLEScanHandle
+}
+
+// newScanner starts a CoreBluetooth scan. services is ignored: the scan is
+// unfiltered and the engine matches UUIDs in Go, because CoreBluetooth's own
+// service filter also drops peripherals whose advertisement omits the UUID.
+func newScanner(_ context.Context, _ []string) (scanner, error) {
+	handle := C.wendy_blescan_start(C.int(readyTimeoutSeconds))
+	if handle == nil {
+		return nil, errors.New("Bluetooth unavailable - your terminal may not have Bluetooth permission")
+	}
+	return &darwinScanner{handle: handle}, nil
+}
+
+// Snapshot ignores ctx: it reads CoreBluetooth's already-cached state through a
+// non-blocking cgo call, so there is nothing here that can hang.
+func (s *darwinScanner) Snapshot(_ context.Context) ([]BLEDeviceInfo, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.handle == nil {
+		return nil, errors.New("BLE scan session is closed")
+	}
+
+	snapshot := C.wendy_blescan_snapshot(s.handle)
+	defer C.wendy_blescan_free_snapshot(snapshot)
+
+	if snapshot.error != nil {
+		return nil, errors.New(C.GoString(snapshot.error))
+	}
+	if snapshot.count == 0 || snapshot.devices == nil {
+		return nil, nil
+	}
+
+	count := int(snapshot.count)
+	cDevices := unsafe.Slice(snapshot.devices, count)
+	devices := make([]BLEDeviceInfo, 0, count)
+	for _, cd := range cDevices {
+		devices = append(devices, BLEDeviceInfo{
+			Address:      C.GoString(cd.address),
+			Name:         C.GoString(cd.name),
+			ServiceUUIDs: splitList(C.GoString(cd.service_uuids)),
+			RSSI:         int(cd.rssi),
+		})
+	}
+	return devices, nil
+}
+
+// Close stops the scan. Idempotent, and it holds the same lock Snapshot does so
+// it can never release the session out from under an in-flight snapshot.
+func (s *darwinScanner) Close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.handle == nil {
+		return
+	}
+	C.wendy_blescan_stop(s.handle)
+	s.handle = nil
+}
+
+// splitList parses the comma-separated service UUID list the Objective-C bridge
+// produces, dropping empty entries. A C array of strings would need a second
+// allocation and free per device for no real gain.
+func splitList(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/go/internal/shared/ble/scan/scan_darwin.h
+++ b/go/internal/shared/ble/scan/scan_darwin.h
@@ -1,0 +1,57 @@
+// CoreBluetooth scanning bridge for internal/shared/ble/scan.
+//
+// Symbol naming is not free here: three cgo BLE translation units link into one
+// wendy binary — this one, internal/shared/ble/central/ble_darwin.m
+// (wendy_ble_connect and friends, class WendyBLEConnection) and
+// internal/shared/discovery/bluetooth_darwin.m (wendy_ble_scan/_check/
+// _free_result, class WendyBLEScanner). Objective-C class names are
+// process-global and a duplicate makes the runtime pick one arbitrarily, so
+// everything here is prefixed wendy_blescan_ and the class is
+// WendyBLEScanSession.
+#ifndef BLE_SCAN_DARWIN_H
+#define BLE_SCAN_DARWIN_H
+
+#include <stdint.h>
+
+// Opaque handle to a running scan session.
+typedef void *WendyBLEScanHandle;
+
+// WendyBLEScanDeviceC is one discovered peripheral.
+typedef struct {
+    const char *address;       // CoreBluetooth peripheral identifier UUID string
+    const char *name;          // advertised local name, or "" when unknown
+    const char *service_uuids; // comma-separated advertised service UUIDs, or ""
+    int rssi;                  // signal strength in dBm
+} WendyBLEScanDeviceC;
+
+// WendyBLEScanSnapshot is the set of peripherals seen so far this session.
+typedef struct {
+    WendyBLEScanDeviceC *devices;
+    int count;
+    const char *error; // NULL when fine, otherwise a message
+} WendyBLEScanSnapshot;
+
+// wendy_blescan_check tests whether CoreBluetooth is usable. Returns 0 when BLE
+// is available, 1 when denied, restricted or absent. May SIGABRT in a sandboxed
+// terminal, so callers run it in a subprocess.
+int wendy_blescan_check(void);
+
+// wendy_blescan_start begins an open-ended scan for every advertising
+// peripheral, waiting up to ready_timeout_seconds for the adapter to power on.
+// Returns NULL when BLE is unavailable. Filtering by service UUID is left to
+// the caller: CoreBluetooth's own service filter drops peripherals whose
+// advertisement omits the UUID, which is exactly the case a name-based fallback
+// exists to catch.
+WendyBLEScanHandle wendy_blescan_start(int ready_timeout_seconds);
+
+// wendy_blescan_snapshot copies out everything seen so far. The caller must
+// release it with wendy_blescan_free_snapshot.
+WendyBLEScanSnapshot wendy_blescan_snapshot(WendyBLEScanHandle handle);
+
+// wendy_blescan_free_snapshot frees a snapshot's strings and device array.
+void wendy_blescan_free_snapshot(WendyBLEScanSnapshot snapshot);
+
+// wendy_blescan_stop stops scanning and releases the session.
+void wendy_blescan_stop(WendyBLEScanHandle handle);
+
+#endif

--- a/go/internal/shared/ble/scan/scan_darwin.m
+++ b/go/internal/shared/ble/scan/scan_darwin.m
@@ -1,0 +1,238 @@
+#import <CoreBluetooth/CoreBluetooth.h>
+#import <Foundation/Foundation.h>
+#include <stdlib.h>
+#include <string.h>
+#include "scan_darwin.h"
+
+// ── WendyBLEScanSession ─────────────────────────────────────────────
+// A long-lived CoreBluetooth scan. Unlike the one-shot scanner in
+// shared/discovery, this keeps scanning until stopped and lets Go sample the
+// accumulated set whenever it likes, so there is no cgo->Go callback and
+// nothing ever calls into Go from a CoreBluetooth thread.
+
+@interface WendyBLEScanSession : NSObject <CBCentralManagerDelegate>
+
+@property (nonatomic, strong) CBCentralManager *centralManager;
+@property (nonatomic, strong) dispatch_queue_t bleQueue;
+// discovered maps peripheral UUID string -> device dictionary. Guarded by
+// discoveredLock: the delegate writes it on bleQueue while Go reads it from
+// whatever goroutine calls snapshot.
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSDictionary *> *discovered;
+@property (nonatomic, strong) NSLock *discoveredLock;
+@property (nonatomic) dispatch_semaphore_t readySem;
+@property (nonatomic) BOOL isReady;
+@property (nonatomic) BOOL scanning;
+
+@end
+
+@implementation WendyBLEScanSession
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _discovered = [NSMutableDictionary new];
+        _discoveredLock = [[NSLock alloc] init];
+        _readySem = dispatch_semaphore_create(0);
+        _isReady = NO;
+        _scanning = NO;
+        _bleQueue = dispatch_queue_create("sh.wendy.ble.scan.session", DISPATCH_QUEUE_SERIAL);
+        _centralManager = [[CBCentralManager alloc] initWithDelegate:self
+                                                               queue:_bleQueue
+                                                             options:nil];
+    }
+    return self;
+}
+
+#pragma mark - CBCentralManagerDelegate
+
+- (void)centralManagerDidUpdateState:(CBCentralManager *)central {
+    switch (central.state) {
+        case CBManagerStatePoweredOn:
+            self.isReady = YES;
+            dispatch_semaphore_signal(self.readySem);
+            break;
+        case CBManagerStatePoweredOff:
+        case CBManagerStateUnauthorized:
+        case CBManagerStateUnsupported:
+            // Bluetooth not usable — unblock the caller rather than hang.
+            dispatch_semaphore_signal(self.readySem);
+            break;
+        default:
+            // Resetting / unknown — keep waiting.
+            break;
+    }
+}
+
+- (void)centralManager:(CBCentralManager *)central
+ didDiscoverPeripheral:(CBPeripheral *)peripheral
+     advertisementData:(NSDictionary<NSString *, id> *)advertisementData
+                  RSSI:(NSNumber *)RSSI {
+
+    NSString *address = peripheral.identifier.UUIDString;
+    if (address.length == 0) {
+        return;
+    }
+
+    // The advertised local name is the live value; peripheral.name is
+    // CoreBluetooth's cache (the GATT device name once the OS has connected)
+    // and may be stale, so it is only a fallback.
+    NSString *name = advertisementData[CBAdvertisementDataLocalNameKey];
+    if (name.length == 0) {
+        name = peripheral.name;
+    }
+    if (name == nil) {
+        name = @"";
+    }
+
+    // CBUUID.UUIDString gives four hex characters for a 16-bit UUID and full
+    // 128-bit form otherwise. Go's CanonicalUUID normalizes both.
+    NSArray<CBUUID *> *serviceUUIDs = advertisementData[CBAdvertisementDataServiceUUIDsKey];
+    NSMutableArray<NSString *> *uuidStrings = [NSMutableArray arrayWithCapacity:serviceUUIDs.count];
+    for (CBUUID *svc in serviceUUIDs) {
+        NSString *s = svc.UUIDString;
+        if (s.length > 0) {
+            [uuidStrings addObject:s];
+        }
+    }
+    NSString *joined = [uuidStrings componentsJoinedByString:@","];
+
+    [self.discoveredLock lock];
+    NSDictionary *existing = self.discovered[address];
+    // Preserve fields a later, sparser advertisement omits: a device may
+    // advertise its name and its service UUIDs in different packets.
+    if (existing) {
+        if (name.length == 0) {
+            name = existing[@"name"];
+        }
+        if (joined.length == 0) {
+            joined = existing[@"service_uuids"];
+        }
+    }
+    self.discovered[address] = @{
+        @"name": name ?: @"",
+        @"service_uuids": joined ?: @"",
+        @"rssi": RSSI ?: @0,
+    };
+    [self.discoveredLock unlock];
+}
+
+#pragma mark - Session control
+
+- (void)waitForReady:(int)timeoutSeconds {
+    dispatch_semaphore_wait(self.readySem,
+        dispatch_time(DISPATCH_TIME_NOW, (int64_t)timeoutSeconds * NSEC_PER_SEC));
+}
+
+- (void)startScanning {
+    // AllowDuplicates YES so RSSI and late-arriving advertisement fields keep
+    // refreshing for the whole session; the one-shot scanner in
+    // shared/discovery passes NO because it only needs each device once.
+    // Services nil so nothing is filtered out here — see scan_darwin.h.
+    dispatch_async(self.bleQueue, ^{
+        [self.centralManager scanForPeripheralsWithServices:nil options:@{
+            CBCentralManagerScanOptionAllowDuplicatesKey: @YES
+        }];
+    });
+    self.scanning = YES;
+}
+
+- (void)stopScanning {
+    if (!self.scanning) {
+        return;
+    }
+    self.scanning = NO;
+    // Synchronous so the delegate is quiet before the session is released.
+    dispatch_sync(self.bleQueue, ^{
+        [self.centralManager stopScan];
+    });
+}
+
+- (WendyBLEScanSnapshot)buildSnapshot {
+    [self.discoveredLock lock];
+    NSArray<NSString *> *addresses = [self.discovered allKeys];
+    int count = (int)addresses.count;
+    if (count == 0) {
+        [self.discoveredLock unlock];
+        return (WendyBLEScanSnapshot){NULL, 0, NULL};
+    }
+
+    WendyBLEScanDeviceC *devices = (WendyBLEScanDeviceC *)calloc(count, sizeof(WendyBLEScanDeviceC));
+    if (devices == NULL) {
+        [self.discoveredLock unlock];
+        return (WendyBLEScanSnapshot){NULL, 0, strdup("out of memory building BLE scan snapshot")};
+    }
+    for (int i = 0; i < count; i++) {
+        NSString *address = addresses[i];
+        NSDictionary *d = self.discovered[address];
+        devices[i].address = strdup([address UTF8String]);
+        devices[i].name = strdup([(d[@"name"] ?: @"") UTF8String]);
+        devices[i].service_uuids = strdup([(d[@"service_uuids"] ?: @"") UTF8String]);
+        devices[i].rssi = [d[@"rssi"] intValue];
+    }
+    [self.discoveredLock unlock];
+
+    return (WendyBLEScanSnapshot){devices, count, NULL};
+}
+
+@end
+
+#pragma mark - C entry points
+
+int wendy_blescan_check(void) {
+    @autoreleasepool {
+        // A full session with a delegate, not just a manager: the abort from a
+        // sandboxed terminal happens asynchronously when CoreBluetooth reaches
+        // bluetoothd over XPC, so the state callback has to actually fire.
+        WendyBLEScanSession *session = [[WendyBLEScanSession alloc] init];
+        [session waitForReady:5];
+        return session.isReady ? 0 : 1;
+    }
+}
+
+WendyBLEScanHandle wendy_blescan_start(int ready_timeout_seconds) {
+    @autoreleasepool {
+        WendyBLEScanSession *session = [[WendyBLEScanSession alloc] init];
+        [session waitForReady:ready_timeout_seconds];
+        if (!session.isReady) {
+            return NULL;
+        }
+        [session startScanning];
+        // Hand ARC's reference to the caller; wendy_blescan_stop takes it back.
+        return (WendyBLEScanHandle)CFBridgingRetain(session);
+    }
+}
+
+WendyBLEScanSnapshot wendy_blescan_snapshot(WendyBLEScanHandle handle) {
+    if (handle == NULL) {
+        return (WendyBLEScanSnapshot){NULL, 0, strdup("BLE scan session is not running")};
+    }
+    @autoreleasepool {
+        WendyBLEScanSession *session = (__bridge WendyBLEScanSession *)handle;
+        return [session buildSnapshot];
+    }
+}
+
+void wendy_blescan_free_snapshot(WendyBLEScanSnapshot snapshot) {
+    if (snapshot.error != NULL) {
+        free((void *)snapshot.error);
+    }
+    if (snapshot.devices == NULL) {
+        return;
+    }
+    for (int i = 0; i < snapshot.count; i++) {
+        free((void *)snapshot.devices[i].address);
+        free((void *)snapshot.devices[i].name);
+        free((void *)snapshot.devices[i].service_uuids);
+    }
+    free(snapshot.devices);
+}
+
+void wendy_blescan_stop(WendyBLEScanHandle handle) {
+    if (handle == NULL) {
+        return;
+    }
+    @autoreleasepool {
+        WendyBLEScanSession *session = (WendyBLEScanSession *)CFBridgingRelease(handle);
+        [session stopScanning];
+    }
+}

--- a/go/internal/shared/ble/scan/scan_linux.go
+++ b/go/internal/shared/ble/scan/scan_linux.go
@@ -1,0 +1,160 @@
+//go:build linux
+
+package scan
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/godbus/dbus/v5"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/ble/bluez"
+)
+
+// snapshotTimeout bounds a single GetManagedObjects round trip, matching the
+// D-Bus timeouts the sibling central package uses for BlueZ calls that can
+// hang (gattOpTimeout, stopDiscoveryTimeout). Without it, a wedged bluetoothd
+// would stall the sampling loop indefinitely even when the caller never
+// cancels — the loop calls Snapshot synchronously on every tick.
+const snapshotTimeout = 5 * time.Second
+
+// RunBLECheck is a no-op on Linux. The CoreBluetooth entitlement problem it
+// exists for is macOS-only, and BlueZ reports adapter trouble as an ordinary
+// error from newScanner instead of aborting the process.
+func RunBLECheck() int { return 0 }
+
+// linuxScanner holds a BlueZ discovery session. The D-Bus plumbing lives in
+// the sibling bluez package, which the central's GATT client shares.
+type linuxScanner struct {
+	mu          sync.Mutex
+	conn        *dbus.Conn
+	adapterPath string
+	closed      bool
+}
+
+// newScanner powers on an adapter and starts LE discovery, filtered to the
+// requested services where BlueZ can do it natively.
+func newScanner(ctx context.Context, services []string) (scanner, error) {
+	conn, err := dbus.ConnectSystemBus()
+	if err != nil {
+		return nil, fmt.Errorf("connecting to system bus: %w", err)
+	}
+
+	managed, err := bluez.GetManagedObjects(ctx, conn)
+	if err != nil {
+		conn.Close() //nolint:errcheck
+		return nil, err
+	}
+
+	adapterPath, err := bluez.ResolveAdapterPath(managed)
+	if err != nil {
+		conn.Close() //nolint:errcheck
+		return nil, err
+	}
+
+	if err := bluez.PowerOn(ctx, conn, adapterPath); err != nil {
+		conn.Close() //nolint:errcheck
+		return nil, fmt.Errorf("powering on adapter %s: %w", adapterPath, err)
+	}
+
+	adapter := conn.Object(bluez.Service, dbus.ObjectPath(adapterPath))
+
+	// Ask BlueZ to filter for us. Transport "le" keeps classic Bluetooth out,
+	// DuplicateData keeps advertisement fields refreshing rather than being
+	// reported once, and UUIDs is BlueZ's own service filter. The engine still
+	// matches in Go so behavior is identical on every platform.
+	filter := map[string]dbus.Variant{
+		"Transport":     dbus.MakeVariant("le"),
+		"DuplicateData": dbus.MakeVariant(true),
+	}
+	if len(services) > 0 {
+		filter["UUIDs"] = dbus.MakeVariant(services)
+	}
+	if call := adapter.CallWithContext(ctx, bluez.AdapterIface+".SetDiscoveryFilter", 0, filter); call.Err != nil {
+		// Not fatal: an older BlueZ may reject a key, and an unfiltered scan
+		// still produces correct results once the engine filters in Go.
+	}
+
+	if call := adapter.CallWithContext(ctx, bluez.AdapterIface+".StartDiscovery", 0); call.Err != nil {
+		conn.Close() //nolint:errcheck
+		return nil, fmt.Errorf("starting discovery on %s: %w", adapterPath, call.Err)
+	}
+
+	return &linuxScanner{conn: conn, adapterPath: adapterPath}, nil
+}
+
+// Snapshot re-reads the object tree. Device properties are read as typed D-Bus
+// values rather than parsed out of bluetoothctl's text output, which is what
+// makes service UUIDs and RSSI available at all.
+//
+// ctx is wrapped with snapshotTimeout rather than passed straight through: that
+// way both a caller cancellation and a bluetoothd that simply stops replying
+// unblock this call, instead of only the former.
+func (s *linuxScanner) Snapshot(ctx context.Context) ([]BLEDeviceInfo, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil, fmt.Errorf("BLE scan session is closed")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, snapshotTimeout)
+	defer cancel()
+	managed, err := bluez.GetManagedObjects(ctx, s.conn)
+	if err != nil {
+		return nil, err
+	}
+
+	// Device objects are nested under the adapter, e.g.
+	// /org/bluez/hci0/dev_XX_XX_XX_XX_XX_XX.
+	prefix := s.adapterPath + "/"
+	var devices []BLEDeviceInfo
+	for path, ifaces := range managed {
+		props, ok := ifaces[bluez.DeviceIface]
+		if !ok || !strings.HasPrefix(string(path), prefix) {
+			continue
+		}
+		address, ok := bluez.StringProp(props, "Address")
+		if !ok || address == "" {
+			continue
+		}
+		devices = append(devices, BLEDeviceInfo{
+			Address:      address,
+			Name:         deviceName(props, address),
+			ServiceUUIDs: bluez.StringsProp(props, "UUIDs"),
+			RSSI:         bluez.RSSIProp(props),
+		})
+	}
+	return devices, nil
+}
+
+// Close stops discovery and drops the bus connection. Idempotent.
+func (s *linuxScanner) Close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return
+	}
+	s.closed = true
+
+	adapter := s.conn.Object(bluez.Service, dbus.ObjectPath(s.adapterPath))
+	// Best-effort: the adapter may already have gone away.
+	_ = adapter.Call(bluez.AdapterIface+".StopDiscovery", 0).Err
+	s.conn.Close() //nolint:errcheck
+}
+
+// deviceName resolves the display name. Alias is the user-facing value and
+// falls back to Name, but BlueZ synthesizes an Alias for devices advertising no
+// name, which must not count as a name or every anonymous device would appear
+// named.
+func deviceName(props map[string]dbus.Variant, address string) string {
+	if alias, ok := bluez.StringProp(props, "Alias"); ok && alias != "" && !bluez.IsDefaultAlias(alias, address) {
+		return alias
+	}
+	if name, ok := bluez.StringProp(props, "Name"); ok {
+		return name
+	}
+	return ""
+}

--- a/go/internal/shared/ble/scan/scan_test.go
+++ b/go/internal/shared/ble/scan/scan_test.go
@@ -1,0 +1,487 @@
+package scan
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeScanner is a scanner whose readings the test controls. It stands in for a
+// real radio via the newScannerFn seam.
+type fakeScanner struct {
+	mu       sync.Mutex
+	readings [][]BLEDeviceInfo
+	err      error
+	// errWithLastReading, if set, is returned alongside the final configured
+	// reading instead of nil — simulating a backend that reports something new
+	// in the very call that it reports a fatal error, the way windowsScanner's
+	// accumulated map can.
+	errWithLastReading error
+	calls              int
+	closed             bool
+}
+
+// Snapshot returns each queued reading in turn, then repeats the last one — a
+// real backend keeps reporting what it can see, it does not run out.
+func (f *fakeScanner) Snapshot(_ context.Context) ([]BLEDeviceInfo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	if len(f.readings) == 0 {
+		return nil, nil
+	}
+	if f.calls-1 < len(f.readings)-1 {
+		return f.readings[f.calls-1], nil
+	}
+	return f.readings[len(f.readings)-1], f.errWithLastReading
+}
+
+func (f *fakeScanner) Close() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closed = true
+}
+
+func (f *fakeScanner) isClosed() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.closed
+}
+
+// withFakeScanner installs f as the backend for the duration of the test.
+func withFakeScanner(t *testing.T, f *fakeScanner) {
+	t.Helper()
+	orig := newScannerFn
+	newScannerFn = func(context.Context, []string) (scanner, error) { return f, nil }
+	t.Cleanup(func() { newScannerFn = orig })
+}
+
+// testInterval keeps the tests fast; the engine samples on this cadence.
+const testInterval = 5 * time.Millisecond
+
+// recv reads one emit with a generous timeout so a slow CI machine does not
+// produce a flake.
+func recv(t *testing.T, ch <-chan []BLEDeviceInfo) []BLEDeviceInfo {
+	t.Helper()
+	select {
+	case devices, ok := <-ch:
+		if !ok {
+			t.Fatal("channel closed while awaiting an emit")
+		}
+		return devices
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out awaiting an emit")
+		return nil
+	}
+}
+
+func TestDiscoverEmitsFirstReadingImmediately(t *testing.T) {
+	withFakeScanner(t, &fakeScanner{readings: [][]BLEDeviceInfo{
+		{{Address: "AA:BB:CC:DD:EE:FF", Name: "one", RSSI: -50}},
+	}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch, err := DiscoverBluetoothContinuous(ctx, Options{Interval: time.Hour})
+	if err != nil {
+		t.Fatalf("DiscoverBluetoothContinuous: %v", err)
+	}
+
+	// Interval is an hour, so anything received proves the up-front sample
+	// happened rather than the first tick.
+	got := recv(t, ch)
+	if len(got) != 1 || got[0].Name != "one" {
+		t.Fatalf("first emit = %+v, want the single device", got)
+	}
+}
+
+func TestDiscoverSortsByRSSIDescending(t *testing.T) {
+	withFakeScanner(t, &fakeScanner{readings: [][]BLEDeviceInfo{{
+		{Address: "03", Name: "weak", RSSI: -90},
+		{Address: "01", Name: "strong", RSSI: -30},
+		{Address: "02", Name: "middle", RSSI: -60},
+	}}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch, err := DiscoverBluetoothContinuous(ctx, Options{Interval: time.Hour})
+	if err != nil {
+		t.Fatalf("DiscoverBluetoothContinuous: %v", err)
+	}
+
+	got := recv(t, ch)
+	want := []string{"strong", "middle", "weak"}
+	names := make([]string, len(got))
+	for i, d := range got {
+		names[i] = d.Name
+	}
+	if !reflect.DeepEqual(names, want) {
+		t.Errorf("emit order = %v, want %v (strongest first)", names, want)
+	}
+}
+
+func TestDiscoverAccumulatesAndNeverRemoves(t *testing.T) {
+	// The second reading drops the first device entirely, as BlueZ does when it
+	// evicts a stale entry. It must still appear.
+	withFakeScanner(t, &fakeScanner{readings: [][]BLEDeviceInfo{
+		{{Address: "01", Name: "first", RSSI: -50}},
+		{{Address: "02", Name: "second", RSSI: -40}},
+	}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch, err := DiscoverBluetoothContinuous(ctx, Options{Interval: testInterval})
+	if err != nil {
+		t.Fatalf("DiscoverBluetoothContinuous: %v", err)
+	}
+
+	// Read until both devices are present, or time out.
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case got, ok := <-ch:
+			if !ok {
+				t.Fatal("channel closed before both devices appeared")
+			}
+			if len(got) == 2 {
+				names := map[string]bool{got[0].Name: true, got[1].Name: true}
+				if !names["first"] || !names["second"] {
+					t.Fatalf("emit = %+v, want both first and second", got)
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for both devices to accumulate")
+		}
+	}
+}
+
+func TestDiscoverPreservesFieldsASparseSightingOmits(t *testing.T) {
+	// A device commonly splits its name and its service UUIDs across the
+	// advertisement and the scan response, so a later reading may carry only
+	// a refreshed RSSI.
+	withFakeScanner(t, &fakeScanner{readings: [][]BLEDeviceInfo{
+		{{Address: "01", Name: "named", ServiceUUIDs: []string{"180F"}, RSSI: -50}},
+		{{Address: "01", RSSI: -55}},
+	}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch, err := DiscoverBluetoothContinuous(ctx, Options{Interval: testInterval})
+	if err != nil {
+		t.Fatalf("DiscoverBluetoothContinuous: %v", err)
+	}
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case got, ok := <-ch:
+			if !ok {
+				t.Fatal("channel closed before the RSSI update arrived")
+			}
+			if len(got) != 1 {
+				t.Fatalf("emit = %+v, want one device", got)
+			}
+			if got[0].RSSI != -55 {
+				continue // not yet the second reading
+			}
+			if got[0].Name != "named" {
+				t.Errorf("Name = %q after a sparse sighting, want it preserved", got[0].Name)
+			}
+			if len(got[0].ServiceUUIDs) != 1 {
+				t.Errorf("ServiceUUIDs = %v after a sparse sighting, want them preserved", got[0].ServiceUUIDs)
+			}
+			return
+		case <-deadline:
+			t.Fatal("timed out waiting for the RSSI update")
+		}
+	}
+}
+
+func TestDiscoverFiltersByService(t *testing.T) {
+	wanted := "7565e9eb-4c20-4b67-9272-d708b397b631"
+	withFakeScanner(t, &fakeScanner{readings: [][]BLEDeviceInfo{{
+		{Address: "01", Name: "wanted", ServiceUUIDs: []string{wanted}, RSSI: -50},
+		{Address: "02", Name: "other", ServiceUUIDs: []string{"180F"}, RSSI: -40},
+		{Address: "03", Name: "silent", RSSI: -30},
+	}}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Filter given in a different case and spelling than the device reports, to
+	// prove canonicalization runs on both sides.
+	ch, err := DiscoverBluetoothContinuous(ctx, Options{
+		Services: []string{"7565E9EB-4C20-4B67-9272-D708B397B631"},
+		Interval: time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("DiscoverBluetoothContinuous: %v", err)
+	}
+
+	got := recv(t, ch)
+	if len(got) != 1 || got[0].Name != "wanted" {
+		t.Fatalf("emit = %+v, want only the device advertising the wanted service", got)
+	}
+	if got[0].ServiceUUIDs[0] != CanonicalUUID(wanted) {
+		t.Errorf("ServiceUUIDs = %v, want canonicalized", got[0].ServiceUUIDs)
+	}
+}
+
+func TestDiscoverEmptyServicesReportsEverything(t *testing.T) {
+	withFakeScanner(t, &fakeScanner{readings: [][]BLEDeviceInfo{{
+		{Address: "01", ServiceUUIDs: []string{"180F"}, RSSI: -50},
+		{Address: "02", RSSI: -40},
+	}}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch, err := DiscoverBluetoothContinuous(ctx, Options{Interval: time.Hour})
+	if err != nil {
+		t.Fatalf("DiscoverBluetoothContinuous: %v", err)
+	}
+
+	if got := recv(t, ch); len(got) != 2 {
+		t.Fatalf("emit = %+v, want both devices when no filter is set", got)
+	}
+}
+
+func TestDiscoverSkipsAddresslessDevices(t *testing.T) {
+	withFakeScanner(t, &fakeScanner{readings: [][]BLEDeviceInfo{{
+		{Address: "", Name: "no address", RSSI: -50},
+		{Address: "01", Name: "fine", RSSI: -40},
+	}}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch, err := DiscoverBluetoothContinuous(ctx, Options{Interval: time.Hour})
+	if err != nil {
+		t.Fatalf("DiscoverBluetoothContinuous: %v", err)
+	}
+
+	got := recv(t, ch)
+	if len(got) != 1 || got[0].Name != "fine" {
+		t.Fatalf("emit = %+v, want only the addressed device", got)
+	}
+}
+
+// TestDiscoverDoesNotReemitUnchangedSet is the coalescing guarantee: without it
+// an unchanging device would push an emit on every single tick.
+func TestDiscoverDoesNotReemitUnchangedSet(t *testing.T) {
+	withFakeScanner(t, &fakeScanner{readings: [][]BLEDeviceInfo{
+		{{Address: "01", Name: "steady", RSSI: -50}},
+	}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch, err := DiscoverBluetoothContinuous(ctx, Options{Interval: testInterval})
+	if err != nil {
+		t.Fatalf("DiscoverBluetoothContinuous: %v", err)
+	}
+
+	recv(t, ch) // the initial emit
+
+	// Many ticks pass with an identical reading; nothing more should arrive.
+	select {
+	case got, ok := <-ch:
+		if ok {
+			t.Fatalf("re-emitted an unchanged set: %+v", got)
+		}
+		t.Fatal("channel closed unexpectedly")
+	case <-time.After(20 * testInterval):
+	}
+}
+
+func TestDiscoverStopsAndClosesBackendOnCancel(t *testing.T) {
+	fake := &fakeScanner{readings: [][]BLEDeviceInfo{
+		{{Address: "01", Name: "one", RSSI: -50}},
+	}}
+	withFakeScanner(t, fake)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch, err := DiscoverBluetoothContinuous(ctx, Options{Interval: testInterval})
+	if err != nil {
+		t.Fatalf("DiscoverBluetoothContinuous: %v", err)
+	}
+	recv(t, ch)
+
+	cancel()
+
+	// Draining to closure proves the goroutine returned.
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				if !fake.isClosed() {
+					t.Error("backend was not closed when the stream ended")
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("channel was not closed after ctx cancellation")
+		}
+	}
+}
+
+func TestDiscoverEndsStreamOnBackendError(t *testing.T) {
+	withFakeScanner(t, &fakeScanner{err: errors.New("adapter went away")})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch, err := DiscoverBluetoothContinuous(ctx, Options{Interval: testInterval})
+	if err != nil {
+		t.Fatalf("DiscoverBluetoothContinuous: %v", err)
+	}
+
+	select {
+	case got, ok := <-ch:
+		if ok {
+			t.Fatalf("emitted %+v despite a failing backend", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream did not end when the backend failed")
+	}
+}
+
+// TestDiscoverFlushesFinalReadingBeforeEndingOnBackendError guards the fix for
+// a backend (windowsScanner) that can report a newly-seen device in the very
+// same call that it reports the fatal error which ends the backend for good.
+// That device must still reach the consumer before the stream closes.
+func TestDiscoverFlushesFinalReadingBeforeEndingOnBackendError(t *testing.T) {
+	fake := &fakeScanner{
+		readings: [][]BLEDeviceInfo{
+			{{Address: "01", Name: "first", RSSI: -50}},
+			{{Address: "01", Name: "first", RSSI: -50}, {Address: "02", Name: "second", RSSI: -40}},
+		},
+		errWithLastReading: errors.New("watcher died"),
+	}
+	withFakeScanner(t, fake)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch, err := DiscoverBluetoothContinuous(ctx, Options{Interval: testInterval})
+	if err != nil {
+		t.Fatalf("DiscoverBluetoothContinuous: %v", err)
+	}
+
+	recv(t, ch) // the first reading, no error yet
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case got, ok := <-ch:
+			if !ok {
+				t.Fatal("channel closed before the final reading was flushed")
+			}
+			if len(got) != 2 {
+				continue // not yet the reading paired with the error
+			}
+			select {
+			case _, ok := <-ch:
+				if ok {
+					t.Fatal("stream kept emitting after a fatal backend error")
+				}
+				return
+			case <-time.After(2 * time.Second):
+				t.Fatal("stream did not end after the fatal backend error")
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for the final reading to be flushed")
+		}
+	}
+}
+
+func TestDiscoverPreflightFailureIsReturned(t *testing.T) {
+	fake := &fakeScanner{}
+	withFakeScanner(t, fake)
+
+	want := errors.New("Bluetooth unavailable")
+	_, err := DiscoverBluetoothContinuous(context.Background(), Options{
+		Preflight: func(context.Context) error { return want },
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("error = %v, want %v", err, want)
+	}
+	if fake.isClosed() {
+		t.Error("backend was opened despite Preflight failing")
+	}
+}
+
+func TestDiscoverDefaultsInterval(t *testing.T) {
+	// A zero Interval must not mean "tick as fast as possible", which would
+	// spin a core; it means DefaultInterval.
+	withFakeScanner(t, &fakeScanner{readings: [][]BLEDeviceInfo{
+		{{Address: "01", Name: "one", RSSI: -50}},
+	}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch, err := DiscoverBluetoothContinuous(ctx, Options{})
+	if err != nil {
+		t.Fatalf("DiscoverBluetoothContinuous: %v", err)
+	}
+	// The up-front sample is unconditional, so this arrives without waiting a
+	// full DefaultInterval.
+	if got := recv(t, ch); len(got) != 1 {
+		t.Fatalf("emit = %+v, want one device", got)
+	}
+}
+
+func TestDeviceStoreMergeReportsChange(t *testing.T) {
+	store := newDeviceStore()
+
+	if !store.merge(BLEDeviceInfo{Address: "01", Name: "a", RSSI: -50}) {
+		t.Fatal("first sighting reported no change")
+	}
+	if store.merge(BLEDeviceInfo{Address: "01", Name: "a", RSSI: -50}) {
+		t.Error("identical sighting reported a change")
+	}
+	if !store.merge(BLEDeviceInfo{Address: "01", Name: "a", RSSI: -60}) {
+		t.Error("changed RSSI reported no change")
+	}
+	if !store.merge(BLEDeviceInfo{Address: "01", Name: "b", RSSI: -60}) {
+		t.Error("changed name reported no change")
+	}
+	if store.merge(BLEDeviceInfo{Address: "01"}) {
+		t.Error("empty sighting reported a change")
+	}
+
+	got := store.snapshot()
+	if len(got) != 1 || got[0].Name != "b" || got[0].RSSI != -60 {
+		t.Errorf("snapshot = %+v, want the merged latest values", got)
+	}
+}
+
+// TestDeviceStoreSnapshotIsStable guards the tiebreak: without it, equal-RSSI
+// devices would reorder between emits because Go randomizes map iteration, and
+// a picker would visibly shuffle.
+func TestDeviceStoreSnapshotIsStable(t *testing.T) {
+	store := newDeviceStore()
+	for _, addr := range []string{"03", "01", "04", "02"} {
+		store.merge(BLEDeviceInfo{Address: addr, RSSI: -50})
+	}
+
+	first := store.snapshot()
+	for i := 0; i < 20; i++ {
+		if got := store.snapshot(); !reflect.DeepEqual(got, first) {
+			t.Fatalf("snapshot %d = %+v, want the stable order %+v", i, got, first)
+		}
+	}
+}

--- a/go/internal/shared/ble/scan/scan_windows.go
+++ b/go/internal/shared/ble/scan/scan_windows.go
@@ -1,0 +1,251 @@
+//go:build windows
+
+package scan
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/env"
+)
+
+// RunBLECheck is a no-op on Windows. The CoreBluetooth entitlement problem it
+// exists for is macOS-only; here an unavailable radio surfaces as an ordinary
+// error from newScanner.
+func RunBLECheck() int { return 0 }
+
+// watcherScript drives a WinRT BluetoothLEAdvertisementWatcher from Windows
+// PowerShell 5.1 and prints one JSON object per sighting to stdout.
+//
+// PowerShell 5.1 specifically: it is the WinRT-projecting host, so
+// [Type, Assembly, ContentType=WindowsRuntime] resolves. PowerShell 7 dropped
+// that projection. env.PowershellExe resolves WindowsPowerShell\v1.0, which is
+// exactly 5.1.
+//
+// Events are queued with Register-ObjectEvent and drained by the main loop
+// rather than printed from an -Action block: an action scriptblock runs in its
+// own runspace and its output does not reach the parent's stdout, which is the
+// classic way this pattern fails.
+//
+// %s is replaced by the service-UUID filter setup.
+const watcherScript = `
+$ErrorActionPreference = 'Stop'
+try {
+    $watcher = New-Object 'Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementWatcher, Windows, ContentType=WindowsRuntime'
+    # Active scanning solicits scan responses, where devices commonly put the
+    # local name and the full service UUID list.
+    $watcher.ScanningMode = [Windows.Devices.Bluetooth.Advertisement.BluetoothLEScanningMode, Windows, ContentType=WindowsRuntime]::Active
+%s
+    Register-ObjectEvent -InputObject $watcher -EventName Received -SourceIdentifier BLESighting | Out-Null
+    $watcher.Start()
+
+    while ($true) {
+        $events = @(Get-Event -SourceIdentifier BLESighting -ErrorAction SilentlyContinue)
+        foreach ($e in $events) {
+            Remove-Event -EventIdentifier $e.EventIdentifier -ErrorAction SilentlyContinue
+            $args0 = $e.SourceArgs[1]
+            if ($null -eq $args0) { continue }
+            $uuids = @()
+            foreach ($u in $args0.Advertisement.ServiceUuids) { $uuids += $u.ToString() }
+            $record = [ordered]@{
+                address = ('{0:X12}' -f $args0.BluetoothAddress)
+                name    = [string]$args0.Advertisement.LocalName
+                uuids   = $uuids
+                rssi    = [int]$args0.RawSignalStrengthInDBm
+            }
+            Write-Output ($record | ConvertTo-Json -Compress -Depth 3)
+        }
+        [Console]::Out.Flush()
+        Start-Sleep -Milliseconds 200
+    }
+} catch {
+    [Console]::Error.WriteLine($_.Exception.Message)
+    exit 1
+}
+`
+
+// buildWatcherScript fills in the service filter. WinRT wants full 128-bit
+// GUIDs, which is what the engine's canonicalization already produces.
+func buildWatcherScript(services []string) string {
+	if len(services) == 0 {
+		return fmt.Sprintf(watcherScript, "")
+	}
+	var b strings.Builder
+	for _, svc := range services {
+		// Only canonical 36-character UUIDs are accepted; anything else would
+		// make [Guid] throw and kill the whole scan for one bad entry.
+		if len(svc) != 36 {
+			continue
+		}
+		fmt.Fprintf(&b, "    $watcher.AdvertisementFilter.Advertisement.ServiceUuids.Add([Guid]'%s')\n", svc)
+	}
+	return fmt.Sprintf(watcherScript, b.String())
+}
+
+// windowsScanner holds the PowerShell watcher process and the sightings read
+// from it so far.
+type windowsScanner struct {
+	cmd    *exec.Cmd
+	cancel context.CancelFunc
+
+	mu        sync.Mutex
+	devices   map[string]BLEDeviceInfo
+	readErr   error
+	closeOnce sync.Once
+}
+
+// newScanner starts one long-lived PowerShell watcher for the whole session.
+// Re-invoking it per sample would be far too slow — process start plus WinRT
+// projection is on the order of a second.
+func newScanner(ctx context.Context, services []string) (scanner, error) {
+	// A child context, so Close stops the process even when the caller's ctx
+	// outlives the scan.
+	scanCtx, cancel := context.WithCancel(ctx)
+
+	cmd := exec.CommandContext(scanCtx, env.PowershellExe(),
+		"-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
+		"-Command", buildWatcherScript(services))
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("opening PowerShell stdout: %w", err)
+	}
+	// Drained concurrently with stdout: PowerShell writing a long error would
+	// otherwise fill the stderr pipe and block the process.
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("opening PowerShell stderr: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, fmt.Errorf("starting PowerShell BLE watcher: %w", err)
+	}
+
+	s := &windowsScanner{
+		cmd:     cmd,
+		cancel:  cancel,
+		devices: make(map[string]BLEDeviceInfo),
+	}
+
+	// cmd.Wait must not run until both pipe readers are done — exec closes the
+	// pipes underneath them otherwise, which is a documented race. So the two
+	// readers are tracked and reaped by a third goroutine.
+	var readers sync.WaitGroup
+	readers.Add(2)
+	go func() {
+		defer readers.Done()
+		s.readLoop(stdout)
+	}()
+	go func() {
+		defer readers.Done()
+		s.drainStderr(stderr)
+	}()
+	go func() {
+		readers.Wait()
+		s.reap(s.cmd.Wait())
+	}()
+
+	return s, nil
+}
+
+// readLoop folds stdout lines into the device map until the pipe closes.
+func (s *windowsScanner) readLoop(stdout io.ReadCloser) {
+	scanner := bufio.NewScanner(stdout)
+	// A sighting line is small, but a device advertising many UUIDs plus a long
+	// name can exceed bufio's default 64 KiB ceiling on a pathological record.
+	scanner.Buffer(make([]byte, 0, 4096), 256*1024)
+
+	for scanner.Scan() {
+		dev, ok := parseWinRTLine(scanner.Text())
+		if !ok {
+			continue
+		}
+		s.mu.Lock()
+		s.devices[dev.Address] = dev
+		s.mu.Unlock()
+	}
+
+	// Scan stops on a clean EOF (Err() == nil) when Close kills the process —
+	// expected, nothing to report. Any other Err() (a pipe I/O error, or
+	// bufio.ErrTooLong from a pathologically long line) means stdout has
+	// stopped being drained while the process may still be running and
+	// writing: left alone it will eventually block on a full pipe. Cancel it
+	// so it can't leak, and record why.
+	if err := scanner.Err(); err != nil {
+		s.setReadErr(fmt.Errorf("PowerShell BLE watcher stdout: %w", err))
+		s.cancel()
+	}
+}
+
+// setReadErr records the first fatal error, ignoring later ones so the
+// original cause of failure is preserved.
+func (s *windowsScanner) setReadErr(err error) {
+	s.mu.Lock()
+	if s.readErr == nil {
+		s.readErr = err
+	}
+	s.mu.Unlock()
+}
+
+// reap records that PowerShell exited. The watcher is meant to run until Close
+// kills it, so an exit on its own has to end the stream rather than leave
+// Snapshot returning a frozen set forever. A Close-initiated kill also lands
+// here, which is harmless: the engine has already stopped sampling by then.
+func (s *windowsScanner) reap(err error) {
+	if err != nil {
+		s.setReadErr(fmt.Errorf("PowerShell BLE watcher exited: %w", err))
+		return
+	}
+	s.setReadErr(fmt.Errorf("PowerShell BLE watcher exited unexpectedly"))
+}
+
+// drainStderr keeps the stderr pipe empty and captures the first line, which is
+// the message the script's catch block prints.
+func (s *windowsScanner) drainStderr(stderr io.ReadCloser) {
+	sc := bufio.NewScanner(stderr)
+	first := ""
+	for sc.Scan() {
+		if line := strings.TrimSpace(sc.Text()); line != "" && first == "" {
+			first = line
+		}
+	}
+	if first == "" {
+		return
+	}
+	s.setReadErr(fmt.Errorf("PowerShell BLE watcher: %s", first))
+}
+
+// Snapshot ignores ctx: it reads in-memory state a background PowerShell
+// watcher already populated, so there is nothing here that can hang.
+//
+// Devices and a fatal readErr are returned together rather than favoring one
+// or the other — sample in scan.go merges and emits whatever is here before
+// honoring a non-nil error, so nothing found right up to the moment the
+// watcher died is lost.
+func (s *windowsScanner) Snapshot(_ context.Context) ([]BLEDeviceInfo, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	out := make([]BLEDeviceInfo, 0, len(s.devices))
+	for _, d := range s.devices {
+		out = append(out, d)
+	}
+	return out, s.readErr
+}
+
+// Close stops the watcher process. Idempotent.
+func (s *windowsScanner) Close() {
+	s.closeOnce.Do(func() {
+		// Cancelling the command context kills PowerShell, which ends readLoop
+		// and drainStderr by closing their pipes.
+		s.cancel()
+	})
+}

--- a/go/internal/shared/ble/scan/scan_windows_test.go
+++ b/go/internal/shared/ble/scan/scan_windows_test.go
@@ -1,0 +1,134 @@
+//go:build windows
+
+package scan
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+)
+
+// errAfterReader plays back data, then returns err on every subsequent Read
+// instead of the io.EOF a real closed pipe would produce — standing in for a
+// stdout pipe that fails mid-stream.
+type errAfterReader struct {
+	data []byte
+	err  error
+}
+
+func (r *errAfterReader) Read(p []byte) (int, error) {
+	if len(r.data) == 0 {
+		return 0, r.err
+	}
+	n := copy(p, r.data)
+	r.data = r.data[n:]
+	return n, nil
+}
+
+func (r *errAfterReader) Close() error { return nil }
+
+// newTestScanner builds a windowsScanner bypassing newScanner/exec.Cmd, so
+// readLoop can be exercised directly against a fake pipe. cancel records
+// whether it was invoked.
+func newTestScanner() (s *windowsScanner, canceled *bool) {
+	canceled = new(bool)
+	s = &windowsScanner{
+		devices: make(map[string]BLEDeviceInfo),
+		cancel:  func() { *canceled = true },
+	}
+	return s, canceled
+}
+
+func TestReadLoopRecordsRealErrorAndCancels(t *testing.T) {
+	s, canceled := newTestScanner()
+	sentinel := errors.New("pipe boom")
+	r := &errAfterReader{
+		data: []byte(`{"address":"AABBCCDDEEFF"}` + "\n"),
+		err:  sentinel,
+	}
+
+	s.readLoop(r)
+
+	if !*canceled {
+		t.Error("expected cancel to be called after a real scanner error")
+	}
+	if s.readErr == nil || !errors.Is(s.readErr, sentinel) {
+		t.Errorf("expected readErr to wrap the sentinel error, got %v", s.readErr)
+	}
+	// The line read before the error still landed.
+	if len(s.devices) != 1 {
+		t.Errorf("expected 1 device collected before the error, got %d", len(s.devices))
+	}
+}
+
+func TestReadLoopRecordsTooLongLineAndCancels(t *testing.T) {
+	s, canceled := newTestScanner()
+	// One "line" with no newline, well past the 256 KiB buffer ceiling.
+	big := bytes.Repeat([]byte{'a'}, 300*1024)
+	r := &errAfterReader{data: big, err: errors.New("unreachable")}
+
+	s.readLoop(r)
+
+	if !*canceled {
+		t.Error("expected cancel to be called on bufio.ErrTooLong")
+	}
+	if s.readErr == nil {
+		t.Error("expected readErr to be set on bufio.ErrTooLong")
+	}
+}
+
+func TestReadLoopCleanEOFRecordsNoError(t *testing.T) {
+	s, canceled := newTestScanner()
+	r := &errAfterReader{
+		data: []byte(`{"address":"AABBCCDDEEFF"}` + "\n"),
+		err:  io.EOF,
+	}
+
+	s.readLoop(r)
+
+	if *canceled {
+		t.Error("expected cancel not to be called on a clean EOF")
+	}
+	if s.readErr != nil {
+		t.Errorf("expected no readErr on a clean EOF, got %v", s.readErr)
+	}
+	if len(s.devices) != 1 {
+		t.Errorf("expected 1 device collected, got %d", len(s.devices))
+	}
+}
+
+// TestSnapshotAlwaysReturnsDevicesAndError locks in the current policy:
+// Snapshot never favors one over the other. sample in scan.go is the one that
+// decides what to do with a fatal error — it merges and emits whatever
+// devices came back, then ends the stream — so Snapshot itself just reports
+// both, matching darwinScanner and linuxScanner.
+func TestSnapshotAlwaysReturnsDevicesAndError(t *testing.T) {
+	s, _ := newTestScanner()
+	s.devices["AA:BB:CC:DD:EE:FF"] = BLEDeviceInfo{Address: "AA:BB:CC:DD:EE:FF"}
+	sentinel := errors.New("watcher died")
+	s.readErr = sentinel
+
+	devices, err := s.Snapshot(context.Background())
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected Snapshot to surface the error alongside the devices, got %v", err)
+	}
+	if len(devices) != 1 {
+		t.Errorf("expected the collected device to still be reported, got %d devices", len(devices))
+	}
+}
+
+func TestSnapshotSurfacesErrorWhenEmpty(t *testing.T) {
+	s, _ := newTestScanner()
+	sentinel := errors.New("watcher died before finding anything")
+	s.readErr = sentinel
+
+	devices, err := s.Snapshot(context.Background())
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected Snapshot to surface the error on an empty device set, got %v", err)
+	}
+	if len(devices) != 0 {
+		t.Errorf("expected no devices alongside the error, got %v", devices)
+	}
+}

--- a/go/internal/shared/ble/scan/uuid.go
+++ b/go/internal/shared/ble/scan/uuid.go
@@ -1,0 +1,96 @@
+package scan
+
+import "strings"
+
+// bluetoothBaseUUID is the template every 16- and 32-bit Bluetooth UUID
+// expands against: the short value occupies the first group and the rest is
+// fixed (Core Specification, Vol 3, Part B, 2.5.1).
+const bluetoothBaseUUID = "00000000-0000-1000-8000-00805F9B34FB"
+
+// CanonicalUUID normalizes a service UUID to uppercase 128-bit form, expanding
+// the 16-bit ("180F") and 32-bit ("0000180F") shorthands against the Bluetooth
+// base UUID. Input that is not a recognizable UUID is returned uppercased and
+// otherwise untouched, so an unexpected spelling degrades to an exact-match
+// comparison rather than being silently dropped.
+//
+// Normalizing matters because the platforms disagree on spelling for the very
+// same service: BlueZ reports full lowercase 128-bit, CoreBluetooth's
+// CBUUID.UUIDString returns four hex characters for a 16-bit UUID and full
+// form otherwise, and WinRT returns full uppercase GUIDs. Comparing raw
+// strings across them would miss matches.
+func CanonicalUUID(s string) string {
+	s = strings.ToUpper(strings.TrimSpace(s))
+	s = strings.TrimPrefix(s, "{")
+	s = strings.TrimSuffix(s, "}")
+
+	switch len(s) {
+	case 4, 8:
+		if !isHex(s) {
+			return s
+		}
+		// Left-pad a 16-bit value to the base UUID's 8-character first group.
+		return strings.Repeat("0", 8-len(s)) + s + bluetoothBaseUUID[8:]
+	case 36:
+		return s
+	case 32:
+		// Dashless 128-bit form.
+		if !isHex(s) {
+			return s
+		}
+		return s[0:8] + "-" + s[8:12] + "-" + s[12:16] + "-" + s[16:20] + "-" + s[20:32]
+	default:
+		return s
+	}
+}
+
+// canonicalUUIDs normalizes a list, dropping empties and duplicates while
+// preserving the order the platform reported.
+func canonicalUUIDs(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	seen := make(map[string]bool, len(in))
+	for _, u := range in {
+		c := CanonicalUUID(u)
+		if c == "" || seen[c] {
+			continue
+		}
+		seen[c] = true
+		out = append(out, c)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// matchesServices reports whether a device advertising the given UUIDs should
+// be reported for a scan filtered on want. An empty want matches everything —
+// that is how a caller asks for every device in range. Both sides are assumed
+// already canonical.
+func matchesServices(advertised, want []string) bool {
+	if len(want) == 0 {
+		return true
+	}
+	for _, w := range want {
+		for _, a := range advertised {
+			if a == w {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isHex(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		if !((c >= '0' && c <= '9') || (c >= 'A' && c <= 'F')) {
+			return false
+		}
+	}
+	return true
+}

--- a/go/internal/shared/ble/scan/uuid_test.go
+++ b/go/internal/shared/ble/scan/uuid_test.go
@@ -1,0 +1,171 @@
+package scan
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCanonicalUUID(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			// CoreBluetooth's CBUUID.UUIDString reports a 16-bit UUID as four
+			// hex characters; BlueZ reports the same service in full form.
+			name: "16-bit expands against the base UUID",
+			in:   "180F",
+			want: "0000180F-0000-1000-8000-00805F9B34FB",
+		},
+		{
+			name: "16-bit lowercase is uppercased",
+			in:   "180f",
+			want: "0000180F-0000-1000-8000-00805F9B34FB",
+		},
+		{
+			name: "32-bit expands against the base UUID",
+			in:   "0000180F",
+			want: "0000180F-0000-1000-8000-00805F9B34FB",
+		},
+		{
+			name: "full 128-bit lowercase is uppercased",
+			in:   "7565e9eb-4c20-4b67-9272-d708b397b631",
+			want: "7565E9EB-4C20-4B67-9272-D708B397B631",
+		},
+		{
+			name: "full 128-bit uppercase is unchanged",
+			in:   "7565E9EB-4C20-4B67-9272-D708B397B631",
+			want: "7565E9EB-4C20-4B67-9272-D708B397B631",
+		},
+		{
+			name: "surrounding whitespace is trimmed",
+			in:   "  180F  ",
+			want: "0000180F-0000-1000-8000-00805F9B34FB",
+		},
+		{
+			name: "registry-style braces are stripped",
+			in:   "{7565e9eb-4c20-4b67-9272-d708b397b631}",
+			want: "7565E9EB-4C20-4B67-9272-D708B397B631",
+		},
+		{
+			name: "dashless 128-bit form gains dashes",
+			in:   "7565e9eb4c204b679272d708b397b631",
+			want: "7565E9EB-4C20-4B67-9272-D708B397B631",
+		},
+		{
+			// Not a UUID at all: uppercased and passed through, so it can only
+			// ever match itself rather than being silently dropped.
+			name: "unrecognized input degrades to exact match",
+			in:   "not-a-uuid",
+			want: "NOT-A-UUID",
+		},
+		{
+			name: "non-hex of UUID-ish length is left alone",
+			in:   "ZZZZ",
+			want: "ZZZZ",
+		},
+		{
+			name: "empty stays empty",
+			in:   "",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CanonicalUUID(tt.in); got != tt.want {
+				t.Errorf("CanonicalUUID(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCanonicalUUIDCrossPlatformAgreement is the reason this normalization
+// exists: the same service spelled the way each platform spells it must
+// canonicalize to one value.
+func TestCanonicalUUIDCrossPlatformAgreement(t *testing.T) {
+	coreBluetooth := CanonicalUUID("180F")                         // macOS 16-bit shorthand
+	bluez := CanonicalUUID("0000180f-0000-1000-8000-00805f9b34fb") // BlueZ lowercase
+	winrt := CanonicalUUID("0000180F-0000-1000-8000-00805F9B34FB") // WinRT GUID
+	if coreBluetooth != bluez || bluez != winrt {
+		t.Errorf("platforms disagree after canonicalization: macOS=%q bluez=%q winrt=%q",
+			coreBluetooth, bluez, winrt)
+	}
+}
+
+func TestCanonicalUUIDs(t *testing.T) {
+	got := canonicalUUIDs([]string{"180F", "", "0000180f-0000-1000-8000-00805f9b34fb", "180A"})
+	want := []string{
+		"0000180F-0000-1000-8000-00805F9B34FB",
+		"0000180A-0000-1000-8000-00805F9B34FB",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("canonicalUUIDs deduped to %v, want %v", got, want)
+	}
+
+	if got := canonicalUUIDs(nil); got != nil {
+		t.Errorf("canonicalUUIDs(nil) = %v, want nil", got)
+	}
+	if got := canonicalUUIDs([]string{"", "  "}); got != nil {
+		t.Errorf("canonicalUUIDs of only-empties = %v, want nil", got)
+	}
+}
+
+func TestMatchesServices(t *testing.T) {
+	agent := CanonicalUUID("7565e9eb-4c20-4b67-9272-d708b397b631")
+	other := CanonicalUUID("180F")
+
+	tests := []struct {
+		name       string
+		advertised []string
+		want       []string
+		matches    bool
+	}{
+		{
+			name:       "empty filter matches everything",
+			advertised: nil,
+			want:       nil,
+			matches:    true,
+		},
+		{
+			name:       "empty filter matches a device with services",
+			advertised: []string{agent},
+			want:       nil,
+			matches:    true,
+		},
+		{
+			name:       "matching service is reported",
+			advertised: []string{other, agent},
+			want:       []string{agent},
+			matches:    true,
+		},
+		{
+			name:       "device advertising nothing is filtered out",
+			advertised: nil,
+			want:       []string{agent},
+			matches:    false,
+		},
+		{
+			name:       "unrelated service is filtered out",
+			advertised: []string{other},
+			want:       []string{agent},
+			matches:    false,
+		},
+		{
+			name:       "any of several wanted services suffices",
+			advertised: []string{other},
+			want:       []string{agent, other},
+			matches:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchesServices(tt.advertised, tt.want); got != tt.matches {
+				t.Errorf("matchesServices(%v, %v) = %v, want %v",
+					tt.advertised, tt.want, got, tt.matches)
+			}
+		})
+	}
+}

--- a/go/internal/shared/ble/scan/winrt_parse.go
+++ b/go/internal/shared/ble/scan/winrt_parse.go
@@ -1,0 +1,76 @@
+package scan
+
+// This file is intentionally NOT build-tagged for windows. The Windows backend
+// cannot run in CI — the test job is Linux-only and only cross-compiles the
+// Windows files — so the one part with real parsing logic lives here where the
+// Linux test run exercises it.
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// winrtSighting is one line of the PowerShell scanner's stdout. Address is 12
+// hex characters because a WinRT BluetoothAddress is a UInt64 and JSON numbers
+// are floats; formatting it to hex in the script sidesteps the question
+// entirely.
+type winrtSighting struct {
+	Address string   `json:"address"`
+	Name    string   `json:"name"`
+	UUIDs   []string `json:"uuids"`
+	RSSI    int      `json:"rssi"`
+}
+
+// parseWinRTLine parses one stdout line into a device. It reports ok=false for
+// anything unusable — a blank line, a PowerShell warning, a record with no
+// address — so the reader can skip noise instead of failing the scan.
+func parseWinRTLine(line string) (BLEDeviceInfo, bool) {
+	line = strings.TrimSpace(line)
+	// Cheap guard so ordinary PowerShell chatter is not fed to the JSON decoder.
+	if !strings.HasPrefix(line, "{") {
+		return BLEDeviceInfo{}, false
+	}
+
+	var s winrtSighting
+	if err := json.Unmarshal([]byte(line), &s); err != nil {
+		return BLEDeviceInfo{}, false
+	}
+
+	address := formatBTAddress(s.Address)
+	if address == "" {
+		return BLEDeviceInfo{}, false
+	}
+
+	uuids := s.UUIDs
+	if len(uuids) == 0 {
+		// A JSON "[]" decodes to an empty non-nil slice. Normalize it away so a
+		// Windows sighting with no services is indistinguishable from the nil
+		// the macOS and Linux backends produce for the same thing.
+		uuids = nil
+	}
+
+	return BLEDeviceInfo{
+		Address:      address,
+		Name:         s.Name,
+		ServiceUUIDs: uuids,
+		RSSI:         s.RSSI,
+	}, true
+}
+
+// formatBTAddress renders 12 hex characters as "AA:BB:CC:DD:EE:FF", the form
+// central.Connect parses on Linux and Windows. Anything else yields "".
+func formatBTAddress(hex string) string {
+	hex = strings.ToUpper(strings.TrimSpace(hex))
+	if len(hex) != 12 || !isHex(hex) {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(17)
+	for i := 0; i < 12; i += 2 {
+		if i > 0 {
+			b.WriteByte(':')
+		}
+		b.WriteString(hex[i : i+2])
+	}
+	return b.String()
+}

--- a/go/internal/shared/ble/scan/winrt_parse_test.go
+++ b/go/internal/shared/ble/scan/winrt_parse_test.go
@@ -1,0 +1,112 @@
+package scan
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseWinRTLine(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want BLEDeviceInfo
+		ok   bool
+	}{
+		{
+			name: "full record",
+			line: `{"address":"AABBCCDDEEFF","name":"Wendy-1234","uuids":["0000180F-0000-1000-8000-00805F9B34FB"],"rssi":-52}`,
+			want: BLEDeviceInfo{
+				Address:      "AA:BB:CC:DD:EE:FF",
+				Name:         "Wendy-1234",
+				ServiceUUIDs: []string{"0000180F-0000-1000-8000-00805F9B34FB"},
+				RSSI:         -52,
+			},
+			ok: true,
+		},
+		{
+			// A device that advertises neither a name nor any service UUID is
+			// still a valid sighting; Windows has no cached name to fall back on.
+			name: "no name and no services",
+			line: `{"address":"AABBCCDDEEFF","name":"","uuids":[],"rssi":-70}`,
+			want: BLEDeviceInfo{Address: "AA:BB:CC:DD:EE:FF", RSSI: -70},
+			ok:   true,
+		},
+		{
+			name: "lowercase address is uppercased",
+			line: `{"address":"aabbccddeeff","name":"x","uuids":[],"rssi":-40}`,
+			want: BLEDeviceInfo{Address: "AA:BB:CC:DD:EE:FF", Name: "x", RSSI: -40},
+			ok:   true,
+		},
+		{
+			name: "several service UUIDs are preserved in order",
+			line: `{"address":"010203040506","name":"","uuids":["A","B"],"rssi":-10}`,
+			want: BLEDeviceInfo{
+				Address:      "01:02:03:04:05:06",
+				ServiceUUIDs: []string{"A", "B"},
+				RSSI:         -10,
+			},
+			ok: true,
+		},
+		{name: "blank line is skipped", line: "", ok: false},
+		{name: "whitespace is skipped", line: "   ", ok: false},
+		{
+			// PowerShell chatter must not fail the scan.
+			name: "non-JSON chatter is skipped",
+			line: "WARNING: something happened",
+			ok:   false,
+		},
+		{name: "malformed JSON is skipped", line: `{"address":`, ok: false},
+		{
+			name: "missing address is skipped",
+			line: `{"name":"x","uuids":[],"rssi":-40}`,
+			ok:   false,
+		},
+		{
+			name: "short address is skipped",
+			line: `{"address":"AABBCC","name":"x","uuids":[],"rssi":-40}`,
+			ok:   false,
+		},
+		{
+			name: "non-hex address is skipped",
+			line: `{"address":"ZZBBCCDDEEFF","name":"x","uuids":[],"rssi":-40}`,
+			ok:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseWinRTLine(tt.line)
+			if ok != tt.ok {
+				t.Fatalf("parseWinRTLine(%q) ok = %v, want %v", tt.line, ok, tt.ok)
+			}
+			if !ok {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseWinRTLine(%q) = %+v, want %+v", tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatBTAddress(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"AABBCCDDEEFF", "AA:BB:CC:DD:EE:FF"},
+		{"aabbccddeeff", "AA:BB:CC:DD:EE:FF"},
+		{"000000000000", "00:00:00:00:00:00"},
+		{"  AABBCCDDEEFF  ", "AA:BB:CC:DD:EE:FF"},
+		{"AABBCCDDEE", ""},     // too short
+		{"AABBCCDDEEFFAA", ""}, // too long
+		{"ZZBBCCDDEEFF", ""},   // not hex
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		if got := formatBTAddress(tt.in); got != tt.want {
+			t.Errorf("formatBTAddress(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
**2 of 4.** Splits #1926 (291,218 bytes, over the AI security review's 140,000-byte limit). Disjoint from the other parts; merging all four reproduces #1926's tree byte-for-byte.

**This code is not used by anything yet** — nothing imports it, and it is not reachable from any binary.

## Contents (13 files)

`go/internal/shared/ble/scan/` — the BLE scanner, with three platform backends:

- **darwin** — cgo bridge to CoreBluetooth (`scan_darwin.go/.h/.m`)
- **linux** — BlueZ over D-Bus (`scan_linux.go`)
- **windows** — PowerShell/WinRT, with its own output parser (`scan_windows.go`, `winrt_parse.go`)

## Notes

- **Depends on #1927 (part 1).** `scan_linux.go` imports `shared/ble/bluez`, so **Test/Vet/CodeQL will be red on this PR until #1927 merges.** Once it does, I'll merge main in and they go green. The AI security review does not build, so it runs now.
- **No dependency changes.** `go.mod` and `go.sum` are untouched.
- The one cross-package import outside `bluez` is `shared/env` (`env.PowershellExe()` in `scan_windows.go`), unchanged from main.
- `live_test.go` self-skips unless `WENDY_BLE_LIVE_SCAN` is set, so it is inert in CI.

## Sequence

1. #1927 — bluez + permission + README
2. **this PR** — scan
3. `central` production files
4. #1926 — `central` tests

Independent of part 3; either can merge first once #1927 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)