### PR TITLE
shared/ble 3/4: central package (GATT/L2CAP client)

### DIFF
--- a/go/internal/shared/ble/central/ble_darwin.go
+++ b/go/internal/shared/ble/central/ble_darwin.go
@@ -1,0 +1,220 @@
+//go:build darwin
+
+package central
+
+/*
+#cgo CFLAGS: -fobjc-arc
+#cgo LDFLAGS: -framework CoreBluetooth -framework Foundation
+#include <stdlib.h>
+#include "ble_darwin.h"
+*/
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+type Connection struct {
+	handle C.WendyBLEConn
+}
+
+// Connect establishes a BLE connection to the peripheral identified by its UUID.
+func Connect(peripheralUUID string, timeoutSeconds int) (*Connection, error) {
+	cUUID := C.CString(peripheralUUID)
+	defer C.free(unsafe.Pointer(cUUID))
+
+	var errCode C.WendyBLEError
+	handle := C.wendy_ble_connect(cUUID, C.int(timeoutSeconds), &errCode)
+	if handle == nil {
+		return nil, bleError(errCode, "connecting to peripheral")
+	}
+	return &Connection{handle: handle}, nil
+}
+
+// DiscoverServices discovers all services and characteristics on the peripheral.
+func (c *Connection) DiscoverServices(timeoutSeconds int) error {
+	err := C.wendy_ble_discover_services(c.handle, C.int(timeoutSeconds))
+	if err != C.WENDY_BLE_OK {
+		return bleError(err, "discovering services")
+	}
+	return nil
+}
+
+func (c *Connection) WriteCharacteristic(serviceUUID, charUUID string, data []byte) error {
+	cSvc := C.CString(serviceUUID)
+	defer C.free(unsafe.Pointer(cSvc))
+	cChr := C.CString(charUUID)
+	defer C.free(unsafe.Pointer(cChr))
+
+	var cData *C.uint8_t
+	if len(data) > 0 {
+		cData = (*C.uint8_t)(unsafe.Pointer(&data[0]))
+	}
+	err := C.wendy_ble_write_characteristic(c.handle, cSvc, cChr, cData, C.int(len(data)))
+	if err != C.WENDY_BLE_OK {
+		return bleError(err, "writing characteristic")
+	}
+	return nil
+}
+
+func (c *Connection) WriteCharacteristicNoResponse(serviceUUID, charUUID string, data []byte) error {
+	cSvc := C.CString(serviceUUID)
+	defer C.free(unsafe.Pointer(cSvc))
+	cChr := C.CString(charUUID)
+	defer C.free(unsafe.Pointer(cChr))
+
+	var cData *C.uint8_t
+	if len(data) > 0 {
+		cData = (*C.uint8_t)(unsafe.Pointer(&data[0]))
+	}
+	err := C.wendy_ble_write_characteristic_no_response(c.handle, cSvc, cChr, cData, C.int(len(data)))
+	if err != C.WENDY_BLE_OK {
+		return bleError(err, "writing characteristic (no response)")
+	}
+	return nil
+}
+
+// ReadCharacteristic reads data from a GATT characteristic.
+func (c *Connection) ReadCharacteristic(serviceUUID, charUUID string) ([]byte, error) {
+	cSvc := C.CString(serviceUUID)
+	defer C.free(unsafe.Pointer(cSvc))
+	cChr := C.CString(charUUID)
+	defer C.free(unsafe.Pointer(cChr))
+
+	result := C.wendy_ble_read_characteristic(c.handle, cSvc, cChr)
+	if result.error != C.WENDY_BLE_OK {
+		return nil, bleError(result.error, "reading characteristic")
+	}
+	defer C.wendy_ble_free_data(result.data)
+
+	if result.length == 0 || result.data == nil {
+		return nil, nil
+	}
+	return C.GoBytes(unsafe.Pointer(result.data), result.length), nil
+}
+
+// Subscribe enables notifications for a GATT characteristic.
+func (c *Connection) Subscribe(serviceUUID, charUUID string) error {
+	cSvc := C.CString(serviceUUID)
+	defer C.free(unsafe.Pointer(cSvc))
+	cChr := C.CString(charUUID)
+	defer C.free(unsafe.Pointer(cChr))
+
+	err := C.wendy_ble_subscribe(c.handle, cSvc, cChr)
+	if err != C.WENDY_BLE_OK {
+		return bleError(err, "subscribing to characteristic")
+	}
+	return nil
+}
+
+// WaitNotification waits for a notification on a subscribed characteristic.
+func (c *Connection) WaitNotification(serviceUUID, charUUID string, timeoutSeconds int) ([]byte, error) {
+	cSvc := C.CString(serviceUUID)
+	defer C.free(unsafe.Pointer(cSvc))
+	cChr := C.CString(charUUID)
+	defer C.free(unsafe.Pointer(cChr))
+
+	result := C.wendy_ble_wait_notification(c.handle, cSvc, cChr, C.int(timeoutSeconds))
+	if result.error != C.WENDY_BLE_OK {
+		return nil, bleError(result.error, "waiting for notification")
+	}
+	defer C.wendy_ble_free_data(result.data)
+
+	if result.length == 0 || result.data == nil {
+		return nil, nil
+	}
+	return C.GoBytes(unsafe.Pointer(result.data), result.length), nil
+}
+
+// OpenL2CAP opens an L2CAP channel on the given PSM.
+func (c *Connection) OpenL2CAP(psm uint16, timeoutSeconds int) error {
+	err := C.wendy_ble_open_l2cap(c.handle, C.uint16_t(psm), C.int(timeoutSeconds))
+	if err != C.WENDY_BLE_OK {
+		return bleError(err, "opening L2CAP channel")
+	}
+	return nil
+}
+
+// L2CAPSend sends data over the L2CAP channel.
+func (c *Connection) L2CAPSend(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	cData := (*C.uint8_t)(unsafe.Pointer(&data[0]))
+	err := C.wendy_ble_l2cap_send(c.handle, cData, C.int(len(data)))
+	if err != C.WENDY_BLE_OK {
+		return bleError(err, "sending L2CAP data")
+	}
+	return nil
+}
+
+// L2CAPRecv receives data from the L2CAP channel.
+func (c *Connection) L2CAPRecv(timeoutSeconds int) ([]byte, error) {
+	result := C.wendy_ble_l2cap_recv(c.handle, C.int(timeoutSeconds))
+	if result.error == C.WENDY_BLE_ERR_TIMEOUT {
+		// Distinguishable so a caller with no deadline of its own can retry.
+		// bleError would flatten it into a string indistinguishable from a dead
+		// channel. Only recv does this: a timeout from OpenL2CAP,
+		// DiscoverServices or WaitNotification really is a hard failure.
+		return nil, ErrRecvTimeout
+	}
+	if result.error != C.WENDY_BLE_OK {
+		return nil, bleError(result.error, "receiving L2CAP data")
+	}
+	defer C.wendy_ble_free_data(result.data)
+
+	if result.length == 0 || result.data == nil {
+		return nil, nil
+	}
+	return C.GoBytes(unsafe.Pointer(result.data), result.length), nil
+}
+
+// HasService checks whether a specific service UUID was discovered.
+func (c *Connection) HasService(serviceUUID string) bool {
+	cSvc := C.CString(serviceUUID)
+	defer C.free(unsafe.Pointer(cSvc))
+	return C.wendy_ble_has_service(c.handle, cSvc) == 1
+}
+
+func (c *Connection) ListServices() string {
+	cStr := C.wendy_ble_list_services(c.handle)
+	if cStr == nil {
+		return ""
+	}
+	defer C.free(unsafe.Pointer(cStr))
+	return C.GoString(cStr)
+}
+
+// Close disconnects and frees all BLE resources.
+func (c *Connection) Close() {
+	if c.handle != nil {
+		C.wendy_ble_disconnect(c.handle)
+		c.handle = nil
+	}
+}
+
+func bleError(code C.WendyBLEError, context string) error {
+	var msg string
+	switch code {
+	case C.WENDY_BLE_ERR_TIMEOUT:
+		msg = "timeout"
+	case C.WENDY_BLE_ERR_NOT_FOUND:
+		msg = "not found"
+	case C.WENDY_BLE_ERR_CONNECT_FAILED:
+		msg = "connection failed"
+	case C.WENDY_BLE_ERR_DISCOVER_FAILED:
+		msg = "service discovery failed"
+	case C.WENDY_BLE_ERR_WRITE_FAILED:
+		msg = "write failed"
+	case C.WENDY_BLE_ERR_READ_FAILED:
+		msg = "read failed"
+	case C.WENDY_BLE_ERR_L2CAP_FAILED:
+		msg = "L2CAP channel failed"
+	case C.WENDY_BLE_ERR_DISCONNECTED:
+		msg = "disconnected"
+	default:
+		msg = "unknown error"
+	}
+	return fmt.Errorf("BLE %s: %s", context, msg)
+}

--- a/go/internal/shared/ble/central/ble_darwin.h
+++ b/go/internal/shared/ble/central/ble_darwin.h
@@ -1,0 +1,89 @@
+#ifndef BLE_CLIENT_DARWIN_H
+#define BLE_CLIENT_DARWIN_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// WendyBLEError codes
+typedef enum {
+    WENDY_BLE_OK = 0,
+    WENDY_BLE_ERR_TIMEOUT = 1,
+    WENDY_BLE_ERR_NOT_FOUND = 2,
+    WENDY_BLE_ERR_CONNECT_FAILED = 3,
+    WENDY_BLE_ERR_DISCOVER_FAILED = 4,
+    WENDY_BLE_ERR_WRITE_FAILED = 5,
+    WENDY_BLE_ERR_READ_FAILED = 6,
+    WENDY_BLE_ERR_L2CAP_FAILED = 7,
+    WENDY_BLE_ERR_DISCONNECTED = 8,
+} WendyBLEError;
+
+// Opaque handle to a BLE connection
+typedef void *WendyBLEConn;
+
+// Result of a read operation
+typedef struct {
+    uint8_t *data;
+    int length;
+    WendyBLEError error;
+} WendyBLEReadResult;
+
+// Result of an L2CAP receive operation
+typedef struct {
+    uint8_t *data;
+    int length;
+    WendyBLEError error;
+} WendyBLEL2CAPRecvResult;
+
+// Connect to a BLE peripheral by UUID string.
+// Returns an opaque connection handle or NULL on failure.
+// timeout_seconds: how long to wait for connection.
+WendyBLEConn wendy_ble_connect(const char *peripheral_uuid, int timeout_seconds, WendyBLEError *out_error);
+
+// Discover services and characteristics for the connection.
+// Must be called after connect and before read/write/subscribe.
+WendyBLEError wendy_ble_discover_services(WendyBLEConn conn, int timeout_seconds);
+
+// Write data to a GATT characteristic (write with response).
+WendyBLEError wendy_ble_write_characteristic(WendyBLEConn conn, const char *service_uuid,
+                                              const char *char_uuid, const uint8_t *data, int length);
+
+// Write data to a GATT characteristic (write without response).
+WendyBLEError wendy_ble_write_characteristic_no_response(WendyBLEConn conn, const char *service_uuid,
+                                                          const char *char_uuid, const uint8_t *data, int length);
+
+// Read data from a GATT characteristic.
+WendyBLEReadResult wendy_ble_read_characteristic(WendyBLEConn conn, const char *service_uuid,
+                                                  const char *char_uuid);
+
+// Subscribe to notifications on a GATT characteristic.
+// After subscribing, use wendy_ble_wait_notification to receive values.
+WendyBLEError wendy_ble_subscribe(WendyBLEConn conn, const char *service_uuid,
+                                   const char *char_uuid);
+
+// Wait for a notification value on a subscribed characteristic.
+// Blocks until a notification arrives or timeout_seconds elapses.
+WendyBLEReadResult wendy_ble_wait_notification(WendyBLEConn conn, const char *service_uuid,
+                                                const char *char_uuid, int timeout_seconds);
+
+// Open an L2CAP channel on the given PSM.
+WendyBLEError wendy_ble_open_l2cap(WendyBLEConn conn, uint16_t psm, int timeout_seconds);
+
+// Send data over the L2CAP channel.
+WendyBLEError wendy_ble_l2cap_send(WendyBLEConn conn, const uint8_t *data, int length);
+
+// Receive data from the L2CAP channel (blocks until data or timeout).
+WendyBLEL2CAPRecvResult wendy_ble_l2cap_recv(WendyBLEConn conn, int timeout_seconds);
+
+// Check whether a specific service UUID was discovered. Returns 1 if found, 0 if not.
+int wendy_ble_has_service(WendyBLEConn conn, const char *service_uuid);
+
+// Get a comma-separated list of discovered service UUIDs. Caller must free the result.
+char *wendy_ble_list_services(WendyBLEConn conn);
+
+// Disconnect and free all resources.
+void wendy_ble_disconnect(WendyBLEConn conn);
+
+// Free data returned by read/recv results.
+void wendy_ble_free_data(uint8_t *data);
+
+#endif

--- a/go/internal/shared/ble/central/ble_darwin.m
+++ b/go/internal/shared/ble/central/ble_darwin.m
@@ -1,0 +1,632 @@
+#import <CoreBluetooth/CoreBluetooth.h>
+#import <Foundation/Foundation.h>
+#include "ble_darwin.h"
+
+// ── WendyBLEConnection ──────────────────────────────────────────────
+// Manages a single connection to a BLE peripheral including GATT and L2CAP.
+
+@interface WendyBLEConnection : NSObject <CBCentralManagerDelegate, CBPeripheralDelegate>
+
+@property (strong) CBCentralManager *centralManager;
+@property (strong) CBPeripheral *peripheral;
+@property (strong) dispatch_queue_t bleQueue;
+
+// Connection state
+@property (strong) dispatch_semaphore_t connectSema;
+@property BOOL connected;
+@property BOOL connectError;
+
+// Service discovery
+@property (strong) dispatch_semaphore_t discoverSema;
+@property BOOL discoverDone;
+@property BOOL discoverError;
+@property int pendingCharDiscovery;
+
+// Write state
+@property (strong) dispatch_semaphore_t writeSema;
+@property BOOL writeError;
+
+// Read state
+@property (strong) dispatch_semaphore_t readSema;
+@property (strong) NSData *readData;
+@property BOOL readError;
+
+// Notification state
+@property (strong) dispatch_semaphore_t notifySema;
+@property (strong) NSMutableDictionary<NSString *, NSMutableArray<NSData *> *> *notifyQueues;
+@property (strong) NSLock *notifyLock;
+
+// L2CAP state
+@property (strong) dispatch_semaphore_t l2capSema;
+@property (strong) CBL2CAPChannel *l2capChannel;
+@property BOOL l2capError;
+
+// L2CAP receive state
+@property (strong) NSMutableData *l2capRecvBuffer;
+@property (strong) dispatch_semaphore_t l2capRecvSema;
+@property (strong) NSLock *l2capRecvLock;
+
+// L2CAP I/O thread — runs a real NSRunLoop so NSStreamDelegate events are delivered.
+// Required in CLI binaries where the main run loop is never started.
+@property (strong) NSThread *l2capIOThread;
+@property BOOL l2capIORunning;
+@property BOOL l2capOutputReady; // YES once outputStream fires NSStreamEventHasSpaceAvailable
+
+// Write dispatch: wendy_ble_l2cap_send uses performSelector:onThread:waitUntilDone:YES
+// so writes always happen on the I/O thread that owns the stream's run loop.
+@property NSInteger l2capWriteResult;
+
+// Target peripheral UUID for scanning
+@property (strong) NSString *targetUUID;
+
+@end
+
+@implementation WendyBLEConnection
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _bleQueue = dispatch_queue_create("sh.wendy.ble.client", DISPATCH_QUEUE_SERIAL);
+        _connectSema = dispatch_semaphore_create(0);
+        _discoverSema = dispatch_semaphore_create(0);
+        _writeSema = dispatch_semaphore_create(0);
+        _readSema = dispatch_semaphore_create(0);
+        _notifySema = dispatch_semaphore_create(0);
+        _l2capSema = dispatch_semaphore_create(0);
+        _l2capRecvSema = dispatch_semaphore_create(0);
+        _notifyQueues = [NSMutableDictionary dictionary];
+        _notifyLock = [[NSLock alloc] init];
+        _l2capRecvBuffer = [NSMutableData data];
+        _l2capRecvLock = [[NSLock alloc] init];
+    }
+    return self;
+}
+
+// ── CBCentralManagerDelegate ────────────────────────────────────────
+
+- (void)centralManagerDidUpdateState:(CBCentralManager *)central {
+    if (central.state == CBManagerStatePoweredOn && self.targetUUID) {
+        // Check the OS peripheral cache first. CoreBluetooth shares peripheral
+        // knowledge across all CBCentralManager instances in the same process, so
+        // the peripheral seen during discovery is already known here — no re-scan
+        // needed. This avoids a 10-second timeout when the device stops advertising
+        // between discovery and the connect call.
+        NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:self.targetUUID];
+        if (uuid) {
+            NSArray<CBPeripheral *> *known = [central retrievePeripheralsWithIdentifiers:@[uuid]];
+            if (known.count > 0) {
+                CBPeripheral *p = known[0];
+                self.peripheral = p;
+                p.delegate = self;
+                [central connectPeripheral:p options:nil];
+                return;
+            }
+        }
+        // Not in cache — fall back to scanning.
+        [central scanForPeripheralsWithServices:nil options:@{
+            CBCentralManagerScanOptionAllowDuplicatesKey: @NO
+        }];
+    }
+}
+
+- (void)centralManager:(CBCentralManager *)central
+ didDiscoverPeripheral:(CBPeripheral *)peripheral
+     advertisementData:(NSDictionary<NSString *, id> *)advertisementData
+                  RSSI:(NSNumber *)RSSI {
+    if ([peripheral.identifier.UUIDString isEqualToString:self.targetUUID]) {
+        [central stopScan];
+        self.peripheral = peripheral;
+        peripheral.delegate = self;
+        [central connectPeripheral:peripheral options:nil];
+    }
+}
+
+- (void)centralManager:(CBCentralManager *)central
+  didConnectPeripheral:(CBPeripheral *)peripheral {
+    self.connected = YES;
+    dispatch_semaphore_signal(self.connectSema);
+}
+
+- (void)centralManager:(CBCentralManager *)central
+didFailToConnectPeripheral:(CBPeripheral *)peripheral
+                 error:(NSError *)error {
+    self.connectError = YES;
+    dispatch_semaphore_signal(self.connectSema);
+}
+
+- (void)centralManager:(CBCentralManager *)central
+didDisconnectPeripheral:(CBPeripheral *)peripheral
+                 error:(NSError *)error {
+    self.connected = NO;
+    self.l2capIORunning = NO; // wake the I/O thread so it exits
+    // Signal any blocked operations
+    dispatch_semaphore_signal(self.readSema);
+    dispatch_semaphore_signal(self.writeSema);
+    dispatch_semaphore_signal(self.l2capRecvSema);
+}
+
+// ── CBPeripheralDelegate ────────────────────────────────────────────
+
+- (void)peripheral:(CBPeripheral *)peripheral
+didDiscoverServices:(NSError *)error {
+    if (error) {
+        self.discoverError = YES;
+        dispatch_semaphore_signal(self.discoverSema);
+        return;
+    }
+    if (peripheral.services.count == 0) {
+        self.discoverDone = YES;
+        dispatch_semaphore_signal(self.discoverSema);
+        return;
+    }
+    self.pendingCharDiscovery = (int)peripheral.services.count;
+    for (CBService *svc in peripheral.services) {
+        [peripheral discoverCharacteristics:nil forService:svc];
+    }
+}
+
+- (void)peripheral:(CBPeripheral *)peripheral
+didDiscoverCharacteristicsForService:(CBService *)service
+             error:(NSError *)error {
+    self.pendingCharDiscovery--;
+    if (self.pendingCharDiscovery <= 0) {
+        self.discoverDone = !error;
+        self.discoverError = (error != nil);
+        dispatch_semaphore_signal(self.discoverSema);
+    }
+}
+
+- (void)peripheral:(CBPeripheral *)peripheral
+didWriteValueForCharacteristic:(CBCharacteristic *)characteristic
+             error:(NSError *)error {
+    self.writeError = (error != nil);
+    dispatch_semaphore_signal(self.writeSema);
+}
+
+- (void)peripheral:(CBPeripheral *)peripheral
+didUpdateValueForCharacteristic:(CBCharacteristic *)characteristic
+             error:(NSError *)error {
+    if (error) {
+        self.readError = YES;
+        self.readData = nil;
+        dispatch_semaphore_signal(self.readSema);
+        return;
+    }
+
+    // Check if this is a notification for a subscribed characteristic
+    NSString *key = [NSString stringWithFormat:@"%@:%@",
+                     characteristic.service.UUID.UUIDString,
+                     characteristic.UUID.UUIDString];
+
+    [self.notifyLock lock];
+    NSMutableArray *queue = self.notifyQueues[key];
+    if (queue) {
+        if (characteristic.value) {
+            [queue addObject:[characteristic.value copy]];
+        }
+        [self.notifyLock unlock];
+        dispatch_semaphore_signal(self.notifySema);
+        return;
+    }
+    [self.notifyLock unlock];
+
+    // Regular read response
+    self.readData = characteristic.value ? [characteristic.value copy] : nil;
+    self.readError = NO;
+    dispatch_semaphore_signal(self.readSema);
+}
+
+- (void)peripheral:(CBPeripheral *)peripheral
+didUpdateNotificationStateForCharacteristic:(CBCharacteristic *)characteristic
+             error:(NSError *)error {
+    // Handled by subscribe call checking isNotifying
+    dispatch_semaphore_signal(self.writeSema); // reuse write sema for subscribe ack
+}
+
+- (void)peripheral:(CBPeripheral *)peripheral
+didOpenL2CAPChannel:(CBL2CAPChannel *)channel
+             error:(NSError *)error {
+    if (error || !channel) {
+        self.l2capError = YES;
+        dispatch_semaphore_signal(self.l2capSema);
+        return;
+    }
+    self.l2capChannel = channel;
+    // Both streams are scheduled and opened on the I/O thread's run loop.
+    // CBL2CAP output stream writes MUST come from the thread that owns the run
+    // loop — writing from a foreign thread (e.g. the Go TLS goroutine) returns
+    // -1 even when streamStatus is NSStreamStatusOpen.
+    channel.inputStream.delegate = (id<NSStreamDelegate>)self;
+    channel.outputStream.delegate = (id<NSStreamDelegate>)self;
+    self.l2capIORunning = YES;
+    self.l2capIOThread = [[NSThread alloc] initWithTarget:self
+                                                 selector:@selector(l2capIOThreadMain)
+                                                   object:nil];
+    [self.l2capIOThread start];
+}
+
+// Runs on the dedicated L2CAP I/O thread.
+// Schedules and opens BOTH streams so all NSStreamDelegate events are delivered
+// here. Waits for NSStreamEventHasSpaceAvailable on the output stream before
+// signalling l2capSema — that event confirms the BLE stack is ready for writes.
+// All subsequent writes from wendy_ble_l2cap_send are dispatched here via
+// performSelector:onThread:withObject:waitUntilDone:YES.
+- (void)l2capIOThreadMain {
+    @autoreleasepool {
+        NSRunLoop *rl = [NSRunLoop currentRunLoop];
+
+        [self.l2capChannel.inputStream scheduleInRunLoop:rl forMode:NSDefaultRunLoopMode];
+        [self.l2capChannel.outputStream scheduleInRunLoop:rl forMode:NSDefaultRunLoopMode];
+        [self.l2capChannel.inputStream open];
+        [self.l2capChannel.outputStream open];
+
+        // Wait until the output stream fires NSStreamEventHasSpaceAvailable,
+        // which is the BLE stack's confirmation that writes are accepted.
+        NSDate *readyDeadline = [NSDate dateWithTimeIntervalSinceNow:5.0];
+        while (!self.l2capOutputReady && !self.l2capError) {
+            if ([[NSDate date] compare:readyDeadline] != NSOrderedAscending) {
+                self.l2capError = YES;
+                break;
+            }
+            [rl runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
+        }
+        dispatch_semaphore_signal(self.l2capSema);
+
+        while (self.l2capIORunning) {
+            [rl runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.5]];
+        }
+        [self.l2capChannel.inputStream close];
+        [self.l2capChannel.inputStream removeFromRunLoop:rl forMode:NSDefaultRunLoopMode];
+        [self.l2capChannel.outputStream close];
+        [self.l2capChannel.outputStream removeFromRunLoop:rl forMode:NSDefaultRunLoopMode];
+    }
+}
+
+// Performs a single write on the I/O thread, called via performSelector:onThread:waitUntilDone:YES.
+- (void)performL2CAPWrite:(NSData *)data {
+    self.l2capWriteResult = [self.l2capChannel.outputStream write:data.bytes maxLength:data.length];
+}
+
+// ── NSStreamDelegate (both L2CAP streams) ───────────────────────────
+
+- (void)stream:(NSStream *)aStream handleEvent:(NSStreamEvent)eventCode {
+    if (aStream == self.l2capChannel.outputStream) {
+        if (eventCode == NSStreamEventHasSpaceAvailable) {
+            self.l2capOutputReady = YES;
+        } else if (eventCode == NSStreamEventErrorOccurred || eventCode == NSStreamEventEndEncountered) {
+            self.l2capError = YES;
+            self.l2capIORunning = NO;
+            dispatch_semaphore_signal(self.l2capRecvSema);
+        }
+        return;
+    }
+
+    if (eventCode == NSStreamEventHasBytesAvailable && aStream == self.l2capChannel.inputStream) {
+        uint8_t buf[4096];
+        NSInteger bytesRead = [(NSInputStream *)aStream read:buf maxLength:sizeof(buf)];
+        if (bytesRead > 0) {
+            [self.l2capRecvLock lock];
+            [self.l2capRecvBuffer appendBytes:buf length:bytesRead];
+            [self.l2capRecvLock unlock];
+            dispatch_semaphore_signal(self.l2capRecvSema);
+        }
+    } else if (eventCode == NSStreamEventEndEncountered || eventCode == NSStreamEventErrorOccurred) {
+        self.l2capIORunning = NO;
+        dispatch_semaphore_signal(self.l2capRecvSema);
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+- (CBCharacteristic *)findCharacteristic:(NSString *)charUUID inService:(NSString *)serviceUUID {
+    CBUUID *svcUUID = [CBUUID UUIDWithString:serviceUUID];
+    CBUUID *chrUUID = [CBUUID UUIDWithString:charUUID];
+    for (CBService *svc in self.peripheral.services) {
+        if ([svc.UUID isEqual:svcUUID]) {
+            for (CBCharacteristic *chr in svc.characteristics) {
+                if ([chr.UUID isEqual:chrUUID]) {
+                    return chr;
+                }
+            }
+        }
+    }
+    return nil;
+}
+
+@end
+
+// ── C API Implementation ────────────────────────────────────────────
+
+WendyBLEConn wendy_ble_connect(const char *peripheral_uuid, int timeout_seconds, WendyBLEError *out_error) {
+    WendyBLEConnection *conn = [[WendyBLEConnection alloc] init];
+    conn.targetUUID = [NSString stringWithUTF8String:peripheral_uuid];
+
+    conn.centralManager = [[CBCentralManager alloc] initWithDelegate:conn
+                                                               queue:conn.bleQueue
+                                                             options:nil];
+
+    long result = dispatch_semaphore_wait(conn.connectSema,
+        dispatch_time(DISPATCH_TIME_NOW, (int64_t)timeout_seconds * NSEC_PER_SEC));
+
+    if (result != 0 || conn.connectError || !conn.connected) {
+        if (out_error) *out_error = result != 0 ? WENDY_BLE_ERR_TIMEOUT : WENDY_BLE_ERR_CONNECT_FAILED;
+        // Clean up
+        if (conn.peripheral && conn.connected) {
+            [conn.centralManager cancelPeripheralConnection:conn.peripheral];
+        }
+        return NULL;
+    }
+
+    if (out_error) *out_error = WENDY_BLE_OK;
+    return (__bridge_retained void *)conn;
+}
+
+WendyBLEError wendy_ble_discover_services(WendyBLEConn handle, int timeout_seconds) {
+    WendyBLEConnection *conn = (__bridge WendyBLEConnection *)handle;
+    if (!conn.connected) return WENDY_BLE_ERR_DISCONNECTED;
+
+    conn.discoverDone = NO;
+    conn.discoverError = NO;
+    [conn.peripheral discoverServices:nil];
+
+    long result = dispatch_semaphore_wait(conn.discoverSema,
+        dispatch_time(DISPATCH_TIME_NOW, (int64_t)timeout_seconds * NSEC_PER_SEC));
+
+    if (result != 0) return WENDY_BLE_ERR_TIMEOUT;
+    if (conn.discoverError) return WENDY_BLE_ERR_DISCOVER_FAILED;
+    return WENDY_BLE_OK;
+}
+
+WendyBLEError wendy_ble_write_characteristic(WendyBLEConn handle, const char *service_uuid,
+                                              const char *char_uuid, const uint8_t *data, int length) {
+    WendyBLEConnection *conn = (__bridge WendyBLEConnection *)handle;
+    if (!conn.connected) return WENDY_BLE_ERR_DISCONNECTED;
+
+    CBCharacteristic *chr = [conn findCharacteristic:[NSString stringWithUTF8String:char_uuid]
+                                           inService:[NSString stringWithUTF8String:service_uuid]];
+    if (!chr) return WENDY_BLE_ERR_NOT_FOUND;
+
+    conn.writeError = NO;
+    NSData *writeData = [NSData dataWithBytes:data length:length];
+    [conn.peripheral writeValue:writeData forCharacteristic:chr type:CBCharacteristicWriteWithResponse];
+
+    long result = dispatch_semaphore_wait(conn.writeSema,
+        dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC));
+
+    if (result != 0) return WENDY_BLE_ERR_TIMEOUT;
+    if (conn.writeError) return WENDY_BLE_ERR_WRITE_FAILED;
+    return WENDY_BLE_OK;
+}
+
+WendyBLEError wendy_ble_write_characteristic_no_response(WendyBLEConn handle, const char *service_uuid,
+                                                          const char *char_uuid, const uint8_t *data, int length) {
+    WendyBLEConnection *conn = (__bridge WendyBLEConnection *)handle;
+    if (!conn.connected) return WENDY_BLE_ERR_DISCONNECTED;
+
+    CBCharacteristic *chr = [conn findCharacteristic:[NSString stringWithUTF8String:char_uuid]
+                                           inService:[NSString stringWithUTF8String:service_uuid]];
+    if (!chr) return WENDY_BLE_ERR_NOT_FOUND;
+
+    NSData *writeData = [NSData dataWithBytes:data length:length];
+    [conn.peripheral writeValue:writeData forCharacteristic:chr type:CBCharacteristicWriteWithoutResponse];
+    return WENDY_BLE_OK;
+}
+
+WendyBLEReadResult wendy_ble_read_characteristic(WendyBLEConn handle, const char *service_uuid,
+                                                  const char *char_uuid) {
+    WendyBLEReadResult res = { .data = NULL, .length = 0, .error = WENDY_BLE_OK };
+    WendyBLEConnection *conn = (__bridge WendyBLEConnection *)handle;
+    if (!conn.connected) { res.error = WENDY_BLE_ERR_DISCONNECTED; return res; }
+
+    CBCharacteristic *chr = [conn findCharacteristic:[NSString stringWithUTF8String:char_uuid]
+                                           inService:[NSString stringWithUTF8String:service_uuid]];
+    if (!chr) { res.error = WENDY_BLE_ERR_NOT_FOUND; return res; }
+
+    conn.readError = NO;
+    conn.readData = nil;
+    [conn.peripheral readValueForCharacteristic:chr];
+
+    long result = dispatch_semaphore_wait(conn.readSema,
+        dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC));
+
+    if (result != 0) { res.error = WENDY_BLE_ERR_TIMEOUT; return res; }
+    if (conn.readError) { res.error = WENDY_BLE_ERR_READ_FAILED; return res; }
+
+    if (conn.readData && conn.readData.length > 0) {
+        res.length = (int)conn.readData.length;
+        res.data = (uint8_t *)malloc(res.length);
+        memcpy(res.data, conn.readData.bytes, res.length);
+    }
+    return res;
+}
+
+WendyBLEError wendy_ble_subscribe(WendyBLEConn handle, const char *service_uuid,
+                                   const char *char_uuid) {
+    WendyBLEConnection *conn = (__bridge WendyBLEConnection *)handle;
+    if (!conn.connected) return WENDY_BLE_ERR_DISCONNECTED;
+
+    CBCharacteristic *chr = [conn findCharacteristic:[NSString stringWithUTF8String:char_uuid]
+                                           inService:[NSString stringWithUTF8String:service_uuid]];
+    if (!chr) return WENDY_BLE_ERR_NOT_FOUND;
+
+    // Set up notification queue
+    NSString *key = [NSString stringWithFormat:@"%@:%@",
+                     [NSString stringWithUTF8String:service_uuid],
+                     [NSString stringWithUTF8String:char_uuid]];
+    [conn.notifyLock lock];
+    conn.notifyQueues[key] = [NSMutableArray array];
+    [conn.notifyLock unlock];
+
+    [conn.peripheral setNotifyValue:YES forCharacteristic:chr];
+
+    long result = dispatch_semaphore_wait(conn.writeSema,
+        dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC));
+
+    if (result != 0) return WENDY_BLE_ERR_TIMEOUT;
+    return WENDY_BLE_OK;
+}
+
+WendyBLEReadResult wendy_ble_wait_notification(WendyBLEConn handle, const char *service_uuid,
+                                                const char *char_uuid, int timeout_seconds) {
+    WendyBLEReadResult res = { .data = NULL, .length = 0, .error = WENDY_BLE_OK };
+    WendyBLEConnection *conn = (__bridge WendyBLEConnection *)handle;
+    if (!conn.connected) { res.error = WENDY_BLE_ERR_DISCONNECTED; return res; }
+
+    NSString *key = [NSString stringWithFormat:@"%@:%@",
+                     [NSString stringWithUTF8String:service_uuid],
+                     [NSString stringWithUTF8String:char_uuid]];
+
+    // Check if there's already a queued notification
+    [conn.notifyLock lock];
+    NSMutableArray *queue = conn.notifyQueues[key];
+    if (queue && queue.count > 0) {
+        NSData *data = queue[0];
+        [queue removeObjectAtIndex:0];
+        [conn.notifyLock unlock];
+
+        res.length = (int)data.length;
+        res.data = (uint8_t *)malloc(res.length);
+        memcpy(res.data, data.bytes, res.length);
+        return res;
+    }
+    [conn.notifyLock unlock];
+
+    // Wait for notification
+    long result = dispatch_semaphore_wait(conn.notifySema,
+        dispatch_time(DISPATCH_TIME_NOW, (int64_t)timeout_seconds * NSEC_PER_SEC));
+
+    if (result != 0) { res.error = WENDY_BLE_ERR_TIMEOUT; return res; }
+
+    [conn.notifyLock lock];
+    queue = conn.notifyQueues[key];
+    if (queue && queue.count > 0) {
+        NSData *data = queue[0];
+        [queue removeObjectAtIndex:0];
+        [conn.notifyLock unlock];
+
+        res.length = (int)data.length;
+        res.data = (uint8_t *)malloc(res.length);
+        memcpy(res.data, data.bytes, res.length);
+        return res;
+    }
+    [conn.notifyLock unlock];
+
+    res.error = WENDY_BLE_ERR_TIMEOUT;
+    return res;
+}
+
+WendyBLEError wendy_ble_open_l2cap(WendyBLEConn handle, uint16_t psm, int timeout_seconds) {
+    WendyBLEConnection *conn = (__bridge WendyBLEConnection *)handle;
+    if (!conn.connected) return WENDY_BLE_ERR_DISCONNECTED;
+
+    conn.l2capError = NO;
+    conn.l2capChannel = nil;
+    [conn.peripheral openL2CAPChannel:psm];
+
+    long result = dispatch_semaphore_wait(conn.l2capSema,
+        dispatch_time(DISPATCH_TIME_NOW, (int64_t)timeout_seconds * NSEC_PER_SEC));
+
+    if (result != 0) return WENDY_BLE_ERR_TIMEOUT;
+    if (conn.l2capError || !conn.l2capChannel) return WENDY_BLE_ERR_L2CAP_FAILED;
+
+    return WENDY_BLE_OK;
+}
+
+WendyBLEError wendy_ble_l2cap_send(WendyBLEConn handle, const uint8_t *data, int length) {
+    WendyBLEConnection *conn = (__bridge WendyBLEConnection *)handle;
+    if (!conn.connected || !conn.l2capChannel || !conn.l2capIORunning) return WENDY_BLE_ERR_DISCONNECTED;
+
+    // Dispatch the write to the I/O thread that owns the output stream's run loop.
+    // CBL2CAP NSOutputStream writes must come from the owning run loop thread;
+    // calling write:maxLength: from any other thread returns -1.
+    NSData *writeData = [NSData dataWithBytes:data length:length];
+    [conn performSelector:@selector(performL2CAPWrite:)
+                 onThread:conn.l2capIOThread
+               withObject:writeData
+            waitUntilDone:YES];
+
+    if (conn.l2capWriteResult < 0) return WENDY_BLE_ERR_WRITE_FAILED;
+    return WENDY_BLE_OK;
+}
+
+WendyBLEL2CAPRecvResult wendy_ble_l2cap_recv(WendyBLEConn handle, int timeout_seconds) {
+    WendyBLEL2CAPRecvResult res = { .data = NULL, .length = 0, .error = WENDY_BLE_OK };
+    WendyBLEConnection *conn = (__bridge WendyBLEConnection *)handle;
+    if (!conn.connected || !conn.l2capChannel) { res.error = WENDY_BLE_ERR_DISCONNECTED; return res; }
+
+    // Check if data is already buffered
+    [conn.l2capRecvLock lock];
+    if (conn.l2capRecvBuffer.length > 0) {
+        res.length = (int)conn.l2capRecvBuffer.length;
+        res.data = (uint8_t *)malloc(res.length);
+        memcpy(res.data, conn.l2capRecvBuffer.bytes, res.length);
+        conn.l2capRecvBuffer.length = 0;
+        [conn.l2capRecvLock unlock];
+        return res;
+    }
+    [conn.l2capRecvLock unlock];
+
+    // Wait for data
+    long result = dispatch_semaphore_wait(conn.l2capRecvSema,
+        dispatch_time(DISPATCH_TIME_NOW, (int64_t)timeout_seconds * NSEC_PER_SEC));
+
+    if (result != 0) { res.error = WENDY_BLE_ERR_TIMEOUT; return res; }
+
+    [conn.l2capRecvLock lock];
+    if (conn.l2capRecvBuffer.length > 0) {
+        res.length = (int)conn.l2capRecvBuffer.length;
+        res.data = (uint8_t *)malloc(res.length);
+        memcpy(res.data, conn.l2capRecvBuffer.bytes, res.length);
+        conn.l2capRecvBuffer.length = 0;
+    } else if (conn.connected && conn.l2capIORunning && !conn.l2capError) {
+        // The buffered fast path above drains everything in one copy without
+        // consuming a semaphore count, so several signalled arrivals collapse
+        // into one return and leave the semaphore over-signalled. A later wait
+        // then succeeds immediately with the buffer already empty. The channel
+        // is still up, so report a timeout and let the caller retry rather than
+        // tearing the link down.
+        res.error = WENDY_BLE_ERR_TIMEOUT;
+    } else {
+        res.error = WENDY_BLE_ERR_DISCONNECTED;
+    }
+    [conn.l2capRecvLock unlock];
+
+    return res;
+}
+
+int wendy_ble_has_service(WendyBLEConn handle, const char *service_uuid) {
+    WendyBLEConnection *conn = (__bridge WendyBLEConnection *)handle;
+    CBUUID *svcUUID = [CBUUID UUIDWithString:[NSString stringWithUTF8String:service_uuid]];
+    for (CBService *svc in conn.peripheral.services) {
+        if ([svc.UUID isEqual:svcUUID]) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+char *wendy_ble_list_services(WendyBLEConn handle) {
+    WendyBLEConnection *conn = (__bridge WendyBLEConnection *)handle;
+    NSMutableArray<NSString *> *uuids = [NSMutableArray array];
+    for (CBService *svc in conn.peripheral.services) {
+        [uuids addObject:svc.UUID.UUIDString];
+    }
+    NSString *joined = [uuids componentsJoinedByString:@", "];
+    return strdup([joined UTF8String]);
+}
+
+void wendy_ble_disconnect(WendyBLEConn handle) {
+    if (!handle) return;
+    WendyBLEConnection *conn = (__bridge_transfer WendyBLEConnection *)handle;
+
+    conn.l2capIORunning = NO; // stop the I/O thread's run loop
+    // Both streams are closed and unscheduled by the I/O thread when l2capIORunning goes NO.
+
+    if (conn.peripheral && conn.connected) {
+        [conn.centralManager cancelPeripheralConnection:conn.peripheral];
+    }
+}
+
+void wendy_ble_free_data(uint8_t *data) {
+    free(data);
+}

--- a/go/internal/shared/ble/central/ble_linux.go
+++ b/go/internal/shared/ble/central/ble_linux.go
@@ -1,0 +1,424 @@
+//go:build linux
+
+package central
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/godbus/dbus/v5"
+	"golang.org/x/sys/unix"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/ble/bluez"
+)
+
+// Connection is two halves that share only the peer's address.
+//
+// The L2CAP half is a raw AF_BLUETOOTH socket: no cgo, no D-Bus, and no link
+// until OpenL2CAP. The GATT half (gatt_linux.go, bluez_linux.go) goes through
+// BlueZ over D-Bus and stays nil until the first GATT call, so a connection
+// that only carries a channel allocates no bus connection and starts no
+// goroutine.
+type Connection struct {
+	fd        int     // -1 once closed, so Close is idempotent
+	addr      [6]byte // MSB-first; x/sys reverses it into the kernel's bdaddr_t
+	addrType  uint8   // unix.BDADDR_LE_PUBLIC / BDADDR_LE_RANDOM
+	addrKnown bool    // false: nothing authoritative has told us the type yet
+	l2capOpen bool    // an open channel forbids tearing the ACL link down
+	sndMTU    int     // negotiated max SDU for L2CAPSend; 0 until a channel is open
+
+	address string // "AA:BB:CC:DD:EE:FF", uppercased, for BlueZ lookups
+
+	g *gattSession // nil until the first GATT call
+}
+
+// Connect parses the Bluetooth address and creates an AF_BLUETOOTH socket.
+//
+// It deliberately touches neither the radio nor D-Bus, and ignores its timeout:
+// no link comes up here. OpenL2CAP brings one up through the kernel, and
+// DiscoverServices brings one up through BlueZ, and which of those a caller
+// wants is not knowable yet.
+//
+// Staying lazy is what keeps the pure-L2CAP callers working against a device
+// BlueZ has no object for — it evicts unpaired devices roughly 30s after
+// discovery stops, while the kernel's L2CAP connect does its own
+// scan-and-connect and needs no cached object at all.
+func Connect(peripheralAddress string, _ int) (*Connection, error) {
+	addr, err := parseBTAddr(peripheralAddress)
+	if err != nil {
+		return nil, fmt.Errorf("parse BT address: %w", err)
+	}
+
+	fd, err := newL2CAPSocket()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Connection{
+		fd:       fd,
+		addr:     addr,
+		addrType: unix.BDADDR_LE_PUBLIC,
+		address:  strings.ToUpper(peripheralAddress),
+	}, nil
+}
+
+// newL2CAPSocket creates an L2CAP socket and binds it as an LE one.
+//
+// The bind is not optional and its address is not the point: binding is what
+// sets the channel's source address type, and l2cap_sock_connect only switches
+// the channel into LE credit-based flow control when that type is LE. Without
+// it the channel stays in basic L2CAP mode, and the kernel then writes each
+// payload as a bare PDU with no 2-byte SDU-length header — so the peer reads
+// the first two bytes of the data as the SDU length, gets a nonsense value, and
+// drops the channel. A TLS ClientHello starts 0x16 0x03, which reads as an SDU
+// of 790 bytes; anything over the peer's MTU is an instant disconnect.
+//
+// BDADDR_ANY leaves the controller choice to the kernel. The peripheral side in
+// internal/agent/bluetooth/l2cap_server_linux.go binds the same way, for the
+// same reason.
+func newL2CAPSocket() (int, error) {
+	fd, err := unix.Socket(unix.AF_BLUETOOTH, unix.SOCK_SEQPACKET|unix.SOCK_CLOEXEC, unix.BTPROTO_L2CAP)
+	if err != nil {
+		return -1, fmt.Errorf("create L2CAP socket: %w", err)
+	}
+	if err := unix.Bind(fd, &unix.SockaddrL2{AddrType: unix.BDADDR_LE_PUBLIC}); err != nil {
+		unix.Close(fd) //nolint:errcheck
+		return -1, fmt.Errorf("bind L2CAP socket as LE: %w", err)
+	}
+	return fd, nil
+}
+
+// addressProbeTimeout bounds the best-effort BlueZ lookup OpenL2CAP does to
+// learn the peer's LE address type. It is one D-Bus round trip against a local
+// socket, so anything longer would only be waiting out a wedged bluetoothd —
+// and the fallback below handles that fine.
+const addressProbeTimeout = 2 * time.Second
+
+// Socket options for the negotiated LE CoC SDU sizes. They are absent from
+// x/sys/unix, so the values come from the kernel's bluetooth.h.
+const (
+	solBluetooth = 274
+	btSndMTU     = 12
+)
+
+// l2capMinMTU is the smallest SDU an LE credit-based channel may negotiate
+// (Core Specification, Vol 3, Part A, 4.22). It is the fallback when the
+// kernel will not report the negotiated value: slow, but never wrong.
+const l2capMinMTU = 23
+
+// OpenL2CAP connects the socket to the remote device on the given PSM, using
+// non-blocking connect + Poll to respect the timeout.
+//
+// The LE address type has to match the one the peer advertises with, or the
+// controller pages an address nobody answers. BlueZ knows it, so ask — but
+// treat a miss as "unknown" rather than an error, because a device BlueZ has
+// never seen is exactly the case this path exists to serve.
+func (c *Connection) OpenL2CAP(psm uint16, timeoutSeconds int) error {
+	if c.fd < 0 {
+		return fmt.Errorf("connection is closed")
+	}
+	if !c.addrKnown {
+		// Lazy, not in Connect: a caller that only reads GATT never needs this,
+		// and DiscoverServices resolves the device anyway and fills it in.
+		if t, ok := probeAddressType(c.address); ok {
+			c.addrType, c.addrKnown = t, true
+		}
+	}
+
+	if c.addrKnown {
+		if err := c.connectL2CAP(psm, c.addrType, timeoutSeconds); err != nil {
+			return err
+		}
+		c.noteChannelOpen()
+		return nil
+	}
+
+	// Nothing authoritative to go on. Try public first — the WendyOS agent and
+	// the Wendy Lite firmware both use public addresses — then random. A wrong
+	// guess usually times out rather than failing fast, so split the caller's
+	// budget instead of spending it twice and blowing through the deadline.
+	each := timeoutSeconds / 2
+	if each < 1 {
+		each = 1
+	}
+	publicErr := c.connectL2CAP(psm, unix.BDADDR_LE_PUBLIC, each)
+	if publicErr == nil {
+		c.addrType, c.addrKnown = unix.BDADDR_LE_PUBLIC, true
+		c.noteChannelOpen()
+		return nil
+	}
+	// A socket whose connect failed cannot be reconnected; start clean.
+	if err := c.resetSocket(); err != nil {
+		return fmt.Errorf("connect as public address: %w (could not retry as random: %v)", publicErr, err)
+	}
+	if randomErr := c.connectL2CAP(psm, unix.BDADDR_LE_RANDOM, each); randomErr != nil {
+		return fmt.Errorf("connect as public address: %w; as random address: %w", publicErr, randomErr)
+	}
+	c.addrType, c.addrKnown = unix.BDADDR_LE_RANDOM, true
+	c.noteChannelOpen()
+	return nil
+}
+
+// noteChannelOpen records a freshly opened channel and reads back the SDU size
+// the two ends negotiated, which is what L2CAPSend has to chunk to.
+func (c *Connection) noteChannelOpen() {
+	c.l2capOpen = true
+	c.sndMTU = l2capMinMTU
+	// Only known once the channel is up: it comes from the peer's half of the
+	// LE credit-based connection response.
+	if mtu, err := unix.GetsockoptInt(c.fd, solBluetooth, btSndMTU); err == nil && mtu >= l2capMinMTU {
+		c.sndMTU = mtu
+	}
+}
+
+// pollFD waits for events on fd, retrying when a signal interrupts the wait.
+//
+// The Go runtime preempts goroutines by sending SIGURG, so any poll long enough
+// to matter gets interrupted sooner or later on a busy process. Reporting that
+// as a failure turned an ordinary idle wait into "interrupted system call" —
+// which is what an L2CAP receive did whenever nothing arrived promptly.
+func pollFD(fd int, events int16, timeout time.Duration) (int, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		remaining := time.Until(deadline)
+		if remaining < 0 {
+			remaining = 0
+		}
+		pfd := []unix.PollFd{{Fd: int32(fd), Events: events}}
+		n, err := unix.Poll(pfd, int(remaining.Milliseconds()))
+		if err == unix.EINTR {
+			continue
+		}
+		return n, err
+	}
+}
+
+// connectL2CAP performs one non-blocking connect attempt with a specific LE
+// address type, leaving the socket blocking on success.
+func (c *Connection) connectL2CAP(psm uint16, addrType uint8, timeoutSeconds int) error {
+	if err := unix.SetNonblock(c.fd, true); err != nil {
+		return fmt.Errorf("set nonblock: %w", err)
+	}
+
+	sa := &unix.SockaddrL2{
+		PSM:      psm,
+		Addr:     c.addr,
+		AddrType: addrType,
+	}
+
+	err := unix.Connect(c.fd, sa)
+	if err != nil && err != unix.EINPROGRESS {
+		return fmt.Errorf("connect: %w", err)
+	}
+
+	if err == unix.EINPROGRESS {
+		// Wait for connection to complete.
+		n, pollErr := pollFD(c.fd, unix.POLLOUT, time.Duration(timeoutSeconds)*time.Second)
+		if pollErr != nil {
+			return fmt.Errorf("poll connect: %w", pollErr)
+		}
+		if n == 0 {
+			return fmt.Errorf("connect timeout after %ds", timeoutSeconds)
+		}
+		// Check if the connection actually succeeded.
+		errno, sockErr := unix.GetsockoptInt(c.fd, unix.SOL_SOCKET, unix.SO_ERROR)
+		if sockErr != nil {
+			return fmt.Errorf("getsockopt: %w", sockErr)
+		}
+		if errno != 0 {
+			return fmt.Errorf("connect failed: %w", unix.Errno(errno))
+		}
+	}
+
+	// Switch back to blocking mode for subsequent reads/writes.
+	if err := unix.SetNonblock(c.fd, false); err != nil {
+		return fmt.Errorf("set blocking: %w", err)
+	}
+
+	return nil
+}
+
+// resetSocket replaces the socket after a failed connect, which leaves it
+// unusable for another attempt.
+func (c *Connection) resetSocket() error {
+	if c.fd >= 0 {
+		unix.Close(c.fd) //nolint:errcheck
+		c.fd = -1
+	}
+	fd, err := newL2CAPSocket()
+	if err != nil {
+		return fmt.Errorf("recreate L2CAP socket: %w", err)
+	}
+	c.fd = fd
+	c.l2capOpen, c.sndMTU = false, 0
+	return nil
+}
+
+// L2CAPSend sends raw bytes over the L2CAP channel, splitting them across as
+// many SDUs as the negotiated MTU requires.
+//
+// The socket is SOCK_SEQPACKET, so one write is one SDU: the kernel either
+// takes the whole buffer or fails with EMSGSIZE, and never reports a partial
+// write. A loop over the remainder therefore cannot chunk anything on its own —
+// it just fails on the first oversized buffer, which is what a TLS handshake
+// record is. Splitting here is safe because the channel is a byte stream to
+// everything above (see NewL2CAPStream): both peers reassemble by the length
+// prefix, not by SDU boundary.
+//
+// Framing (length prefix) is handled by the caller (agent_client.go).
+func (c *Connection) L2CAPSend(data []byte) error {
+	if c.fd < 0 {
+		return fmt.Errorf("connection is closed")
+	}
+	chunk := c.sndMTU
+	if chunk <= 0 {
+		chunk = l2capMinMTU
+	}
+
+	for written := 0; written < len(data); {
+		end := written + chunk
+		if end > len(data) {
+			end = len(data)
+		}
+		n, err := unix.Write(c.fd, data[written:end])
+		if err == unix.EINTR {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("write: %w", err)
+		}
+		if n == 0 {
+			return fmt.Errorf("write: no progress")
+		}
+		written += n
+	}
+	return nil
+}
+
+// L2CAPRecv receives one L2CAP SDU with a timeout.
+// Returns the raw bytes (including any framing added by the caller).
+func (c *Connection) L2CAPRecv(timeoutSeconds int) ([]byte, error) {
+	if c.fd < 0 {
+		return nil, fmt.Errorf("connection is closed")
+	}
+	// Poll with timeout.
+	n, err := pollFD(c.fd, unix.POLLIN, time.Duration(timeoutSeconds)*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("poll recv: %w", err)
+	}
+	if n == 0 {
+		return nil, fmt.Errorf("%w after %ds", ErrRecvTimeout, timeoutSeconds)
+	}
+
+	buf := make([]byte, 65536)
+	nRead, err := unix.Read(c.fd, buf)
+	for err == unix.EINTR {
+		nRead, err = unix.Read(c.fd, buf)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read: %w", err)
+	}
+	if nRead == 0 {
+		return nil, fmt.Errorf("connection closed by peer")
+	}
+	result := make([]byte, nRead)
+	copy(result, buf[:nRead])
+	return result, nil
+}
+
+// Close releases both halves. It is idempotent: the fd is cleared, so a second
+// call cannot close an unrelated descriptor that has since taken the number.
+func (c *Connection) Close() {
+	if c.g != nil {
+		// Whether the ACL link goes down with it depends on who brought it up
+		// and whether a channel is still riding on it — see gattSession.close.
+		c.g.close(c.l2capOpen)
+		c.g = nil
+	}
+	if c.fd >= 0 {
+		unix.Close(c.fd) //nolint:errcheck
+		c.fd = -1
+	}
+	c.l2capOpen, c.sndMTU = false, 0
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+// probeAddressType asks BlueZ for a device's LE address type over a short-lived
+// bus connection. Best-effort by design: every failure — no bus, no adapter, no
+// cached device — reports "unknown" so the caller falls back to guessing rather
+// than refusing to connect.
+//
+// The bus is dropped again immediately. An L2CAP-only session must not be left
+// holding a connection it will never use.
+func probeAddressType(address string) (uint8, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), addressProbeTimeout)
+	defer cancel()
+
+	bus, err := dbus.ConnectSystemBus()
+	if err != nil {
+		return unix.BDADDR_LE_PUBLIC, false
+	}
+	defer bus.Close() //nolint:errcheck
+
+	managed, err := bluez.GetManagedObjects(ctx, bus)
+	if err != nil {
+		return unix.BDADDR_LE_PUBLIC, false
+	}
+	// An adapter that cannot be resolved is not fatal here: an unrestricted
+	// lookup still finds the device on whichever controller saw it.
+	adapter, _ := bluez.ResolveAdapterPath(managed)
+	_, _, props, ok := bluez.FindDeviceByAddress(bluez.RestrictToAdapter(managed, adapter), address)
+	if !ok {
+		return unix.BDADDR_LE_PUBLIC, false
+	}
+	return addressTypeFromProps(props)
+}
+
+// addressTypeFromProps maps org.bluez.Device1.AddressType onto the constant
+// SockaddrL2 wants. ok is false when BlueZ reported nothing usable, which the
+// caller must treat as "guess" rather than as "public".
+func addressTypeFromProps(props map[string]dbus.Variant) (uint8, bool) {
+	s, _ := bluez.StringProp(props, "AddressType")
+	switch strings.ToLower(s) {
+	case "public":
+		return unix.BDADDR_LE_PUBLIC, true
+	case "random":
+		return unix.BDADDR_LE_RANDOM, true
+	default:
+		return unix.BDADDR_LE_PUBLIC, false
+	}
+}
+
+// parseBTAddr parses "AA:BB:CC:DD:EE:FF" into the [6]byte unix.SockaddrL2
+// takes: most-significant byte first, the order the address is written in.
+//
+// That is deliberately NOT the kernel's byte order. A bdaddr_t is little-endian,
+// but x/sys/unix reverses SockaddrL2.Addr while marshalling the struct, so it
+// wants the human order and does the conversion itself. Handing it an
+// already-reversed address cancels the reversal out and aims the connect at a
+// byte-reversed peer, which nothing answers — every PSM then times out
+// identically instead of being refused, which is what this looked like.
+func parseBTAddr(s string) ([6]byte, error) {
+	var addr [6]byte
+	s = strings.ToUpper(s)
+	if len(s) != 17 {
+		return addr, fmt.Errorf("invalid BT address length: %q", s)
+	}
+	for i, offset := range []int{0, 3, 6, 9, 12, 15} {
+		// Guard on offset, not on i: the pair at offset 0 is the one with no
+		// separator in front of it. Guarding on i once indexed s[-1] on every
+		// valid address, which panicked instead of parsing.
+		if offset > 0 && s[offset-1] != ':' {
+			return addr, fmt.Errorf("invalid BT address separator at position %d: %q", offset-1, s)
+		}
+		var b byte
+		if _, err := fmt.Sscanf(s[offset:offset+2], "%02X", &b); err != nil {
+			return addr, fmt.Errorf("invalid BT address byte at position %d: %w", offset, err)
+		}
+		addr[i] = b
+	}
+	return addr, nil
+}

--- a/go/internal/shared/ble/central/ble_windows.go
+++ b/go/internal/shared/ble/central/ble_windows.go
@@ -1,0 +1,63 @@
+//go:build windows
+
+package central
+
+import "fmt"
+
+type Connection struct{}
+
+// Connect establishes a BLE connection to the peripheral identified by its address.
+func Connect(peripheralAddress string, timeoutSeconds int) (*Connection, error) {
+	return nil, fmt.Errorf("BLE client not yet implemented on Windows; use a LAN connection instead")
+}
+
+// DiscoverServices discovers all services and characteristics on the peripheral.
+func (c *Connection) DiscoverServices(timeoutSeconds int) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (c *Connection) WriteCharacteristic(serviceUUID, charUUID string, data []byte) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (c *Connection) WriteCharacteristicNoResponse(serviceUUID, charUUID string, data []byte) error {
+	return fmt.Errorf("not implemented")
+}
+
+// ReadCharacteristic reads data from a GATT characteristic.
+func (c *Connection) ReadCharacteristic(serviceUUID, charUUID string) ([]byte, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// Subscribe enables notifications for a GATT characteristic.
+func (c *Connection) Subscribe(serviceUUID, charUUID string) error {
+	return fmt.Errorf("not implemented")
+}
+
+// WaitNotification waits for a notification on a subscribed characteristic.
+func (c *Connection) WaitNotification(serviceUUID, charUUID string, timeoutSeconds int) ([]byte, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// OpenL2CAP opens an L2CAP channel on the given PSM.
+func (c *Connection) OpenL2CAP(psm uint16, timeoutSeconds int) error {
+	return fmt.Errorf("not implemented")
+}
+
+// L2CAPSend sends data over the L2CAP channel.
+func (c *Connection) L2CAPSend(data []byte) error {
+	return fmt.Errorf("not implemented")
+}
+
+// L2CAPRecv receives data from the L2CAP channel.
+func (c *Connection) L2CAPRecv(timeoutSeconds int) ([]byte, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// HasService checks whether a specific service UUID was discovered.
+func (c *Connection) HasService(serviceUUID string) bool { return false }
+
+func (c *Connection) ListServices() string { return "" }
+
+// Close disconnects and frees all BLE resources.
+func (c *Connection) Close() {}

--- a/go/internal/shared/ble/central/bluez_linux.go
+++ b/go/internal/shared/ble/central/bluez_linux.go
@@ -1,0 +1,475 @@
+//go:build linux
+
+package central
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/godbus/dbus/v5"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/ble/bluez"
+)
+
+const (
+	// gattOpTimeout bounds one characteristic operation. It matches the hard
+	// 10s the darwin backend uses, so a caller sees the same worst case on
+	// either platform.
+	gattOpTimeout = 10 * time.Second
+	// resolvePollInterval is how often on-demand discovery re-enumerates the
+	// object tree looking for the target device. Devices typically appear a few
+	// hundred ms in, so a sub-second poll keeps the added latency small.
+	resolvePollInterval = 300 * time.Millisecond
+	// resolvedPollInterval is how often ServicesResolved is re-read while
+	// waiting. The signal usually arrives first; this only has to cover a
+	// resolve that happened before the match rule took effect.
+	resolvedPollInterval = 250 * time.Millisecond
+	// stopDiscoveryTimeout and disconnectTimeout bound best-effort cleanup,
+	// which often runs after the request context is already canceled. Without
+	// their own deadlines a plain Call would block forever on a wedged
+	// bluetoothd.
+	stopDiscoveryTimeout = 3 * time.Second
+	disconnectTimeout    = 3 * time.Second
+	// signalChanDepth buffers PropertiesChanged signals ahead of the router.
+	// godbus does not drop when a registered channel is full — it spawns a
+	// goroutine per signal — so depth here is what keeps a burst from turning
+	// into goroutines.
+	signalChanDepth = 64
+	// notifyQueueDepth buffers notifications per characteristic between the
+	// router and WaitNotification.
+	notifyQueueDepth = 16
+)
+
+// charKey identifies a characteristic by the pair of canonical UUIDs the public
+// API takes. Object paths never leave this file.
+type charKey struct {
+	service        string
+	characteristic string
+}
+
+type charEntry struct {
+	path  dbus.ObjectPath
+	flags []string // GattCharacteristic1.Flags, for error messages
+	mtu   uint16   // GattCharacteristic1.MTU; 0 before BlueZ 5.62
+}
+
+// gattSession is the BlueZ half of a Connection: one bus, one device object,
+// the discovered characteristic index, and the goroutine that fans
+// PropertiesChanged signals into per-characteristic queues.
+type gattSession struct {
+	bus         *dbus.Conn
+	address     string // for messages
+	adapterPath string
+	devicePath  dbus.ObjectPath
+	weConnected bool // we brought the ACL link up, so we may take it down
+
+	// objFn is a seam: production hands back a bus object, tests hand back a
+	// fake, so the D-Bus call/response shapes are testable with no bus.
+	objFn func(dbus.ObjectPath) bluez.Caller
+
+	signals    chan *dbus.Signal
+	routerDone chan struct{}
+	resolved   chan struct{} // buffered(1); the router pokes it, never blocks on it
+	lost       chan struct{} // closed once, when Connected goes false
+	lostOnce   sync.Once
+	closeOnce  sync.Once
+
+	mu       sync.Mutex
+	services []string // canonical, sorted
+	svcSet   map[string]bool
+	chars    map[charKey]charEntry
+	notify   map[dbus.ObjectPath]chan []byte
+}
+
+// ensureSession opens the bus, resolves the device object and starts the signal
+// router. It is idempotent for the life of the Connection.
+func (c *Connection) ensureSession(ctx context.Context) (*gattSession, error) {
+	if c.g != nil {
+		return c.g, nil
+	}
+
+	bus, err := dbus.ConnectSystemBus()
+	if err != nil {
+		return nil, fmt.Errorf("connecting to system bus: %w", err)
+	}
+
+	devicePath, adapterPath, props, err := c.resolveDevice(ctx, bus)
+	if err != nil {
+		bus.Close() //nolint:errcheck
+		return nil, err
+	}
+
+	// Free win for the L2CAP half: BlueZ has now told us the address type
+	// authoritatively, and liteclient reads the info service before it opens a
+	// channel, so OpenL2CAP no longer has to guess.
+	if t, ok := addressTypeFromProps(props); ok {
+		c.addrType, c.addrKnown = t, true
+	}
+
+	g := &gattSession{
+		bus:         bus,
+		address:     c.address,
+		adapterPath: adapterPath,
+		devicePath:  devicePath,
+		signals:     make(chan *dbus.Signal, signalChanDepth),
+		routerDone:  make(chan struct{}),
+		resolved:    make(chan struct{}, 1),
+		lost:        make(chan struct{}),
+		svcSet:      map[string]bool{},
+		chars:       map[charKey]charEntry{},
+		notify:      map[dbus.ObjectPath]chan []byte{},
+	}
+	g.objFn = func(p dbus.ObjectPath) bluez.Caller { return bus.Object(bluez.Service, p) }
+
+	// One rule for the device and everything nested under it: the device object
+	// itself carries ServicesResolved and Connected, its children carry the
+	// characteristic Values. Per-characteristic rules would cost a bus round
+	// trip per Subscribe and buy nothing, since the router filters on interface
+	// anyway.
+	//
+	// Installed before Device1.Connect below, because a device that resolves
+	// immediately would otherwise emit ServicesResolved into a rule that does
+	// not exist yet.
+	if err := bus.AddMatchSignalContext(ctx,
+		dbus.WithMatchSender(bluez.Service),
+		dbus.WithMatchInterface(bluez.PropsIface),
+		dbus.WithMatchMember("PropertiesChanged"),
+		dbus.WithMatchPathNamespace(devicePath),
+	); err != nil {
+		bus.Close() //nolint:errcheck
+		return nil, fmt.Errorf("subscribing to BlueZ property changes: %w", err)
+	}
+	bus.Signal(g.signals)
+	go g.route()
+
+	c.g = g
+	return g, nil
+}
+
+// resolveDevice finds the BlueZ object for this connection's address, running a
+// bounded discovery when there is none.
+//
+// The device is matched on its Address property rather than by building
+// /org/bluez/hciX/dev_AA_BB_..., which is only a naming convention and says
+// nothing about whether the object exists.
+func (c *Connection) resolveDevice(ctx context.Context, bus *dbus.Conn) (dbus.ObjectPath, string, map[string]dbus.Variant, error) {
+	managed, err := bluez.GetManagedObjects(ctx, bus)
+	if err != nil {
+		return "", "", nil, err
+	}
+	adapterPath, err := bluez.ResolveAdapterPath(managed)
+	if err != nil {
+		return "", "", nil, err
+	}
+	if path, _, props, ok := bluez.FindDeviceByAddress(bluez.RestrictToAdapter(managed, adapterPath), c.address); ok {
+		return path, adapterPath, props, nil
+	}
+
+	// Not cached. BlueZ evicts unpaired devices roughly 30s after discovery
+	// stops, so this is the ordinary case when connecting a while after a scan
+	// — and unlike the raw L2CAP socket, a GATT connect genuinely needs the
+	// object to exist.
+	if err := bluez.PowerOn(ctx, bus, adapterPath); err != nil {
+		return "", "", nil, fmt.Errorf("powering on adapter %s: %w", adapterPath, err)
+	}
+	adapter := bus.Object(bluez.Service, dbus.ObjectPath(adapterPath))
+	if call := adapter.CallWithContext(ctx, bluez.AdapterIface+".StartDiscovery", 0); call.Err != nil {
+		// Another client already scanning works for us too.
+		if !bluez.IsErrorName(call.Err, "org.bluez.Error.InProgress") {
+			return "", "", nil, fmt.Errorf("starting discovery on %s: %w", adapterPath, call.Err)
+		}
+	}
+	// Discovery must stop before the connect that follows: on older kernels an
+	// outgoing LE connect issued while the controller is scanning fails.
+	defer func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), stopDiscoveryTimeout)
+		defer cancel()
+		_ = adapter.CallWithContext(stopCtx, bluez.AdapterIface+".StopDiscovery", 0).Err
+	}()
+
+	ticker := time.NewTicker(resolvePollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return "", "", nil, fmt.Errorf("%w: %s was not seen advertising within the timeout",
+				bluez.ErrDeviceNotFound, c.address)
+		case <-ticker.C:
+			managed, err := bluez.GetManagedObjects(ctx, bus)
+			if err != nil {
+				// The context expiring mid-call lands here; the next loop turn
+				// reports it as the not-found it is.
+				continue
+			}
+			if path, _, props, ok := bluez.FindDeviceByAddress(bluez.RestrictToAdapter(managed, adapterPath), c.address); ok {
+				return path, adapterPath, props, nil
+			}
+		}
+	}
+}
+
+// connect brings the ACL link up if it is not up already.
+//
+// A link someone else established is used as-is and never claimed: taking it
+// down in Close would break whoever owns it.
+func (g *gattSession) connect(ctx context.Context) error {
+	dev := g.objFn(g.devicePath)
+	if connected, ok := bluez.LiveBoolProp(ctx, dev, bluez.DeviceIface, "Connected"); ok && connected {
+		return nil
+	}
+	if call := dev.CallWithContext(ctx, bluez.DeviceIface+".Connect", 0); call.Err != nil {
+		if bluez.IsErrorName(call.Err, "org.bluez.Error.AlreadyConnected") {
+			// Raced someone else's connect; same as the branch above.
+			return nil
+		}
+		return wrapGATTError("connecting to "+g.address, call.Err)
+	}
+	g.weConnected = true
+	return nil
+}
+
+// waitServicesResolved blocks until BlueZ finishes GATT discovery, which is
+// when the GattService1 and GattCharacteristic1 objects appear.
+//
+// Signal and poll together: Device1.Connect normally returns only after
+// bluetoothd has resolved, so the first read usually wins, and the signal
+// covers the case where another client's connect is still in flight.
+func (g *gattSession) waitServicesResolved(ctx context.Context) error {
+	dev := g.objFn(g.devicePath)
+	for {
+		if resolved, ok := bluez.LiveBoolProp(ctx, dev, bluez.DeviceIface, "ServicesResolved"); ok && resolved {
+			return nil
+		}
+		select {
+		case <-g.resolved:
+			return nil
+		case <-g.lost:
+			return fmt.Errorf("%w: link to %s dropped before services resolved", ErrGATTDisconnected, g.address)
+		case <-ctx.Done():
+			return fmt.Errorf("services on %s did not resolve within the timeout", g.address)
+		case <-time.After(resolvedPollInterval):
+		}
+	}
+}
+
+// rebuildIndex re-reads the object tree and swaps in a fresh characteristic
+// index. Safe to call more than once: a caller that reads the info service and
+// later opens a provisioning session discovers twice on one connection.
+func (g *gattSession) rebuildIndex(ctx context.Context) error {
+	managed, err := bluez.GetManagedObjects(ctx, g.bus)
+	if err != nil {
+		return err
+	}
+	services, chars := buildIndex(managed, g.devicePath)
+
+	set := make(map[string]bool, len(services))
+	for _, s := range services {
+		set[s] = true
+	}
+
+	g.mu.Lock()
+	g.services, g.svcSet, g.chars = services, set, chars
+	g.mu.Unlock()
+	return nil
+}
+
+// buildIndex maps BlueZ's object tree under devicePath to the canonical UUID
+// pairs the public API takes. Pure — no bus, no I/O — which is what makes it
+// the most useful thing in this file to test without a radio.
+func buildIndex(managed bluez.ManagedObjects, devicePath dbus.ObjectPath) (services []string, chars map[charKey]charEntry) {
+	prefix := string(devicePath) + "/"
+	chars = map[charKey]charEntry{}
+
+	// Pass 1: service object path -> canonical UUID.
+	svcUUID := map[dbus.ObjectPath]string{}
+	seen := map[string]bool{}
+	for path, ifaces := range managed {
+		props, ok := ifaces[bluez.GattServiceIface]
+		if !ok || !strings.HasPrefix(string(path), prefix) {
+			continue
+		}
+		raw, _ := bluez.StringProp(props, "UUID")
+		uuid := canonicalUUID(raw)
+		if uuid == "" {
+			continue
+		}
+		svcUUID[path] = uuid
+		if !seen[uuid] {
+			seen[uuid] = true
+			services = append(services, uuid)
+		}
+	}
+	// Sorted so ListServices is stable; map iteration order alone is randomized.
+	sort.Strings(services)
+
+	// Pass 2: characteristics, keyed by their parent service's UUID.
+	for path, ifaces := range managed {
+		props, ok := ifaces[bluez.GattCharIface]
+		if !ok || !strings.HasPrefix(string(path), prefix) {
+			continue
+		}
+		// The Service property is authoritative; the parent path is the
+		// fallback for a BlueZ that omits it.
+		svcPath := bluez.ObjectPathProp(props, "Service")
+		if svcPath == "" {
+			svcPath = parentPath(path)
+		}
+		service, ok := svcUUID[svcPath]
+		if !ok {
+			continue
+		}
+		raw, _ := bluez.StringProp(props, "UUID")
+		uuid := canonicalUUID(raw)
+		if uuid == "" {
+			continue
+		}
+
+		key := charKey{service: service, characteristic: uuid}
+		// A service may legitimately expose one characteristic UUID twice.
+		// Lowest object path wins so repeated runs pick the same one.
+		if prev, dup := chars[key]; dup && prev.path <= path {
+			continue
+		}
+		chars[key] = charEntry{
+			path:  path,
+			flags: bluez.StringsProp(props, "Flags"),
+			mtu:   bluez.Uint16Prop(props, "MTU"),
+		}
+	}
+	return services, chars
+}
+
+func parentPath(p dbus.ObjectPath) dbus.ObjectPath {
+	s := string(p)
+	if i := strings.LastIndex(s, "/"); i > 0 {
+		return dbus.ObjectPath(s[:i])
+	}
+	return ""
+}
+
+// route fans PropertiesChanged signals out until the bus closes.
+//
+// bus.Close is what ends this: godbus's Terminate closes every registered
+// signal channel. RemoveSignal would not — it unregisters without closing — so
+// the router would range forever.
+func (g *gattSession) route() {
+	defer close(g.routerDone)
+	for sig := range g.signals {
+		g.handleSignal(sig)
+	}
+}
+
+// handleSignal is split from route so it can be driven with hand-built signals
+// and no bus at all.
+func (g *gattSession) handleSignal(sig *dbus.Signal) {
+	if sig == nil || sig.Name != bluez.PropsChangedName || len(sig.Body) < 2 {
+		return
+	}
+	iface, _ := sig.Body[0].(string)
+	changed, _ := sig.Body[1].(map[string]dbus.Variant)
+	if changed == nil {
+		return
+	}
+
+	switch iface {
+	case bluez.DeviceIface:
+		if v, ok := changed["ServicesResolved"]; ok {
+			if resolved, _ := v.Value().(bool); resolved {
+				// Buffered(1) and non-blocking: a waiter that has already moved
+				// on must not wedge the router.
+				select {
+				case g.resolved <- struct{}{}:
+				default:
+				}
+			}
+		}
+		if v, ok := changed["Connected"]; ok {
+			if connected, _ := v.Value().(bool); !connected {
+				g.markLost()
+			}
+		}
+	case bluez.GattCharIface:
+		v, ok := changed["Value"]
+		if !ok {
+			return
+		}
+		val, ok := v.Value().([]byte)
+		if !ok {
+			return
+		}
+		// Copy: the variant's slice belongs to the unmarshaled message.
+		g.deliver(sig.Path, append([]byte(nil), val...))
+	}
+}
+
+// deliver queues one notification for the characteristic at path.
+//
+// It must never block. godbus does not drop signals for a full registered
+// channel — it spawns a goroutine per signal — so a router parked on a full
+// queue would turn a chatty peripheral into unbounded goroutine growth. When a
+// queue is full the oldest value goes: these carry device state, where the
+// freshest reading is the useful one.
+func (g *gattSession) deliver(path dbus.ObjectPath, value []byte) {
+	g.mu.Lock()
+	queue := g.notify[path]
+	g.mu.Unlock()
+	if queue == nil {
+		// Not subscribed: another client's notification, or the echo BlueZ
+		// emits for our own ReadValue on a characteristic nobody watches.
+		return
+	}
+
+	select {
+	case queue <- value:
+	default:
+		select {
+		case <-queue:
+		default:
+		}
+		select {
+		case queue <- value:
+		default:
+		}
+	}
+}
+
+func (g *gattSession) markLost() {
+	g.lostOnce.Do(func() { close(g.lost) })
+}
+
+// close tears the session down. l2capOpen reports whether a channel is still
+// riding on the ACL link, which decides whether the link may go down with it.
+func (g *gattSession) close(l2capOpen bool) {
+	g.closeOnce.Do(func() {
+		// Disconnect drops the HCI link, taking every L2CAP channel on it with
+		// it — ours or another process's. Only tear it down when we brought it
+		// up and nothing of ours is still using it.
+		if g.weConnected && !l2capOpen {
+			ctx, cancel := context.WithTimeout(context.Background(), disconnectTimeout)
+			defer cancel()
+			_ = g.objFn(g.devicePath).CallWithContext(ctx, bluez.DeviceIface+".Disconnect", 0).Err
+		}
+		// No StopNotify: bluetoothd tracks notify clients per bus name and
+		// drops ours when the connection goes away.
+		g.bus.Close() //nolint:errcheck
+		<-g.routerDone
+	})
+}
+
+// wrapGATTError turns a raw D-Bus failure into a user-facing error, keeping the
+// underlying dbus.Error wrapped so errors.As still yields the org.bluez.Error.*
+// name for a caller that wants to branch on it.
+func wrapGATTError(op string, err error) error {
+	name, message, ok := bluez.ErrorInfo(err)
+	if !ok {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	if text, ok := friendlyGATTError(name, message); ok {
+		return fmt.Errorf("%s: %s (%w)", op, text, err)
+	}
+	return fmt.Errorf("%s: %w", op, err)
+}

--- a/go/internal/shared/ble/central/conn.go
+++ b/go/internal/shared/ble/central/conn.go
@@ -1,0 +1,189 @@
+// Package central is a generic, cross-platform BLE central (client): connect to
+// a peripheral, talk GATT, and open an L2CAP channel that can carry TLS.
+//
+// Nothing here is specific to any device or protocol — every method takes plain
+// service/characteristic UUIDs and PSMs. The Wendy protocol clients live in
+// internal/cli/ble; peripheral discovery lives beside this package in
+// internal/shared/ble/scan, which yields the address Connect takes.
+//
+// The API is blocking, with whole-second timeouts, and Connection is not
+// goroutine-safe for GATT. See ../README.md for the capability matrix per
+// platform and the concurrency rules.
+package central
+
+import (
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// ErrRecvTimeout reports that no L2CAP data arrived within the timeout passed to
+// (*Connection).L2CAPRecv. It is a sentinel, not a failure: the channel is still
+// open, and a caller with no deadline of its own is expected to retry.
+var ErrRecvTimeout = errors.New("BLE L2CAP receive timeout")
+
+// ErrGATTNotFound reports that a service or characteristic is absent from what
+// discovery found — the device is reachable, it simply does not have this. It
+// is the one GATT failure a caller can reasonably act on differently, which is
+// why it is a sentinel and the rest are strings.
+//
+// It also covers a GATT call made before DiscoverServices, since the effect is
+// the same: nothing is in the index.
+var ErrGATTNotFound = errors.New("BLE GATT service or characteristic not found")
+
+// ErrGATTDisconnected reports that the link dropped while an operation was in
+// flight or a waiter was parked. Distinguishable from a timeout because there
+// is nothing to wait for any more.
+var ErrGATTDisconnected = errors.New("BLE peripheral disconnected")
+
+// recvChunkSeconds bounds one L2CAPRecv call. It is polling granularity, not a
+// timeout any caller sees: Read retries until its own deadline expires, or
+// forever if it has none. It also bounds how long Close waits for an in-flight
+// Read to come back out of the platform layer, so keep it small.
+const recvChunkSeconds = 2
+
+// TimeoutSeconds converts a duration to the whole seconds the platform layer
+// takes, rounding up and never returning less than 1. Both backends read a
+// 0-second timeout as "return immediately" — dispatch_semaphore_wait with
+// DISPATCH_TIME_NOW on darwin, poll(2) with 0ms on Linux — so truncating a
+// sub-second budget to 0 would turn a short wait into a hot spin. A negative
+// value would make poll(2) block forever.
+func TimeoutSeconds(d time.Duration) int {
+	if d <= 0 {
+		return 1
+	}
+	return int((d + time.Second - 1) / time.Second)
+}
+
+// NewL2CAPStream presents an open L2CAP channel as a net.Conn, which is all
+// crypto/tls and the framing above it need. Call it after OpenL2CAP. Closing the
+// returned conn closes the underlying BLE connection.
+//
+// The channel is a byte stream, not a datagram sequence: CoreBluetooth delivers
+// it through an NSStream and drops SDU boundaries, so nothing above may assume
+// one Read is one SDU. Leftover bytes from an oversized read are buffered for
+// subsequent Read calls.
+func NewL2CAPStream(c *Connection) net.Conn {
+	return &l2capNetConn{conn: c}
+}
+
+type l2capNetConn struct {
+	conn         *Connection
+	buf          []byte     // leftover from a previous L2CAPRecv
+	readDeadline time.Time  // zero means no deadline; owned by the single reader
+	recvMu       sync.Mutex // held across L2CAPRecv so Close can't free under it
+	closed       atomic.Bool
+}
+
+// Read blocks until data arrives, the deadline expires, or the channel closes.
+// With no deadline set it waits indefinitely, as net.Conn requires: the
+// platform recv is polled in recvChunkSeconds slices and a slice that expires
+// with nothing to show is retried rather than reported.
+func (c *l2capNetConn) Read(b []byte) (int, error) {
+	if len(c.buf) > 0 {
+		n := copy(b, c.buf)
+		c.buf = c.buf[n:]
+		return n, nil
+	}
+
+	for {
+		chunk := recvChunkSeconds
+		if !c.readDeadline.IsZero() {
+			remaining := time.Until(c.readDeadline)
+			if remaining <= 0 {
+				return 0, &timeoutErr{}
+			}
+			if secs := TimeoutSeconds(remaining); secs < chunk {
+				chunk = secs
+			}
+		}
+
+		data, err := c.recv(chunk)
+		if errors.Is(err, ErrRecvTimeout) {
+			// An idle channel is not a dead one. With no deadline the caller
+			// asked to wait indefinitely — liteclient's read loop sits here
+			// between device events — so keep waiting; with a deadline, the
+			// check above ends it.
+			continue
+		}
+		if err != nil {
+			return 0, err
+		}
+		if len(data) == 0 {
+			return 0, io.EOF
+		}
+
+		n := copy(b, data)
+		if n < len(data) {
+			c.buf = append([]byte(nil), data[n:]...)
+		}
+		return n, nil
+	}
+}
+
+// recv runs one L2CAPRecv under recvMu so Close cannot tear the platform
+// connection down while the call is still inside it. On darwin
+// wendy_ble_disconnect hands the CoreBluetooth wrapper to ARC, which releases
+// it — while a blocked reader still holds a bare pointer to the same object.
+func (c *l2capNetConn) recv(chunkSeconds int) ([]byte, error) {
+	c.recvMu.Lock()
+	defer c.recvMu.Unlock()
+	if c.closed.Load() {
+		return nil, net.ErrClosed
+	}
+	return c.conn.L2CAPRecv(chunkSeconds)
+}
+
+func (c *l2capNetConn) Write(b []byte) (int, error) {
+	if err := c.conn.L2CAPSend(b); err != nil {
+		return 0, err
+	}
+	return len(b), nil
+}
+
+// Close waits out an in-flight Read, which takes at most recvChunkSeconds, so
+// the platform connection cannot be torn down while a reader is still inside
+// it. That is what matters on darwin, where wendy_ble_disconnect hands the
+// CoreBluetooth wrapper to ARC.
+//
+// Its idempotency is belt and braces these days — Connection.Close is
+// idempotent on both backends — but it costs a bool and keeps this type's own
+// contract independent of theirs.
+func (c *l2capNetConn) Close() error {
+	if c.closed.Swap(true) {
+		return nil
+	}
+	c.recvMu.Lock()
+	defer c.recvMu.Unlock()
+	c.conn.Close()
+	return nil
+}
+
+func (c *l2capNetConn) LocalAddr() net.Addr  { return bleNetAddr{} }
+func (c *l2capNetConn) RemoteAddr() net.Addr { return bleNetAddr{} }
+
+func (c *l2capNetConn) SetDeadline(t time.Time) error {
+	c.readDeadline = t
+	return nil
+}
+func (c *l2capNetConn) SetReadDeadline(t time.Time) error {
+	c.readDeadline = t
+	return nil
+}
+func (c *l2capNetConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+// bleNetAddr is a minimal net.Addr for the BLE transport.
+type bleNetAddr struct{}
+
+func (bleNetAddr) Network() string { return "ble-l2cap" }
+func (bleNetAddr) String() string  { return "ble" }
+
+// timeoutErr is returned when a read deadline is exceeded.
+type timeoutErr struct{}
+
+func (e *timeoutErr) Error() string   { return "BLE L2CAP: i/o timeout" }
+func (e *timeoutErr) Timeout() bool   { return true }
+func (e *timeoutErr) Temporary() bool { return true }

--- a/go/internal/shared/ble/central/gatt_errors.go
+++ b/go/internal/shared/ble/central/gatt_errors.go
@@ -1,0 +1,49 @@
+package central
+
+import "github.com/wendylabsinc/wendy/go/internal/shared/ble/bluez"
+
+// friendlyGATTError renders a BlueZ failure on a characteristic operation as
+// user-facing text, or returns ok=false to say the raw error is the best
+// available and the caller should keep it.
+//
+// It sits in front of bluez.FriendlyError rather than replacing it, because a
+// few names mean something different once the object in question is a
+// characteristic rather than a device:
+//
+//   - UnknownObject on a device path means "rescan"; on a characteristic path
+//     it means bluetoothd tore the GATT tree down, which only happens when the
+//     link dropped.
+//   - Failed on a device path carries a bearer reason; on a characteristic it
+//     carries an ATT error, which has no bearer vocabulary at all.
+//
+// This file carries no build tag, and imports only the untagged half of bluez,
+// so its test runs on every platform.
+func friendlyGATTError(name, message string) (text string, ok bool) {
+	switch name {
+	case "org.freedesktop.DBus.Error.UnknownMethod",
+		"org.freedesktop.DBus.Error.UnknownObject",
+		"org.freedesktop.DBus.Error.UnknownInterface",
+		"org.bluez.Error.DoesNotExist":
+		return "the characteristic is gone — the link dropped, or the device changed its GATT layout; reconnect and rediscover", true
+
+	case "org.bluez.Error.InvalidValueLength":
+		return "the device rejected the value's length — it may exceed the negotiated MTU", true
+	case "org.bluez.Error.InvalidArguments":
+		return "the device rejected the request arguments", true
+
+	case "org.bluez.Error.Failed":
+		// An ATT-layer failure, not a bearer one: pass the device's own words
+		// through rather than running them past the bearer-reason table, which
+		// has nothing to say about them.
+		if message == "" {
+			return "the device rejected the operation", true
+		}
+		return message, true
+	}
+
+	// Everything else — NotPermitted, NotAuthorized, NotSupported,
+	// NotConnected, InProgress, AccessDenied, ServiceUnknown, NoReply — means
+	// the same thing for a characteristic as for a device.
+	text, _, ok = bluez.FriendlyError(name, message)
+	return text, ok
+}

--- a/go/internal/shared/ble/central/gatt_linux.go
+++ b/go/internal/shared/ble/central/gatt_linux.go
@@ -1,0 +1,257 @@
+//go:build linux
+
+package central
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/godbus/dbus/v5"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/ble/bluez"
+)
+
+// maxAttributeLen is the largest a GATT attribute value may be (Core
+// Specification, Vol 3, Part F, 3.2.9). It bounds the read-long loop below.
+const maxAttributeLen = 512
+
+// defaultATTPayload is ATT_MTU-1 for the 23-byte default MTU: the most a single
+// Read Response can carry before the MTU is negotiated upward. Used only as the
+// truncation heuristic when BlueZ does not publish a characteristic's MTU.
+const defaultATTPayload = 22
+
+// DiscoverServices connects to the peripheral and indexes its GATT services and
+// characteristics. Every other GATT method needs the index this builds.
+//
+// On Linux this is where the link comes up, unlike OpenL2CAP, which reaches the
+// device through the kernel instead. The two coexist: the kernel reuses an ACL
+// link BlueZ already established rather than opening a second one.
+func (c *Connection) DiscoverServices(timeoutSeconds int) error {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSeconds)*time.Second)
+	defer cancel()
+
+	g, err := c.ensureSession(ctx)
+	if err != nil {
+		return err
+	}
+	if err := g.connect(ctx); err != nil {
+		return err
+	}
+	if err := g.waitServicesResolved(ctx); err != nil {
+		return err
+	}
+	return g.rebuildIndex(ctx)
+}
+
+// HasService reports whether discovery found the given service.
+func (c *Connection) HasService(serviceUUID string) bool {
+	if c.g == nil {
+		return false
+	}
+	c.g.mu.Lock()
+	defer c.g.mu.Unlock()
+	return c.g.svcSet[canonicalUUID(serviceUUID)]
+}
+
+// ListServices returns the discovered service UUIDs, comma-separated. The
+// separator matches darwin's componentsJoinedByString so a message built from
+// this reads the same on either platform.
+func (c *Connection) ListServices() string {
+	if c.g == nil {
+		return ""
+	}
+	c.g.mu.Lock()
+	defer c.g.mu.Unlock()
+	return strings.Join(c.g.services, ", ")
+}
+
+// ReadCharacteristic reads a characteristic's value.
+func (c *Connection) ReadCharacteristic(serviceUUID, charUUID string) ([]byte, error) {
+	entry, err := c.lookupChar(serviceUUID, charUUID)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), gattOpTimeout)
+	defer cancel()
+	obj := c.g.objFn(entry.path)
+
+	value, err := readValueAt(ctx, obj, 0)
+	if err != nil {
+		return nil, wrapGATTError("reading "+charUUID, err)
+	}
+
+	// bluetoothd runs a read-long procedure only when an offset is given;
+	// without one it issues a single ATT Read Request, which is capped at the
+	// negotiated MTU. bluetoothd asks for a large MTU by default, so this loop
+	// almost never runs — but a value truncated at the payload boundary would
+	// be silent corruption, and that is worth a few lines.
+	//
+	// The test is on the length of the LAST chunk, not the total: a full chunk
+	// is what says "there may be more", and the running total crosses the
+	// boundary after the first append.
+	for lastChunk := len(value); lastChunk > 0 && len(value) < maxAttributeLen && chunkLooksFull(lastChunk, entry.mtu); {
+		more, err := readValueAt(ctx, obj, uint16(len(value)))
+		if err != nil || len(more) == 0 {
+			break
+		}
+		lastChunk = len(more)
+		value = append(value, more...)
+	}
+	return value, nil
+}
+
+func readValueAt(ctx context.Context, obj bluez.Caller, offset uint16) ([]byte, error) {
+	options := map[string]dbus.Variant{}
+	if offset > 0 {
+		options["offset"] = dbus.MakeVariant(offset)
+	}
+	call := obj.CallWithContext(ctx, bluez.GattCharIface+".ReadValue", 0, options)
+	if call.Err != nil {
+		return nil, call.Err
+	}
+	var value []byte
+	if err := call.Store(&value); err != nil {
+		return nil, fmt.Errorf("decoding value: %w", err)
+	}
+	return value, nil
+}
+
+// chunkLooksFull reports whether a read may have stopped at the ATT payload
+// boundary rather than at the end of the value. Exact when the characteristic's
+// MTU is known; before BlueZ 5.62 it is not published, and the default ATT
+// payload is the best available guess.
+func chunkLooksFull(n int, mtu uint16) bool {
+	if mtu >= 2 {
+		return n == int(mtu)-1
+	}
+	return n >= defaultATTPayload
+}
+
+// WriteCharacteristic writes with a response (ATT Write Request). bluetoothd
+// falls back to prepare/execute writes on its own when the value exceeds the
+// MTU, so long values need nothing here.
+func (c *Connection) WriteCharacteristic(serviceUUID, charUUID string, data []byte) error {
+	return c.writeChar(serviceUUID, charUUID, data, "request")
+}
+
+// WriteCharacteristicNoResponse writes without a response (ATT Write Command).
+// A command cannot be long: a value over the MTU is rejected rather than split.
+func (c *Connection) WriteCharacteristicNoResponse(serviceUUID, charUUID string, data []byte) error {
+	return c.writeChar(serviceUUID, charUUID, data, "command")
+}
+
+func (c *Connection) writeChar(serviceUUID, charUUID string, data []byte, writeType string) error {
+	entry, err := c.lookupChar(serviceUUID, charUUID)
+	if err != nil {
+		return err
+	}
+	if data == nil {
+		// The "ay" signature needs an array, not nothing.
+		data = []byte{}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), gattOpTimeout)
+	defer cancel()
+	options := map[string]dbus.Variant{"type": dbus.MakeVariant(writeType)}
+	call := c.g.objFn(entry.path).CallWithContext(ctx, bluez.GattCharIface+".WriteValue", 0, data, options)
+	if call.Err != nil {
+		// The flags go in the message on purpose. A write-without-response to a
+		// characteristic that only accepts requests fails with an error that is
+		// otherwise impossible to diagnose — and switching write type silently
+		// would hide a real mismatch, which darwin does not do either.
+		return wrapGATTError(
+			fmt.Sprintf("writing %s as %s (characteristic flags: %s)", charUUID, writeType, flagList(entry.flags)),
+			call.Err)
+	}
+	return nil
+}
+
+// Subscribe enables notifications for a characteristic.
+func (c *Connection) Subscribe(serviceUUID, charUUID string) error {
+	entry, err := c.lookupChar(serviceUUID, charUUID)
+	if err != nil {
+		return err
+	}
+
+	// The queue goes in before StartNotify, not after: bluetoothd can deliver
+	// the first notification before the method reply lands, and the router
+	// drops values for a path it has no queue for.
+	c.g.mu.Lock()
+	if _, exists := c.g.notify[entry.path]; !exists {
+		c.g.notify[entry.path] = make(chan []byte, notifyQueueDepth)
+	}
+	c.g.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), gattOpTimeout)
+	defer cancel()
+	if call := c.g.objFn(entry.path).CallWithContext(ctx, bluez.GattCharIface+".StartNotify", 0); call.Err != nil {
+		// Already notifying is what we wanted anyway.
+		if !bluez.IsErrorName(call.Err, "org.bluez.Error.InProgress") {
+			return wrapGATTError("subscribing to "+charUUID, call.Err)
+		}
+	}
+	return nil
+}
+
+// WaitNotification returns the next queued notification for a subscribed
+// characteristic, or an error if none arrives in time.
+//
+// Each characteristic has its own queue, so a notification on one can never
+// wake a waiter on another — the failure mode the darwin backend still has.
+func (c *Connection) WaitNotification(serviceUUID, charUUID string, timeoutSeconds int) ([]byte, error) {
+	entry, err := c.lookupChar(serviceUUID, charUUID)
+	if err != nil {
+		return nil, err
+	}
+
+	c.g.mu.Lock()
+	queue := c.g.notify[entry.path]
+	c.g.mu.Unlock()
+	if queue == nil {
+		return nil, fmt.Errorf("not subscribed to %s — call Subscribe first", charUUID)
+	}
+
+	timer := time.NewTimer(time.Duration(timeoutSeconds) * time.Second)
+	defer timer.Stop()
+	select {
+	case value := <-queue:
+		return value, nil
+	case <-c.g.lost:
+		return nil, fmt.Errorf("%w while waiting for a notification on %s", ErrGATTDisconnected, charUUID)
+	case <-timer.C:
+		return nil, fmt.Errorf("no notification on %s within %ds", charUUID, timeoutSeconds)
+	}
+}
+
+// lookupChar resolves a (service, characteristic) UUID pair against the index
+// DiscoverServices built. A call before discovery and a call for a
+// characteristic the device does not have are the same failure: nothing is in
+// the index either way.
+func (c *Connection) lookupChar(serviceUUID, charUUID string) (charEntry, error) {
+	if c.g == nil {
+		return charEntry{}, fmt.Errorf("%w: %s in %s — call DiscoverServices first",
+			ErrGATTNotFound, charUUID, serviceUUID)
+	}
+
+	c.g.mu.Lock()
+	defer c.g.mu.Unlock()
+	entry, ok := c.g.chars[charKey{
+		service:        canonicalUUID(serviceUUID),
+		characteristic: canonicalUUID(charUUID),
+	}]
+	if !ok {
+		return charEntry{}, fmt.Errorf("%w: characteristic %s in service %s; device exposes [%s]",
+			ErrGATTNotFound, charUUID, serviceUUID, strings.Join(c.g.services, ", "))
+	}
+	return entry, nil
+}
+
+func flagList(flags []string) string {
+	if len(flags) == 0 {
+		return "none reported"
+	}
+	return strings.Join(flags, ", ")
+}

--- a/go/internal/shared/ble/central/uuid.go
+++ b/go/internal/shared/ble/central/uuid.go
@@ -1,0 +1,64 @@
+package central
+
+import "strings"
+
+// bluetoothBaseUUID is the template every 16- and 32-bit Bluetooth UUID
+// expands against: the short value occupies the first group and the rest is
+// fixed (Core Specification, Vol 3, Part B, 2.5.1).
+const bluetoothBaseUUID = "00000000-0000-1000-8000-00805F9B34FB"
+
+// canonicalUUID normalizes a service or characteristic UUID to uppercase
+// 128-bit form, expanding the 16-bit ("180F") and 32-bit ("0000180F")
+// shorthands against the Bluetooth base UUID. Input that is not a recognizable
+// UUID is returned uppercased and otherwise untouched, so an unexpected
+// spelling degrades to an exact-match comparison rather than being silently
+// dropped.
+//
+// Both sides of every comparison go through this. BlueZ reports full lowercase
+// 128-bit while callers pass uppercase, so raw string comparison would miss
+// every match on Linux.
+//
+// This is a logic copy of scan.CanonicalUUID and must produce identical
+// output for identical input: central deliberately does not import scan
+// (that would invert the address-producer/consumer relationship and pull
+// scan's cgo into central's build graph), but a UUID that passes the scan
+// filter has to match what service discovery finds. The two test tables are
+// kept in sync for that reason.
+//
+// This file carries no build tag so its test runs on every platform.
+func canonicalUUID(s string) string {
+	s = strings.ToUpper(strings.TrimSpace(s))
+	s = strings.TrimPrefix(s, "{")
+	s = strings.TrimSuffix(s, "}")
+
+	switch len(s) {
+	case 4, 8:
+		if !isHexUUID(s) {
+			return s
+		}
+		// Left-pad a 16-bit value to the base UUID's 8-character first group.
+		return strings.Repeat("0", 8-len(s)) + s + bluetoothBaseUUID[8:]
+	case 36:
+		return s
+	case 32:
+		// Dashless 128-bit form.
+		if !isHexUUID(s) {
+			return s
+		}
+		return s[0:8] + "-" + s[8:12] + "-" + s[12:16] + "-" + s[16:20] + "-" + s[20:32]
+	default:
+		return s
+	}
+}
+
+func isHexUUID(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		if !((c >= '0' && c <= '9') || (c >= 'A' && c <= 'F')) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
**3 of 4.** Splits #1926 (291,218 bytes, over the AI security review's 140,000-byte limit). Disjoint from the other parts; merging all four reproduces #1926's tree byte-for-byte.

**This code is not used by anything yet** — nothing imports it, and it is not reachable from any binary. This is the largest and most security-relevant chunk of the split: it parses data off the wire from untrusted peripherals.

## Contents (10 files)

`go/internal/shared/ble/central/` — GATT/L2CAP client, production code only:

- **shared** — `conn.go`, `gatt_errors.go`, `uuid.go`
- **darwin** — cgo CoreBluetooth bridge (`ble_darwin.go/.h/.m`)
- **linux** — D-Bus/BlueZ (`ble_linux.go`, `bluez_linux.go`, `gatt_linux.go`)
- **windows** — `ble_windows.go`

The package's 5 `*_test.go` files land separately in #1926 (part 4). They are split off purely to fit the size limit — this PR is the complete production surface of the package.

## Notes

- **Depends on #1927 (part 1).** `gatt_errors.go` imports `shared/ble/bluez` with no build tag, so every platform needs it and **Test/Vet/CodeQL will be red here until #1927 merges.** I'll merge main in afterward to green them. The AI security review does not build, so it runs now.
- **No dependency changes.** `go.mod` and `go.sum` are untouched.
- The `Connection` type is declared separately in each platform backend, which is why this package could not be split by platform — `conn.go` needs one to compile.
- Builds and vets clean on darwin and `GOOS=linux` once `bluez` is present.

## Sequence

1. #1927 — bluez + permission + README
2. #1928 — scan
3. **this PR** — central production files
4. #1926 — central tests; needs this

Independent of part 2; either can merge first once #1927 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)