### PR TITLE
shared/ble: bound peripheral-controlled lengths, fix notification wakeups

### DIFF
--- a/go/internal/shared/ble/central/ble_darwin.go
+++ b/go/internal/shared/ble/central/ble_darwin.go
@@ -213,6 +213,8 @@ func bleError(code C.WendyBLEError, context string) error {
 		msg = "L2CAP channel failed"
 	case C.WENDY_BLE_ERR_DISCONNECTED:
 		msg = "disconnected"
+	case C.WENDY_BLE_ERR_SUBSCRIBE_FAILED:
+		msg = "subscribe failed"
 	default:
 		msg = "unknown error"
 	}

--- a/go/internal/shared/ble/central/ble_darwin.h
+++ b/go/internal/shared/ble/central/ble_darwin.h
@@ -15,6 +15,7 @@ typedef enum {
     WENDY_BLE_ERR_READ_FAILED = 6,
     WENDY_BLE_ERR_L2CAP_FAILED = 7,
     WENDY_BLE_ERR_DISCONNECTED = 8,
+    WENDY_BLE_ERR_SUBSCRIBE_FAILED = 9,
 } WendyBLEError;
 
 // Opaque handle to a BLE connection

--- a/go/internal/shared/ble/central/ble_darwin.m
+++ b/go/internal/shared/ble/central/ble_darwin.m
@@ -2,6 +2,42 @@
 #import <Foundation/Foundation.h>
 #include "ble_darwin.h"
 
+// Longest GATT characteristic value the Bluetooth core spec allows (Vol 3,
+// Part F). A compliant peripheral cannot exceed this, so a longer value is
+// treated as an error rather than truncated: a GATT value is one indivisible
+// unit, and silently shortening it would corrupt the protocol above us.
+static const NSUInteger kWendyBLEMaxGATTValue = 512;
+
+// Most bytes one wendy_ble_l2cap_recv hands back. L2CAP is a byte stream, so
+// returning less than is buffered is lossless — the remainder stays queued for
+// the next call. Matches the linux path's per-read buffer (ble_linux.go), so
+// both platforms cap a chunk at the same size.
+static const NSUInteger kWendyBLEMaxL2CAPChunk = 65536;
+
+// Copies n bytes into a fresh malloc'd buffer for the Go side to take over.
+//
+// Result lengths cross into Go as a 32-bit signed int while the sources are
+// NSUInteger, so an unbounded cast could truncate or go negative and leave
+// malloc, memcpy and C.GoBytes disagreeing about the size. Callers bound n
+// first; this keeps all three agreeing on that one already-bounded value.
+// Returns NO if the allocation fails, so no caller memcpys into NULL.
+static BOOL wendyBLECopyOut(const void *bytes, NSUInteger n, uint8_t **outData, int *outLength) {
+    // malloc(0) may legally return NULL, which would look like failure here.
+    // An empty value is not an error: hand back NULL/0, which the Go side
+    // already reads as "no data" and frees harmlessly.
+    if (n == 0) {
+        *outData = NULL;
+        *outLength = 0;
+        return YES;
+    }
+    uint8_t *copy = (uint8_t *)malloc(n);
+    if (!copy) return NO;
+    memcpy(copy, bytes, n);
+    *outData = copy;
+    *outLength = (int)n;
+    return YES;
+}
+
 // ── WendyBLEConnection ──────────────────────────────────────────────
 // Manages a single connection to a BLE peripheral including GATT and L2CAP.
 
@@ -31,10 +67,15 @@
 @property (strong) NSData *readData;
 @property BOOL readError;
 
-// Notification state
-@property (strong) dispatch_semaphore_t notifySema;
+// Notification state. notifyCond guards notifyQueues and is broadcast on every
+// enqueue and on disconnect. It replaces a lock plus a counting semaphore: the
+// queues are per characteristic but one semaphore was shared by all of them, so
+// a notification for one characteristic woke a waiter on another, and a value
+// taken by the queued fast path left a count behind that made the next wait
+// return instantly. A condition has no count to drift, and a waiter that wakes
+// for someone else's characteristic simply loops and waits again.
+@property (strong) NSCondition *notifyCond;
 @property (strong) NSMutableDictionary<NSString *, NSMutableArray<NSData *> *> *notifyQueues;
-@property (strong) NSLock *notifyLock;
 
 // L2CAP state
 @property (strong) dispatch_semaphore_t l2capSema;
@@ -71,11 +112,10 @@
         _discoverSema = dispatch_semaphore_create(0);
         _writeSema = dispatch_semaphore_create(0);
         _readSema = dispatch_semaphore_create(0);
-        _notifySema = dispatch_semaphore_create(0);
         _l2capSema = dispatch_semaphore_create(0);
         _l2capRecvSema = dispatch_semaphore_create(0);
         _notifyQueues = [NSMutableDictionary dictionary];
-        _notifyLock = [[NSLock alloc] init];
+        _notifyCond = [[NSCondition alloc] init];
         _l2capRecvBuffer = [NSMutableData data];
         _l2capRecvLock = [[NSLock alloc] init];
     }
@@ -139,10 +179,19 @@ didDisconnectPeripheral:(CBPeripheral *)peripheral
                  error:(NSError *)error {
     self.connected = NO;
     self.l2capIORunning = NO; // wake the I/O thread so it exits
-    // Signal any blocked operations
+    // Signal any blocked operations. A stray signal left on a semaphore nobody is
+    // currently waiting on is harmless: every caller below checks conn.connected
+    // before it would ever reach dispatch_semaphore_wait again.
     dispatch_semaphore_signal(self.readSema);
     dispatch_semaphore_signal(self.writeSema);
     dispatch_semaphore_signal(self.l2capRecvSema);
+    dispatch_semaphore_signal(self.discoverSema);
+    dispatch_semaphore_signal(self.l2capSema);
+    // Broadcast rather than signal: every notification waiter has to learn the
+    // link is gone, not just whichever one happens to be woken first.
+    [self.notifyCond lock];
+    [self.notifyCond broadcast];
+    [self.notifyCond unlock];
 }
 
 // ── CBPeripheralDelegate ────────────────────────────────────────────
@@ -168,10 +217,12 @@ didDiscoverServices:(NSError *)error {
 - (void)peripheral:(CBPeripheral *)peripheral
 didDiscoverCharacteristicsForService:(CBService *)service
              error:(NSError *)error {
+    if (error) {
+        self.discoverError = YES;
+    }
     self.pendingCharDiscovery--;
     if (self.pendingCharDiscovery <= 0) {
-        self.discoverDone = !error;
-        self.discoverError = (error != nil);
+        self.discoverDone = !self.discoverError;
         dispatch_semaphore_signal(self.discoverSema);
     }
 }
@@ -198,17 +249,17 @@ didUpdateValueForCharacteristic:(CBCharacteristic *)characteristic
                      characteristic.service.UUID.UUIDString,
                      characteristic.UUID.UUIDString];
 
-    [self.notifyLock lock];
+    [self.notifyCond lock];
     NSMutableArray *queue = self.notifyQueues[key];
     if (queue) {
         if (characteristic.value) {
             [queue addObject:[characteristic.value copy]];
         }
-        [self.notifyLock unlock];
-        dispatch_semaphore_signal(self.notifySema);
+        [self.notifyCond broadcast];
+        [self.notifyCond unlock];
         return;
     }
-    [self.notifyLock unlock];
+    [self.notifyCond unlock];
 
     // Regular read response
     self.readData = characteristic.value ? [characteristic.value copy] : nil;
@@ -219,7 +270,7 @@ didUpdateValueForCharacteristic:(CBCharacteristic *)characteristic
 - (void)peripheral:(CBPeripheral *)peripheral
 didUpdateNotificationStateForCharacteristic:(CBCharacteristic *)characteristic
              error:(NSError *)error {
-    // Handled by subscribe call checking isNotifying
+    self.writeError = (error != nil);
     dispatch_semaphore_signal(self.writeSema); // reuse write sema for subscribe ack
 }
 
@@ -373,6 +424,7 @@ WendyBLEError wendy_ble_discover_services(WendyBLEConn handle, int timeout_secon
         dispatch_time(DISPATCH_TIME_NOW, (int64_t)timeout_seconds * NSEC_PER_SEC));
 
     if (result != 0) return WENDY_BLE_ERR_TIMEOUT;
+    if (!conn.connected) return WENDY_BLE_ERR_DISCONNECTED;
     if (conn.discoverError) return WENDY_BLE_ERR_DISCOVER_FAILED;
     return WENDY_BLE_OK;
 }
@@ -394,6 +446,7 @@ WendyBLEError wendy_ble_write_characteristic(WendyBLEConn handle, const char *se
         dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC));
 
     if (result != 0) return WENDY_BLE_ERR_TIMEOUT;
+    if (!conn.connected) return WENDY_BLE_ERR_DISCONNECTED;
     if (conn.writeError) return WENDY_BLE_ERR_WRITE_FAILED;
     return WENDY_BLE_OK;
 }
@@ -430,12 +483,14 @@ WendyBLEReadResult wendy_ble_read_characteristic(WendyBLEConn handle, const char
         dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC));
 
     if (result != 0) { res.error = WENDY_BLE_ERR_TIMEOUT; return res; }
+    if (!conn.connected) { res.error = WENDY_BLE_ERR_DISCONNECTED; return res; }
     if (conn.readError) { res.error = WENDY_BLE_ERR_READ_FAILED; return res; }
 
     if (conn.readData && conn.readData.length > 0) {
-        res.length = (int)conn.readData.length;
-        res.data = (uint8_t *)malloc(res.length);
-        memcpy(res.data, conn.readData.bytes, res.length);
+        if (conn.readData.length > kWendyBLEMaxGATTValue ||
+            !wendyBLECopyOut(conn.readData.bytes, conn.readData.length, &res.data, &res.length)) {
+            res.error = WENDY_BLE_ERR_READ_FAILED;
+        }
     }
     return res;
 }
@@ -449,20 +504,27 @@ WendyBLEError wendy_ble_subscribe(WendyBLEConn handle, const char *service_uuid,
                                            inService:[NSString stringWithUTF8String:service_uuid]];
     if (!chr) return WENDY_BLE_ERR_NOT_FOUND;
 
-    // Set up notification queue
+    // Key the notification queue off CoreBluetooth's own CBUUID.UUIDString (via the
+    // resolved characteristic) rather than the caller's spelling: for 16/32-bit UUIDs
+    // CoreBluetooth's UUIDString is the short form ("180F"), which can differ from a
+    // caller-supplied expanded 128-bit form. chr is the same CBCharacteristic instance
+    // CoreBluetooth will hand back to didUpdateValueForCharacteristic:, so this
+    // guarantees the keys match exactly.
     NSString *key = [NSString stringWithFormat:@"%@:%@",
-                     [NSString stringWithUTF8String:service_uuid],
-                     [NSString stringWithUTF8String:char_uuid]];
-    [conn.notifyLock lock];
+                     chr.service.UUID.UUIDString, chr.UUID.UUIDString];
+    [conn.notifyCond lock];
     conn.notifyQueues[key] = [NSMutableArray array];
-    [conn.notifyLock unlock];
+    [conn.notifyCond unlock];
 
+    conn.writeError = NO;
     [conn.peripheral setNotifyValue:YES forCharacteristic:chr];
 
     long result = dispatch_semaphore_wait(conn.writeSema,
         dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC));
 
     if (result != 0) return WENDY_BLE_ERR_TIMEOUT;
+    if (!conn.connected) return WENDY_BLE_ERR_DISCONNECTED;
+    if (conn.writeError) return WENDY_BLE_ERR_SUBSCRIBE_FAILED;
     return WENDY_BLE_OK;
 }
 
@@ -472,47 +534,47 @@ WendyBLEReadResult wendy_ble_wait_notification(WendyBLEConn handle, const char *
     WendyBLEConnection *conn = (__bridge WendyBLEConnection *)handle;
     if (!conn.connected) { res.error = WENDY_BLE_ERR_DISCONNECTED; return res; }
 
+    // Re-resolve the characteristic to derive the same canonical key wendy_ble_subscribe
+    // used — see the comment there.
+    CBCharacteristic *chr = [conn findCharacteristic:[NSString stringWithUTF8String:char_uuid]
+                                           inService:[NSString stringWithUTF8String:service_uuid]];
+    if (!chr) { res.error = WENDY_BLE_ERR_NOT_FOUND; return res; }
+
     NSString *key = [NSString stringWithFormat:@"%@:%@",
-                     [NSString stringWithUTF8String:service_uuid],
-                     [NSString stringWithUTF8String:char_uuid]];
+                     chr.service.UUID.UUIDString, chr.UUID.UUIDString];
 
-    // Check if there's already a queued notification
-    [conn.notifyLock lock];
-    NSMutableArray *queue = conn.notifyQueues[key];
-    if (queue && queue.count > 0) {
-        NSData *data = queue[0];
-        [queue removeObjectAtIndex:0];
-        [conn.notifyLock unlock];
+    // One deadline for the whole call, fixed up front: a broadcast meant for
+    // another characteristic sends us back to waiting, and recomputing the
+    // timeout each time round would let those wakeups stretch the wait well
+    // past what the caller asked for.
+    NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:timeout_seconds];
 
-        res.length = (int)data.length;
-        res.data = (uint8_t *)malloc(res.length);
-        memcpy(res.data, data.bytes, res.length);
-        return res;
+    [conn.notifyCond lock];
+    for (;;) {
+        NSMutableArray *queue = conn.notifyQueues[key];
+        if (queue && queue.count > 0) {
+            NSData *data = queue[0];
+            [queue removeObjectAtIndex:0];
+            [conn.notifyCond unlock];
+
+            if (data.length > kWendyBLEMaxGATTValue ||
+                !wendyBLECopyOut(data.bytes, data.length, &res.data, &res.length)) {
+                res.error = WENDY_BLE_ERR_READ_FAILED;
+            }
+            return res;
+        }
+        if (!conn.connected) {
+            [conn.notifyCond unlock];
+            res.error = WENDY_BLE_ERR_DISCONNECTED;
+            return res;
+        }
+        if (![conn.notifyCond waitUntilDate:deadline]) {
+            // NO means the deadline passed rather than a broadcast arriving.
+            [conn.notifyCond unlock];
+            res.error = conn.connected ? WENDY_BLE_ERR_TIMEOUT : WENDY_BLE_ERR_DISCONNECTED;
+            return res;
+        }
     }
-    [conn.notifyLock unlock];
-
-    // Wait for notification
-    long result = dispatch_semaphore_wait(conn.notifySema,
-        dispatch_time(DISPATCH_TIME_NOW, (int64_t)timeout_seconds * NSEC_PER_SEC));
-
-    if (result != 0) { res.error = WENDY_BLE_ERR_TIMEOUT; return res; }
-
-    [conn.notifyLock lock];
-    queue = conn.notifyQueues[key];
-    if (queue && queue.count > 0) {
-        NSData *data = queue[0];
-        [queue removeObjectAtIndex:0];
-        [conn.notifyLock unlock];
-
-        res.length = (int)data.length;
-        res.data = (uint8_t *)malloc(res.length);
-        memcpy(res.data, data.bytes, res.length);
-        return res;
-    }
-    [conn.notifyLock unlock];
-
-    res.error = WENDY_BLE_ERR_TIMEOUT;
-    return res;
 }
 
 WendyBLEError wendy_ble_open_l2cap(WendyBLEConn handle, uint16_t psm, int timeout_seconds) {
@@ -527,6 +589,7 @@ WendyBLEError wendy_ble_open_l2cap(WendyBLEConn handle, uint16_t psm, int timeou
         dispatch_time(DISPATCH_TIME_NOW, (int64_t)timeout_seconds * NSEC_PER_SEC));
 
     if (result != 0) return WENDY_BLE_ERR_TIMEOUT;
+    if (!conn.connected) return WENDY_BLE_ERR_DISCONNECTED;
     if (conn.l2capError || !conn.l2capChannel) return WENDY_BLE_ERR_L2CAP_FAILED;
 
     return WENDY_BLE_OK;
@@ -557,10 +620,15 @@ WendyBLEL2CAPRecvResult wendy_ble_l2cap_recv(WendyBLEConn handle, int timeout_se
     // Check if data is already buffered
     [conn.l2capRecvLock lock];
     if (conn.l2capRecvBuffer.length > 0) {
-        res.length = (int)conn.l2capRecvBuffer.length;
-        res.data = (uint8_t *)malloc(res.length);
-        memcpy(res.data, conn.l2capRecvBuffer.bytes, res.length);
-        conn.l2capRecvBuffer.length = 0;
+        // Drain at most one chunk and keep the rest queued. L2CAP is a byte
+        // stream, so a short return is lossless — l2capNetConn.Read stashes
+        // whatever it can't take and the next call picks the remainder up here.
+        NSUInteger n = MIN(conn.l2capRecvBuffer.length, kWendyBLEMaxL2CAPChunk);
+        if (!wendyBLECopyOut(conn.l2capRecvBuffer.bytes, n, &res.data, &res.length)) {
+            res.error = WENDY_BLE_ERR_L2CAP_FAILED;
+        } else {
+            [conn.l2capRecvBuffer replaceBytesInRange:NSMakeRange(0, n) withBytes:NULL length:0];
+        }
         [conn.l2capRecvLock unlock];
         return res;
     }
@@ -574,17 +642,22 @@ WendyBLEL2CAPRecvResult wendy_ble_l2cap_recv(WendyBLEConn handle, int timeout_se
 
     [conn.l2capRecvLock lock];
     if (conn.l2capRecvBuffer.length > 0) {
-        res.length = (int)conn.l2capRecvBuffer.length;
-        res.data = (uint8_t *)malloc(res.length);
-        memcpy(res.data, conn.l2capRecvBuffer.bytes, res.length);
-        conn.l2capRecvBuffer.length = 0;
+        // Drain at most one chunk and keep the rest queued. L2CAP is a byte
+        // stream, so a short return is lossless — l2capNetConn.Read stashes
+        // whatever it can't take and the next call picks the remainder up here.
+        NSUInteger n = MIN(conn.l2capRecvBuffer.length, kWendyBLEMaxL2CAPChunk);
+        if (!wendyBLECopyOut(conn.l2capRecvBuffer.bytes, n, &res.data, &res.length)) {
+            res.error = WENDY_BLE_ERR_L2CAP_FAILED;
+        } else {
+            [conn.l2capRecvBuffer replaceBytesInRange:NSMakeRange(0, n) withBytes:NULL length:0];
+        }
     } else if (conn.connected && conn.l2capIORunning && !conn.l2capError) {
-        // The buffered fast path above drains everything in one copy without
-        // consuming a semaphore count, so several signalled arrivals collapse
-        // into one return and leave the semaphore over-signalled. A later wait
-        // then succeeds immediately with the buffer already empty. The channel
-        // is still up, so report a timeout and let the caller retry rather than
-        // tearing the link down.
+        // The buffered fast path above returns a whole chunk in one copy
+        // without consuming a semaphore count, so several signalled arrivals
+        // collapse into one return and leave the semaphore over-signalled. A
+        // later wait then succeeds immediately with the buffer already empty.
+        // The channel is still up, so report a timeout and let the caller retry
+        // rather than tearing the link down.
         res.error = WENDY_BLE_ERR_TIMEOUT;
     } else {
         res.error = WENDY_BLE_ERR_DISCONNECTED;

--- a/go/internal/shared/ble/central/ble_linux.go
+++ b/go/internal/shared/ble/central/ble_linux.go
@@ -323,9 +323,7 @@ func (c *Connection) L2CAPRecv(timeoutSeconds int) ([]byte, error) {
 	if nRead == 0 {
 		return nil, fmt.Errorf("connection closed by peer")
 	}
-	result := make([]byte, nRead)
-	copy(result, buf[:nRead])
-	return result, nil
+	return buf[:nRead], nil
 }
 
 // Close releases both halves. It is idempotent: the fd is cleared, so a second

--- a/go/internal/shared/ble/central/conn.go
+++ b/go/internal/shared/ble/central/conn.go
@@ -165,6 +165,7 @@ func (c *l2capNetConn) Close() error {
 func (c *l2capNetConn) LocalAddr() net.Addr  { return bleNetAddr{} }
 func (c *l2capNetConn) RemoteAddr() net.Addr { return bleNetAddr{} }
 
+// WARNING: SetDeadline only ever bounds reads — see SetWriteDeadline.
 func (c *l2capNetConn) SetDeadline(t time.Time) error {
 	c.readDeadline = t
 	return nil
@@ -173,6 +174,8 @@ func (c *l2capNetConn) SetReadDeadline(t time.Time) error {
 	c.readDeadline = t
 	return nil
 }
+
+// WARNING: SetWriteDeadline is currently not implemented and is a no-op.
 func (c *l2capNetConn) SetWriteDeadline(_ time.Time) error { return nil }
 
 // bleNetAddr is a minimal net.Addr for the BLE transport.

--- a/go/internal/shared/ble/lite_info.go
+++ b/go/internal/shared/ble/lite_info.go
@@ -62,8 +62,8 @@ var ErrLiteInfoUnavailable = errors.New("Wendy Lite info service unavailable")
 // device.
 //
 // address is what a scan reported for this platform — a CoreBluetooth
-// peripheral UUID on macOS, a MAC elsewhere. timeout bounds each step, not the
-// whole sequence, matching ReadLiteInfo.
+// peripheral UUID on macOS, a MAC elsewhere. timeout bounds the initial connect
+// and service discovery; characteristic reads use backend per-op timeouts.
 func ReadLiteInfoAt(address string, timeout time.Duration) (*LiteInfo, error) {
 	conn, err := central.Connect(address, central.TimeoutSeconds(timeout))
 	if err != nil {

--- a/go/internal/shared/ble/lite_info.go
+++ b/go/internal/shared/ble/lite_info.go
@@ -1,0 +1,153 @@
+// Package ble is the one Wendy-specific resident of internal/shared/ble, whose
+// central and scan subpackages are otherwise free of Wendy identifiers.
+//
+// It lives here rather than in internal/cli/ble — where the rest of the Wendy
+// protocol layer is — for one reason: internal/shared/discovery reads a Lite
+// board's info service to learn its L2CAP PSM, and a shared package importing a
+// cli one is an upward edge. Nothing else about it wants to be shared, so keep
+// this package to the info service and let internal/cli/ble own the rest.
+//
+// internal/cli/ble is also named ble. No file currently needs both, and none
+// should have to; a future one must alias.
+//
+// This package must never import internal/shared/discovery, which imports it.
+package ble
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/ble/central"
+)
+
+// Wendy Lite device info service. Base 4E57454E-4459-0002-xxxx-000000000000
+// ("NWENDY" + service 0002) — sibling of the 0001 provisioning service in
+// lite_client.go. The device publishes this before any TLS work happens, so it
+// is untrusted: treat it as a label for picking a device, never as proof of
+// identity. The mTLS handshake is what authenticates.
+const (
+	// LiteInfoServiceUUID is exported because a Lite board also advertises it,
+	// so it doubles as the scan filter that finds one (see shared/discovery's
+	// BLELiteDeviceDiscoverContinuous). Every other UUID here is only ever read
+	// off an open connection.
+	LiteInfoServiceUUID     = "4E57454E-4459-0002-0000-000000000000"
+	liteInfoPSMCharUUID     = "4E57454E-4459-0002-0001-000000000000"
+	liteInfoDeviceIDUUID    = "4E57454E-4459-0002-0002-000000000000"
+	liteInfoDeviceNameUUID  = "4E57454E-4459-0002-0003-000000000000"
+	liteInfoDisplayNameUUID = "4E57454E-4459-0002-0004-000000000000"
+	liteInfoMTLSUUID        = "4E57454E-4459-0002-0005-000000000000"
+)
+
+// LiteInfo is the content of a Wendy Lite device's GATT info service.
+type LiteInfo struct {
+	PSM         uint16
+	DeviceID    string
+	DeviceName  string
+	DisplayName string
+	MTLSEnabled bool
+}
+
+// ErrLiteInfoUnavailable reports that the device does not publish the info
+// service, or that this platform cannot read GATT at all — Windows has no GATT
+// client, so it always takes this path. Callers fall back to
+// liteclient.DefaultL2CAPPSM rather than failing.
+var ErrLiteInfoUnavailable = errors.New("Wendy Lite info service unavailable")
+
+// ReadLiteInfoAt connects to a device, reads its info service and drops the
+// link before returning. It is what a discovery pass wants: a Lite board
+// accepts one BLE connection at a time, so a probe that kept the connection
+// open would lock out the ConnectViaBLE that follows when the user picks the
+// device.
+//
+// address is what a scan reported for this platform — a CoreBluetooth
+// peripheral UUID on macOS, a MAC elsewhere. timeout bounds each step, not the
+// whole sequence, matching ReadLiteInfo.
+func ReadLiteInfoAt(address string, timeout time.Duration) (*LiteInfo, error) {
+	conn, err := central.Connect(address, central.TimeoutSeconds(timeout))
+	if err != nil {
+		return nil, fmt.Errorf("%w: connecting to %s: %w", ErrLiteInfoUnavailable, address, err)
+	}
+	defer conn.Close()
+	return ReadLiteInfo(conn, timeout)
+}
+
+// ReadLiteInfo reads the device's GATT info service, which carries the L2CAP
+// PSM to open along with the identity the device advertises for itself.
+//
+// Every characteristic in the service is required — identity, mTLS, and PSM
+// alike; a device that answers some but not all of them is not recognized, and
+// this returns ErrLiteInfoUnavailable rather than a partially filled LiteInfo.
+// A caller must never be handed a partial identity — bleExternalDevice would
+// surface a blank name, and MicroWendyProvider's mTLS filter cannot tell "not
+// provisioned" from "couldn't read it". Every failure is wrapped in
+// ErrLiteInfoUnavailable so a caller can fall back to its own default PSM, as
+// liteclient.DefaultL2CAPPSM does.
+func ReadLiteInfo(conn *central.Connection, timeout time.Duration) (*LiteInfo, error) {
+	// Required before any characteristic op: both backends resolve a
+	// characteristic against what discovery found, and report "not found"
+	// against an empty index. This is also where Windows bows out.
+	if err := conn.DiscoverServices(central.TimeoutSeconds(timeout)); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrLiteInfoUnavailable, err)
+	}
+	if !conn.HasService(LiteInfoServiceUUID) {
+		return nil, fmt.Errorf("%w: device exposes [%s]", ErrLiteInfoUnavailable, conn.ListServices())
+	}
+
+	raw, err := conn.ReadCharacteristic(LiteInfoServiceUUID, liteInfoPSMCharUUID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: reading PSM: %w", ErrLiteInfoUnavailable, err)
+	}
+	if len(raw) < 2 {
+		return nil, fmt.Errorf("%w: PSM characteristic is %d bytes, want 2", ErrLiteInfoUnavailable, len(raw))
+	}
+	// Little-endian, matching what the firmware publishes.
+	psm := binary.LittleEndian.Uint16(raw[:2])
+	if psm == 0 {
+		return nil, fmt.Errorf("%w: device published PSM 0", ErrLiteInfoUnavailable)
+	}
+
+	deviceID, err := readLiteInfoString(conn, liteInfoDeviceIDUUID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: reading device ID: %w", ErrLiteInfoUnavailable, err)
+	}
+	deviceName, err := readLiteInfoString(conn, liteInfoDeviceNameUUID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: reading device name: %w", ErrLiteInfoUnavailable, err)
+	}
+	displayName, err := readLiteInfoString(conn, liteInfoDisplayNameUUID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: reading display name: %w", ErrLiteInfoUnavailable, err)
+	}
+	mtls, err := conn.ReadCharacteristic(LiteInfoServiceUUID, liteInfoMTLSUUID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: reading mTLS flag: %w", ErrLiteInfoUnavailable, err)
+	}
+	if len(mtls) == 0 {
+		return nil, fmt.Errorf("%w: mTLS characteristic is empty", ErrLiteInfoUnavailable)
+	}
+
+	return &LiteInfo{
+		PSM:         psm,
+		DeviceID:    deviceID,
+		DeviceName:  deviceName,
+		DisplayName: displayName,
+		MTLSEnabled: mtls[0] != 0,
+	}, nil
+}
+
+// readLiteInfoString reads one UTF-8 characteristic. Every characteristic in
+// the service is required (see ReadLiteInfo), so an empty value is as much a
+// failure here as a GATT read error — ReadCharacteristic returns (nil, nil)
+// when the characteristic holds no bytes, which this turns into an error too.
+func readLiteInfoString(conn *central.Connection, charUUID string) (string, error) {
+	data, err := conn.ReadCharacteristic(LiteInfoServiceUUID, charUUID)
+	if err != nil {
+		return "", err
+	}
+	if len(data) == 0 {
+		return "", fmt.Errorf("characteristic %s is empty", charUUID)
+	}
+	return string(data), nil
+}

--- a/go/internal/shared/ble/scan/live_test.go
+++ b/go/internal/shared/ble/scan/live_test.go
@@ -3,6 +3,8 @@ package scan
 import (
 	"context"
 	"os"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -62,16 +64,53 @@ func TestLiveScan(t *testing.T) {
 // splitCommaList is a test-only reader for WENDY_BLE_LIVE_SERVICES. The
 // production comma parser lives in the darwin file, which is not built
 // everywhere.
+//
+// Entries are trimmed here so "180F, 180A" reads as two UUIDs rather than one
+// with a leading space. CanonicalUUID trims again downstream, so this is not
+// what makes the filter work — it keeps the logged filter honest and stops the
+// values this test hands to Options.Services depending on that later trim.
 func splitCommaList(s string) []string {
 	var out []string
 	start := 0
 	for i := 0; i <= len(s); i++ {
 		if i == len(s) || s[i] == ',' {
-			if part := s[start:i]; part != "" {
+			// Trim before the empty check, so a whitespace-only entry is
+			// dropped instead of becoming "".
+			if part := strings.TrimSpace(s[start:i]); part != "" {
 				out = append(out, part)
 			}
 			start = i + 1
 		}
 	}
 	return out
+}
+
+// TestSplitCommaList runs everywhere, unlike TestLiveScan above: it is the only
+// thing that checks the env var reader without a radio present.
+func TestSplitCommaList(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"no spaces", "180F,180A", []string{"180F", "180A"}},
+		{"space after comma", "180F, 180A", []string{"180F", "180A"}},
+		{"spaces everywhere", "  180F , 180A  ", []string{"180F", "180A"}},
+		{"whitespace-only entry", "180F, ,180A", []string{"180F", "180A"}},
+		{"single entry", "180F", []string{"180F"}},
+		{"trailing comma", "180F,", []string{"180F"}},
+		{"full 128-bit form", "0000180F-0000-1000-8000-00805F9B34FB, 180A",
+			[]string{"0000180F-0000-1000-8000-00805F9B34FB", "180A"}},
+		{"empty", "", nil},
+		{"only a comma", ",", nil},
+		{"only whitespace", "   ", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := splitCommaList(tt.in); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("splitCommaList(%q) = %#v, want %#v", tt.in, got, tt.want)
+			}
+		})
+	}
 }

--- a/go/internal/shared/ble/scan/scan_windows.go
+++ b/go/internal/shared/ble/scan/scan_windows.go
@@ -77,9 +77,13 @@ func buildWatcherScript(services []string) string {
 	}
 	var b strings.Builder
 	for _, svc := range services {
-		// Only canonical 36-character UUIDs are accepted; anything else would
-		// make [Guid] throw and kill the whole scan for one bad entry.
-		if len(svc) != 36 {
+		// Only canonical hyphenated UUIDs are accepted. Anything else would make
+		// [Guid] throw and kill the whole scan for one bad entry — and, more
+		// importantly, svc is interpolated into a single-quoted PowerShell
+		// literal below, so it must be known to hold nothing but hex and
+		// hyphens: a length-only check would let a 36-character value carrying a
+		// quote break out of the literal and inject commands.
+		if !isCanonicalUUID(svc) {
 			continue
 		}
 		fmt.Fprintf(&b, "    $watcher.AdvertisementFilter.Advertisement.ServiceUuids.Add([Guid]'%s')\n", svc)

--- a/go/internal/shared/ble/scan/uuid.go
+++ b/go/internal/shared/ble/scan/uuid.go
@@ -94,3 +94,34 @@ func isHex(s string) bool {
 	}
 	return true
 }
+
+// isCanonicalUUID reports whether s is a canonical 128-bit UUID in hyphenated
+// 8-4-4-4-12 form (e.g. "0000180F-0000-1000-8000-00805F9B34FB"): exactly 36
+// characters, ASCII hex digits (either case) everywhere except hyphens at
+// positions 8, 13, 18 and 23.
+//
+// buildWatcherScript interpolates each service UUID into a single-quoted
+// PowerShell literal, so a value reaching that point must contain nothing but
+// hex and hyphens. A length-only check let a 36-character string carrying a
+// quote break out of the literal; this is the gate that closes that. Both hex
+// cases are accepted so this stands on its own — CanonicalUUID happens to
+// uppercase first, but the safety here must not depend on that.
+func isCanonicalUUID(s string) bool {
+	if len(s) != 36 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch i {
+		case 8, 13, 18, 23:
+			if c != '-' {
+				return false
+			}
+		default:
+			if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/go/internal/shared/ble/scan/uuid_test.go
+++ b/go/internal/shared/ble/scan/uuid_test.go
@@ -112,6 +112,40 @@ func TestCanonicalUUIDs(t *testing.T) {
 	}
 }
 
+func TestIsCanonicalUUID(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"uppercase canonical", "0000180F-0000-1000-8000-00805F9B34FB", true},
+		{"lowercase canonical", "7565e9eb-4c20-4b67-9272-d708b397b631", true},
+		{"the real filter constant", "4E57454E-4459-0002-0000-000000000000", true},
+		{
+			// The regression this exists for: a 36-character value carrying a
+			// quote passed the old len==36 check and broke out of the PowerShell
+			// literal. It must be rejected.
+			name: "quote-injection payload of the right length",
+			in:   "4E57454E-4459-0002-0000-00000000000'",
+			want: false,
+		},
+		{"too short", "0000180F-0000-1000-8000-00805F9B34F", false},
+		{"too long", "0000180F-0000-1000-8000-00805F9B34FBB", false},
+		{"dashless 32-char form is not canonical", "7565E9EB4C204B679272D708B397B631", false},
+		{"hyphen in the wrong position", "0000180F0-000-1000-8000-00805F9B34FB", false},
+		{"non-hex character in a hex position", "0000180Z-0000-1000-8000-00805F9B34FB", false},
+		{"empty", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isCanonicalUUID(tt.in); got != tt.want {
+				t.Errorf("isCanonicalUUID(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMatchesServices(t *testing.T) {
 	agent := CanonicalUUID("7565e9eb-4c20-4b67-9272-d708b397b631")
 	other := CanonicalUUID("180F")


### PR DESCRIPTION
Pulls the `shared/ble` work forward out of #1903 so the two security fixes land without waiting on the CLI refactor behind them. 33,562 bytes — comfortably under the AI security review's 140,000-byte limit, unlike #1903 itself.

**Nothing imports any of this yet.** `shared/ble` has no consumer on main; the wiring that uses it stays on `gab/ble`.

## The two fixes

**Bound peripheral-controlled lengths before the cast to `int`** — this is the MEDIUM the security review raised on #1929. Read, notification and L2CAP results cast an `NSUInteger` length straight to the 32-bit signed `int` the result structs carry, then used it for `malloc`, `memcpy` and `C.GoBytes`. Nothing bounded it, so a buffer past `INT_MAX` truncates or goes negative and the three disagree about the size. All five sites now go through one helper that copies an already-bounded length:

- GATT values are indivisible, so truncating would corrupt the protocol above. 512 is the spec maximum; longer is an error, not a silent shortening.
- L2CAP is a byte stream, so a short return is lossless. It drains at most 64KiB and leaves the remainder queued — `l2capNetConn.Read` already stashes what it can't take. 64KiB matches the linux path's per-read buffer.

**Wake notification waiters per characteristic.** `notifyQueues` is keyed per characteristic but one counting semaphore was shared by all of them, so a notification for B woke a waiter on A, which returned `WENDY_BLE_ERR_TIMEOUT` *immediately*. Separately, the queued fast path dequeued without consuming a count, so after any fast-path delivery the next wait succeeded on the stale count and reported a timeout with an empty queue — reachable with a single characteristic. Replaced the semaphore and lock with an `NSCondition` and a loop against a deadline fixed at entry; disconnect now broadcasts so every waiter learns the link is gone. This is the model `gatt_linux.go` already uses.

## Also here

`lite_info.go` — the Lite info-service reader `internal/shared/discovery` needs (it lives in `shared` to avoid a shared→cli import edge; see the package comment). Plus scan UUID handling and a windows scan fix.

## Verified

Darwin build, vet and tests pass; linux build, vet and all four test-compiles pass; existing `cli/...` consumers on main still build untouched. The darwin cgo bridge has no unit coverage — it needs a radio — so the `live_test.go` paths are unexercised here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)