### PR TITLE
WDY-3013: keep Mac agent alive after failed mTLS handshakes

### DIFF
--- a/swift/WendyAgentCore/Package.swift
+++ b/swift/WendyAgentCore/Package.swift
@@ -38,6 +38,12 @@ let package = Package(
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.9.1"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "4.0.0"),
         .package(url: "https://github.com/apple/swift-certificates.git", from: "1.0.0"),
+        // Replace this revision with the first release containing
+        // https://github.com/apple/swift-nio-ssl/pull/604.
+        .package(
+            url: "https://github.com/apple/swift-nio-ssl.git",
+            revision: "76afd00803dd83dfdf2ec6fc56e1e460e60fd4e2"
+        ),
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
     ],
     targets: [
@@ -49,6 +55,7 @@ let package = Package(
                 .product(name: "GRPCNIOTransportHTTP2", package: "grpc-swift-nio-transport"),
                 .product(name: "GRPCCore", package: "grpc-swift-2"),
                 .product(name: "Logging", package: "swift-log"),
+                .product(name: "NIOSSL", package: "swift-nio-ssl"),
                 .product(name: "SwiftProtobuf", package: "swift-protobuf"),
                 .product(name: "Hummingbird", package: "hummingbird"),
                 .product(name: "HummingbirdTesting", package: "hummingbird"),
@@ -62,6 +69,7 @@ let package = Package(
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "GRPCNIOTransportHTTP2", package: "grpc-swift-nio-transport"),
                 .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
+                .product(name: "NIOSSL", package: "swift-nio-ssl"),
                 .product(name: "GRPCCore", package: "grpc-swift-2"),
                 .product(name: "SwiftProtobuf", package: "swift-protobuf"),
                 .product(name: "GRPCServiceLifecycle", package: "grpc-swift-extras"),

--- a/swift/WendyAgentCore/Sources/WendyAgent/WendyAgent.swift
+++ b/swift/WendyAgentCore/Sources/WendyAgent/WendyAgent.swift
@@ -473,15 +473,32 @@ public actor WendyAgent {
                     }
                 }(),
                 transportSecurity: security,
-                config: .defaults {
-                    $0.http2.maxFrameSize = 256 * 1024
-                    $0.http2.targetWindowSize = 8 * 1024 * 1024
-                    $0.rpc.maxRequestPayloadSize = 16 * 1024 * 1024
-                }
+                config: Self.mainServerConfig
             ),
             services: services
         )
         return (server, certs != nil)
+    }
+
+    /// Transport configuration shared by the plaintext and mTLS main servers.
+    ///
+    /// Flush coalescing is off. The transport writes its HTTP/2 preface before
+    /// the TLS handshake finishes, so NIOSSL holds that write until the
+    /// handshake completes. When a peer drops the connection mid-handshake,
+    /// NIOSSL reports the failure downstream before discarding the held write;
+    /// the connection handler closes in response, and the coalescing handler
+    /// turns that close into a flush that NIOSSL then tries to encrypt on a dead
+    /// connection. BoringSSL cannot make progress and NIOSSL aborts the process
+    /// (`doUnbufferActions(context:) looped too many times`). Without the
+    /// coalescing handler nothing flushes during that error path.
+    /// See `MTLSHandshakeAbortTests`.
+    nonisolated static var mainServerConfig: HTTP2ServerTransport.Posix.Config {
+        .defaults {
+            $0.http2.maxFrameSize = 256 * 1024
+            $0.http2.targetWindowSize = 8 * 1024 * 1024
+            $0.rpc.maxRequestPayloadSize = 16 * 1024 * 1024
+            $0.connection.flushCoalescing = nil
+        }
     }
 
     /// Constructs the mTLS transport security for the main server.
@@ -499,6 +516,20 @@ public actor WendyAgent {
     private func mTLSSecurity(
         certs: ProvisioningService.ProvisioningCerts
     ) throws -> HTTP2ServerTransport.Posix.TransportSecurity {
+        try Self.makeMTLSSecurity(
+            certs: certs,
+            environment: ProcessInfo.processInfo.environment,
+            logger: self.logger
+        )
+    }
+
+    /// The production mTLS transport security, factored out so tests can stand
+    /// up a real gRPC listener with exactly the configuration the agent uses.
+    nonisolated static func makeMTLSSecurity(
+        certs: ProvisioningService.ProvisioningCerts,
+        environment: [String: String],
+        logger: Logger
+    ) throws -> HTTP2ServerTransport.Posix.TransportSecurity {
         let leaf = TLSConfig.CertificateSource.bytes(Array(certs.certPEM.utf8), format: .pem)
         let chain = TLSConfig.CertificateSource.bytes(Array(certs.chainPEM.utf8), format: .pem)
         let key = try tlsPrivateKeySource(certs.keyBacking, seKey: certs.seKey)
@@ -506,7 +537,7 @@ public actor WendyAgent {
         let trustRootsPEM = certs.chainPEM
         let deviceOrg = ClientCertAuthorizer.organizationID(fromLeafPEM: certs.certPEM)
         if deviceOrg == nil {
-            self.logger.error(
+            logger.error(
                 "Could not determine device organization from its own certificate; mTLS will reject all clients (fail closed). Re-provision the device to recover."
             )
         }
@@ -514,17 +545,17 @@ public actor WendyAgent {
         // Org-enforcement mode (WENDY_MTLS_ORG_ENFORCEMENT: off|grace|strict).
         // Defaults to grace so today's CLI user certs — which carry no org claim
         // — can connect while cert rotation to org-bearing URNs completes.
-        let rawOrgEnforcement = ProcessInfo.processInfo.environment["WENDY_MTLS_ORG_ENFORCEMENT"]
+        let rawOrgEnforcement = environment["WENDY_MTLS_ORG_ENFORCEMENT"]
         let (orgMode, recognized) = ClientCertAuthorizer.OrgEnforcementMode.parse(rawOrgEnforcement)
         if !recognized {
-            self.logger.warning(
+            logger.warning(
                 "Unrecognized WENDY_MTLS_ORG_ENFORCEMENT value; defaulting to grace",
                 metadata: [
                     "value": "\(rawOrgEnforcement ?? "")"
                 ]
             )
         }
-        self.logger.info(
+        logger.info(
             "mTLS client org enforcement",
             metadata: ["mode": "\(orgMode.name)"]
         )

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/MTLSHandshakeAbortTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/MTLSHandshakeAbortTests.swift
@@ -1,0 +1,212 @@
+import Foundation
+import GRPCCore
+import GRPCNIOTransportHTTP2
+import Logging
+import NIOCore
+import NIOPosix
+import NIOSSL
+import Testing
+
+@testable import WendyAgentCore
+
+/// Real-socket regression for WDY-3013: a peer that drops the TCP connection
+/// while the mTLS handshake is still in flight must cost the agent one
+/// connection, not the process.
+///
+/// The server pipeline writes the HTTP/2 preface before the handshake
+/// completes, so the TLS handler holds a buffered, flushed write when the
+/// socket goes away. If the TLS handler lets a downstream handler flush that
+/// buffer after it has already declared the connection closed, BoringSSL
+/// cannot make progress and `NIOSSLHandler.doUnbufferActions` aborts the
+/// process with "looped too many times". On an affected `swift-nio-ssl` this
+/// test does not fail: it kills the test runner with that exact message.
+@Suite("mTLS handshake abort", .serialized)
+struct MTLSHandshakeAbortTests {
+    private struct HandshakeTimeout: Error {}
+    private struct NoListeningPort: Error {}
+
+    private static func currentPOSIXError() -> POSIXError {
+        POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+    }
+
+    private typealias PosixGRPCServer = GRPCServer<HTTP2ServerTransport.Posix>
+
+    private static func makeServer(
+        ca: TestPKI.CA,
+        deviceOrg: Int32
+    ) throws -> PosixGRPCServer {
+        let device = try TestPKI.makeDeviceIdentity(org: deviceOrg, asset: 1, ca: ca)
+        let certs = ProvisioningService.ProvisioningCerts(
+            certPEM: device.certPEM,
+            chainPEM: ca.pem,
+            keyBacking: .softwarePEM(device.keyPEM),
+            seKey: nil
+        )
+        let security = try WendyAgent.makeMTLSSecurity(
+            certs: certs,
+            environment: [:],
+            logger: Logger(label: "test.mtls-handshake-abort")
+        )
+        return PosixGRPCServer(
+            transport: HTTP2ServerTransport.Posix(
+                address: .ipv4(host: "127.0.0.1", port: 0),
+                transportSecurity: security,
+                config: WendyAgent.mainServerConfig
+            ),
+            services: []
+        )
+    }
+
+    private static func listeningPort(of server: PosixGRPCServer) async throws -> Int {
+        guard let address = try await server.listeningAddress, let port = address.ipv4?.port else {
+            throw NoListeningPort()
+        }
+        return port
+    }
+
+    /// Opens a TCP connection and closes it without sending a byte, using raw
+    /// sockets so the FIN reaches the server within the same event-loop tick
+    /// as the accept. That is what a peer that connects and immediately gives
+    /// up looks like: the server's TLS handler is still waiting for a
+    /// ClientHello, the HTTP/2 preface is buffered behind it, and the
+    /// transport's flush coalescing has not yet released its pending flush.
+    private static func connectAndAbort(port: Int) throws {
+        let fileDescriptor = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)
+        guard fileDescriptor >= 0 else {
+            throw currentPOSIXError()
+        }
+        defer { Darwin.close(fileDescriptor) }
+
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = in_port_t(port).bigEndian
+        address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+
+        try withUnsafePointer(to: &address) { pointer in
+            try pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+                guard
+                    connect(
+                        fileDescriptor,
+                        socketAddress,
+                        socklen_t(MemoryLayout<sockaddr_in>.size)
+                    ) == 0
+                else {
+                    throw currentPOSIXError()
+                }
+            }
+        }
+    }
+
+    /// Resolves once decrypted application data arrives — the server only
+    /// releases its buffered HTTP/2 preface after the handshake completes — or
+    /// fails on error/close.
+    private final class HandshakeObserver: ChannelInboundHandler, @unchecked Sendable {
+        typealias InboundIn = ByteBuffer
+
+        private let promise: EventLoopPromise<Void>
+        private var completed = false
+        private var timeout: Scheduled<Void>?
+
+        init(promise: EventLoopPromise<Void>) {
+            self.promise = promise
+        }
+
+        private func complete(_ result: Result<Void, any Error>) {
+            guard !self.completed else { return }
+            self.completed = true
+            self.timeout?.cancel()
+            self.promise.completeWith(result)
+        }
+
+        func handlerAdded(context: ChannelHandlerContext) {
+            self.timeout = context.eventLoop.scheduleTask(in: .seconds(10)) {
+                self.complete(.failure(HandshakeTimeout()))
+                context.close(promise: nil)
+            }
+        }
+
+        func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+            self.complete(.success(()))
+        }
+
+        func errorCaught(context: ChannelHandlerContext, error: any Error) {
+            self.complete(.failure(error))
+            context.close(promise: nil)
+        }
+
+        func channelInactive(context: ChannelHandlerContext) {
+            self.complete(.failure(HandshakeTimeout()))
+            context.fireChannelInactive()
+        }
+    }
+
+    /// Completes a full mTLS handshake with a CA-issued client identity, which
+    /// exercises the server's asynchronous `ClientCertAuthorizer` path, and
+    /// waits for the server's HTTP/2 preface to arrive over the encrypted link.
+    private static func completeHandshake(
+        port: Int,
+        clientIdentity: TestPKI.Identity,
+        ca: TestPKI.CA,
+        group: any EventLoopGroup
+    ) async throws {
+        var tls = TLSConfiguration.makeClientConfiguration()
+        tls.certificateVerification = .noHostnameVerification
+        tls.trustRoots = .certificates(try NIOSSLCertificate.fromPEMBytes(Array(ca.pem.utf8)))
+        tls.certificateChain = try NIOSSLCertificate.fromPEMBytes(
+            Array(clientIdentity.certPEM.utf8)
+        )
+        .map { .certificate($0) }
+        tls.privateKey = .privateKey(
+            try NIOSSLPrivateKey(bytes: Array(clientIdentity.keyPEM.utf8), format: .pem)
+        )
+        let context = try NIOSSLContext(configuration: tls)
+
+        let eventLoop = group.next()
+        let handshake = eventLoop.makePromise(of: Void.self)
+        let channel = try await ClientBootstrap(group: eventLoop)
+            .channelInitializer { channel in
+                channel.eventLoop.makeCompletedFuture {
+                    try channel.pipeline.syncOperations.addHandlers(
+                        try NIOSSLClientHandler(context: context, serverHostname: nil),
+                        HandshakeObserver(promise: handshake)
+                    )
+                }
+            }
+            .connect(host: "127.0.0.1", port: port)
+            .get()
+        defer { channel.close(promise: nil) }
+        try await handshake.futureResult.get()
+    }
+
+    @Test("A peer closing mid-handshake does not take the mTLS listener down")
+    func peerAbortMidHandshakeKeepsListenerAlive() async throws {
+        let ca = try TestPKI.makeCA()
+        let deviceOrg: Int32 = 7
+        let server = try Self.makeServer(ca: ca, deviceOrg: deviceOrg)
+        let serveTask = Task { try await server.serve() }
+        defer {
+            server.beginGracefulShutdown()
+            serveTask.cancel()
+        }
+        let port = try await Self.listeningPort(of: server)
+
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { group.shutdownGracefully { _ in } }
+
+        // A burst of aborted connections: several are already half-closed by
+        // the time the accept loop reaches them, which is the ordering that
+        // matters. Repeating removes any dependence on one lucky schedule.
+        for _ in 0..<50 {
+            try Self.connectAndAbort(port: port)
+        }
+
+        // Give the server loop a beat to process the closes: on an affected
+        // TLS handler the process is already gone by the time this returns.
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        // The same listener must still complete a genuine mTLS handshake.
+        let client = try TestPKI.makeDeviceIdentity(org: deviceOrg, asset: 2, ca: ca)
+        try await Self.completeHandshake(port: port, clientIdentity: client, ca: ca, group: group)
+    }
+}

--- a/swift/WendyAgentCore/Tests/WendyAgentTests/RegistryTLSListenerTests.swift
+++ b/swift/WendyAgentCore/Tests/WendyAgentTests/RegistryTLSListenerTests.swift
@@ -239,7 +239,7 @@ struct RegistryTLSListenerTests {
         await Self.stop(task)
     }
 
-    @Test("a handshake without a client certificate is rejected")
+    @Test("a missing client certificate is rejected without stopping the listener")
     func rejectsMissingClientCert() async throws {
         let ca = try TestPKI.makeCA()
         let (port, task) = try await Self.startListener(
@@ -248,10 +248,14 @@ struct RegistryTLSListenerTests {
 
         let response = try await Self.tlsGET(port: port, clientIdentity: nil)
         #expect(!response.contains("200 OK"))
+
+        let trusted = try TestPKI.makeIdentity(commonName: "wendy/user/tester", ca: ca)
+        let subsequentResponse = try await Self.tlsGET(port: port, clientIdentity: trusted)
+        #expect(subsequentResponse.contains("200 OK"))
         await Self.stop(task)
     }
 
-    @Test("a client certificate from a different CA is rejected")
+    @Test("an untrusted client certificate is rejected without stopping the listener")
     func rejectsUntrustedClientCert() async throws {
         let ca = try TestPKI.makeCA()
         let otherCA = try TestPKI.makeCA(commonName: "Impostor CA")
@@ -262,10 +266,14 @@ struct RegistryTLSListenerTests {
         let impostor = try TestPKI.makeIdentity(commonName: "wendy/user/impostor", ca: otherCA)
         let response = try await Self.tlsGET(port: port, clientIdentity: impostor)
         #expect(!response.contains("200 OK"))
+
+        let trusted = try TestPKI.makeIdentity(commonName: "wendy/user/tester", ca: ca)
+        let subsequentResponse = try await Self.tlsGET(port: port, clientIdentity: trusted)
+        #expect(subsequentResponse.contains("200 OK"))
         await Self.stop(task)
     }
 
-    @Test("plain HTTP against the TLS listener fails fast")
+    @Test("plain HTTP is rejected without stopping the TLS listener")
     func rejectsPlainHTTP() async throws {
         let ca = try TestPKI.makeCA()
         let (port, task) = try await Self.startListener(
@@ -274,6 +282,10 @@ struct RegistryTLSListenerTests {
 
         let response = try await Self.plainGET(port: port)
         #expect(!response.contains("200 OK"))
+
+        let trusted = try TestPKI.makeIdentity(commonName: "wendy/user/tester", ca: ca)
+        let subsequentResponse = try await Self.tlsGET(port: port, clientIdentity: trusted)
+        #expect(subsequentResponse.contains("200 OK"))
         await Self.stop(task)
     }
 


### PR DESCRIPTION
- **Closes:** [WDY-3013 — Mac agent exits when an mTLS peer rejects or closes the handshake](https://linear.app/wendylabsinc/issue/WDY-3013/mac-agent-exits-when-an-mtls-peer-rejects-or-closes-the-handshake)
- **Unblocks live validation of:** [WendyOS #1924 — WDY-3009: stream Mac cameras to Companion Live](https://github.com/wendylabsinc/WendyOS/pull/1924)

> **In plain terms:** A client that connects to Wendy Agent for Mac and drops the connection before the secure handshake finishes now costs one connection instead of the whole agent.

## Summary
- Turn off HTTP/2 flush coalescing on the main gRPC server. The transport queues its HTTP/2 preface behind the TLS handshake; when a peer drops mid-handshake, the coalescing handler turned the resulting close into a flush that NIOSSL tried to satisfy on a dead connection and aborted with `doUnbufferActions(context:) looped too many times` — the exact signature in both crash reports. Without the coalescing handler nothing flushes during that failure path.
- Add a real-socket regression that drives the production mTLS configuration: a burst of connections that close without sending a byte, then a full mTLS handshake against the same listener. Against the previous configuration it kills the test process with the production message on every run (5/5); with this change it passes (5/5).
- Keep `swift-nio-ssl` pinned to Apple's merged fix for the separate half-closure reentrancy in 2.37.4 ([apple/swift-nio-ssl #604](https://github.com/apple/swift-nio-ssl/pull/604)). That path applies to the Hummingbird registry listener, which enables remote half-closure; it is not what produced the observed crash, and the pin reverts to a tagged release once one includes the fix.
- Verify missing, untrusted, and non-TLS peers do not stop the registry TLS listener from accepting a subsequent valid client.

## Root cause note
The affected ordering is in `NIOSSLHandler.channelInactive`, which reports the failure downstream before discarding the writes it was holding for the handshake; it is unchanged on upstream `main`. A one-line reorder there also makes the regression pass, so an upstream report is worth filing separately. Release builds compile `assertionFailure` out and would degrade to a busy loop plus a thrown error instead of aborting; the crash reports come from Debug development builds.

## Tests
- `swift test --filter MTLSHandshakeAbortTests` — passes 5/5 with the fix; aborts the runner 5/5 without it
- `swift test --filter RegistryTLSListenerTests` — 6 passed
- `make lint`
- `make test` — 345 passed; 7 Secure Enclave/Keychain tests failed only with `errSecInteractionNotAllowed` because the login Keychain was locked in the validation session, identically on the untouched branch
- `make agent-build` — Xcode build succeeded; the post-build re-sign step failed for the same locked-Keychain reason
- Live check (2026-09-11, Debug app freshly enrolled as asset 478): one agent process (PID 86389) took 200 raw connect-and-drops, 20 TLS clients rejecting the server certificate, 20 handshakes without a client certificate, 20 plaintext requests, and a Companion connection that the agent rejected with `bad_certificate` — the sequence behind both crash reports. Same PID throughout, `50052` still listening, no new crash reports, and a real mTLS RPC succeeded afterwards.
