### PR TITLE
verify sdkconfig before building an ESP-IDF native app

### DIFF
--- a/go/internal/cli/espidftoolchain/toolchain.go
+++ b/go/internal/cli/espidftoolchain/toolchain.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -91,6 +92,104 @@ func ProjectTarget(dir string) string {
 		return ""
 	}
 	return config.IdfTarget
+}
+
+// ReadSdkconfig reads the sdkconfig of the ESP-IDF project in dir and returns
+// the value of each requested setting, typed: a boolean option comes back as a
+// bool, an integer one as an int, and a string one with its quotes stripped.
+//
+// A setting that is not set is left out of the result rather than reported, so
+// a lookup of it yields nil, which stays distinct from an option genuinely set
+// to an empty string (CONFIG_WENDY_WIFI_SSID="" is a real one). Only a failure
+// to read the file is an error.
+//
+// This reads the sdkconfig idf.py generates in the project directory, which
+// exists only once the project has been configured — not sdkconfig.defaults,
+// which merely seeds it. Its lines look like:
+//
+//	CONFIG_ESP_CONSOLE_UART_DEFAULT=y
+//	# CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG is not set
+//	CONFIG_ESP_CONSOLE_UART_BAUDRATE=115200
+//	CONFIG_IDF_TARGET="esp32c6"
+func ReadSdkconfig(dir string, keys []string) (map[string]any, error) {
+	f, err := os.Open(filepath.Join(dir, "sdkconfig"))
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	wanted := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		wanted[key] = struct{}{}
+	}
+
+	values := make(map[string]any, len(keys))
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		// Skipping every comment is what detects an unset option: Kconfig
+		// writes those as "# CONFIG_X is not set" rather than leaving them
+		// out, and either way the option never enters the map.
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, found := strings.Cut(line, "=")
+		if !found {
+			continue
+		}
+		// The generated file never pads the assignment, but a hand-edited one
+		// can, and a padded key would otherwise read as unset.
+		key = strings.TrimSpace(key)
+		if _, ok := wanted[key]; !ok {
+			continue
+		}
+		// Last one wins, as Kconfig itself resolves it. IDF appends a
+		// deprecated-alias section naming retired options
+		// (CONFIG_CONSOLE_UART_DEFAULT for CONFIG_ESP_CONSOLE_UART_DEFAULT),
+		// but never the same option twice, so this only matters for a
+		// hand-edited file.
+		values[key] = parseSdkconfigValue(strings.TrimSpace(value))
+	}
+	// Without this a truncated read would look like a project with every
+	// option unset, i.e. a misconfiguration rather than a failure to read.
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return values, nil
+}
+
+// parseSdkconfigValue converts the right-hand side of an sdkconfig assignment
+// to the Go type the option holds:
+//
+//	y      -> true
+//	n      -> false
+//	"text" -> "text"
+//	115200 -> 115200
+//	0x8000 -> 32768
+//
+// An unrecognized form is returned as its raw string, so an option this does
+// not know how to type stays visible to the caller instead of vanishing.
+func parseSdkconfigValue(value string) any {
+	switch value {
+	case "y":
+		return true
+	case "n":
+		// The generated sdkconfig writes "# CONFIG_X is not set" instead, but
+		// a sdkconfig.defaults does use =n.
+		return false
+	}
+	// A matched pair only: strings.Trim(value, `"`), the idiom used elsewhere
+	// in the repo, would also eat an unbalanced quote belonging to the value.
+	if len(value) >= 2 && strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`) {
+		return value[1 : len(value)-1]
+	}
+	// Base 0 so hex values (CONFIG_PARTITION_TABLE_OFFSET=0x8000) parse too.
+	// int rather than int64, so an untyped constant in a caller's comparison
+	// — which boxes into any as an int — actually matches.
+	if n, err := strconv.ParseInt(value, 0, strconv.IntSize); err == nil {
+		return int(n)
+	}
+	return value
 }
 
 // EnsureVersion verifies that eim is installed and that the DefaultVersion

--- a/go/internal/cli/espidftoolchain/toolchain_test.go
+++ b/go/internal/cli/espidftoolchain/toolchain_test.go
@@ -208,12 +208,28 @@ func TestReadSdkconfig(t *testing.T) {
 			},
 		},
 		{
+			name:    "unbalanced quote is kept as-is, not stripped",
+			content: "CONFIG_IDF_TARGET=\"esp32c6\n",
+			keys:    []string{"CONFIG_IDF_TARGET"},
+			want: map[string]any{
+				"CONFIG_IDF_TARGET": "\"esp32c6",
+			},
+		},
+		{
 			name:    "integer values, decimal and hex",
 			content: "CONFIG_ESP_CONSOLE_UART_BAUDRATE=115200\nCONFIG_PARTITION_TABLE_OFFSET=0x8000\n",
 			keys:    []string{"CONFIG_ESP_CONSOLE_UART_BAUDRATE", "CONFIG_PARTITION_TABLE_OFFSET"},
 			want: map[string]any{
 				"CONFIG_ESP_CONSOLE_UART_BAUDRATE": 115200,
 				"CONFIG_PARTITION_TABLE_OFFSET":    32768,
+			},
+		},
+		{
+			name:    "trailing comment after a value is not stripped",
+			content: "CONFIG_ESP_CONSOLE_UART_BAUDRATE=115200 # default baud rate\n",
+			keys:    []string{"CONFIG_ESP_CONSOLE_UART_BAUDRATE"},
+			want: map[string]any{
+				"CONFIG_ESP_CONSOLE_UART_BAUDRATE": "115200 # default baud rate",
 			},
 		},
 		{

--- a/go/internal/cli/espidftoolchain/toolchain_test.go
+++ b/go/internal/cli/espidftoolchain/toolchain_test.go
@@ -177,6 +177,91 @@ func TestProjectTarget(t *testing.T) {
 	}
 }
 
+func TestReadSdkconfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string // sdkconfig content; "" means no file
+		keys    []string
+		want    map[string]any
+		wantErr bool
+	}{
+		{
+			name: "boolean option, unrequested option left out",
+			content: "CONFIG_ESP_CONSOLE_UART_DEFAULT=y\n" +
+				"CONFIG_ESP_CONSOLE_SECONDARY_NONE=y\n",
+			keys: []string{"CONFIG_ESP_CONSOLE_UART_DEFAULT"},
+			want: map[string]any{"CONFIG_ESP_CONSOLE_UART_DEFAULT": true},
+		},
+		{
+			name:    "option that is not set is absent",
+			content: "# CONFIG_ESP_CONSOLE_UART_DEFAULT is not set\n",
+			keys:    []string{"CONFIG_ESP_CONSOLE_UART_DEFAULT"},
+			want:    map[string]any{},
+		},
+		{
+			name:    "string values, an empty one distinct from unset",
+			content: "CONFIG_IDF_TARGET=\"esp32c6\"\nCONFIG_WENDY_WIFI_SSID=\"\"\n",
+			keys:    []string{"CONFIG_IDF_TARGET", "CONFIG_WENDY_WIFI_SSID"},
+			want: map[string]any{
+				"CONFIG_IDF_TARGET":      "esp32c6",
+				"CONFIG_WENDY_WIFI_SSID": "",
+			},
+		},
+		{
+			name:    "integer values, decimal and hex",
+			content: "CONFIG_ESP_CONSOLE_UART_BAUDRATE=115200\nCONFIG_PARTITION_TABLE_OFFSET=0x8000\n",
+			keys:    []string{"CONFIG_ESP_CONSOLE_UART_BAUDRATE", "CONFIG_PARTITION_TABLE_OFFSET"},
+			want: map[string]any{
+				"CONFIG_ESP_CONSOLE_UART_BAUDRATE": 115200,
+				"CONFIG_PARTITION_TABLE_OFFSET":    32768,
+			},
+		},
+		{
+			name: "deprecated alias is not the requested option",
+			content: "# CONFIG_ESP_CONSOLE_UART_DEFAULT is not set\n" +
+				"#\n# Deprecated options for backward compatibility\n#\n" +
+				"CONFIG_CONSOLE_UART_DEFAULT=y\n# End of deprecated options\n",
+			keys: []string{"CONFIG_ESP_CONSOLE_UART_DEFAULT"},
+			want: map[string]any{},
+		},
+		{
+			name:    "no keys requested",
+			content: "CONFIG_ESP_CONSOLE_UART_DEFAULT=y\n",
+			keys:    nil,
+			want:    map[string]any{},
+		},
+		{
+			name:    "missing sdkconfig",
+			content: "",
+			keys:    []string{"CONFIG_ESP_CONSOLE_UART_DEFAULT"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tt.content != "" {
+				if err := os.WriteFile(filepath.Join(dir, "sdkconfig"), []byte(tt.content), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got, err := ReadSdkconfig(dir, tt.keys)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ReadSdkconfig() = %#v, want an error", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ReadSdkconfig() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ReadSdkconfig() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
 // stubExecCommandContext replaces execCommandContext for the duration of the
 // test, recording each invocation and delegating to fake to pick the command
 // actually run.

--- a/go/internal/cli/providers/microwendy.go
+++ b/go/internal/cli/providers/microwendy.go
@@ -645,7 +645,7 @@ func (p *MicroWendyProvider) buildEspIdf(ctx context.Context, device models.Exte
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("idf.py build: %w", err)
+		return nil, fmt.Errorf("build: idf.py gen_project_binary: %w", err)
 	}
 
 	// verify the presence of the output bin file

--- a/go/internal/cli/providers/microwendy.go
+++ b/go/internal/cli/providers/microwendy.go
@@ -623,8 +623,24 @@ func (p *MicroWendyProvider) buildEspIdf(ctx context.Context, device models.Exte
 		}
 	}
 
+	// verify the configuration
+	sdkconfig, err := espidftoolchain.ReadSdkconfig(projectPath, []string{
+		"CONFIG_WENDY_CORE",
+		"CONFIG_WENDY_USJ",
+		"CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG_ENABLED",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("reading sdkconfig: %w", err)
+	}
+	if sdkconfig["CONFIG_WENDY_USJ"] == true && sdkconfig["CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG_ENABLED"] == true {
+		return nil, errors.New("Wendy Lite owns the USB Serial/JTAG controller, so the console must not be routed to it — set CONFIG_ESP_CONSOLE_UART_DEFAULT=y and CONFIG_ESP_CONSOLE_SECONDARY_NONE=y in sdkconfig")
+	}
+	if sdkconfig["CONFIG_WENDY_CORE"] != true {
+		return nil, errors.New("this project does not include the wendy_core component — add it to the project's dependencies, then call wendy_core_init() as the very first statement of app_main()")
+	}
+
 	// build the project
-	cmd := espidftoolchain.IdfCommandContext(ctx, "build")
+	cmd := espidftoolchain.IdfCommandContext(ctx, "gen_project_binary") // build only the app binary, not the whole firmware image
 	cmd.Dir = projectPath
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
## Summary
- Add `espidftoolchain.ReadSdkconfig`, a single-pass parser that returns requested sdkconfig options as typed values (bool for y/n, int for numeric, unquoted string), leaving unset options out of the result so a lookup answers `nil` distinctly from an empty string.
- `buildEspIdf` now checks the generated sdkconfig before building: it fails fast with the remedy spelled out if the project doesn't depend on `wendy_core`, or if the console is routed to the USB Serial/JTAG controller that Wendy Lite drives itself — previously both misconfigurations built without complaint and only misbehaved on-device.
- Switch the build step from `idf.py build` to `idf.py gen_project_binary`, which builds just the app binary instead of the whole firmware image.

## Test plan
- [x] `go/internal/cli/espidftoolchain/toolchain_test.go` covers `ReadSdkconfig` (typed values, unset vs empty-string, comments, hex, unbalanced quotes)
- [x] Manual: build a native app missing `wendy_core` and confirm the new error message
- [x] Manual: build a native app with console routed to USB Serial/JTAG and confirm the new error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)