### PR TITLE
Warn about missing mTLS on Wendy Lite picker rows

### DIFF
--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -3522,6 +3522,14 @@ func mergePickerItem(existing *tui.PickerItem, incoming tui.PickerItem) {
 		existing.Provisioned = incoming.Provisioned
 		existing.Hint = incoming.Hint
 	}
+	// A Wendy Lite row has no LAN probe to speak for it: each of its transports
+	// reports its own mTLS state, and pickerSelection connects over the
+	// highest-ranked one (Externals[0], kept sorted above). Recompute from that
+	// transport so the warning describes the connection we would actually make,
+	// whichever order the transports were discovered in.
+	if md.LAN == nil && len(md.Externals) > 0 {
+		existing.Insecure = liteExternalInsecure(md.Externals[0])
+	}
 	// The no-access hint must stay consistent with the version cell no matter
 	// which transport supplied the version: AgentVersion is carried over from
 	// earlier LAN probes or backfilled from BLE above, and a hint claiming
@@ -3575,6 +3583,16 @@ func hideLocalProviders(excludes map[string]bool) map[string]bool {
 	return merged
 }
 
+// liteExternalInsecure reports whether a Wendy Lite transport will run without
+// mTLS. The Lite firmware advertises mtls=false until it is enrolled (see the
+// wendy-com doc), and connectClient dials such a device with ConnectInsecure —
+// so the row deserves the same warning a plaintext WendyOS device gets. Only an
+// explicit "false" counts: a serial row carries no mtls key at all, and an
+// absent key is not evidence of an unsecured connection.
+func liteExternalInsecure(dev *models.ExternalDevice) bool {
+	return dev != nil && dev.ConnectionInfo["mtls"] == "false"
+}
+
 // unflashedLiteDedupKey keys a board with no Wendy Lite firmware by its port
 // rather than its synthetic display name, so the row it gets once it identifies
 // itself can supersede it.
@@ -3592,6 +3610,7 @@ func externalProviderPickerItem(prov providers.DeviceProvider, dev *models.Exter
 			DedupKey:     dev.ConnectionInfo["deviceId"],
 			Type:         dev.ConnectionType() + " (Lite)",
 			Address:      dev.ConnectionInfo["ip"],
+			Insecure:     liteExternalInsecure(dev),
 			AgentVersion: dev.AgentVersion,
 			OS:           dev.OS,
 			OSVersion:    dev.OSVersion,

--- a/go/internal/cli/commands/helpers.go
+++ b/go/internal/cli/commands/helpers.go
@@ -3585,7 +3585,7 @@ func hideLocalProviders(excludes map[string]bool) map[string]bool {
 
 // liteExternalInsecure reports whether a Wendy Lite transport will run without
 // mTLS. The Lite firmware advertises mtls=false until it is enrolled (see the
-// wendy-com doc), and connectClient dials such a device with ConnectInsecure —
+// wendy-com doc), and connectClient dials such a device with ConnectInsecure (or ConnectViaBLEInsecure for BLE) —
 // so the row deserves the same warning a plaintext WendyOS device gets. Only an
 // explicit "false" counts: a serial row carries no mtls key at all, and an
 // absent key is not evidence of an unsecured connection.

--- a/go/internal/cli/commands/helpers_test.go
+++ b/go/internal/cli/commands/helpers_test.go
@@ -2302,6 +2302,112 @@ func TestExternalProviderPickerItem(t *testing.T) {
 		}
 	})
 
+	// An unenrolled Wendy Lite board advertises mtls=false and connectClient
+	// then dials it with ConnectInsecure, so its row must carry the same
+	// warning a plaintext WendyOS device gets.
+	t.Run("insecure flag follows the transport's mtls key", func(t *testing.T) {
+		tests := []struct {
+			name string
+			info map[string]string
+			want bool
+		}{
+			{
+				name: "LAN board that is not enrolled",
+				info: map[string]string{"type": "LAN", "ip": "10.0.0.9", "deviceId": "lite-board-1", "mtls": "false"},
+				want: true,
+			},
+			{
+				name: "LAN board that is enrolled",
+				info: map[string]string{"type": "LAN", "ip": "10.0.0.9", "deviceId": "lite-board-1", "mtls": "true"},
+				want: false,
+			},
+			// Serial carries no mtls key at all, so an absent key must not be
+			// read as an unsecured connection (an `!= "true"` test would).
+			{
+				name: "USB board reports no mtls at all",
+				info: map[string]string{"type": "USB", "serialPort": "/dev/cu.usbmodem2101", "deviceId": "lite-board-1"},
+				want: false,
+			},
+			{
+				name: "unflashed board reports no mtls at all",
+				info: map[string]string{"type": "USB", "serialPort": "/dev/cu.usbmodem2101", "needsInstall": "true"},
+				want: false,
+			},
+		}
+
+		prov := &fakeProvider{key: "wendy-lite"}
+		for _, tt := range tests {
+			dev := models.ExternalDevice{
+				ID:             "wendy-lite:board",
+				DisplayName:    "Lite Board",
+				ProviderKey:    "wendy-lite",
+				ConnectionInfo: tt.info,
+			}
+			if got := externalProviderPickerItem(prov, &dev).Insecure; got != tt.want {
+				t.Errorf("%s: Insecure = %v, want %v", tt.name, got, tt.want)
+			}
+		}
+	})
+
+	// End to end over the picker: the reported gap was an unenrolled Lite board
+	// presented as if its connection were secure.
+	t.Run("insecure Lite row warns in the picker", func(t *testing.T) {
+		prov := &fakeProvider{key: "wendy-lite"}
+		lan := models.ExternalDevice{
+			ID:          "wendy-lite:board.local",
+			DisplayName: "Lite Board",
+			ProviderKey: "wendy-lite",
+			ConnectionInfo: map[string]string{
+				"type": "LAN", "ip": "10.0.0.9", "deviceId": "lite-board-1", "mtls": "false",
+			},
+		}
+		usb := models.ExternalDevice{
+			ID:          "wendy-lite:/dev/cu.usbmodem2101",
+			DisplayName: "Lite Board",
+			ProviderKey: "wendy-lite",
+			ConnectionInfo: map[string]string{
+				"type": "USB", "serialPort": "/dev/cu.usbmodem2101", "deviceId": "lite-board-1",
+			},
+		}
+
+		pickerView := func(devs ...*models.ExternalDevice) string {
+			picker := tui.NewPicker()
+			picker.MergeItem = mergePickerItem
+			model, _ := picker.Update(tui.PickerAddMsg{
+				Items: []tui.PickerItem{externalProviderPickerItem(prov, devs[0])},
+			})
+			for _, dev := range devs[1:] {
+				model, _ = model.(tui.PickerModel).Update(tui.PickerAddMsg{
+					Items: []tui.PickerItem{externalProviderPickerItem(prov, dev)},
+				})
+			}
+			return model.(tui.PickerModel).View()
+		}
+
+		view := pickerView(&lan)
+		if !strings.Contains(view, "Connection is not secured with mTLS") {
+			t.Errorf("picker does not warn about the unenrolled board:\n%s", view)
+		}
+		if !strings.Contains(view, tui.LegendInsecure) {
+			t.Errorf("picker legend does not document the warning glyph:\n%s", view)
+		}
+
+		// The merged row must describe the connection pickerSelection would
+		// actually make: USB outranks LAN, and serial is not an mTLS question —
+		// so the warning goes away, whichever order the transports arrive in.
+		for _, order := range [][]*models.ExternalDevice{{&lan, &usb}, {&usb, &lan}} {
+			view := pickerView(order...)
+			if strings.Contains(view, "Connection is not secured with mTLS") {
+				t.Errorf("%s then %s: merged row still warns although it connects over USB:\n%s",
+					order[0].ConnectionInfo["type"], order[1].ConnectionInfo["type"], view)
+			}
+			if strings.Contains(view, tui.LegendInsecure) {
+				t.Errorf("%s then %s: merged row still documents the warning glyph:\n%s",
+					order[0].ConnectionInfo["type"], order[1].ConnectionInfo["type"], view)
+			}
+		}
+	})
+
 	t.Run("other providers keep provider row layout", func(t *testing.T) {
 		prov := &fakeProvider{key: "fake"}
 		dev := models.ExternalDevice{ID: "fake:1", DisplayName: "Dev", ProviderKey: "fake"}


### PR DESCRIPTION
## Summary
- Wendy Lite rows in the device picker never surfaced the "Connection is not secured with mTLS" warning, even though an unenrolled board is dialed with `ConnectInsecure`. The warning was only ever wired up for LAN rows (`lanPickerItem`), not `externalProviderPickerItem`.
- `liteExternalInsecure` reads the transport's own `mtls` TXT record (only an explicit `"false"` counts, so serial rows with no `mtls` key at all aren't flagged).
- When a board arrives as multiple rows that dedup on device id (e.g. LAN + USB), `mergePickerItem` now recomputes `Insecure` from `Externals[0]` — the transport actually connected to — instead of keeping whichever value landed first.

## Test plan
- [x] `go test` covers `externalProviderPickerItem` insecure-flag derivation across LAN (enrolled/unenrolled), USB, and unflashed boards
- [x] `go test` covers the merged picker view end-to-end for both LAN-then-USB and USB-then-LAN discovery orders