### PR TITLE
Back off the serial handshake sentinel, re-arm echo mode with each one

### DIFF
--- a/go/internal/cli/assets/docs/wendy-lite/wendy-com.md
+++ b/go/internal/cli/assets/docs/wendy-lite/wendy-com.md
@@ -78,6 +78,43 @@ USB layer on both sides.  The handshake uses echo mode for this:
 
 The channel is now in `USJ_MODE_COM` with no stale data in either buffer.
 
+#### Implementation notes
+
+A board that has just rebooted is a hostile environment for this sequence: boot
+logs keep the stream continuously readable so it never goes quiet, bytes can be
+dropped, and the device is not ready to serve WendyCom for some time after USB
+comes up. The CLI's implementation (`serialHandshake`, in
+`go/internal/cli/liteclient/link_direct.go`) is therefore more aggressive than
+the steps above, collapsing 2-5 into a single retry loop:
+
+- **Steps 2 and 5 go out as one write.** Each attempt sends
+  `DLE DLE DLE DLE e` immediately followed by 16 spaces of padding and a fresh
+  32-character random sentinel, as a single payload.
+- **The echo mode command is repeated with every attempt.** The device refuses
+  `DLE e` until its WendyCom agent is running, and the window between USB
+  initialization and that point is wide enough to swallow the first attempt.
+  Applying the command is a plain mode assignment, so re-issuing it is
+  idempotent. Escape sequences are consumed by the mode parser and never echoed,
+  so the prefix cannot show up in the echoed stream.
+- **Every attempt carries a fresh sentinel.** The sentinel is a stream position
+  marker, not a liveness probe: because the echo is FIFO, seeing the *latest*
+  one come back proves nothing the host wrote earlier is still in flight, which
+  is what step 4 is really after. Matching an older sentinel would leave the
+  later echoes queued, and the WendyCom framer reads their leading padding as a
+  frame header.
+- **The padding is 16 spaces.** A `DLE` whose command byte is lost stays latched
+  and consumes the byte after it, so a run of expendable bytes ahead of the
+  sentinel keeps a dropped byte from corrupting it.
+- **Matching uses a rolling window.** The host reads one byte at a time, keeping
+  the last 32, and compares that window to the sentinel just sent. Draining the
+  channel (step 4) falls out of this for free, without the stream ever having to
+  go quiet.
+- **Retries widen.** The first attempt goes out immediately, then the host waits
+  100 ms before retrying, then 200, 300, 400 and 500 ms, holding at 500 ms,
+  within a total budget of 3 seconds — about eight attempts. Widening keeps
+  probing a device that is still booting without pushing a kilobyte of sentinels
+  at it.
+
 ### Switching to program mode
 
 In addition to the modes described above, the host can reset the device into program mode via the DTR and RTS signals exposed by the USB Serial JTAG peripheral. The `wendy os install` command uses this to flash the firmware.

--- a/go/internal/cli/liteclient/link_direct.go
+++ b/go/internal/cli/liteclient/link_direct.go
@@ -80,12 +80,32 @@ type serialHandshakePort interface {
 	SetReadTimeout(time.Duration) error
 }
 
-func serialHandshake(port serialHandshakePort) error {
-	if _, err := port.Write([]byte{escapeChar, escapeChar, escapeChar, escapeChar, 'e'}); err != nil {
-		return fmt.Errorf("serial handshake: send escape: %w", err)
-	}
+// The gap after each sentinel widens by one step, holding at
+// sentinelIntervalMax: 100, 200, 300, 400, 500, 500... The device rejects the
+// echo-mode command until its WendyCom agent is running, so early sentinels are
+// expected to go unanswered — widening keeps probing without pushing a kilobyte
+// of sentinels at a board that is still booting.
+//
+// sentinelIntervalStep doubles as the read timeout: it is the finest
+// granularity the scheduler needs, and it keeps handshakeBudget accurate to one
+// step. Vars so tests can shrink them.
+var (
+	sentinelIntervalStep = 100 * time.Millisecond
+	sentinelIntervalMax  = 500 * time.Millisecond
+	handshakeBudget      = 3 * time.Second
+)
 
-	if err := port.SetReadTimeout(100 * time.Millisecond); err != nil {
+// nextSentinelInterval widens the gap that follows a sentinel by one step,
+// holding at sentinelIntervalMax. Zero yields the first gap.
+func nextSentinelInterval(current time.Duration) time.Duration {
+	if next := current + sentinelIntervalStep; next < sentinelIntervalMax {
+		return next
+	}
+	return sentinelIntervalMax
+}
+
+func serialHandshake(port serialHandshakePort) error {
+	if err := port.SetReadTimeout(sentinelIntervalStep); err != nil {
 		return fmt.Errorf("serial handshake: set timeout: %w", err)
 	}
 
@@ -97,75 +117,82 @@ func serialHandshake(port serialHandshakePort) error {
 	// only prove that some send was echoed, leaving the echoes of the later
 	// sends queued for the frame parser, which rejects them as a bad magic byte.
 	var sentinel string
+	var nextSentinel time.Time
+	var interval time.Duration
 	sendSentinel := func() error {
 		var randBytes [16]byte
 		if _, err := rand.Read(randBytes[:]); err != nil {
 			return fmt.Errorf("serial handshake: generate sentinel: %w", err)
 		}
 		sentinel = hex.EncodeToString(randBytes[:])
-		if _, err := port.Write([]byte(strings.Repeat(" ", 16) + sentinel)); err != nil {
+		// Re-arm echo mode with every sentinel: the device refuses the command
+		// until its WendyCom agent is running, and applying it is a plain mode
+		// assignment, so re-issuing it is idempotent. The device consumes
+		// escape bytes without echoing them, so this prefix never reaches the
+		// sentinel window. The 16 spaces absorb the case where the trailing 'e'
+		// is dropped and the latched escape char swallows the byte after it.
+		payload := make([]byte, 0, 5+16+len(sentinel))
+		payload = append(payload, escapeChar, escapeChar, escapeChar, escapeChar, 'e')
+		payload = append(payload, strings.Repeat(" ", 16)...)
+		payload = append(payload, sentinel...)
+		if _, err := port.Write(payload); err != nil {
 			return fmt.Errorf("serial handshake: send sentinel: %w", err)
 		}
+		interval = nextSentinelInterval(interval)
+		nextSentinel = time.Now().Add(interval)
 		return nil
 	}
 	// Send immediately. Waiting for a quiet read timeout before the first send
 	// makes reconnecting after a physical reboot fail whenever boot or
 	// auto-started app logs keep the serial stream continuously readable for
-	// the entire 3-second handshake budget.
+	// the entire handshake budget.
 	if err := sendSentinel(); err != nil {
 		return err
 	}
-	// The mode switch may be applied asynchronously by the device after the
-	// escape command is consumed, and console mode swallows host input without
-	// echoing it. Keep sending while draining output so at least one sentinel
-	// lands after that transition even if Read never times out because boot
-	// logs are continuous.
-	nextSentinel := time.Now().Add(100 * time.Millisecond)
 
 	window := make([]byte, 0, 32)
 	oneByte := make([]byte, 1)
-	deadline := time.Now().Add(3 * time.Second)
+	deadline := time.Now().Add(handshakeBudget)
 	for time.Now().Before(deadline) {
+		// The mode switch may be applied asynchronously by the device after the
+		// escape command is consumed, and console mode swallows host input
+		// without echoing it. Keep sending while draining output so at least
+		// one sentinel lands after that transition even if Read never times out
+		// because boot logs are continuous.
 		if !time.Now().Before(nextSentinel) {
 			if err := sendSentinel(); err != nil {
 				return err
 			}
-			nextSentinel = time.Now().Add(100 * time.Millisecond)
 		}
 		n, err := port.Read(oneByte)
 		if err != nil {
 			return fmt.Errorf("serial handshake: read: %w", err)
 		}
 		if n == 0 {
-			// The echo may have been lost while the device was switching modes,
-			// or to a dropped byte (USB Serial JTAG has no flow control);
-			// resend whenever the receive buffer goes quiet.
-			window = window[:0]
-			if err := sendSentinel(); err != nil {
-				return err
-			}
-			nextSentinel = time.Now().Add(100 * time.Millisecond)
+			// Nothing arrived within one step; the scheduler above decides when
+			// to resend. The window is deliberately kept: it is a rolling
+			// 32-byte match against a random sentinel, so a stale prefix can
+			// neither cause a false match nor block a real one, and keeping it
+			// lets an echo split across a read timeout still match.
 			continue
 		}
-		if n == 1 {
-			if len(window) < 32 {
-				window = append(window, oneByte[0])
-			} else {
-				copy(window, window[1:])
-				window[31] = oneByte[0]
+		if len(window) < 32 {
+			window = append(window, oneByte[0])
+		} else {
+			copy(window, window[1:])
+			window[31] = oneByte[0]
+		}
+		if len(window) == 32 && string(window) == sentinel {
+			if err := port.SetReadTimeout(serial.NoTimeout); err != nil {
+				return fmt.Errorf("serial handshake: clear timeout: %w", err)
 			}
-			if len(window) == 32 && string(window) == sentinel {
-				if err := port.SetReadTimeout(serial.NoTimeout); err != nil {
-					return fmt.Errorf("serial handshake: clear timeout: %w", err)
-				}
-				if _, err := port.Write([]byte{escapeChar, 'm'}); err != nil {
-					return fmt.Errorf("serial handshake: send mode switch: %w", err)
-				}
-				return nil
+			if _, err := port.Write([]byte{escapeChar, 'm'}); err != nil {
+				return fmt.Errorf("serial handshake: send mode switch: %w", err)
 			}
+			return nil
 		}
 	}
-	return fmt.Errorf("serial handshake: sentinel not received within 3 seconds")
+	return fmt.Errorf("serial handshake: sentinel not received within %s", handshakeBudget)
 }
 
 func (l *directLink) send(req *wendypb.WendyComMessage) error {

--- a/go/internal/cli/liteclient/link_direct_test.go
+++ b/go/internal/cli/liteclient/link_direct_test.go
@@ -8,52 +8,62 @@ import (
 	"time"
 )
 
+// escapePrefixLen is the length of the echo mode command that prefixes every
+// sentinel; sentinelWriteLen adds the 16 spaces of padding and the 32 hex
+// characters of the sentinel itself.
+const (
+	escapePrefixLen  = 5
+	sentinelWriteLen = escapePrefixLen + 16 + 32
+)
+
 // noisyHandshakePort models a freshly rebooted board over USB Serial JTAG.
 //
 // backlog is console output the device queued before echo mode took effect;
 // draining it one byte at a time keeps Read continuously ready, so the
 // handshake never sees the idle read the pre-65df7e0e implementation waited
-// for. backlogDelay paces that drain, letting the handshake's 100 ms resend
-// timer fire while echoes are still stuck behind the backlog.
+// for. backlogDelay paces that drain, letting the handshake's resend timer fire
+// while echoes are still stuck behind the backlog.
 //
-// swallow models the mode switch being applied asynchronously: that many
-// sentinels are discarded unechoed (console mode does not echo host input)
-// before echo mode goes live.
+// swallow models the device refusing the echo mode command because its WendyCom
+// agent is not running yet: that many sentinels are consumed in console mode,
+// unechoed, before echo mode goes live.
 type noisyHandshakePort struct {
 	backlog      int           // console bytes still to emit before any echo
 	backlogDelay time.Duration // per-byte pacing while the backlog drains
-	swallow      int           // sentinels discarded before echo mode is live
+	swallow      int           // sentinels consumed before echo mode is live
 
-	sentinels    [][]byte // every sentinel written, in order
-	rx           []byte   // echoes, queued behind the backlog
+	sentinels    [][]byte      // every sentinel written, in order
+	escapeWrites int           // sentinel writes that re-armed echo mode
+	readTimeout  time.Duration // last timeout the handshake asked for
+	rx           []byte        // echoes, queued behind the backlog
 	modeSwitched bool
 	rxAtSwitch   int // bytes still unread when DLE m was written
 }
 
 func (p *noisyHandshakePort) Write(data []byte) (int, error) {
-	switch {
-	case bytes.Equal(data, []byte{escapeChar, escapeChar, escapeChar, escapeChar, 'e'}):
-		if len(p.sentinels) > 0 {
-			return 0, errors.New("echo mode switch written after a sentinel")
-		}
-		return len(data), nil
-	case bytes.Equal(data, []byte{escapeChar, 'm'}):
+	if bytes.Equal(data, []byte{escapeChar, 'm'}) {
 		p.modeSwitched = true
 		p.rxAtSwitch = p.backlog + len(p.rx)
 		return len(data), nil
-	default:
-		if len(data) != 48 {
-			return 0, fmt.Errorf("unexpected handshake write of %d bytes", len(data))
-		}
-		p.sentinels = append(p.sentinels, append([]byte(nil), data[16:]...))
-		if p.swallow > 0 {
-			p.swallow--
-			return len(data), nil
-		}
-		// Echo mode echoes every received byte, padding included.
-		p.rx = append(p.rx, data...)
+	}
+	if len(data) != sentinelWriteLen {
+		return 0, fmt.Errorf("unexpected handshake write of %d bytes", len(data))
+	}
+	// Every sentinel has to re-arm echo mode: the device refuses the command
+	// until its WendyCom agent runs, so sending it once is not enough.
+	if !bytes.Equal(data[:escapePrefixLen], []byte{escapeChar, escapeChar, escapeChar, escapeChar, 'e'}) {
+		return 0, errors.New("sentinel written without the echo mode command")
+	}
+	p.escapeWrites++
+	p.sentinels = append(p.sentinels, append([]byte(nil), data[escapePrefixLen+16:]...))
+	if p.swallow > 0 {
+		p.swallow--
 		return len(data), nil
 	}
+	// Echo mode echoes every received byte, padding included, but escape
+	// commands are consumed by the mode parser and never echoed.
+	p.rx = append(p.rx, data[escapePrefixLen:]...)
+	return len(data), nil
 }
 
 func (p *noisyHandshakePort) Read(dst []byte) (int, error) {
@@ -67,14 +77,49 @@ func (p *noisyHandshakePort) Read(dst []byte) (int, error) {
 		return 1, nil
 	}
 	if len(p.rx) == 0 {
-		return 0, nil // read timeout: nothing pending
+		// Block for the timeout the caller asked for, then report it, the way
+		// a real port does. Returning instantly would busy-spin the handshake.
+		time.Sleep(p.readTimeout)
+		return 0, nil
 	}
 	dst[0] = p.rx[0]
 	p.rx = p.rx[1:]
 	return 1, nil
 }
 
-func (*noisyHandshakePort) SetReadTimeout(time.Duration) error { return nil }
+func (p *noisyHandshakePort) SetReadTimeout(d time.Duration) error {
+	p.readTimeout = d
+	return nil
+}
+
+// shrinkHandshakeTimings speeds up tests that need the resend scheduler to
+// actually fire. The handshake timings are package vars for exactly this, which
+// is also why no test in this file may run in parallel.
+func shrinkHandshakeTimings(t *testing.T) {
+	t.Helper()
+	prevStep, prevMax, prevBudget := sentinelIntervalStep, sentinelIntervalMax, handshakeBudget
+	sentinelIntervalStep = 10 * time.Millisecond
+	sentinelIntervalMax = 50 * time.Millisecond
+	handshakeBudget = 300 * time.Millisecond
+	t.Cleanup(func() {
+		sentinelIntervalStep, sentinelIntervalMax, handshakeBudget = prevStep, prevMax, prevBudget
+	})
+}
+
+func TestNextSentinelInterval(t *testing.T) {
+	for _, tc := range []struct{ current, want time.Duration }{
+		{0, 100 * time.Millisecond},
+		{100 * time.Millisecond, 200 * time.Millisecond},
+		{200 * time.Millisecond, 300 * time.Millisecond},
+		{300 * time.Millisecond, 400 * time.Millisecond},
+		{400 * time.Millisecond, 500 * time.Millisecond},
+		{500 * time.Millisecond, 500 * time.Millisecond},
+	} {
+		if got := nextSentinelInterval(tc.current); got != tc.want {
+			t.Errorf("nextSentinelInterval(%s) = %s, want %s", tc.current, got, tc.want)
+		}
+	}
+}
 
 func TestSerialHandshakeSendsSentinelBeforeDrainingBootLogs(t *testing.T) {
 	port := &noisyHandshakePort{backlog: 48}
@@ -117,10 +162,11 @@ func TestSerialHandshakeMatchesTheLastSentinelSent(t *testing.T) {
 	}
 }
 
-// TestSerialHandshakeResendsAfterSwallowedSentinels covers the device applying
-// the echo mode switch only after some sentinels have already been written and
-// silently dropped.
+// TestSerialHandshakeResendsAfterSwallowedSentinels covers the device refusing
+// the echo mode command until its WendyCom agent is up, so the first sentinels
+// are consumed in console mode and silently dropped.
 func TestSerialHandshakeResendsAfterSwallowedSentinels(t *testing.T) {
+	shrinkHandshakeTimings(t)
 	port := &noisyHandshakePort{swallow: 2}
 	if err := serialHandshake(port); err != nil {
 		t.Fatalf("serialHandshake() = %v", err)
@@ -128,7 +174,41 @@ func TestSerialHandshakeResendsAfterSwallowedSentinels(t *testing.T) {
 	if len(port.sentinels) != 3 {
 		t.Errorf("sent %d sentinels, want 3 (two swallowed, one echoed)", len(port.sentinels))
 	}
+	if port.escapeWrites != len(port.sentinels) {
+		t.Errorf("%d of %d sentinels re-armed echo mode, want all: a device that "+
+			"refused the first command would never recover",
+			port.escapeWrites, len(port.sentinels))
+	}
 	if port.rxAtSwitch != 0 {
 		t.Errorf("%d unread byte(s) left in the stream at the mode switch", port.rxAtSwitch)
+	}
+}
+
+// TestSerialHandshakeBacksOffInsteadOfFlooding covers a device that never
+// reaches its WendyCom agent: every echo mode command is refused, so no
+// sentinel comes back and the handshake runs its whole budget. The resend
+// interval has to widen over that budget rather than pushing a sentinel every
+// step at a board that is still booting.
+func TestSerialHandshakeBacksOffInsteadOfFlooding(t *testing.T) {
+	shrinkHandshakeTimings(t)
+	port := &noisyHandshakePort{swallow: 1000}
+	if err := serialHandshake(port); err == nil {
+		t.Fatal("serialHandshake() = nil, want a timeout error")
+	}
+	if port.modeSwitched {
+		t.Error("handshake switched to WendyCom mode without ever matching a sentinel")
+	}
+	flooded := int(handshakeBudget / sentinelIntervalStep)
+	if len(port.sentinels) >= flooded {
+		t.Errorf("sent %d sentinels in %s, want well under %d: the resend interval is not backing off",
+			len(port.sentinels), handshakeBudget, flooded)
+	}
+	if len(port.sentinels) < 4 {
+		t.Errorf("sent only %d sentinels in %s: the resend scheduler stalled",
+			len(port.sentinels), handshakeBudget)
+	}
+	if port.escapeWrites != len(port.sentinels) {
+		t.Errorf("%d of %d sentinels re-armed echo mode, want all",
+			port.escapeWrites, len(port.sentinels))
 	}
 }


### PR DESCRIPTION
## Summary
- The handshake resent its sentinel every 100ms from two independent triggers (periodic timer and read timeout), pushing ~30 sentinels (~1.4KB) at a board that is usually still booting. A single scheduler now owns every resend and widens the gap after each send by 100ms up to 500ms (0, 100, 300, 600, 1000, 1500, 2000, 2500ms — eight sentinels over the 3s budget instead of thirty).
- The echo-mode command is now sent with every sentinel instead of once, since the device gates it behind `wcom_is_running()` and the boot window between USB init and that point can swallow the first attempt, which previously stalled the handshake for its full budget before a retry.
- The quiet-read branch no longer clears the rolling match window, since a stale prefix can't cause a false match against a random 32-byte sentinel, and keeping it lets an echo split across a read timeout still match.

## Test plan
- [x] `go test ./go/internal/cli/liteclient/...`