### PR TITLE
feat(agent): enrol and renew a pki-core device identity for data platform ingest

### DIFF
--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -953,6 +953,26 @@ func main() {
 	// coming up locally (mDNS discovery still works unenrolled).
 	go provisioningSvc.ApplyEnrollmentFile(context.Background())
 
+	// The device's SECOND identity: a pki-core device certificate whose only
+	// URI Subject Alternative Name is
+	// spiffe://wendy.sh/tenant/<tenant>/device/<name>. It is presented to the
+	// Wendy Data Platform's ingest endpoint and to nothing else; every cloud
+	// dialer keeps presenting the enrolled asset certificate above, because
+	// Wendy Cloud's interceptors read only the urn:wendy:org: form. Enrolment
+	// is driven by a token staged at <configPath>/pki-enrollment.json, exactly
+	// as enrollment.json drives the cloud enrolment above, and is a no-op when
+	// no such file exists.
+	pkiEnrollment := services.NewPKIEnrollment(logger, configPath, provisioningSvc)
+	go func() {
+		pkiEnrollment.ApplyStagedFile(context.Background())
+		// Renewal starts after enrolment so a device enrolled on this boot
+		// does not wait for a restart to be renewable. A device with no pki
+		// identity gets no renewer, which is the ordinary case.
+		if renewer := pkiEnrollment.Renewer(); renewer != nil {
+			renewer.Run(ctx)
+		}
+	}()
+
 	// Restore audio peripherals paired before the last reboot. Nothing else
 	// does: BlueZ only reconnects after a link supervision timeout and has no
 	// startup path, and a speaker that was already powered when the host went
@@ -1050,6 +1070,11 @@ func main() {
 	// and gating on it would silently leave every sealed episode unuploaded
 	// until the quota evicted it.
 	dataTransferWorker := services.NewDataTransferWorker(logger, dataManager, provisioningSvc)
+	// Present the pki-core device identity to the ingest endpoint when one is
+	// stored. The store is read per dial, so a device enrolled after the agent
+	// came up switches identity on its next upload pass without a restart, and
+	// a device with no pki identity keeps presenting the asset certificate.
+	dataTransferWorker.SetPKIIdentity(pkiEnrollment.Store())
 	// WENDY_DATA_INGEST_URL names the DataIngestService endpoint episode uploads
 	// dial (ingest.data.wendy.sh in dev). There is no fallback: the enrolled
 	// cloud host does not serve DataIngestService. Unset disables uploads, the

--- a/go/internal/agent/pkienroll/chain.go
+++ b/go/internal/agent/pkienroll/chain.go
@@ -1,0 +1,45 @@
+package pkienroll
+
+import (
+	"bytes"
+	"encoding/pem"
+	"errors"
+	"fmt"
+)
+
+// SplitLeafAndChain splits a PEM bundle into its first certificate and the
+// remainder. pki-core answers an enrolment or a renewal with a leaf-first chain
+// in one blob (root excluded), while the agent stores the leaf and the chain
+// separately because its dialers concatenate them in that order.
+//
+// Lifted from go/internal/cli/commands/certrenew.go on
+// origin/sem/wdy-2899-acme-enrollment, which already had to solve exactly this
+// for the CLI's renewal pre-flight. Non-CERTIFICATE blocks are skipped rather
+// than treated as chain material.
+func SplitLeafAndChain(bundlePEM string) (leaf, chain string, err error) {
+	rest := []byte(bundlePEM)
+	var blocks []*pem.Block
+	for {
+		block, remainder := pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type == "CERTIFICATE" {
+			blocks = append(blocks, block)
+		}
+		rest = remainder
+	}
+	if len(blocks) == 0 {
+		return "", "", errors.New("certificate response carried no certificate")
+	}
+	var leafBuf, chainBuf bytes.Buffer
+	if err := pem.Encode(&leafBuf, blocks[0]); err != nil {
+		return "", "", fmt.Errorf("re-encoding issued leaf: %w", err)
+	}
+	for _, b := range blocks[1:] {
+		if err := pem.Encode(&chainBuf, b); err != nil {
+			return "", "", fmt.Errorf("re-encoding issued chain: %w", err)
+		}
+	}
+	return leafBuf.String(), chainBuf.String(), nil
+}

--- a/go/internal/agent/pkienroll/config.go
+++ b/go/internal/agent/pkienroll/config.go
@@ -74,3 +74,10 @@ func withScheme(v string) string {
 	}
 	return "https://" + v
 }
+
+// StagedFileName is the credential file, relative to the agent's config
+// directory, that hands the agent an enrollment token once. It is defined here
+// rather than in the services package because the wendy CLI writes it and the
+// CLI is cross-compiled for Windows, where the services package (which pulls in
+// the audio and data managers) does not build.
+const StagedFileName = "pki-enrollment.json"

--- a/go/internal/agent/pkienroll/config.go
+++ b/go/internal/agent/pkienroll/config.go
@@ -1,0 +1,76 @@
+package pkienroll
+
+import (
+	"os"
+	"strings"
+)
+
+// pki-core's CSR frontend hosts, per environment. Both are public edge
+// endpoints; the fabric relay that mints the enrollment token is private and is
+// not reachable from a device, which is why the token arrives staged rather
+// than fetched.
+const (
+	ProdCSRFrontendHost = "csr.pki.wendy.sh"
+	DevCSRFrontendHost  = "csr.dev.pki.wendy.sh"
+)
+
+// Environment names accepted by CSRFrontendURL. Anything else is treated as
+// production, because guessing "dev" from an unrecognised value is the failure
+// that sends a production device to a dev certificate authority.
+const (
+	EnvProd = "prod"
+	EnvDev  = "dev"
+)
+
+// Environment variables. The endpoint override is named after
+// WENDY_PKI_RENEW_ENDPOINT on origin/sem/wdy-2899-acme-enrollment, which
+// established both the naming and the rule that follows.
+//
+// There is deliberately NO derivation from the enrolled cloud host. Guessing a
+// pki host and port from another service's address is what once sent enrollment
+// tokens to the wrong place in cleartext (WDY-2799).
+const (
+	// CSREndpointEnv fully overrides the frontend URL, e.g.
+	// "https://csr.dev.pki.wendy.sh". A value already carrying a /v1/ path is
+	// used verbatim.
+	CSREndpointEnv = "WENDY_PKI_CSR_ENDPOINT"
+
+	// EnvironmentEnv selects the derived host, "dev" or "prod".
+	EnvironmentEnv = "WENDY_PKI_ENV"
+)
+
+// CSRFrontendURL resolves the frontend base URL.
+//
+// Precedence, most specific first: an explicit override (the staged credential
+// file's csrEndpoint, then CSREndpointEnv), then the derived host for the named
+// environment. The override wins so that a local pki-core, a staging tenant or
+// a port-forwarded frontend needs no code change.
+func CSRFrontendURL(override, environment string) string {
+	if v := strings.TrimSpace(override); v != "" {
+		return withScheme(v)
+	}
+	if v := strings.TrimSpace(os.Getenv(CSREndpointEnv)); v != "" {
+		return withScheme(v)
+	}
+	return withScheme(csrFrontendHost(environment))
+}
+
+// csrFrontendHost maps an environment name to a host. An empty environment
+// falls back to EnvironmentEnv, and an unrecognised one to production.
+func csrFrontendHost(environment string) string {
+	environment = strings.ToLower(strings.TrimSpace(environment))
+	if environment == "" {
+		environment = strings.ToLower(strings.TrimSpace(os.Getenv(EnvironmentEnv)))
+	}
+	if environment == EnvDev {
+		return DevCSRFrontendHost
+	}
+	return ProdCSRFrontendHost
+}
+
+func withScheme(v string) string {
+	if strings.Contains(v, "://") {
+		return v
+	}
+	return "https://" + v
+}

--- a/go/internal/agent/pkienroll/pkienroll.go
+++ b/go/internal/agent/pkienroll/pkienroll.go
@@ -1,0 +1,477 @@
+// Package pkienroll obtains and renews a pki-core device identity certificate
+// through pki-core's CSR frontend, using an enrollment token staged on the
+// device.
+//
+// WHY A SECOND IDENTITY AND NOT A REPLACEMENT. The agent already holds one
+// certificate, issued by Google Certificate Authority Service (CAS) through the
+// Wendy Cloud broker, whose identity is the URI Subject Alternative Name (SAN)
+// "urn:wendy:org:<org>:asset:<asset>". Wendy Cloud's interceptors understand
+// only that form: a leaf carrying a SPIFFE SAN instead resolves to no identity
+// there, and the agent's own inbound mTLS server silently disables its
+// org-equality gate when it cannot read an org out of its own certificate. The
+// Wendy Data Platform's ingest surface wants the opposite — exactly one
+// "spiffe://wendy.sh/tenant/<tenant>/device/<name>" SAN, and it rejects any
+// other principal kind. So the device holds two identities on two PEM triples
+// and presents each to the peer that understands it. Nothing in this package
+// reads or writes the CAS triple.
+//
+// The pki-core facts below cost hours to discover, so they are recorded where
+// they bite:
+//
+//   - the tenant is a canonical lowercase UUID and rides in the path,
+//     /v1/<tenant>/enroll, never as a slug and never as a body field;
+//   - the CSR is PEM here. The Enrollment over Secure Transport (EST) frontend
+//     wants base64-of-DER instead, and answers with a Cryptographic Message
+//     Syntax (CMS) blob that no current OpenSSL build can parse, which is why
+//     this client speaks to the CSR frontend;
+//   - device_id must equal the enrollment token's device_id byte for byte. The
+//     SPIFFE device name is decided when the token is minted, not by the
+//     device, so a mismatch is a hard refusal and not a rename;
+//   - the "tier" body field is informational. pki-core derives certificate
+//     authority, profile and tenant from the token row alone;
+//   - pki-core stamps the SPIFFE SAN itself and discards every URI SAN the CSR
+//     carried, so this client asserts no identity of its own. It still verifies
+//     the one it got back, because a leaf whose SAN is not the expected device
+//     principal is useless to the ingest surface and must not be stored;
+//   - a device tier pins no key algorithm ("a device leaf follows the CSR"), so
+//     the agent's existing ECDSA P-256 key is accepted unchanged;
+//   - renewal is authenticated by presenting the current leaf as the TLS client
+//     certificate, and only while it is still valid. Past expiry the request
+//     takes a grant-required branch this client cannot satisfy, which is why
+//     renewal has to run ahead of expiry rather than in response to a failure.
+package pkienroll
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
+)
+
+const (
+	// DefaultTier is the value sent in the request body's "tier" field. It is
+	// informational: pki-core reads the real profile off the token row. Sent
+	// anyway because the frontend's request shape includes it.
+	DefaultTier = "standard"
+
+	// requestTimeout bounds a single enrol or renew round trip. Generous
+	// because a Jetson's boot-time network can be slow, bounded because a hung
+	// request would stall the renewal loop past the leaf's expiry.
+	requestTimeout = 30 * time.Second
+
+	// maxResponseBytes caps how much of a response body is read. The frontend
+	// answers with a certificate chain of a few kilobytes; anything far larger
+	// is a wrong endpoint, and reading it into memory on a device is not free.
+	maxResponseBytes = 1 << 20
+)
+
+// EnrollRequest is everything needed for one bearer-token enrolment.
+type EnrollRequest struct {
+	// CSRFrontendURL is the frontend's base URL, e.g.
+	// "https://csr.dev.pki.wendy.sh". A URL that already ends in the
+	// /v1/<tenant>/enroll path is accepted as-is, so an operator who pasted a
+	// full endpoint is not silently sent somewhere else.
+	CSRFrontendURL string
+
+	// TenantUUID is the canonical lowercase tenant UUID. It selects the path
+	// segment AND is the tenant the returned leaf's SAN is checked against, so
+	// a wrong value fails loudly rather than storing a foreign identity.
+	TenantUUID string
+
+	// EnrollmentToken is the single-use bearer credential an operator minted
+	// through pki-core's fabric relay. The agent only consumes it; nothing here
+	// can mint one.
+	EnrollmentToken string
+
+	// Key is the PEM-encoded ECDSA P-256 private key whose public half goes
+	// into the CSR. Callers own the slice and may zero it after the call; this
+	// package does not retain it.
+	Key []byte
+
+	// CommonName is the CSR subject Common Name. The agent passes the same
+	// "sh/wendy/<org>/<asset>" it builds for its CAS certificate. pki-core
+	// derives the leaf's Distinguished Name from the minted SPIFFE identity
+	// instead, so this only matters to frontends that read the CN — which
+	// pki-core's own dev shim does, to derive device_id.
+	CommonName string
+
+	// DeviceID must equal the token's device_id byte for byte. Empty means
+	// "use CommonName", which is the pairing pki-core's dev shim assumes and
+	// the convention its own token minting follows.
+	DeviceID string
+
+	// HTTPClient is optional; nil uses a plain client with requestTimeout.
+	HTTPClient *http.Client
+}
+
+// RenewRequest renews a leaf by presenting it. There is no token: possession of
+// the current certificate IS the credential, proven by the TLS handshake.
+type RenewRequest struct {
+	CSRFrontendURL string
+	TenantUUID     string
+
+	// CurrentLeafPEM and CurrentChainPEM are the certificate presented as the
+	// TLS client certificate. The renewed leaf carries the same device name,
+	// read off this certificate's SAN and never off the renewal CSR.
+	CurrentLeafPEM  string
+	CurrentChainPEM string
+
+	// Key is the device's long-lived key. It is reused rather than rotated:
+	// the enrolment key is generated once on the device and carried across
+	// renewals, so a renewal cannot orphan a key the store already committed.
+	Key []byte
+
+	HTTPClient *http.Client
+}
+
+// Result is an accepted, verified issuance.
+type Result struct {
+	// LeafPEM is the issued leaf on its own.
+	LeafPEM string
+	// ChainPEM is the intermediates below the leaf, root excluded (pki-core
+	// does not return the root). Empty when the response carried a leaf alone.
+	ChainPEM string
+	// DeviceName is the SPIFFE device name the SAN actually carries. Recorded
+	// rather than assumed, because the name is the token's to decide and
+	// logging what was issued is the only way to notice a surprise.
+	DeviceName string
+	// SPIFFEURI is the full verified principal.
+	SPIFFEURI string
+	// NotBefore and NotAfter bound the leaf's validity; the renewal schedule is
+	// computed from them and not from an assumed tier length.
+	NotBefore time.Time
+	NotAfter  time.Time
+}
+
+// StatusError reports a frontend refusal, carrying the HTTP status and whatever
+// detail the body held. It is a distinct type because the remedies differ and
+// collapsing them into one message is what makes an enrolment failure
+// unactionable: 401 means the token is wrong, consumed or revoked and a fresh
+// one must be minted; 400 means the request itself is malformed, most often a
+// device_id that does not match the token's.
+type StatusError struct {
+	StatusCode int
+	Detail     string
+}
+
+func (e *StatusError) Error() string {
+	if e.Detail != "" {
+		return fmt.Sprintf("pki-core csr frontend answered %d: %s", e.StatusCode, e.Detail)
+	}
+	return fmt.Sprintf("pki-core csr frontend answered %d", e.StatusCode)
+}
+
+// Unauthorized reports whether the refusal was a credential problem.
+func (e *StatusError) Unauthorized() bool { return e.StatusCode == http.StatusUnauthorized }
+
+// IdentityError reports that a certificate came back, but not the identity that
+// was asked for. It carries the SANs actually seen so the log says what was
+// issued rather than only that something was wrong.
+type IdentityError struct {
+	Want string
+	Got  []string
+}
+
+func (e *IdentityError) Error() string {
+	if len(e.Got) == 0 {
+		return fmt.Sprintf("issued leaf carries no tenant SPIFFE URI SAN; want exactly one %q", e.Want)
+	}
+	return fmt.Sprintf("issued leaf carries tenant SPIFFE URI SAN(s) %s; want exactly one %q",
+		strings.Join(e.Got, ", "), e.Want)
+}
+
+type enrollRequestBody struct {
+	CSR      string `json:"csr"`
+	DeviceID string `json:"device_id"`
+	Tier     string `json:"tier"`
+}
+
+type renewRequestBody struct {
+	CSR string `json:"csr"`
+}
+
+type certificateResponseBody struct {
+	Certificate string `json:"certificate"`
+}
+
+type detailResponseBody struct {
+	Detail string `json:"detail"`
+	Error  string `json:"error"`
+}
+
+// Enroll exchanges the staged enrollment token for a device certificate.
+//
+// It returns a *StatusError for any refusal the frontend expressed as a status
+// code, and an *IdentityError when the issued leaf is not the expected device
+// principal. In the second case nothing is stored: a leaf whose SAN the ingest
+// surface will reject is worse than no leaf at all, because it looks enrolled.
+func Enroll(ctx context.Context, req EnrollRequest) (Result, error) {
+	if err := req.validate(); err != nil {
+		return Result{}, err
+	}
+	deviceID := req.DeviceID
+	if deviceID == "" {
+		deviceID = req.CommonName
+	}
+
+	csrPEM, err := buildCSR(req.Key, req.CommonName)
+	if err != nil {
+		return Result{}, err
+	}
+	body, err := json.Marshal(enrollRequestBody{CSR: csrPEM, DeviceID: deviceID, Tier: DefaultTier})
+	if err != nil {
+		return Result{}, fmt.Errorf("encoding enrollment request: %w", err)
+	}
+
+	endpoint, err := frontendEndpoint(req.CSRFrontendURL, req.TenantUUID, "enroll")
+	if err != nil {
+		return Result{}, err
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return Result{}, fmt.Errorf("building enrollment request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+req.EnrollmentToken)
+
+	client := req.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: requestTimeout}
+	}
+	return exchange(client, httpReq, req.TenantUUID)
+}
+
+// Renew exchanges a CSR for a fresh leaf, authenticated by presenting the
+// current one. The device name is not sent and cannot be changed: pki-core
+// reads it off the presented certificate.
+func Renew(ctx context.Context, req RenewRequest) (Result, error) {
+	if req.CSRFrontendURL == "" {
+		return Result{}, errors.New("pki enrollment: no csr frontend url")
+	}
+	if req.TenantUUID == "" {
+		return Result{}, errors.New("pki enrollment: no tenant uuid")
+	}
+	if req.CurrentLeafPEM == "" {
+		return Result{}, errors.New("pki enrollment: no current certificate to renew")
+	}
+	if len(req.Key) == 0 {
+		return Result{}, errors.New("pki enrollment: no private key")
+	}
+
+	commonName, err := leafCommonName(req.CurrentLeafPEM)
+	if err != nil {
+		return Result{}, err
+	}
+	csrPEM, err := buildCSR(req.Key, commonName)
+	if err != nil {
+		return Result{}, err
+	}
+	body, err := json.Marshal(renewRequestBody{CSR: csrPEM})
+	if err != nil {
+		return Result{}, fmt.Errorf("encoding renewal request: %w", err)
+	}
+
+	endpoint, err := frontendEndpoint(req.CSRFrontendURL, req.TenantUUID, "renew")
+	if err != nil {
+		return Result{}, err
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return Result{}, fmt.Errorf("building renewal request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	client := req.HTTPClient
+	if client == nil {
+		// The handshake is the credential, so the client certificate is not
+		// optional here: without it pki-core sees an anonymous caller and
+		// answers 401. The server side is verified against the system roots,
+		// as everywhere else the agent dials a public Wendy endpoint.
+		tlsCfg, err := certs.LoadTLSConfig(req.CurrentLeafPEM, req.CurrentChainPEM, string(req.Key), "")
+		if err != nil {
+			return Result{}, fmt.Errorf("building renewal mTLS config: %w", err)
+		}
+		client = &http.Client{
+			Timeout:   requestTimeout,
+			Transport: &http.Transport{TLSClientConfig: tlsCfg},
+		}
+	}
+	return exchange(client, httpReq, req.TenantUUID)
+}
+
+func (r EnrollRequest) validate() error {
+	var missing []string
+	for _, f := range []struct{ name, value string }{
+		{"csr frontend url", r.CSRFrontendURL},
+		{"tenant uuid", r.TenantUUID},
+		{"enrollment token", r.EnrollmentToken},
+		{"common name", r.CommonName},
+	} {
+		if strings.TrimSpace(f.value) == "" {
+			missing = append(missing, f.name)
+		}
+	}
+	if len(r.Key) == 0 {
+		missing = append(missing, "private key")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("pki enrollment request is missing %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+// buildCSR builds the PKCS#10 request. The EKUs match what the agent already
+// asks CAS for: the device identity acts as a TLS client to the data platform
+// and as a TLS server on the agent's own mTLS port, and pki-core's device tiers
+// issue both regardless, so asking for both keeps the two CSRs comparable.
+//
+// The URI SAN is deliberately empty. pki-core replaces it with the principal it
+// minted from the token, so stamping a URN here would be a claim the server
+// discards — and an identity this client is not entitled to assert.
+func buildCSR(keyPEM []byte, commonName string) (string, error) {
+	csrPEM, err := certs.GenerateCSR(keyPEM, commonName, "",
+		x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth)
+	if err != nil {
+		return "", fmt.Errorf("generating pki enrollment CSR: %w", err)
+	}
+	return csrPEM, nil
+}
+
+// frontendEndpoint builds /v1/<tenant>/<action> under base. A base that already
+// carries a /v1/ path is returned unchanged, so a fully-specified endpoint from
+// configuration is honoured rather than having a second path appended to it.
+func frontendEndpoint(base, tenantUUID, action string) (string, error) {
+	base = strings.TrimSpace(base)
+	if !strings.Contains(base, "://") {
+		base = "https://" + base
+	}
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("parsing csr frontend url %q: %w", base, err)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("csr frontend url %q has no host", base)
+	}
+	if strings.Contains(u.Path, "/v1/") {
+		return u.String(), nil
+	}
+	u.Path = strings.TrimSuffix(u.Path, "/") + "/v1/" + tenantUUID + "/" + action
+	return u.String(), nil
+}
+
+// exchange performs the request and turns the response into a verified Result.
+func exchange(client *http.Client, req *http.Request, tenantUUID string) (Result, error) {
+	resp, err := client.Do(req)
+	if err != nil {
+		return Result{}, fmt.Errorf("contacting pki-core csr frontend: %w", err)
+	}
+	defer resp.Body.Close()
+
+	limited := &limitedReader{r: resp.Body, remaining: maxResponseBytes}
+	if resp.StatusCode != http.StatusOK {
+		var d detailResponseBody
+		_ = json.NewDecoder(limited).Decode(&d)
+		detail := d.Detail
+		if detail == "" {
+			detail = d.Error
+		}
+		return Result{}, &StatusError{StatusCode: resp.StatusCode, Detail: detail}
+	}
+
+	var ok certificateResponseBody
+	if err := json.NewDecoder(limited).Decode(&ok); err != nil {
+		return Result{}, fmt.Errorf("decoding pki-core certificate response: %w", err)
+	}
+	return parseAndVerify(ok.Certificate, tenantUUID)
+}
+
+// parseAndVerify splits the returned leaf-first chain and refuses anything that
+// is not exactly one device principal for tenantUUID.
+func parseAndVerify(bundlePEM, tenantUUID string) (Result, error) {
+	leafPEM, chainPEM, err := SplitLeafAndChain(bundlePEM)
+	if err != nil {
+		return Result{}, err
+	}
+	// ParseCertsFromPEM is the ML-DSA-aware parser the agent's mTLS paths use,
+	// and LeafCertificatePEM strips the trailing ASN.1 bytes some pki-core
+	// leaves carry. Verifying through the same pair the handshake will use is
+	// the point: a leaf this cannot read is a leaf that cannot be presented.
+	normalizedLeaf, err := certs.LeafCertificatePEM(leafPEM)
+	if err != nil {
+		return Result{}, fmt.Errorf("extracting issued leaf: %w", err)
+	}
+	parsed, err := certs.ParseCertsFromPEM([]byte(normalizedLeaf))
+	if err != nil {
+		return Result{}, fmt.Errorf("parsing issued leaf: %w", err)
+	}
+	if len(parsed) == 0 {
+		return Result{}, errors.New("pki-core response carried no parseable leaf")
+	}
+	leaf := parsed[0]
+
+	uris := certs.TenantSPIFFEURIs(leaf)
+	if len(uris) != 1 {
+		return Result{}, &IdentityError{Want: certs.DeviceSPIFFEURI(tenantUUID, "<name>"), Got: uris}
+	}
+	gotTenant, deviceName, err := certs.ParseDeviceSPIFFEURI(uris[0])
+	if err != nil {
+		return Result{}, &IdentityError{Want: certs.DeviceSPIFFEURI(tenantUUID, "<name>"), Got: uris}
+	}
+	if !strings.EqualFold(gotTenant, tenantUUID) {
+		return Result{}, &IdentityError{Want: certs.DeviceSPIFFEURI(tenantUUID, "<name>"), Got: uris}
+	}
+
+	return Result{
+		LeafPEM:    normalizedLeaf,
+		ChainPEM:   chainPEM,
+		DeviceName: deviceName,
+		SPIFFEURI:  uris[0],
+		NotBefore:  leaf.NotBefore,
+		NotAfter:   leaf.NotAfter,
+	}, nil
+}
+
+// leafCommonName reads the CN off a stored leaf, so a renewal CSR restates the
+// subject the current certificate has rather than rebuilding it from state that
+// may since have changed.
+func leafCommonName(leafPEM string) (string, error) {
+	normalized, err := certs.LeafCertificatePEM(leafPEM)
+	if err != nil {
+		return "", fmt.Errorf("extracting current leaf: %w", err)
+	}
+	parsed, err := certs.ParseCertsFromPEM([]byte(normalized))
+	if err != nil {
+		return "", fmt.Errorf("parsing current leaf: %w", err)
+	}
+	if len(parsed) == 0 {
+		return "", errors.New("current leaf PEM carried no certificate")
+	}
+	return parsed[0].Subject.CommonName, nil
+}
+
+// limitedReader is io.LimitedReader with a distinguishable exhaustion error, so
+// an oversized body is reported as such rather than as a truncated JSON parse.
+type limitedReader struct {
+	r         interface{ Read([]byte) (int, error) }
+	remaining int64
+}
+
+func (l *limitedReader) Read(p []byte) (int, error) {
+	if l.remaining <= 0 {
+		return 0, fmt.Errorf("pki-core response exceeded %d bytes", int64(maxResponseBytes))
+	}
+	if int64(len(p)) > l.remaining {
+		p = p[:l.remaining]
+	}
+	n, err := l.r.Read(p)
+	l.remaining -= int64(n)
+	return n, err
+}

--- a/go/internal/agent/pkienroll/pkienroll_test.go
+++ b/go/internal/agent/pkienroll/pkienroll_test.go
@@ -1,0 +1,599 @@
+package pkienroll
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
+)
+
+const testTenant = "022b7284-f7f3-4d86-b844-d105a7c06d9e"
+
+// fakeFrontend mimics pki-core's CSR frontend closely enough to pin this
+// client's wire shape: it checks the path, the bearer scheme and the body, and
+// it issues a leaf whose SPIFFE SAN it stamps itself from the request's
+// device_id — the behaviour that makes the CSR's own URI SANs irrelevant.
+type fakeFrontend struct {
+	t *testing.T
+
+	caKey  *ecdsa.PrivateKey
+	caCert *x509.Certificate
+	caPEM  string
+
+	// wantToken, when set, is the only token accepted; anything else is 401.
+	wantToken string
+	// wantDeviceID, when set, is the only device_id accepted; anything else
+	// is 400, as pki-core answers a token/device_id mismatch.
+	wantDeviceID string
+	// tenant is stamped into the issued SAN. Deliberately settable so a test
+	// can serve a leaf for the wrong tenant.
+	tenant string
+	// kind overrides the SPIFFE principal kind ("device" unless set), so a
+	// test can serve a service principal the ingest surface would reject.
+	kind string
+	// sanCount is how many tenant SPIFFE SANs to stamp (1 unless set).
+	sanCount int
+	// notAfter overrides the issued validity.
+	lifetime time.Duration
+	// includeChain controls whether the issuer is appended after the leaf.
+	includeChain bool
+
+	// Captured for assertions.
+	lastPath       string
+	lastAuth       string
+	lastDeviceID   string
+	lastTier       string
+	lastCSRSubject string
+	lastCSRURIs    []string
+	lastDeviceName string
+	calls          int
+}
+
+func newFakeFrontend(t *testing.T) *fakeFrontend {
+	t.Helper()
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating test CA key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test Device Identity CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour * 365),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("creating test CA cert: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parsing test CA cert: %v", err)
+	}
+	return &fakeFrontend{
+		t:            t,
+		caKey:        caKey,
+		caCert:       caCert,
+		caPEM:        string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})),
+		tenant:       testTenant,
+		sanCount:     1,
+		lifetime:     30 * 24 * time.Hour,
+		includeChain: true,
+	}
+}
+
+func (f *fakeFrontend) serve() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(f.handle))
+}
+
+func (f *fakeFrontend) handle(w http.ResponseWriter, r *http.Request) {
+	f.calls++
+	f.lastPath = r.URL.Path
+	f.lastAuth = r.Header.Get("Authorization")
+
+	var body enrollRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, `{"detail":"invalid request body"}`, http.StatusBadRequest)
+		return
+	}
+	f.lastDeviceID = body.DeviceID
+	f.lastTier = body.Tier
+
+	if f.wantToken != "" && f.lastAuth != "Bearer "+f.wantToken {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"detail":"bearer token required"}`))
+		return
+	}
+	if f.wantDeviceID != "" && body.DeviceID != f.wantDeviceID {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"detail":"ca: enrollment token device_id mismatch"}`))
+		return
+	}
+
+	csrBlock, _ := pem.Decode([]byte(body.CSR))
+	if csrBlock == nil {
+		http.Error(w, `{"detail":"csr is not PEM"}`, http.StatusBadRequest)
+		return
+	}
+	csr, err := x509.ParseCertificateRequest(csrBlock.Bytes)
+	if err != nil {
+		http.Error(w, `{"detail":"csr does not parse"}`, http.StatusBadRequest)
+		return
+	}
+	f.lastCSRSubject = csr.Subject.CommonName
+	f.lastCSRURIs = nil
+	for _, u := range csr.URIs {
+		f.lastCSRURIs = append(f.lastCSRURIs, u.String())
+	}
+
+	// On a renewal pki-core reads the device name off the PRESENTED
+	// certificate's SAN, never off the renewal CSR, so the name carries
+	// forward from the previous issuance. The fake reproduces that by reusing
+	// the last name it minted rather than reading the CSR subject.
+	deviceName := body.DeviceID
+	if deviceName == "" {
+		if strings.HasSuffix(r.URL.Path, "/renew") && f.lastDeviceName != "" {
+			deviceName = f.lastDeviceName
+		} else {
+			deviceName = csr.Subject.CommonName
+		}
+	}
+	f.lastDeviceName = deviceName
+	kind := f.kind
+	if kind == "" {
+		kind = "device"
+	}
+	var uris []*url.URL
+	for i := 0; i < f.sanCount; i++ {
+		name := deviceName
+		if i > 0 {
+			name = deviceName + "-extra"
+		}
+		u, err := url.Parse("spiffe://wendy.sh/tenant/" + f.tenant + "/" + kind + "/" + name)
+		if err != nil {
+			f.t.Fatalf("building test SAN: %v", err)
+		}
+		uris = append(uris, u)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(int64(f.calls + 100)),
+		// pki-core derives the leaf DN from the minted identity, so the test
+		// server does too: it must not echo the CSR subject.
+		Subject:     pkix.Name{CommonName: kind + ":" + deviceName},
+		NotBefore:   time.Now().Add(-time.Minute),
+		NotAfter:    time.Now().Add(f.lifetime),
+		KeyUsage:    x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		URIs:        uris,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, f.caCert, csr.PublicKey, f.caKey)
+	if err != nil {
+		f.t.Fatalf("issuing test leaf: %v", err)
+	}
+	leafPEM := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+	bundle := leafPEM
+	if f.includeChain {
+		bundle += f.caPEM
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(certificateResponseBody{Certificate: bundle})
+}
+
+func testKey(t *testing.T) []byte {
+	t.Helper()
+	keyPEM, err := certs.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generating test key: %v", err)
+	}
+	return []byte(keyPEM)
+}
+
+func TestEnrollSuccess(t *testing.T) {
+	f := newFakeFrontend(t)
+	f.wantToken = "tok-abc"
+	f.wantDeviceID = "sh/wendy/2/408"
+	srv := f.serve()
+	defer srv.Close()
+
+	result, err := Enroll(context.Background(), EnrollRequest{
+		CSRFrontendURL:  srv.URL,
+		TenantUUID:      testTenant,
+		EnrollmentToken: "tok-abc",
+		Key:             testKey(t),
+		CommonName:      "sh/wendy/2/408",
+	})
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+
+	if got, want := f.lastPath, "/v1/"+testTenant+"/enroll"; got != want {
+		t.Errorf("path = %q, want %q", got, want)
+	}
+	if f.lastAuth != "Bearer tok-abc" {
+		t.Errorf("Authorization = %q", f.lastAuth)
+	}
+	// device_id defaults to the Common Name, which is what pki-core's own
+	// minting convention pairs it with.
+	if f.lastDeviceID != "sh/wendy/2/408" {
+		t.Errorf("device_id = %q, want the Common Name", f.lastDeviceID)
+	}
+	if f.lastTier != DefaultTier {
+		t.Errorf("tier = %q, want %q", f.lastTier, DefaultTier)
+	}
+	if f.lastCSRSubject != "sh/wendy/2/408" {
+		t.Errorf("CSR CN = %q, want the CAS Common Name form", f.lastCSRSubject)
+	}
+	// The client asserts no identity of its own: pki-core discards CSR URI
+	// SANs on a device profile, so sending one would be a claim it is not
+	// entitled to make.
+	if len(f.lastCSRURIs) != 0 {
+		t.Errorf("CSR carried URI SANs %v, want none", f.lastCSRURIs)
+	}
+
+	wantURI := certs.DeviceSPIFFEURI(testTenant, "sh/wendy/2/408")
+	if result.SPIFFEURI != wantURI {
+		t.Errorf("SPIFFEURI = %q, want %q", result.SPIFFEURI, wantURI)
+	}
+	if result.DeviceName != "sh/wendy/2/408" {
+		t.Errorf("DeviceName = %q", result.DeviceName)
+	}
+	if result.LeafPEM == "" || !strings.Contains(result.LeafPEM, "BEGIN CERTIFICATE") {
+		t.Errorf("LeafPEM is not a certificate: %q", result.LeafPEM)
+	}
+	if result.ChainPEM == "" {
+		t.Error("ChainPEM is empty, want the issuer below the leaf")
+	}
+	if strings.Contains(result.LeafPEM, result.ChainPEM) {
+		t.Error("leaf and chain were not separated")
+	}
+	if result.NotAfter.Before(result.NotBefore) || result.NotAfter.IsZero() {
+		t.Errorf("validity window is nonsense: %v to %v", result.NotBefore, result.NotAfter)
+	}
+	// The CSR requests both EKUs, matching what the agent asks CAS for.
+	assertCSREKUs(t, f)
+}
+
+func assertCSREKUs(t *testing.T, f *fakeFrontend) {
+	t.Helper()
+	// Re-derive the CSR from a fresh build rather than re-reading the wire:
+	// the assertion is about what buildCSR requests.
+	csrPEM, err := buildCSR(testKey(t), "sh/wendy/2/408")
+	if err != nil {
+		t.Fatalf("buildCSR: %v", err)
+	}
+	block, _ := pem.Decode([]byte(csrPEM))
+	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		t.Fatalf("parsing CSR: %v", err)
+	}
+	var haveEKU bool
+	for _, ext := range csr.Extensions {
+		if ext.Id.String() == "2.5.29.37" {
+			haveEKU = true
+		}
+	}
+	if !haveEKU {
+		t.Error("CSR carries no extendedKeyUsage extension")
+	}
+}
+
+func TestEnrollUsesExplicitDeviceID(t *testing.T) {
+	f := newFakeFrontend(t)
+	f.wantDeviceID = "408"
+	srv := f.serve()
+	defer srv.Close()
+
+	result, err := Enroll(context.Background(), EnrollRequest{
+		CSRFrontendURL:  srv.URL,
+		TenantUUID:      testTenant,
+		EnrollmentToken: "tok",
+		Key:             testKey(t),
+		CommonName:      "sh/wendy/2/408",
+		DeviceID:        "408",
+	})
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	if result.DeviceName != "408" {
+		t.Errorf("DeviceName = %q, want the token's device_id", result.DeviceName)
+	}
+}
+
+func TestEnrollUnauthorized(t *testing.T) {
+	f := newFakeFrontend(t)
+	f.wantToken = "the-real-token"
+	srv := f.serve()
+	defer srv.Close()
+
+	_, err := Enroll(context.Background(), EnrollRequest{
+		CSRFrontendURL:  srv.URL,
+		TenantUUID:      testTenant,
+		EnrollmentToken: "wrong",
+		Key:             testKey(t),
+		CommonName:      "sh/wendy/2/408",
+	})
+	var statusErr *StatusError
+	if !errors.As(err, &statusErr) {
+		t.Fatalf("err = %v, want *StatusError", err)
+	}
+	if !statusErr.Unauthorized() {
+		t.Errorf("StatusCode = %d, want 401", statusErr.StatusCode)
+	}
+	if !strings.Contains(statusErr.Detail, "bearer token required") {
+		t.Errorf("Detail = %q, want the frontend's own detail", statusErr.Detail)
+	}
+}
+
+func TestEnrollBadRequestOnDeviceIDMismatch(t *testing.T) {
+	f := newFakeFrontend(t)
+	f.wantDeviceID = "sh/wendy/2/408"
+	srv := f.serve()
+	defer srv.Close()
+
+	_, err := Enroll(context.Background(), EnrollRequest{
+		CSRFrontendURL:  srv.URL,
+		TenantUUID:      testTenant,
+		EnrollmentToken: "tok",
+		Key:             testKey(t),
+		CommonName:      "sh/wendy/2/408",
+		DeviceID:        "sh/wendy/2/999",
+	})
+	var statusErr *StatusError
+	if !errors.As(err, &statusErr) {
+		t.Fatalf("err = %v, want *StatusError", err)
+	}
+	if statusErr.StatusCode != http.StatusBadRequest {
+		t.Errorf("StatusCode = %d, want 400", statusErr.StatusCode)
+	}
+	if statusErr.Unauthorized() {
+		t.Error("a 400 must not report as unauthorized: the remedies differ")
+	}
+	if !strings.Contains(statusErr.Detail, "device_id mismatch") {
+		t.Errorf("Detail = %q", statusErr.Detail)
+	}
+}
+
+func TestEnrollRefusesWrongTenant(t *testing.T) {
+	f := newFakeFrontend(t)
+	f.tenant = "11111111-2222-3333-4444-555555555555"
+	srv := f.serve()
+	defer srv.Close()
+
+	_, err := Enroll(context.Background(), EnrollRequest{
+		CSRFrontendURL:  srv.URL,
+		TenantUUID:      testTenant,
+		EnrollmentToken: "tok",
+		Key:             testKey(t),
+		CommonName:      "sh/wendy/2/408",
+	})
+	var identityErr *IdentityError
+	if !errors.As(err, &identityErr) {
+		t.Fatalf("err = %v, want *IdentityError", err)
+	}
+	if len(identityErr.Got) != 1 || !strings.Contains(identityErr.Got[0], "11111111") {
+		t.Errorf("Got = %v, want the SAN actually issued recorded for logging", identityErr.Got)
+	}
+}
+
+func TestEnrollRefusesNonDeviceKind(t *testing.T) {
+	f := newFakeFrontend(t)
+	f.kind = "service"
+	srv := f.serve()
+	defer srv.Close()
+
+	_, err := Enroll(context.Background(), EnrollRequest{
+		CSRFrontendURL:  srv.URL,
+		TenantUUID:      testTenant,
+		EnrollmentToken: "tok",
+		Key:             testKey(t),
+		CommonName:      "sh/wendy/2/408",
+	})
+	var identityErr *IdentityError
+	if !errors.As(err, &identityErr) {
+		t.Fatalf("err = %v, want *IdentityError for a service principal", err)
+	}
+}
+
+func TestEnrollRefusesMultipleTenantSANs(t *testing.T) {
+	f := newFakeFrontend(t)
+	f.sanCount = 2
+	srv := f.serve()
+	defer srv.Close()
+
+	_, err := Enroll(context.Background(), EnrollRequest{
+		CSRFrontendURL:  srv.URL,
+		TenantUUID:      testTenant,
+		EnrollmentToken: "tok",
+		Key:             testKey(t),
+		CommonName:      "sh/wendy/2/408",
+	})
+	var identityErr *IdentityError
+	if !errors.As(err, &identityErr) {
+		t.Fatalf("err = %v, want *IdentityError", err)
+	}
+	if len(identityErr.Got) != 2 {
+		t.Errorf("Got = %v, want both SANs recorded", identityErr.Got)
+	}
+}
+
+func TestEnrollAcceptsLeafWithoutChain(t *testing.T) {
+	f := newFakeFrontend(t)
+	f.includeChain = false
+	srv := f.serve()
+	defer srv.Close()
+
+	result, err := Enroll(context.Background(), EnrollRequest{
+		CSRFrontendURL:  srv.URL,
+		TenantUUID:      testTenant,
+		EnrollmentToken: "tok",
+		Key:             testKey(t),
+		CommonName:      "sh/wendy/2/408",
+	})
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	if result.ChainPEM != "" {
+		t.Errorf("ChainPEM = %q, want empty", result.ChainPEM)
+	}
+}
+
+func TestEnrollValidatesRequest(t *testing.T) {
+	_, err := Enroll(context.Background(), EnrollRequest{TenantUUID: testTenant})
+	if err == nil {
+		t.Fatal("want an error naming the missing fields")
+	}
+	for _, want := range []string{"csr frontend url", "enrollment token", "common name", "private key"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not name %q", err, want)
+		}
+	}
+}
+
+func TestRenewSuccess(t *testing.T) {
+	f := newFakeFrontend(t)
+	srv := f.serve()
+	defer srv.Close()
+	key := testKey(t)
+
+	enrolled, err := Enroll(context.Background(), EnrollRequest{
+		CSRFrontendURL:  srv.URL,
+		TenantUUID:      testTenant,
+		EnrollmentToken: "tok",
+		Key:             key,
+		CommonName:      "sh/wendy/2/408",
+	})
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+
+	// The renewal is driven over the plain test transport: pki-core's own
+	// possession proof is the mTLS handshake, which is its contract to test,
+	// not this client's. What is pinned here is that the renewal sends no
+	// token, restates the current subject, and verifies the returned SAN.
+	renewed, err := Renew(context.Background(), RenewRequest{
+		CSRFrontendURL:  srv.URL,
+		TenantUUID:      testTenant,
+		CurrentLeafPEM:  enrolled.LeafPEM,
+		CurrentChainPEM: enrolled.ChainPEM,
+		Key:             key,
+		HTTPClient:      srv.Client(),
+	})
+	if err != nil {
+		t.Fatalf("Renew: %v", err)
+	}
+	if got, want := f.lastPath, "/v1/"+testTenant+"/renew"; got != want {
+		t.Errorf("path = %q, want %q", got, want)
+	}
+	if f.lastAuth != "" {
+		t.Errorf("renewal sent Authorization %q; possession of the leaf is the credential", f.lastAuth)
+	}
+	if renewed.SPIFFEURI != enrolled.SPIFFEURI {
+		t.Errorf("renewed identity changed: %q -> %q", enrolled.SPIFFEURI, renewed.SPIFFEURI)
+	}
+	if renewed.LeafPEM == enrolled.LeafPEM {
+		t.Error("renewal returned the same leaf")
+	}
+}
+
+func TestRenewRequiresCurrentLeaf(t *testing.T) {
+	_, err := Renew(context.Background(), RenewRequest{
+		CSRFrontendURL: "https://csr.dev.pki.wendy.sh",
+		TenantUUID:     testTenant,
+		Key:            testKey(t),
+	})
+	if err == nil || !strings.Contains(err.Error(), "no current certificate") {
+		t.Fatalf("err = %v, want a refusal naming the missing certificate", err)
+	}
+}
+
+func TestFrontendEndpoint(t *testing.T) {
+	tests := []struct {
+		name, base, action, want string
+	}{
+		{"bare host", "csr.dev.pki.wendy.sh", "enroll", "https://csr.dev.pki.wendy.sh/v1/" + testTenant + "/enroll"},
+		{"scheme and host", "https://csr.pki.wendy.sh", "renew", "https://csr.pki.wendy.sh/v1/" + testTenant + "/renew"},
+		{"trailing slash", "https://csr.pki.wendy.sh/", "enroll", "https://csr.pki.wendy.sh/v1/" + testTenant + "/enroll"},
+		{"host and port", "https://localhost:8451", "enroll", "https://localhost:8451/v1/" + testTenant + "/enroll"},
+		// A fully specified endpoint is honoured, so an operator who pasted
+		// one is not silently sent somewhere else.
+		{"full path passthrough", "https://csr.pki.wendy.sh/v1/other/enroll", "renew", "https://csr.pki.wendy.sh/v1/other/enroll"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := frontendEndpoint(tc.base, testTenant, tc.action)
+			if err != nil {
+				t.Fatalf("frontendEndpoint: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCSRFrontendURL(t *testing.T) {
+	t.Setenv(CSREndpointEnv, "")
+	t.Setenv(EnvironmentEnv, "")
+
+	if got, want := CSRFrontendURL("", EnvDev), "https://"+DevCSRFrontendHost; got != want {
+		t.Errorf("dev = %q, want %q", got, want)
+	}
+	if got, want := CSRFrontendURL("", EnvProd), "https://"+ProdCSRFrontendHost; got != want {
+		t.Errorf("prod = %q, want %q", got, want)
+	}
+	// An unrecognised environment must not be read as dev: sending a
+	// production device to a dev certificate authority is the failure this
+	// guards.
+	if got, want := CSRFrontendURL("", "staging"), "https://"+ProdCSRFrontendHost; got != want {
+		t.Errorf("unknown environment = %q, want %q", got, want)
+	}
+	if got, want := CSRFrontendURL("http://127.0.0.1:8451", EnvProd), "http://127.0.0.1:8451"; got != want {
+		t.Errorf("override = %q, want %q", got, want)
+	}
+
+	t.Setenv(EnvironmentEnv, EnvDev)
+	if got, want := CSRFrontendURL("", ""), "https://"+DevCSRFrontendHost; got != want {
+		t.Errorf("environment from env = %q, want %q", got, want)
+	}
+	t.Setenv(CSREndpointEnv, "csr.internal:9443")
+	if got, want := CSRFrontendURL("", ""), "https://csr.internal:9443"; got != want {
+		t.Errorf("endpoint from env = %q, want %q", got, want)
+	}
+	if got, want := CSRFrontendURL("explicit.example", ""), "https://explicit.example"; got != want {
+		t.Errorf("explicit override must beat the environment variable, got %q want %q", got, want)
+	}
+}
+
+func TestSplitLeafAndChain(t *testing.T) {
+	if _, _, err := SplitLeafAndChain("not pem at all"); err == nil {
+		t.Error("want an error for a bundle with no certificate")
+	}
+	f := newFakeFrontend(t)
+	leaf, chain, err := SplitLeafAndChain(f.caPEM + f.caPEM)
+	if err != nil {
+		t.Fatalf("SplitLeafAndChain: %v", err)
+	}
+	if leaf == "" || chain == "" {
+		t.Errorf("leaf = %q chain = %q, want both populated", leaf, chain)
+	}
+}

--- a/go/internal/agent/pkienroll/renewer.go
+++ b/go/internal/agent/pkienroll/renewer.go
@@ -1,0 +1,192 @@
+package pkienroll
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
+)
+
+// Renewer keeps the stored pki-core device identity fresh.
+//
+// It is the agent's FIRST certificate renewal loop of any kind. The CAS leaf
+// has never been renewed by the device either, so this does not replace a
+// working mechanism — but a device-tier pki-core leaf lasts 30 days where the
+// CAS leaf lasts 365, and the same silence that was survivable for a year is
+// not survivable for a month.
+type Renewer struct {
+	logger *zap.Logger
+	store  *Store
+
+	// frontendURL and tenantUUID are resolved once, when the identity is
+	// enrolled, and persisted alongside it. Renewal does not re-derive them:
+	// a leaf must be renewed at the tenant that issued it.
+	frontendURL string
+	tenantUUID  string
+
+	// Injection points for deterministic tests. now and jitter replace the
+	// clock and the random source; renew replaces the network call; sleep
+	// replaces the wait so a test does not spend the interval it is asserting.
+	now    func() time.Time
+	jitter func() float64
+	renew  func(context.Context, RenewRequest) (Result, error)
+	sleep  func(context.Context, time.Duration)
+}
+
+// NewRenewer builds a renewer for the identity in store.
+func NewRenewer(logger *zap.Logger, store *Store, frontendURL, tenantUUID string) *Renewer {
+	return &Renewer{
+		logger:      logger,
+		store:       store,
+		frontendURL: frontendURL,
+		tenantUUID:  tenantUUID,
+		now:         time.Now,
+		jitter:      rand.Float64,
+		renew:       Renew,
+		sleep:       sleepCtx,
+	}
+}
+
+// Run drives renewal until ctx is cancelled. It blocks; start it in a
+// goroutine. A store holding no identity is not an error: the loop waits, so
+// that enrolling a device later does not need an agent restart to start
+// renewing it.
+func (r *Renewer) Run(ctx context.Context) {
+	if r.store == nil || r.frontendURL == "" || r.tenantUUID == "" {
+		return
+	}
+	failures := 0
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		material, err := r.store.Load()
+		if err != nil {
+			// No identity yet. Poll rather than exit: the staged credential
+			// file may arrive after the agent came up.
+			r.sleep(ctx, pollFloor)
+			continue
+		}
+		notBefore, notAfter, err := leafValidity(material.LeafPEM)
+		zeroBytes(material.KeyData)
+		if err != nil {
+			r.logger.Error("pki identity renewal: stored leaf is unreadable; re-enrolment is required",
+				zap.String("leaf", r.store.LeafPath()), zap.Error(err))
+			r.sleep(ctx, backoffMax)
+			continue
+		}
+
+		decision := NextRenewal(notBefore, notAfter, r.now(), failures, r.jitter())
+		if decision.Critical {
+			// Loud, and it says what to do. A WARN that only reports a failed
+			// attempt would be indistinguishable from the transient failures
+			// the backoff exists to absorb.
+			r.logger.Error("pki identity renewal keeps failing and the certificate is about to expire; "+
+				"episode uploads to the data platform will stop until the device is re-enrolled",
+				zap.Time("not_after", notAfter),
+				zap.Duration("remaining", notAfter.Sub(r.now())),
+				zap.Int("consecutive_failures", failures),
+				zap.Bool("already_expired", decision.Expired))
+		}
+		if !decision.Attempt {
+			r.sleep(ctx, decision.Wait)
+			continue
+		}
+
+		if err := r.renewOnce(ctx); err != nil {
+			failures++
+			r.logger.Warn("pki identity renewal attempt failed",
+				zap.Int("consecutive_failures", failures), zap.Error(err))
+			r.sleep(ctx, backoffFor(failures))
+			continue
+		}
+		failures = 0
+	}
+}
+
+// renewOnce performs a single renewal and persists the result.
+//
+// The store is written only after the new leaf has been parsed and its SPIFFE
+// SAN verified, so a refusal or a surprise identity leaves the still-valid
+// current certificate in place. That ordering is the reason a failed renewal
+// costs nothing but a retry.
+func (r *Renewer) renewOnce(ctx context.Context) error {
+	material, err := r.store.Load()
+	if err != nil {
+		return err
+	}
+	defer zeroBytes(material.KeyData)
+
+	result, err := r.renew(ctx, RenewRequest{
+		CSRFrontendURL:  r.frontendURL,
+		TenantUUID:      r.tenantUUID,
+		CurrentLeafPEM:  material.LeafPEM,
+		CurrentChainPEM: material.ChainPEM,
+		Key:             material.KeyData,
+	})
+	if err != nil {
+		var identityErr *IdentityError
+		if errors.As(err, &identityErr) {
+			// A renewed leaf with the wrong principal is not a transport
+			// problem and retrying will reproduce it exactly. Say so at error
+			// level; the backoff still applies, because stopping would remove
+			// the only signal.
+			r.logger.Error("pki identity renewal returned an unexpected identity; not stored",
+				zap.Error(identityErr))
+		}
+		return err
+	}
+	if err := r.store.Save(result); err != nil {
+		return err
+	}
+	r.logger.Info("pki identity renewed",
+		zap.String("spiffe_uri", result.SPIFFEURI),
+		zap.String("device_name", result.DeviceName),
+		zap.Time("not_after", result.NotAfter))
+	return nil
+}
+
+// leafValidity reads the stored leaf's window through the same ML-DSA-aware
+// parser the handshake uses, so the schedule is computed from the certificate
+// that will actually be presented.
+func leafValidity(leafPEM string) (notBefore, notAfter time.Time, err error) {
+	normalized, err := certs.LeafCertificatePEM(leafPEM)
+	if err != nil {
+		return time.Time{}, time.Time{}, err
+	}
+	parsed, err := certs.ParseCertsFromPEM([]byte(normalized))
+	if err != nil {
+		return time.Time{}, time.Time{}, err
+	}
+	if len(parsed) == 0 {
+		return time.Time{}, time.Time{}, errors.New("stored leaf PEM carried no certificate")
+	}
+	return parsed[0].NotBefore, parsed[0].NotAfter, nil
+}
+
+// sleepCtx waits for d, returning early when ctx is done so shutdown is not
+// held up by a renewal interval measured in days.
+func sleepCtx(ctx context.Context, d time.Duration) {
+	if d <= 0 {
+		d = pollFloor
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+	case <-ctx.Done():
+	}
+}
+
+// zeroBytes overwrites b in place as best-effort key-material hygiene, matching
+// what the cloud dialers already do with the CAS key.
+func zeroBytes(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}

--- a/go/internal/agent/pkienroll/schedule.go
+++ b/go/internal/agent/pkienroll/schedule.go
@@ -1,0 +1,131 @@
+package pkienroll
+
+import "time"
+
+// Renewal timing. The device holds a pki-core device-tier leaf, which is 30
+// days at most on the bearer-token path, so an unrenewed certificate is a
+// one-month fuse rather than the one-year fuse the CAS leaf is. Nothing in the
+// agent renewed anything before this, on any certificate, so these constants
+// are the first statement of the policy the certificate proto has documented
+// all along: refresh about two thirds of the way through the lifetime.
+const (
+	// renewFraction is how far through the leaf's own validity window the
+	// renewal is attempted. Computed from NotBefore and NotAfter as issued,
+	// never from an assumed tier length, so a policy change at the tenant
+	// shortens the interval without a code change.
+	renewFraction = 2.0 / 3.0
+
+	// renewJitterFraction spreads the attempt over this share of the remaining
+	// window after the 2/3 point. A fleet enrolled in one batch would otherwise
+	// renew in one thundering herd, 20 days later to the second.
+	renewJitterFraction = 0.1
+
+	// backoffBase and backoffMax bound the retry interval after a failure.
+	// The base is small because the first failure is usually a boot-time
+	// network that is seconds away from working; the ceiling is an hour
+	// because past that the operator, not the retry, is the fix.
+	backoffBase = 1 * time.Minute
+	backoffMax  = 1 * time.Hour
+
+	// criticalWindow is how close to expiry a still-failing renewal starts
+	// being logged loudly. Inside it the device is about to lose its data
+	// platform identity, and past expiry pki-core will not renew at all
+	// without an operator-signed grant the agent cannot produce, so the
+	// message has to arrive while it can still be acted on.
+	criticalWindow = 24 * time.Hour
+
+	// pollFloor bounds how long the loop sleeps when it has nothing else to
+	// say, so a clock jump backwards cannot park it for a month.
+	pollFloor = 1 * time.Minute
+)
+
+// Schedule is one renewal decision: what to do now, and how long to wait if
+// the answer is "not yet".
+type Schedule struct {
+	// Attempt is true when a renewal should be tried immediately.
+	Attempt bool
+	// Wait is how long to sleep before asking again. Zero when Attempt is true.
+	Wait time.Duration
+	// Critical is true when the leaf is inside criticalWindow of expiry and
+	// renewal has already failed at least once — the state worth shouting
+	// about, because a device with a healthy certificate 12 hours from renewal
+	// is not news and a device 12 hours from losing its identity is.
+	Critical bool
+	// Expired is true once the leaf's validity has passed. Renewal is no
+	// longer possible on its own; re-enrolment with a fresh token is.
+	Expired bool
+}
+
+// NextRenewal decides what the renewal loop does next. It is pure: every input
+// including the jitter is a parameter, so the whole policy is testable without
+// a clock, a network or a random source.
+//
+// notBefore and notAfter are the issued leaf's own validity bounds. failures is
+// the count of consecutive failed attempts, which selects the backoff and gates
+// Critical. jitterFrac is a value in [0,1) — a random draw in production, a
+// constant in tests.
+func NextRenewal(notBefore, notAfter, now time.Time, failures int, jitterFrac float64) Schedule {
+	if !notAfter.After(now) {
+		// Past expiry, keep trying on the backoff anyway: a renewal cannot
+		// succeed, but the attempt is what produces the error that says
+		// re-enrolment is needed, and the alternative is a silent stop.
+		return Schedule{Attempt: failures == 0, Wait: backoffFor(failures), Critical: true, Expired: true}
+	}
+
+	critical := failures > 0 && notAfter.Sub(now) <= criticalWindow
+
+	if failures > 0 {
+		// A failure means the 2/3 point is already behind us, so the only
+		// question left is how long to wait before retrying.
+		return Schedule{Wait: backoffFor(failures), Critical: critical}
+	}
+
+	lifetime := notAfter.Sub(notBefore)
+	if lifetime <= 0 {
+		// A leaf whose window is empty or inverted tells us nothing about when
+		// to renew. Try now rather than compute a nonsense delay from it.
+		return Schedule{Attempt: true}
+	}
+	renewAt := notBefore.Add(time.Duration(float64(lifetime) * renewFraction))
+	if jitterFrac > 0 {
+		remaining := notAfter.Sub(renewAt)
+		if remaining > 0 {
+			renewAt = renewAt.Add(time.Duration(float64(remaining) * renewJitterFraction * clampUnit(jitterFrac)))
+		}
+	}
+	if !now.Before(renewAt) {
+		return Schedule{Attempt: true, Critical: critical}
+	}
+	wait := renewAt.Sub(now)
+	if wait < pollFloor {
+		wait = pollFloor
+	}
+	return Schedule{Wait: wait, Critical: critical}
+}
+
+// backoffFor is exponential from backoffBase, capped at backoffMax.
+func backoffFor(failures int) time.Duration {
+	if failures <= 0 {
+		return backoffBase
+	}
+	d := backoffBase
+	for i := 1; i < failures; i++ {
+		d *= 2
+		if d >= backoffMax {
+			return backoffMax
+		}
+	}
+	return d
+}
+
+func clampUnit(f float64) float64 {
+	if f < 0 {
+		return 0
+	}
+	if f >= 1 {
+		// Strictly below 1 so jitter never pushes the attempt to the expiry
+		// instant itself.
+		return 0.999
+	}
+	return f
+}

--- a/go/internal/agent/pkienroll/schedule_test.go
+++ b/go/internal/agent/pkienroll/schedule_test.go
@@ -1,0 +1,171 @@
+package pkienroll
+
+import (
+	"testing"
+	"time"
+)
+
+// The schedule is the whole renewal policy, and it is a pure function so it can
+// be pinned without a clock, a network or a random source. These tests are the
+// specification: 2/3 of the leaf's own lifetime, jitter on top, exponential
+// backoff on failure, and a loud state inside the last 24 hours.
+func TestNextRenewalWaitsUntilTwoThirds(t *testing.T) {
+	notBefore := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+	notAfter := notBefore.Add(30 * 24 * time.Hour)
+
+	// Day 1 of 30: nothing to do, and the wait lands on the 2/3 point (day 20)
+	// rather than on a fixed poll interval.
+	now := notBefore.Add(24 * time.Hour)
+	got := NextRenewal(notBefore, notAfter, now, 0, 0)
+	if got.Attempt {
+		t.Error("Attempt = true on day 1 of 30")
+	}
+	wantWait := notBefore.Add(20 * 24 * time.Hour).Sub(now)
+	if got.Wait != wantWait {
+		t.Errorf("Wait = %v, want %v", got.Wait, wantWait)
+	}
+	if got.Critical || got.Expired {
+		t.Errorf("Critical = %v Expired = %v, want both false", got.Critical, got.Expired)
+	}
+}
+
+func TestNextRenewalAttemptsAtTwoThirds(t *testing.T) {
+	notBefore := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+	notAfter := notBefore.Add(30 * 24 * time.Hour)
+
+	// Exactly the 2/3 point, no jitter.
+	got := NextRenewal(notBefore, notAfter, notBefore.Add(20*24*time.Hour), 0, 0)
+	if !got.Attempt {
+		t.Error("Attempt = false at the 2/3 point")
+	}
+	if got.Wait != 0 {
+		t.Errorf("Wait = %v, want 0 when attempting", got.Wait)
+	}
+}
+
+func TestNextRenewalJitterDelaysTheAttempt(t *testing.T) {
+	notBefore := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+	notAfter := notBefore.Add(30 * 24 * time.Hour)
+	twoThirds := notBefore.Add(20 * 24 * time.Hour)
+
+	// A full jitter draw pushes the attempt into the remaining third by
+	// renewJitterFraction of it: one day of the ten that are left. Without
+	// this a fleet enrolled in one batch renews in one thundering herd.
+	got := NextRenewal(notBefore, notAfter, twoThirds, 0, 0.999)
+	if got.Attempt {
+		t.Error("Attempt = true at the 2/3 point with full jitter; want the jittered delay")
+	}
+	if got.Wait < 23*time.Hour || got.Wait > 25*time.Hour {
+		t.Errorf("Wait = %v, want about 24h (a tenth of the remaining ten days)", got.Wait)
+	}
+
+	// And the jitter never pushes past expiry.
+	if twoThirds.Add(got.Wait).After(notAfter) {
+		t.Error("jitter pushed the attempt beyond the leaf's expiry")
+	}
+}
+
+func TestNextRenewalNeverSleepsBelowThePollFloor(t *testing.T) {
+	notBefore := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+	notAfter := notBefore.Add(30 * 24 * time.Hour)
+	// One second short of the 2/3 point: a one-second sleep would busy-loop.
+	got := NextRenewal(notBefore, notAfter, notBefore.Add(20*24*time.Hour-time.Second), 0, 0)
+	if got.Attempt {
+		t.Error("Attempt = true before the 2/3 point")
+	}
+	if got.Wait != pollFloor {
+		t.Errorf("Wait = %v, want the poll floor %v", got.Wait, pollFloor)
+	}
+}
+
+func TestNextRenewalBacksOffOnFailure(t *testing.T) {
+	notBefore := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+	notAfter := notBefore.Add(30 * 24 * time.Hour)
+	now := notBefore.Add(21 * 24 * time.Hour)
+
+	for _, tc := range []struct {
+		failures int
+		want     time.Duration
+	}{
+		{1, backoffBase},
+		{2, 2 * backoffBase},
+		{3, 4 * backoffBase},
+		{7, backoffMax},
+		{99, backoffMax},
+	} {
+		got := NextRenewal(notBefore, notAfter, now, tc.failures, 0)
+		if got.Attempt {
+			t.Errorf("failures=%d: Attempt = true, want a backoff wait", tc.failures)
+		}
+		if got.Wait != tc.want {
+			t.Errorf("failures=%d: Wait = %v, want %v", tc.failures, got.Wait, tc.want)
+		}
+	}
+}
+
+func TestNextRenewalCriticalOnlyWhenFailingNearExpiry(t *testing.T) {
+	notBefore := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+	notAfter := notBefore.Add(30 * 24 * time.Hour)
+	nearExpiry := notAfter.Add(-12 * time.Hour)
+
+	// Healthy and 12 hours from renewal is not news.
+	if got := NextRenewal(notBefore, notAfter, nearExpiry, 0, 0); got.Critical {
+		t.Error("Critical = true with no failures; a healthy certificate must not shout")
+	}
+	// Failing and 12 hours from losing the identity is.
+	if got := NextRenewal(notBefore, notAfter, nearExpiry, 1, 0); !got.Critical {
+		t.Error("Critical = false while failing inside the 24h window")
+	}
+	// Failing but 9 days out is still just a retry.
+	if got := NextRenewal(notBefore, notAfter, notAfter.Add(-9*24*time.Hour), 3, 0); got.Critical {
+		t.Error("Critical = true nine days from expiry")
+	}
+}
+
+func TestNextRenewalPastExpiry(t *testing.T) {
+	notBefore := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+	notAfter := notBefore.Add(30 * 24 * time.Hour)
+
+	got := NextRenewal(notBefore, notAfter, notAfter.Add(time.Hour), 0, 0)
+	if !got.Expired {
+		t.Error("Expired = false past NotAfter")
+	}
+	if !got.Critical {
+		t.Error("Critical = false past NotAfter; an expired identity is always news")
+	}
+	// One attempt is still made, because the attempt is what produces the
+	// error that says re-enrolment is needed.
+	if !got.Attempt {
+		t.Error("Attempt = false past expiry; the failure is the only signal")
+	}
+	// And once it has failed, it backs off rather than spinning.
+	after := NextRenewal(notBefore, notAfter, notAfter.Add(time.Hour), 4, 0)
+	if after.Attempt {
+		t.Error("Attempt = true past expiry after four failures")
+	}
+	if after.Wait != 8*backoffBase {
+		t.Errorf("Wait = %v, want %v", after.Wait, 8*backoffBase)
+	}
+}
+
+func TestNextRenewalHandlesNonsenseWindow(t *testing.T) {
+	now := time.Date(2026, 9, 10, 0, 0, 0, 0, time.UTC)
+	// NotBefore after NotAfter tells us nothing about when to renew, so try
+	// now rather than compute a negative delay from it.
+	got := NextRenewal(now.Add(time.Hour), now.Add(time.Minute), now, 0, 0)
+	if !got.Attempt {
+		t.Error("Attempt = false for an inverted validity window")
+	}
+}
+
+func TestClampUnit(t *testing.T) {
+	if got := clampUnit(-1); got != 0 {
+		t.Errorf("clampUnit(-1) = %v, want 0", got)
+	}
+	if got := clampUnit(5); got >= 1 {
+		t.Errorf("clampUnit(5) = %v, want strictly below 1", got)
+	}
+	if got := clampUnit(0.25); got != 0.25 {
+		t.Errorf("clampUnit(0.25) = %v", got)
+	}
+}

--- a/go/internal/agent/pkienroll/store.go
+++ b/go/internal/agent/pkienroll/store.go
@@ -192,6 +192,11 @@ func (s *Store) Save(result Result) error {
 		if err := atomicfile.Write(s.ChainPath(), []byte(result.ChainPEM), certMode); err != nil {
 			return fmt.Errorf("writing pki identity chain: %w", err)
 		}
+	} else if err := os.Remove(s.ChainPath()); err != nil && !os.IsNotExist(err) {
+		// A leaf-only issuance must not inherit the previous chain: an
+		// intermediate that does not sign the new leaf fails the handshake in
+		// a way that looks like a server-side refusal.
+		return fmt.Errorf("removing stale pki identity chain: %w", err)
 	}
 	if err := atomicfile.Write(s.LeafPath(), []byte(result.LeafPEM), certMode); err != nil {
 		return fmt.Errorf("writing pki identity leaf: %w", err)

--- a/go/internal/agent/pkienroll/store.go
+++ b/go/internal/agent/pkienroll/store.go
@@ -1,0 +1,200 @@
+package pkienroll
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/atomicfile"
+	"github.com/wendylabsinc/wendy/go/internal/shared/certs"
+)
+
+// Directory and file names of the pki-core identity, kept deliberately
+// separate from the Certificate Authority Service (CAS) triple in the parent
+// directory. The CAS files are /etc/wendy-agent/{device-key.pem,device.pem,
+// ca.pem} and are read by the cloud dialers, the agent's inbound mTLS server
+// and the mesh; nothing in this package touches them. The names repeat inside
+// the subdirectory rather than being prefixed, so a reader who knows the CAS
+// layout can read this one without a second convention to learn.
+const (
+	// StoreSubdir is appended to the agent's config path.
+	StoreSubdir = "pki"
+
+	keyFileName   = "device-key.pem"
+	leafFileName  = "device.pem"
+	chainFileName = "chain.pem"
+
+	// metaFileName records the tenant and frontend the identity was enrolled
+	// at. It exists because renewal has to go back to the same tenant, and
+	// after a restart there is no staged credential file left to read it from:
+	// the file is deleted once redeemed, exactly as enrollment.json is.
+	metaFileName = "identity.json"
+
+	// keyMode is 0600 and not 0400. The CAS path writes 0400 on first generate
+	// and 0600 through WritePEMFiles, so the mode there tells you which code
+	// path wrote last; one mode here means a renewal never has to widen it.
+	keyMode  = 0o600
+	certMode = 0o644
+	dirMode  = 0o700
+)
+
+// Metadata is what renewal needs and the certificate does not carry in a form
+// worth re-deriving: which tenant issued it and which frontend to go back to.
+type Metadata struct {
+	TenantUUID  string `json:"tenantUUID"`
+	CSREndpoint string `json:"csrEndpoint"`
+	// DeviceName is the SPIFFE name the issued SAN carried. Stored for logging
+	// and for operator commands that report what this device's identity is;
+	// renewal reads the name off the presented certificate, not from here.
+	DeviceName string `json:"deviceName"`
+}
+
+// Material is the stored pki-core identity: a leaf, the intermediates below it,
+// and the private key. It mirrors the shape ProvisioningCerts returns for the
+// CAS triple so the dialer can treat the two interchangeably.
+type Material struct {
+	LeafPEM  string
+	ChainPEM string
+	// KeyData is a copy the caller owns and should zero after use.
+	KeyData []byte
+}
+
+// Store holds the pki-core PEM triple under <configPath>/pki.
+type Store struct {
+	dir string
+}
+
+// NewStore returns the store rooted at <configPath>/pki.
+func NewStore(configPath string) *Store {
+	return &Store{dir: filepath.Join(configPath, StoreSubdir)}
+}
+
+// Dir is the directory the triple lives in.
+func (s *Store) Dir() string { return s.dir }
+
+// KeyPath, LeafPath and ChainPath are exposed because operator-facing messages
+// and logs name the files, and a hand-built path elsewhere would drift.
+func (s *Store) KeyPath() string   { return filepath.Join(s.dir, keyFileName) }
+func (s *Store) LeafPath() string  { return filepath.Join(s.dir, leafFileName) }
+func (s *Store) ChainPath() string { return filepath.Join(s.dir, chainFileName) }
+func (s *Store) MetaPath() string  { return filepath.Join(s.dir, metaFileName) }
+
+// SaveMetadata records the tenant and frontend this identity belongs to.
+func (s *Store) SaveMetadata(m Metadata) error {
+	if err := os.MkdirAll(s.dir, dirMode); err != nil {
+		return fmt.Errorf("creating pki identity directory: %w", err)
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		return fmt.Errorf("encoding pki identity metadata: %w", err)
+	}
+	if err := atomicfile.Write(s.MetaPath(), append(data, '\n'), certMode); err != nil {
+		return fmt.Errorf("writing pki identity metadata: %w", err)
+	}
+	return nil
+}
+
+// LoadMetadata reads it back. A missing file yields the zero Metadata and no
+// error: a device that was never enrolled has none, and the renewer treats an
+// empty tenant as "nothing to renew".
+func (s *Store) LoadMetadata() (Metadata, error) {
+	data, err := os.ReadFile(s.MetaPath())
+	if os.IsNotExist(err) {
+		return Metadata{}, nil
+	}
+	if err != nil {
+		return Metadata{}, fmt.Errorf("reading pki identity metadata: %w", err)
+	}
+	var m Metadata
+	if err := json.Unmarshal(data, &m); err != nil {
+		return Metadata{}, fmt.Errorf("decoding pki identity metadata: %w", err)
+	}
+	return m, nil
+}
+
+// LoadOrGenerateKey returns the device's pki-core private key, generating and
+// persisting an ECDSA P-256 key on first call and reusing it afterwards.
+//
+// The key is generated ON THE DEVICE and never leaves it: pki-core does not
+// implement server-side key generation, and enrolling from a laptop would put
+// the device's key on the laptop. It is a SEPARATE key from the CAS
+// device-key.pem — sharing one key across the two identities would make them
+// one identity wearing two certificates, so a compromise of either would be a
+// compromise of both.
+//
+// The returned slice is the caller's to zero.
+func (s *Store) LoadOrGenerateKey() ([]byte, error) {
+	if err := os.MkdirAll(s.dir, dirMode); err != nil {
+		return nil, fmt.Errorf("creating pki identity directory: %w", err)
+	}
+	if data, err := os.ReadFile(s.KeyPath()); err == nil && len(data) > 0 {
+		return data, nil
+	}
+	keyPEM, err := certs.GenerateKeyPair()
+	if err != nil {
+		return nil, fmt.Errorf("generating pki identity key: %w", err)
+	}
+	if err := atomicfile.Write(s.KeyPath(), []byte(keyPEM), keyMode); err != nil {
+		return nil, fmt.Errorf("writing pki identity key: %w", err)
+	}
+	return []byte(keyPEM), nil
+}
+
+// ErrNoIdentity says the store holds no usable identity. It is an ordinary
+// state, not a failure: a device that has never been enrolled against pki-core
+// reports it, and every caller answers by falling back to the CAS identity.
+var ErrNoIdentity = errors.New("no pki-core device identity stored")
+
+// Load reads the stored triple. It returns ErrNoIdentity when the leaf or the
+// key is missing or empty, so a half-written store (a key generated but never
+// enrolled) reads as absent rather than as broken.
+func (s *Store) Load() (Material, error) {
+	leaf, err := os.ReadFile(s.LeafPath())
+	if err != nil || len(leaf) == 0 {
+		return Material{}, ErrNoIdentity
+	}
+	key, err := os.ReadFile(s.KeyPath())
+	if err != nil || len(key) == 0 {
+		return Material{}, ErrNoIdentity
+	}
+	// An absent chain file is legitimate: pki-core returns a leaf alone when
+	// there are no intermediates below the issuing certificate authority.
+	chain, err := os.ReadFile(s.ChainPath())
+	if err != nil && !os.IsNotExist(err) {
+		return Material{}, fmt.Errorf("reading pki identity chain: %w", err)
+	}
+	return Material{LeafPEM: string(leaf), ChainPEM: string(chain), KeyData: key}, nil
+}
+
+// Has reports whether a usable identity is stored.
+func (s *Store) Has() bool {
+	_, err := s.Load()
+	return err == nil
+}
+
+// Save writes the issued leaf and chain, atomically and leaf last.
+//
+// Order matters: Load treats a missing leaf as "no identity", so writing the
+// chain first means a crash between the two writes leaves the store readable as
+// absent rather than as an identity whose chain does not match its leaf. The
+// key is written by LoadOrGenerateKey and is never rewritten here, because the
+// key that signed the CSR is the key the issued leaf attests.
+func (s *Store) Save(result Result) error {
+	if result.LeafPEM == "" {
+		return errors.New("refusing to store an empty pki identity leaf")
+	}
+	if err := os.MkdirAll(s.dir, dirMode); err != nil {
+		return fmt.Errorf("creating pki identity directory: %w", err)
+	}
+	if result.ChainPEM != "" {
+		if err := atomicfile.Write(s.ChainPath(), []byte(result.ChainPEM), certMode); err != nil {
+			return fmt.Errorf("writing pki identity chain: %w", err)
+		}
+	}
+	if err := atomicfile.Write(s.LeafPath(), []byte(result.LeafPEM), certMode); err != nil {
+		return fmt.Errorf("writing pki identity leaf: %w", err)
+	}
+	return nil
+}

--- a/go/internal/agent/pkienroll/store_test.go
+++ b/go/internal/agent/pkienroll/store_test.go
@@ -1,0 +1,280 @@
+package pkienroll
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"go.uber.org/zap/zaptest"
+)
+
+func TestStoreKeyGeneratedOnceAndReused(t *testing.T) {
+	dir := t.TempDir()
+	s := NewStore(dir)
+
+	first, err := s.LoadOrGenerateKey()
+	if err != nil {
+		t.Fatalf("LoadOrGenerateKey: %v", err)
+	}
+	second, err := s.LoadOrGenerateKey()
+	if err != nil {
+		t.Fatalf("LoadOrGenerateKey (second): %v", err)
+	}
+	if string(first) != string(second) {
+		t.Error("the key was regenerated; a renewal must reuse the key the leaf attests")
+	}
+
+	// It lives under <configPath>/pki, never beside the Certificate Authority
+	// Service triple in the parent directory.
+	if got, want := s.KeyPath(), filepath.Join(dir, StoreSubdir, "device-key.pem"); got != want {
+		t.Errorf("KeyPath = %q, want %q", got, want)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "device-key.pem")); !os.IsNotExist(err) {
+		t.Error("the pki key was written where the CAS key lives")
+	}
+
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(s.KeyPath())
+		if err != nil {
+			t.Fatalf("stat key: %v", err)
+		}
+		if got := info.Mode().Perm(); got != keyMode {
+			t.Errorf("key mode = %v, want %v", got, os.FileMode(keyMode))
+		}
+	}
+}
+
+func TestStoreLoadReportsNoIdentity(t *testing.T) {
+	s := NewStore(t.TempDir())
+
+	if _, err := s.Load(); !errors.Is(err, ErrNoIdentity) {
+		t.Errorf("Load on an empty store = %v, want ErrNoIdentity", err)
+	}
+	if s.Has() {
+		t.Error("Has = true on an empty store")
+	}
+
+	// A key with no leaf is a half-enrolled store. It must read as absent, so
+	// the dialer falls back rather than presenting nothing.
+	if _, err := s.LoadOrGenerateKey(); err != nil {
+		t.Fatalf("LoadOrGenerateKey: %v", err)
+	}
+	if _, err := s.Load(); !errors.Is(err, ErrNoIdentity) {
+		t.Errorf("Load with a key but no leaf = %v, want ErrNoIdentity", err)
+	}
+}
+
+func TestStoreSaveAndLoad(t *testing.T) {
+	s := NewStore(t.TempDir())
+	if _, err := s.LoadOrGenerateKey(); err != nil {
+		t.Fatalf("LoadOrGenerateKey: %v", err)
+	}
+
+	f := newFakeFrontend(t)
+	srv := f.serve()
+	defer srv.Close()
+	key, err := s.LoadOrGenerateKey()
+	if err != nil {
+		t.Fatalf("LoadOrGenerateKey: %v", err)
+	}
+	result, err := Enroll(context.Background(), EnrollRequest{
+		CSRFrontendURL:  srv.URL,
+		TenantUUID:      testTenant,
+		EnrollmentToken: "tok",
+		Key:             key,
+		CommonName:      "sh/wendy/2/408",
+	})
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	if err := s.Save(result); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if !s.Has() {
+		t.Fatal("Has = false after Save")
+	}
+
+	material, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if material.LeafPEM != result.LeafPEM {
+		t.Error("loaded leaf differs from the one saved")
+	}
+	if material.ChainPEM != result.ChainPEM {
+		t.Error("loaded chain differs from the one saved")
+	}
+	if string(material.KeyData) != string(key) {
+		t.Error("loaded key differs from the one that signed the CSR")
+	}
+}
+
+func TestStoreRefusesEmptyLeaf(t *testing.T) {
+	s := NewStore(t.TempDir())
+	if err := s.Save(Result{}); err == nil {
+		t.Error("Save accepted an empty leaf")
+	}
+}
+
+func TestStoreMetadataRoundTrip(t *testing.T) {
+	s := NewStore(t.TempDir())
+
+	// Absent metadata is the zero value and not an error: a device that was
+	// never enrolled has none, and the renewer reads that as nothing to renew.
+	meta, err := s.LoadMetadata()
+	if err != nil {
+		t.Fatalf("LoadMetadata on an empty store: %v", err)
+	}
+	if meta.TenantUUID != "" {
+		t.Errorf("TenantUUID = %q, want empty", meta.TenantUUID)
+	}
+
+	want := Metadata{TenantUUID: testTenant, CSREndpoint: "https://" + DevCSRFrontendHost, DeviceName: "sh/wendy/2/408"}
+	if err := s.SaveMetadata(want); err != nil {
+		t.Fatalf("SaveMetadata: %v", err)
+	}
+	got, err := s.LoadMetadata()
+	if err != nil {
+		t.Fatalf("LoadMetadata: %v", err)
+	}
+	if got != want {
+		t.Errorf("metadata = %+v, want %+v", got, want)
+	}
+}
+
+// TestRenewerRenewsAndPersists drives the loop with the clock, the jitter and
+// the network all injected, so the schedule under test is the real one but the
+// test spends no time and touches no host.
+func TestRenewerRenewsAndPersists(t *testing.T) {
+	s := NewStore(t.TempDir())
+	f := newFakeFrontend(t)
+	srv := f.serve()
+	defer srv.Close()
+
+	key, err := s.LoadOrGenerateKey()
+	if err != nil {
+		t.Fatalf("LoadOrGenerateKey: %v", err)
+	}
+	enrolled, err := Enroll(context.Background(), EnrollRequest{
+		CSRFrontendURL:  srv.URL,
+		TenantUUID:      testTenant,
+		EnrollmentToken: "tok",
+		Key:             key,
+		CommonName:      "sh/wendy/2/408",
+	})
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	if err := s.Save(enrolled); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	r := NewRenewer(zaptest.NewLogger(t), s, srv.URL, testTenant)
+	// Well past the 2/3 point of the issued 30-day leaf, no jitter, and the
+	// renewal driven over the test transport.
+	r.now = func() time.Time { return enrolled.NotBefore.Add(25 * 24 * time.Hour) }
+	r.jitter = func() float64 { return 0 }
+	ctx, cancel := context.WithCancel(context.Background())
+	// One renewal, then stop. The cancel hangs off the renewal itself and not
+	// off the sleep, because a successful pass with a frozen clock schedules
+	// the next attempt immediately and never sleeps. Save still runs; the loop
+	// then sees the cancelled context and returns.
+	inner := r.renew
+	r.renew = func(ctx context.Context, req RenewRequest) (Result, error) {
+		req.HTTPClient = srv.Client()
+		defer cancel()
+		return inner(ctx, req)
+	}
+	r.sleep = func(context.Context, time.Duration) { cancel() }
+	done := make(chan struct{})
+	go func() { r.Run(ctx); close(done) }()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("renewer did not return")
+	}
+
+	renewedMaterial, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load after renewal: %v", err)
+	}
+	if renewedMaterial.LeafPEM == enrolled.LeafPEM {
+		t.Error("the store still holds the old leaf; the renewal was not persisted")
+	}
+	if string(renewedMaterial.KeyData) != string(key) {
+		t.Error("the key changed across renewal; it must be reused")
+	}
+}
+
+// TestRenewerKeepsTheCurrentLeafOnFailure is the property that makes a failed
+// renewal cost nothing: the store is written only after a verified issuance.
+func TestRenewerKeepsTheCurrentLeafOnFailure(t *testing.T) {
+	s := NewStore(t.TempDir())
+	f := newFakeFrontend(t)
+	srv := f.serve()
+	defer srv.Close()
+
+	key, err := s.LoadOrGenerateKey()
+	if err != nil {
+		t.Fatalf("LoadOrGenerateKey: %v", err)
+	}
+	enrolled, err := Enroll(context.Background(), EnrollRequest{
+		CSRFrontendURL:  srv.URL,
+		TenantUUID:      testTenant,
+		EnrollmentToken: "tok",
+		Key:             key,
+		CommonName:      "sh/wendy/2/408",
+	})
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	if err := s.Save(enrolled); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	r := NewRenewer(zaptest.NewLogger(t), s, srv.URL, testTenant)
+	r.now = func() time.Time { return enrolled.NotBefore.Add(25 * 24 * time.Hour) }
+	r.jitter = func() float64 { return 0 }
+	attempts := 0
+	r.renew = func(context.Context, RenewRequest) (Result, error) {
+		attempts++
+		return Result{}, &StatusError{StatusCode: 503}
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	r.sleep = func(context.Context, time.Duration) { cancel() }
+	done := make(chan struct{})
+	go func() { r.Run(ctx); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("renewer did not return")
+	}
+
+	if attempts == 0 {
+		t.Fatal("no renewal was attempted")
+	}
+	material, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load after a failed renewal: %v", err)
+	}
+	if material.LeafPEM != enrolled.LeafPEM {
+		t.Error("a failed renewal replaced the still-valid leaf")
+	}
+}
+
+func TestRenewerDoesNothingWithoutMetadata(t *testing.T) {
+	s := NewStore(t.TempDir())
+	r := NewRenewer(zaptest.NewLogger(t), s, "", "")
+	done := make(chan struct{})
+	go func() { r.Run(context.Background()); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return with no tenant configured")
+	}
+}

--- a/go/internal/agent/pkienroll/store_test.go
+++ b/go/internal/agent/pkienroll/store_test.go
@@ -278,3 +278,24 @@ func TestRenewerDoesNothingWithoutMetadata(t *testing.T) {
 		t.Fatal("Run did not return with no tenant configured")
 	}
 }
+
+// A renewal that returns a leaf alone must not leave the previous chain in
+// place: an intermediate that does not sign the new leaf fails the handshake.
+func TestStoreSaveDropsStaleChain(t *testing.T) {
+	s := NewStore(t.TempDir())
+	if err := s.Save(Result{LeafPEM: "leaf-1", ChainPEM: "chain-1"}); err != nil {
+		t.Fatalf("Save with chain: %v", err)
+	}
+	if _, err := os.Stat(s.ChainPath()); err != nil {
+		t.Fatalf("chain not written: %v", err)
+	}
+	if err := s.Save(Result{LeafPEM: "leaf-2"}); err != nil {
+		t.Fatalf("Save without chain: %v", err)
+	}
+	if _, err := os.Stat(s.ChainPath()); !os.IsNotExist(err) {
+		t.Fatalf("stale chain still present after leaf-only Save (err=%v)", err)
+	}
+	if err := s.Save(Result{LeafPEM: "leaf-3"}); err != nil {
+		t.Fatalf("Save without chain when none exists: %v", err)
+	}
+}

--- a/go/internal/agent/services/data_transfer_worker.go
+++ b/go/internal/agent/services/data_transfer_worker.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/wendylabsinc/wendy/go/internal/agent/data"
+	"github.com/wendylabsinc/wendy/go/internal/agent/pkienroll"
 	cloudpb "github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
 )
 
@@ -117,6 +118,18 @@ type DataTransferWorker struct {
 	// disabled and Run says so once. Enrollment still provides the asset
 	// identity and client certificate; this is only the destination.
 	ingestHost string
+	// pkiIdentity, when set, is the device's pki-core identity: a leaf whose
+	// only URI Subject Alternative Name is
+	// spiffe://wendy.sh/tenant/<tenant>/device/<name>. The data platform's
+	// ingest interceptor prefers that principal and rejects any SPIFFE kind
+	// other than "device"; Wendy Cloud's interceptors, by contrast, read only
+	// the legacy Wendy organization URN that the enrolled asset certificate
+	// carries (see certs.AssetURN). So this identity is used HERE and nowhere
+	// else, and the asset certificate stays what every cloud dialer presents.
+	// When no pki identity is stored the worker behaves exactly as before,
+	// presenting the asset certificate, which the ingest surface still accepts
+	// as a legacy identity.
+	pkiIdentity pkiIdentityReader
 	// onWiFi reports whether the device is currently on Wi-Fi, gating campaigns
 	// whose upload.when is "wifi". When nil, no network-type signal is wired and
 	// "wifi" is treated as "always" (see resolveShouldUpload).
@@ -188,6 +201,54 @@ func contextSleeper(ctx context.Context) func(time.Duration) {
 	}
 }
 
+// pkiIdentityReader reads the device's stored pki-core identity.
+// *pkienroll.Store implements it; tests substitute a stub. ErrNoIdentity (or
+// any error) means "no pki identity", which is a supported state and not a
+// failure.
+type pkiIdentityReader interface {
+	Load() (pkienroll.Material, error)
+}
+
+// SetPKIIdentity gives the worker a pki-core device identity to present to the
+// data platform in preference to the enrolled asset certificate. Passing nil
+// restores the previous behaviour.
+func (w *DataTransferWorker) SetPKIIdentity(r pkiIdentityReader) { w.pkiIdentity = r }
+
+// identitySource names which of the device's two identities a dial used. It
+// exists so the choice is testable and so the log says which certificate was
+// presented — a question that is otherwise unanswerable after the fact.
+type identitySource string
+
+const (
+	identitySourcePKI   identitySource = "pki-core-spiffe"
+	identitySourceAsset identitySource = "cloud-asset-urn"
+)
+
+// ingestIdentity picks the client certificate for an ingest dial: the pki-core
+// device identity when one is stored, otherwise the enrolled asset
+// certificate.
+//
+// The fallback is unconditional and silent by design. A device that has not
+// been enrolled against pki-core must keep uploading exactly as it does today,
+// so an absent pki identity is not a warning; and a stored-but-unreadable one
+// is reported rather than papered over, because that is a real fault.
+//
+// The caller owns keyData and must zero it.
+func (w *DataTransferWorker) ingestIdentity() (certPEM, chainPEM string, keyData []byte, source identitySource, err error) {
+	if w.pkiIdentity != nil {
+		material, loadErr := w.pkiIdentity.Load()
+		switch {
+		case loadErr == nil && material.LeafPEM != "" && len(material.KeyData) > 0:
+			return material.LeafPEM, material.ChainPEM, material.KeyData, identitySourcePKI, nil
+		case loadErr != nil && !errors.Is(loadErr, pkienroll.ErrNoIdentity):
+			w.logger.Warn("data transfer worker: pki identity is present but unreadable; "+
+				"falling back to the enrolled asset certificate", zap.Error(loadErr))
+		}
+	}
+	certPEM, chainPEM, keyData = w.provisioningSvc.ProvisioningCerts()
+	return certPEM, chainPEM, keyData, identitySourceAsset, nil
+}
+
 // dialFactory is the production ingestClientFactory: it waits for provisioning,
 // dials the cloud over mTLS, and returns a DataIngestService client.
 func (w *DataTransferWorker) dialFactory(ctx context.Context) (cloudpb.DataIngestServiceClient, func(), error) {
@@ -197,11 +258,16 @@ func (w *DataTransferWorker) dialFactory(ctx context.Context) (cloudpb.DataInges
 	if w.ingestHost == "" {
 		return nil, nil, errors.New("data transfer worker: no ingest endpoint configured")
 	}
-	certPEM, chainPEM, keyData := w.provisioningSvc.ProvisioningCerts()
-	// The identity is the enrolled asset certificate, presented in the TLS
-	// handshake and read by the service from the validated leaf. Nothing else
-	// is sent: no header, nothing from the environment, nothing an app on the
-	// device can influence.
+	certPEM, chainPEM, keyData, source, err := w.ingestIdentity()
+	if err != nil {
+		return nil, nil, err
+	}
+	// The identity is a client certificate, presented in the TLS handshake and
+	// read by the service from the validated leaf. Nothing else is sent: no
+	// header, nothing from the environment, nothing an app on the device can
+	// influence. The server side is verified against the system roots either
+	// way, which is unchanged: the ingest endpoint presents a publicly trusted
+	// certificate.
 	conn, err := func() (*grpc.ClientConn, error) {
 		defer zeroBytes(keyData)
 		return dialCloudMTLS(w.ingestHost, certPEM, chainPEM, keyData)
@@ -209,6 +275,8 @@ func (w *DataTransferWorker) dialFactory(ctx context.Context) (cloudpb.DataInges
 	if err != nil {
 		return nil, nil, err
 	}
+	w.logger.Debug("data transfer worker: dialled ingest",
+		zap.String("host", w.ingestHost), zap.String("identity", string(source)))
 	return cloudpb.NewDataIngestServiceClient(conn), func() { _ = conn.Close() }, nil
 }
 

--- a/go/internal/agent/services/data_transfer_worker_pki_test.go
+++ b/go/internal/agent/services/data_transfer_worker_pki_test.go
@@ -1,0 +1,165 @@
+package services
+
+import (
+	"errors"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/pkienroll"
+)
+
+// stubPKIIdentity stands in for the pki-core store so the choice of identity
+// can be tested without issuing certificates.
+type stubPKIIdentity struct {
+	material pkienroll.Material
+	err      error
+	calls    int
+}
+
+func (s *stubPKIIdentity) Load() (pkienroll.Material, error) {
+	s.calls++
+	return s.material, s.err
+}
+
+// workerWithIdentities builds a worker whose asset (Certificate Authority
+// Service) identity is the given material. ProvisioningService is used
+// directly rather than mocked because ProvisioningCerts reads only its own
+// fields.
+func workerWithIdentities(t *testing.T, assetCert, assetChain, assetKey string) *DataTransferWorker {
+	t.Helper()
+	prov := &ProvisioningService{
+		logger:   zap.NewNop(),
+		enrolled: true,
+		orgID:    2,
+		assetID:  408,
+		certPEM:  assetCert,
+		chainPEM: assetChain,
+		keyPEM:   []byte(assetKey),
+	}
+	return &DataTransferWorker{
+		logger:          zap.NewNop(),
+		provisioningSvc: prov,
+		ingestHost:      "ingest.data.wendy.sh:443",
+	}
+}
+
+func TestIngestIdentityPrefersPKITriple(t *testing.T) {
+	w := workerWithIdentities(t, "asset-leaf", "asset-chain", "asset-key")
+	stub := &stubPKIIdentity{material: pkienroll.Material{
+		LeafPEM:  "pki-leaf",
+		ChainPEM: "pki-chain",
+		KeyData:  []byte("pki-key"),
+	}}
+	w.SetPKIIdentity(stub)
+
+	certPEM, chainPEM, keyData, source, err := w.ingestIdentity()
+	if err != nil {
+		t.Fatalf("ingestIdentity: %v", err)
+	}
+	if source != identitySourcePKI {
+		t.Errorf("source = %q, want %q", source, identitySourcePKI)
+	}
+	if certPEM != "pki-leaf" || chainPEM != "pki-chain" || string(keyData) != "pki-key" {
+		t.Errorf("got (%q, %q, %q), want the pki triple", certPEM, chainPEM, keyData)
+	}
+	if stub.calls != 1 {
+		t.Errorf("store consulted %d times, want 1", stub.calls)
+	}
+}
+
+func TestIngestIdentityFallsBackWhenNoPKIIdentity(t *testing.T) {
+	// No store wired at all: exactly today's behaviour, and the case every
+	// device that has never been enrolled against pki-core is in.
+	w := workerWithIdentities(t, "asset-leaf", "asset-chain", "asset-key")
+	certPEM, chainPEM, keyData, source, err := w.ingestIdentity()
+	if err != nil {
+		t.Fatalf("ingestIdentity: %v", err)
+	}
+	if source != identitySourceAsset {
+		t.Errorf("source = %q, want %q", source, identitySourceAsset)
+	}
+	if certPEM != "asset-leaf" || chainPEM != "asset-chain" || string(keyData) != "asset-key" {
+		t.Errorf("got (%q, %q, %q), want the asset triple", certPEM, chainPEM, keyData)
+	}
+}
+
+func TestIngestIdentityFallsBackOnEmptyStore(t *testing.T) {
+	w := workerWithIdentities(t, "asset-leaf", "asset-chain", "asset-key")
+	w.SetPKIIdentity(&stubPKIIdentity{err: pkienroll.ErrNoIdentity})
+
+	certPEM, _, _, source, err := w.ingestIdentity()
+	if err != nil {
+		t.Fatalf("ingestIdentity: %v", err)
+	}
+	if source != identitySourceAsset {
+		t.Errorf("source = %q, want %q", source, identitySourceAsset)
+	}
+	if certPEM != "asset-leaf" {
+		t.Errorf("certPEM = %q, want the asset leaf", certPEM)
+	}
+}
+
+func TestIngestIdentityFallsBackOnUnreadableStore(t *testing.T) {
+	// A real read fault, not an absent identity. The dial still has to happen,
+	// so the asset certificate is used and the fault is reported rather than
+	// stopping uploads.
+	w := workerWithIdentities(t, "asset-leaf", "asset-chain", "asset-key")
+	w.SetPKIIdentity(&stubPKIIdentity{err: errors.New("permission denied")})
+
+	_, _, _, source, err := w.ingestIdentity()
+	if err != nil {
+		t.Fatalf("ingestIdentity: %v", err)
+	}
+	if source != identitySourceAsset {
+		t.Errorf("source = %q, want %q", source, identitySourceAsset)
+	}
+}
+
+func TestIngestIdentityFallsBackOnHalfWrittenStore(t *testing.T) {
+	// A leaf with no key (or the reverse) is not a usable identity. Presenting
+	// it would fail the handshake, so it must read as absent.
+	for name, material := range map[string]pkienroll.Material{
+		"no key":  {LeafPEM: "pki-leaf"},
+		"no leaf": {KeyData: []byte("pki-key")},
+	} {
+		t.Run(name, func(t *testing.T) {
+			w := workerWithIdentities(t, "asset-leaf", "asset-chain", "asset-key")
+			w.SetPKIIdentity(&stubPKIIdentity{material: material})
+			_, _, _, source, err := w.ingestIdentity()
+			if err != nil {
+				t.Fatalf("ingestIdentity: %v", err)
+			}
+			if source != identitySourceAsset {
+				t.Errorf("source = %q, want %q", source, identitySourceAsset)
+			}
+		})
+	}
+}
+
+func TestIngestIdentityReadsThePKIStorePerDial(t *testing.T) {
+	// The store is consulted on every dial rather than cached, so a device
+	// enrolled after the agent came up switches identity on its next upload
+	// pass without a restart.
+	w := workerWithIdentities(t, "asset-leaf", "asset-chain", "asset-key")
+	stub := &stubPKIIdentity{err: pkienroll.ErrNoIdentity}
+	w.SetPKIIdentity(stub)
+
+	if _, _, _, source, _ := w.ingestIdentity(); source != identitySourceAsset {
+		t.Fatalf("source = %q before enrolment, want %q", source, identitySourceAsset)
+	}
+	stub.err = nil
+	stub.material = pkienroll.Material{LeafPEM: "pki-leaf", KeyData: []byte("pki-key")}
+	if _, _, _, source, _ := w.ingestIdentity(); source != identitySourcePKI {
+		t.Errorf("source = %q after enrolment, want %q", source, identitySourcePKI)
+	}
+}
+
+func TestSetPKIIdentityNilRestoresPreviousBehaviour(t *testing.T) {
+	w := workerWithIdentities(t, "asset-leaf", "asset-chain", "asset-key")
+	w.SetPKIIdentity(&stubPKIIdentity{material: pkienroll.Material{LeafPEM: "pki-leaf", KeyData: []byte("k")}})
+	w.SetPKIIdentity(nil)
+	if _, _, _, source, _ := w.ingestIdentity(); source != identitySourceAsset {
+		t.Errorf("source = %q, want %q", source, identitySourceAsset)
+	}
+}

--- a/go/internal/agent/services/pem_files.go
+++ b/go/internal/agent/services/pem_files.go
@@ -5,64 +5,20 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/atomicfile"
 )
 
 // syncWriteFile atomically writes data to path: write to a temp file, fsync,
 // rename over the target, then fsync the directory. This ensures that a power
 // loss mid-write cannot leave the target file empty or partially written —
 // critical for security files (private keys, certificates) on embedded devices.
+//
+// The implementation now lives in internal/shared/atomicfile so the pki-core
+// enrolment store writes its second PEM triple through exactly the same
+// durability guarantee rather than a second copy of this code.
 func syncWriteFile(path string, data []byte, perm os.FileMode) error {
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, ".pem-tmp-*")
-	if err != nil {
-		return err
-	}
-	tmpName := tmp.Name()
-	removeOnFail := true
-	tmpClosed := false
-	defer func() {
-		if !tmpClosed {
-			_ = tmp.Close() // best-effort: file will be removed in error paths
-		}
-		if removeOnFail {
-			os.Remove(tmpName)
-		}
-	}()
-
-	if err := tmp.Chmod(perm); err != nil {
-		return err
-	}
-	if _, err := tmp.Write(data); err != nil {
-		return err
-	}
-	if err := tmp.Sync(); err != nil {
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	tmpClosed = true
-	if err := os.Rename(tmpName, path); err != nil {
-		return err
-	}
-	removeOnFail = false
-
-	// fsync the directory so the rename is durable on power loss. Open/close
-	// failures are reported too: skipping the fsync silently would drop the
-	// durability guarantee this helper exists to provide.
-	d, err := os.Open(dir)
-	if err != nil {
-		return fmt.Errorf("open dir for fsync after rename: %w", err)
-	}
-	syncErr := d.Sync()
-	closeErr := d.Close()
-	if syncErr != nil {
-		return fmt.Errorf("fsync dir after rename: %w", syncErr)
-	}
-	if closeErr != nil {
-		return fmt.Errorf("close dir after fsync: %w", closeErr)
-	}
-	return nil
+	return atomicfile.Write(path, data, perm)
 }
 
 func WritePEMFiles(configPath, keyPEM, certPEM, chainPEM string) error {

--- a/go/internal/agent/services/pki_enrollment_file.go
+++ b/go/internal/agent/services/pki_enrollment_file.go
@@ -1,0 +1,284 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/pkienroll"
+	"github.com/wendylabsinc/wendy/go/internal/shared/enrolltoken"
+)
+
+// PKIEnrollmentFileName is the staged credential file that hands the agent a
+// pki-core enrollment token once.
+//
+// PRECEDENT. This is deliberately the same mechanism as enrollment.json, read
+// by ApplyEnrollmentFile in enrollment_file.go and written by the installer
+// (go/internal/cli/assets/docs/agent.sh). The properties that made it the right
+// shape there are the same ones needed here: the credential is single-use and
+// short-lived, it has to survive being staged before the agent is running, it
+// must not be added to a long-lived configuration file, and it must be deleted
+// once redeemed. Choosing it over a new provisioning RPC also keeps the change
+// free of a proto addition, so nothing regenerates and no cloud surface grows.
+//
+// The two files never overlap: enrollment.json carries a Wendy Cloud asset
+// token and produces the Certificate Authority Service (CAS) triple, this one
+// carries a pki-core enrollment token and produces the pki-core triple.
+const PKIEnrollmentFileName = "pki-enrollment.json"
+
+// stagedPKIEnrollment is the on-disk shape. Only token is always required:
+// tenantUUID may instead come from the token's own tenant_uuid claim, and
+// csrEndpoint may instead be derived from the environment.
+type stagedPKIEnrollment struct {
+	// Token is the pki-core enrollment token an operator minted through
+	// pki-core's fabric relay. The agent only consumes it.
+	Token string `json:"token"`
+	// TenantUUID is the pki-core tenant. Optional when the token is a Wendy
+	// JWT carrying tenant_uuid; required when it is one of pki-core's own
+	// opaque tokens, which carry no claims at all.
+	TenantUUID string `json:"tenantUUID"`
+	// DeviceID must equal the device_id the token was minted with, byte for
+	// byte. Empty means "use the CSR Common Name", which is the pairing
+	// pki-core's own token minting follows.
+	DeviceID string `json:"deviceID"`
+	// CSREndpoint overrides the derived frontend URL.
+	CSREndpoint string `json:"csrEndpoint"`
+	// Environment is "dev" or "prod" and selects the derived frontend host
+	// when CSREndpoint is empty.
+	Environment string `json:"environment"`
+}
+
+// PKIEnrollment owns the device's pki-core identity: the staged credential
+// file, the PEM triple under <configPath>/pki, and the renewal loop.
+//
+// It never reads or writes the CAS triple. It borrows exactly one thing from
+// the CAS side, the "sh/wendy/<org>/<asset>" Common Name, so that the two CSRs
+// state the same subject and pki-core's dev shim (which derives device_id from
+// the CN) lines up with no special case.
+type PKIEnrollment struct {
+	logger     *zap.Logger
+	configPath string
+	store      *pkienroll.Store
+
+	// provisioningSvc supplies the org and asset the Common Name is built
+	// from. A device that is not yet enrolled with Wendy Cloud has no such
+	// pair, so pki enrolment waits for it rather than inventing one.
+	provisioningSvc *ProvisioningService
+
+	// enroll is indirected for tests.
+	enroll func(context.Context, pkienroll.EnrollRequest) (pkienroll.Result, error)
+	// httpClient, when set, is passed to enroll. Tests point it at an
+	// httptest server; production leaves it nil for the package default.
+	httpClient *http.Client
+}
+
+// NewPKIEnrollment builds the pki identity manager for configPath.
+func NewPKIEnrollment(logger *zap.Logger, configPath string, provisioningSvc *ProvisioningService) *PKIEnrollment {
+	return &PKIEnrollment{
+		logger:          logger,
+		configPath:      configPath,
+		store:           pkienroll.NewStore(configPath),
+		provisioningSvc: provisioningSvc,
+		enroll:          pkienroll.Enroll,
+	}
+}
+
+// Store is the PEM triple the data platform dialer reads.
+func (p *PKIEnrollment) Store() *pkienroll.Store { return p.store }
+
+// StagedFilePath is where the credential is expected.
+func (p *PKIEnrollment) StagedFilePath() string {
+	return filepath.Join(p.configPath, PKIEnrollmentFileName)
+}
+
+// ApplyStagedFile enrolls the device against pki-core from a staged token, then
+// deletes the file. It is best-effort and safe to call unconditionally at
+// startup: an absent file is a no-op, an already-enrolled store keeps its
+// identity and clears the file, and a malformed or refused token is logged and
+// the file removed because the token's own short lifetime self-limits it
+// anyway. This mirrors ApplyEnrollmentFile, including the bounded three
+// attempts for a slow boot-time network.
+func (p *PKIEnrollment) ApplyStagedFile(ctx context.Context) {
+	path := p.StagedFilePath()
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return
+	}
+	if err != nil {
+		p.logger.Error("Failed to read pki enrollment file", zap.String("path", path), zap.Error(err))
+		p.removeStagedFile(path)
+		return
+	}
+
+	if p.store.Has() {
+		// Renewal, not re-enrolment, keeps an existing identity alive. Burning
+		// a fresh single-use token to replace a working certificate would also
+		// discard the renewal lineage pki-core tracks against it.
+		p.logger.Info("pki identity already present; discarding staged pki enrollment token",
+			zap.String("leaf", p.store.LeafPath()))
+		p.removeStagedFile(path)
+		return
+	}
+
+	var staged stagedPKIEnrollment
+	if err := json.Unmarshal(data, &staged); err != nil {
+		p.logger.Error("Failed to parse pki enrollment file, removing", zap.Error(err))
+		p.removeStagedFile(path)
+		return
+	}
+	if staged.Token == "" {
+		p.logger.Error("pki enrollment file carries no token, removing")
+		p.removeStagedFile(path)
+		return
+	}
+
+	tenantUUID, ok := p.resolveTenant(staged)
+	if !ok {
+		p.logger.Error("pki enrollment file has no tenant: the token carries no tenant_uuid claim " +
+			"and no tenantUUID was staged; removing")
+		p.removeStagedFile(path)
+		return
+	}
+	commonName, ok := p.commonName()
+	if !ok {
+		// Left in place on purpose: this is the one failure a later retry can
+		// fix without a new token, because the cloud enrolment that supplies
+		// the org and asset pair may simply not have happened yet.
+		p.logger.Warn("pki enrollment deferred: the device is not enrolled with Wendy Cloud yet, " +
+			"so the certificate Common Name cannot be built; the staged token is kept")
+		return
+	}
+
+	frontendURL := pkienroll.CSRFrontendURL(staged.CSREndpoint, staged.Environment)
+
+	key, err := p.store.LoadOrGenerateKey()
+	if err != nil {
+		p.logger.Error("Failed to prepare pki identity key", zap.Error(err))
+		p.removeStagedFile(path)
+		return
+	}
+	defer zeroBytes(key)
+
+	var lastErr error
+	for attempt := 1; attempt <= 3; attempt++ {
+		var result pkienroll.Result
+		result, lastErr = p.enroll(ctx, pkienroll.EnrollRequest{
+			CSRFrontendURL:  frontendURL,
+			TenantUUID:      tenantUUID,
+			EnrollmentToken: staged.Token,
+			Key:             key,
+			CommonName:      commonName,
+			DeviceID:        staged.DeviceID,
+			HTTPClient:      p.httpClient,
+		})
+		if lastErr == nil {
+			if err := p.store.Save(result); err != nil {
+				lastErr = fmt.Errorf("storing pki identity: %w", err)
+				break
+			}
+			if err := p.store.SaveMetadata(pkienroll.Metadata{
+				TenantUUID:  tenantUUID,
+				CSREndpoint: frontendURL,
+				DeviceName:  result.DeviceName,
+			}); err != nil {
+				// The identity is usable; only renewal loses its bearings, so
+				// this is reported and not treated as an enrolment failure.
+				p.logger.Warn("pki identity stored but its metadata could not be written; "+
+					"renewal will not start until this is fixed", zap.Error(err))
+			}
+			p.logger.Info("Enrolled pki-core device identity",
+				zap.String("spiffe_uri", result.SPIFFEURI),
+				zap.String("device_name", result.DeviceName),
+				zap.Time("not_after", result.NotAfter),
+				zap.String("leaf", p.store.LeafPath()))
+			break
+		}
+
+		// A refused credential will be refused identically on a retry: the
+		// token is single-use and consumed atomically with issuance, so a 401
+		// means it is wrong, already spent or revoked. Retrying only delays
+		// the message that a fresh token is needed.
+		var statusErr *pkienroll.StatusError
+		if errors.As(lastErr, &statusErr) && statusErr.Unauthorized() {
+			break
+		}
+		var identityErr *pkienroll.IdentityError
+		if errors.As(lastErr, &identityErr) {
+			break
+		}
+		p.logger.Warn("pki enrollment attempt failed", zap.Int("attempt", attempt), zap.Error(lastErr))
+		if attempt < 3 {
+			select {
+			case <-ctx.Done():
+				lastErr = ctx.Err()
+			case <-time.After(5 * time.Second):
+			}
+		}
+	}
+	if lastErr != nil {
+		p.logger.Error("pki-core enrollment from staged token failed; "+
+			"a fresh enrollment token has to be minted and staged again",
+			zap.String("tenant", tenantUUID), zap.String("frontend", frontendURL), zap.Error(lastErr))
+	}
+	p.removeStagedFile(path)
+}
+
+// Renewer builds the renewal loop for the stored identity, or nil when there is
+// nothing to renew. nil is an ordinary answer: a device with no pki identity
+// has no renewal to run.
+func (p *PKIEnrollment) Renewer() *pkienroll.Renewer {
+	meta, err := p.store.LoadMetadata()
+	if err != nil {
+		p.logger.Warn("Failed to read pki identity metadata; renewal is not started", zap.Error(err))
+		return nil
+	}
+	if meta.TenantUUID == "" || meta.CSREndpoint == "" {
+		return nil
+	}
+	return pkienroll.NewRenewer(p.logger, p.store, meta.CSREndpoint, meta.TenantUUID)
+}
+
+// resolveTenant prefers the token's own tenant_uuid claim over the staged
+// field, so an operator who staged the wrong tenant alongside a Wendy-minted
+// token cannot send the enrolment to a tenant the token was not for. The
+// staged field is the fallback, and the only source for pki-core's own opaque
+// tokens.
+func (p *PKIEnrollment) resolveTenant(staged stagedPKIEnrollment) (string, bool) {
+	if claimed, ok := enrolltoken.TenantUUIDFromToken(staged.Token); ok {
+		if staged.TenantUUID != "" && staged.TenantUUID != claimed {
+			p.logger.Warn("staged tenantUUID disagrees with the token's tenant_uuid claim; using the claim",
+				zap.String("staged", staged.TenantUUID), zap.String("claim", claimed))
+		}
+		return claimed, true
+	}
+	if staged.TenantUUID != "" {
+		return staged.TenantUUID, true
+	}
+	return "", false
+}
+
+// commonName is the "sh/wendy/<org>/<asset>" subject the agent already builds
+// for its CAS certificate.
+func (p *PKIEnrollment) commonName() (string, bool) {
+	if p.provisioningSvc == nil {
+		return "", false
+	}
+	_, orgID, assetID, enrolled := p.provisioningSvc.ProvisioningInfo()
+	if !enrolled || orgID == 0 || assetID == 0 {
+		return "", false
+	}
+	return fmt.Sprintf("sh/wendy/%d/%d", orgID, assetID), true
+}
+
+func (p *PKIEnrollment) removeStagedFile(path string) {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		p.logger.Warn("Failed to remove pki enrollment file", zap.String("path", path), zap.Error(err))
+	}
+}

--- a/go/internal/agent/services/pki_enrollment_file.go
+++ b/go/internal/agent/services/pki_enrollment_file.go
@@ -31,7 +31,7 @@ import (
 // The two files never overlap: enrollment.json carries a Wendy Cloud asset
 // token and produces the Certificate Authority Service (CAS) triple, this one
 // carries a pki-core enrollment token and produces the pki-core triple.
-const PKIEnrollmentFileName = "pki-enrollment.json"
+const PKIEnrollmentFileName = pkienroll.StagedFileName
 
 // stagedPKIEnrollment is the on-disk shape. Only token is always required:
 // tenantUUID may instead come from the token's own tenant_uuid claim, and

--- a/go/internal/agent/services/pki_enrollment_file_test.go
+++ b/go/internal/agent/services/pki_enrollment_file_test.go
@@ -1,0 +1,293 @@
+package services
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/pkienroll"
+)
+
+func newTestPKIEnrollment(t *testing.T, configPath string, enrolledWithCloud bool) *PKIEnrollment {
+	t.Helper()
+	prov := &ProvisioningService{
+		logger:     zap.NewNop(),
+		configPath: configPath,
+		enrolled:   enrolledWithCloud,
+	}
+	if enrolledWithCloud {
+		prov.orgID = 2
+		prov.assetID = 408
+	}
+	return NewPKIEnrollment(zap.NewNop(), configPath, prov)
+}
+
+func stageFile(t *testing.T, configPath string, staged map[string]string) string {
+	t.Helper()
+	data, err := json.Marshal(staged)
+	if err != nil {
+		t.Fatalf("encoding staged file: %v", err)
+	}
+	path := filepath.Join(configPath, PKIEnrollmentFileName)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("writing staged file: %v", err)
+	}
+	return path
+}
+
+// jwtWithTenant builds a token whose payload carries a tenant_uuid claim. The
+// signature is not checked here or by the agent: verification is the issuer's
+// job at certificate-issuance time.
+func jwtWithTenant(t *testing.T, tenant string) string {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{"type": "asset_enrollment", "org_id": 2, "asset_id": 408, "tenant_uuid": tenant})
+	if err != nil {
+		t.Fatalf("encoding claims: %v", err)
+	}
+	enc := base64.RawURLEncoding.EncodeToString
+	return enc([]byte(`{"alg":"none"}`)) + "." + enc(payload) + "." + "sig"
+}
+
+func TestApplyStagedFileEnrollsAndDeletes(t *testing.T) {
+	dir := t.TempDir()
+	p := newTestPKIEnrollment(t, dir, true)
+	path := stageFile(t, dir, map[string]string{
+		"token":       "tok-abc",
+		"tenantUUID":  "022b7284-f7f3-4d86-b844-d105a7c06d9e",
+		"csrEndpoint": "https://csr.dev.pki.wendy.sh",
+	})
+
+	var got pkienroll.EnrollRequest
+	p.enroll = func(_ context.Context, req pkienroll.EnrollRequest) (pkienroll.Result, error) {
+		got = req
+		return pkienroll.Result{
+			LeafPEM:    "-----BEGIN CERTIFICATE-----\nleaf\n-----END CERTIFICATE-----\n",
+			ChainPEM:   "-----BEGIN CERTIFICATE-----\nchain\n-----END CERTIFICATE-----\n",
+			DeviceName: "sh/wendy/2/408",
+			SPIFFEURI:  "spiffe://wendy.sh/tenant/022b7284-f7f3-4d86-b844-d105a7c06d9e/device/sh/wendy/2/408",
+		}, nil
+	}
+	p.ApplyStagedFile(context.Background())
+
+	if got.EnrollmentToken != "tok-abc" {
+		t.Errorf("token = %q", got.EnrollmentToken)
+	}
+	if got.TenantUUID != "022b7284-f7f3-4d86-b844-d105a7c06d9e" {
+		t.Errorf("tenant = %q", got.TenantUUID)
+	}
+	if got.CSRFrontendURL != "https://csr.dev.pki.wendy.sh" {
+		t.Errorf("frontend = %q", got.CSRFrontendURL)
+	}
+	// The Common Name is the same "sh/wendy/<org>/<asset>" the agent builds
+	// for its Certificate Authority Service certificate, so the two CSRs state
+	// the same subject.
+	if got.CommonName != "sh/wendy/2/408" {
+		t.Errorf("common name = %q, want sh/wendy/2/408", got.CommonName)
+	}
+	if len(got.Key) == 0 {
+		t.Error("no key was passed; one must be generated on the device")
+	}
+
+	if !p.Store().Has() {
+		t.Error("the issued identity was not stored")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("the staged credential file was not deleted after redemption")
+	}
+	meta, err := p.Store().LoadMetadata()
+	if err != nil {
+		t.Fatalf("LoadMetadata: %v", err)
+	}
+	if meta.TenantUUID == "" || meta.CSREndpoint == "" {
+		t.Errorf("metadata = %+v, want the tenant and frontend renewal needs", meta)
+	}
+	if p.Renewer() == nil {
+		t.Error("Renewer = nil after a successful enrolment")
+	}
+}
+
+func TestApplyStagedFilePrefersTheTokenClaim(t *testing.T) {
+	dir := t.TempDir()
+	p := newTestPKIEnrollment(t, dir, true)
+	claimTenant := "022b7284-f7f3-4d86-b844-d105a7c06d9e"
+	stageFile(t, dir, map[string]string{
+		// A staged tenant that disagrees with the token must not win: the
+		// token is only valid for the tenant it was minted in.
+		"token":      jwtWithTenant(t, claimTenant),
+		"tenantUUID": "99999999-9999-9999-9999-999999999999",
+	})
+
+	var got pkienroll.EnrollRequest
+	p.enroll = func(_ context.Context, req pkienroll.EnrollRequest) (pkienroll.Result, error) {
+		got = req
+		return pkienroll.Result{LeafPEM: "leaf"}, nil
+	}
+	p.ApplyStagedFile(context.Background())
+
+	if got.TenantUUID != claimTenant {
+		t.Errorf("tenant = %q, want the token's tenant_uuid claim %q", got.TenantUUID, claimTenant)
+	}
+}
+
+func TestApplyStagedFileDerivesTheFrontendFromEnvironment(t *testing.T) {
+	dir := t.TempDir()
+	p := newTestPKIEnrollment(t, dir, true)
+	stageFile(t, dir, map[string]string{
+		"token":       "tok",
+		"tenantUUID":  "022b7284-f7f3-4d86-b844-d105a7c06d9e",
+		"environment": "dev",
+	})
+
+	var got pkienroll.EnrollRequest
+	p.enroll = func(_ context.Context, req pkienroll.EnrollRequest) (pkienroll.Result, error) {
+		got = req
+		return pkienroll.Result{LeafPEM: "leaf"}, nil
+	}
+	p.ApplyStagedFile(context.Background())
+
+	if want := "https://" + pkienroll.DevCSRFrontendHost; got.CSRFrontendURL != want {
+		t.Errorf("frontend = %q, want %q", got.CSRFrontendURL, want)
+	}
+}
+
+func TestApplyStagedFileNoFileIsANoOp(t *testing.T) {
+	dir := t.TempDir()
+	p := newTestPKIEnrollment(t, dir, true)
+	p.enroll = func(context.Context, pkienroll.EnrollRequest) (pkienroll.Result, error) {
+		t.Fatal("enrolled with no staged file")
+		return pkienroll.Result{}, nil
+	}
+	p.ApplyStagedFile(context.Background())
+	if p.Renewer() != nil {
+		t.Error("Renewer is non-nil with no identity")
+	}
+}
+
+func TestApplyStagedFileKeepsAnExistingIdentity(t *testing.T) {
+	dir := t.TempDir()
+	p := newTestPKIEnrollment(t, dir, true)
+	if _, err := p.Store().LoadOrGenerateKey(); err != nil {
+		t.Fatalf("LoadOrGenerateKey: %v", err)
+	}
+	if err := p.Store().Save(pkienroll.Result{LeafPEM: "existing-leaf"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	path := stageFile(t, dir, map[string]string{"token": "tok", "tenantUUID": "t"})
+
+	p.enroll = func(context.Context, pkienroll.EnrollRequest) (pkienroll.Result, error) {
+		t.Fatal("re-enrolled over a working identity; renewal keeps it alive instead")
+		return pkienroll.Result{}, nil
+	}
+	p.ApplyStagedFile(context.Background())
+
+	material, err := p.Store().Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if material.LeafPEM != "existing-leaf" {
+		t.Errorf("leaf = %q, want the existing identity untouched", material.LeafPEM)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("the redundant staged token was not cleared")
+	}
+}
+
+func TestApplyStagedFileRemovesUnusableFiles(t *testing.T) {
+	for name, contents := range map[string]string{
+		"malformed json": "{not json",
+		"no token":       `{"tenantUUID":"022b7284-f7f3-4d86-b844-d105a7c06d9e"}`,
+		"no tenant":      `{"token":"opaque-pki-core-token"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			p := newTestPKIEnrollment(t, dir, true)
+			path := filepath.Join(dir, PKIEnrollmentFileName)
+			if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+				t.Fatalf("writing staged file: %v", err)
+			}
+			p.enroll = func(context.Context, pkienroll.EnrollRequest) (pkienroll.Result, error) {
+				t.Fatal("enrolled from an unusable staged file")
+				return pkienroll.Result{}, nil
+			}
+			p.ApplyStagedFile(context.Background())
+			if _, err := os.Stat(path); !os.IsNotExist(err) {
+				t.Error("the unusable file was left in place")
+			}
+		})
+	}
+}
+
+func TestApplyStagedFileKeepsTokenWhenNotCloudEnrolled(t *testing.T) {
+	// The one deferral: without a Wendy Cloud org and asset there is no Common
+	// Name to build, and that is fixable later without a new token. Keeping
+	// the file is the difference between a deferred enrolment and a burnt
+	// credential.
+	dir := t.TempDir()
+	p := newTestPKIEnrollment(t, dir, false)
+	path := stageFile(t, dir, map[string]string{"token": "tok", "tenantUUID": "022b7284-f7f3-4d86-b844-d105a7c06d9e"})
+
+	p.enroll = func(context.Context, pkienroll.EnrollRequest) (pkienroll.Result, error) {
+		t.Fatal("enrolled before the device has an org and asset")
+		return pkienroll.Result{}, nil
+	}
+	p.ApplyStagedFile(context.Background())
+
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("the staged token was removed although it is still usable: %v", err)
+	}
+}
+
+func TestApplyStagedFileDoesNotRetryARefusedToken(t *testing.T) {
+	// A 401 will be refused identically on a retry: the token is single-use
+	// and consumed atomically with issuance, so retrying only delays the
+	// message that a fresh one is needed.
+	dir := t.TempDir()
+	p := newTestPKIEnrollment(t, dir, true)
+	stageFile(t, dir, map[string]string{"token": "spent", "tenantUUID": "022b7284-f7f3-4d86-b844-d105a7c06d9e"})
+
+	attempts := 0
+	p.enroll = func(context.Context, pkienroll.EnrollRequest) (pkienroll.Result, error) {
+		attempts++
+		return pkienroll.Result{}, &pkienroll.StatusError{StatusCode: 401, Detail: "bearer token required"}
+	}
+	p.ApplyStagedFile(context.Background())
+
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1", attempts)
+	}
+	if p.Store().Has() {
+		t.Error("something was stored after a refusal")
+	}
+}
+
+func TestApplyStagedFileDoesNotStoreAWrongIdentity(t *testing.T) {
+	dir := t.TempDir()
+	p := newTestPKIEnrollment(t, dir, true)
+	stageFile(t, dir, map[string]string{"token": "tok", "tenantUUID": "022b7284-f7f3-4d86-b844-d105a7c06d9e"})
+
+	attempts := 0
+	p.enroll = func(context.Context, pkienroll.EnrollRequest) (pkienroll.Result, error) {
+		attempts++
+		return pkienroll.Result{}, &pkienroll.IdentityError{Want: "device", Got: []string{"spiffe://wendy.sh/tenant/x/service/y"}}
+	}
+	p.ApplyStagedFile(context.Background())
+
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1: a wrong identity is not a transient failure", attempts)
+	}
+	if p.Store().Has() {
+		t.Error("a leaf with the wrong principal was stored")
+	}
+}
+
+func TestRenewerNilWithoutMetadata(t *testing.T) {
+	p := newTestPKIEnrollment(t, t.TempDir(), true)
+	if p.Renewer() != nil {
+		t.Error("Renewer is non-nil with no stored metadata")
+	}
+}

--- a/go/internal/cli/commands/data.go
+++ b/go/internal/cli/commands/data.go
@@ -21,7 +21,7 @@ import (
 
 func newDataCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "data", Short: "Record and retrieve synchronized device data"}
-	cmd.AddCommand(newDataSourcesCmd(), newDataRecordCmd(), newDataStopCmd(), newDataEpisodesCmd(), newDataInspectCmd(), newDataDownloadCmd(), newDataCampaignCmd())
+	cmd.AddCommand(newDataSourcesCmd(), newDataRecordCmd(), newDataStopCmd(), newDataEpisodesCmd(), newDataInspectCmd(), newDataDownloadCmd(), newDataCampaignCmd(), newDataEnrollCmd())
 	return cmd
 }
 

--- a/go/internal/cli/commands/data_enroll.go
+++ b/go/internal/cli/commands/data_enroll.go
@@ -1,0 +1,139 @@
+package commands
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/pkienroll"
+	"github.com/wendylabsinc/wendy/go/internal/agent/services"
+	"github.com/wendylabsinc/wendy/go/internal/shared/atomicfile"
+	"github.com/wendylabsinc/wendy/go/internal/shared/enrolltoken"
+)
+
+// defaultAgentConfigPath is the agent's config directory, the same default
+// wendy-agent applies and overrides with WENDY_CONFIG_PATH.
+const defaultAgentConfigPath = "/etc/wendy-agent"
+
+// newDataEnrollCmd stages a pki-core enrollment token for the agent.
+//
+// WHY A STAGED FILE AND NOT AN RPC. The agent already takes exactly one
+// one-shot provisioning input this way: agent.sh writes
+// <configPath>/enrollment.json and ApplyEnrollmentFile
+// (go/internal/agent/services/enrollment_file.go) redeems and deletes it at
+// startup. Following that precedent keeps the credential off the control plane
+// and out of any long-lived configuration file, and adds no proto surface for
+// a token that is used once. This command is the operator-facing way to write
+// that file, so nobody has to hand-compose JSON on a device.
+//
+// It runs ON the device, next to the agent whose files it writes.
+func newDataEnrollCmd() *cobra.Command {
+	var (
+		tenant      string
+		token       string
+		deviceID    string
+		csrEndpoint string
+		environment string
+		configPath  string
+	)
+	cmd := &cobra.Command{
+		Use:   "enroll",
+		Short: "Stage a pki-core device enrollment token for the agent",
+		Long: strings.TrimSpace(`
+Stage a pki-core enrollment token so the agent enrolls a data platform device
+identity on its next start.
+
+The identity is a second certificate: its only URI Subject Alternative Name is
+spiffe://wendy.sh/tenant/<tenant>/device/<name>, and it is presented to the
+Wendy Data Platform ingest endpoint. The certificate the device presents to
+Wendy Cloud is not touched, because Wendy Cloud's interceptors read only the
+urn:wendy:org: form.
+
+The token is minted by an operator through pki-core's fabric relay and is
+single-use. --tenant may be omitted when the token carries a tenant_uuid claim.
+The SPIFFE device name is fixed when the token is minted, so --device-id must
+match the token's device_id byte for byte; omit it to use the certificate
+Common Name the agent already builds.
+
+This command writes a file the agent reads at startup; it does not contact
+pki-core. Run it on the device.`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if strings.TrimSpace(token) == "" {
+				return errors.New("--token is required")
+			}
+			if strings.TrimSpace(tenant) == "" {
+				claimed, ok := enrolltoken.TenantUUIDFromToken(token)
+				if !ok {
+					return errors.New("--tenant is required: the token carries no tenant_uuid claim")
+				}
+				tenant = claimed
+			}
+			if configPath == "" {
+				configPath = agentConfigPath()
+			}
+			path, err := stagePKIEnrollment(configPath, tenant, token, deviceID, csrEndpoint, environment)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(),
+				"Staged pki-core enrollment token at %s\n"+
+					"  tenant:   %s\n"+
+					"  frontend: %s\n"+
+					"The agent redeems and deletes it on its next start; restart wendy-agent to apply now.\n",
+				path, tenant, pkienroll.CSRFrontendURL(csrEndpoint, environment))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&tenant, "tenant", "", "pki-core tenant UUID (default: the token's tenant_uuid claim)")
+	cmd.Flags().StringVar(&token, "token", "", "pki-core enrollment token (required)")
+	cmd.Flags().StringVar(&deviceID, "device-id", "", "device_id the token was minted with (default: the agent's certificate Common Name)")
+	cmd.Flags().StringVar(&csrEndpoint, "csr-endpoint", "", "pki-core CSR frontend URL (default: derived from --environment)")
+	cmd.Flags().StringVar(&environment, "environment", "", "\"dev\" or \"prod\"; selects the derived CSR frontend host")
+	cmd.Flags().StringVar(&configPath, "config-path", "", "agent config directory (default: $WENDY_CONFIG_PATH or "+defaultAgentConfigPath+")")
+	return cmd
+}
+
+// agentConfigPath resolves the agent's config directory the same way the agent
+// does, so staging a file here and reading it there cannot disagree.
+func agentConfigPath() string {
+	if v := strings.TrimSpace(os.Getenv("WENDY_CONFIG_PATH")); v != "" {
+		return v
+	}
+	return defaultAgentConfigPath
+}
+
+// stagePKIEnrollment writes the credential file. 0600 and atomic: it holds a
+// bearer credential, and a half-written one would be redeemed and burned.
+func stagePKIEnrollment(configPath, tenant, token, deviceID, csrEndpoint, environment string) (string, error) {
+	if err := os.MkdirAll(configPath, 0o700); err != nil {
+		return "", fmt.Errorf("creating agent config directory %s: %w", configPath, err)
+	}
+	payload := map[string]string{
+		"token":      token,
+		"tenantUUID": tenant,
+	}
+	for k, v := range map[string]string{
+		"deviceID":    deviceID,
+		"csrEndpoint": csrEndpoint,
+		"environment": environment,
+	} {
+		if strings.TrimSpace(v) != "" {
+			payload[k] = v
+		}
+	}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("encoding pki enrollment file: %w", err)
+	}
+	path := filepath.Join(configPath, services.PKIEnrollmentFileName)
+	if err := atomicfile.Write(path, append(data, '\n'), 0o600); err != nil {
+		return "", fmt.Errorf("writing %s: %w", path, err)
+	}
+	return path, nil
+}

--- a/go/internal/cli/commands/data_enroll.go
+++ b/go/internal/cli/commands/data_enroll.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/wendylabsinc/wendy/go/internal/agent/pkienroll"
-	"github.com/wendylabsinc/wendy/go/internal/agent/services"
 	"github.com/wendylabsinc/wendy/go/internal/shared/atomicfile"
 	"github.com/wendylabsinc/wendy/go/internal/shared/enrolltoken"
 )
@@ -131,7 +130,7 @@ func stagePKIEnrollment(configPath, tenant, token, deviceID, csrEndpoint, enviro
 	if err != nil {
 		return "", fmt.Errorf("encoding pki enrollment file: %w", err)
 	}
-	path := filepath.Join(configPath, services.PKIEnrollmentFileName)
+	path := filepath.Join(configPath, pkienroll.StagedFileName)
 	if err := atomicfile.Write(path, append(data, '\n'), 0o600); err != nil {
 		return "", fmt.Errorf("writing %s: %w", path, err)
 	}

--- a/go/internal/cli/commands/data_enroll_test.go
+++ b/go/internal/cli/commands/data_enroll_test.go
@@ -1,0 +1,130 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/services"
+)
+
+func runDataEnroll(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := newDataEnrollCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+func readStaged(t *testing.T, dir string) map[string]string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, services.PKIEnrollmentFileName))
+	if err != nil {
+		t.Fatalf("reading staged file: %v", err)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("decoding staged file: %v", err)
+	}
+	return got
+}
+
+func TestDataEnrollStagesTheCredential(t *testing.T) {
+	dir := t.TempDir()
+	out, err := runDataEnroll(t,
+		"--tenant", "022b7284-f7f3-4d86-b844-d105a7c06d9e",
+		"--token", "tok-abc",
+		"--device-id", "sh/wendy/2/408",
+		"--environment", "dev",
+		"--config-path", dir,
+	)
+	if err != nil {
+		t.Fatalf("data enroll: %v (%s)", err, out)
+	}
+
+	got := readStaged(t, dir)
+	if got["token"] != "tok-abc" {
+		t.Errorf("token = %q", got["token"])
+	}
+	if got["tenantUUID"] != "022b7284-f7f3-4d86-b844-d105a7c06d9e" {
+		t.Errorf("tenantUUID = %q", got["tenantUUID"])
+	}
+	if got["deviceID"] != "sh/wendy/2/408" {
+		t.Errorf("deviceID = %q", got["deviceID"])
+	}
+	if got["environment"] != "dev" {
+		t.Errorf("environment = %q", got["environment"])
+	}
+	// Optional fields that were not given must be absent rather than empty,
+	// so the agent's own defaulting decides them.
+	if _, present := got["csrEndpoint"]; present {
+		t.Error("csrEndpoint was written although it was not given")
+	}
+
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(filepath.Join(dir, services.PKIEnrollmentFileName))
+		if err != nil {
+			t.Fatalf("stat staged file: %v", err)
+		}
+		// It holds a bearer credential.
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Errorf("mode = %v, want 0600", got)
+		}
+	}
+}
+
+func TestDataEnrollTakesTheTenantFromTheTokenClaim(t *testing.T) {
+	dir := t.TempDir()
+	enc := base64.RawURLEncoding.EncodeToString
+	payload, err := json.Marshal(map[string]any{"type": "asset_enrollment", "org_id": 2, "asset_id": 408,
+		"tenant_uuid": "022b7284-f7f3-4d86-b844-d105a7c06d9e"})
+	if err != nil {
+		t.Fatalf("encoding claims: %v", err)
+	}
+	token := enc([]byte(`{"alg":"none"}`)) + "." + enc(payload) + ".sig"
+
+	if out, err := runDataEnroll(t, "--token", token, "--config-path", dir); err != nil {
+		t.Fatalf("data enroll: %v (%s)", err, out)
+	}
+	if got := readStaged(t, dir)["tenantUUID"]; got != "022b7284-f7f3-4d86-b844-d105a7c06d9e" {
+		t.Errorf("tenantUUID = %q, want the token's claim", got)
+	}
+}
+
+func TestDataEnrollRequiresATenantForAnOpaqueToken(t *testing.T) {
+	// pki-core's own enrollment tokens are opaque and carry no claims, so the
+	// tenant has to be given. Refusing here is better than staging a file the
+	// agent will reject at startup.
+	dir := t.TempDir()
+	_, err := runDataEnroll(t, "--token", "opaque-value", "--config-path", dir)
+	if err == nil {
+		t.Fatal("want an error naming --tenant")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, services.PKIEnrollmentFileName)); !os.IsNotExist(statErr) {
+		t.Error("a file was staged despite the refusal")
+	}
+}
+
+func TestDataEnrollRequiresAToken(t *testing.T) {
+	if _, err := runDataEnroll(t, "--tenant", "t", "--config-path", t.TempDir()); err == nil {
+		t.Fatal("want an error naming --token")
+	}
+}
+
+func TestAgentConfigPathFollowsTheAgent(t *testing.T) {
+	t.Setenv("WENDY_CONFIG_PATH", "")
+	if got := agentConfigPath(); got != defaultAgentConfigPath {
+		t.Errorf("agentConfigPath = %q, want %q", got, defaultAgentConfigPath)
+	}
+	t.Setenv("WENDY_CONFIG_PATH", "/tmp/wendy-scratch")
+	if got := agentConfigPath(); got != "/tmp/wendy-scratch" {
+		t.Errorf("agentConfigPath = %q, want the override", got)
+	}
+}

--- a/go/internal/cli/commands/data_enroll_test.go
+++ b/go/internal/cli/commands/data_enroll_test.go
@@ -9,7 +9,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/wendylabsinc/wendy/go/internal/agent/services"
+	"github.com/wendylabsinc/wendy/go/internal/agent/pkienroll"
 )
 
 func runDataEnroll(t *testing.T, args ...string) (string, error) {
@@ -25,7 +25,7 @@ func runDataEnroll(t *testing.T, args ...string) (string, error) {
 
 func readStaged(t *testing.T, dir string) map[string]string {
 	t.Helper()
-	data, err := os.ReadFile(filepath.Join(dir, services.PKIEnrollmentFileName))
+	data, err := os.ReadFile(filepath.Join(dir, pkienroll.StagedFileName))
 	if err != nil {
 		t.Fatalf("reading staged file: %v", err)
 	}
@@ -69,7 +69,7 @@ func TestDataEnrollStagesTheCredential(t *testing.T) {
 	}
 
 	if runtime.GOOS != "windows" {
-		info, err := os.Stat(filepath.Join(dir, services.PKIEnrollmentFileName))
+		info, err := os.Stat(filepath.Join(dir, pkienroll.StagedFileName))
 		if err != nil {
 			t.Fatalf("stat staged file: %v", err)
 		}
@@ -107,7 +107,7 @@ func TestDataEnrollRequiresATenantForAnOpaqueToken(t *testing.T) {
 	if err == nil {
 		t.Fatal("want an error naming --tenant")
 	}
-	if _, statErr := os.Stat(filepath.Join(dir, services.PKIEnrollmentFileName)); !os.IsNotExist(statErr) {
+	if _, statErr := os.Stat(filepath.Join(dir, pkienroll.StagedFileName)); !os.IsNotExist(statErr) {
 		t.Error("a file was staged despite the refusal")
 	}
 }

--- a/go/internal/shared/atomicfile/atomicfile.go
+++ b/go/internal/shared/atomicfile/atomicfile.go
@@ -1,0 +1,76 @@
+// Package atomicfile writes a file so that a power loss cannot leave a partial
+// one behind.
+//
+// It is the implementation that used to live as services.syncWriteFile, lifted
+// here unchanged so that code outside the agent's services package can share it
+// rather than grow a second, subtly different copy. The agent writes private
+// keys and certificates on embedded devices that lose power without warning,
+// and a half-written key file is indistinguishable from a corrupt one.
+package atomicfile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Write atomically writes data to path: write to a temp file in the same
+// directory, fsync it, rename it over the target, then fsync the directory so
+// the rename itself is durable.
+//
+// perm is applied to the temp file before the rename, so the target never
+// exists with a wider mode than asked for — which is why a 0o600 key file is
+// never briefly world-readable.
+func Write(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".pem-tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	removeOnFail := true
+	tmpClosed := false
+	defer func() {
+		if !tmpClosed {
+			_ = tmp.Close() // best-effort: file will be removed in error paths
+		}
+		if removeOnFail {
+			os.Remove(tmpName)
+		}
+	}()
+
+	if err := tmp.Chmod(perm); err != nil {
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	tmpClosed = true
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	removeOnFail = false
+
+	// fsync the directory so the rename is durable on power loss. Open/close
+	// failures are reported too: skipping the fsync silently would drop the
+	// durability guarantee this helper exists to provide.
+	d, err := os.Open(dir)
+	if err != nil {
+		return fmt.Errorf("open dir for fsync after rename: %w", err)
+	}
+	syncErr := d.Sync()
+	closeErr := d.Close()
+	if syncErr != nil {
+		return fmt.Errorf("fsync dir after rename: %w", syncErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close dir after fsync: %w", closeErr)
+	}
+	return nil
+}

--- a/go/internal/shared/atomicfile/atomicfile_test.go
+++ b/go/internal/shared/atomicfile/atomicfile_test.go
@@ -1,0 +1,63 @@
+package atomicfile
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestWriteCreatesTheFileWithTheGivenMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "device-key.pem")
+	if err := Write(path, []byte("key material\n"), 0o600); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != "key material\n" {
+		t.Errorf("contents = %q", data)
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("Stat: %v", err)
+		}
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Errorf("mode = %v, want 0600", got)
+		}
+	}
+}
+
+func TestWriteReplacesAndLeavesNoTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "device.pem")
+	if err := Write(path, []byte("first"), 0o644); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := Write(path, []byte("second"), 0o644); err != nil {
+		t.Fatalf("Write (replace): %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != "second" {
+		t.Errorf("contents = %q, want the replacement", data)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("directory holds %d entries, want only the target: %v", len(entries), entries)
+	}
+}
+
+func TestWriteFailsOnAMissingDirectory(t *testing.T) {
+	if err := Write(filepath.Join(t.TempDir(), "nope", "device.pem"), []byte("x"), 0o600); err == nil {
+		t.Error("Write into a missing directory returned no error")
+	}
+}

--- a/go/internal/shared/certs/orgident.go
+++ b/go/internal/shared/certs/orgident.go
@@ -36,6 +36,74 @@ func AssetURN(orgID, assetID int32) string {
 	return WendyIdentity{OrgID: orgID, EntityType: "asset", EntityID: strconv.Itoa(int(assetID))}.IdentityKey()
 }
 
+// TenantSPIFFEPrefix is the trust domain and tenant path every pki-core
+// principal is minted under. Taken from the tenantSPIFFEPrefix constant on
+// origin/sem/wdy-2899-acme-enrollment, exported here because the device
+// enrolment client has to recognise the prefix as well as build it.
+//
+// Note the kind that follows the tenant segment differs by issuance path, and
+// the difference is load-bearing. Wendy Cloud relays a client leaf through
+// pki-core's "service-identity" profile, so a cloud-minted principal is
+// ".../service/asset-<id>". A leaf enrolled directly against pki-core's device
+// profile is ".../device/<name>", and the Wendy Data Platform's ingest
+// interceptor rejects any kind other than "device" outright. The two are
+// separate identities on separate certificates, not two spellings of one.
+const TenantSPIFFEPrefix = "spiffe://wendy.sh/tenant/"
+
+// spiffeDeviceKind is the principal kind pki-core stamps for a leaf issued
+// from one of its device tiers.
+const spiffeDeviceKind = "device"
+
+// DeviceSPIFFEURI returns the canonical pki-core device principal:
+// "spiffe://wendy.sh/tenant/<tenantUUID>/device/<deviceName>".
+//
+// It is built here only so the agent can state what it expects and compare.
+// pki-core stamps this SAN server-side from the enrollment token's device_id
+// and discards whatever URI SANs the CSR carried, so nothing the device puts in
+// a CSR can influence the issued identity. deviceName may be multi-segment
+// (for example "sh/wendy/2/408"); each "/"-separated segment must match
+// ^[A-Za-z0-9._-]{1,64}$.
+func DeviceSPIFFEURI(tenantUUID, deviceName string) string {
+	return TenantSPIFFEPrefix + tenantUUID + "/" + spiffeDeviceKind + "/" + deviceName
+}
+
+// ParseDeviceSPIFFEURI splits a pki-core device principal back into its tenant
+// UUID and device name. A principal of any other kind ("service", "operator")
+// is an error rather than a miss, because accepting one where a device identity
+// is required is precisely the mistake this function exists to prevent.
+func ParseDeviceSPIFFEURI(uri string) (tenantUUID, deviceName string, err error) {
+	rest, ok := strings.CutPrefix(uri, TenantSPIFFEPrefix)
+	if !ok {
+		return "", "", fmt.Errorf("not a tenant SPIFFE URI: %s", uri)
+	}
+	tenantUUID, rest, ok = strings.Cut(rest, "/")
+	if !ok || tenantUUID == "" {
+		return "", "", fmt.Errorf("tenant SPIFFE URI carries no tenant segment: %s", uri)
+	}
+	kind, name, ok := strings.Cut(rest, "/")
+	if !ok || name == "" {
+		return "", "", fmt.Errorf("tenant SPIFFE URI carries no %s name: %s", spiffeDeviceKind, uri)
+	}
+	if kind != spiffeDeviceKind {
+		return "", "", fmt.Errorf("tenant SPIFFE URI is a %q principal, not a %s: %s", kind, spiffeDeviceKind, uri)
+	}
+	return tenantUUID, name, nil
+}
+
+// TenantSPIFFEURIs returns every tenant SPIFFE URI SAN on leaf, in the order
+// the certificate carries them. Callers that require a single identity check
+// the length themselves so they can report how many were found.
+func TenantSPIFFEURIs(leaf *x509.Certificate) []string {
+	var out []string
+	for _, u := range leaf.URIs {
+		raw := u.String()
+		if strings.HasPrefix(raw, TenantSPIFFEPrefix) {
+			out = append(out, raw)
+		}
+	}
+	return out
+}
+
 // ParseIdentityURN parses a canonical Wendy identity URN —
 // "urn:wendy:org:<org>:(user|asset):<id>", the exact string IdentityKey
 // produces — back into a WendyIdentity.

--- a/go/internal/shared/certs/orgident_test.go
+++ b/go/internal/shared/certs/orgident_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"net/url"
+	"strings"
 	"testing"
 )
 
@@ -262,5 +263,76 @@ func TestOrgFromClientCert_StillWorks(t *testing.T) {
 	orgID, ok, err := OrgFromClientCert(cert)
 	if err != nil || !ok || orgID != 7 {
 		t.Errorf("OrgFromClientCert() = %d, %v, %v; want 7, true, nil", orgID, ok, err)
+	}
+}
+
+func TestDeviceSPIFFEURI(t *testing.T) {
+	const tenant = "022b7284-f7f3-4d86-b844-d105a7c06d9e"
+	// A multi-segment device name is first-class: pki-core's own convention
+	// for a Wendy device is "sh/wendy/<org>/<asset>".
+	got := DeviceSPIFFEURI(tenant, "sh/wendy/2/408")
+	want := "spiffe://wendy.sh/tenant/" + tenant + "/device/sh/wendy/2/408"
+	if got != want {
+		t.Errorf("DeviceSPIFFEURI = %q, want %q", got, want)
+	}
+	if !strings.HasPrefix(got, TenantSPIFFEPrefix) {
+		t.Errorf("%q does not start with the tenant prefix", got)
+	}
+}
+
+func TestParseDeviceSPIFFEURI(t *testing.T) {
+	const tenant = "022b7284-f7f3-4d86-b844-d105a7c06d9e"
+
+	tenantGot, name, err := ParseDeviceSPIFFEURI(DeviceSPIFFEURI(tenant, "sh/wendy/2/408"))
+	if err != nil {
+		t.Fatalf("ParseDeviceSPIFFEURI: %v", err)
+	}
+	if tenantGot != tenant {
+		t.Errorf("tenant = %q, want %q", tenantGot, tenant)
+	}
+	if name != "sh/wendy/2/408" {
+		t.Errorf("name = %q, want the whole multi-segment name", name)
+	}
+
+	// A service or operator principal must be an error and not a miss:
+	// accepting one where a device identity is required is the mistake this
+	// parser exists to prevent, and the data platform's ingest interceptor
+	// rejects any kind but "device" anyway.
+	for _, bad := range []string{
+		"spiffe://wendy.sh/tenant/" + tenant + "/service/asset-408",
+		"spiffe://wendy.sh/tenant/" + tenant + "/operator/martien",
+		"urn:wendy:org:2:asset:408",
+		"spiffe://wendy.sh/tenant/" + tenant,
+		"spiffe://wendy.sh/tenant/" + tenant + "/device/",
+		"spiffe://wendy.sh/tenant//device/x",
+	} {
+		if _, _, err := ParseDeviceSPIFFEURI(bad); err == nil {
+			t.Errorf("ParseDeviceSPIFFEURI(%q) = nil error, want a refusal", bad)
+		}
+	}
+}
+
+func TestTenantSPIFFEURIs(t *testing.T) {
+	const tenant = "022b7284-f7f3-4d86-b844-d105a7c06d9e"
+	leaf := &x509.Certificate{URIs: []*url.URL{
+		mustParseURL(t, "urn:wendy:org:2:asset:408"),
+		mustParseURL(t, DeviceSPIFFEURI(tenant, "sh/wendy/2/408")),
+		mustParseURL(t, "spiffe://wendy.sh/tenant/"+tenant+"/service/asset-408"),
+	}}
+	got := TenantSPIFFEURIs(leaf)
+	if len(got) != 2 {
+		t.Fatalf("TenantSPIFFEURIs returned %d SANs, want the 2 tenant ones: %v", len(got), got)
+	}
+	if got[0] != DeviceSPIFFEURI(tenant, "sh/wendy/2/408") {
+		t.Errorf("order was not preserved: %v", got)
+	}
+	// The urn form is not a tenant SPIFFE URI and must not be reported as one.
+	for _, u := range got {
+		if strings.HasPrefix(u, "urn:") {
+			t.Errorf("the urn SAN leaked into the SPIFFE list: %v", got)
+		}
+	}
+	if TenantSPIFFEURIs(&x509.Certificate{}) != nil {
+		t.Error("a certificate with no SANs must yield nil")
 	}
 }

--- a/go/internal/shared/enrolltoken/enrolltoken.go
+++ b/go/internal/shared/enrolltoken/enrolltoken.go
@@ -17,6 +17,31 @@ type Claims struct {
 	AssetID        int32  `json:"asset_id"`
 	UserID         string `json:"user_id"`
 	Type           string `json:"type"`
+	// TenantUUID is the org's pki-core tenant, as a lowercase canonical UUID.
+	// It is OPTIONAL: cloud omits it for organizations with no pki tenant,
+	// which is the normal state for the local and GCP CAS backends. Absence
+	// means "the caller has to be told the tenant another way", never an error
+	// (WDY-2584).
+	//
+	// The field and this reasoning are taken from
+	// origin/sem/wdy-2899-acme-enrollment, which introduced the claim.
+	TenantUUID string `json:"tenant_uuid"`
+}
+
+// TenantUUIDFromToken returns the tenant_uuid claim carried by an enrollment
+// token, and whether one was there at all.
+//
+// ok=false covers two ordinary states and does not distinguish them, because a
+// caller can do nothing different about either: a Wendy-minted token for an org
+// with no pki tenant, and a token that is not a Wendy JWT in the first place
+// (pki-core's own enrollment tokens are opaque values with no claims to read).
+// Both mean "take the tenant from the enrol input instead".
+func TenantUUIDFromToken(token string) (tenantUUID string, ok bool) {
+	c, err := Parse(token)
+	if err != nil || c.TenantUUID == "" {
+		return "", false
+	}
+	return c.TenantUUID, true
 }
 
 // Parse decodes the base64url JSON payload (the second dot-separated segment)

--- a/go/internal/shared/enrolltoken/enrolltoken_test.go
+++ b/go/internal/shared/enrolltoken/enrolltoken_test.go
@@ -42,3 +42,35 @@ func TestParseAsset_MissingIDs(t *testing.T) {
 		t.Fatal("expected error for missing org/asset, got nil")
 	}
 }
+
+func TestTenantUUIDFromToken(t *testing.T) {
+	const tenant = "022b7284-f7f3-4d86-b844-d105a7c06d9e"
+	tok := makeToken(t, `{"type":"asset_enrollment","org_id":2,"asset_id":408,"tenant_uuid":"`+tenant+`"}`)
+	got, ok := TenantUUIDFromToken(tok)
+	if !ok {
+		t.Fatal("ok = false for a token carrying tenant_uuid")
+	}
+	if got != tenant {
+		t.Errorf("tenant = %q, want %q", got, tenant)
+	}
+}
+
+func TestTenantUUIDFromTokenAbsentIsNotAnError(t *testing.T) {
+	// Two ordinary states, deliberately indistinguishable because a caller
+	// can do nothing different about either: an org with no pki tenant, and a
+	// token that is not a Wendy JWT at all (pki-core's own enrollment tokens
+	// are opaque values with no claims to read). Both mean "take the tenant
+	// from the enrol input instead".
+	for name, tok := range map[string]string{
+		"no claim":     makeToken(t, `{"type":"asset_enrollment","org_id":2,"asset_id":408}`),
+		"empty claim":  makeToken(t, `{"type":"asset_enrollment","tenant_uuid":""}`),
+		"opaque token": "an-opaque-pki-core-token",
+		"empty":        "",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got, ok := TenantUUIDFromToken(tok); ok {
+				t.Errorf("ok = true, tenant = %q", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The Wendy Data Platform's ingest endpoint (`ingest.data.wendy.sh:443`) wants a device identity whose only URI Subject Alternative Name (SAN) is `spiffe://wendy.sh/tenant/<tenant>/device/<name>`, and its `DeviceIdentityInterceptor` rejects any SPIFFE principal kind other than `device`. The agent has exactly one certificate: the leaf Google Certificate Authority Service (CAS) issues through the Wendy Cloud broker, whose identity is the legacy Wendy organization URN.

Swapping one for the other fixes the ingest leg and breaks three others. Wendy Cloud's interceptors resolve no identity at all from a SPIFFE SAN. The agent's own inbound mutual TLS (mTLS) server on port 50052 derives its organization from its own certificate and, failing that, disables organization-equality enforcement as a fail-safe. And replacing `ca.pem` with pki-core's chain makes every CAS-issued command-line certificate untrusted, which costs the device its manageability.

Separately, the agent renews nothing today, on any certificate. That was survivable for a 365-day CAS leaf. pki-core's bearer-token path can only mint a `device-tier-c` leaf, which is 30 days.

## Cause

One identity triple, `/etc/wendy-agent/{device-key.pem,device.pem,ca.pem}`, is presented to four peers that do not agree on what an identity is, and no timer or expiry check exists anywhere in the agent to refresh it. The certificate proto has documented the intended policy ("refresh about two thirds through the lifetime") since it was written, and nothing implemented it.

## Solution

Two identities, two PEM triples, each presented to the peer that understands it. The CAS triple is not read or written by any new code.

**`go/internal/agent/pkienroll`** — the CSR-frontend flow, which is simpler than the ACME and External Account Binding path and needs no `permanent-identifier` handling.

- `Enroll` builds a PKCS#10 request (Common Name `sh/wendy/<org>/<asset>`, `clientAuth` and `serverAuth` extended key usages, exactly what the agent already asks CAS for) and posts it to `POST /v1/<tenant>/enroll` with the enrollment token as a bearer credential. The CSR carries no URI SAN: pki-core stamps the principal it minted and discards the CSR's own, so asserting one would be a claim the client is not entitled to make.
- `Renew` posts to `POST /v1/<tenant>/renew` over mTLS with the current leaf. Possession of that leaf is the credential; the device name carries forward off the presented certificate.
- Both parse the leaf-first chain and refuse to store anything whose SAN is not exactly one device principal for the expected tenant, recording the SANs actually issued so a surprise is visible in the log rather than only reported as a failure. A wrong tenant, a `service` principal and two tenant SANs are each covered by a test.
- `Store` holds the triple under `/etc/wendy-agent/pki/{device-key.pem,device.pem,chain.pem}`. The key is ECDSA P-256, generated once on the device, written atomically at 0600, and reused across renewals; a device tier pins no algorithm, so the agent's existing key type is accepted unchanged. It is a separate key from the CAS one on purpose: sharing it would make the two identities one identity wearing two certificates. Load reports a leaf without a key (or the reverse) as absent, so a half-written store falls back rather than presenting nothing.

**A renewal loop, the agent's first.** Renew at two thirds of the leaf's own validity window as issued (not an assumed tier length), plus jitter over a tenth of the remaining window so a fleet enrolled in one batch does not renew in one thundering herd. Exponential backoff from one minute to one hour on failure. Once the leaf is inside 24 hours of expiry and renewal is still failing, an error-level message says what will stop working and what the remedy is. `NextRenewal` is pure and every input including the jitter is a parameter, so the whole policy is pinned without a clock, a network or a random source.

**Handing over the token.** `/etc/wendy-agent/pki-enrollment.json`, read at startup and deleted once redeemed. This is deliberately the same mechanism `enrollment.json` and `ApplyEnrollmentFile` already use for cloud enrolment, and the properties that made it right there hold here: the credential is single-use and short-lived, it has to survive being staged before the agent runs, and it must not land in a long-lived configuration file. Choosing it over a new provisioning remote procedure call also means no proto addition and no cloud surface growth. `wendy data enroll --tenant <uuid> --token <t>` is the operator-facing way to write that file, so nobody hand-composes JSON on a device. A refused (401) or wrong-identity enrolment is not retried, because a single-use token consumed atomically with issuance will be refused identically; a missing cloud organization and asset pair is the one case that keeps the staged token, because it is fixable later without minting a new one.

**The dialer.** `data_transfer_worker.go` presents the pki triple when one is stored and the asset certificate when it is not, deciding per dial so a device enrolled after the agent came up switches on its next upload pass. The server side is still verified against the system pool, unchanged: the ingest endpoint presents a publicly trusted certificate. No cloud dialer is touched.

**Configuration.** The frontend host is derived per environment (`csr.dev.pki.wendy.sh` / `csr.pki.wendy.sh`) and overridable through the staged file or `WENDY_PKI_CSR_ENDPOINT`; an unrecognised environment resolves to production, never to dev. The tenant comes from the token's `tenant_uuid` claim when it has one and from the enrol input otherwise, and the claim wins over a disagreeing staged value. Nothing is derived from the enrolled cloud host.

## What was reused from `origin/sem/wdy-2899-acme-enrollment`

- The `tenantSPIFFEPrefix` constant and its reasoning, exported as `certs.TenantSPIFFEPrefix`. That branch reads as if one identity is being built where there are two, so the comment now spells out the distinction: cloud relays through pki-core's `service-identity` profile and mints `/service/asset-<id>`, while a direct device enrolment is `/device/<name>`, and the ingest surface accepts only the second.
- The optional `tenant_uuid` enrollment-token claim on `enrolltoken.Claims`, verbatim including the WDY-2584 note, plus a `TenantUUIDFromToken` helper in the same spirit as its `TenantSPIFFEURIFromToken`.
- `splitLeafAndChain` from `go/internal/cli/commands/certrenew.go`, which already solved the leaf-first-chain split for the command-line renewal pre-flight.
- The `WENDY_PKI_*` environment-variable naming and its rule that no pki endpoint is ever guessed from another service's address (WDY-2799).
- Its `leafNotAfter` shape: read validity through `certs.LeafCertificatePEM` plus `certs.ParseCertsFromPEM`, so the schedule is computed from the certificate the handshake can actually present.

The `acmeenroll` package itself is not used. Its ACME and External Account Binding flow is the class-A and class-B path; the bearer-token CSR frontend is class C, which is what an enrollment token redeems against.

## Also in this change

`services.syncWriteFile` moves to `internal/shared/atomicfile` and the old name delegates to it, so both PEM triples share one durability implementation instead of growing a second copy. All existing call sites and tests are unchanged.

## Verification

`go build ./...` clean. `go test ./...`: 87 packages pass. One failure, `TestBuildCmd_MultiService_BuildsFromManifestOnly`, reproduces on `origin/feature/wendy-data-platform-complete` unchanged and is the macOS `/private/var` temporary-directory symlink, unrelated to this change. `gofmt` clean, `go vet ./...` clean.

## What could not be verified

Nothing here has spoken to pki-core's real CSR frontend with a real token. An enrollment token is mintable only through `FabricRelayService.RelayEnrollment`, which is a private-endpoint-only service whose dev allow-list has exactly one entry, and no code calls it yet. So the following are pinned only against a local server that mimics the frontend, including its 200 chain, 401 and 400 responses:

- that pki-core accepts a PEM PKCS#10 body with `{csr, device_id, tier}` in the shape this client sends;
- that a `device_id` mismatch really returns 400 and a bad token really returns 401 with a `detail` field;
- that the issued leaf's trailing-ASN.1 handling and the chain's leaf-first ordering behave as the spike read them out of pki-core's source.

Also unverified, because they are outside this repository: whether the ingest listener's trust bundle yet holds the tenant's Device Identity certificate authority, and the `tenantLegacyOrgs` cutover consequence (a device presenting a SPIFFE leaf writes episodes under the tenant UUID while Wendy BI's reads still resolve that tenant to the numeric organization, making the new episodes invisible). That has to be settled in the data repository before the first device is flipped.

Not implemented, as scoped: the operator side that mints the token, any pki-core change, and any device build or deploy.
