### PR TITLE
fix(agent): harden pki enrolment, apply degraded time consensus, exclude generated files from security review

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,10 @@
 # Mark generated protobuf/gRPC Swift files so GitHub collapses them in PRs
 swift/Sources/*/Proto/**/*.pb.swift    linguist-generated=true
 swift/Sources/*/Proto/**/*.grpc.swift  linguist-generated=true
+
+# Mark generated protobuf/gRPC Go files so GitHub collapses them in PRs, and so
+# the AI security review spends its byte budget on hand-written code only
+# (.github/scripts/security_review.py reads these patterns).
+go/proto/gen/**                        linguist-generated=true
+*.pb.go                                linguist-generated=true
+*_grpc.pb.go                           linguist-generated=true

--- a/.github/scripts/security_review.py
+++ b/.github/scripts/security_review.py
@@ -62,6 +62,162 @@ class ReviewError(RuntimeError):
     """A deterministic security-review failure that must fail the check."""
 
 
+# Paths whose contents no human wrote and no reviewer can act on. They are
+# excluded from the byte budget and from the diff the model reads.
+#
+# WHY THIS EXISTS. The budget is a guard against a partial review: a diff that
+# does not fit is rejected outright rather than truncated, so that nobody
+# mistakes a review of the first half for a review. Regenerated protobuf stubs
+# defeat that guard from the other side. A single `go/proto/gen/**` refresh runs
+# to tens of thousands of bytes of code that is a mechanical function of the
+# .proto files in the same pull request, so a change with a few hand-written
+# lines exceeded the limit and received no review at all. Excluding them keeps
+# the reviewer on the lines a person actually wrote, which are also the lines
+# the .proto diff itself still shows.
+DEFAULT_GENERATED_GLOBS = (
+    "go/proto/gen/**",
+    "*.pb.go",
+    "*_grpc.pb.go",
+)
+GITATTRIBUTES_NAME = ".gitattributes"
+LINGUIST_GENERATED = "linguist-generated"
+DIFF_SECTION_RE = re.compile(r"^diff --git ", re.MULTILINE)
+
+
+def _glob_to_regex(pattern: str) -> re.Pattern[str]:
+    """Translate one gitattributes/gitignore-style path glob into a regex.
+
+    Git's rules, as far as they matter here: a pattern with no slash matches the
+    basename at any depth, a trailing slash means "everything under it", `**`
+    crosses directory separators and a single `*` does not.
+    """
+    pattern = pattern.strip().lstrip("/")
+    if pattern.endswith("/"):
+        pattern += "**"
+    if "/" not in pattern.rstrip("*"):
+        pattern = "**/" + pattern
+    out: list[str] = []
+    index = 0
+    while index < len(pattern):
+        if pattern.startswith("**/", index):
+            out.append("(?:.*/)?")
+            index += 3
+        elif pattern.startswith("**", index):
+            out.append(".*")
+            index += 2
+        elif pattern[index] == "*":
+            out.append("[^/]*")
+            index += 1
+        elif pattern[index] == "?":
+            out.append("[^/]")
+            index += 1
+        else:
+            out.append(re.escape(pattern[index]))
+            index += 1
+    return re.compile("".join(out) + r"\Z")
+
+
+def gitattributes_generated_globs(text: str) -> tuple[str, ...]:
+    """Read the patterns a .gitattributes marks linguist-generated.
+
+    Parsed here rather than shelled out to `git check-attr` so the rule is the
+    same one a reader of the file sees, and so the script stays runnable outside
+    a checkout (its own tests included).
+    """
+    globs: list[str] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        fields = line.split()
+        pattern, attributes = fields[0], fields[1:]
+        for attribute in attributes:
+            name, _, value = attribute.partition("=")
+            if name.lstrip("-!") != LINGUIST_GENERATED:
+                continue
+            # "-attr" and "attr=false" unset it; a bare name or "=true" sets it.
+            if name.startswith("-") or value.lower() in {"false", "0"}:
+                break
+            globs.append(pattern)
+            break
+    return tuple(globs)
+
+
+def generated_globs(repo_root: str | pathlib.Path | None = None) -> tuple[str, ...]:
+    """The built-in conventions plus whatever .gitattributes marks generated."""
+    root = pathlib.Path(repo_root) if repo_root is not None else pathlib.Path.cwd()
+    attributes = root / GITATTRIBUTES_NAME
+    from_file: tuple[str, ...] = ()
+    if attributes.is_file():
+        from_file = gitattributes_generated_globs(
+            attributes.read_text(encoding="utf-8", errors="replace")
+        )
+    return tuple(dict.fromkeys(DEFAULT_GENERATED_GLOBS + from_file))
+
+
+def is_generated_path(path: str, globs: tuple[str, ...]) -> bool:
+    path = path.strip().lstrip("/")
+    return any(_glob_to_regex(pattern).match(path) for pattern in globs)
+
+
+def _section_path(section: str) -> str:
+    """The path a single `diff --git` section is about.
+
+    Read off the `+++ b/` line where there is one, because it survives paths
+    containing spaces, which the `diff --git a/x b/x` header does not. A
+    deletion falls back to `--- a/`, and a binary or mode-only change to the
+    header, parsed on the assumption both halves name the same path.
+    """
+    lines = section.split("\n")
+    for line in lines:
+        if line.startswith("+++ b/"):
+            return line[len("+++ b/") :].strip()
+    for line in lines:
+        if line.startswith("--- a/"):
+            return line[len("--- a/") :].strip()
+    header = lines[0][len("diff --git ") :].strip() if lines else ""
+    match = re.fullmatch(r'"?a/(.+?)"? "?b/\1"?', header)
+    if match:
+        return match.group(1)
+    _, _, second = header.partition(" b/")
+    return second.strip().strip('"')
+
+
+def split_diff_sections(diff_text: str) -> list[tuple[str, str]]:
+    """Split a unified diff into (path, section) pairs that rejoin exactly."""
+    starts = [match.start() for match in DIFF_SECTION_RE.finditer(diff_text)]
+    if not starts:
+        return [("", diff_text)] if diff_text else []
+    sections: list[tuple[str, str]] = []
+    if starts[0] > 0:
+        sections.append(("", diff_text[: starts[0]]))
+    for index, start in enumerate(starts):
+        end = starts[index + 1] if index + 1 < len(starts) else len(diff_text)
+        section = diff_text[start:end]
+        sections.append((_section_path(section), section))
+    return sections
+
+
+def partition_generated(
+    diff_text: str, globs: tuple[str, ...] | None = None
+) -> tuple[str, list[str]]:
+    """Return (reviewable diff, paths excluded as generated)."""
+    if globs is None:
+        globs = generated_globs()
+    kept: list[str] = []
+    excluded: list[str] = []
+    for path, section in split_diff_sections(diff_text):
+        if path and is_generated_path(path, globs):
+            excluded.append(path)
+            continue
+        kept.append(section)
+    return "".join(kept), excluded
+
+
+def reviewable_diff(diff_text: str, globs: tuple[str, ...] | None = None) -> str:
+    return partition_generated(diff_text, globs)[0]
+
+
 def _load_json(path: str | pathlib.Path) -> Any:
     return json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
 
@@ -106,6 +262,7 @@ def build_input_manifest(
     expected_pr_number: int,
     expected_head_sha: str,
     max_diff_bytes: int = MAX_DIFF_BYTES,
+    globs: tuple[str, ...] | None = None,
 ) -> dict[str, Any]:
     if not isinstance(metadata, dict):
         raise ReviewError("PR metadata must be a JSON object")
@@ -152,34 +309,57 @@ def build_input_manifest(
         )
 
     byte_count = len(diff_bytes)
+    # The budget is spent on lines a person wrote. Generated files are dropped
+    # from the count and from the reviewed diff, so a protobuf regeneration
+    # cannot push a hand-written change past the limit and out of review; the
+    # full diff's size and digest are still recorded, so the exclusion is
+    # visible rather than silent.
+    reviewable_text, generated_paths = partition_generated(diff_text, globs)
+    reviewable_bytes = len(reviewable_text.encode("utf-8"))
     manifest = {
         "additions": additions,
         "changed_files": changed_files,
         "deletions": deletions,
         "diff_bytes": byte_count,
         "diff_characters": len(diff_text),
+        "generated_bytes_excluded": byte_count - reviewable_bytes,
+        "generated_files_excluded": len(generated_paths),
         "head_sha": head_sha.lower(),
         "max_diff_bytes": max_diff_bytes,
         "pr_number": number,
-        "prepared_bytes": byte_count if byte_count <= max_diff_bytes else 0,
+        "prepared_bytes": reviewable_bytes if reviewable_bytes <= max_diff_bytes else 0,
+        "reviewable_bytes": reviewable_bytes,
+        "reviewed_files": changed_files - len(generated_paths),
         "sha256": hashlib.sha256(diff_bytes).hexdigest(),
-        "truncation": "none" if byte_count <= max_diff_bytes else "rejected",
+        "truncation": "none" if reviewable_bytes <= max_diff_bytes else "rejected",
     }
-    if byte_count > max_diff_bytes:
+    if reviewable_bytes > max_diff_bytes:
         raise ReviewError(
             "PR diff is too large for one complete AI review: "
-            f"{byte_count:,} bytes across {changed_files} files exceeds the "
-            f"{max_diff_bytes:,}-byte limit. Split the PR; no partial review was performed."
+            f"{reviewable_bytes:,} hand-written bytes across "
+            f"{changed_files - len(generated_paths)} files exceeds the "
+            f"{max_diff_bytes:,}-byte limit "
+            f"({len(generated_paths)} generated file(s) already excluded). "
+            "Split the PR; no partial review was performed."
         )
     return manifest
 
 
 def coverage_text(manifest: dict[str, Any], *, reviewed: bool) -> str:
-    byte_count = manifest["diff_bytes"] if reviewed else manifest["prepared_bytes"]
+    reviewable = manifest.get("reviewable_bytes", manifest["diff_bytes"])
+    byte_count = reviewable if reviewed else manifest["prepared_bytes"]
+    reviewed_files = manifest.get("reviewed_files", manifest["changed_files"])
     verb = "reviewed" if reviewed else "prepared for review"
+    excluded = manifest.get("generated_files_excluded", 0)
+    generated = ""
+    if excluded:
+        generated = (
+            f" {excluded} generated file(s) excluded "
+            f"({manifest.get('generated_bytes_excluded', 0):,} bytes);"
+        )
     return (
-        f"**Input coverage:** {manifest['changed_files']}/{manifest['changed_files']} changed files; "
-        f"{byte_count:,}/{manifest['diff_bytes']:,} bytes {verb}; "
+        f"**Input coverage:** {reviewed_files}/{manifest['changed_files']} changed files; "
+        f"{byte_count:,}/{manifest['diff_bytes']:,} bytes {verb};{generated} "
         f"diff SHA-256 `{manifest['sha256']}`; truncation: {manifest['truncation']}."
     )
 
@@ -781,7 +961,14 @@ def command_review(args: argparse.Namespace) -> None:
 
     metadata = _load_json(args.metadata)
     manifest = _load_json(args.manifest)
-    diff = pathlib.Path(args.diff).read_text(encoding="utf-8")
+    # Filtered with the same rule prepare-input costed, so the model reads
+    # exactly the bytes the budget was spent on.
+    diff = reviewable_diff(pathlib.Path(args.diff).read_text(encoding="utf-8"))
+    if not diff.strip():
+        diff = (
+            "(Every changed file in this pull request is a generated file "
+            "excluded from review. There are no hand-written changes to assess.)"
+        )
     previous_review = pathlib.Path(args.previous).read_text(encoding="utf-8")
     client = anthropic.Anthropic()
 

--- a/.github/scripts/security_review_test.py
+++ b/.github/scripts/security_review_test.py
@@ -112,6 +112,111 @@ class InputManifestTests(unittest.TestCase):
             security_review.build_input_manifest(metadata(0), b"x", 42, HEAD_SHA)
 
 
+class GeneratedExclusionTests(unittest.TestCase):
+    """Generated files must not spend the byte budget or reach the reviewer."""
+
+    GLOBS = ("go/proto/gen/**", "*.pb.go", "*_grpc.pb.go")
+
+    def test_generated_paths_are_recognized(self) -> None:
+        for path in (
+            "go/proto/gen/agentpb/v2/data_service.pb.go",
+            "go/proto/gen/agentpb/v2/data_service_grpc.pb.go",
+            "go/proto/gen/anything.txt",
+            "some/other/place/thing.pb.go",
+        ):
+            self.assertTrue(
+                security_review.is_generated_path(path, self.GLOBS), path
+            )
+
+    def test_hand_written_paths_are_not_excluded(self) -> None:
+        for path in (
+            "go/internal/agent/pkienroll/pkienroll.go",
+            "go/proto/wendy/agent/services/v2/data_service.proto",
+            "docs/why-pb.go.md",
+            ".github/scripts/security_review.py",
+        ):
+            self.assertFalse(
+                security_review.is_generated_path(path, self.GLOBS), path
+            )
+
+    def test_gitattributes_patterns_are_read(self) -> None:
+        globs = security_review.gitattributes_generated_globs(
+            "# comment\n"
+            "swift/Sources/*/Proto/**/*.pb.swift linguist-generated=true\n"
+            "vendor/** linguist-generated\n"
+            "keep/me.go -linguist-generated\n"
+            "also/keep.go linguist-generated=false\n"
+            "unrelated.go text eol=lf\n"
+        )
+        self.assertEqual(
+            globs, ("swift/Sources/*/Proto/**/*.pb.swift", "vendor/**")
+        )
+        self.assertTrue(
+            security_review.is_generated_path(
+                "swift/Sources/WendyAgent/Proto/v2/agent.pb.swift", globs
+            )
+        )
+
+    def test_repo_gitattributes_marks_generated_go_protos(self) -> None:
+        globs = security_review.generated_globs(MODULE_PATH.parents[2])
+        self.assertTrue(
+            security_review.is_generated_path(
+                "go/proto/gen/agentpb/shared.pb.go", globs
+            )
+        )
+
+    def test_sections_rejoin_byte_for_byte(self) -> None:
+        raw = (diff("go/a.go") + diff("go/proto/gen/b.pb.go")).decode()
+        sections = security_review.split_diff_sections(raw)
+        self.assertEqual([path for path, _ in sections], ["go/a.go", "go/proto/gen/b.pb.go"])
+        self.assertEqual("".join(section for _, section in sections), raw)
+
+    def test_generated_file_leaves_the_budget_to_hand_written_code(self) -> None:
+        handwritten = diff("go/internal/thing.go")
+        generated = diff("go/proto/gen/agentpb/v2/data_service.pb.go")
+        raw = handwritten + generated
+        manifest = security_review.build_input_manifest(
+            metadata(2), raw, 42, HEAD_SHA, len(handwritten), self.GLOBS
+        )
+        self.assertEqual(manifest["diff_bytes"], len(raw))
+        self.assertEqual(manifest["reviewable_bytes"], len(handwritten))
+        self.assertEqual(manifest["prepared_bytes"], len(handwritten))
+        self.assertEqual(manifest["generated_files_excluded"], 1)
+        self.assertEqual(manifest["generated_bytes_excluded"], len(generated))
+        self.assertEqual(manifest["reviewed_files"], 1)
+        self.assertEqual(manifest["truncation"], "none")
+        # The digest still covers the whole diff, so `enforce` keeps matching a
+        # result to the exact input it was produced from.
+        self.assertEqual(manifest["sha256"], hashlib.sha256(raw).hexdigest())
+
+    def test_reviewed_diff_drops_the_generated_sections(self) -> None:
+        raw = (
+            diff("go/internal/thing.go", line="handWrittenMarker := 1")
+            + diff("go/proto/gen/x.pb.go", line="generatedMarker := 2")
+        ).decode()
+        kept, excluded = security_review.partition_generated(raw, self.GLOBS)
+        self.assertIn("handWrittenMarker", kept)
+        self.assertNotIn("generatedMarker", kept)
+        self.assertEqual(excluded, ["go/proto/gen/x.pb.go"])
+
+    def test_hand_written_diff_over_the_limit_still_fails(self) -> None:
+        handwritten = diff("go/internal/thing.go")
+        raw = handwritten + diff("go/proto/gen/x.pb.go")
+        with self.assertRaisesRegex(security_review.ReviewError, "no partial review"):
+            security_review.build_input_manifest(
+                metadata(2), raw, 42, HEAD_SHA, len(handwritten) - 1, self.GLOBS
+            )
+
+    def test_coverage_names_the_exclusion(self) -> None:
+        raw = diff("go/internal/thing.go") + diff("go/proto/gen/x.pb.go")
+        manifest = security_review.build_input_manifest(
+            metadata(2), raw, 42, HEAD_SHA, security_review.MAX_DIFF_BYTES, self.GLOBS
+        )
+        text = security_review.coverage_text(manifest, reviewed=True)
+        self.assertIn("1/2 changed files", text)
+        self.assertIn("1 generated file(s) excluded", text)
+
+
 class PayloadTests(unittest.TestCase):
     def test_no_findings_is_exact_and_valid(self) -> None:
         parsed = security_review.extract_payload("NO_FINDINGS")

--- a/go/internal/agent/pkienroll/config.go
+++ b/go/internal/agent/pkienroll/config.go
@@ -1,6 +1,9 @@
 package pkienroll
 
 import (
+	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"strings"
 )
@@ -39,20 +42,36 @@ const (
 	EnvironmentEnv = "WENDY_PKI_ENV"
 )
 
+// ErrPlaintextEndpoint reports a configured frontend URL that would carry the
+// enrollment token, a single-use bearer credential, over cleartext HyperText
+// Transfer Protocol (HTTP) to somewhere other than this machine.
+//
+// It is refused at configuration time rather than at request time so that the
+// enrolment never starts: by the time a request is on the wire the token has
+// already left the device, and a token seen in cleartext must be treated as
+// spent and revoked. Loopback is exempt because a local pki-core, a port
+// forward and the package's own tests all speak plain HTTP to 127.0.0.1, where
+// the packet never reaches a network interface.
+var ErrPlaintextEndpoint = fmt.Errorf("pki enrollment: refusing a plaintext http endpoint")
+
 // CSRFrontendURL resolves the frontend base URL.
 //
 // Precedence, most specific first: an explicit override (the staged credential
 // file's csrEndpoint, then CSREndpointEnv), then the derived host for the named
 // environment. The override wins so that a local pki-core, a staging tenant or
 // a port-forwarded frontend needs no code change.
-func CSRFrontendURL(override, environment string) string {
+//
+// A scheme-less value is given https. An explicit http:// value is accepted
+// only for a loopback host; anything else returns ErrPlaintextEndpoint, so a
+// misconfiguration cannot send the bearer enrolment token in cleartext.
+func CSRFrontendURL(override, environment string) (string, error) {
 	if v := strings.TrimSpace(override); v != "" {
-		return withScheme(v)
+		return checkedScheme(v)
 	}
 	if v := strings.TrimSpace(os.Getenv(CSREndpointEnv)); v != "" {
-		return withScheme(v)
+		return checkedScheme(v)
 	}
-	return withScheme(csrFrontendHost(environment))
+	return checkedScheme(csrFrontendHost(environment))
 }
 
 // csrFrontendHost maps an environment name to a host. An empty environment
@@ -68,11 +87,56 @@ func csrFrontendHost(environment string) string {
 	return ProdCSRFrontendHost
 }
 
+// checkedScheme applies the default scheme and then the plaintext rule.
+func checkedScheme(v string) (string, error) {
+	withDefault := withScheme(v)
+	if err := checkTransport(withDefault); err != nil {
+		return "", err
+	}
+	return withDefault, nil
+}
+
 func withScheme(v string) string {
 	if strings.Contains(v, "://") {
 		return v
 	}
 	return "https://" + v
+}
+
+// checkTransport refuses a cleartext endpoint that is not on this machine. It
+// is deliberately permissive about everything else: an unparseable URL and an
+// unknown scheme are frontendEndpoint's to report, with its own message.
+func checkTransport(endpoint string) error {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return fmt.Errorf("parsing csr frontend url %q: %w", endpoint, err)
+	}
+	if !strings.EqualFold(u.Scheme, "http") {
+		return nil
+	}
+	if isLoopbackHost(u.Hostname()) {
+		return nil
+	}
+	return fmt.Errorf("%w: %q would send the single-use enrollment token in cleartext; "+
+		"use https, or a loopback host (127.0.0.0/8, ::1, localhost) for a local frontend",
+		ErrPlaintextEndpoint, endpoint)
+}
+
+// isLoopbackHost reports whether host names this machine. "localhost" is
+// accepted by name because a local frontend is normally reached that way and
+// resolving it here would make the check depend on the resolver.
+func isLoopbackHost(host string) bool {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return false
+	}
+	if strings.EqualFold(host, "localhost") || strings.HasSuffix(strings.ToLower(host), ".localhost") {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }
 
 // StagedFileName is the credential file, relative to the agent's config

--- a/go/internal/agent/pkienroll/pkienroll.go
+++ b/go/internal/agent/pkienroll/pkienroll.go
@@ -44,8 +44,10 @@ package pkienroll
 import (
 	"bytes"
 	"context"
+	"crypto"
 	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"net/http"
@@ -188,6 +190,20 @@ func (e *IdentityError) Error() string {
 		strings.Join(e.Got, ", "), e.Want)
 }
 
+// ErrKeyMismatch reports a leaf whose public key is not the one the CSR was
+// signed with.
+//
+// WHY THIS IS CHECKED. Everything else about the response is about identity:
+// the SPIFFE SAN says who the leaf claims to be. This says whether the device
+// can actually use it. A leaf attesting somebody else's key cannot complete a
+// handshake with the key on disk, so storing it would replace a working
+// identity with one that fails at the first mutual Transport Layer Security
+// (mTLS) connection — and it would do so silently, because nothing in the
+// store re-checks the pairing. It is also the shape a substituted or
+// misrouted issuance takes, which is reason enough to refuse it rather than
+// diagnose it later from a handshake error.
+var ErrKeyMismatch = errors.New("pki enrollment: the issued leaf attests a different public key than the CSR")
+
 type enrollRequestBody struct {
 	CSR      string `json:"csr"`
 	DeviceID string `json:"device_id"`
@@ -226,6 +242,10 @@ func Enroll(ctx context.Context, req EnrollRequest) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
+	csrPub, err := csrPublicKey(csrPEM)
+	if err != nil {
+		return Result{}, err
+	}
 	body, err := json.Marshal(enrollRequestBody{CSR: csrPEM, DeviceID: deviceID, Tier: DefaultTier})
 	if err != nil {
 		return Result{}, fmt.Errorf("encoding enrollment request: %w", err)
@@ -246,7 +266,7 @@ func Enroll(ctx context.Context, req EnrollRequest) (Result, error) {
 	if client == nil {
 		client = &http.Client{Timeout: requestTimeout}
 	}
-	return exchange(client, httpReq, req.TenantUUID)
+	return exchange(client, httpReq, req.TenantUUID, csrPub)
 }
 
 // Renew exchanges a CSR for a fresh leaf, authenticated by presenting the
@@ -271,6 +291,10 @@ func Renew(ctx context.Context, req RenewRequest) (Result, error) {
 		return Result{}, err
 	}
 	csrPEM, err := buildCSR(req.Key, commonName)
+	if err != nil {
+		return Result{}, err
+	}
+	csrPub, err := csrPublicKey(csrPEM)
 	if err != nil {
 		return Result{}, err
 	}
@@ -304,7 +328,7 @@ func Renew(ctx context.Context, req RenewRequest) (Result, error) {
 			Transport: &http.Transport{TLSClientConfig: tlsCfg},
 		}
 	}
-	return exchange(client, httpReq, req.TenantUUID)
+	return exchange(client, httpReq, req.TenantUUID, csrPub)
 }
 
 func (r EnrollRequest) validate() error {
@@ -348,6 +372,11 @@ func buildCSR(keyPEM []byte, commonName string) (string, error) {
 // frontendEndpoint builds /v1/<tenant>/<action> under base. A base that already
 // carries a /v1/ path is returned unchanged, so a fully-specified endpoint from
 // configuration is honoured rather than having a second path appended to it.
+//
+// The plaintext rule is re-applied here and not only in CSRFrontendURL, because
+// a caller may fill EnrollRequest.CSRFrontendURL from somewhere that never went
+// through the resolver. Both Enroll and Renew reach this before any byte of the
+// request is built, so a refused endpoint costs no token.
 func frontendEndpoint(base, tenantUUID, action string) (string, error) {
 	base = strings.TrimSpace(base)
 	if !strings.Contains(base, "://") {
@@ -360,6 +389,9 @@ func frontendEndpoint(base, tenantUUID, action string) (string, error) {
 	if u.Host == "" {
 		return "", fmt.Errorf("csr frontend url %q has no host", base)
 	}
+	if err := checkTransport(base); err != nil {
+		return "", err
+	}
 	if strings.Contains(u.Path, "/v1/") {
 		return u.String(), nil
 	}
@@ -368,7 +400,9 @@ func frontendEndpoint(base, tenantUUID, action string) (string, error) {
 }
 
 // exchange performs the request and turns the response into a verified Result.
-func exchange(client *http.Client, req *http.Request, tenantUUID string) (Result, error) {
+// csrPub is the public half of the key that signed the CSR; the issued leaf has
+// to attest exactly that key or it is refused.
+func exchange(client *http.Client, req *http.Request, tenantUUID string, csrPub crypto.PublicKey) (Result, error) {
 	resp, err := client.Do(req)
 	if err != nil {
 		return Result{}, fmt.Errorf("contacting pki-core csr frontend: %w", err)
@@ -390,12 +424,13 @@ func exchange(client *http.Client, req *http.Request, tenantUUID string) (Result
 	if err := json.NewDecoder(limited).Decode(&ok); err != nil {
 		return Result{}, fmt.Errorf("decoding pki-core certificate response: %w", err)
 	}
-	return parseAndVerify(ok.Certificate, tenantUUID)
+	return parseAndVerify(ok.Certificate, tenantUUID, csrPub)
 }
 
 // parseAndVerify splits the returned leaf-first chain and refuses anything that
-// is not exactly one device principal for tenantUUID.
-func parseAndVerify(bundlePEM, tenantUUID string) (Result, error) {
+// is not exactly one device principal for tenantUUID, attesting the key that
+// signed the CSR.
+func parseAndVerify(bundlePEM, tenantUUID string, csrPub crypto.PublicKey) (Result, error) {
 	leafPEM, chainPEM, err := SplitLeafAndChain(bundlePEM)
 	if err != nil {
 		return Result{}, err
@@ -428,6 +463,9 @@ func parseAndVerify(bundlePEM, tenantUUID string) (Result, error) {
 	if !strings.EqualFold(gotTenant, tenantUUID) {
 		return Result{}, &IdentityError{Want: certs.DeviceSPIFFEURI(tenantUUID, "<name>"), Got: uris}
 	}
+	if err := checkPublicKeyMatch(leaf.PublicKey, csrPub); err != nil {
+		return Result{}, err
+	}
 
 	return Result{
 		LeafPEM:    normalizedLeaf,
@@ -437,6 +475,45 @@ func parseAndVerify(bundlePEM, tenantUUID string) (Result, error) {
 		NotBefore:  leaf.NotBefore,
 		NotAfter:   leaf.NotAfter,
 	}, nil
+}
+
+// csrPublicKey reads the public half back off the CSR that is about to be sent,
+// rather than deriving it from the private key a second time. It is the same
+// bytes the frontend will see, so the later comparison is against what was
+// actually asked for.
+func csrPublicKey(csrPEM string) (crypto.PublicKey, error) {
+	block, _ := pem.Decode([]byte(csrPEM))
+	if block == nil {
+		return nil, errors.New("pki enrollment: generated CSR is not PEM")
+	}
+	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing generated CSR: %w", err)
+	}
+	return csr.PublicKey, nil
+}
+
+// checkPublicKeyMatch compares the issued leaf's key with the CSR's.
+//
+// Every public key type in crypto/x509 (ECDSA, RSA, Ed25519 and the ML-DSA keys
+// the agent's parser also handles) offers Equal(crypto.PublicKey) bool, so the
+// comparison is done through that interface rather than a type switch that
+// would have to be extended for each new algorithm — and would, by defaulting
+// to "cannot compare", turn a new algorithm into a silently skipped check. A
+// key that does not implement it is refused for the same reason.
+func checkPublicKeyMatch(leafPub, csrPub crypto.PublicKey) error {
+	if csrPub == nil {
+		return fmt.Errorf("%w: the CSR carried no public key to compare", ErrKeyMismatch)
+	}
+	equaler, ok := csrPub.(interface{ Equal(crypto.PublicKey) bool })
+	if !ok {
+		return fmt.Errorf("%w: the CSR public key (%T) cannot be compared", ErrKeyMismatch, csrPub)
+	}
+	if !equaler.Equal(leafPub) {
+		return fmt.Errorf("%w: the leaf attests a %T, the CSR a %T; the device could not "+
+			"complete a handshake with it, so it is not stored", ErrKeyMismatch, leafPub, csrPub)
+	}
+	return nil
 }
 
 // leafCommonName reads the CN off a stored leaf, so a renewal CSR restates the

--- a/go/internal/agent/pkienroll/pkienroll_test.go
+++ b/go/internal/agent/pkienroll/pkienroll_test.go
@@ -51,6 +51,9 @@ type fakeFrontend struct {
 	lifetime time.Duration
 	// includeChain controls whether the issuer is appended after the leaf.
 	includeChain bool
+	// substituteKey issues the leaf against a freshly generated key instead of
+	// the CSR's, reproducing an issuance the device could never present.
+	substituteKey bool
 
 	// Captured for assertions.
 	lastPath       string
@@ -185,7 +188,15 @@ func (f *fakeFrontend) handle(w http.ResponseWriter, r *http.Request) {
 		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		URIs:        uris,
 	}
-	der, err := x509.CreateCertificate(rand.Reader, tmpl, f.caCert, csr.PublicKey, f.caKey)
+	leafPub := csr.PublicKey
+	if f.substituteKey {
+		other, keyErr := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if keyErr != nil {
+			f.t.Fatalf("generating substitute key: %v", keyErr)
+		}
+		leafPub = &other.PublicKey
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, f.caCert, leafPub, f.caKey)
 	if err != nil {
 		f.t.Fatalf("issuing test leaf: %v", err)
 	}
@@ -555,32 +566,187 @@ func TestCSRFrontendURL(t *testing.T) {
 	t.Setenv(CSREndpointEnv, "")
 	t.Setenv(EnvironmentEnv, "")
 
-	if got, want := CSRFrontendURL("", EnvDev), "https://"+DevCSRFrontendHost; got != want {
+	if got, want := mustCSRFrontendURL(t, "", EnvDev), "https://"+DevCSRFrontendHost; got != want {
 		t.Errorf("dev = %q, want %q", got, want)
 	}
-	if got, want := CSRFrontendURL("", EnvProd), "https://"+ProdCSRFrontendHost; got != want {
+	if got, want := mustCSRFrontendURL(t, "", EnvProd), "https://"+ProdCSRFrontendHost; got != want {
 		t.Errorf("prod = %q, want %q", got, want)
 	}
 	// An unrecognised environment must not be read as dev: sending a
 	// production device to a dev certificate authority is the failure this
 	// guards.
-	if got, want := CSRFrontendURL("", "staging"), "https://"+ProdCSRFrontendHost; got != want {
+	if got, want := mustCSRFrontendURL(t, "", "staging"), "https://"+ProdCSRFrontendHost; got != want {
 		t.Errorf("unknown environment = %q, want %q", got, want)
 	}
-	if got, want := CSRFrontendURL("http://127.0.0.1:8451", EnvProd), "http://127.0.0.1:8451"; got != want {
+	// A loopback plaintext override stays allowed: a local pki-core and a port
+	// forward are both reached that way, and the packet never leaves the host.
+	if got, want := mustCSRFrontendURL(t, "http://127.0.0.1:8451", EnvProd), "http://127.0.0.1:8451"; got != want {
 		t.Errorf("override = %q, want %q", got, want)
 	}
 
 	t.Setenv(EnvironmentEnv, EnvDev)
-	if got, want := CSRFrontendURL("", ""), "https://"+DevCSRFrontendHost; got != want {
+	if got, want := mustCSRFrontendURL(t, "", ""), "https://"+DevCSRFrontendHost; got != want {
 		t.Errorf("environment from env = %q, want %q", got, want)
 	}
 	t.Setenv(CSREndpointEnv, "csr.internal:9443")
-	if got, want := CSRFrontendURL("", ""), "https://csr.internal:9443"; got != want {
+	if got, want := mustCSRFrontendURL(t, "", ""), "https://csr.internal:9443"; got != want {
 		t.Errorf("endpoint from env = %q, want %q", got, want)
 	}
-	if got, want := CSRFrontendURL("explicit.example", ""), "https://explicit.example"; got != want {
+	if got, want := mustCSRFrontendURL(t, "explicit.example", ""), "https://explicit.example"; got != want {
 		t.Errorf("explicit override must beat the environment variable, got %q want %q", got, want)
+	}
+}
+
+func mustCSRFrontendURL(t *testing.T, override, environment string) string {
+	t.Helper()
+	got, err := CSRFrontendURL(override, environment)
+	if err != nil {
+		t.Fatalf("CSRFrontendURL(%q, %q): %v", override, environment, err)
+	}
+	return got
+}
+
+// A plaintext override to anything but this machine is refused where it is
+// configured, so the single-use bearer token is never put on the wire in
+// cleartext. Loopback stays allowed, and the accepted form is checked here too
+// so the allowance cannot be widened by accident.
+func TestCSRFrontendURLRefusesNonLoopbackPlaintext(t *testing.T) {
+	t.Setenv(CSREndpointEnv, "")
+	t.Setenv(EnvironmentEnv, "")
+
+	refused := []string{
+		"http://csr.dev.pki.wendy.sh",
+		"http://csr.internal:9443/v1/tenant/enroll",
+		"http://10.0.0.4:8451",
+		"http://[2001:db8::1]:8451",
+	}
+	for _, endpoint := range refused {
+		t.Run(endpoint, func(t *testing.T) {
+			got, err := CSRFrontendURL(endpoint, EnvProd)
+			if !errors.Is(err, ErrPlaintextEndpoint) {
+				t.Fatalf("CSRFrontendURL(%q) = %q, %v; want ErrPlaintextEndpoint", endpoint, got, err)
+			}
+			if got != "" {
+				t.Errorf("a refused endpoint must not also be returned, got %q", got)
+			}
+		})
+	}
+
+	accepted := []string{
+		"http://127.0.0.1:8451",
+		"http://127.0.0.2:8451",
+		"http://[::1]:8451",
+		"http://localhost:8451",
+		"https://csr.dev.pki.wendy.sh",
+		"csr.dev.pki.wendy.sh",
+	}
+	for _, endpoint := range accepted {
+		t.Run(endpoint, func(t *testing.T) {
+			if _, err := CSRFrontendURL(endpoint, EnvProd); err != nil {
+				t.Fatalf("CSRFrontendURL(%q): %v", endpoint, err)
+			}
+		})
+	}
+
+	// The environment-variable override takes the same route, so a device
+	// cannot be talked into cleartext through WENDY_PKI_CSR_ENDPOINT either.
+	t.Setenv(CSREndpointEnv, "http://csr.internal:9443")
+	if _, err := CSRFrontendURL("", ""); !errors.Is(err, ErrPlaintextEndpoint) {
+		t.Fatalf("environment override err = %v, want ErrPlaintextEndpoint", err)
+	}
+}
+
+// Enroll must not proceed on a plaintext endpoint even when the URL reached the
+// request without passing through CSRFrontendURL. Nothing is sent: the fake
+// frontend records no call.
+func TestEnrollRefusesNonLoopbackPlaintext(t *testing.T) {
+	f := newFakeFrontend(t)
+	srv := f.serve()
+	defer srv.Close()
+
+	_, err := Enroll(context.Background(), EnrollRequest{
+		CSRFrontendURL:  "http://csr.dev.pki.wendy.sh",
+		TenantUUID:      testTenant,
+		EnrollmentToken: "tok",
+		Key:             testKey(t),
+		CommonName:      "sh/wendy/2/408",
+	})
+	if !errors.Is(err, ErrPlaintextEndpoint) {
+		t.Fatalf("err = %v, want ErrPlaintextEndpoint", err)
+	}
+	if f.calls != 0 {
+		t.Errorf("the frontend was called %d time(s); a refused endpoint must spend no token", f.calls)
+	}
+
+	_, err = Renew(context.Background(), RenewRequest{
+		CSRFrontendURL: "http://csr.dev.pki.wendy.sh",
+		TenantUUID:     testTenant,
+		CurrentLeafPEM: f.caPEM,
+		Key:            testKey(t),
+		HTTPClient:     srv.Client(),
+	})
+	if !errors.Is(err, ErrPlaintextEndpoint) {
+		t.Fatalf("Renew err = %v, want ErrPlaintextEndpoint", err)
+	}
+}
+
+// A leaf attesting a key the device does not hold cannot complete a handshake,
+// so it is refused before Save is ever reached. The fake frontend is told to
+// issue against a key of its own rather than the one in the CSR.
+func TestEnrollRefusesLeafForAnotherKey(t *testing.T) {
+	f := newFakeFrontend(t)
+	f.substituteKey = true
+	srv := f.serve()
+	defer srv.Close()
+
+	_, err := Enroll(context.Background(), EnrollRequest{
+		CSRFrontendURL:  srv.URL,
+		TenantUUID:      testTenant,
+		EnrollmentToken: "tok",
+		Key:             testKey(t),
+		CommonName:      "sh/wendy/2/408",
+	})
+	if !errors.Is(err, ErrKeyMismatch) {
+		t.Fatalf("err = %v, want ErrKeyMismatch", err)
+	}
+	// The identity is right and the key is wrong: the SAN check alone would
+	// have accepted this, which is the gap the comparison closes.
+	var identityErr *IdentityError
+	if errors.As(err, &identityErr) {
+		t.Errorf("err = %v, want a key mismatch and not an identity error", err)
+	}
+}
+
+// The same check on renewal: a renewed leaf for another key would replace a
+// working certificate with one the device cannot present.
+func TestRenewRefusesLeafForAnotherKey(t *testing.T) {
+	f := newFakeFrontend(t)
+	srv := f.serve()
+	defer srv.Close()
+	key := testKey(t)
+
+	enrolled, err := Enroll(context.Background(), EnrollRequest{
+		CSRFrontendURL:  srv.URL,
+		TenantUUID:      testTenant,
+		EnrollmentToken: "tok",
+		Key:             key,
+		CommonName:      "sh/wendy/2/408",
+	})
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+
+	f.substituteKey = true
+	_, err = Renew(context.Background(), RenewRequest{
+		CSRFrontendURL:  srv.URL,
+		TenantUUID:      testTenant,
+		CurrentLeafPEM:  enrolled.LeafPEM,
+		CurrentChainPEM: enrolled.ChainPEM,
+		Key:             key,
+		HTTPClient:      srv.Client(),
+	})
+	if !errors.Is(err, ErrKeyMismatch) {
+		t.Fatalf("err = %v, want ErrKeyMismatch", err)
 	}
 }
 

--- a/go/internal/agent/services/pki_enrollment_file.go
+++ b/go/internal/agent/services/pki_enrollment_file.go
@@ -242,7 +242,15 @@ func (p *PKIEnrollment) ApplyStagedFile(ctx context.Context) PKIEnrollmentOutcom
 		}
 	}
 
-	frontendURL := pkienroll.CSRFrontendURL(staged.CSREndpoint, staged.Environment)
+	// A refused frontend URL is a configuration failure, not a transport one,
+	// and the token has not been spent: the staged file goes, because the same
+	// file would be refused identically on every restart.
+	frontendURL, err := pkienroll.CSRFrontendURL(staged.CSREndpoint, staged.Environment)
+	if err != nil {
+		p.logger.Error("pki enrollment file names an unusable CSR frontend, removing", zap.Error(err))
+		p.removeStagedFile(path)
+		return PKIEnrollmentOutcome{Status: PKIEnrollmentFailed, Reason: err.Error()}
+	}
 
 	key, err := p.store.LoadOrGenerateKey()
 	if err != nil {

--- a/go/internal/agent/timesync/consensus.go
+++ b/go/internal/agent/timesync/consensus.go
@@ -88,18 +88,18 @@ func queryConsensus(ctx context.Context, servers []roughtime.Server, query query
 		}(i, srv)
 	}
 	wg.Wait()
-	c := Consensus{Confidence: "unbounded", Evidence: evidence, ObservedUnixNanos: time.Now().UnixNano()}
+	c := Consensus{Confidence: ConfidenceUnbounded, Evidence: evidence, ObservedUnixNanos: time.Now().UnixNano()}
 	idx, lo, hi := largestIntersection(evidence)
 	for _, i := range idx {
 		c.Evidence[i].Included = true
 	}
 	c.Quorum = len(idx)
 	if len(idx) >= 3 {
-		c.Confidence = "verified"
+		c.Confidence = ConfidenceVerified
 		c.LowerOffsetNanos = lo
 		c.UpperOffsetNanos = hi
 	} else if len(idx) == 2 {
-		c.Confidence = "degraded"
+		c.Confidence = ConfidenceDegraded
 		c.LowerOffsetNanos = lo
 		c.UpperOffsetNanos = hi
 	}

--- a/go/internal/agent/timesync/manager.go
+++ b/go/internal/agent/timesync/manager.go
@@ -1,9 +1,11 @@
 package timesync
 
 import (
+	"context"
 	"sync"
 	"time"
 
+	"github.com/wendylabsinc/wendy/go/internal/shared/roughtime"
 	"go.uber.org/zap"
 )
 
@@ -14,6 +16,37 @@ type Manager struct {
 	configPath string
 	mu         sync.RWMutex
 	latest     *Consensus
+
+	// Injection points for deterministic tests of RunDirect. They replace the
+	// network query, the clock write and the wait, so a test can drive the
+	// loop's policy without a Roughtime server, root privileges or the real
+	// six-hour interval. Nil means "use the real one", so a zero-value Manager
+	// still behaves.
+	query func(context.Context, []roughtime.Server) (Consensus, error)
+	apply func(time.Time)
+	sleep func(time.Duration) <-chan time.Time
+}
+
+func (m *Manager) queryConsensus(ctx context.Context, servers []roughtime.Server) (Consensus, error) {
+	if m.query != nil {
+		return m.query(ctx, servers)
+	}
+	return QueryConsensus(ctx, servers)
+}
+
+func (m *Manager) applyTime(t time.Time) {
+	if m.apply != nil {
+		m.apply(t)
+		return
+	}
+	m.Apply(t)
+}
+
+func (m *Manager) after(d time.Duration) <-chan time.Time {
+	if m.sleep != nil {
+		return m.sleep(d)
+	}
+	return time.After(d)
 }
 
 func (m *Manager) RecordConsensus(c Consensus) {

--- a/go/internal/agent/timesync/roughtime.go
+++ b/go/internal/agent/timesync/roughtime.go
@@ -15,27 +15,76 @@ var backoffSchedule = []time.Duration{
 	30 * time.Minute,
 }
 
-// RunDirect queries the baked-in Roughtime servers in a loop, backing off on
-// failure and re-querying every 6 hours after a successful sync.
+// resyncInterval is the wait after a query that disciplined the clock.
+const resyncInterval = 6 * time.Hour
+
+// Confidence levels a Consensus can carry, in descending strength.
+const (
+	// ConfidenceVerified is a quorum of at least three servers whose intervals
+	// intersect.
+	ConfidenceVerified = "verified"
+	// ConfidenceDegraded is two independent signed responses that agree.
+	ConfidenceDegraded = "degraded"
+	// ConfidenceUnbounded is one response or none: no interval was agreed.
+	ConfidenceUnbounded = "unbounded"
+)
+
+// disciplinesClock reports whether a consensus is strong enough to move the
+// wall clock.
+//
+// WHY DEGRADED COUNTS. Two independent Roughtime servers, each response signed
+// by a long-term key baked into the image and each interval intersecting the
+// other, is strictly stronger evidence than the policy this loop replaced,
+// which applied whatever the first server said. It is also stronger than the
+// multicast path, which still applies a single relayed response. Requiring
+// three left the realistic failure — a device that can reach some Roughtime
+// servers but not others, behind a firewall or on a partitioned network — with
+// a clock that never advanced at all, and a stale clock fails every
+// certificate check on the device. One response remains insufficient: a single
+// server can lie on its own, and nothing else contradicts it.
+func disciplinesClock(c Consensus) bool {
+	return c.Confidence == ConfidenceVerified || c.Confidence == ConfidenceDegraded
+}
+
+// RunDirect queries the baked-in Roughtime servers in a loop and disciplines the
+// clock from any result that reaches at least degraded confidence. A weaker
+// result is retried on the backoff schedule rather than waiting out the full
+// re-sync interval, because a device that reached only one server has not
+// synced and will not be helped by six hours of silence.
 // Blocks until ctx is cancelled. Call as a goroutine.
 func (m *Manager) RunDirect(ctx context.Context) {
 	attempt := 0
 	for {
 		qCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		result, err := QueryConsensus(qCtx, Servers)
+		result, err := m.queryConsensus(qCtx, Servers)
 		cancel()
 		if err != nil {
 			if m.logger != nil {
 				m.logger.Warn("timesync: direct Roughtime query failed",
 					zap.Error(err), zap.Int("attempt", attempt))
 			}
-			delay := backoffSchedule[min(attempt, len(backoffSchedule)-1)]
-			attempt++
-			select {
-			case <-ctx.Done():
+			if !m.waitBackoff(ctx, attempt) {
 				return
-			case <-time.After(delay):
 			}
+			attempt++
+			continue
+		}
+
+		m.RecordConsensus(result)
+		if !disciplinesClock(result) {
+			// Observed but not applied. Retrying soon is the point: this is a
+			// device that reached too few servers, and the servers it could
+			// not reach may be reachable in thirty seconds.
+			if m.logger != nil {
+				m.logger.Warn("timesync: Roughtime consensus too weak to set the clock; retrying",
+					zap.Int("quorum", result.Quorum),
+					zap.String("confidence", result.Confidence),
+					zap.Int("attempt", attempt))
+			}
+			if !m.waitBackoff(ctx, attempt) {
+				return
+			}
+			attempt++
 			continue
 		}
 
@@ -46,20 +95,27 @@ func (m *Manager) RunDirect(ctx context.Context) {
 				zap.String("confidence", result.Confidence),
 				zap.Duration("uncertainty", time.Duration((result.UpperOffsetNanos-result.LowerOffsetNanos)/2)))
 		}
-		m.RecordConsensus(result)
-		// Clock discipline is deliberately separate from observation. Only a
-		// verified quorum may advance an obviously stale wall clock.
-		if result.Confidence == "verified" {
-			boot, _ := bootTimeNanos()
-			mid := result.LowerOffsetNanos + (result.UpperOffsetNanos-result.LowerOffsetNanos)/2
-			m.Apply(time.Unix(0, boot+mid))
-		}
+		boot, _ := bootTimeNanos()
+		mid := result.LowerOffsetNanos + (result.UpperOffsetNanos-result.LowerOffsetNanos)/2
+		m.applyTime(time.Unix(0, boot+mid))
 
-		// Re-query every 6 hours.
-		select {
-		case <-ctx.Done():
+		if !m.wait(ctx, resyncInterval) {
 			return
-		case <-time.After(6 * time.Hour):
 		}
+	}
+}
+
+// waitBackoff sleeps the delay for attempt, reporting false when ctx ended.
+func (m *Manager) waitBackoff(ctx context.Context, attempt int) bool {
+	return m.wait(ctx, backoffSchedule[min(attempt, len(backoffSchedule)-1)])
+}
+
+// wait sleeps d, reporting false when ctx ended first.
+func (m *Manager) wait(ctx context.Context, d time.Duration) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-m.after(d):
+		return true
 	}
 }

--- a/go/internal/agent/timesync/roughtime_test.go
+++ b/go/internal/agent/timesync/roughtime_test.go
@@ -1,0 +1,180 @@
+package timesync
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/roughtime"
+)
+
+// directResult is one scripted answer from the replaced Roughtime query.
+type directResult struct {
+	consensus Consensus
+	err       error
+}
+
+// directHarness drives RunDirect with the network, the clock write and the wait
+// all replaced, so a test asserts the loop's policy rather than a real sync.
+type directHarness struct {
+	mu sync.Mutex
+
+	// results are returned in order, one per query; the last one repeats.
+	results []directResult
+	queries int
+	applied []time.Time
+	waits   []time.Duration
+
+	// stopAfter cancels the context once this many waits have been observed,
+	// so the loop terminates without depending on wall-clock time.
+	stopAfter int
+	cancel    context.CancelFunc
+	manager   *Manager
+}
+
+func newDirectHarness(stopAfter int, results ...directResult) *directHarness {
+	h := &directHarness{results: results, stopAfter: stopAfter}
+	m := NewManager(nil, "")
+	m.query = func(context.Context, []roughtime.Server) (Consensus, error) {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		i := min(h.queries, len(h.results)-1)
+		h.queries++
+		return h.results[i].consensus, h.results[i].err
+	}
+	m.apply = func(t time.Time) {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		h.applied = append(h.applied, t)
+	}
+	m.sleep = func(d time.Duration) <-chan time.Time {
+		h.mu.Lock()
+		h.waits = append(h.waits, d)
+		last := len(h.waits) >= h.stopAfter
+		h.mu.Unlock()
+		if last {
+			h.cancel()
+			// A cancelled context wins the select, so this never fires.
+			return make(chan time.Time)
+		}
+		fired := make(chan time.Time, 1)
+		fired <- time.Now()
+		return fired
+	}
+	h.manager = m
+	return h
+}
+
+func (h *directHarness) run(t *testing.T) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	h.cancel = cancel
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		h.manager.RunDirect(ctx)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunDirect did not return after its context was cancelled")
+	}
+}
+
+func consensusResult(confidence string, quorum int) directResult {
+	return directResult{consensus: Consensus{
+		Confidence:       confidence,
+		Quorum:           quorum,
+		LowerOffsetNanos: 1_000,
+		UpperOffsetNanos: 3_000,
+	}}
+}
+
+// Two independent signed responses that agree are applied. Before this, only a
+// quorum of three set the clock, so a device that could reach two servers never
+// advanced its clock at all while logging a successful sync every six hours.
+func TestRunDirectAppliesDegradedConsensus(t *testing.T) {
+	h := newDirectHarness(1, consensusResult(ConfidenceDegraded, 2))
+	h.run(t)
+
+	if len(h.applied) != 1 {
+		t.Fatalf("applied %d time(s), want the degraded consensus to set the clock once", len(h.applied))
+	}
+	if len(h.waits) != 1 || h.waits[0] != resyncInterval {
+		t.Errorf("waits = %v, want one re-sync interval of %v after a successful discipline", h.waits, resyncInterval)
+	}
+	latest, ok := h.manager.LatestConsensus()
+	if !ok || latest.Confidence != ConfidenceDegraded {
+		t.Errorf("latest consensus = %+v (recorded: %v), want the degraded result recorded", latest, ok)
+	}
+}
+
+// A single-server result does not set the clock, and it does not cost six hours
+// either: it retries on the backoff ladder, because the servers that were
+// unreachable may be reachable again shortly.
+func TestRunDirectRetriesWhenNotVerified(t *testing.T) {
+	h := newDirectHarness(3, consensusResult(ConfidenceUnbounded, 1))
+	h.run(t)
+
+	if len(h.applied) != 0 {
+		t.Fatalf("applied %v; a single unverified response must not set the clock", h.applied)
+	}
+	want := []time.Duration{backoffSchedule[0], backoffSchedule[1], backoffSchedule[2]}
+	if len(h.waits) != len(want) {
+		t.Fatalf("waits = %v, want the backoff ladder %v", h.waits, want)
+	}
+	for i, d := range want {
+		if h.waits[i] != d {
+			t.Errorf("wait %d = %v, want %v", i, h.waits[i], d)
+		}
+		if h.waits[i] == resyncInterval {
+			t.Errorf("wait %d slept the full re-sync interval on an unsynced clock", i)
+		}
+	}
+}
+
+// A weak result followed by a strong one syncs on the second attempt, and the
+// wait after it is the re-sync interval rather than another backoff step.
+func TestRunDirectRecoversFromWeakToVerified(t *testing.T) {
+	h := newDirectHarness(2,
+		consensusResult(ConfidenceUnbounded, 1),
+		consensusResult(ConfidenceVerified, 3),
+	)
+	h.run(t)
+
+	if len(h.applied) != 1 {
+		t.Fatalf("applied %d time(s), want exactly the verified result", len(h.applied))
+	}
+	if len(h.waits) != 2 || h.waits[0] != backoffSchedule[0] || h.waits[1] != resyncInterval {
+		t.Errorf("waits = %v, want [%v %v]", h.waits, backoffSchedule[0], resyncInterval)
+	}
+}
+
+// A query error keeps the existing behaviour: warn, back off, retry.
+func TestRunDirectBacksOffOnQueryError(t *testing.T) {
+	h := newDirectHarness(2, directResult{err: errors.New("no valid Roughtime evidence")})
+	h.run(t)
+
+	if len(h.applied) != 0 {
+		t.Fatalf("applied %v after a failed query", h.applied)
+	}
+	if len(h.waits) != 2 || h.waits[0] != backoffSchedule[0] || h.waits[1] != backoffSchedule[1] {
+		t.Errorf("waits = %v, want the backoff ladder", h.waits)
+	}
+}
+
+func TestDisciplinesClock(t *testing.T) {
+	for confidence, want := range map[string]bool{
+		ConfidenceVerified:  true,
+		ConfidenceDegraded:  true,
+		ConfidenceUnbounded: false,
+		"":                  false,
+	} {
+		if got := disciplinesClock(Consensus{Confidence: confidence}); got != want {
+			t.Errorf("disciplinesClock(%q) = %v, want %v", confidence, got, want)
+		}
+	}
+}

--- a/go/internal/agent/timesync/servers.go
+++ b/go/internal/agent/timesync/servers.go
@@ -8,8 +8,17 @@ import (
 )
 
 // Servers is the baked-in set of Roughtime servers queried on startup and on
-// network-up events. Query uses the first valid response — one honest server
-// suffices for Roughtime's security guarantee.
+// network-up events. All four are queried at once and the answers are
+// intersected, rather than the first valid response being taken: Roughtime's
+// guarantee is that a lying server can be CAUGHT, not that any one server can
+// be trusted, and catching it needs more than one answer to compare.
+//
+// The direct loop applies the intersection at "verified" (three or more
+// agreeing) and at "degraded" (two agreeing), and retries on the backoff
+// schedule below that; see disciplinesClock in roughtime.go for why two is the
+// floor. The multicast relay path is separate and applies a single relayed
+// response, because there the sender is a machine on the local network that
+// the device is already trusting for provisioning.
 //
 // Keys must be fetched from each operator's published ecosystem JSON and
 // encoded as 32-byte ed25519.PublicKey. See design doc for retrieval steps.

--- a/go/internal/cli/commands/data_enroll.go
+++ b/go/internal/cli/commands/data_enroll.go
@@ -123,6 +123,12 @@ func runDataEnrollLocal(cmd *cobra.Command, configPath, tenant, token, deviceID,
 	if configPath == "" {
 		configPath = agentConfigPath()
 	}
+	// Resolved before staging, not after: a frontend URL the agent will refuse
+	// must not first be written to disk alongside the token.
+	frontendURL, err := pkienroll.CSRFrontendURL(csrEndpoint, environment)
+	if err != nil {
+		return err
+	}
 	path, err := pkienroll.Stage(configPath, pkienroll.StagedEnrollment{
 		Token:       token,
 		TenantUUID:  tenant,
@@ -138,7 +144,7 @@ func runDataEnrollLocal(cmd *cobra.Command, configPath, tenant, token, deviceID,
 			"  tenant:   %s\n"+
 			"  frontend: %s\n"+
 			"The agent redeems and deletes it on its next start; restart wendy-agent to apply now.\n",
-		path, tenant, pkienroll.CSRFrontendURL(csrEndpoint, environment))
+		path, tenant, frontendURL)
 	return nil
 }
 

--- a/swift/WendyE2ETests/Tests/WendyE2ETests/WendyBuildTests.swift
+++ b/swift/WendyE2ETests/Tests/WendyE2ETests/WendyBuildTests.swift
@@ -23,7 +23,7 @@ struct `'wendy build'` {
                 #expect(stdout.contains("--build-type"))
                 #expect(stdout.contains("--builder"))
                 #expect(stdout.contains("--dockerfile"))
-                #expect(!Self.helpDeclaresFlag("--build-host", in: stdout))
+                #expect(!stdout.contains("--build-host"))
                 #expect(stdout.contains("--json"))
                 #expect(result.stderr == "")
             }
@@ -167,27 +167,5 @@ struct `'wendy build'` {
     )
     func `rejects undocumented positional arguments`() async throws {
         // TODO: enable when build rejects positional arguments (WDY-1934).
-    }
-
-    /**
-     Reports whether a help listing declares `flag` as an option the command
-     accepts, meaning some line opens its flag column with it, optionally
-     behind a shorthand such as `-d, --device`.
-
-     A flag named inside another flag's description is prose, not an offered
-     option, so the global `--device` help mentioning `--build-host` must not
-     read as `wendy build` accepting `--build-host`.
-     */
-    private static func helpDeclaresFlag(_ flag: String, in help: String) -> Bool {
-        help.split(separator: "\n", omittingEmptySubsequences: false).contains { line in
-            var column = line.drop(while: { $0.isWhitespace })
-            if column.count > 4, column.first == "-", column.dropFirst(2).hasPrefix(", ") {
-                column = column.dropFirst(4)
-            }
-            guard column.hasPrefix(flag) else { return false }
-            // `--build-hostname` must not answer for `--build-host`.
-            guard let separator = column.dropFirst(flag.count).first else { return true }
-            return separator.isWhitespace || separator == "="
-        }
     }
 }


### PR DESCRIPTION
## Problem

Four review findings against `feature/wendy-data-platform-complete`, three of them defects that fail silently.

1. **SEAMS-F2 (i), high.** `pkienroll.CSRFrontendURL` honoured a plaintext `http://` override verbatim, and the package's own test pinned that behaviour. A misconfigured staged credential file or `WENDY_PKI_CSR_ENDPOINT` would have sent the single-use bearer enrolment token over cleartext HyperText Transfer Protocol (HTTP) to a public host.
2. **SEAMS-F2 (ii), high.** `parseAndVerify` checked that the issued leaf carried exactly one device SPIFFE Uniform Resource Identifier (URI) for the expected tenant, and nothing about its public key. A leaf attesting a different key would have been stored and would then have failed every mutual Transport Layer Security (mTLS) handshake, with the failure surfacing far from its cause.
3. **S1-2-F8, medium.** `timesync.RunDirect` disciplined the clock only at `Confidence == "verified"` (a quorum of at least three). A `degraded` result (two independent signed responses agreeing) or a single-server result reset the attempt counter and slept six hours, so a device that could reach only some Roughtime servers never advanced its clock while logging a successful query every six hours. The multicast path meanwhile applies a single relayed response, and `servers.go` still described a first-valid-response policy the code had not used for some time.
4. **S3-F10, low.** `.github/scripts/security_review.py` set `MAX_DIFF_BYTES = 140_000` with no exclusion for generated files, so a pull request that regenerated the protobuf stubs under `go/proto/gen/**` exceeded the budget, was rejected outright, and had its hand-written lines reviewed by nobody.

Plus **S7a-F6, low**: the Swift end-to-end assertion `#expect(!stdout.contains("--build-host"))` had been loosened to a helper that permits the hidden flag's name to appear in prose.

## Cause

Each check stopped one step short of the property it was protecting. `CSRFrontendURL` applied a default scheme but never questioned an explicit one. `parseAndVerify` answered "is this the right identity" and never "can this device use it". `RunDirect` treated the three-server quorum as the only acceptable evidence, even though the multicast path applies a single relayed response and the policy the change replaced took the first server's answer. And the byte budget, written to prevent a partial review, had no notion of a file no human wrote: it counted mechanically derived bytes exactly as it counted authored ones.

## Solution

* **Plaintext refusal.** `pkienroll` refuses a non-loopback `http://` endpoint at configuration time, in `CSRFrontendURL` and again in `frontendEndpoint`, so `Enroll` and `Renew` return before a byte is built and no token is spent. Loopback (127.0.0.0/8, ::1, `localhost`) stays allowed so a local pki-core, a port forward and the package's own `httptest` fakes keep working. `CSRFrontendURL` now returns `(string, error)`; the agent's enrolment path removes the staged file and reports the failure, and `wendy data enroll --local` resolves the URL **before** staging so a rejected endpoint is never written to disk beside the token.
* **Key binding.** `parseAndVerify` compares the leaf's public key with the key that signed the CSR, read back off the generated CSR itself, through the `Equal(crypto.PublicKey) bool` interface every `crypto/x509` key type implements (a type switch would silently skip a future algorithm). A mismatch returns `ErrKeyMismatch` and nothing is stored. Renewal shares the path, so the check applies there too.
* **Time-sync policy.** `RunDirect` disciplines the clock at `verified` **and** `degraded`, and retries anything weaker on the backoff ladder instead of sleeping the full re-sync interval. Two independent signed responses whose intervals intersect is strictly stronger evidence than the pre-change single-server policy and than the multicast path. `servers.go` now describes what the code does. The confidence strings became exported constants so the loop and `consensus.go` cannot drift apart.
* **Byte budget.** `security_review.py` gains `partition_generated`, which splits the unified diff per file and drops generated paths from both the byte count and the diff the model reads. The pattern set is `go/proto/gen/**`, `*.pb.go`, `*_grpc.pb.go` plus everything `.gitattributes` marks `linguist-generated` (parsed in-process, so the rule is the one a reader of the file sees). The full diff's byte count and SHA-256 are still recorded and now reported alongside the exclusion, so nothing is hidden; `enforce` still matches a result to the exact input it came from. The Go protobuf paths are now marked `linguist-generated` in `.gitattributes`, which also collapses them in the GitHub diff view.
* **Swift assertion.** Reverted to main's strict line and `helpDeclaresFlag` removed; the file is now byte-identical to `origin/main`.

## Findings

| Finding | Verdict | Evidence |
| --- | --- | --- |
| SEAMS-F2 (i) plaintext CSR frontend | **FIXED** | `ErrPlaintextEndpoint` in `go/internal/agent/pkienroll/config.go`, re-applied in `frontendEndpoint`; `TestCSRFrontendURLRefusesNonLoopbackPlaintext`, `TestEnrollRefusesNonLoopbackPlaintext` (asserts the fake frontend saw zero calls). |
| SEAMS-F2 (ii) leaf key not bound to CSR | **FIXED** | `checkPublicKeyMatch` in `pkienroll.go`, called from `parseAndVerify` before `Save`; `TestEnrollRefusesLeafForAnotherKey`, `TestRenewRefusesLeafForAnotherKey`. |
| SEAMS-F2 extra audit (key modes, token handling) | **NO CHANGE NEEDED** | Key `0o600`, staged credential `0o600`, directories `0o700`, certificates `0o644`; `atomicfile.Write` chmods the temporary file before the rename, so a key is never briefly world-readable. The token is never logged, never placed in a URL, and `StatusError` carries only the server's own detail. One residual noted below. |
| S1-2-F8 degraded consensus never applied | **FIXED** | `disciplinesClock` and the backoff-on-weak-result path in `roughtime.go`; `servers.go` comment rewritten; `TestRunDirectAppliesDegradedConsensus`, `TestRunDirectRetriesWhenNotVerified`, `TestRunDirectRecoversFromWeakToVerified`, `TestRunDirectBacksOffOnQueryError`, `TestDisciplinesClock`. |
| S7a-F6 loosened Swift assertion | **FIXED** | `go run ./cmd/wendy build --help` on this branch contains zero occurrences of `--build-host` (the flag is `MarkHidden`, and the `--device` description says "a remote build host", not the flag name). Test file now diffs clean against `origin/main`. |
| S3-F10 generated files spend the byte budget | **FIXED** | `partition_generated` / `generated_globs` / `is_generated_path` in `security_review.py`, nine new unit tests, `.gitattributes` updated. Dry run below. |
| SEAMS-F3 `generate-proto.sh` references a deleted proto | **ALREADY FIXED** | Fixed in `7336d6fc0 refactor(proto): move app-facing SensorService into wendy.agent.apps.v1`, which removed the `appspb` generator block; the only remaining mention of `sensor_service.proto` is the comment recording why the block is gone. Verified by running it: `bash go/scripts/generate-proto.sh` exits 0 through all six generator blocks, and the only diff it produces is the `protoc` version stamp of the locally installed toolchain (v7.36.0 against the pinned v7.35.1). |
| SEAMS-F9 "Build docs" job fails | **MAIN PROBLEM, NOT FIXED** | Latest Fumadocs run on `main` (34462684080, 2026-09-10) fails at `npm audit --audit-level=high` with 5 vulnerabilities (2 moderate, 2 high, 1 critical, one requiring `npm audit fix --force`, in `postcss` and `sharp`). Not a property of this branch; needs its own dependency bump. |

### S3-F10 dry run

Against a real mixed diff: the 75 files `generate-proto.sh` rewrites when the local `protoc` differs (37,410 bytes), concatenated with this branch's own hand-written `pkienroll` change (21,204 bytes), 78 files and 58,614 bytes in total. The limit is set to 40,000 to make the effect visible on a sample this size.

```
WITHOUT EXCLUSION rejected: PR diff is too large for one complete AI review:
58,614 hand-written bytes across 78 files exceeds the 40,000-byte limit
(0 generated file(s) already excluded). Split the PR; no partial review was performed.

WITH EXCLUSION accepted:
  changed_files            78
  reviewed_files            3
  diff_bytes           58,614
  reviewable_bytes     21,204
  generated_files_excluded 75
  generated_bytes_excluded 37,410
  truncation             none

**Input coverage:** 3/78 changed files; 21,204/58,614 bytes reviewed;
75 generated file(s) excluded (37,410 bytes); diff SHA-256 `f755affa...`; truncation: none.
```

## Verification

From `go/`:

```
go build ./...                                                              clean
go vet ./internal/agent/pkienroll/... ./internal/agent/timesync/...          clean
GOOS=linux go vet ./internal/agent/pkienroll/... ./internal/agent/timesync/... clean
go test -race ./internal/agent/pkienroll/ ./internal/agent/timesync/         ok, ok
go test ./internal/agent/... ./internal/shared/...                           pass
python3 .github/scripts/security_review_test.py                              39 tests, OK
go run ./cmd/wendy build --help                                              0 hits for --build-host
bash go/scripts/generate-proto.sh                                            exit 0
```

Two failures seen on the way are not from this change and reproduce on the unmodified branch: `TestBuildCmd_MultiService_BuildsFromManifestOnly` in `internal/cli/commands` compares a macOS temporary directory against its `/private` symlink resolution, and `TestSampleGPUFallsBackToTegrastatsForOrin` in `internal/agent/hoststats` is timing-sensitive under a parallel package run and passes on every rerun.

The Swift end-to-end suite cannot run here. The change to it is safe because the assertion it restores is main's, the file is byte-identical to main, and the property it asserts was confirmed empirically rather than by inspection: `wendy build --help` built from this branch prints no occurrence of the flag name at all.

## Residual, not fixed

`Store.LoadOrGenerateKey` reuses an existing key file without re-checking its mode. A key written by this code is always `0o600`, so this only matters for a file some other tool left behind with a wider mode. Widening or narrowing modes on files the agent did not write is a behaviour change beyond these findings, so it is noted rather than done.


## Continuous integration on this pull request

Every check passes except `Integration Tests (macOS) / Integration (macOS -> wendy-SER9.local)`, which is a pre-existing hardware-in-the-loop failure and not attributable to this change.

* The failing case is `python-multiservice (all services)`, which errors with `creating container for service db: ... dial unix /Users/wendy/.wendy/sessions/617511a3b96ae40c9a51.sock: connect: no such file or directory`, a stale session socket on the runner Mac, alongside a `PrepareImage` `Unimplemented` fallback from an older agent on the device. Nothing in this change touches the container, session or tunnel path.
* That same case has failed on every recorded run of this job on every branch: 34342005842 (`jo/macos-buildkit-service`, 2 failed), 34235688232 (`feat/WDY-2846_dragonwing-cli-flash`, 3 failed), 34263253759 (3 failed). This branch reports 23 passed and 1 failed, the best result in that set.
* Re-running the job reproduced the identical failure with the identical cached session id, which is the signature of stale runner state rather than a flake.
