### PR TITLE
fix(data): charge transport failures to the pass, not to each episode

### DIFF
--- a/go/internal/agent/data/manager.go
+++ b/go/internal/agent/data/manager.go
@@ -831,6 +831,16 @@ func evictionTier(state string) int {
 	return 2
 }
 
+// BeginDownload pins an episode against quota eviction for as long as its
+// payload is being read, and EndDownload releases that pin. They nest: the
+// count is what enforceQuota consults, so an episode a device download and an
+// upload are both reading survives until the last reader is done.
+//
+// Named for the first caller (DataService.DownloadEpisode), but the contract is
+// "somebody is reading these bytes right now", which is equally true of the
+// transfer worker streaming an episode to the cloud. Every reader must take the
+// pin: an evicted episode's files vanish under an open stream, and the reader
+// then fails with an error naming the file rather than the eviction.
 func (m *Manager) BeginDownload(id string) { m.mu.Lock(); defer m.mu.Unlock(); m.downloads[id]++ }
 func (m *Manager) EndDownload(id string) {
 	m.mu.Lock()

--- a/go/internal/agent/data/manager_test.go
+++ b/go/internal/agent/data/manager_test.go
@@ -394,3 +394,44 @@ func TestStartDoesNotBlockOnRoughtimeConsensus(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// TestEnforceQuotaSkipsPinnedEpisode pins the retention-versus-transfer race.
+// An episode whose bytes are being read right now (a device download, or the
+// transfer worker streaming it to the cloud) must survive eviction even when
+// the quota cannot hold it: deleting it removes the files from under an open
+// stream, and the reader then fails with an error naming the file rather than
+// the eviction. The "uploading" upload state alone did not protect it, because
+// enforceQuota consults the pin count and nothing else.
+func TestEnforceQuotaSkipsPinnedEpisode(t *testing.T) {
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.SetWarnLogger(func(string) {})
+	pinned := recordEpisode(t, m, StartOptions{Sources: []string{"applications"}, Trigger: EpisodeTrigger{Reason: "event:test", CampaignName: "forklift"}})
+	setUploadState(t, m, pinned.ID, "uploading", "forklift")
+
+	// A quota of one byte cannot hold anything, so every unpinned candidate
+	// goes and enforceQuota reports it could not get under the ceiling.
+	m.SetQuota(1, 0)
+	m.BeginDownload(pinned.ID)
+	if _, err = m.Start(StartOptions{Sources: []string{"applications"}}); err == nil {
+		if _, stopErr := m.Stop(AdHocEpisodeKey); stopErr != nil {
+			t.Fatal(stopErr)
+		}
+	}
+	if _, err = m.episodeDir(pinned.ID); err != nil {
+		t.Fatalf("pinned episode was evicted while its payload was being read: %v", err)
+	}
+
+	// Releasing the pin makes it a candidate again.
+	m.EndDownload(pinned.ID)
+	if _, err = m.Start(StartOptions{Sources: []string{"applications"}}); err == nil {
+		if _, stopErr := m.Stop(AdHocEpisodeKey); stopErr != nil {
+			t.Fatal(stopErr)
+		}
+	}
+	if _, err = m.episodeDir(pinned.ID); err == nil {
+		t.Fatal("episode survived eviction after its pin was released")
+	}
+}

--- a/go/internal/agent/services/data_transfer_worker.go
+++ b/go/internal/agent/services/data_transfer_worker.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"math/rand/v2"
+	"os"
 	"strings"
 	"time"
 
@@ -26,11 +28,23 @@ const (
 	// (except the final short chunk of each file).
 	transferChunkBytes = 1 << 20
 
-	// transferMaxAttempts bounds how many times a single episode is retried on
-	// retryable (transport) failures before the worker gives up and records the
-	// episode as permanently "failed". Verification failures are terminal on the
-	// first occurrence and do not consume the retry budget.
+	// transferMaxAttempts bounds how many times a single episode is retried
+	// before the worker gives up and records it as permanently "failed".
+	//
+	// The budget pays only for failures that belong to THIS episode: a server
+	// that rejects its manifest or its stream (InvalidArgument, Internal,
+	// FailedPrecondition and anything else answered for that one stream). It
+	// does not pay for the network. A transport failure (Unavailable,
+	// DeadlineExceeded, a dead connection) says nothing about the episode and
+	// every queued episode would meet it identically, so it costs wall clock
+	// through the pass-level backoff and leaves the attempt counter untouched;
+	// see transportStalled. Verification failures are terminal on the first
+	// occurrence and do not consume the budget either.
 	transferMaxAttempts = 5
+
+	// transferBackoffBase is the first pass-level backoff step. Successive
+	// failed passes double it, with jitter, up to transferMaxBackoff.
+	transferBackoffBase = time.Second
 
 	// transferMaxBackoff caps the per-pass exponential backoff between failed
 	// upload passes, matching the telemetry flusher's ceiling.
@@ -39,6 +53,18 @@ const (
 	// transferIdlePause is the pause between successful passes when there is no
 	// backlog, to avoid busy-looping the disk scan.
 	transferIdlePause = 10 * time.Second
+
+	// transferRequeueInterval is how often the worker re-arms episodes it has
+	// already marked "failed".
+	//
+	// EpisodesAwaitingUpload returns only "pending" and "uploading", so a
+	// failed episode is invisible to every later pass and nothing would look at
+	// it again. Re-arming only at process start meant an outage that outlived
+	// one episode's retry budget stranded the backlog until somebody restarted
+	// the agent. Half an hour is long enough that a genuinely unshippable
+	// episode is not retried in a tight loop, and short enough that a device
+	// nobody is watching recovers on its own.
+	transferRequeueInterval = 30 * time.Minute
 )
 
 // errIngestBlocked wraps a failure that says the ROUTE is wrong rather than the
@@ -75,6 +101,54 @@ func ingestBlocked(err error) *errIngestBlocked {
 	switch st.Code() {
 	case codes.Unimplemented, codes.Unauthenticated, codes.PermissionDenied:
 		return &errIngestBlocked{code: st.Code(), cause: err}
+	}
+	return nil
+}
+
+// errTransportStalled wraps a failure that says the NETWORK is down rather than
+// that the episode is bad. Like errIngestBlocked it is a pass-level condition,
+// but unlike it the cure is time rather than a configuration change, so the
+// worker backs the whole pass off and tries again.
+type errTransportStalled struct {
+	code  codes.Code
+	cause error
+}
+
+func (e *errTransportStalled) Error() string {
+	return fmt.Sprintf("ingest transport is unavailable (%s): %v", e.code, e.cause)
+}
+func (e *errTransportStalled) Unwrap() error { return e.cause }
+
+// transportStalled reports whether err is the network failing rather than this
+// episode failing.
+//
+// This distinction is the difference between an outage and a data loss. The
+// ingest client is built with grpc.NewClient, which connects lazily, so an
+// offline device does not fail when it dials: it fails on the first call of
+// each episode, with Unavailable. Charged to the episode, roughly a minute of
+// outage spent the whole five-attempt budget of every queued episode and marked
+// them all permanently failed, and only a restart brought them back. Charged to
+// the pass, the same outage costs wall clock and nothing else.
+//
+// Unavailable covers the dial and connection failures grpc.NewClient defers to
+// call time; DeadlineExceeded covers a link too slow or too broken to finish.
+// context.DeadlineExceeded is included because a client-side timeout arrives
+// unwrapped from some call sites. Every other code, including Unknown, stays
+// with the episode: those are answers from a server that reached us.
+func transportStalled(err error) *errTransportStalled {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return &errTransportStalled{code: codes.DeadlineExceeded, cause: err}
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		return nil
+	}
+	switch st.Code() {
+	case codes.Unavailable, codes.DeadlineExceeded:
+		return &errTransportStalled{code: st.Code(), cause: err}
 	}
 	return nil
 }
@@ -134,10 +208,17 @@ type DataTransferWorker struct {
 	// whose upload.when is "wifi". When nil, no network-type signal is wired and
 	// "wifi" is treated as "always" (see resolveShouldUpload).
 	onWiFi func() bool
-	// now and newSleeper are injection points for deterministic tests; both
-	// default to real time.
+	// requeueInterval is how often the Run loop re-arms episodes that were
+	// marked "failed" (see transferRequeueInterval).
+	requeueInterval time.Duration
+	// now, newSleeper, wait and newTicker are injection points for
+	// deterministic tests; all four default to real time. newSleeper paces the
+	// byte stream, wait drives the Run loop's backoff and idle pause, and
+	// newTicker drives the periodic requeue.
 	now        func() time.Time
 	newSleeper func(ctx context.Context) func(time.Duration)
+	wait       func(ctx context.Context, d time.Duration)
+	newTicker  func(d time.Duration) (<-chan time.Time, func())
 }
 
 // NewDataTransferWorker builds a worker that reads cloud credentials and the
@@ -149,8 +230,11 @@ func NewDataTransferWorker(logger *zap.Logger, manager *data.Manager, provisioni
 		manager:         manager,
 		provisioningSvc: provisioningSvc,
 		maxAttempts:     transferMaxAttempts,
+		requeueInterval: transferRequeueInterval,
 		now:             time.Now,
 		newSleeper:      contextSleeper,
+		wait:            waitFor,
+		newTicker:       realTicker,
 	}
 	w.factory = w.dialFactory
 	return w
@@ -199,6 +283,26 @@ func contextSleeper(ctx context.Context) func(time.Duration) {
 		case <-ctx.Done():
 		}
 	}
+}
+
+// waitFor blocks for d, returning early when ctx is done. It is the production
+// implementation of DataTransferWorker.wait.
+func waitFor(ctx context.Context, d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+	case <-ctx.Done():
+	}
+}
+
+// realTicker is the production implementation of DataTransferWorker.newTicker.
+func realTicker(d time.Duration) (<-chan time.Time, func()) {
+	t := time.NewTicker(d)
+	return t.C, t.Stop
 }
 
 // pkiIdentityReader reads the device's stored pki-core identity.
@@ -311,14 +415,38 @@ func (w *DataTransferWorker) Run(ctx context.Context) {
 		return
 	}
 
-	// A restart is usually what follows fixing whatever broke uploads, so give
-	// the episodes that exhausted their budget one more life. Bounded: this
-	// runs once per process, not per pass.
-	if moved, err := w.manager.RequeueFailedUploads(); err != nil {
-		w.logger.Warn("data transfer worker: requeue of failed episodes failed", zap.Error(err))
-	} else if moved > 0 {
-		w.logger.Info("data transfer worker: requeued previously failed episodes", zap.Int("episodes", moved))
+	wait := w.wait
+	if wait == nil {
+		wait = waitFor
 	}
+	newTicker := w.newTicker
+	if newTicker == nil {
+		newTicker = realTicker
+	}
+	interval := w.requeueInterval
+	if interval <= 0 {
+		interval = transferRequeueInterval
+	}
+
+	// Re-arm the episodes that exhausted their budget. A restart is usually
+	// what follows fixing whatever broke uploads, but an outage that outlasts
+	// the budget needs no fixing at all and no restart should be required to
+	// recover from it, so this also runs on a slow ticker below.
+	requeue := func(trigger string) {
+		moved, err := w.manager.RequeueFailedUploads()
+		switch {
+		case err != nil:
+			w.logger.Warn("data transfer worker: requeue of failed episodes failed",
+				zap.String("trigger", trigger), zap.Error(err))
+		case moved > 0:
+			w.logger.Info("data transfer worker: requeued previously failed episodes",
+				zap.Int("episodes", moved), zap.String("trigger", trigger))
+		}
+	}
+	requeue("startup")
+
+	tickC, stopTicker := newTicker(interval)
+	defer stopTicker()
 
 	w.logger.Info("data transfer worker: started")
 	attempt := 0
@@ -326,15 +454,24 @@ func (w *DataTransferWorker) Run(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
+		select {
+		case <-tickC:
+			requeue("periodic")
+		default:
+		}
 		err := w.runPass(ctx)
 		if err != nil {
 			if ctx.Err() != nil {
 				return
 			}
+			delay := passBackoff(attempt)
+			blocked := ingestBlocked(err)
+			stalled := transportStalled(err)
+			switch {
 			// A blocked route persists until someone changes configuration, so
 			// it would otherwise log identically every minute forever. Say it
 			// loudly once, then keep it at debug until the cause changes.
-			if blocked := ingestBlocked(err); blocked != nil {
+			case blocked != nil:
 				if w.lastBlockedCause != blocked.Error() {
 					w.lastBlockedCause = blocked.Error()
 					w.logger.Error("data transfer worker: ingest endpoint is not accepting uploads; "+
@@ -343,34 +480,40 @@ func (w *DataTransferWorker) Run(ctx context.Context) {
 				} else {
 					w.logger.Debug("data transfer worker: ingest still blocked", zap.Error(blocked))
 				}
-			} else {
+			case stalled != nil:
 				w.lastBlockedCause = ""
-				w.logger.Warn("data transfer worker: pass failed", zap.Error(err))
+				w.logger.Warn("data transfer worker: ingest transport is unavailable; the whole pass "+
+					"backs off and no episode was charged an attempt",
+					zap.String("code", stalled.code.String()), zap.Duration("backoff", delay), zap.Error(stalled))
+			default:
+				w.lastBlockedCause = ""
+				w.logger.Warn("data transfer worker: pass failed", zap.Duration("backoff", delay), zap.Error(err))
 			}
-			w.backoff(ctx, attempt)
+			wait(ctx, delay)
 			if attempt < 6 { // 2^6 = 64s > 60s cap
 				attempt++
 			}
 			continue
 		}
 		attempt = 0
-		select {
-		case <-time.After(transferIdlePause):
-		case <-ctx.Done():
-			return
-		}
+		wait(ctx, transferIdlePause)
 	}
 }
 
-func (w *DataTransferWorker) backoff(ctx context.Context, attempt int) {
-	d := time.Second << attempt
+// passBackoff returns how long to wait after the attempt-th consecutive failed
+// pass: transferBackoffBase doubled per attempt, capped at transferMaxBackoff,
+// then jittered over the upper half of that window.
+//
+// The jitter is not decoration. A fleet whose devices all lost the same uplink
+// resumes on the same schedule without it, and every one of them retries in the
+// same second the link returns.
+func passBackoff(attempt int) time.Duration {
+	d := transferBackoffBase << attempt
 	if d > transferMaxBackoff || d <= 0 {
 		d = transferMaxBackoff
 	}
-	select {
-	case <-time.After(d):
-	case <-ctx.Done():
-	}
+	half := d / 2
+	return half + time.Duration(rand.Float64()*float64(half))
 }
 
 // runPass dials the cloud, enumerates the upload backlog, and uploads each
@@ -460,21 +603,36 @@ func (w *DataTransferWorker) uploadRate(mf data.Manifest) int64 {
 // backoff (or to "failed" once the retry ceiling is hit), verification failures
 // move it straight to "failed", and success marks it "uploaded".
 //
-// It returns a non-nil error ONLY when the failure is the route rather than the
-// episode, which is the caller's signal to abandon the pass. The episode is
-// left exactly as it was found in that case: it did nothing wrong, so it keeps
-// its attempt count and its place in the queue.
+// It returns a non-nil error ONLY when the failure is the route or the network
+// rather than the episode, which is the caller's signal to abandon the pass.
+// The episode is left exactly as it was found in that case: it did nothing
+// wrong, so it keeps its attempt count and its place in the queue.
 func (w *DataTransferWorker) processEpisode(ctx context.Context, client cloudpb.DataIngestServiceClient, mf data.Manifest) error {
 	if ok, reason := w.resolveShouldUpload(mf); !ok {
 		w.logger.Debug("data transfer worker: skipping episode", zap.String("episode", mf.ID), zap.String("reason", reason))
 		return nil
 	}
 
+	// Pin the episode for the whole transfer. Quota eviction skips a pinned
+	// episode, so retention cannot delete the payload from under an open
+	// stream. The "uploading" state alone did not do this: enforceQuota reads
+	// the pin count and nothing else, and an episode that lost its files
+	// mid-transfer failed on every retry with an error that named the file
+	// rather than the eviction.
+	w.manager.BeginDownload(mf.ID)
+	defer w.manager.EndDownload(mf.ID)
+
 	// Mark uploading (durably) before any network work so a crash mid-transfer
 	// is recoverable and the quota manager knows the payload is in flight.
 	if _, err := w.manager.UpdateUploadState(mf.ID, func(ws *data.WorkflowState) {
 		ws.State = uploadStateUploading
 	}); err != nil {
+		if w.episodeGone(mf.ID, err) {
+			// Evicted between the backlog scan and the pin. There is no
+			// manifest left to record anything on, and nothing to retry.
+			w.logger.Info("data transfer worker: episode is gone, skipping", zap.String("episode", mf.ID))
+			return nil
+		}
 		w.logger.Warn("data transfer worker: mark uploading failed", zap.String("episode", mf.ID), zap.Error(err))
 		return nil
 	}
@@ -497,16 +655,25 @@ func (w *DataTransferWorker) processEpisode(ctx context.Context, client cloudpb.
 			w.logger.Info("data transfer worker: shutdown mid-upload, episode left for resume", zap.String("episode", mf.ID))
 			return nil
 		}
+		if w.episodeGone(mf.ID, retryErr) {
+			// Retention evicted the episode mid-transfer. Nothing to retry and
+			// nothing to record: the manifest went with the payload.
+			w.logger.Info("data transfer worker: episode was evicted mid-transfer, abandoning it",
+				zap.String("episode", mf.ID), zap.Error(retryErr))
+			return nil
+		}
 		if blocked := ingestBlocked(retryErr); blocked != nil {
 			// The route is wrong, not the episode. Put it back exactly as it
 			// was and let the caller stop the pass.
-			if _, err := w.manager.UpdateUploadState(mf.ID, func(ws *data.WorkflowState) {
-				ws.State = mf.Upload.State
-				ws.LastError = blocked.Error()
-			}); err != nil {
-				w.logger.Warn("data transfer worker: restore state failed", zap.String("episode", mf.ID), zap.Error(err))
-			}
+			w.restoreState(mf, blocked)
 			return blocked
+		}
+		if stalled := transportStalled(retryErr); stalled != nil {
+			// The network is down, not the episode. Charging this to the
+			// episode's retry budget marks the whole backlog failed within a
+			// minute of an outage, so it costs the pass wall clock instead.
+			w.restoreState(mf, stalled)
+			return stalled
 		}
 		w.handleRetryable(mf, retryErr)
 	default:
@@ -523,9 +690,41 @@ func (w *DataTransferWorker) processEpisode(ctx context.Context, client cloudpb.
 	return nil
 }
 
-// handleRetryable records a retryable failure: it bumps the attempt count and
-// either re-queues the episode with a backoff or, once the ceiling is reached,
-// marks it permanently failed.
+// episodeGone reports whether err is a not-exist failure BECAUSE the whole
+// episode has left the store, which on this device means quota eviction removed
+// it. That is not a retryable condition: there is nothing left to send and no
+// manifest left to record an attempt on, so the worker drops it quietly.
+//
+// The store is re-read rather than trusting the error alone, because a single
+// missing file inside an episode that is still there raises the same
+// os.ErrNotExist and is a completely different thing: a real, episode-specific
+// fault that must spend the retry budget and end as "failed". Treating it as an
+// eviction would leave the episode "uploading" forever, retried on every pass
+// and counted by nothing.
+func (w *DataTransferWorker) episodeGone(id string, err error) bool {
+	if !errors.Is(err, os.ErrNotExist) {
+		return false
+	}
+	_, _, inspectErr := w.manager.Inspect(id, false)
+	return errors.Is(inspectErr, os.ErrNotExist)
+}
+
+// restoreState puts an episode back exactly as the pass found it, recording why
+// the pass gave up. Used for pass-level failures, which the episode did not
+// cause and must not be charged for.
+func (w *DataTransferWorker) restoreState(mf data.Manifest, cause error) {
+	if _, err := w.manager.UpdateUploadState(mf.ID, func(ws *data.WorkflowState) {
+		ws.State = mf.Upload.State
+		ws.LastError = cause.Error()
+	}); err != nil && !w.episodeGone(mf.ID, err) {
+		w.logger.Warn("data transfer worker: restore state failed", zap.String("episode", mf.ID), zap.Error(err))
+	}
+}
+
+// handleRetryable records a failure that belongs to THIS episode: it bumps the
+// attempt count and either re-queues the episode with a backoff or, once the
+// ceiling is reached, marks it permanently failed. Transport failures never
+// reach here; see transportStalled and transferMaxAttempts.
 func (w *DataTransferWorker) handleRetryable(mf data.Manifest, cause error) {
 	attempts := mf.Upload.Attempts + 1
 	if attempts >= w.maxAttempts {
@@ -608,37 +807,40 @@ func (w *DataTransferWorker) uploadEpisode(ctx context.Context, client cloudpb.D
 		return nil, fmt.Errorf("open upload stream: %w", err)
 	}
 
-	// Drain acks concurrently so large uploads do not deadlock on flow control.
+	// Drain acks concurrently so large uploads do not deadlock on flow control,
+	// recording the durable offset each one reports.
 	//
-	// The acks are read and discarded, not matched. That is deliberate, and it
-	// is why the (episode_id, path) matching rule the wire contract states for
-	// EpisodeChunkAck does not apply to this client today.
-	//
-	// Nothing here is keyed on an ack. Resume offsets come from
-	// BeginEpisodeUpload's per-file FileUploadState, above, which is scoped to
-	// one episode by construction; the acks contribute no state. Draining them
-	// serves two other purposes: gRPC flow control stalls a large upload if the
-	// receive side is never read, and a server-side stream error arrives here
-	// rather than being lost.
+	// Acks drive no resume decision: resume offsets come from
+	// BeginEpisodeUpload's per-file FileUploadState, above. What the recorded
+	// offsets answer is a different question, asked once, at commit: did the
+	// whole object actually reach durable storage? A checksum the server
+	// computed over a file it never finished storing is a fact about the
+	// transfer, not about our bytes, and commitFailureTerminal needs to tell
+	// those apart. Draining also matters for two reasons that predate this:
+	// gRPC flow control stalls a large upload if the receive side is never
+	// read, and a server-side stream error arrives here rather than being lost.
 	//
 	// The contract's hazard is a client that matches acks on `path` alone while
 	// one stream carries chunks for several episodes, which credits one
-	// episode's committed offset to another. This client cannot hit it from
-	// either direction: it matches on nothing, and it opens exactly one
-	// UploadEpisodeChunk stream per episode, here inside uploadEpisode, which
-	// processEpisode calls once per manifest. That is precisely the "keep to one
-	// stream per episode" fallback the contract requires of a client that cannot
-	// rely on the new episode_id field, and a server built before that field
-	// leaves it empty anyway.
+	// episode's committed offset to another. This client cannot hit it. It
+	// matches on the (episode_id, path) pair the contract requires, and it
+	// opens exactly one UploadEpisodeChunk stream per episode, here inside
+	// uploadEpisode, which processEpisode calls once per manifest. An ack that
+	// names a different episode is ignored; an empty episode_id means a server
+	// built before the field, and one-stream-per-episode makes `path` alone
+	// unambiguous in exactly that case.
 	//
 	// TestUploadStreamCarriesOneEpisode pins the one-stream-per-episode
-	// invariant. Batching several episodes onto a single stream, or using ack
-	// offsets to drive resume, means matching on the (episode_id, path) pair
-	// first; do not do one without the other.
+	// invariant. Batching several episodes onto one stream breaks the empty
+	// episode_id fallback below; do not do it.
+	//
+	// acked is written only by this goroutine and read only after ackErrCh
+	// delivers, which orders the writes before the reads.
+	acked := make(map[string]int64, len(mf.Files))
 	ackErrCh := make(chan error, 1)
 	go func() {
 		for {
-			_, rerr := stream.Recv()
+			ack, rerr := stream.Recv()
 			if rerr == io.EOF {
 				ackErrCh <- nil
 				return
@@ -646,6 +848,12 @@ func (w *DataTransferWorker) uploadEpisode(ctx context.Context, client cloudpb.D
 			if rerr != nil {
 				ackErrCh <- rerr
 				return
+			}
+			if id := ack.GetEpisodeId(); id != "" && id != mf.ID {
+				continue
+			}
+			if v := ack.GetCommittedOffset(); v <= math.MaxInt64 && int64(v) > acked[ack.GetPath()] {
+				acked[ack.GetPath()] = int64(v)
 			}
 		}
 	}()
@@ -655,14 +863,8 @@ func (w *DataTransferWorker) uploadEpisode(ctx context.Context, client cloudpb.D
 	closeErr := stream.CloseSend()
 	ackErr := <-ackErrCh
 
-	if sendErr != nil {
-		return nil, fmt.Errorf("stream chunks: %w", sendErr)
-	}
-	if closeErr != nil {
-		return nil, fmt.Errorf("close send: %w", closeErr)
-	}
-	if ackErr != nil {
-		return nil, fmt.Errorf("chunk ack: %w", ackErr)
+	if err := streamFailure(sendErr, closeErr, ackErr); err != nil {
+		return nil, err
 	}
 
 	commit, err := client.CommitEpisode(ctx, &cloudpb.CommitEpisodeRequest{EpisodeId: mf.ID})
@@ -672,21 +874,102 @@ func (w *DataTransferWorker) uploadEpisode(ctx context.Context, client cloudpb.D
 	if commit.GetState() == cloudpb.EpisodeState_EPISODE_STATE_COMPLETE {
 		return nil, nil
 	}
-	// Not complete: collect per-file verification detail. Any failed file is a
-	// terminal corruption verdict.
-	var details []string
+
+	// Not complete: split the per-file verdicts into the ones that condemn our
+	// bytes and the ones that only ask for the file again.
+	durable := make(map[string]bool, len(mf.Files))
+	for _, f := range mf.Files {
+		durable[f.Path] = acked[f.Path] >= f.Size || committed[f.Path] >= f.Size
+	}
+	var terminal, retriable []string
 	for _, v := range commit.GetFiles() {
-		if !v.GetOk() {
-			details = append(details, fmt.Sprintf("%s: %s (expected %s, actual %s)",
-				v.GetPath(), v.GetDetail(), v.GetExpectedSha256(), v.GetActualSha256()))
+		if v.GetOk() {
+			continue
+		}
+		detail := fmt.Sprintf("%s: %s (expected %s, actual %s)",
+			v.GetPath(), v.GetDetail(), v.GetExpectedSha256(), v.GetActualSha256())
+		if commitFailureTerminal(v, durable[v.GetPath()]) {
+			terminal = append(terminal, detail)
+		} else {
+			retriable = append(retriable, detail)
 		}
 	}
-	if len(details) > 0 {
-		return errors.New(strings.Join(details, "; ")), nil
+	// A genuine mismatch decides the episode even if other files merely need
+	// re-sending: re-sending cannot change the bytes that already disagree.
+	if len(terminal) > 0 {
+		return errors.New(strings.Join(terminal, "; ")), nil
+	}
+	if len(retriable) > 0 {
+		return nil, fmt.Errorf("commit needs these files sent again: %s", strings.Join(retriable, "; "))
 	}
 	// Commit returned a non-complete state with no per-file failure detail:
 	// treat as retryable so we do not permanently fail on an ambiguous verdict.
 	return nil, fmt.Errorf("commit returned state %s without completion", commit.GetState())
+}
+
+// streamFailure picks the error that explains a failed chunk stream.
+//
+// When the server aborts a stream, the client's Send returns io.EOF: the
+// transport is saying the stream is closed, not why. The reason is on the
+// receive side, which the ack reader already holds. Returning the io.EOF first
+// masked every server-side abort as an anonymous "stream chunks: EOF", so a
+// PermissionDenied route looked like an ordinary write failure, was classified
+// as neither blocked nor stalled, and burned the episode's retry budget.
+func streamFailure(sendErr, closeErr, ackErr error) error {
+	if sendErr != nil {
+		if errors.Is(sendErr, io.EOF) && ackErr != nil {
+			return fmt.Errorf("stream chunks: %w", ackErr)
+		}
+		return fmt.Errorf("stream chunks: %w", sendErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close send: %w", closeErr)
+	}
+	if ackErr != nil {
+		return fmt.Errorf("chunk ack: %w", ackErr)
+	}
+	return nil
+}
+
+// commitFailureTerminal decides whether one failed FileVerification condemns
+// the episode or merely asks for the file again. durable says whether the whole
+// object reached the server's storage, from the acks on this stream or from the
+// committed offset BeginEpisodeUpload reported.
+//
+// Exactly one shape is terminal: the server holds the complete object and the
+// SHA-256 it computed over it differs from the manifest's. That is local
+// corruption, re-sending the same bytes fails identically, and the episode is
+// dead.
+//
+// Everything else is evidence about the transfer, not about our bytes, and the
+// old code treating every ok == false as terminal threw away shippable
+// episodes:
+//   - an empty actual_sha256 means the server hashed nothing
+//   - a detail naming a missing object means there is nothing stored to hash
+//   - a file whose durable offset never reached its size was truncated in
+//     flight, so any hash over it is a hash of a fragment
+//
+// Re-sending costs nothing extra: BeginEpisodeUpload reports a committed offset
+// of 0 for anything not durably stored, so the next attempt streams exactly the
+// files that still need bytes.
+func commitFailureTerminal(v *cloudpb.FileVerification, durable bool) bool {
+	if v.GetActualSha256() == "" {
+		return false
+	}
+	if detailSaysMissing(v.GetDetail()) {
+		return false
+	}
+	return durable
+}
+
+// detailSaysMissing reads the server's human-readable failure detail for the
+// "missing object" case the wire contract names. Matching prose is a weak
+// signal, which is why it is not the only one: the empty-hash and durability
+// checks in commitFailureTerminal classify a server that words this differently
+// without help from here.
+func detailSaysMissing(detail string) bool {
+	d := strings.ToLower(detail)
+	return strings.Contains(d, "missing") || strings.Contains(d, "not found") || strings.Contains(d, "no such")
 }
 
 // streamFiles sends every file that still needs bytes, honoring the committed

--- a/go/internal/agent/services/data_transfer_worker_adversarial_test.go
+++ b/go/internal/agent/services/data_transfer_worker_adversarial_test.go
@@ -138,9 +138,14 @@ func TestDataTransferWorker_PacingAbortsOnShutdown(t *testing.T) {
 }
 
 // TestDataTransferWorker_TransientCommitErrorIsRetryable proves a network drop
-// during CommitEpisode is classified as retryable (episode returns to pending
-// with a backoff), not misclassified as a terminal verification failure that
-// would strand a good episode forever.
+// during CommitEpisode is classified as retryable, not misclassified as a
+// terminal verification failure that would strand a good episode forever.
+//
+// The drop surfaces as DeadlineExceeded, which is the network rather than the
+// episode, so it is a pass-level condition: the episode goes back to pending
+// with its attempt count untouched and the worker backs the whole pass off.
+// Charging it to the episode is what let a short outage mark a whole backlog
+// failed; see TestTransportOutageSpendsNoRetryBudget.
 func TestDataTransferWorker_TransientCommitErrorIsRetryable(t *testing.T) {
 	mgr, root := newTestManager(t)
 	writeFixtureEpisode(t, root, "ep-commiterr", "", "pending", map[string][]byte{"blob.bin": []byte("good bytes")})
@@ -149,18 +154,19 @@ func TestDataTransferWorker_TransientCommitErrorIsRetryable(t *testing.T) {
 	client := startFakeIngest2(t, srv)
 	w := newTestWorker(mgr, client)
 
-	if err := w.runPass(context.Background()); err != nil {
-		t.Fatalf("runPass: %v", err)
+	err := w.runPass(context.Background())
+	if err == nil {
+		t.Fatal("runPass returned nil; a transport failure must surface as a pass failure")
+	}
+	if transportStalled(err) == nil {
+		t.Fatalf("runPass error %v is not classified as a transport stall", err)
 	}
 	st := uploadState(t, mgr, "ep-commiterr")
 	if st.State != uploadStatePending {
 		t.Fatalf("state = %q, want pending (transient commit error must be retryable, not failed)", st.State)
 	}
-	if st.Attempts != 1 {
-		t.Errorf("attempts = %d, want 1", st.Attempts)
-	}
-	if st.NextAttemptUnixNanos == 0 {
-		t.Errorf("no backoff timestamp recorded for retryable commit failure")
+	if st.Attempts != 0 {
+		t.Errorf("attempts = %d, want 0: the network failing is not the episode's fault", st.Attempts)
 	}
 }
 

--- a/go/internal/agent/services/data_transfer_worker_resilience_test.go
+++ b/go/internal/agent/services/data_transfer_worker_resilience_test.go
@@ -1,0 +1,545 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/data"
+	cloudpb "github.com/wendylabsinc/wendy/go/proto/gen/cloudpb"
+)
+
+// beginErrorServer answers BeginEpisodeUpload with a fixed status and counts
+// the calls, standing in for a server the device cannot reach (Unavailable) or
+// one that rejects this particular episode (InvalidArgument and friends).
+type beginErrorServer struct {
+	*fakeIngestServer
+	err   error
+	calls atomic.Int64
+}
+
+func (s *beginErrorServer) BeginEpisodeUpload(context.Context, *cloudpb.BeginEpisodeUploadRequest) (*cloudpb.BeginEpisodeUploadResponse, error) {
+	s.calls.Add(1)
+	return nil, s.err
+}
+
+// TestTransportOutageSpendsNoRetryBudget is the regression for the outage that
+// ate a backlog. The ingest client connects lazily, so an offline device does
+// not fail when it dials: it fails on each episode's first call, with
+// Unavailable. Charged to the episode, five passes at the ten second idle
+// cadence, under a minute of outage, marked every queued episode permanently
+// failed, and only an agent restart brought them back. The network being down
+// must cost wall clock and nothing else.
+func TestTransportOutageSpendsNoRetryBudget(t *testing.T) {
+	mgr, root := newTestManager(t)
+	ids := []string{"ep-a", "ep-b", "ep-c"}
+	for _, id := range ids {
+		writeFixtureEpisode(t, root, id, "", "pending", map[string][]byte{"blob.bin": []byte("payload")})
+	}
+
+	srv := &beginErrorServer{fakeIngestServer: newFakeIngestServer(), err: status.Error(codes.Unavailable, "connection refused")}
+	w := newTestWorker(mgr, startFakeIngest2(t, srv))
+
+	// More passes than the retry ceiling: the budget must survive all of them.
+	for pass := 0; pass < transferMaxAttempts+2; pass++ {
+		err := w.runPass(context.Background())
+		if err == nil {
+			t.Fatalf("pass %d: runPass returned nil; an unreachable ingest must fail the pass", pass)
+		}
+		if transportStalled(err) == nil {
+			t.Fatalf("pass %d: error %v is not classified as a transport stall", pass, err)
+		}
+	}
+	// One episode per pass: the pass abandons the backlog on the first stall
+	// rather than walking it and meeting the same wall on every episode.
+	if got := srv.calls.Load(); got != int64(transferMaxAttempts+2) {
+		t.Errorf("BeginEpisodeUpload called %d times over %d passes; the pass must stop at the first stall",
+			got, transferMaxAttempts+2)
+	}
+	for _, id := range ids {
+		st := uploadState(t, mgr, id)
+		if st.State != uploadStatePending {
+			t.Errorf("%s: state = %q, want %q; an outage may not fail an episode", id, st.State, uploadStatePending)
+		}
+		if st.Attempts != 0 {
+			t.Errorf("%s: attempts = %d, want 0; an outage may not spend the retry budget", id, st.Attempts)
+		}
+	}
+}
+
+// TestEpisodeSpecificErrorSpendsRetryBudget is the other half of the rule: an
+// error the server answered about THIS episode is exactly what the per-episode
+// budget is for, and must still count.
+func TestEpisodeSpecificErrorSpendsRetryBudget(t *testing.T) {
+	for _, code := range []codes.Code{codes.InvalidArgument, codes.Internal, codes.FailedPrecondition} {
+		t.Run(code.String(), func(t *testing.T) {
+			mgr, root := newTestManager(t)
+			writeFixtureEpisode(t, root, "ep-bad", "", "pending", map[string][]byte{"blob.bin": []byte("payload")})
+
+			srv := &beginErrorServer{fakeIngestServer: newFakeIngestServer(), err: status.Error(code, "this episode is wrong")}
+			w := newTestWorker(mgr, startFakeIngest2(t, srv))
+
+			if err := w.runPass(context.Background()); err != nil {
+				t.Fatalf("runPass: %v; an episode-specific rejection stays with the episode", err)
+			}
+			st := uploadState(t, mgr, "ep-bad")
+			if st.State != uploadStatePending {
+				t.Fatalf("state = %q, want %q", st.State, uploadStatePending)
+			}
+			if st.Attempts != 1 {
+				t.Errorf("attempts = %d, want 1", st.Attempts)
+			}
+			if st.NextAttemptUnixNanos == 0 {
+				t.Errorf("no per-episode backoff recorded")
+			}
+		})
+	}
+}
+
+// TestTransportStalledClassification pins which codes are the network. Too wide
+// and a server that rejects one episode stalls the whole worker forever; too
+// narrow and an outage eats the backlog again.
+func TestTransportStalledClassification(t *testing.T) {
+	for code, want := range map[codes.Code]bool{
+		codes.Unavailable:        true,
+		codes.DeadlineExceeded:   true,
+		codes.Unimplemented:      false,
+		codes.Unauthenticated:    false,
+		codes.PermissionDenied:   false,
+		codes.InvalidArgument:    false,
+		codes.Internal:           false,
+		codes.FailedPrecondition: false,
+		codes.ResourceExhausted:  false,
+		codes.Unknown:            false,
+	} {
+		if got := transportStalled(status.Error(code, "x")) != nil; got != want {
+			t.Errorf("transportStalled(%s) = %v, want %v", code, got, want)
+		}
+	}
+	if transportStalled(nil) != nil {
+		t.Error("transportStalled(nil) must be nil")
+	}
+	if transportStalled(errors.New("plain")) != nil {
+		t.Error("a plain error is not a transport stall")
+	}
+	if transportStalled(context.DeadlineExceeded) == nil {
+		t.Error("a client-side deadline is a transport stall")
+	}
+	// A wrapped status keeps its classification: the worker wraps every RPC
+	// failure with the stage it happened in before returning it.
+	if transportStalled(errors.Join(errors.New("begin"), status.Error(codes.Unavailable, "x"))) == nil {
+		t.Error("a wrapped Unavailable must still classify as a transport stall")
+	}
+}
+
+// TestPassBackoffGrowsAndIsCapped pins the pass-level backoff policy that
+// replaces the per-episode attempt charge for transport failures: exponential
+// from one second, jittered over the upper half of the window, capped at a
+// minute.
+func TestPassBackoffGrowsAndIsCapped(t *testing.T) {
+	var sawSpread bool
+	var first time.Duration
+	for attempt := 0; attempt < 10; attempt++ {
+		want := transferBackoffBase << attempt
+		if want > transferMaxBackoff || want <= 0 {
+			want = transferMaxBackoff
+		}
+		for i := 0; i < 64; i++ {
+			got := passBackoff(attempt)
+			if got < want/2 || got > want {
+				t.Fatalf("passBackoff(%d) = %v, want within [%v, %v]", attempt, got, want/2, want)
+			}
+			if attempt == 0 {
+				if first == 0 {
+					first = got
+				} else if got != first {
+					sawSpread = true
+				}
+			}
+		}
+	}
+	if !sawSpread {
+		t.Error("passBackoff never varied; without jitter a fleet retries in lockstep the second the link returns")
+	}
+}
+
+// TestPeriodicRequeueRearmsFailedEpisodes proves the worker recovers from an
+// outage that outlived the retry budget without an agent restart.
+// EpisodesAwaitingUpload returns only pending and uploading episodes, so a
+// failed one is invisible to every later pass; re-arming only at process start
+// meant the backlog stayed dead until somebody restarted the agent.
+func TestPeriodicRequeueRearmsFailedEpisodes(t *testing.T) {
+	mgr, root := newTestManager(t)
+	srv := newFakeIngestServer()
+	w := newTestWorker(mgr, startFakeIngest(t, srv))
+	w.ingestHost = "ingest.test"
+
+	tick := make(chan time.Time, 1)
+	w.newTicker = func(time.Duration) (<-chan time.Time, func()) { return tick, func() {} }
+	// Keep the loop off real time, but do not spin: the pass does disk work.
+	w.wait = func(ctx context.Context, _ time.Duration) { waitFor(ctx, time.Millisecond) }
+
+	var passes atomic.Int64
+	inner := w.factory
+	w.factory = func(ctx context.Context) (cloudpb.DataIngestServiceClient, func(), error) {
+		passes.Add(1)
+		return inner(ctx)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { w.Run(ctx); close(done) }()
+	defer func() { cancel(); <-done }()
+
+	waitPasses := func(n int64) {
+		t.Helper()
+		deadline := time.Now().Add(10 * time.Second)
+		for passes.Load() < n {
+			if time.Now().After(deadline) {
+				t.Fatalf("worker made %d passes, waited for %d", passes.Load(), n)
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}
+	// Let the startup requeue happen before the episode exists, so only the
+	// ticker can explain what follows.
+	waitPasses(1)
+
+	writeFixtureEpisode(t, root, "ep-late", "", "failed", map[string][]byte{"blob.bin": []byte("stranded")})
+	waitPasses(passes.Load() + 3)
+	if got := uploadState(t, mgr, "ep-late").State; got != uploadStateFailed {
+		t.Fatalf("state = %q before any requeue tick, want %q", got, uploadStateFailed)
+	}
+
+	tick <- time.Now()
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if got := uploadState(t, mgr, "ep-late").State; got == uploadStateUploaded {
+			break
+		} else if time.Now().After(deadline) {
+			t.Fatalf("state = %q after the requeue tick, want %q", got, uploadStateUploaded)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// blockingBeginServer holds BeginEpisodeUpload open so a test can act while an
+// episode's transfer is in flight.
+type blockingBeginServer struct {
+	*fakeIngestServer
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (s *blockingBeginServer) BeginEpisodeUpload(ctx context.Context, req *cloudpb.BeginEpisodeUploadRequest) (*cloudpb.BeginEpisodeUploadResponse, error) {
+	close(s.entered)
+	<-s.release
+	return s.fakeIngestServer.BeginEpisodeUpload(ctx, req)
+}
+
+// TestUploadInFlightIsPinnedAgainstEviction proves the worker holds the
+// manager's read pin for the whole transfer. Quota eviction filters candidates
+// on the pin count alone, so before this the "uploading" state bought an
+// episode nothing: retention could delete its files from under an open stream,
+// and the transfer then failed with an error naming the file rather than the
+// eviction.
+func TestUploadInFlightIsPinnedAgainstEviction(t *testing.T) {
+	mgr, root := newTestManager(t)
+	writeFixtureEpisode(t, root, "ep-inflight", "", "pending", map[string][]byte{"blob.bin": []byte("payload under eviction pressure")})
+	mgr.SetWarnLogger(func(string) {})
+
+	srv := &blockingBeginServer{
+		fakeIngestServer: newFakeIngestServer(),
+		entered:          make(chan struct{}),
+		release:          make(chan struct{}),
+	}
+	w := newTestWorker(mgr, startFakeIngest2(t, srv))
+
+	passErr := make(chan error, 1)
+	go func() { passErr <- w.runPass(context.Background()) }()
+
+	select {
+	case <-srv.entered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("transfer never started")
+	}
+
+	// A quota that cannot hold anything, then a sweep. The in-flight episode
+	// must not be a candidate.
+	mgr.SetQuota(1, 0)
+	if _, err := mgr.Start(data.StartOptions{Sources: []string{"applications"}}); err == nil {
+		if _, stopErr := mgr.Stop(data.AdHocEpisodeKey); stopErr != nil {
+			t.Fatalf("Stop: %v", stopErr)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(root, "ep-inflight")); err != nil {
+		close(srv.release)
+		<-passErr
+		t.Fatalf("in-flight episode was evicted mid-transfer: %v", err)
+	}
+
+	close(srv.release)
+	if err := <-passErr; err != nil {
+		t.Fatalf("runPass: %v", err)
+	}
+	if got := uploadState(t, mgr, "ep-inflight").State; got != uploadStateUploaded {
+		t.Fatalf("state = %q, want %q", got, uploadStateUploaded)
+	}
+}
+
+// TestEvictedEpisodeStopsQuietly pins the other side of the retention race. An
+// episode that vanishes mid-transfer is not a retry: there is nothing left to
+// send and no manifest left to record an attempt on. It used to reach
+// handleRetryable, which then failed to write the attempt to a manifest that no
+// longer existed and warned about the write instead of the eviction.
+func TestEvictedEpisodeStopsQuietly(t *testing.T) {
+	mgr, root := newTestManager(t)
+	writeFixtureEpisode(t, root, "ep-evicted", "", "pending", map[string][]byte{"blob.bin": []byte("payload")})
+
+	core, logs := observer.New(zap.InfoLevel)
+	srv := &blockingBeginServer{
+		fakeIngestServer: newFakeIngestServer(),
+		entered:          make(chan struct{}),
+		release:          make(chan struct{}),
+	}
+	w := newTestWorker(mgr, startFakeIngest2(t, srv))
+	w.logger = zap.New(core)
+
+	passErr := make(chan error, 1)
+	go func() { passErr <- w.runPass(context.Background()) }()
+
+	select {
+	case <-srv.entered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("transfer never started")
+	}
+	// Evict it out from under the open stream, then let the transfer proceed.
+	if err := os.RemoveAll(filepath.Join(root, "ep-evicted")); err != nil {
+		t.Fatalf("remove episode: %v", err)
+	}
+	close(srv.release)
+
+	if err := <-passErr; err != nil {
+		t.Fatalf("runPass: %v; an evicted episode is not a pass failure", err)
+	}
+	if _, _, err := mgr.Inspect("ep-evicted", false); err == nil {
+		t.Fatal("the evicted episode came back")
+	}
+	if n := logs.FilterMessageSnippet("evicted mid-transfer").Len(); n != 1 {
+		t.Errorf("worker logged the eviction %d times, want 1; entries: %v", n, logs.All())
+	}
+	if n := logs.FilterMessageSnippet("requeue").Len(); n != 0 {
+		t.Errorf("worker tried to requeue an episode that no longer exists: %v", logs.All())
+	}
+}
+
+// TestMissingFileIsNotAnEviction is the boundary of the rule above: one file
+// gone from an episode that is still in the store raises the same
+// os.ErrNotExist but is a real, episode-specific fault. Reading it as an
+// eviction would drop the episode silently and leave it "uploading" forever,
+// retried on every pass and counted by nothing.
+func TestMissingFileIsNotAnEviction(t *testing.T) {
+	mgr, root := newTestManager(t)
+	writeFixtureEpisode(t, root, "ep-holed", "", "pending", map[string][]byte{"blob.bin": []byte("payload")})
+	if err := os.Remove(filepath.Join(root, "ep-holed", "blob.bin")); err != nil {
+		t.Fatalf("remove file: %v", err)
+	}
+
+	w := newTestWorker(mgr, startFakeIngest(t, newFakeIngestServer()))
+	if err := w.runPass(context.Background()); err != nil {
+		t.Fatalf("runPass: %v", err)
+	}
+	st := uploadState(t, mgr, "ep-holed")
+	if st.State != uploadStatePending {
+		t.Fatalf("state = %q, want %q", st.State, uploadStatePending)
+	}
+	if st.Attempts != 1 {
+		t.Errorf("attempts = %d, want 1: a hole in a live episode is the episode's fault", st.Attempts)
+	}
+}
+
+// commitVerdictServer answers commit with a fixed set of per-file verdicts and
+// optionally suppresses the durable offset in its acks, which is how a
+// truncated transfer looks on the wire.
+type commitVerdictServer struct {
+	*fakeIngestServer
+	files       []*cloudpb.FileVerification
+	withholdAck bool
+}
+
+func (s *commitVerdictServer) UploadEpisodeChunk(stream grpc.BidiStreamingServer[cloudpb.EpisodeChunk, cloudpb.EpisodeChunkAck]) error {
+	if !s.withholdAck {
+		return s.fakeIngestServer.UploadEpisodeChunk(stream)
+	}
+	for {
+		chunk, err := stream.Recv()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		// received_offset only: nothing was made durable.
+		if err := stream.Send(&cloudpb.EpisodeChunkAck{
+			EpisodeId:      chunk.GetEpisodeId(),
+			Path:           chunk.GetPath(),
+			ReceivedOffset: chunk.GetOffset() + uint64(len(chunk.GetData())),
+		}); err != nil {
+			return err
+		}
+	}
+}
+
+func (s *commitVerdictServer) CommitEpisode(context.Context, *cloudpb.CommitEpisodeRequest) (*cloudpb.CommitEpisodeResponse, error) {
+	return &cloudpb.CommitEpisodeResponse{State: cloudpb.EpisodeState_EPISODE_STATE_FAILED, Files: s.files}, nil
+}
+
+// TestCommitVerdictClassification pins which commit verdicts are terminal.
+// Treating every ok == false as local corruption threw away episodes that were
+// only ever asking to be sent again: an object the server never stored has no
+// hash to disagree with, and a hash over a fragment is a fact about the
+// transfer, not about the bytes on disk.
+func TestCommitVerdictClassification(t *testing.T) {
+	const path = "blob.bin"
+	payload := []byte("verify me")
+
+	cases := []struct {
+		name        string
+		verdict     *cloudpb.FileVerification
+		withholdAck bool
+		wantState   string
+	}{
+		{
+			name:      "sha mismatch on a stored object is terminal",
+			verdict:   &cloudpb.FileVerification{Path: path, Ok: false, ExpectedSha256: "aa", ActualSha256: "bb", Detail: "checksum mismatch"},
+			wantState: uploadStateFailed,
+		},
+		{
+			name:      "missing object is retriable",
+			verdict:   &cloudpb.FileVerification{Path: path, Ok: false, ExpectedSha256: "aa", ActualSha256: "", Detail: "missing object in storage"},
+			wantState: uploadStatePending,
+		},
+		{
+			name:      "an empty actual hash is retriable whatever the detail says",
+			verdict:   &cloudpb.FileVerification{Path: path, Ok: false, ExpectedSha256: "aa", ActualSha256: "", Detail: "checksum mismatch"},
+			wantState: uploadStatePending,
+		},
+		{
+			name:        "a hash over a never-committed file is retriable",
+			verdict:     &cloudpb.FileVerification{Path: path, Ok: false, ExpectedSha256: "aa", ActualSha256: "bb", Detail: "checksum mismatch"},
+			withholdAck: true,
+			wantState:   uploadStatePending,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mgr, root := newTestManager(t)
+			writeFixtureEpisode(t, root, "ep-commit", "", "pending", map[string][]byte{path: payload})
+			srv := &commitVerdictServer{
+				fakeIngestServer: newFakeIngestServer(),
+				files:            []*cloudpb.FileVerification{tc.verdict},
+				withholdAck:      tc.withholdAck,
+			}
+			w := newTestWorker(mgr, startFakeIngest2(t, srv))
+			if err := w.runPass(context.Background()); err != nil {
+				t.Fatalf("runPass: %v", err)
+			}
+			st := uploadState(t, mgr, "ep-commit")
+			if st.State != tc.wantState {
+				t.Fatalf("state = %q, want %q (lastError %q)", st.State, tc.wantState, st.LastError)
+			}
+			if st.LastError == "" {
+				t.Error("failure reason not recorded")
+			}
+		})
+	}
+}
+
+// abortingStreamServer accepts the Begin call and then aborts the chunk stream
+// with a fixed status, the way a server that revokes a device's access does.
+type abortingStreamServer struct {
+	*fakeIngestServer
+	err error
+}
+
+func (s *abortingStreamServer) UploadEpisodeChunk(stream grpc.BidiStreamingServer[cloudpb.EpisodeChunk, cloudpb.EpisodeChunkAck]) error {
+	if _, err := stream.Recv(); err != nil {
+		return err
+	}
+	return s.err
+}
+
+// TestStreamAbortSurfacesServerStatus proves a server-side abort reaches the
+// worker as the server's own status. When the server aborts, the client's Send
+// returns io.EOF, which says the stream is closed and nothing about why;
+// returning that first masked every abort as an anonymous write failure, so a
+// PermissionDenied route was classified as neither blocked nor stalled and the
+// episode burned its retry budget against it.
+func TestStreamAbortSurfacesServerStatus(t *testing.T) {
+	mgr, root := newTestManager(t)
+	// Several chunks, so the send loop is still running when the server aborts
+	// and Send has an io.EOF to return.
+	payload := make([]byte, 4*transferChunkBytes)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+	writeFixtureEpisode(t, root, "ep-abort", "", "pending", map[string][]byte{"blob.bin": payload})
+
+	srv := &abortingStreamServer{fakeIngestServer: newFakeIngestServer(), err: status.Error(codes.PermissionDenied, "device is not allowed to upload")}
+	w := newTestWorker(mgr, startFakeIngest2(t, srv))
+
+	err := w.runPass(context.Background())
+	if err == nil {
+		t.Fatal("runPass returned nil; a PermissionDenied abort is a blocked route")
+	}
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.PermissionDenied {
+		t.Fatalf("error %v does not carry PermissionDenied; the server's reason was masked", err)
+	}
+	if ingestBlocked(err) == nil {
+		t.Errorf("error %v is not classified as a blocked route", err)
+	}
+	if state := uploadState(t, mgr, "ep-abort"); state.Attempts != 0 {
+		t.Errorf("attempts = %d, want 0: a blocked route costs the episode nothing", state.Attempts)
+	}
+}
+
+// TestStreamFailurePrefersTheServerReason unit-pins the choice streamFailure
+// makes, which the integration test above can only observe indirectly because
+// whether Send loses the race and returns io.EOF depends on flow control.
+func TestStreamFailurePrefersTheServerReason(t *testing.T) {
+	served := status.Error(codes.PermissionDenied, "denied")
+
+	got := streamFailure(io.EOF, nil, served)
+	if st, ok := status.FromError(got); !ok || st.Code() != codes.PermissionDenied {
+		t.Errorf("streamFailure(io.EOF, nil, PermissionDenied) = %v, want the server status", got)
+	}
+
+	// An io.EOF with no ack error still reports the EOF: there is nothing else.
+	if got := streamFailure(io.EOF, nil, nil); got == nil || !errors.Is(got, io.EOF) {
+		t.Errorf("streamFailure(io.EOF, nil, nil) = %v, want the EOF", got)
+	}
+	// A real send failure is its own reason and is not replaced.
+	sendFail := errors.New("write: broken pipe")
+	if got := streamFailure(sendFail, nil, served); !errors.Is(got, sendFail) {
+		t.Errorf("streamFailure replaced a genuine send error with the ack error: %v", got)
+	}
+	if got := streamFailure(nil, nil, served); !errors.Is(got, served) {
+		t.Errorf("streamFailure(nil, nil, ack) = %v, want the ack error", got)
+	}
+	if got := streamFailure(nil, nil, nil); got != nil {
+		t.Errorf("streamFailure with no failure = %v, want nil", got)
+	}
+}


### PR DESCRIPTION
## Problem

Four review findings against the agent's episode transfer worker
(`go/internal/agent/services/data_transfer_worker.go`) and the data manager
(`go/internal/agent/data/manager.go`).

1. A short network outage destroyed the whole upload backlog. The ingest client
   is built with `grpc.NewClient`, which connects lazily, so an offline device
   does not fail when it dials: it fails on each episode's first call with
   `Unavailable`. That was charged to the episode, so five passes at the ten
   second idle cadence, under a minute of being offline, marked every queued
   episode permanently `failed`. Nothing looks at a `failed` episode again:
   `EpisodesAwaitingUpload` returns only `pending` and `uploading`, and
   `RequeueFailedUploads` only ran once, at agent start. The data was then
   stranded until somebody restarted the agent.
2. Quota eviction could delete an episode while the worker was uploading it.
   `enforceQuota` filters candidates on the read pin count alone; the worker set
   the manifest state to `uploading` but never took a pin.
3. Every `FileVerification` with `ok == false` on commit was read as terminal
   local corruption. An object the server never stored has no hash to disagree
   with, and a hash computed over a fragment is a fact about the transfer, not
   about the bytes on disk. Good episodes were thrown away.
4. A server-side stream abort was masked. When the server aborts,
   `stream.Send` returns `io.EOF`, which says the stream is closed and nothing
   about why; that was returned ahead of the ack reader's error, so a
   `PermissionDenied` route surfaced as an anonymous `stream chunks: EOF`, was
   classified as neither blocked nor stalled, and burned the episode's retry
   budget.

## Cause

The retry model had one budget and charged everything to it. It could not tell
apart three different kinds of failure: the route is misconfigured (already
handled, `errIngestBlocked`), the network is down, and this one episode is bad.
Only the first had been separated out. Retention and transfer, likewise, had two
independent notions of "this episode is in use" (`uploading` in the manifest, the
pin count in memory) and eviction consulted only one of them.

## Solution

Transport failures become a pass-level condition alongside the existing blocked
route. `transportStalled` classifies `Unavailable`, `DeadlineExceeded` and a
client-side `context.DeadlineExceeded`; the episode is restored exactly as the
pass found it, the pass aborts, and the worker backs off, exponentially from one
second to the sixty second cap, jittered over the upper half of the window so a
fleet that lost the same uplink does not retry in lockstep. The per-episode
attempt counter is now reserved for errors the server answered about that
episode. `RequeueFailedUploads` runs at startup as before and additionally on a
`transferRequeueInterval` (thirty minute) ticker, so an outage longer than the
budget recovers on its own.

The transfer takes the manager's read pin (`BeginDownload` / `EndDownload`)
around the whole episode, which is what eviction actually consults, and an
episode that leaves the store mid-transfer is dropped quietly instead of
retried. That check re-reads the store rather than trusting `os.ErrNotExist`
alone: one missing file inside an episode that is still there raises the same
error and is a real, episode-specific fault that must still spend the budget.

On commit, only a SHA-256 mismatch over an object the server durably holds is
terminal. An empty `actual_sha256`, a detail naming a missing object, or a file
whose acknowledged durable offset never reached its size is retriable and gets
sent again on the next attempt for free, since `BeginEpisodeUpload` reports a
committed offset of zero for anything not durably stored. Making the durability
signal available meant recording the acks, which are now matched on the
`(episode_id, path)` pair the wire contract requires rather than discarded.

Finally, `streamFailure` prefers the ack reader's error when the send side only
has an `io.EOF` to offer, so a server's own status reaches the classifier.

## Findings

| ID | Verdict | Where |
| --- | --- | --- |
| S6-F2 | FIXED | `data_transfer_worker.go`: `transportStalled`, `errTransportStalled`, `passBackoff`, `transferRequeueInterval`, the ticker in `Run`, the stall branch in `processEpisode`, and the rewritten doc comments on `transferMaxAttempts` and `handleRetryable` |
| S6-F4 | FIXED | `data_transfer_worker.go`: `BeginDownload` / `EndDownload` around the transfer in `processEpisode`, plus `episodeGone`; `manager.go`: documented the pin pair as the contract every reader must take |
| S6-F5 | FIXED | `data_transfer_worker.go`: `commitFailureTerminal`, `detailSaysMissing`, the ack-offset recording in `uploadEpisode`, and the terminal/retriable split at commit |
| S6-F6 | FIXED | `data_transfer_worker.go`: `streamFailure` |

All four were verified as present in the current code before being changed;
none was already fixed and none was refuted.

## Tests

New regression coverage, all of which was confirmed to fail against the code as
it stood before this change:

- `TestTransportOutageSpendsNoRetryBudget`: seven passes against an ingest that
  answers `Unavailable`; every episode stays `pending` with attempts at zero and
  the pass stops at the first stall.
- `TestEpisodeSpecificErrorSpendsRetryBudget`: `InvalidArgument`, `Internal` and
  `FailedPrecondition` still cost the episode an attempt and a backoff.
- `TestTransportStalledClassification`, `TestPassBackoffGrowsAndIsCapped`.
- `TestPeriodicRequeueRearmsFailedEpisodes`: injected ticker and wait function; an
  episode written `failed` after startup stays `failed` across several passes and
  is only re-armed once the ticker fires.
- `TestUploadInFlightIsPinnedAgainstEviction`: a quota sweep during an in-flight
  transfer leaves the episode alone; `TestEnforceQuotaSkipsPinnedEpisode` in the
  data package covers the manager side, including that releasing the pin makes
  the episode a candidate again.
- `TestEvictedEpisodeStopsQuietly` and `TestMissingFileIsNotAnEviction`.
- `TestCommitVerdictClassification`: four commit shapes across the terminal and
  retriable split, including a truncated transfer whose acks never reported a
  durable offset.
- `TestStreamAbortSurfacesServerStatus` and
  `TestStreamFailurePrefersTheServerReason`.

`TestDataTransferWorker_TransientCommitErrorIsRetryable` was updated: its
`DeadlineExceeded` commit failure is now attributed to the pass rather than to
the episode. Its point, that a network drop during commit is not a terminal
verification failure, is unchanged and is asserted more strictly.

Commands run, all green:

```
go build ./...
go vet ./...
GOOS=linux GOARCH=arm64 go vet ./internal/agent/services/... ./internal/agent/data/...
go test -race ./internal/agent/services/ -count=1
go test -race ./internal/agent/data/ -count=1
gofmt -l -s .
```
