### PR TITLE
fix(agent/data): attribute ROS 2 files to real sources and seal off the lock

### DIFF
--- a/go/internal/agent/data/manager.go
+++ b/go/internal/agent/data/manager.go
@@ -656,12 +656,7 @@ func (m *Manager) interrupt(key, reason string, drain bool) (Manifest, error) {
 	if err != nil {
 		return Manifest{}, err
 	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if !m.stillOpenLocked(a) {
-		return Manifest{}, ErrNoActiveEpisode
-	}
-	return m.finalizeLocked(a, "interrupted", reason)
+	return m.finalize(a, "interrupted", reason)
 }
 
 func (m *Manager) sampleEpisode(ctx context.Context, a *activeEpisode) {
@@ -845,15 +840,17 @@ func (m *Manager) EndDownload(id string) {
 // RecordApplication validates and stamps an entitled application's record.
 // It returns buffered or recorded; protocol-level validation happens before it.
 func (m *Manager) RecordApplication(appID string, record ApplicationRecord) (string, error) {
-	m.mu.Lock()
+	// The receipt is sampled BEFORE m.mu is taken. It is the agent's statement
+	// of when this record arrived, so any wait for the lock belongs outside it:
+	// stamped after the wait, a record that queued behind a seal or another
+	// record was dated to when the manager got round to it, and the pre-roll
+	// window and the episode offsets derived from it inherited that error.
 	before, err := readBootTime()
 	if err != nil {
-		m.mu.Unlock()
 		return "rejected", err
 	}
 	after, err := readBootTime()
 	if err != nil {
-		m.mu.Unlock()
 		return "rejected", err
 	}
 	receipt := before + (after-before)/2
@@ -872,6 +869,7 @@ func (m *Manager) RecordApplication(appID string, record ApplicationRecord) (str
 		stamp = record.ClientBootNanos
 	}
 	stored := storedApplicationRecord{ApplicationRecord: record, AppID: appID, AgentReceiptBootNanos: receipt, ClientTimestampAccepted: accepted, TimestampUncertaintyNanos: (after - before + 1) / 2}
+	m.mu.Lock()
 	// Every open episode that selected the applications source receives the
 	// record on its own timeline; episodes that excluded it are skipped. Open
 	// means capturing OR inside its post-seal drain: the drain exists precisely
@@ -1128,7 +1126,7 @@ func (m *Manager) stillOpenLocked(a *activeEpisode) bool {
 // configured drain (see beginSeal) so an application that scores asynchronously
 // can still file its verdict here. It gives up its campaign key as it enters
 // that window, so the campaign can start its next episode immediately.
-// StoppedEpisodeNS is stamped in finalizeLocked, after the drain, so records
+// StoppedEpisodeNS is stamped in the seal, after the drain, so records
 // that arrive during the drain carry an EpisodeNanos below it exactly as live
 // ones do.
 func (m *Manager) Stop(key string) (Manifest, error) {
@@ -1136,26 +1134,80 @@ func (m *Manager) Stop(key string) (Manifest, error) {
 	if err != nil {
 		return Manifest{}, err
 	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if !m.stillOpenLocked(a) {
-		return Manifest{}, ErrNoActiveEpisode
-	}
-	return m.finalizeLocked(a, "complete", "")
+	return m.finalize(a, "complete", "")
 }
 
-func (m *Manager) finalizeLocked(a *activeEpisode, state, reason string) (Manifest, error) {
-	now, err := readBootTime()
-	if err != nil {
+// sealMux is the seal's playable remux, indirected so a test can substitute a
+// slow one and observe that the rest of the manager keeps serving during it.
+// Production always runs muxPlayableClips.
+var sealMux = muxPlayableClips
+
+// finalize seals an episode whose capture has stopped and whose post-seal
+// drain, if it had one, has already been served.
+//
+// It runs in three phases so that the cost of a seal is not charged to every
+// other caller of the manager. A seal rewrites every camera byte (the playable
+// remux) and then reads every byte again (the per-file SHA-256), which on a
+// multi-gigabyte episode is seconds of input and output. Holding m.mu across
+// that blocked Start, Status, ActiveEpisodeKeys, UpdateUploadState and, worst
+// of all, RecordApplication, whose agent receipt was then taken after the wait:
+// the whole seal duration was added to a timestamp whose entire purpose is to
+// say when the agent received the record.
+//
+//  1. Under the lock the episode is detached from m.active and m.sealing. That
+//     detachment is the fence the unlocked phase relies on: openEpisodesLocked
+//     no longer returns the episode, so no application record and no model
+//     input can be appended to it once its bytes are being hashed, and no
+//     second Stop or Interrupt can claim it.
+//  2. With the lock released the episode's clock is read, its ledger is
+//     flushed, and its bytes are muxed and hashed. Nothing else can reach the
+//     episode by then, and enforceQuota skips ".partial" directories, so the
+//     store cannot evict it mid-seal either.
+//  3. The lock is retaken to write the manifest and rename the directory out
+//     of ".partial", which is what publishes the episode to every path that
+//     walks the store.
+//
+// A failure in any phase abandons the episode rather than parking it. It is
+// already detached, so it can neither be sealed twice nor absorb further
+// records, and its directory keeps its ".partial" suffix, which is exactly
+// what recoverPartials seals on the next start. Leaving it in m.sealing
+// instead, as an earlier version did, produced an episode no caller could
+// reach (Stop and Interrupt look only in m.active) that nevertheless kept
+// answering "recorded" for records nothing would ever seal.
+func (m *Manager) finalize(a *activeEpisode, state, reason string) (Manifest, error) {
+	m.mu.Lock()
+	if !m.stillOpenLocked(a) {
+		m.mu.Unlock()
+		return Manifest{}, ErrNoActiveEpisode
+	}
+	m.forgetLocked(a)
+	a.manifest.State, a.manifest.Interruption = state, reason
+	consensus := m.consensus
+	m.mu.Unlock()
+
+	if err := m.sealDetached(a, consensus); err != nil {
+		m.Warnf("episode %s: seal failed, leaving %s for recovery on the next start: %v",
+			a.manifest.ID, filepath.Base(a.dir), err)
 		return Manifest{}, err
 	}
+	return a.manifest, nil
+}
+
+// sealDetached is phases two and three of finalize: everything the seal does
+// once the episode belongs to this call alone. Only the caller may run it, and
+// only after the episode has left m.active and m.sealing.
+func (m *Manager) sealDetached(a *activeEpisode, consensus func(context.Context) (timesync.Consensus, error)) error {
+	now, err := readBootTime()
+	if err != nil {
+		return err
+	}
 	a.manifest.StoppedEpisodeNS = now - a.manifest.RequestBootNanos
-	if obs, err := observeUTC(a.manifest.RequestBootNanos, "system_reported", "linux_realtime_sandwich"); err == nil {
+	if obs, obsErr := observeUTC(a.manifest.RequestBootNanos, "system_reported", "linux_realtime_sandwich"); obsErr == nil {
 		a.manifest.UTCObservations = append(a.manifest.UTCObservations, obs)
 	}
-	if m.consensus != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		c, queryErr := m.consensus(ctx)
+	if consensus != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), consensusQueryTimeout)
+		c, queryErr := consensus(ctx)
 		cancel()
 		if queryErr == nil {
 			a.manifest.Roughtime = append(a.manifest.Roughtime, c)
@@ -1164,7 +1216,6 @@ func (m *Manager) finalizeLocked(a *activeEpisode, state, reason string) (Manife
 			}
 		}
 	}
-	a.manifest.State, a.manifest.Interruption = state, reason
 	// The model-input ledger is appended without per-sample fsync, so it must
 	// reach the disk before its checksum is taken.
 	if a.modelInputs != nil {
@@ -1172,7 +1223,7 @@ func (m *Manager) finalizeLocked(a *activeEpisode, state, reason string) (Manife
 		closeErr := a.modelInputs.Close()
 		a.modelInputs = nil
 		if err := errors.Join(syncErr, closeErr); err != nil {
-			return Manifest{}, err
+			return err
 		}
 	}
 	// The playable remux runs before sealFiles so each derived
@@ -1182,25 +1233,23 @@ func (m *Manager) finalizeLocked(a *activeEpisode, state, reason string) (Manife
 	// the remux is a copy, not a transcode, so this keeps the seal's shape:
 	// one more read of the camera bytes, never a failure. A source that
 	// cannot be muxed honestly seals without its clip and the notes say why.
-	a.manifest.PlayableNotes = muxPlayableClips(a.dir)
+	a.manifest.PlayableNotes = sealMux(a.dir)
 	for _, note := range a.manifest.PlayableNotes {
-		m.warnf("episode %s: %s", a.manifest.ID, note)
+		m.Warnf("episode %s: %s", a.manifest.ID, note)
 	}
 	files, err := sealFiles(a.dir)
 	if err != nil {
-		return Manifest{}, err
+		return err
 	}
 	associateFileSources(files, a.manifest.Sources)
 	a.manifest.Files = files
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if err := writeManifest(a.dir, a.manifest); err != nil {
-		return Manifest{}, err
+		return err
 	}
-	final := strings.TrimSuffix(a.dir, ".partial")
-	if err := os.Rename(a.dir, final); err != nil {
-		return Manifest{}, err
-	}
-	m.forgetLocked(a)
-	return a.manifest, nil
+	return os.Rename(a.dir, strings.TrimSuffix(a.dir, ".partial"))
 }
 
 // forgetLocked drops a finalized episode from whichever collection holds it:
@@ -1665,37 +1714,91 @@ func payloadFormat(path string) (string, string) {
 	}
 }
 
+// sourceForPath names the source behind the two files whose episode-relative
+// path is fixed rather than derived from a source identifier. Every other file
+// is attributed by associateFileSources, which matches it against the sources
+// the manifest actually declares. A path component is deliberately NOT used as
+// a fallback identifier: it is safeName of an identifier, and safeName is not
+// invertible, so a file no source claims is left unattributed rather than
+// labelled with a fragment that matches nothing on the device or in the cloud
+// catalog.
 func sourceForPath(path string) string {
-	if path == "events.jsonl" {
+	switch path {
+	case "events.jsonl":
 		return "applications"
-	}
-	if path == "telemetry.jsonl" {
+	case "telemetry.jsonl":
 		return "telemetry"
-	}
-	parts := strings.Split(path, "/")
-	if len(parts) >= 2 && (parts[0] == "cameras" || parts[0] == "ros2" || parts[0] == "audio") {
-		return parts[1]
 	}
 	return ""
 }
 
+// fileSourceKey is the path component that a source's files are written under.
+// It is safeName of the source identifier, except for a ROS 2 topic source: one
+// recorder per DDS domain records every selected topic on that domain into a
+// single bag, and both the bag directory and its clock-sample sidecar are named
+// for the domain, so a topic source's files live under the domain's key.
+func fileSourceKey(id string) string {
+	if domainID, _, ok := ParseROS2SourceID(id); ok {
+		return safeName(domainID)
+	}
+	return safeName(id)
+}
+
+// fileHasSourceKey reports whether an episode-relative path, with its
+// kind directory already stripped, belongs to the source encoded as key: the
+// payload directory itself, a file inside it, the source's calibration
+// blob, or a sidecar such as "<key>-clock_samples.jsonl".
+func fileHasSourceKey(path, key string) bool {
+	return path == key || path == key+".calibration" ||
+		strings.HasPrefix(path, key+"/") || strings.HasPrefix(path, key+"-")
+}
+
+// associateFileSources attaches every sealed file to the episode sources that
+// produced it.
+//
+// Most files have exactly one source. A ROS 2 bag has as many as the campaign
+// selected topics on its domain, because the domain is recorded once: the bag
+// and its clock samples are the payload of each of those sources, not of a
+// domain source the campaign never named. SourceID stays single valued for the
+// consumers that key on it, so it carries the domain-level source when the
+// campaign selected one and the first selected topic source otherwise, and the
+// remaining sources are listed in AdditionalSourceIDs.
 func associateFileSources(files []File, sources []SourceStats) {
 	for i := range files {
-		if files[i].SourceID == "applications" || files[i].SourceID == "telemetry" {
+		if files[i].SourceID != "" {
 			continue
 		}
 		path := strings.TrimPrefix(files[i].Path, "cameras/")
 		path = strings.TrimPrefix(path, "ros2/")
 		path = strings.TrimPrefix(path, "audio/")
+		var matched []string
+		var additional []string
+		primary := -1
 		for _, stats := range sources {
-			encoded := safeName(stats.Source.ID)
-			if path == encoded || path == encoded+".calibration" || strings.HasPrefix(path, encoded+"/") || strings.HasPrefix(path, encoded+"-") {
-				files[i].SourceID = stats.Source.ID
-				break
+			id := stats.Source.ID
+			if !fileHasSourceKey(path, fileSourceKey(id)) {
+				continue
+			}
+			if _, topic, isROS2 := ParseROS2SourceID(id); isROS2 && topic == "" && primary < 0 {
+				primary = len(matched)
+			}
+			matched = append(matched, id)
+		}
+		if len(matched) == 0 {
+			continue
+		}
+		if primary < 0 {
+			primary = 0
+		}
+		for j, id := range matched {
+			if j != primary {
+				additional = append(additional, id)
 			}
 		}
+		files[i].SourceID, files[i].AdditionalSourceIDs = matched[primary], additional
 	}
 }
+
 func writeManifest(dir string, m Manifest) error {
 	b, e := json.MarshalIndent(m, "", "  ")
 	if e != nil {

--- a/go/internal/agent/data/model.go
+++ b/go/internal/agent/data/model.go
@@ -223,12 +223,22 @@ type MonotonicMappingSample struct {
 const FileRoleDerived = "derived"
 
 type File struct {
-	Path      string `json:"path"`
-	Size      int64  `json:"size"`
-	SHA256    string `json:"sha256"`
-	SourceID  string `json:"source_id,omitempty"`
-	Format    string `json:"format"`
-	MediaType string `json:"media_type"`
+	Path     string `json:"path"`
+	Size     int64  `json:"size"`
+	SHA256   string `json:"sha256"`
+	SourceID string `json:"source_id,omitempty"`
+	// AdditionalSourceIDs names the other episode sources this one file also
+	// belongs to; SourceID together with this list is the complete set. One
+	// file can serve several sources because a Robot Operating System 2 (ROS
+	// 2) recorder writes ONE bag per Data Distribution Service (DDS) domain
+	// however many topics on that domain the campaign selected, and each
+	// selected topic is its own episode source. It is empty for the ordinary
+	// one file, one source case, and it is never a stand-in for "unknown": a
+	// file no manifest source claims carries an empty SourceID instead of a
+	// guess derived from its path.
+	AdditionalSourceIDs []string `json:"additional_source_ids,omitempty"`
+	Format              string   `json:"format"`
+	MediaType           string   `json:"media_type"`
 	// Role distinguishes what a file is to the episode. Empty means capture
 	// payload or capture metadata written while recording; FileRoleDerived
 	// marks an artifact computed from that payload at seal time.

--- a/go/internal/agent/data/playable_test.go
+++ b/go/internal/agent/data/playable_test.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"os"
@@ -107,7 +108,14 @@ func TestSealWritesPlayableClipListedInManifest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err = m.Start(StartOptions{Sources: []string{"applications"}}); err != nil {
+	// The camera is declared as an episode source, exactly as a device with a
+	// camera declares it. A sealed file is attributed to the source the
+	// manifest names, never to the directory component it happens to sit
+	// under, which is a lossy encoding of an identifier and not one.
+	m.SetSourceProvider(func(context.Context) []Source {
+		return []Source{{ID: "cam-front", Kind: "camera", ClockDomain: "CLOCK_BOOTTIME", Healthy: true}}
+	})
+	if _, err = m.Start(StartOptions{Sources: []string{"applications", "cam-front"}}); err != nil {
 		t.Fatal(err)
 	}
 	session, ok := m.ActiveSession(AdHocEpisodeKey)

--- a/go/internal/agent/data/seal_phases_test.go
+++ b/go/internal/agent/data/seal_phases_test.go
@@ -1,0 +1,190 @@
+package data
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestFailedSealAbandonsTheEpisodeInsteadOfParkingIt pins what happens when a
+// seal fails on an episode that has already given up its campaign key.
+//
+// beginSeal moves a draining episode from m.active to m.sealing. Every error
+// return in the finalize path used to precede the removal from m.sealing, so a
+// seal that failed (no space left for the manifest, a symlink in the episode
+// directory, a rename that could not complete) left the episode there
+// permanently. Nothing could reach it afterwards: Stop and Interrupt look only
+// in m.active, so it could never be retried, while RecordApplication walks the
+// draining episodes too and kept appending records to it, answering "recorded"
+// to the application for data that would never be sealed or uploaded.
+//
+// The failure is injected with a symlink, which sealFiles refuses by design.
+func TestFailedSealAbandonsTheEpisodeInsteadOfParkingIt(t *testing.T) {
+	root := t.TempDir()
+	m, err := NewManager(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := m.Start(StartOptions{
+		Sources:       []string{"applications"},
+		DrainDuration: 20 * time.Millisecond,
+		Trigger:       EpisodeTrigger{Reason: "event:seal-failure", CampaignName: "camp"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(root, started.ID+".partial")
+	if err = os.Symlink(filepath.Join(root, "elsewhere"), filepath.Join(dir, "dangling")); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err = m.Stop("camp"); err == nil {
+		t.Fatal("Stop reported success although the episode could not be sealed")
+	} else if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("Stop failed with %v, want the symlink refusal from sealFiles", err)
+	}
+
+	m.mu.Lock()
+	stillActive, stillSealing := len(m.active), len(m.sealing)
+	m.mu.Unlock()
+	if stillActive != 0 || stillSealing != 0 {
+		t.Fatalf("after a failed seal the manager still holds %d active and %d sealing episode(s), want none", stillActive, stillSealing)
+	}
+
+	// The application must be told the truth: nothing is open, so the record
+	// is buffered for the next episode rather than acknowledged into one that
+	// will never be sealed.
+	state, err := m.RecordApplication("com.example.scorer", ApplicationRecord{Version: 1, Type: "event", Name: "after-failed-seal"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state != "buffered" {
+		t.Fatalf("record after a failed seal: state=%q, want %q", state, "buffered")
+	}
+	if containsName(recordNames(t, readEvents(t, dir)), "after-failed-seal") {
+		t.Fatal("a record reached an episode the manager had already failed to seal")
+	}
+
+	// The directory keeps its ".partial" suffix, which is what recoverPartials
+	// picks up on the next start: the episode has an owner again.
+	if _, err = os.Stat(dir); err != nil {
+		t.Fatalf("failed seal did not leave the episode for recovery: %v", err)
+	}
+	if _, err = os.Stat(filepath.Join(root, started.ID)); err == nil {
+		t.Fatal("failed seal published the episode anyway")
+	}
+
+	// The campaign key is free, so the campaign records again immediately
+	// rather than being wedged behind an episode nobody can finalize.
+	if _, err = m.Start(StartOptions{
+		Sources: []string{"applications"},
+		Trigger: EpisodeTrigger{Reason: "event:next", CampaignName: "camp"},
+	}); err != nil {
+		t.Fatalf("the campaign could not start its next episode: %v", err)
+	}
+}
+
+// TestSealDoesNotBlockOtherEpisodesOrDelayReceipts pins that the expensive part
+// of a seal runs with m.mu released.
+//
+// The playable remux rewrites every camera byte and the checksum pass reads
+// every byte again, which is seconds of input and output on a real episode.
+// Run under the lock they blocked every other manager call, and the damage was
+// not only latency: RecordApplication took its agent receipt after acquiring
+// the lock, so a record that arrived during a seal was stamped with the time
+// the manager got round to it, minutes off on a large episode, and the
+// pre-roll window and episode offsets derived from that stamp inherited the
+// error.
+func TestSealDoesNotBlockOtherEpisodesOrDelayReceipts(t *testing.T) {
+	const mux = 750 * time.Millisecond
+
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The episode being sealed, and a second, unrelated episode that must keep
+	// serving throughout.
+	if _, err = m.Start(StartOptions{
+		Sources: []string{"applications"},
+		Trigger: EpisodeTrigger{Reason: "event:slow", CampaignName: "slow"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	other, err := m.Start(StartOptions{Sources: []string{"applications"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	muxing := make(chan struct{})
+	defer func(original func(string) []string) { sealMux = original }(sealMux)
+	sealMux = func(string) []string {
+		close(muxing)
+		time.Sleep(mux)
+		return nil
+	}
+
+	sealed := make(chan error, 1)
+	go func() {
+		_, stopErr := m.Stop("slow")
+		sealed <- stopErr
+	}()
+	<-muxing
+
+	// A record for the other episode, written while the seal is muxing.
+	before, err := readBootTime()
+	if err != nil {
+		t.Fatal(err)
+	}
+	begin := time.Now()
+	state, err := m.RecordApplication("com.example.scorer", ApplicationRecord{Version: 1, Type: "event", Name: "during-seal"})
+	elapsed := time.Since(begin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state != "recorded" {
+		t.Fatalf("record written during another episode's seal: state=%q, want %q", state, "recorded")
+	}
+	if elapsed > mux/3 {
+		t.Fatalf("RecordApplication took %s during a %s seal: it is waiting for the seal to finish", elapsed, mux)
+	}
+
+	// Also check the other manager calls a device makes constantly.
+	begin = time.Now()
+	m.ActiveEpisodeKeys()
+	m.Status()
+	if _, err = m.Start(StartOptions{
+		Sources: []string{"applications"},
+		Trigger: EpisodeTrigger{Reason: "event:concurrent", CampaignName: "concurrent"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if elapsed = time.Since(begin); elapsed > mux/3 {
+		t.Fatalf("status and start calls took %s during a %s seal", elapsed, mux)
+	}
+
+	if err = <-sealed; err != nil {
+		t.Fatal(err)
+	}
+
+	// The receipt is the agent's statement of when the record arrived, so it
+	// must sit at the moment of the call and not at the end of the seal.
+	dir, err := m.episodeDir(other.ID)
+	if err != nil {
+		// The other episode is still open, so its directory is the partial one.
+		dir = filepath.Join(m.root, other.ID+".partial")
+	}
+	var receipt int64
+	for _, stored := range decodeRecords(t, readEvents(t, dir)) {
+		if stored.Name == "during-seal" {
+			receipt = stored.AgentReceiptBootNanos
+		}
+	}
+	if receipt == 0 {
+		t.Fatal("the record written during the seal did not reach the other episode")
+	}
+	if late := time.Duration(receipt - before); late > mux/3 {
+		t.Fatalf("agent receipt is %s after the record was written, which is the seal duration leaking into the timestamp", late)
+	}
+}

--- a/go/internal/agent/data/seal_ros2_sources_test.go
+++ b/go/internal/agent/data/seal_ros2_sources_test.go
@@ -1,0 +1,167 @@
+package data
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+// The Robot Operating System 2 (ROS 2) recorder writes ONE bag per Data
+// Distribution Service (DDS) domain, however many topics on that domain the
+// campaign selected, and names it for the domain. These are the exact paths
+// the agent's ROS 2 adapter creates in startOne: the bag under
+// ros2/<safeName(domain identifier)>/ and the clock samples beside it as
+// ros2/<safeName(domain identifier)>-clock_samples.jsonl.
+const (
+	ros2TestRMW      = "rmw_cyclonedds_cpp"
+	ros2TestDomainNo = 42
+)
+
+func writeROS2Bag(t *testing.T, episodeDir string) {
+	t.Helper()
+	key := safeName(ROS2DomainSourceID(ros2TestRMW, ros2TestDomainNo))
+	bag := filepath.Join(episodeDir, "ros2", key)
+	if err := os.MkdirAll(bag, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	for name, contents := range map[string]string{
+		filepath.Join(bag, "metadata.yaml"):                           "rosbag2_bagfile_information:\n  version: 5\n",
+		filepath.Join(bag, "bag_0.db3"):                               "sqlite",
+		filepath.Join(episodeDir, "ros2", key+"-clock_samples.jsonl"): "{\"episode_nanos\":1}\n",
+	} {
+		if err := os.WriteFile(name, []byte(contents), 0o640); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestSealAttributesROS2BagToEveryTopicSource pins what a sealed manifest says
+// a ROS 2 bag belongs to.
+//
+// The bag's path component is safeName of the DOMAIN identifier, and safeName
+// is not invertible, so reading a source identifier back out of it produced
+// "ros2_rmw_cyclonedds_cpp_domain-42": a string that matches no source in the
+// manifest, no source on the device and nothing in the cloud catalog the
+// transfer worker forwards it to. A campaign that selects individual topics is
+// the ordinary case since per-topic sources exist, so that was the ordinary
+// outcome, and the clock sidecar was labelled with its own file name.
+func TestSealAttributesROS2BagToEveryTopicSource(t *testing.T) {
+	domain := ROS2DomainSourceID(ros2TestRMW, ros2TestDomainNo)
+	lidar := ROS2TopicSourceID(ros2TestRMW, ros2TestDomainNo, "/lidar/points")
+	image := ROS2TopicSourceID(ros2TestRMW, ros2TestDomainNo, "/camera/image_raw")
+	bagKey := safeName(domain)
+
+	cases := []struct {
+		name           string
+		selected       []string
+		wantPrimary    string
+		wantAdditional []string
+	}{
+		// The finding's case: no domain source is declared at all, so the bag
+		// belongs to the topic sources and to nothing else.
+		{"topics only", []string{lidar, image}, lidar, []string{image}},
+		// The pre-per-topic spelling, which must keep behaving as it did.
+		{"domain only", []string{domain}, domain, nil},
+		// Both granularities selected: the domain source is the one identifier
+		// that covers the whole bag, so it is the primary.
+		{"domain and topics", []string{domain, lidar, image}, domain, []string{lidar, image}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := NewManager(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			declared := append([]string{"applications"}, tc.selected...)
+			m.SetSourceProvider(func(context.Context) []Source {
+				var out []Source
+				for _, id := range tc.selected {
+					out = append(out, Source{ID: id, Kind: "ros2", ClockDomain: "CLOCK_BOOTTIME", Healthy: true})
+				}
+				return out
+			})
+			if _, err = m.Start(StartOptions{Name: "ros2", Sources: declared}); err != nil {
+				t.Fatal(err)
+			}
+			session, ok := m.ActiveSession(AdHocEpisodeKey)
+			if !ok {
+				t.Fatal("no active session")
+			}
+			writeROS2Bag(t, session.Directory)
+			sealed, err := m.Stop(AdHocEpisodeKey)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for _, rel := range []string{
+				"ros2/" + bagKey + "/metadata.yaml",
+				"ros2/" + bagKey + "/bag_0.db3",
+				"ros2/" + bagKey + "-clock_samples.jsonl",
+			} {
+				entry, listed := fileByPath(sealed.Files, rel)
+				if !listed {
+					t.Fatalf("manifest does not list %s: %+v", rel, sealed.Files)
+				}
+				if entry.SourceID != tc.wantPrimary {
+					t.Errorf("%s source_id %q, want %q", rel, entry.SourceID, tc.wantPrimary)
+				}
+				if !slices.Equal(entry.AdditionalSourceIDs, tc.wantAdditional) {
+					t.Errorf("%s additional_source_ids %v, want %v", rel, entry.AdditionalSourceIDs, tc.wantAdditional)
+				}
+			}
+
+			// Nothing in the manifest may name a source the manifest does not
+			// declare. This is the assertion that fails on a path fragment,
+			// whichever fragment a future layout produces.
+			declaredIDs := map[string]bool{}
+			for _, stats := range sealed.Sources {
+				declaredIDs[stats.Source.ID] = true
+			}
+			for _, f := range sealed.Files {
+				for _, id := range append([]string{f.SourceID}, f.AdditionalSourceIDs...) {
+					if id != "" && !declaredIDs[id] {
+						t.Errorf("file %s names source %q, which the episode never declared", f.Path, id)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestSealLeavesUnclaimedFileWithoutASource pins the other half: a file no
+// declared source claims carries no source identifier at all. An empty field
+// says "unattributed", which a consumer can act on; a mangled path component
+// says "attributed to something that does not exist", which it cannot.
+func TestSealLeavesUnclaimedFileWithoutASource(t *testing.T) {
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = m.Start(StartOptions{Sources: []string{"applications"}}); err != nil {
+		t.Fatal(err)
+	}
+	session, ok := m.ActiveSession(AdHocEpisodeKey)
+	if !ok {
+		t.Fatal("no active session")
+	}
+	writeROS2Bag(t, session.Directory)
+	sealed, err := m.Stop(AdHocEpisodeKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rel := "ros2/" + safeName(ROS2DomainSourceID(ros2TestRMW, ros2TestDomainNo)) + "/metadata.yaml"
+	entry, listed := fileByPath(sealed.Files, rel)
+	if !listed {
+		t.Fatalf("manifest does not list %s", rel)
+	}
+	if entry.SourceID != "" {
+		t.Errorf("%s source_id %q, want it empty: no declared source claims this file", rel, entry.SourceID)
+	}
+	// The fixed-name files keep their sources, which are not path derived.
+	events, listed := fileByPath(sealed.Files, "events.jsonl")
+	if !listed || events.SourceID != "applications" {
+		t.Errorf("events.jsonl source_id %q, want applications", events.SourceID)
+	}
+}

--- a/go/internal/agent/services/data_ros2_adapter.go
+++ b/go/internal/agent/services/data_ros2_adapter.go
@@ -366,6 +366,14 @@ func (a *ros2DataAdapter) startOne(ctx context.Context, session data.CaptureSess
 	// Paths are keyed by the domain, not by any one selected source: a domain
 	// yields exactly one bag per episode, whether it was selected whole or by
 	// a list of topics, and a topic name is not a safe path component.
+	//
+	// The seal reads this layout back the same way round. It never decodes a
+	// path component into a source identifier, which safeCaptureName makes
+	// impossible; it encodes each declared source's DOMAIN identifier and
+	// matches that against the component, so the bag and its clock sidecar are
+	// attributed to every topic source the campaign selected on this domain
+	// (data.associateFileSources). Renaming these paths after anything but a
+	// source's domain identifier therefore breaks manifest attribution.
 	key := ros2DomainSourceID(sc)
 	name := safeCaptureName("wendy-" + session.ID + "-" + key)
 	staging := filepath.Join(a.service.bagDir, name)


### PR DESCRIPTION
## Problem

Three review findings on the episode seal path in `go/internal/agent/data`, all verified against current code on this branch.

1. A sealed manifest labelled Robot Operating System 2 (ROS 2) files with a source that does not exist. With a campaign selecting only topics, for example `ros2: /lidar/points`, the bag sealed as `source_id: "ros2_rmw_cyclonedds_cpp_domain-42"` and its clock sidecar as `source_id: "ros2_rmw_cyclonedds_cpp_domain-42-clock_samples.jsonl"`. Neither matches any source in the manifest, on the device, or in the cloud catalog the transfer worker forwards `source_id` to verbatim.
2. A seal that failed on a draining episode left an un-retriable zombie. `beginSeal` moves the episode from `m.active` to `m.sealing`; every error return preceded `forgetLocked`, and `Stop` and `Interrupt` look only in `m.active`. The episode stayed in `m.sealing` forever, `RecordApplication` kept appending to its `.partial/events.jsonl` and answering "recorded" for data nothing would ever seal, and the campaign key it had given up was fine but the episode itself was unreachable.
3. The whole seal ran under `m.mu`. The playable remux rewrites every camera byte and the checksum pass reads every byte again, seconds of input and output on a real episode, and during that window `Start`, `Status`, `ActiveEpisodeKeys`, `UpdateUploadState` and `RecordApplication` all blocked. Worse than the latency: `RecordApplication` sampled its agent receipt after acquiring the lock, so a record that arrived during a seal was dated to when the manager got round to it, and the pre-roll window and episode offsets derived from that stamp inherited the error.

## Cause

1. `sealFiles` pre-filled `SourceID` with the second component of the path, and `associateFileSources` only overwrote it when `safeName(source.ID)` was a prefix of that path. Both directions were wrong for ROS 2. One recorder per Data Distribution Service (DDS) domain records every selected topic into a single bag named for the DOMAIN, so a topic source's `safeName` never matches; and `safeName` is not invertible, so a path component can never be read back as an identifier. The pre-fill turned "no source matched" into a confident wrong answer instead of no answer.
2. Detaching the episode was the last step of `finalizeLocked` rather than the first, so every failure path skipped it.
3. `finalizeLocked` was called with the lock already held by `Stop` and `interrupt`, and did all of its work there, including a Roughtime consensus query with a five second timeout.

## Solution

Attribution now runs the encoding forwards instead of trying to invert it. Each declared source is encoded to the path component its files live under (`fileSourceKey`: `safeName` of the source identifier, or of its DOMAIN identifier for a ROS 2 topic source), and the file is matched against that. A bag is therefore attached to every topic source the campaign selected on its domain. `File.SourceID` stays single valued for the consumers that key on it, carrying the domain-level source when the campaign selected one and the first selected topic source otherwise; the remaining sources go into a new `additional_source_ids` field on the manifest file entry. `sourceForPath` keeps only the two fixed-name files (`events.jsonl`, `telemetry.jsonl`), so a file no declared source claims seals with an empty `source_id` rather than a fragment.

`finalizeLocked` becomes `finalize` plus `sealDetached`, in three phases. Under the lock the episode is detached from `m.active` and `m.sealing`, which is the fence the rest relies on: `openEpisodesLocked` no longer returns it, so no application record or model input can be appended while its bytes are hashed, and no second `Stop` or `Interrupt` can claim it. With the lock released the clock is read, the model-input ledger is flushed, and the episode is muxed and hashed; `enforceQuota` skips `.partial` directories, so the store cannot evict it mid-seal. The lock is retaken only to write the manifest and rename the directory out of `.partial`. Any failure abandons the episode, already detached, leaving the `.partial` for `recoverPartials` and logging why.

`RecordApplication` samples its agent receipt before contending for `m.mu`.

The ROS 2 adapter's file layout is unchanged (one bag per domain is correct); `startOne` gains a comment stating that the seal reads the layout back by encoding domain identifiers forwards, so renaming those paths after anything else breaks attribution.

## Findings

| Finding | Verdict | Evidence |
| --- | --- | --- |
| S7c-F1 topic-only ROS 2 selection seals a mangled `source_id` | FIXED | Reproduced by `TestSealAttributesROS2BagToEveryTopicSource` against the pre-fix code: bag and clock file sealed as `ros2_rmw_cyclonedds_cpp_domain-42` and `..._domain-42-clock_samples.jsonl`. The domain-only case was already correct and stays so. |
| S7c-F2 failed finalize leaves an un-retriable zombie in `m.sealing` | FIXED | Reproduced by `TestFailedSealAbandonsTheEpisodeInsteadOfParkingIt`: pre-fix, `m.sealing` still held one episode after a failed `Stop`. |
| S7c-F5 mux and hashing run under `m.mu`, delaying receipts | FIXED | Reproduced by `TestSealDoesNotBlockOtherEpisodesOrDelayReceipts`: pre-fix, `RecordApplication` for an unrelated episode took 758 ms during a 750 ms seal. |

## Tests

New regression tests, each verified to fail against the pre-fix code and pass after:

- `TestSealAttributesROS2BagToEveryTopicSource` shapes a temporary episode directory exactly as the adapter's `startOne` does and asserts the sealed source identifiers for the topic-only, domain-only and domain-plus-topics cases, plus a blanket assertion that no file names a source the episode never declared.
- `TestSealLeavesUnclaimedFileWithoutASource` pins the empty `source_id` for an unclaimed file.
- `TestFailedSealAbandonsTheEpisodeInsteadOfParkingIt` injects a symlink so `sealFiles` fails deterministically, then asserts the episode is gone from both collections, the next application record is classified "buffered" and does not reach it, the directory is still `.partial`, and the campaign key is free.
- `TestSealDoesNotBlockOtherEpisodesOrDelayReceipts` injects a slow mux and asserts that a record for a different episode is served promptly and that its agent receipt does not carry the seal duration.

One existing test changed: `TestSealWritesPlayableClipListedInManifest` declared no camera source and relied on the path pre-fill for its `cam-front` assertion. It now declares the camera as an episode source, as a device with a camera does, and asserts the same attribution for the right reason.

Verified from `go/`: `go build ./...`, `gofmt -l -s .` clean, `GOOS=linux go vet ./internal/agent/data/... ./internal/agent/services/...` clean, `go test -race ./internal/agent/...` green.
