### PR TITLE
fix(agent): correct capture-adapter lifetimes, loss accounting and degradation

### DIFF
--- a/go/internal/agent/data/campaign.go
+++ b/go/internal/agent/data/campaign.go
@@ -448,6 +448,9 @@ func (m *Manager) DeployCampaign(contents []byte) (Campaign, error) {
 		return Campaign{}, err
 	}
 	campaign.DeployedUnixNanos = time.Now().UnixNano()
+	if absent := m.unpublishedROS2Selectors(campaign); len(absent) > 0 {
+		campaign.Warnings = append(campaign.Warnings, "no healthy ROS 2 graph currently publishes these selectors; the campaign still deploys, and a trigger records its other sources and marks the absent one in the episode manifest: "+strings.Join(absent, ", "))
+	}
 	if campaign.BufferDuration() > 0 {
 		for _, source := range campaign.Sources {
 			if source.Audio != "" || source.ROS2 != "" {
@@ -538,10 +541,35 @@ func (m *Manager) Campaigns() ([]Campaign, error) {
 // ROS 2 and telemetry policies are not plumbed because those adapters
 // implement only continuous capture (deployment warns).
 func (m *Manager) ResolveCampaignSources(campaign Campaign) ([]string, []string, map[string]*SourceCapture, error) {
+	ids, topics, captures, _, err := m.resolveCampaignSources(campaign, false)
+	return ids, topics, captures, err
+}
+
+// ResolveCampaignSourcesDegrading is ResolveCampaignSources with one selector
+// class downgraded from a failure to a report: a Robot Operating System 2
+// (ROS 2) topic that nobody is publishing at the moment of the trigger.
+//
+// Aborting the whole episode for it was the wrong trade. A ROS 2 node that has
+// not come up yet, or that restarts between triggers, took the camera, the
+// telemetry and the application records of the triggering event down with it,
+// and the operator was left with no episode at all rather than an episode
+// missing one source. The unresolved selectors come back as unhealthy Source
+// entries so the caller can record them in the manifest, where the episode says
+// plainly which source was absent and why.
+func (m *Manager) ResolveCampaignSourcesDegrading(campaign Campaign) ([]string, []string, map[string]*SourceCapture, []Source, error) {
+	return m.resolveCampaignSources(campaign, true)
+}
+
+// ROS2AbsentDetail explains a ROS 2 source entry that names a selector nothing
+// published when the episode opened.
+const ROS2AbsentDetail = "no healthy ROS 2 graph published this selector when the episode was triggered; the episode recorded its other sources"
+
+func (m *Manager) resolveCampaignSources(campaign Campaign, degradeROS2 bool) ([]string, []string, map[string]*SourceCapture, []Source, error) {
 	all := m.Sources(context.Background())
 	selected := map[string]bool{"applications": true}
 	captures := map[string]*SourceCapture{}
 	var topics []string
+	var unresolved []Source
 	for _, requested := range campaign.Sources {
 		switch {
 		case requested.Telemetry:
@@ -550,7 +578,16 @@ func (m *Manager) ResolveCampaignSources(campaign Campaign) ([]string, []string,
 			topics = append(topics, requested.ROS2)
 			ids, err := resolveROS2Selector(all, requested.ROS2)
 			if err != nil {
-				return nil, nil, nil, err
+				if !degradeROS2 {
+					return nil, nil, nil, nil, err
+				}
+				unresolved = append(unresolved, Source{
+					ID:      ROS2SourcePrefix + strings.TrimPrefix(requested.ROS2, ROS2SourcePrefix),
+					Kind:    "ros2",
+					Healthy: false,
+					Detail:  ROS2AbsentDetail + ": " + err.Error(),
+				})
+				continue
 			}
 			for _, id := range ids {
 				selected[id] = true
@@ -558,7 +595,7 @@ func (m *Manager) ResolveCampaignSources(campaign Campaign) ([]string, []string,
 		case requested.Camera != "":
 			id, err := resolveCameraSelector(all, requested.Camera)
 			if err != nil {
-				return nil, nil, nil, err
+				return nil, nil, nil, nil, err
 			}
 			selected[id] = true
 			if requested.Capture != nil {
@@ -567,7 +604,7 @@ func (m *Manager) ResolveCampaignSources(campaign Campaign) ([]string, []string,
 		case requested.Audio != "":
 			id, err := resolveKindSelector(all, "audio", requested.Audio)
 			if err != nil {
-				return nil, nil, nil, err
+				return nil, nil, nil, nil, err
 			}
 			selected[id] = true
 			if requested.Capture != nil {
@@ -581,7 +618,36 @@ func (m *Manager) ResolveCampaignSources(campaign Campaign) ([]string, []string,
 	}
 	sort.Strings(ids)
 	sort.Strings(topics)
-	return ids, topics, captures, nil
+	return ids, topics, captures, unresolved, nil
+}
+
+// ResolveCampaignCameraSources resolves only a campaign's camera selectors,
+// independently of every other selector in the plan.
+//
+// Arming pre-roll needs the camera sources and nothing else, so it must not be
+// held hostage by an unrelated selector: resolving the whole plan meant that one
+// ROS 2 topic that had not been published yet silently disarmed the camera ring
+// for the entire campaign, and the first trigger then opened with no pre-roll at
+// all. An unresolvable camera selector is still an error, because that one names
+// the source arming is about.
+func (m *Manager) ResolveCampaignCameraSources(campaign Campaign) ([]Source, error) {
+	var cameras []Source
+	var all []Source
+	loaded := false
+	for _, requested := range campaign.Sources {
+		if requested.Camera == "" {
+			continue
+		}
+		if !loaded {
+			all, loaded = m.Sources(context.Background()), true
+		}
+		id, err := resolveCameraSelector(all, requested.Camera)
+		if err != nil {
+			return nil, err
+		}
+		cameras = append(cameras, Source{ID: id, Kind: "camera", Capture: requested.Capture})
+	}
+	return cameras, nil
 }
 
 // resolveROS2Selector maps a campaign `ros2:` selector onto discovered source
@@ -703,6 +769,36 @@ func (m *Manager) checkDeployableAudioSources(campaign Campaign) error {
 		return fmt.Errorf("audio source %q does not name a healthy capture source on this device", requested.Audio)
 	}
 	return nil
+}
+
+// unpublishedROS2Selectors names the campaign's ROS 2 selectors that no healthy
+// graph publishes right now.
+//
+// It WARNS where checkDeployableAudioSources refuses, and the asymmetry is
+// deliberate. An audio selector that does not resolve names a capture device
+// that either exists on the board or does not, so deploy is the last moment an
+// operator can be told. A ROS 2 topic is published by a node that legitimately
+// comes and goes: a plan is routinely deployed before the node that publishes
+// its topic is running, so refusing here would make correct plans undeployable.
+// The trigger degrades rather than aborting (see
+// ResolveCampaignSourcesDegrading), so the warning is the operator's early
+// notice, not the last line of defence.
+func (m *Manager) unpublishedROS2Selectors(campaign Campaign) []string {
+	var absent []string
+	var all []Source
+	loaded := false
+	for _, requested := range campaign.Sources {
+		if requested.ROS2 == "" {
+			continue
+		}
+		if !loaded {
+			all, loaded = m.Sources(context.Background()), true
+		}
+		if _, err := resolveROS2Selector(all, requested.ROS2); err != nil {
+			absent = append(absent, strconv.Quote(requested.ROS2))
+		}
+	}
+	return absent
 }
 
 // matchUnhealthySource finds an unhealthy source of the given kind that the

--- a/go/internal/agent/data/manager.go
+++ b/go/internal/agent/data/manager.go
@@ -461,6 +461,12 @@ func (m *Manager) Start(opts StartOptions) (Manifest, error) {
 		}
 		manifest.Sources = append(manifest.Sources, SourceStats{Source: s, RequestedOffset: requestedOffset, DropAccounting: "unavailable"})
 	}
+	// Sources the plan named and the device could not resolve are recorded as
+	// present-in-the-plan, absent-in-the-episode rather than omitted, so a
+	// degraded episode never reads as one that was never asked for them.
+	for _, s := range opts.UnresolvedSources {
+		manifest.Sources = append(manifest.Sources, SourceStats{Source: s, DropAccounting: "source_absent_at_trigger"})
+	}
 	for source, contents := range opts.Calibrations {
 		name := safeName(source) + ".calibration"
 		p := filepath.Join(dir, name)

--- a/go/internal/agent/data/model.go
+++ b/go/internal/agent/data/model.go
@@ -346,9 +346,15 @@ type StartOptions struct {
 	CollectorVersion string
 	ModelVersions    map[string]string
 	RequestedTopics  []string
-	Privacy          []PrivacyTransformation
-	Upload           WorkflowState
-	Labeling         WorkflowState
+	// UnresolvedSources are sources the campaign asked for that the device could
+	// not resolve when the episode opened, most often a ROS 2 topic nobody is
+	// publishing. They are recorded in the manifest as unhealthy sources that
+	// captured nothing, so an episode that degraded says which source it lost
+	// instead of looking like a plan that never named it.
+	UnresolvedSources []Source
+	Privacy           []PrivacyTransformation
+	Upload            WorkflowState
+	Labeling          WorkflowState
 }
 
 type EpisodeInfo struct {

--- a/go/internal/agent/services/data_audio_adapter.go
+++ b/go/internal/agent/services/data_audio_adapter.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/wendylabsinc/wendy/go/internal/agent/audio"
@@ -49,23 +50,47 @@ const (
 	// audioPipelineDelayEstimate is the capture delay still outstanding once
 	// the chunk in hand has been accounted for: audio already sitting in the
 	// device buffer when that chunk was handed over, plus its transit through
-	// the capture subprocess pipe. MEASURED on a Jetson Orin Nano with a
-	// Logitech C920 microphone over 60 reads, the ALSA device delay ran 12.6 ms
-	// to 20.9 ms and pipe transit about 4 ms, giving 16.6 ms to 24.9 ms and
-	// centring near 20 ms. The 102 ms by which the oldest sample in a chunk was
-	// stale on that hardware is this residue plus the 85.33 ms chunk itself.
+	// the capture subprocess pipe.
+	//
+	// SINGLE-DEVICE CALIBRATION, not a measurement this agent makes at runtime.
+	// It was measured on ONE configuration and is applied to every device: a
+	// Jetson Orin Nano (wendyos-hubert) running the shipped WendyOS image, a
+	// Logitech C920 USB microphone on the raw ALSA path (no PipeWire session),
+	// s16le 48 kHz mono at the 100 ms requested latency this adapter asks for,
+	// on an otherwise idle board, over 60 consecutive reads. Under those
+	// conditions the ALSA device delay ran 12.6 ms to 20.9 ms and pipe transit
+	// about 4 ms, giving 16.6 ms to 24.9 ms and centring near 20 ms. The 102 ms
+	// by which the oldest sample in a chunk was stale on that hardware is this
+	// residue plus the 85.33 ms chunk itself.
+	//
+	// Different hardware, a different period size, a loaded board or the
+	// PipeWire path will land somewhere else inside audioPipelineDelayBound,
+	// which is why the bound and not this number is what the published
+	// uncertainty carries. Every capture says so in its manifest source detail
+	// (see audioPipelineDelayNote) rather than leaving a reader to assume the
+	// correction was measured here.
 	audioPipelineDelayEstimate = 20 * time.Millisecond
 	// audioPipelineDelayBound is the uncertainty half-width published alongside
 	// a corrected stamp. It covers a residual delay anywhere between 0 and
-	// 40 ms, which absorbs the period-size and scheduling variation a single
-	// point measurement cannot pin down, and contains the arecord fallback path
-	// now that audio.ArecordCommand bounds its device buffer to 40 ms.
+	// 40 ms, which absorbs the period-size and scheduling variation the single
+	// point calibration above cannot pin down, and contains the arecord fallback
+	// path now that audio.ArecordCommand bounds its device buffer to 40 ms. It
+	// is the part of the pair a reader should trust on unmeasured hardware.
 	audioPipelineDelayBound = 20 * time.Millisecond
 	// audioMappingSegment labels a stamp corrected by the two constants above,
 	// so a reader can tell corrected audio stamps from the uncorrected
 	// "receipt-bracket-v1" stamps the camera adapters still publish.
 	audioMappingSegment = "receipt-minus-pipeline-v1"
 )
+
+// audioPipelineDelayNote is folded into every audio capture's manifest source
+// detail. A stamp corrected by a constant that was calibrated on one device and
+// one microphone must say so in the episode, not only in this file: a reader
+// comparing audio against camera timing on other hardware needs to know the
+// correction is an estimate carrying a bound, not a per-device measurement.
+var audioPipelineDelayNote = fmt.Sprintf(
+	"segment stamps are corrected by audioPipelineDelayEstimate (%s), a single-device calibration measured on a Jetson Orin Nano with a Logitech C920 microphone on the raw ALSA path, not a measurement taken on this device; treat it as an estimate and the published canonical uncertainty (at least %s) as the bound",
+	audioPipelineDelayEstimate, audioPipelineDelayBound)
 
 // audioStream is the PCM source the capture loop reads from. It is an interface
 // so tests can inject deterministic PCM without a live capture process.
@@ -262,22 +287,32 @@ func (a *audioDataAdapter) startOne(ctx context.Context, session data.CaptureSes
 		}
 	}
 
-	stream, err := a.openStream(ctx, devID)
+	// The recorder subprocess belongs to the capture, not to the caller.
+	// openStream used to be handed the RPC handler's context, which gRPC cancels
+	// the moment the handler returns: exec.CommandContext then killed arecord or
+	// pw-record about one chunk into the episode, the pipe reached end of file,
+	// that read as a clean end of stream, and the episode sealed "complete" with
+	// a single audio chunk in it. captureCtx is owned here and cancelled by Stop,
+	// exactly as the camera and ROS 2 adapters already do.
+	captureCtx, cancel := context.WithCancel(context.Background())
+	stream, err := a.openStream(captureCtx, devID)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 	dir := filepath.Join(session.Directory, "audio", safeCaptureName(source.ID))
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		stream.Close()
+		cancel()
 		return nil, err
 	}
 	index, err := os.OpenFile(filepath.Join(dir, "index.jsonl"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o640)
 	if err != nil {
 		stream.Close()
+		cancel()
 		return nil, err
 	}
 
-	captureCtx, cancel := context.WithCancel(context.Background())
 	c := &audioCapture{
 		source: source, session: session, dir: dir, stream: stream, index: index,
 		ctx: captureCtx, cancel: cancel, done: make(chan struct{}), ready: make(chan error, 1),
@@ -302,8 +337,10 @@ func (a *audioDataAdapter) startOne(ctx context.Context, session data.CaptureSes
 }
 
 // shutdown cancels the capture context and closes the PCM stream, unblocking a
-// pending Read, then waits for run to finish.
+// pending Read, then waits for run to finish. The stopping flag is raised first,
+// so run can tell the end of stream it caused from one the recorder caused.
 func (c *audioCapture) shutdown() {
+	c.stopping.Store(true)
 	c.cancel()
 	c.stream.Close()
 	<-c.done
@@ -337,8 +374,12 @@ type audioCapture struct {
 	ready     chan error
 	readyOnce sync.Once
 	stopOnce  sync.Once
-	result    data.CaptureResult
-	runErr    error
+	// stopping is raised by shutdown before the stream is closed, so the read
+	// loop can tell an end of stream it asked for from one the recorder process
+	// caused by exiting.
+	stopping atomic.Bool
+	result   data.CaptureResult
+	runErr   error
 
 	// mode is "continuous" or "threshold".
 	mode string
@@ -389,6 +430,12 @@ func (c *audioCapture) signalReady(err error) { c.readyOnce.Do(func() { c.ready 
 // run reads PCM until the stream ends. It does not poll c.ctx: Stop closes the
 // stream, which unblocks Read and drains the buffered PCM, so a stop never
 // truncates data the producer already delivered.
+//
+// An end of stream BEFORE Stop is a failure, not a clean end. The recorder is
+// meant to run for the whole episode, so its pipe closing early means the
+// process died: end of file was previously swallowed as a normal finish, and the
+// episode sealed "complete" holding whatever fraction of the audio the recorder
+// managed before it went. Only an end of stream that Stop caused is clean.
 func (c *audioCapture) run() {
 	defer close(c.done)
 	defer c.finish()
@@ -404,12 +451,21 @@ func (c *audioCapture) run() {
 			c.signalReady(nil)
 		}
 		if err != nil {
-			if err != io.EOF {
+			switch {
+			case err != io.EOF && !c.stopping.Load():
 				if msg := c.stream.Err(); msg != "" {
 					c.runErr = errors.New(msg)
 				} else {
 					c.runErr = err
 				}
+			case err == io.EOF && !c.stopping.Load():
+				c.runErr = errors.New("audio capture process exited before the capture was stopped")
+				if msg := c.stream.Err(); msg != "" {
+					c.runErr = fmt.Errorf("%w: %s", c.runErr, msg)
+				}
+			case err != io.EOF:
+				// Stop closed the stream underneath the read; that is the
+				// designed way out, not a capture failure.
 			}
 			c.signalReady(c.runErr)
 			return
@@ -541,8 +597,7 @@ func (c *audioCapture) beginSegment(triggerLevel *float64, firstChunkBytes int) 
 		return err
 	}
 	if err := writeWAVHeader(f, audioSampleRate, audioChannels, 0); err != nil {
-		f.Close()
-		return err
+		return errors.Join(err, f.Close())
 	}
 	c.seg = f
 	c.segRel = filepath.ToSlash(filepath.Join("audio", safeCaptureName(c.source.ID), name))
@@ -652,6 +707,13 @@ func (c *audioCapture) finish() {
 	c.result.SourceID = c.source.ID
 	c.result.ClockDomain = c.source.ClockDomain
 	c.result.ActualOffset = c.firstOffset
+	c.notes = append(c.notes, audioPipelineDelayNote)
+	if c.runErr != nil {
+		// The failure is recorded ON THE SOURCE as well as returned from Stop:
+		// the manifest entry for this microphone is where a reader looks to find
+		// out why an episode holds less audio than it should.
+		c.notes = append(c.notes, "capture ended early: "+c.runErr.Error())
+	}
 	if c.clampedSegments > 0 {
 		// Said in the manifest as well as per segment: an operator reading the
 		// episode summary should not have to open the audio index to learn that

--- a/go/internal/agent/services/data_audio_adapter_test.go
+++ b/go/internal/agent/services/data_audio_adapter_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,22 +16,52 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/agent/data"
 )
 
-// fakeAudioStream yields a fixed sequence of PCM chunks and then EOF.
+// fakeAudioStream yields a fixed sequence of PCM chunks and then waits, like a
+// real recorder subprocess that has nothing more to deliver yet: the stream ends
+// only when Close is called. Setting exitEarly instead models the recorder
+// process dying mid-episode, which the capture must report as a failure rather
+// than as a clean end of stream.
 type fakeAudioStream struct {
-	chunks [][]byte
-	i      int
+	chunks    [][]byte
+	i         int
+	exitEarly bool
+	err       string
+	mu        sync.Mutex
+	done      chan struct{}
+}
+
+func (f *fakeAudioStream) stopped() chan struct{} {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.done == nil {
+		f.done = make(chan struct{})
+	}
+	return f.done
 }
 
 func (f *fakeAudioStream) Read(b []byte) (int, error) {
 	if f.i >= len(f.chunks) {
+		if !f.exitEarly {
+			<-f.stopped()
+		}
 		return 0, io.EOF
 	}
 	n := copy(b, f.chunks[f.i])
 	f.i++
 	return n, nil
 }
-func (f *fakeAudioStream) Close()      {}
-func (f *fakeAudioStream) Err() string { return "" }
+
+func (f *fakeAudioStream) Close() {
+	ch := f.stopped()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	select {
+	case <-ch:
+	default:
+		close(ch)
+	}
+}
+func (f *fakeAudioStream) Err() string { return f.err }
 
 // pcmChunk is silence of an arbitrary length. Anything shorter than
 // audioChunkBytes is a short read: the capture loop offers a 9600-byte buffer
@@ -804,5 +835,100 @@ func TestAudioSegmentStampIsNotClampedWhenItNeedNotBe(t *testing.T) {
 	}
 	if strings.Contains(result.SourceDetail, "clamped") {
 		t.Errorf("source detail = %q mentions a clamp that did not happen", result.SourceDetail)
+	}
+}
+
+// TestAudioCaptureOutlivesTheCallerContext pins the fix for a capture that
+// recorded roughly one chunk and then sealed the episode as complete.
+//
+// Start is called from a gRPC unary handler, and gRPC cancels that handler's
+// context the moment the handler returns. The recorder subprocess used to be
+// launched with exec.CommandContext on THAT context, so arecord or pw-record was
+// killed a few milliseconds into the episode, the pipe reached end of file, and
+// the read loop treated it as a clean end of stream. The recorder's lifetime now
+// belongs to the capture and ends only at Stop.
+func TestAudioCaptureOutlivesTheCallerContext(t *testing.T) {
+	stream := &fakeAudioStream{chunks: [][]byte{silentChunk()}}
+	var streamCtx context.Context
+	adapter := &audioDataAdapter{
+		audio: &AudioService{},
+		openStream: func(ctx context.Context, _ uint32) (audioStream, error) {
+			streamCtx = ctx
+			return stream, nil
+		},
+	}
+	source := data.Source{ID: "audio:0", Kind: "audio", ClockDomain: "TEST_CAPTURE/AGENT_RECEIPT", Healthy: true}
+	session := data.CaptureSession{ID: "ep", Directory: t.TempDir()}
+
+	callerCtx, cancelCaller := context.WithCancel(context.Background())
+	running, err := adapter.Start(callerCtx, session, []data.Source{source})
+	if err != nil {
+		t.Fatalf("adapter start: %v", err)
+	}
+	// The handler returns: gRPC cancels its context.
+	cancelCaller()
+
+	if streamCtx == nil {
+		t.Fatal("openStream was never called")
+	}
+	select {
+	case <-streamCtx.Done():
+		t.Fatal("the recorder's context died with the caller's; the capture process would be killed one chunk into the episode")
+	default:
+	}
+	// Still recording: the fake keeps the read blocked until it is closed, and
+	// it is closed only by Stop.
+	select {
+	case <-stream.stopped():
+		t.Fatal("the PCM stream was closed before Stop")
+	default:
+	}
+
+	results, err := running.Stop(context.Background())
+	if err != nil {
+		t.Fatalf("adapter stop: %v", err)
+	}
+	if len(results) != 1 || results[0].Count == 0 {
+		t.Fatalf("results = %+v, want one source with at least one sealed segment", results)
+	}
+	select {
+	case <-streamCtx.Done():
+	default:
+		t.Fatal("Stop must cancel the capture context that owns the recorder process")
+	}
+}
+
+// TestAudioRecorderExitBeforeStopIsACaptureError pins the other half: a recorder
+// that dies mid-episode must surface as an error on the source, not as a clean
+// end of stream that seals the episode "complete" holding a fraction of the
+// audio it promised.
+func TestAudioRecorderExitBeforeStopIsACaptureError(t *testing.T) {
+	stream := &fakeAudioStream{chunks: [][]byte{silentChunk()}, exitEarly: true, err: "arecord: main:831: read error"}
+	adapter := &audioDataAdapter{
+		audio:      &AudioService{},
+		openStream: func(context.Context, uint32) (audioStream, error) { return stream, nil },
+	}
+	source := data.Source{ID: "audio:0", Kind: "audio", ClockDomain: "TEST_CAPTURE/AGENT_RECEIPT", Healthy: true, Detail: "test mic"}
+	session := data.CaptureSession{ID: "ep", Directory: t.TempDir()}
+
+	running, err := adapter.Start(context.Background(), session, []data.Source{source})
+	if err != nil {
+		t.Fatalf("adapter start: %v", err)
+	}
+	results, stopErr := running.Stop(context.Background())
+	if stopErr == nil {
+		t.Fatal("a recorder that exited before Stop was reported as a clean end of capture")
+	}
+	if !strings.Contains(stopErr.Error(), "exited before the capture was stopped") {
+		t.Fatalf("stop error = %v, want it to name the early exit", stopErr)
+	}
+	if !strings.Contains(stopErr.Error(), "read error") {
+		t.Fatalf("stop error = %v, want it to carry what the recorder printed", stopErr)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results = %+v, want one source result", results)
+	}
+	if !strings.Contains(results[0].SourceDetail, "capture ended early") {
+		t.Fatalf("source detail %q does not record the early end on the source", results[0].SourceDetail)
 	}
 }

--- a/go/internal/agent/services/data_camera_adapter.go
+++ b/go/internal/agent/services/data_camera_adapter.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/wendylabsinc/wendy/go/internal/agent/data"
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
@@ -272,14 +274,11 @@ func (a *cameraDataAdapter) startOne(ctx context.Context, session data.CaptureSe
 	}
 	mappings, err := os.OpenFile(filepath.Join(dir, "clock_samples.jsonl"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o640)
 	if err != nil {
-		index.Close()
-		return nil, err
+		return nil, errors.Join(err, index.Close())
 	}
 	hub, subID, frames, achievedW, achievedH, achievedFPS, restarted, err := a.subscribeHub(ctx, src.key, req)
 	if err != nil {
-		index.Close()
-		mappings.Close()
-		return nil, err
+		return nil, errors.Join(err, index.Close(), mappings.Close())
 	}
 	if restarted {
 		notes = append(notes, fmt.Sprintf("campaign capture parameters took over the camera: restarted the producer, previously running at producer-default parameters for parameter-less subscribers, at the requested %s; those subscribers reattached to the new stream",
@@ -294,7 +293,7 @@ func (a *cameraDataAdapter) startOne(ctx context.Context, session data.CaptureSe
 	rejoin := func(ctx context.Context) (*deviceHub, int, chan *videoFrame, error) {
 		return a.video.joinHub(ctx, src.key, &agentpb.StreamVideoRequest{DeviceId: devID})
 	}
-	c := &cameraCapture{source: source, session: session, dir: dir, hub: hub, subID: subID, frames: frames, rejoin: rejoin, index: index, mappingFile: mappings, ctx: captureCtx, cancel: cancel, done: make(chan struct{}), ready: make(chan error, 1), mode: mode, interval: interval.Nanoseconds(), rateCap: rateCap, notes: notes, lastSnapshotIdx: -1}
+	c := &cameraCapture{source: source, session: session, dir: dir, hub: hub, subID: subID, frames: frames, rejoin: rejoin, logger: a.video.logger, index: index, mappingFile: mappings, ctx: captureCtx, cancel: cancel, done: make(chan struct{}), ready: make(chan error, 1), mode: mode, interval: interval.Nanoseconds(), rateCap: rateCap, notes: notes, lastSnapshotIdx: -1}
 	go c.run()
 	select {
 	case err := <-c.ready:
@@ -422,7 +421,14 @@ type cameraCapture struct {
 	rejoin func(ctx context.Context) (*deviceHub, int, chan *videoFrame, error)
 	// carriedDrops accumulates subscriber-channel drops from hub
 	// subscriptions this capture already left when reattaching.
-	carriedDrops       uint64
+	carriedDrops uint64
+	// deathRejoins counts recoveries from a producer that exited under this
+	// capture, bounding how often one episode chases a failing camera.
+	deathRejoins int
+	// logger is the video service's logger, so a mid-episode failure is said
+	// when it happens rather than only appearing in the manifest at Stop. Nil in
+	// unit tests that drive a bare capture.
+	logger             *zap.Logger
 	index, mappingFile *os.File
 	segment            *os.File
 	segmentRel         string
@@ -439,15 +445,20 @@ type cameraCapture struct {
 	runErr             error
 	lastSequence       uint32
 	haveSequence       bool
-	lastMapping        data.MonotonicMappingSample
-	haveMapping        bool
-	mappingNumber      int
-	mappingStart       int64
-	mappingMaxError    int64
-	mappingSamples     uint64
-	mappingSummaries   []data.ClockMapping
-	maxCanonicalError  int64
-	observedDomains    map[string]bool
+	// sawSequence records that this capture observed at least one frame carrying
+	// a valid producer sequence number, at any point in its life. Unlike
+	// haveSequence it is never reset by a producer restart: it decides which of
+	// the two loss accountings the capture result reports (see run's teardown).
+	sawSequence       bool
+	lastMapping       data.MonotonicMappingSample
+	haveMapping       bool
+	mappingNumber     int
+	mappingStart      int64
+	mappingMaxError   int64
+	mappingSamples    uint64
+	mappingSummaries  []data.ClockMapping
+	maxCanonicalError int64
+	observedDomains   map[string]bool
 	// mode is "continuous" or captureModeSnapshot; interval is the snapshot
 	// period in nanoseconds; rateCap is the campaign's continuous-mode capture
 	// rate cap in hertz (0 when uncapped). alignmentKnown records that the
@@ -545,13 +556,27 @@ func (c *cameraCapture) run() {
 			// workflow, so subscriber-channel drops are not data loss here;
 			// the honest loss unit is an interval that produced no still.
 			c.finishSnapshotAccounting(end)
-		} else {
-			drops := subscriberDrops
+		} else if c.sawSequence {
+			// The producer's own sequence counter already covers a frame the hub
+			// dropped for this subscriber: the frame was produced, it never
+			// reached the capture, and the next frame that did arrives with a
+			// gap in its sequence. Adding the hub's subscriber-drop counter on
+			// top counted every such frame twice, so a camera that dropped five
+			// frames reported ten. When sequences are available they are the
+			// single loss count, and the accounting label says so.
+			drops := uint64(0)
 			if c.result.Drops != nil {
-				drops += *c.result.Drops
+				drops = *c.result.Drops
 			}
 			c.result.Drops = &drops
-			c.result.DropAccounting = "partial_known_driver_and_subscriber"
+			c.result.DropAccounting = "driver_sequence_gaps_include_subscriber_drops"
+		} else {
+			// No sequence numbers from this transport, so a hub-side drop leaves
+			// no trace in the stream: the subscriber counter is the only loss
+			// signal there is, and it sees only what the hub itself discarded.
+			drops := subscriberDrops
+			c.result.Drops = &drops
+			c.result.DropAccounting = "subscriber_drops_only_no_source_sequence"
 		}
 		c.finishResultDetail(end)
 		c.finishMapping(c.result.Count)
@@ -613,9 +638,27 @@ func (c *cameraCapture) run() {
 					}
 					continue
 				}
-				c.runErr = errors.New("camera producer stopped")
-				c.signalReady(c.runErr)
-				return
+				// The producer died mid-episode: a GStreamer crash, a USB
+				// disconnect, a camera that faulted. Say so at the moment it
+				// happens rather than letting the episode carry on marked
+				// "recording" with no camera data until Stop, and try to get the
+				// camera back.
+				c.warn("camera capture: producer stopped mid-episode",
+					zap.String("source", c.source.ID),
+					zap.Uint64("frames_captured", c.result.Count))
+				if c.rejoin == nil || c.deathRejoins >= maxCameraProducerRejoins {
+					c.runErr = errors.New("camera producer stopped")
+					c.signalReady(c.runErr)
+					return
+				}
+				if err := c.rejoinAfterProducerDeath(); err != nil {
+					c.warn("camera capture: producer could not be rejoined; the source is failed for the rest of the episode",
+						zap.String("source", c.source.ID), zap.Error(err))
+					c.runErr = fmt.Errorf("camera producer stopped and could not be rejoined: %w", err)
+					c.signalReady(c.runErr)
+					return
+				}
+				continue
 			}
 			if err := c.handleFrame(frame); errors.Is(err, errAwaitCameraRandomAccess) {
 				continue
@@ -627,6 +670,76 @@ func (c *cameraCapture) run() {
 			c.signalReady(nil)
 		}
 	}
+}
+
+// Bounds on recovering from a producer that died mid-episode. Three attempts
+// half a second apart covers a GStreamer pipeline respawn and a camera that
+// re-enumerates, without turning a genuinely unplugged camera into a capture
+// that spins for the rest of the episode.
+const (
+	maxCameraProducerRejoins = 3
+	cameraProducerRejoinWait = 500 * time.Millisecond
+)
+
+// warn logs one line about this capture, if the adapter was given a logger.
+// Unit tests that drive a bare cameraCapture leave it nil.
+func (c *cameraCapture) warn(msg string, fields ...zap.Field) {
+	if c.logger == nil {
+		return
+	}
+	c.logger.Warn(msg, fields...)
+}
+
+// rejoinAfterProducerDeath tries to get the camera back after its producer
+// exited under the capture.
+//
+// What it can and cannot say honestly is the whole point. Rejoining starts a
+// NEW stream, so the recording has a real discontinuity there and the next write
+// opens a fresh segment. How many frames the gap swallowed is not knowable: the
+// producer is gone, its sequence counter restarts, and nothing counted what the
+// camera would have delivered. So the note records the wall time of the gap,
+// which is knowable, and says the frame count is not, instead of publishing a
+// zero that would read as "nothing was lost".
+func (c *cameraCapture) rejoinAfterProducerDeath() error {
+	_, start, _, _ := c.receiptNow()
+	c.carriedDrops += c.hub.unsubscribe(c.subID)
+	c.deathRejoins++
+	var lastErr error
+	for attempt := 1; attempt <= maxCameraProducerRejoins; attempt++ {
+		hub, subID, frames, err := c.rejoin(c.ctx)
+		if err == nil {
+			c.hub, c.subID, c.frames = hub, subID, frames
+			if c.segment != nil {
+				if syncErr := c.segment.Sync(); syncErr != nil {
+					return syncErr
+				}
+				if closeErr := c.segment.Close(); closeErr != nil {
+					return closeErr
+				}
+				c.segment = nil
+			}
+			// Sequence numbering and access-unit alignment are properties of the
+			// producer, so both classifications reset with the new one.
+			c.haveSequence = false
+			c.alignmentKnown = false
+			c.result.Discontinuities++
+			_, end, _, _ := c.receiptNow()
+			c.notes = append(c.notes, fmt.Sprintf(
+				"camera producer stopped mid-episode and was rejoined after %s on attempt %d of %d; the recording has a discontinuity there and continues in a new segment, and the number of frames lost across the gap is not knowable because the producer that would have counted them is the one that died",
+				time.Duration(end-start).Round(time.Millisecond), attempt, maxCameraProducerRejoins))
+			c.warn("camera capture: rejoined the producer after it stopped",
+				zap.String("source", c.source.ID), zap.Int("attempt", attempt),
+				zap.Duration("gap", time.Duration(end-start)))
+			return nil
+		}
+		lastErr = err
+		select {
+		case <-c.ctx.Done():
+			return c.ctx.Err()
+		case <-time.After(cameraProducerRejoinWait):
+		}
+	}
+	return lastErr
 }
 
 // reattachAfterRestart rejoins the device's hub after an explicit-parameter
@@ -692,17 +805,31 @@ func (c *cameraCapture) handleFrame(frame *videoFrame) error {
 
 // canonicalTime stamps one frame on the canonical CLOCK_BOOTTIME episode
 // timeline, maintaining the native-clock mapping segments as a side effect.
+//
+// The receipt bracket is the one the HUB took when it broadcast the frame
+// (frame.receiptBootNanos), not a fresh read taken here. The hub stamps it once
+// so that every consumer of a frame agrees on it, and the pre-roll replay path
+// already uses it; reading the clock again in the adapter made the capture index
+// and the model-input ledger publish two different receipts for the same
+// sample_id, which is exactly the join those two records exist to support. A
+// zero receipt means the hub's clock read failed (or a unit test drove the
+// capture with a bare frame), and only then is a fresh read taken.
 func (c *cameraCapture) canonicalTime(frame *videoFrame) (canonical, uncertainty int64, mappingID string, receipt int64, err error) {
 	if c.observedDomains == nil {
 		c.observedDomains = make(map[string]bool)
 	}
 	c.observedDomains[frame.nativeClock] = true
-	before, receipt, after, err := c.receiptNow()
-	if err != nil {
-		return 0, 0, "", 0, err
+	if frame.receiptBootNanos != 0 {
+		receipt, uncertainty = frame.receiptBootNanos, frame.receiptUncertaintyNanos
+	} else {
+		var before, after int64
+		before, receipt, after, err = c.receiptNow()
+		if err != nil {
+			return 0, 0, "", 0, err
+		}
+		uncertainty = (after - before + 1) / 2
 	}
 	canonical = receipt
-	uncertainty = (after - before + 1) / 2
 	mappingID = "receipt-bracket-v1"
 	if frame.nativeClock == "CLOCK_MONOTONIC_V4L2" {
 		if !c.haveMapping || receipt-c.lastMapping.BootAfterNanos >= int64(time.Second) {
@@ -772,12 +899,38 @@ func (c *cameraCapture) gateGOP(frame *videoFrame, receipt int64) (skip bool) {
 	return c.skipGOP
 }
 
+// trackSequence follows the producer's own frame counter and accumulates the
+// gaps in it as driver-side losses. It must be called for EVERY frame the
+// capture takes off the hub channel that carries a valid sequence, written or
+// deliberately skipped, or a skipped run is later read as a gap.
+func (c *cameraCapture) trackSequence(frame *videoFrame) {
+	if !frame.sequenceValid {
+		return
+	}
+	c.sawSequence = true
+	if c.haveSequence && frame.sequence > c.lastSequence+1 {
+		d := uint64(frame.sequence - c.lastSequence - 1)
+		if c.result.Drops == nil {
+			c.result.Drops = new(uint64)
+		}
+		*c.result.Drops += d
+	}
+	c.lastSequence, c.haveSequence = frame.sequence, true
+}
+
 func (c *cameraCapture) writeFrame(frame *videoFrame) error {
 	canonical, uncertainty, mappingID, receipt, err := c.canonicalTime(frame)
 	if err != nil {
 		return err
 	}
 	if c.rateCap > 0 && c.gateGOP(frame, receipt) {
+		// A group of pictures skipped to honour the rate cap is not a loss, but
+		// its frames still advance the driver's sequence counter. Tracking them
+		// here is what makes that true: the gate used to return before any
+		// sequence bookkeeping, so the next admitted keyframe saw a sequence jump
+		// spanning the whole skipped group and counted every deliberately
+		// discarded frame as a driver drop.
+		c.trackSequence(frame)
 		return nil
 	}
 	if err := c.writeEncodedFrame(frame, canonical, uncertainty, mappingID, receipt, false); err != nil {
@@ -845,18 +998,11 @@ func (c *cameraCapture) writeEncodedFrame(frame *videoFrame, canonical, uncertai
 		return ioErrShortWrite(n, len(payload))
 	}
 	c.segmentOffset += int64(n)
+	c.trackSequence(frame)
 	var seq *uint32
 	if frame.sequenceValid {
 		v := frame.sequence
 		seq = &v
-		if c.haveSequence && frame.sequence > c.lastSequence+1 {
-			d := uint64(frame.sequence - c.lastSequence - 1)
-			if c.result.Drops == nil {
-				c.result.Drops = new(uint64)
-			}
-			*c.result.Drops += d
-		}
-		c.lastSequence, c.haveSequence = frame.sequence, true
 	}
 	record := cameraIndexRecord{SampleID: frame.sampleID, CanonicalEpisodeNanos: canonical - c.session.RequestBootNanos, CanonicalUncertaintyNanos: uncertainty, NativeTimestampNanos: frame.nativeNs, NativeClockDomain: frame.nativeClock, NativeTimestampFlags: frame.nativeFlags, AgentCaptureRealtimeNanos: frame.tsNs, AgentReceiptBootNanos: receipt, MappingSegment: mappingID, Segment: c.segmentRel, ByteOffset: offset, ByteSize: n, Codec: frame.codec.String(), Sequence: seq}
 	b, _ := json.Marshal(record)

--- a/go/internal/agent/services/data_camera_adapter_test.go
+++ b/go/internal/agent/services/data_camera_adapter_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -549,5 +550,243 @@ func TestDeviceHubCountsSubscriberDrops(t *testing.T) {
 	}
 	if got := hub.unsubscribe(id); got != 2 {
 		t.Fatalf("drops = %d, want 2", got)
+	}
+}
+
+// testSequencedFrame is a native V4L2 frame carrying the driver's own frame
+// counter, which is what makes a loss visible in the stream itself.
+func testSequencedFrame(payload []byte, sequence uint32) *videoFrame {
+	frame := testH264Frame(payload)
+	frame.sequence, frame.sequenceValid = sequence, true
+	return frame
+}
+
+// TestCaptureCountsAHubDropOnceNotTwice pins the double count out of the
+// manifest. A frame the hub dropped for this subscriber is one loss with two
+// witnesses: the hub's own subscriber counter, and the gap it leaves in the
+// driver's sequence numbers. Adding both reported every such frame twice, so a
+// camera that lost five frames claimed to have lost ten.
+func TestCaptureCountsAHubDropOnceNotTwice(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	hub := &deviceHub{subs: make(map[int]*hubSubscriber), subDrops: make(map[int]uint64), ctx: ctx, cancel: cancel}
+	subID, frames, err := hub.subscribe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clock := &fakeReceipt{}
+	c := newTestCameraCapture(t, clock)
+	c.hub, c.subID, c.frames = hub, subID, frames
+	c.ctx, c.cancel = ctx, cancel
+	c.done, c.ready = make(chan struct{}), make(chan error, 1)
+	c.lastSnapshotIdx = -1
+	go c.run()
+
+	// Sequences 1..6, with 5 dropped by the hub while the capture was busy. One
+	// frame was produced and lost: the answer is 1, from either witness.
+	for _, seq := range []uint32{1, 2, 3, 4} {
+		if !hub.broadcast(testSequencedFrame(testRAUFrame, seq)) {
+			t.Fatal("broadcast reported no subscribers")
+		}
+		waitForCaptureCount(t, c, int(seq))
+	}
+	hub.mu.Lock()
+	hub.subDrops[subID]++
+	hub.subs[subID].pendingDrops++
+	hub.mu.Unlock()
+	if !hub.broadcast(testSequencedFrame(testRAUFrame, 6)) {
+		t.Fatal("broadcast reported no subscribers")
+	}
+	waitForCaptureCount(t, c, 5)
+
+	results, err := c.Stop(context.Background())
+	if err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if len(results) != 1 || results[0].Drops == nil {
+		t.Fatalf("results = %+v", results)
+	}
+	if *results[0].Drops != 1 {
+		t.Fatalf("drops = %d, want 1: the hub drop and the sequence gap are the same lost frame", *results[0].Drops)
+	}
+	if results[0].DropAccounting != "driver_sequence_gaps_include_subscriber_drops" {
+		t.Fatalf("drop accounting = %q, want the label that says which witness was counted", results[0].DropAccounting)
+	}
+}
+
+// waitForCaptureCount blocks until the capture has written n index entries.
+// It counts lines in index.jsonl rather than reading c.result.Count, which the
+// capture goroutine owns.
+func waitForCaptureCount(t *testing.T, c *cameraCapture, n int) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	written := 0
+	for time.Now().Before(deadline) {
+		raw, err := os.ReadFile(filepath.Join(c.dir, "index.jsonl"))
+		if err == nil {
+			written = len(bytes.Split(bytes.TrimSpace(raw), []byte("\n")))
+			if len(bytes.TrimSpace(raw)) == 0 {
+				written = 0
+			}
+			if written >= n {
+				return
+			}
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("capture wrote %d index entries, waited for %d", written, n)
+}
+
+// TestRateCappedGOPsDoNotCountAsDriverDrops pins the sequence bookkeeping the
+// rate-cap gate used to skip. A group of pictures dropped to honour the cap is a
+// deliberate choice, not a loss, but its frames still advance the driver's
+// counter: returning before the sequence was tracked made the next admitted
+// keyframe read the whole skipped group as a gap and report it as driver drops,
+// contradicting the gate's own comment.
+func TestRateCappedGOPsDoNotCountAsDriverDrops(t *testing.T) {
+	clock := &fakeReceipt{}
+	c := newTestCameraCapture(t, clock)
+	c.rateCap = 1 // hertz
+
+	// Sequences 1..5. The first group (1, 2) is admitted, the second (3, 4) is
+	// over the cap and skipped, and 5 is back under it.
+	script := []struct {
+		at       time.Duration
+		payload  []byte
+		sequence uint32
+	}{
+		{0, testRAUFrame, 1},
+		{100 * time.Millisecond, testInterFrame, 2},
+		{250 * time.Millisecond, testRAUFrame, 3},
+		{300 * time.Millisecond, testInterFrame, 4},
+		{2 * time.Second, testRAUFrame, 5},
+	}
+	for _, step := range script {
+		clock.now = int64(step.at)
+		if err := c.handleFrame(testSequencedFrame(step.payload, step.sequence)); err != nil {
+			t.Fatalf("frame %d: %v", step.sequence, err)
+		}
+	}
+	if c.result.Count != 3 {
+		t.Fatalf("wrote %d frames, want 3 (the skipped group is 2 frames)", c.result.Count)
+	}
+	if c.result.Drops != nil && *c.result.Drops != 0 {
+		t.Fatalf("drops = %d, want 0: a rate-capped group is not a loss", *c.result.Drops)
+	}
+}
+
+// TestFrameReceiptComesFromTheHubNotAFreshClockRead pins the join between the
+// capture index and the model-input ledger. The hub stamps a frame's receipt
+// once at broadcast so every consumer of that frame agrees on it; reading the
+// clock again in the adapter published two different receipts for one sample_id,
+// which is exactly the correlation the ledger exists to support.
+func TestFrameReceiptComesFromTheHubNotAFreshClockRead(t *testing.T) {
+	clock := &fakeReceipt{now: 9 * int64(time.Second)}
+	c := newTestCameraCapture(t, clock)
+
+	frame := testH264Frame(testRAUFrame)
+	frame.sampleID = 42
+	frame.receiptBootNanos = 3 * int64(time.Second)
+	frame.receiptUncertaintyNanos = 1234
+	if err := c.handleFrame(frame); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.index.Sync(); err != nil {
+		t.Fatal(err)
+	}
+	contents, err := os.ReadFile(filepath.Join(c.dir, "index.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var record cameraIndexRecord
+	if err := json.Unmarshal(bytes.TrimSpace(contents), &record); err != nil {
+		t.Fatal(err)
+	}
+	if record.AgentReceiptBootNanos != frame.receiptBootNanos {
+		t.Fatalf("index receipt = %d, want the hub's %d", record.AgentReceiptBootNanos, frame.receiptBootNanos)
+	}
+	if record.CanonicalEpisodeNanos != frame.receiptBootNanos {
+		t.Fatalf("canonical time = %d, want the hub receipt %d", record.CanonicalEpisodeNanos, frame.receiptBootNanos)
+	}
+	if record.CanonicalUncertaintyNanos != frame.receiptUncertaintyNanos {
+		t.Fatalf("uncertainty = %d, want the hub bracket %d", record.CanonicalUncertaintyNanos, frame.receiptUncertaintyNanos)
+	}
+}
+
+// TestCaptureRejoinsAfterTheProducerDies pins recovery from a producer that
+// exits mid-episode (a GStreamer crash, a camera unplugged and replugged). The
+// capture used to record a run error and stop, silently: no log, no rejoin, and
+// an episode that stayed "recording" with no camera data until Stop finally said
+// interrupted. It now rejoins and says in the manifest that the recording has a
+// discontinuity whose frame cost is not knowable.
+func TestCaptureRejoinsAfterTheProducerDies(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	first, firstCancel := context.WithCancel(context.Background())
+	defer firstCancel()
+	deadHub := &deviceHub{subs: make(map[int]*hubSubscriber), subDrops: make(map[int]uint64), ctx: first, cancel: firstCancel}
+	subID, frames, err := deadHub.subscribe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, secondCancel := context.WithCancel(context.Background())
+	defer secondCancel()
+	liveHub := &deviceHub{subs: make(map[int]*hubSubscriber), subDrops: make(map[int]uint64), ctx: second, cancel: secondCancel}
+
+	clock := &fakeReceipt{}
+	c := newTestCameraCapture(t, clock)
+	c.hub, c.subID, c.frames = deadHub, subID, frames
+	c.ctx, c.cancel = ctx, cancel
+	c.done, c.ready = make(chan struct{}), make(chan error, 1)
+	var rejoins atomic.Int64
+	c.rejoin = func(context.Context) (*deviceHub, int, chan *videoFrame, error) {
+		rejoins.Add(1)
+		id, ch, joinErr := liveHub.subscribe()
+		return liveHub, id, ch, joinErr
+	}
+	go c.run()
+
+	if !deadHub.broadcast(testH264Frame(testRAUFrame)) {
+		t.Fatal("broadcast reported no subscribers")
+	}
+	waitForCaptureCount(t, c, 1)
+
+	// The producer dies: the hub closes its subscriber channels with no terminal
+	// error and no takeover marker, which is exactly what a crashed producer
+	// leaves behind.
+	deadHub.mu.Lock()
+	for _, sub := range deadHub.subs {
+		if !sub.closed {
+			sub.closed = true
+			close(sub.ch)
+		}
+	}
+	deadHub.mu.Unlock()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for rejoins.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if rejoins.Load() == 0 {
+		t.Fatal("the capture never tried to rejoin after its producer died")
+	}
+	if !liveHub.broadcast(testH264Frame(testRAUFrame)) {
+		t.Fatal("replacement hub reported no subscribers")
+	}
+	waitForCaptureCount(t, c, 2)
+
+	results, err := c.Stop(context.Background())
+	if err != nil {
+		t.Fatalf("stop: %v; a rejoined capture must not fail the episode", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results = %+v", results)
+	}
+	if results[0].Discontinuities != 1 {
+		t.Fatalf("discontinuities = %d, want 1", results[0].Discontinuities)
+	}
+	if !strings.Contains(results[0].SourceDetail, "rejoined") || !strings.Contains(results[0].SourceDetail, "not knowable") {
+		t.Fatalf("source detail %q does not record the gap honestly", results[0].SourceDetail)
 	}
 }

--- a/go/internal/agent/services/data_camera_preroll.go
+++ b/go/internal/agent/services/data_camera_preroll.go
@@ -316,7 +316,7 @@ func (a *armedCameraSource) activate(session data.CaptureSession) (*cameraCaptur
 	}
 	c := &cameraCapture{
 		source: a.source, session: session, dir: dir, hub: a.hub, subID: a.subID, frames: a.frames,
-		rejoin: rejoin, index: index, mappingFile: mappings, ctx: captureCtx, cancel: cancel,
+		rejoin: rejoin, logger: a.video.logger, index: index, mappingFile: mappings, ctx: captureCtx, cancel: cancel,
 		done: make(chan struct{}), ready: make(chan error, 1), mode: "continuous", rateCap: rateCap,
 		notes: notes, lastSnapshotIdx: -1, preRoll: preRoll, armed: true,
 	}

--- a/go/internal/agent/services/data_ros2_adapter.go
+++ b/go/internal/agent/services/data_ros2_adapter.go
@@ -396,14 +396,12 @@ func (a *ros2DataAdapter) startOne(ctx context.Context, session data.CaptureSess
 	case result := <-c.recordDone:
 		cancel()
 		<-c.samplerDone
-		clockFile.Close()
-		return nil, fmt.Errorf("rosbag2 exited before recording (code %d): %s", result.code, summarizeROS2Output(result.err, result.output))
+		return nil, errors.Join(fmt.Errorf("rosbag2 exited before recording (code %d): %s", result.code, summarizeROS2Output(result.err, result.output)), clockFile.Close())
 	case <-ctx.Done():
 		cancel()
 		result := <-c.recordDone
 		<-c.samplerDone
-		clockFile.Close()
-		return nil, errors.Join(ctx.Err(), result.err)
+		return nil, errors.Join(ctx.Err(), result.err, clockFile.Close())
 	case <-time.After(750 * time.Millisecond):
 		return c, nil
 	}
@@ -645,8 +643,7 @@ func copyCaptureDirectory(source, destination string) error {
 		}
 		out, err := os.OpenFile(target, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o640)
 		if err != nil {
-			in.Close()
-			return err
+			return errors.Join(err, in.Close())
 		}
 		_, copyErr := io.Copy(out, in)
 		if syncErr := out.Sync(); copyErr == nil {
@@ -655,7 +652,10 @@ func copyCaptureDirectory(source, destination string) error {
 		if closeErr := out.Close(); copyErr == nil {
 			copyErr = closeErr
 		}
-		in.Close()
+		// The read side's close error is not meaningful for a file opened
+		// read-only, so it stays discarded; the write side's is the one that can
+		// report a failed flush of the copied rosbag.
+		_ = in.Close()
 		return copyErr
 	})
 }

--- a/go/internal/agent/services/data_service.go
+++ b/go/internal/agent/services/data_service.go
@@ -58,11 +58,26 @@ type DataService struct {
 	manager   *data.Manager
 	adapterMu sync.RWMutex
 	adapters  []dataCaptureAdapter
+	// captureMu guards the maps below and nothing else. It is never held across
+	// an adapter start or stop, or across a manager call: serialising every
+	// campaign on one device-wide mutex meant a second campaign's trigger waited
+	// behind the first campaign's adapter startup (a camera waits up to 20
+	// seconds for its first frame) and behind its post-seal drain, and since the
+	// episode origin is stamped inside manager.Start, that wait moved the second
+	// episode's origin forward to whenever the first campaign finished. Its own
+	// triggering record then fell outside its pre-roll window. Start and stop for
+	// ONE campaign key are serialised by that key's own mutex instead (see
+	// keyLock), which keeps the invariant that a campaign key has at most one
+	// episode without coupling campaigns to each other.
 	captureMu sync.Mutex
 	// Concurrency is keyed per campaign name; data.AdHocEpisodeKey holds the
 	// campaign-less episode started through the Start RPC.
 	activeCaptures map[string][]runningDataCapture
 	autoStopCancel map[string]context.CancelFunc
+	// keyLocks holds one mutex per campaign key, created on demand. Keys are
+	// campaign names plus data.AdHocEpisodeKey, so the map is bounded by the
+	// number of deployed campaigns.
+	keyLocks map[string]*sync.Mutex
 	// armingAdapter is the capture adapter that supports pre-roll (the camera
 	// adapter). It is kept as a typed handle so the deploy, reconcile, and
 	// post-episode paths can arm and disarm campaigns; nil until a video service
@@ -98,7 +113,7 @@ type runningDataCapture interface {
 }
 
 func NewDataService(m *data.Manager) *DataService {
-	s := &DataService{manager: m, activeCaptures: make(map[string][]runningDataCapture), autoStopCancel: make(map[string]context.CancelFunc), adHocDrain: data.DefaultSealDrain}
+	s := &DataService{manager: m, activeCaptures: make(map[string][]runningDataCapture), autoStopCancel: make(map[string]context.CancelFunc), keyLocks: make(map[string]*sync.Mutex), adHocDrain: data.DefaultSealDrain}
 	m.SetSourceProvider(s.discoverAdapterSources)
 	m.SetApplicationObserver(s.observeApplicationRecord)
 	return s
@@ -209,19 +224,28 @@ func (s *DataService) rearmByName(name string) {
 }
 
 // cameraSourcesFor resolves a campaign's camera sources to the source objects
-// the arming adapter needs (id plus capture policy), dropping non-camera and
-// unresolvable sources.
+// the arming adapter needs (id plus capture policy).
+//
+// Only the camera selectors are resolved. Resolving the whole plan meant a
+// single unrelated selector that did not resolve, a ROS 2 topic whose node has
+// not started yet being the ordinary case, returned nothing and disarmed the
+// camera ring for the entire campaign, silently: the next trigger opened with no
+// pre-roll and nothing anywhere said why.
 func (s *DataService) cameraSourcesFor(campaign data.Campaign) []data.Source {
-	sources, _, captures, err := s.manager.ResolveCampaignSources(campaign)
+	cameras, err := s.manager.ResolveCampaignCameraSources(campaign)
 	if err != nil {
+		// An unresolvable CAMERA selector is the one failure that genuinely
+		// prevents arming, and it is worth a line: pre-roll silently not
+		// happening is indistinguishable from a campaign that never asked for it.
+		s.manager.Warnf("campaign %q: camera pre-roll not armed because a camera selector did not resolve; its next trigger will open at the trigger instant: %v", campaign.Name, err)
 		return nil
 	}
 	var out []data.Source
-	for _, id := range sources {
-		if _, ok := cameraDeviceID(id); !ok {
+	for _, source := range cameras {
+		if _, ok := cameraDeviceID(source.ID); !ok {
 			continue
 		}
-		out = append(out, data.Source{ID: id, Kind: "camera", Capture: captures[id]})
+		out = append(out, source)
 	}
 	return out
 }
@@ -242,10 +266,27 @@ func (s *DataService) Start(ctx context.Context, req *agentpbv2.DataStartRequest
 	return s.startCapture(ctx, data.StartOptions{Name: req.GetName(), Sources: req.GetSources(), ExcludeSources: req.GetExcludeSources(), RequireUTCUncertainty: time.Duration(req.GetRequireUtcUncertaintyNanos()), Calibrations: cal, DrainDuration: s.adHocDrain, CollectorVersion: version.Version})
 }
 
-func (s *DataService) startCapture(ctx context.Context, opts data.StartOptions) (*agentpbv2.DataEpisode, error) {
+// keyLock returns the mutex that serialises start and stop for one campaign
+// key, creating it on first use.
+func (s *DataService) keyLock(key string) *sync.Mutex {
 	s.captureMu.Lock()
 	defer s.captureMu.Unlock()
+	if s.keyLocks == nil {
+		s.keyLocks = make(map[string]*sync.Mutex)
+	}
+	lock := s.keyLocks[key]
+	if lock == nil {
+		lock = &sync.Mutex{}
+		s.keyLocks[key] = lock
+	}
+	return lock
+}
+
+func (s *DataService) startCapture(ctx context.Context, opts data.StartOptions) (*agentpbv2.DataEpisode, error) {
 	key := opts.Trigger.CampaignName
+	lock := s.keyLock(key)
+	lock.Lock()
+	defer lock.Unlock()
 	m, err := s.manager.Start(opts)
 	if err != nil {
 		return nil, status.Error(codes.FailedPrecondition, err.Error())
@@ -275,19 +316,26 @@ func (s *DataService) startCapture(ctx context.Context, opts data.StartOptions) 
 		if applyErr := s.manager.ApplyCaptureResults(key, results); applyErr != nil {
 			s.manager.Warnf("recording capture results for episode key %q after a failed adapter start: %v", key, applyErr)
 		}
-		// Without the drain, deliberately. captureMu has been held since the top
-		// of this function and is what serialises every start and stop on the
-		// device, so a drain taken here is charged to every other caller: with
-		// the default two second drain a Start whose adapter errors took two
-		// seconds to return FailedPrecondition, and with capture.drain: 30s a
-		// flapping camera stalled the data service for thirty seconds per
-		// attempt. Nothing on this path needs the wait either: the adapters
-		// never started, so no application ever read a sample from this episode
-		// and no record about it can be outstanding.
-		_, _ = s.manager.InterruptWithoutDrain(key, "capture_adapter_start_failed")
+		// The drain is skipped only when NOTHING captured. The campaign key's
+		// mutex has been held since the top of this function, so a drain taken
+		// here is charged to every later start and stop of the same campaign:
+		// with the default two second drain a Start whose adapter errors took
+		// two seconds to return FailedPrecondition, and with capture.drain: 30s
+		// a flapping camera stalled that campaign for thirty seconds per
+		// attempt. That reasoning only holds while no adapter ever ran. Once an
+		// earlier adapter started, samples reached the episode and an
+		// application may have read one, so a record about this episode can be
+		// outstanding and the drain has to be served.
+		if len(captures) == 0 {
+			_, _ = s.manager.InterruptWithoutDrain(key, "capture_adapter_start_failed")
+		} else {
+			_, _ = s.manager.Interrupt(key, "capture_adapter_start_failed")
+		}
 		return nil, status.Error(codes.FailedPrecondition, fmt.Sprintf("starting capture adapter: %v", startErr))
 	}
+	s.captureMu.Lock()
 	s.activeCaptures[key] = captures
+	s.captureMu.Unlock()
 	return manifestEpisode(m), nil
 }
 
@@ -312,18 +360,20 @@ func (s *DataService) Stop(ctx context.Context, _ *agentpbv2.DataStopRequest) (*
 }
 
 func (s *DataService) stopCapture(ctx context.Context, key string) (*agentpbv2.DataEpisode, error) {
-	s.captureMu.Lock()
-	defer s.captureMu.Unlock()
+	lock := s.keyLock(key)
+	lock.Lock()
+	defer lock.Unlock()
 	return s.stopCaptureLocked(ctx, key)
 }
 
 // stopCaptureIfCurrent finalizes the episode keyed by key only while the
-// given episode is still the active one. The check runs under captureMu so a
-// stale auto-stop timer that raced a manual stop plus an immediate re-trigger
-// cannot finalize the campaign's new episode.
+// given episode is still the active one. The check runs under the campaign
+// key's mutex so a stale auto-stop timer that raced a manual stop plus an
+// immediate re-trigger cannot finalize the campaign's new episode.
 func (s *DataService) stopCaptureIfCurrent(ctx context.Context, key, episodeID string) {
-	s.captureMu.Lock()
-	defer s.captureMu.Unlock()
+	lock := s.keyLock(key)
+	lock.Lock()
+	defer lock.Unlock()
 	session, ok := s.manager.ActiveSession(key)
 	if !ok || session.ID != episodeID {
 		return
@@ -331,14 +381,19 @@ func (s *DataService) stopCaptureIfCurrent(ctx context.Context, key, episodeID s
 	_, _ = s.stopCaptureLocked(ctx, key)
 }
 
+// stopCaptureLocked finalizes the episode for key. The caller holds that key's
+// mutex; captureMu is taken only around the map reads and writes.
 func (s *DataService) stopCaptureLocked(ctx context.Context, key string) (*agentpbv2.DataEpisode, error) {
+	s.captureMu.Lock()
 	if cancel := s.autoStopCancel[key]; cancel != nil {
 		cancel()
 		delete(s.autoStopCancel, key)
 	}
+	captures := s.activeCaptures[key]
+	delete(s.activeCaptures, key)
+	s.captureMu.Unlock()
 	var results []data.CaptureResult
 	var captureErrs []error
-	captures := s.activeCaptures[key]
 	for i := len(captures) - 1; i >= 0; i-- {
 		r, err := captures[i].Stop(ctx)
 		results = append(results, r...)
@@ -346,7 +401,16 @@ func (s *DataService) stopCaptureLocked(ctx context.Context, key string) (*agent
 			captureErrs = append(captureErrs, err)
 		}
 	}
-	delete(s.activeCaptures, key)
+	// The episode's camera pre-roll ring (if any) was consumed at trigger. Re-arm
+	// the campaign the moment its adapters have released the camera, BEFORE the
+	// seal and its post-seal drain: re-arming afterwards left the ring empty for
+	// the whole drain, so a trigger that landed inside the drain window opened an
+	// episode with no camera pre-roll at all. Armed here, the drain doubles as
+	// the next episode's pre-roll window. Arming subscribes to camera hubs, so it
+	// still runs off this path.
+	if key != data.AdHocEpisodeKey {
+		go s.rearmByName(key)
+	}
 	if len(results) > 0 {
 		// A manifest sealed without its per-source capture results reports an
 		// episode as complete while silently omitting what each source
@@ -367,12 +431,6 @@ func (s *DataService) stopCaptureLocked(ctx context.Context, key string) (*agent
 	}
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
-	}
-	// The episode's camera pre-roll ring (if any) was consumed at trigger. Re-arm
-	// the campaign so its next trigger opens with pre-roll again. Arming
-	// subscribes to camera hubs, so it runs off the finalize path.
-	if key != data.AdHocEpisodeKey {
-		go s.rearmByName(key)
 	}
 	return manifestEpisode(m), nil
 }
@@ -442,9 +500,16 @@ func (s *DataService) CampaignTrigger(ctx context.Context, req *agentpbv2.DataCa
 }
 
 func (s *DataService) triggerCampaign(ctx context.Context, campaign data.Campaign, reason, expression string) (*agentpbv2.DataEpisode, error) {
-	sources, topics, captures, err := s.manager.ResolveCampaignSources(campaign)
+	// Degrading, not aborting: a ROS 2 topic that nobody publishes at the moment
+	// of the trigger costs the episode that source, not the camera, the telemetry
+	// and the application records of the event that fired it. The unresolved
+	// selectors are carried into the manifest as absent sources.
+	sources, topics, captures, unresolved, err := s.manager.ResolveCampaignSourcesDegrading(campaign)
 	if err != nil {
 		return nil, status.Error(codes.FailedPrecondition, err.Error())
+	}
+	for _, source := range unresolved {
+		s.manager.Warnf("campaign %q: source %s did not resolve at trigger; the episode records its other sources and marks this one absent in the manifest: %s", campaign.Name, source.ID, source.Detail)
 	}
 	privacy := make([]data.PrivacyTransformation, 0, len(campaign.Privacy))
 	for _, transform := range campaign.Privacy {
@@ -471,6 +536,7 @@ func (s *DataService) triggerCampaign(ctx context.Context, campaign data.Campaig
 		PreRollDuration:      campaign.BufferDuration(),
 		DrainDuration:        campaign.DrainDuration(),
 		Trigger:              data.EpisodeTrigger{Reason: reason, CampaignName: campaign.Name, CampaignRevision: campaign.Revision, Expression: expression, Notify: campaign.Notify},
+		UnresolvedSources:    unresolved,
 		CollectorVersion:     version.Version,
 		ModelVersions:        campaign.Models,
 		RequestedTopics:      topics,
@@ -508,9 +574,10 @@ func (s *DataService) observeApplicationRecord(_ string, record data.Application
 	// previous episode is inside its post-seal drain is not capturing, and
 	// ActiveEpisodeKeys no longer names it, so a record that matches during the
 	// drain starts the next episode instead of being dropped. That episode
-	// still has to wait for captureMu, which the stopping episode holds until
-	// its drain ends, so it begins up to one capture.drain late rather than not
-	// at all -- documented for operators in the data command reference.
+	// still has to wait for the campaign key's mutex, which the stopping episode
+	// holds until its drain ends, so it begins up to one capture.drain late
+	// rather than not at all -- documented for operators in the data command
+	// reference. Other campaigns are unaffected: the mutex is per key.
 	activeKeys := map[string]bool{}
 	for _, key := range s.manager.ActiveEpisodeKeys() {
 		activeKeys[key] = true

--- a/go/internal/agent/services/data_service_review_test.go
+++ b/go/internal/agent/services/data_service_review_test.go
@@ -1,0 +1,445 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/data"
+	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
+)
+
+// slowStartAdapter models a capture adapter whose Start takes real time, which
+// the camera adapter's does: it waits for the producer's first encoded frame,
+// with a twenty second ceiling.
+type slowStartAdapter struct {
+	delay   time.Duration
+	sources []data.Source
+}
+
+func (a *slowStartAdapter) Discover(context.Context) []data.Source { return a.sources }
+
+func (a *slowStartAdapter) Start(context.Context, data.CaptureSession, []data.Source) (runningDataCapture, error) {
+	time.Sleep(a.delay)
+	return noopCapture{}, nil
+}
+
+type noopCapture struct{}
+
+func (noopCapture) Stop(context.Context) ([]data.CaptureResult, error) { return nil, nil }
+
+// fakeArmingAdapter records the pre-roll arm and disarm calls a campaign makes.
+type fakeArmingAdapter struct {
+	mu   sync.Mutex
+	arms []armCall
+}
+
+type armCall struct {
+	key     string
+	buffer  time.Duration
+	sources []data.Source
+}
+
+func (a *fakeArmingAdapter) Discover(context.Context) []data.Source { return nil }
+
+func (a *fakeArmingAdapter) Start(context.Context, data.CaptureSession, []data.Source) (runningDataCapture, error) {
+	return noopCapture{}, nil
+}
+
+func (a *fakeArmingAdapter) Arm(key string, buffer time.Duration, selected []data.Source) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.arms = append(a.arms, armCall{key: key, buffer: buffer, sources: selected})
+}
+
+func (a *fakeArmingAdapter) Disarm(string) {}
+
+func (a *fakeArmingAdapter) armCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.arms)
+}
+
+func (a *fakeArmingAdapter) lastArm() (armCall, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if len(a.arms) == 0 {
+		return armCall{}, false
+	}
+	return a.arms[len(a.arms)-1], true
+}
+
+// installArming registers an arming adapter the way SetVideoService would.
+func installArming(service *DataService, adapter *fakeArmingAdapter) {
+	service.addAdapter(adapter)
+	service.adapterMu.Lock()
+	service.armingAdapter = adapter
+	service.adapterMu.Unlock()
+}
+
+func mustDeploy(t *testing.T, service *DataService, yaml string) *agentpbv2.DataCampaign {
+	t.Helper()
+	campaign, err := service.CampaignDeploy(context.Background(), &agentpbv2.DataCampaignDeployRequest{CampaignYaml: []byte(yaml)})
+	if err != nil {
+		t.Fatalf("deploy: %v", err)
+	}
+	return campaign
+}
+
+// TestSecondCampaignOriginIsStampedAtItsOwnTrigger pins the episode origin to
+// the instant its campaign fired.
+//
+// Start and stop used to be serialised on one device-wide mutex, and the origin
+// is read inside manager.Start, under that mutex. A campaign whose adapters take
+// real time to come up (a camera waits for its first frame, up to twenty
+// seconds) therefore moved every other campaign's origin forward to whenever it
+// finished: the second campaign's own triggering record then fell OUTSIDE the
+// pre-roll window measured back from that late origin, so the episode opened
+// after the event that caused it.
+func TestSecondCampaignOriginIsStampedAtItsOwnTrigger(t *testing.T) {
+	manager, err := data.NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := NewDataService(manager)
+	service.addAdapter(&slowStartAdapter{delay: 600 * time.Millisecond})
+
+	const preRoll = 200 * time.Millisecond
+	mustDeploy(t, service, `version: 1
+name: slow-campaign
+sources:
+  - telemetry: true
+capture:
+  buffer: 0s
+  drain: 0s
+  after_trigger: 5s
+  triggers:
+    - event: first_event
+upload: {when: wifi, destination: example-episodes}
+export: {annotation: cvat}
+`)
+	mustDeploy(t, service, `version: 1
+name: prompt-campaign
+sources:
+  - telemetry: true
+capture:
+  buffer: 200ms
+  drain: 0s
+  after_trigger: 5s
+  triggers:
+    - event: second_event
+upload: {when: wifi, destination: example-episodes}
+export: {annotation: cvat}
+`)
+
+	// The first campaign fires and sits in its 600ms adapter startup.
+	go func() {
+		_, _ = service.CampaignTrigger(context.Background(), &agentpbv2.DataCampaignTriggerRequest{Name: "slow-campaign", Reason: "first_event"})
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	// The second campaign's triggering record arrives 100ms in, while the first
+	// campaign's adapters are still coming up.
+	_, recordBoot, _, err := data.CaptureReceipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = manager.RecordApplication("test.app", data.ApplicationRecord{Version: 1, Type: "event", Name: "second_event"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var session data.CaptureSession
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if s, ok := manager.ActiveSession("prompt-campaign"); ok {
+			session = s
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if session.ID == "" {
+		t.Fatal("the second campaign never opened an episode")
+	}
+	if lag := time.Duration(session.RequestBootNanos - recordBoot); lag > 250*time.Millisecond {
+		t.Fatalf("episode origin is %s after its triggering record; it must be stamped when the campaign fires, not when another campaign's adapters finish starting", lag)
+	}
+	// The point of stamping it there: the record that fired the campaign has to
+	// be inside the window the episode reaches back over.
+	if window := session.RequestBootNanos - preRoll.Nanoseconds(); window > recordBoot {
+		t.Fatalf("the triggering record is %s before the start of the episode's own pre-roll window", time.Duration(window-recordBoot))
+	}
+
+	_, _ = service.stopCapture(context.Background(), "prompt-campaign")
+	_, _ = service.stopCapture(context.Background(), "slow-campaign")
+}
+
+// TestCameraPreRollArmsDespiteAnUnpublishedROS2Topic pins arming to the camera
+// selectors alone. Resolving the whole plan meant one selector that did not
+// resolve, a ROS 2 topic whose publisher has not started being the ordinary
+// case, returned nothing and left the camera ring disarmed for the entire
+// campaign, with nothing said anywhere.
+func TestCameraPreRollArmsDespiteAnUnpublishedROS2Topic(t *testing.T) {
+	manager, err := data.NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := NewDataService(manager)
+	service.addAdapter(&slowStartAdapter{sources: []data.Source{
+		{ID: "v4l2:/dev/video0", Kind: "camera", ClockDomain: "FAKE_NATIVE", Healthy: true, Detail: "front test camera"},
+	}})
+	arming := &fakeArmingAdapter{}
+	installArming(service, arming)
+
+	mustDeploy(t, service, `version: 1
+name: mixed-sources
+sources:
+  - camera: front
+  - ros2: /scan
+capture:
+  buffer: 2s
+  drain: 0s
+  after_trigger: 30ms
+  triggers:
+    - event: person_detected
+upload: {when: wifi, destination: example-episodes}
+export: {annotation: cvat}
+`)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for arming.armCount() == 0 && time.Now().Before(deadline) {
+		time.Sleep(2 * time.Millisecond)
+	}
+	call, ok := arming.lastArm()
+	if !ok {
+		t.Fatal("the camera was never armed; one unpublished ROS 2 topic disabled pre-roll for the whole campaign")
+	}
+	if call.key != "mixed-sources" || call.buffer != 2*time.Second {
+		t.Fatalf("arm call = %+v", call)
+	}
+	if len(call.sources) != 1 || call.sources[0].ID != "v4l2:/dev/video0" {
+		t.Fatalf("armed sources = %+v, want the one camera", call.sources)
+	}
+}
+
+// TestDeployWarnsAboutAnUnpublishedROS2Topic: deploy is the last moment an
+// operator is present to read the reason, so a topic nothing publishes is worth
+// saying then. It is a warning and not a refusal, because a plan is routinely
+// deployed before the node that publishes its topic is running.
+func TestDeployWarnsAboutAnUnpublishedROS2Topic(t *testing.T) {
+	manager, err := data.NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := NewDataService(manager)
+	campaign := mustDeploy(t, service, `version: 1
+name: lidar-plan
+sources:
+  - telemetry: true
+  - ros2: /scan
+capture:
+  buffer: 0s
+  drain: 0s
+  after_trigger: 30ms
+  triggers:
+    - event: person_detected
+upload: {when: wifi, destination: example-episodes}
+export: {annotation: cvat}
+`)
+	if campaign.GetState() != "armed" {
+		t.Fatalf("campaign state = %q; an unpublished topic must not refuse the deploy", campaign.GetState())
+	}
+	joined := strings.Join(campaign.GetWarnings(), " | ")
+	if !strings.Contains(joined, "/scan") || !strings.Contains(joined, "publishes") {
+		t.Fatalf("warnings %q do not name the unpublished ROS 2 selector", joined)
+	}
+}
+
+// TestTriggerDegradesWhenAROS2TopicIsAbsent: an absent topic costs the episode
+// that source, not the camera, the telemetry and the application records of the
+// event that fired it. The manifest carries the absent source so a reader can
+// see which one was lost rather than inferring it from the plan.
+func TestTriggerDegradesWhenAROS2TopicIsAbsent(t *testing.T) {
+	manager, err := data.NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := NewDataService(manager)
+	mustDeploy(t, service, `version: 1
+name: lidar-plan
+sources:
+  - telemetry: true
+  - ros2: /scan
+capture:
+  buffer: 0s
+  drain: 0s
+  after_trigger: 30ms
+  triggers:
+    - event: person_detected
+upload: {when: wifi, destination: example-episodes}
+export: {annotation: cvat}
+`)
+	episode, err := service.CampaignTrigger(context.Background(), &agentpbv2.DataCampaignTriggerRequest{Name: "lidar-plan", Reason: "manual"})
+	if err != nil {
+		t.Fatalf("trigger: %v; an absent ROS 2 topic must not abort the whole episode", err)
+	}
+	deadline := time.Now().Add(3 * time.Second)
+	for manager.Status() != nil && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	manifest, _, err := manager.Inspect(episode.GetId(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var absent *data.SourceStats
+	for i := range manifest.Sources {
+		if strings.Contains(manifest.Sources[i].Source.ID, "/scan") {
+			absent = &manifest.Sources[i]
+		}
+	}
+	if absent == nil {
+		t.Fatalf("the manifest does not mention the absent ROS 2 source: %+v", manifest.Sources)
+	}
+	if absent.Source.Healthy {
+		t.Fatal("the absent source is recorded as healthy")
+	}
+	if absent.DropAccounting != "source_absent_at_trigger" {
+		t.Fatalf("drop accounting = %q, want source_absent_at_trigger", absent.DropAccounting)
+	}
+	if !strings.Contains(absent.Source.Detail, "triggered") {
+		t.Fatalf("absent source detail %q does not say why it is absent", absent.Source.Detail)
+	}
+	// The rest of the episode is intact.
+	if manifest.State != "complete" {
+		t.Fatalf("episode state = %q, want complete", manifest.State)
+	}
+}
+
+// TestCampaignIsRearmedBeforeThePostSealDrain: the ring must be back up as soon
+// as the adapters release the camera. Re-arming after the seal left the ring
+// empty for the whole drain, so a trigger landing in that window opened an
+// episode with no camera pre-roll at all. Armed at capture stop, the drain
+// doubles as the next episode's pre-roll window.
+func TestCampaignIsRearmedBeforeThePostSealDrain(t *testing.T) {
+	manager, err := data.NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := NewDataService(manager)
+	service.addAdapter(&slowStartAdapter{sources: []data.Source{
+		{ID: "v4l2:/dev/video0", Kind: "camera", ClockDomain: "FAKE_NATIVE", Healthy: true, Detail: "front test camera"},
+	}})
+	arming := &fakeArmingAdapter{}
+	installArming(service, arming)
+
+	mustDeploy(t, service, `version: 1
+name: doorway
+sources:
+  - camera: front
+capture:
+  buffer: 1s
+  drain: 2s
+  after_trigger: 50ms
+  triggers:
+    - event: person_detected
+upload: {when: wifi, destination: example-episodes}
+export: {annotation: cvat}
+`)
+	deadline := time.Now().Add(2 * time.Second)
+	for arming.armCount() == 0 && time.Now().Before(deadline) {
+		time.Sleep(2 * time.Millisecond)
+	}
+	if arming.armCount() == 0 {
+		t.Fatal("the campaign was never armed at deploy")
+	}
+	armsAtTrigger := arming.armCount()
+
+	if _, err = service.CampaignTrigger(context.Background(), &agentpbv2.DataCampaignTriggerRequest{Name: "doorway", Reason: "manual"}); err != nil {
+		t.Fatal(err)
+	}
+	// after_trigger is 50ms and the drain is 2s. Well inside the drain the ring
+	// must already be armed again.
+	deadline = time.Now().Add(time.Second)
+	for arming.armCount() == armsAtTrigger && time.Now().Before(deadline) {
+		time.Sleep(2 * time.Millisecond)
+	}
+	if arming.armCount() == armsAtTrigger {
+		t.Fatal("the campaign was not re-armed within a second of its capture stopping; a trigger inside the post-seal drain would get no camera pre-roll")
+	}
+	// The proof that this happened during the drain, not after it: the episode
+	// is not sealed yet.
+	if list, listErr := manager.List(); listErr != nil {
+		t.Fatal(listErr)
+	} else if len(list) != 0 {
+		t.Fatalf("the episode had already finalized (%d sealed) before the re-arm, so the drain window was still blind", len(list))
+	}
+}
+
+// failingAdapter refuses to start, standing in for a camera that faults after
+// an earlier adapter is already recording.
+type failingAdapter struct{}
+
+func (failingAdapter) Discover(context.Context) []data.Source { return nil }
+func (failingAdapter) Start(context.Context, data.CaptureSession, []data.Source) (runningDataCapture, error) {
+	return nil, errors.New("simulated adapter failure")
+}
+
+// TestAFailedAdapterStartDrainsOnceSomethingHasCaptured pins the drain to the
+// only claim that justifies skipping it.
+//
+// Skipping the drain when NOTHING started is right: no application can have read
+// a sample from an episode whose adapters never ran, and the wait would be
+// charged to every later start and stop of the campaign. Once an earlier adapter
+// has started, that claim is simply untrue, and a record about this episode can
+// still be outstanding.
+func TestAFailedAdapterStartDrainsOnceSomethingHasCaptured(t *testing.T) {
+	const drain = 400 * time.Millisecond
+	plan := `version: 1
+name: partial-start
+sources:
+  - telemetry: true
+capture:
+  buffer: 0s
+  drain: 400ms
+  after_trigger: 5s
+  triggers:
+    - event: person_detected
+upload: {when: wifi, destination: example-episodes}
+export: {annotation: cvat}
+`
+
+	// Nothing started: the failure returns without serving the drain.
+	manager, err := data.NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := NewDataService(manager)
+	service.addAdapter(failingAdapter{})
+	mustDeploy(t, service, plan)
+	start := time.Now()
+	if _, err = service.CampaignTrigger(context.Background(), &agentpbv2.DataCampaignTriggerRequest{Name: "partial-start", Reason: "manual"}); err == nil {
+		t.Fatal("a failing adapter must fail the trigger")
+	}
+	if elapsed := time.Since(start); elapsed >= drain {
+		t.Fatalf("took %s: an episode whose adapters never started must not serve the drain", elapsed)
+	}
+
+	// One adapter captured before the next failed: the drain is owed.
+	manager2, err := data.NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	service2 := NewDataService(manager2)
+	service2.addAdapter(&slowStartAdapter{})
+	service2.addAdapter(failingAdapter{})
+	mustDeploy(t, service2, plan)
+	start = time.Now()
+	if _, err = service2.CampaignTrigger(context.Background(), &agentpbv2.DataCampaignTriggerRequest{Name: "partial-start", Reason: "manual"}); err == nil {
+		t.Fatal("a failing adapter must fail the trigger")
+	}
+	if elapsed := time.Since(start); elapsed < drain {
+		t.Fatalf("took %s: once an adapter has captured, a record about the episode can be outstanding and the drain must be served", elapsed)
+	}
+}

--- a/go/internal/agent/services/hub_loopback_pump.go
+++ b/go/internal/agent/services/hub_loopback_pump.go
@@ -212,30 +212,19 @@ func (p *hubLoopbackPump) pump(ctx context.Context, hub *deviceHub, subID int, f
 // subscription, including hub drops that accrued after the last written frame.
 // On every other return the count is meaningless and returned as zero.
 func (p *hubLoopbackPump) pumpFrom(ctx context.Context, hub *deviceHub, subID int, frames <-chan *videoFrame, writer loopbackFrameWriter, awaitRandomAccess bool, carried uint64) (uint64, error) {
-	// lastDrops is the hub's running drop total for this subscriber as of the
-	// previously WRITTEN frame, so each binding reports the drops since it. This
-	// is drop case 1 from hub_loopback_binding.go: those samples never reach the
-	// node, so the loopback sequence does not gap and cannot report them. If the
-	// pump did not carry this number across, a hub-side loss would be invisible
-	// on both planes.
+	// unreported counts losses no binding has reported yet: hub-side drops the
+	// hub recorded against the frames this pump has taken off its channel, the
+	// count carried in from a previous subscription, and frames the starting
+	// gate skipped after a rejoin. This is drop case 1 from
+	// hub_loopback_binding.go: those samples never reach the node, so the
+	// loopback sequence does not gap and cannot report them. If the pump did not
+	// carry the number across, a hub-side loss would be invisible on both planes.
 	//
-	// One honest limit on the attribution, shared with the gRPC sensor path
-	// (cameraSensorSubscription.Next does exactly the same thing): the counter is
-	// read when the pump CONSUMES a frame, not when the hub queued it. The
-	// subscriber channel is buffered, so a drop that happens while frames are
-	// still sitting in that buffer is attributed to the next frame the pump
-	// consumes rather than to the frame it actually preceded. The RUNNING TOTAL
-	// is exact and no loss is ever unreported; only the frame a given loss is
-	// charged to can be off by up to the channel depth. Reporting the drop
-	// against the wrong neighbouring frame is tolerable; silently losing the
-	// count would not be. Making it exact would mean stamping the drop count onto
-	// the frame at broadcast, which is a change to shared hub behaviour that the
-	// gRPC sensor path and episode capture would also have to absorb.
-	var lastDrops uint64
-	// unreported counts losses no binding has reported yet: the count carried
-	// in from a previous subscription, plus frames the starting gate skipped
-	// after a rejoin. None of them reached the node, so like hub-side drops
-	// they are reported on the next frame that did.
+	// The counts come from hub.dequeueDrops, which hands back the drops recorded
+	// immediately BEFORE the frame just consumed. Reading the running total at
+	// consume time instead (which this pump and the gRPC sensor path both used
+	// to do) charged a drop to whichever frame the consumer happened to pull
+	// next, up to a channel depth after the gap it belonged to.
 	unreported := carried
 	for {
 		select {
@@ -248,13 +237,17 @@ func (p *hubLoopbackPump) pumpFrom(ctx context.Context, hub *deviceHub, subID in
 				}
 				if hub.wasRestarted() {
 					// Hand back everything still unreported, including hub
-					// drops since the last written frame: this subscription
-					// will never write another binding, so they must ride on
-					// the replacement's first one.
-					return unreported + hub.drops(subID) - lastDrops, errLoopbackHubRestarted
+					// drops the subscription never got to deliver: it will
+					// never write another binding, so they must ride on the
+					// replacement's first one.
+					return unreported + hub.unreportedDrops(subID), errLoopbackHubRestarted
 				}
 				return 0, nil
 			}
+			// Taken for EVERY frame off the channel, before anything can
+			// discard it, so the count stays tied to this frame's place in the
+			// stream.
+			unreported += hub.dequeueDrops(subID)
 			if bindable, reason := frameBindableToLoopback(frame); !bindable {
 				// Fail closed rather than writing something the sequence cannot
 				// name. Publishing a node whose frames have no resolvable identity
@@ -278,8 +271,7 @@ func (p *hubLoopbackPump) pumpFrom(ctx context.Context, hub *deviceHub, subID in
 				awaitRandomAccess = false
 			}
 
-			drops := hub.drops(subID)
-			delta := drops - lastDrops + unreported
+			delta := unreported
 
 			// The stamp is the SAME canonical receipt the binding below
 			// records and FrameIdentity publishes, read from the one frame
@@ -289,16 +281,17 @@ func (p *hubLoopbackPump) pumpFrom(ctx context.Context, hub *deviceHub, subID in
 			if err != nil {
 				// A failed write is NOT a dropped frame: the kernel did not advance
 				// its counter and we record no binding, so the sample is simply
-				// absent from both planes rather than appearing as a loss. Keep
-				// lastDrops unadvanced so the next successful write still reports
-				// every hub drop since the last frame that actually reached the node.
+				// absent from both planes rather than appearing as a loss. The
+				// losses this frame was carrying stay unreported so the next
+				// successful write still reports every hub drop since the last
+				// frame that actually reached the node.
+				unreported = delta
 				p.logger.Warn("two-plane: writing frame to loopback node failed",
 					zap.String("node", p.nodePath),
 					zap.Uint64("sample_id", frame.sampleID),
 					zap.Error(err))
 				continue
 			}
-			lastDrops = drops
 			unreported = 0
 
 			binding := loopbackBinding{

--- a/go/internal/agent/services/hub_loopback_pump_test.go
+++ b/go/internal/agent/services/hub_loopback_pump_test.go
@@ -64,15 +64,33 @@ func newPumpTestHub(t *testing.T) (*deviceHub, int, chan *videoFrame) {
 	return hub, subID, frames
 }
 
+// dropForSubscriber records n frames the hub failed to hand to this subscriber,
+// with exactly the bookkeeping broadcast's failed-send branch keeps: the running
+// total and the pending count that the next successfully queued frame carries.
+func dropForSubscriber(hub *deviceHub, subID int, n uint64) {
+	hub.mu.Lock()
+	defer hub.mu.Unlock()
+	hub.subDrops[subID] += n
+	hub.subs[subID].pendingDrops += n
+}
+
+// queueForSubscriber hands a frame to the subscriber through the hub's own
+// broadcast, so the pending drops recorded before it ride on it exactly as they
+// would in production. Pushing straight onto the channel would bypass that
+// bookkeeping and prove nothing about the real path.
+func queueForSubscriber(t *testing.T, hub *deviceHub, frame *videoFrame) {
+	t.Helper()
+	if !hub.broadcast(frame) {
+		t.Fatal("broadcast reported no subscribers")
+	}
+}
+
 // waitForBindings blocks until the pump has recorded n bindings.
 //
-// The drop tests need this because the hub's drop counter is read when the pump
-// CONSUMES a frame, not when the hub queued it (this is the same accounting
-// cameraSensorSubscription.Next does, deliberately). Staging all the frames and
-// all the drops up front would therefore attribute drops to whichever frame the
-// pump happened to reach first, which says nothing about the real behaviour.
-// Interleaving the way the hub actually would is the only way these tests mean
-// anything.
+// The drop tests need this because a loss is attributed to the frame that
+// FOLLOWS it, so the frames and the drops have to be interleaved in the order
+// the hub would really produce them. Staging them all up front says nothing
+// about the real behaviour.
 func waitForBindings(t *testing.T, pump *hubLoopbackPump, n int) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
@@ -212,12 +230,10 @@ func TestPumpReportsHubDroppedFrames(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- pump.pump(context.Background(), hub, subID, frames, writer) }()
 
-	frames <- bindableFrame(1, 100, 1)
+	queueForSubscriber(t, hub, bindableFrame(1, 100, 1))
 	waitForBindings(t, pump, 1)
-	hub.mu.Lock()
-	hub.subDrops[subID] = 3
-	hub.mu.Unlock()
-	frames <- bindableFrame(5, 200, 1)
+	dropForSubscriber(hub, subID, 3)
+	queueForSubscriber(t, hub, bindableFrame(5, 200, 1))
 	waitForBindings(t, pump, 2)
 	close(frames)
 
@@ -263,13 +279,11 @@ func TestPumpWriteFailureIsNotADroppedFrame(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- pump.pump(context.Background(), hub, subID, frames, writer) }()
 
-	frames <- bindableFrame(1, 100, 1)
+	queueForSubscriber(t, hub, bindableFrame(1, 100, 1))
 	waitForBindings(t, pump, 1)
-	hub.mu.Lock()
-	hub.subDrops[subID] = 2 // two samples lost after frame 1 was consumed
-	hub.mu.Unlock()
-	frames <- bindableFrame(4, 200, 1) // this write fails, so it records nothing
-	frames <- bindableFrame(5, 300, 1)
+	dropForSubscriber(hub, subID, 2)                     // two samples lost after frame 1 was consumed
+	queueForSubscriber(t, hub, bindableFrame(4, 200, 1)) // this write fails, so it records nothing
+	queueForSubscriber(t, hub, bindableFrame(5, 300, 1))
 	waitForBindings(t, pump, 2)
 	close(frames)
 
@@ -519,8 +533,8 @@ func TestPumpReturnsUnreportedLossesOnRestart(t *testing.T) {
 	writer := newFakeLoopbackWriter(0)
 	pump := newHubLoopbackPump(zap.NewNop(), "v4l2:/dev/video0", "/dev/video200")
 
+	dropForSubscriber(hub, subID, 3)
 	hub.mu.Lock()
-	hub.subDrops[subID] = 3
 	hub.restarted = true
 	hub.mu.Unlock()
 	close(frames)

--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -415,6 +415,27 @@ type hubSubscriber struct {
 	// broadcast and the final teardown from touching the channel twice.
 	closed bool
 	err    error
+	// pendingDrops counts frames dropped for this subscriber since the last one
+	// that was successfully queued, and queuedDrops holds, in the same order as
+	// the frames sitting in ch, the drops that immediately preceded each of
+	// them. Together they let a consumer attribute a loss to the frame it
+	// actually preceded.
+	//
+	// Reading the running total when a frame is DEQUEUED cannot do that: ch is
+	// buffered, so a drop that happens while frames are still waiting in it was
+	// charged to whichever frame the consumer happened to pull next, which is up
+	// to a channel depth later than the gap. The total was always exact and no
+	// loss went unreported; only the attribution was wrong, and for a model
+	// input ledger the attribution is the point.
+	//
+	// The queue is bounded by the channel's own capacity. A consumer that never
+	// calls dequeueDrops (a dashboard viewer, episode capture, which account
+	// losses in total instead) would otherwise accumulate one entry per frame
+	// forever; past the bound the counts fold into the newest entry, which for
+	// such a consumer changes nothing, and unreportedDrops still returns the
+	// exact outstanding total.
+	pendingDrops uint64
+	queuedDrops  []uint64
 }
 
 // deviceHub multiplexes one camera producer to multiple gRPC subscribers.
@@ -575,12 +596,48 @@ func (h *deviceHub) wasRestarted() bool {
 }
 
 // drops reports how many frames the hub has dropped for one subscriber so far.
-// A subscriber reads it to turn the running total into a per-sample delta, so a
-// gap in sample identifiers always comes with the count that explains it.
+// It is the running total for the whole subscription; a consumer that needs to
+// attribute a loss to the frame it preceded uses dequeueDrops instead.
 func (h *deviceHub) drops(id int) uint64 {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	return h.subDrops[id]
+}
+
+// dequeueDrops reports the frames dropped for this subscriber IMMEDIATELY
+// BEFORE the frame it has just taken off its channel, and consumes that count.
+// It must be called exactly once per frame received, including frames the
+// consumer then discards, or the queue slips against the channel and later
+// frames carry a neighbour's losses.
+func (h *deviceHub) dequeueDrops(id int) uint64 {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	sub := h.subs[id]
+	if sub == nil || len(sub.queuedDrops) == 0 {
+		return 0
+	}
+	drops := sub.queuedDrops[0]
+	sub.queuedDrops = sub.queuedDrops[1:]
+	return drops
+}
+
+// unreportedDrops reports the losses this subscriber has not yet been handed:
+// the drops since the last successfully queued frame plus those still riding on
+// frames left in its channel. A subscription that is about to end carries this
+// total over to its replacement, so a producer restart reports no loss twice and
+// loses none.
+func (h *deviceHub) unreportedDrops(id int) uint64 {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	sub := h.subs[id]
+	if sub == nil {
+		return 0
+	}
+	total := sub.pendingDrops
+	for _, drops := range sub.queuedDrops {
+		total += drops
+	}
+	return total
 }
 
 // terminalErr returns the error recorded by runProducer under h.mu.
@@ -683,8 +740,15 @@ func (h *deviceHub) broadcast(frame *videoFrame) bool {
 		}
 		select {
 		case sub.ch <- frame:
+			if len(sub.queuedDrops) < cap(sub.ch) {
+				sub.queuedDrops = append(sub.queuedDrops, sub.pendingDrops)
+			} else if n := len(sub.queuedDrops); n > 0 {
+				sub.queuedDrops[n-1] += sub.pendingDrops
+			}
+			sub.pendingDrops = 0
 		default:
 			h.subDrops[id]++
+			sub.pendingDrops++
 		}
 	}
 	return true

--- a/go/internal/agent/services/video_service_sensor.go
+++ b/go/internal/agent/services/video_service_sensor.go
@@ -102,18 +102,19 @@ type cameraSensorSubscription struct {
 	hub    *deviceHub
 	subID  int
 	frames chan *videoFrame
-	// lastDrops is the hub's drop counter for this subscriber as of the
-	// previously delivered sample, so each sample reports the drops since it.
-	lastDrops uint64
+	// pending accumulates losses no delivered sample has reported yet: the
+	// hub's per-frame drop counts as each frame is taken off the channel, plus
+	// frames the random-access gate skipped. It is handed to the next sample
+	// that is actually delivered and reset there.
+	pending uint64
 	// awaitRandomAccess gates delivery after a reattach: the subscriber's old
 	// stream ended with the restarted producer, and the new one must begin on
 	// a random-access unit so the app decodes from a clean start rather than
 	// from the middle of a group of pictures. This is the subscriber-side
 	// counterpart of the rule episode capture enforces with
-	// errAwaitCameraRandomAccess. Frames skipped by the gate are reported in
-	// gatedSkips so the sample_id gap they leave stays explained.
+	// errAwaitCameraRandomAccess. Frames skipped by the gate are counted into
+	// pending so the sample_id gap they leave stays explained.
 	awaitRandomAccess bool
-	gatedSkips        uint64
 	closed            bool
 }
 
@@ -140,17 +141,19 @@ func (c *cameraSensorSubscription) Next(ctx context.Context) (SensorSample, erro
 				}
 				return SensorSample{}, errSensorProducerStopped
 			}
+			// Taken for EVERY frame off the channel, before any gate can
+			// discard it: the count belongs to this frame's place in the
+			// stream, so skipping the call would shift it onto a later one.
+			c.pending += c.hub.dequeueDrops(c.subID)
 			if c.awaitRandomAccess && frame.auAligned {
 				if _, randomAccess := frameRandomAccess(frame); !randomAccess {
-					c.gatedSkips++
+					c.pending++
 					continue
 				}
 			}
 			c.awaitRandomAccess = false
-			drops := c.hub.drops(c.subID)
-			delta := drops - c.lastDrops + c.gatedSkips
-			c.lastDrops = drops
-			c.gatedSkips = 0
+			delta := c.pending
+			c.pending = 0
 			return SensorSample{
 				SampleID:         frame.sampleID,
 				BootNanos:        frame.receiptBootNanos,
@@ -165,20 +168,20 @@ func (c *cameraSensorSubscription) Next(ctx context.Context) (SensorSample, erro
 }
 
 // reattach joins the replacement hub after a capture takeover, again asserting
-// no parameters. The hub-side drop counter starts at zero on the new
-// subscription, and delivery is gated to a random-access unit so the app's new
-// stream starts decodable. Drops the old subscription accrued after the last
-// delivered sample can no longer ride on a sample of their own, so they are
-// carried into gatedSkips and reported on the first sample the new
-// subscription delivers; the restart leaves no loss unreported.
+// no parameters. The new subscription starts with an empty drop queue, and
+// delivery is gated to a random-access unit so the app's new stream starts
+// decodable. Losses the old subscription never got to report can no longer ride
+// on a sample of their own, so they are carried into pending and reported on the
+// first sample the new subscription delivers; the restart leaves no loss
+// unreported.
 func (c *cameraSensorSubscription) reattach(ctx context.Context) error {
-	c.gatedSkips += c.hub.unsubscribe(c.subID) - c.lastDrops
+	c.pending += c.hub.unreportedDrops(c.subID)
+	c.hub.unsubscribe(c.subID)
 	hub, subID, frames, err := c.video.joinHub(ctx, c.key, &agentpb.StreamVideoRequest{DeviceId: c.devID})
 	if err != nil {
 		return err
 	}
 	c.hub, c.subID, c.frames = hub, subID, frames
-	c.lastDrops = 0
 	c.awaitRandomAccess = true
 	return nil
 }

--- a/go/internal/agent/services/video_service_sensor_test.go
+++ b/go/internal/agent/services/video_service_sensor_test.go
@@ -113,8 +113,17 @@ func TestSampleIdentitiesSurviveProducerRestart(t *testing.T) {
 }
 
 // TestCameraSensorSubscriptionReportsDropsPerSample checks the honesty of the
-// gap explanation: the subscription must report the drops since the previous
-// delivered sample, not a running total.
+// gap explanation: a loss must be charged to the sample it actually preceded,
+// not to whichever sample the consumer happened to reach next.
+//
+// The subscriber channel holds four frames, so samples 1 to 4 are queued, 5 and
+// 6 are dropped while they sit there, and 7 is queued once the consumer has
+// drained the buffer. Nothing was lost before samples 1 to 4: they were all in
+// the channel before the first drop happened. The two losses belong to sample 7,
+// the first one delivered after them. Reading the hub's running total when a
+// sample is DEQUEUED reported them against sample 1, up to a channel depth
+// earlier than the gap they describe, which is the join a model input ledger
+// exists to make.
 func TestCameraSensorSubscriptionReportsDropsPerSample(t *testing.T) {
 	hub, cancel := newSampleHub(new(atomic.Uint64))
 	defer cancel()
@@ -123,28 +132,41 @@ func TestCameraSensorSubscriptionReportsDropsPerSample(t *testing.T) {
 		t.Fatal(err)
 	}
 	subscription := &cameraSensorSubscription{hub: hub, subID: subID, frames: frames}
-	// The subscriber channel holds four frames; broadcasting six drops two.
+	produce := func() {
+		hub.produce(&videoFrame{data: []byte{1}, codec: agentpb.VideoCodec_VIDEO_CODEC_H264, auAligned: true})
+	}
 	for i := 0; i < 6; i++ {
-		hub.produce(&videoFrame{data: []byte{byte(i)}, codec: agentpb.VideoCodec_VIDEO_CODEC_H264, auAligned: true})
+		produce()
 	}
 	ctx := context.Background()
-	var reported []uint64
-	for i := 0; i < 4; i++ {
+	for i := 1; i <= 4; i++ {
 		sample, err := subscription.Next(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
-		reported = append(reported, sample.DroppedBefore)
+		if sample.SampleID != uint64(i) {
+			t.Fatalf("sample %d has id %d", i, sample.SampleID)
+		}
+		if sample.DroppedBefore != 0 {
+			t.Fatalf("sample %d reports %d drops before it, but every drop happened after it was already queued", i, sample.DroppedBefore)
+		}
 		if sample.Encoding != "h264" || !sample.SelfContained {
 			t.Fatalf("sample %d payload description = %q/%v", i, sample.Encoding, sample.SelfContained)
 		}
 	}
-	total := uint64(0)
-	for _, drops := range reported {
-		total += drops
+	produce()
+	sample, err := subscription.Next(ctx)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if total != 2 {
-		t.Fatalf("reported drops %v sum to %d, want the 2 frames the hub dropped", reported, total)
+	if sample.SampleID != 7 {
+		t.Fatalf("sample id after the gap = %d, want 7", sample.SampleID)
+	}
+	if sample.DroppedBefore != 2 {
+		t.Fatalf("sample 7 reports %d drops before it, want the 2 the hub lost between samples 4 and 7", sample.DroppedBefore)
+	}
+	if total := hub.drops(subID); total != 2 {
+		t.Fatalf("hub running drop total = %d, want 2", total)
 	}
 }
 
@@ -473,9 +495,13 @@ func TestSensorReattachCarriesTailDrops(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	subscription := &cameraSensorSubscription{video: svc, key: "/dev/video0", hub: hub, subID: subID, frames: frames, lastDrops: 1}
+	subscription := &cameraSensorSubscription{video: svc, key: "/dev/video0", hub: hub, subID: subID, frames: frames}
 	hub.mu.Lock()
 	hub.subDrops[subID] = 4
+	// Three of the four have not been handed to a sample yet: one is still
+	// riding on a frame sitting in the channel, two arrived after it.
+	hub.subs[subID].queuedDrops = []uint64{1}
+	hub.subs[subID].pendingDrops = 2
 	hub.mu.Unlock()
 
 	req := &agentpb.StreamVideoRequest{DeviceId: 0, Width: 640, Height: 480, Framerate: 15}
@@ -492,10 +518,10 @@ func TestSensorReattachCarriesTailDrops(t *testing.T) {
 	if subscription.hub != newHub {
 		t.Fatal("reattach did not land on the replacement hub")
 	}
-	if subscription.gatedSkips != 3 {
-		t.Fatalf("gatedSkips = %d, want 3 (4 total drops minus 1 already reported)", subscription.gatedSkips)
+	if subscription.pending != 3 {
+		t.Fatalf("pending = %d, want 3 (4 total drops minus 1 already reported)", subscription.pending)
 	}
-	if subscription.lastDrops != 0 || !subscription.awaitRandomAccess {
-		t.Fatalf("reattach state: lastDrops=%d awaitRandomAccess=%v, want 0/true", subscription.lastDrops, subscription.awaitRandomAccess)
+	if !subscription.awaitRandomAccess {
+		t.Fatal("reattach must gate the new stream to a random-access unit")
 	}
 }


### PR DESCRIPTION
## Problem

A review of the data capture service and its adapters found thirteen defects. Four of them silently produce an episode that looks complete and is not:

- Audio recorded roughly one chunk per episode and sealed `complete`.
- A second campaign's episode origin was stamped when an unrelated campaign's adapters finished starting, which put its own triggering record outside its pre-roll window.
- A camera that lost five frames reported ten, and a rate-capped group of pictures was reported as driver drops.
- One Robot Operating System 2 (ROS 2) topic that nobody publishes aborted the entire episode at trigger, and disarmed camera pre-roll for the whole campaign at deploy, with nothing said anywhere.

## Cause

- `data_audio_adapter.go` passed the gRPC handler's context to `openStream`, and from there to `exec.CommandContext`. gRPC cancels a unary handler's context when the handler returns, so `arecord` or `pw-record` was killed within milliseconds. The read loop treated the resulting end of file as a clean end of stream.
- `data_service.go` held one device-wide `captureMu` across `adapter.Start` (a camera waits up to twenty seconds for its first frame) and across `manager.Stop` (which serves the post-seal drain). The episode origin is read inside `manager.Start`, under that same mutex.
- The camera adapter added the hub's subscriber-drop counter to the gaps in the driver's own sequence numbers. A frame the hub dropped leaves both witnesses, so it was counted twice. The rate-cap gate returned before any sequence bookkeeping, so a skipped group looked like a gap.
- `cameraSourcesFor` and `triggerCampaign` both resolved the whole plan and failed on the first selector that did not resolve.

## Solution

- The recorder subprocess now runs on a capture context the adapter owns and Stop cancels. An end of stream before Stop is an error recorded on the source, not a clean finish.
- Start and stop are serialised per campaign key. `captureMu` guards only the service's maps and is never held across an adapter or manager call, so a campaign's origin is stamped when that campaign fires.
- Where frames carry valid sequence numbers, the sequence gap is the single loss count and the accounting label says so; subscriber drops are used only when no sequence is available. Every frame taken off the hub, written or deliberately skipped, advances the tracked sequence.
- The hub records a subscriber's drops when a send fails and hands them to the next frame it successfully queues, so a loss is attributed to the frame it preceded rather than to whichever frame the consumer reached next. Both the sensor subscription and the two-plane loopback pump consume it that way.
- Camera arming resolves camera selectors independently. An absent ROS 2 topic warns at deploy, and at trigger the episode starts with the sources that did resolve and records the absent one in the manifest as unhealthy with `drop_accounting: source_absent_at_trigger`.
- A producer that dies mid-episode is logged at the moment it happens and rejoined with bounded retries, recording a discontinuity and the wall time of the gap. The frame cost of the gap is stated as not knowable rather than published as zero.

## Findings

| Finding | Verdict | What changed |
| --- | --- | --- |
| S5-F1 audio recorder killed by the handler context | FIXED | Capture context owned by the adapter; early exit is an error on the source |
| S5-F2 episode origin stamped behind another campaign's startup | FIXED | Per campaign key mutex; `captureMu` guards maps only |
| S5-F3 hub drops counted twice | FIXED | Sequence gaps are the sole count when sequences exist |
| S5-F4 rate-capped groups counted as driver drops | FIXED | Sequence tracked before the gate |
| S5-F5 drops read at dequeue | FIXED | Per-subscriber pending count consumed on the next successful send |
| S5-F6 fresh clock read instead of the hub receipt | FIXED | `frame.receiptBootNanos` is the receipt bracket, with a fallback |
| S5-F7 producer death silent, no rejoin | FIXED | Logged at failure, bounded rejoin, honest discontinuity note |
| S5-F10 bare `Close()` on error paths | FIXED | `errors.Join` where the close error is meaningful |
| S7c-F3 one unresolvable selector disarmed pre-roll | FIXED | Camera selectors resolved independently, warn when arming is skipped |
| S7c-F4 absent ROS 2 topic aborts the episode | FIXED | Deploy warns, trigger degrades and records the absent source |
| S7c-F6 re-arm after the drain | FIXED | Re-arm at capture stop, before the seal |
| S7c-F7 audio delay constants are one calibration | FIXED | Device and conditions documented, manifest note names the estimate |
| S7c-F11 drain skipped after an adapter had captured | FIXED | Drain skipped only when `len(captures) == 0` |

## Verification

From `go/`:

```
go build ./...
GOOS=linux go vet ./internal/agent/services/... ./internal/agent/data/...
go test -race ./internal/agent/services/ ./internal/agent/data/
```

All pass. Eleven regression tests were added and three existing tests were rewritten where they pinned the old, wrong behaviour.
