### PR TITLE
fix(agent): close camera hub, two-plane and episode export review findings

### DIFF
--- a/go/cmd/episode-playable/main.go
+++ b/go/cmd/episode-playable/main.go
@@ -88,6 +88,12 @@ The episode directory is never modified.
 		if r.ParameterSetChanges > 0 {
 			fmt.Fprintf(os.Stderr, "episode-playable: warning: camera %s changes its SPS/PPS mid-stream (%d changed unit(s), a producer restart); the clip carries only the first decoder configuration, so frames after the change will misdecode\n", r.Source, r.ParameterSetChanges)
 		}
+		if r.TimestampInversions > 0 {
+			fmt.Fprintf(os.Stderr, "episode-playable: warning: camera %s has %d index entry/entries whose canonical timestamp runs backwards; capture order was preserved and those gaps were written as zero, so the clip's timing is approximate\n", r.Source, r.TimestampInversions)
+		}
+		if r.NominalHold > 0 {
+			fmt.Fprintf(os.Stderr, "episode-playable: warning: camera %s holds a single frame, whose display duration no index entry records; it was given a nominal %s\n", r.Source, r.NominalHold)
+		}
 		if r.BFrames {
 			fmt.Fprintf(os.Stderr, "episode-playable: warning: camera %s contains B slices, so its presentation order differs from the coded order index.jsonl records; the timing written for it is approximate\n", r.Source)
 		} else if r.UndecodedSliceHeaders > 0 {

--- a/go/internal/agent/data/manager.go
+++ b/go/internal/agent/data/manager.go
@@ -614,6 +614,7 @@ func (m *Manager) ApplyCaptureResults(key string, results []CaptureResult) error
 			}
 			stats.Count = result.Count
 			stats.Drops = result.Drops
+			stats.ArmedDrops = result.ArmedDrops
 			if result.DropAccounting != "" {
 				stats.DropAccounting = result.DropAccounting
 			}

--- a/go/internal/agent/data/model.go
+++ b/go/internal/agent/data/model.go
@@ -47,12 +47,22 @@ type Source struct {
 }
 
 type SourceStats struct {
-	Source          Source         `json:"source"`
-	RequestedOffset int64          `json:"requested_offset_nanos"`
-	ActualOffset    int64          `json:"actual_offset_nanos"`
-	Count           uint64         `json:"count"`
-	Drops           *uint64        `json:"drops,omitempty"`
-	DropAccounting  string         `json:"drop_accounting"`
+	Source          Source  `json:"source"`
+	RequestedOffset int64   `json:"requested_offset_nanos"`
+	ActualOffset    int64   `json:"actual_offset_nanos"`
+	Count           uint64  `json:"count"`
+	Drops           *uint64 `json:"drops,omitempty"`
+	DropAccounting  string  `json:"drop_accounting"`
+	// ArmedDrops is present only for a source a campaign armed for pre-roll,
+	// and counts frames the hub dropped for the standby subscription during
+	// the ARMED period, before the trigger opened this episode. Those frames
+	// were never candidates for the episode: the pre-roll ring keeps only the
+	// last `buffer` seconds, and most of the armed period is older than that.
+	// They are reported here rather than in Drops so the episode's own loss
+	// figure stays the loss of the recording it describes. Losses inside the
+	// pre-roll window itself do reach Drops, through the sequence gaps between
+	// the frames the ring retained.
+	ArmedDrops      *uint64        `json:"armed_period_drops,omitempty"`
 	MappingError    *int64         `json:"mapping_error_nanos,omitempty"`
 	Discontinuities uint64         `json:"discontinuities"`
 	Mappings        []ClockMapping `json:"clock_mappings,omitempty"`
@@ -191,13 +201,16 @@ type CaptureSession struct {
 
 // CaptureResult is reported by an adapter before the episode is sealed.
 type CaptureResult struct {
-	SourceID        string
-	ClockDomain     string
-	SourceDetail    string
-	ActualOffset    *int64
-	Count           uint64
-	Drops           *uint64
-	DropAccounting  string
+	SourceID       string
+	ClockDomain    string
+	SourceDetail   string
+	ActualOffset   *int64
+	Count          uint64
+	Drops          *uint64
+	DropAccounting string
+	// ArmedDrops carries the armed-period drops of a pre-roll campaign source.
+	// See SourceStats.ArmedDrops for what it counts and why it is separate.
+	ArmedDrops      *uint64
 	MappingError    *int64
 	Discontinuities uint64
 	Mappings        []ClockMapping

--- a/go/internal/agent/data/playable.go
+++ b/go/internal/agent/data/playable.go
@@ -44,7 +44,7 @@ func muxPlayableClips(dir string) []string {
 	for _, index := range indexes {
 		sourceDir := filepath.Dir(index)
 		rel := path.Join("cameras", filepath.Base(sourceDir), episodeexport.PlayableFileName)
-		result, err := episodeexport.ConvertSourceInPlace(dir, sourceDir)
+		result, err := convertPlayableClip(dir, sourceDir)
 		if reason := playableSkipReason(result, err); reason != "" {
 			// ConvertSourceInPlace only leaves a file behind on success, but a
 			// clip refused by policy (B slices and the like) was written before
@@ -61,8 +61,36 @@ func muxPlayableClips(dir string) []string {
 			}
 			notes = append(notes, note)
 		}
+		if result.NominalHold > 0 {
+			notes = append(notes, fmt.Sprintf(
+				"%s holds a single frame whose display duration no index entry records; it was given a nominal %s",
+				rel, result.NominalHold))
+		}
 	}
 	return notes
+}
+
+// convertClip is the remux entry point. It is a variable only so a test can
+// drive convertPlayableClip's recover without having to find a fixture that
+// makes the muxer panic for real.
+var convertClip = episodeexport.ConvertSourceInPlace
+
+// convertPlayableClip is ConvertSourceInPlace with a bounded recover.
+//
+// The remux parses attacker-shaped-in-principle data (an index and segment
+// files that a crashed or corrupted capture may have left in any state) while
+// running inside the seal. A panic there would abort the seal and lose the
+// episode itself, which is a far worse outcome than losing a derived clip that
+// can be rebuilt from the raw capture at any time. Turning the panic into an
+// ordinary mux error keeps the existing refusal path: the clip is not written
+// and the manifest's playable_notes name the reason.
+func convertPlayableClip(dir, sourceDir string) (result episodeexport.ClipResult, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("remuxing panicked: %v", r)
+		}
+	}()
+	return convertClip(dir, sourceDir)
 }
 
 // playableSkipReason decides whether a mux result is honest enough to publish
@@ -83,6 +111,8 @@ func playableSkipReason(r episodeexport.ClipResult, err error) string {
 		return fmt.Sprintf("%d slice header(s) could not be parsed, so whether the stream carries B slices is unknown and the clip's timing cannot be vouched for", r.UndecodedSliceHeaders)
 	case r.ParameterSetChanges > 0:
 		return fmt.Sprintf("the stream's parameter sets change mid-episode (%d changed SPS/PPS unit(s), a producer restart), and the clip's single decoder configuration would misdecode every frame after the change", r.ParameterSetChanges)
+	case r.TimestampInversions > 0:
+		return fmt.Sprintf("%d index entry/entries record a canonical timestamp earlier than the entry before them, so the recorded timing disagrees with the coded order the clip must preserve and its timing cannot be vouched for", r.TimestampInversions)
 	case r.SyncSamples == 0:
 		return "clip would carry no random-access frame, so players cannot seek in it and many will not open it"
 	}

--- a/go/internal/agent/data/playable_test.go
+++ b/go/internal/agent/data/playable_test.go
@@ -517,3 +517,95 @@ func TestIsDerivedPlayable(t *testing.T) {
 		}
 	}
 }
+
+// The seal must not publish a clip whose index timestamps run backwards: the
+// remux preserves capture order, so a clip built from an inverted index has
+// timing nobody can vouch for.
+func TestSealRefusesClipWithInvertedTimestamps(t *testing.T) {
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = m.Start(StartOptions{Sources: []string{"applications"}}); err != nil {
+		t.Fatal(err)
+	}
+	session, ok := m.ActiveSession(AdHocEpisodeKey)
+	if !ok {
+		t.Fatal("no active session")
+	}
+	writeCameraSource(t, session.Directory, "cam-front", [][]byte{
+		annexB(parsedIDR), annexB(parsedPSlice), annexB(parsedPSlice),
+	})
+	invertLastTwoIndexTimestamps(t, filepath.Join(session.Directory, "cameras", "cam-front", "index.jsonl"))
+
+	stopped, err := m.Stop(AdHocEpisodeKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rel := "cameras/cam-front/" + episodeexport.PlayableFileName
+	if _, ok := fileByPath(stopped.Files, rel); ok {
+		t.Errorf("manifest lists %s despite its index timestamps inverting", rel)
+	}
+	if len(stopped.PlayableNotes) != 1 || !strings.Contains(stopped.PlayableNotes[0], "earlier than the entry before them") {
+		t.Errorf("notes %v do not name the inversion", stopped.PlayableNotes)
+	}
+	if _, statErr := os.Stat(filepath.Join(session.Directory, "cameras", "cam-front", episodeexport.PlayableFileName)); !os.IsNotExist(statErr) {
+		t.Errorf("a refused clip was left on disk: %v", statErr)
+	}
+}
+
+// invertLastTwoIndexTimestamps swaps the canonical timestamps of the last two
+// index entries, leaving the entries themselves in capture order.
+func invertLastTwoIndexTimestamps(t *testing.T, path string) {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(raw)), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("index holds %d entries, need at least two to invert", len(lines))
+	}
+	var a, b map[string]any
+	if err := json.Unmarshal([]byte(lines[len(lines)-2]), &a); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &b); err != nil {
+		t.Fatal(err)
+	}
+	a["canonical_episode_nanos"], b["canonical_episode_nanos"] = b["canonical_episode_nanos"], a["canonical_episode_nanos"]
+	for i, rec := range []map[string]any{a, b} {
+		encoded, err := json.Marshal(rec)
+		if err != nil {
+			t.Fatal(err)
+		}
+		lines[len(lines)-2+i] = string(encoded)
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A panic anywhere in the remux must become an ordinary mux error: the seal
+// writes the episode itself and must never be brought down by a derived
+// artifact that can be rebuilt from the raw capture at any time.
+func TestConvertPlayableClipTurnsAPanicIntoAnError(t *testing.T) {
+	dir := t.TempDir()
+	// A source directory with no index at all: ConvertSourceInPlace returns an
+	// ordinary error, which proves the recover wrapper passes errors through.
+	if _, err := convertPlayableClip(dir, filepath.Join(dir, "cameras", "cam")); err == nil {
+		t.Fatal("expected an error for a source with no index")
+	}
+	original := convertClip
+	t.Cleanup(func() { convertClip = original })
+	convertClip = func(string, string) (episodeexport.ClipResult, error) {
+		panic("synthetic mux panic")
+	}
+	_, err := convertPlayableClip(dir, filepath.Join(dir, "cameras", "cam"))
+	if err == nil {
+		t.Fatal("a panic inside the remux escaped instead of becoming a mux error")
+	}
+	if !strings.Contains(err.Error(), "synthetic mux panic") {
+		t.Fatalf("error does not name the panic: %v", err)
+	}
+}

--- a/go/internal/agent/services/data_camera_adapter.go
+++ b/go/internal/agent/services/data_camera_adapter.go
@@ -100,7 +100,7 @@ func (a *cameraDataAdapter) Start(ctx context.Context, session data.CaptureSessi
 				// records this camera from the trigger rather than losing it.
 				capture, err = a.startOne(ctx, session, source, devID)
 			}
-			if errors.Is(err, errCameraHeldExplicitly) {
+			if isCameraCaptureRefusal(err) {
 				group.refused = append(group.refused, data.CaptureResult{
 					SourceID:     source.ID,
 					SourceDetail: strings.TrimSpace(source.Detail + " (not captured: " + err.Error() + ")"),
@@ -116,9 +116,10 @@ func (a *cameraDataAdapter) Start(ctx context.Context, session data.CaptureSessi
 			continue
 		}
 		capture, err := a.startOne(ctx, session, source, devID)
-		if errors.Is(err, errCameraHeldExplicitly) {
+		if isCameraCaptureRefusal(err) {
 			// Another consumer holds this camera at explicitly requested
-			// parameters that conflict with the campaign's. Refusing this one
+			// parameters that conflict with the campaign's, or the camera it
+			// holds did not release in time for the takeover. Refusing this one
 			// source, with the named error in its manifest entry, is the
 			// honest outcome: the episode continues with its other sources and
 			// the manifest says exactly who holds the camera and at what
@@ -422,7 +423,16 @@ type cameraCapture struct {
 	rejoin func(ctx context.Context) (*deviceHub, int, chan *videoFrame, error)
 	// carriedDrops accumulates subscriber-channel drops from hub
 	// subscriptions this capture already left when reattaching.
-	carriedDrops       uint64
+	carriedDrops uint64
+	// dropBaseline is the hub drop total already accrued on the subscription
+	// this capture inherited, at the moment it inherited it. Only an armed
+	// capture has one: its subscription was delivering throughout the armed
+	// period, and those drops belong to the armed period rather than to the
+	// episode. Subtracted from the final total in run's teardown.
+	dropBaseline uint64
+	// armedDrops is that same baseline, reported in the manifest as the
+	// source's armed-period drops so the number is separated rather than lost.
+	armedDrops         uint64
 	index, mappingFile *os.File
 	segment            *os.File
 	segmentRel         string
@@ -485,6 +495,18 @@ type cameraCapture struct {
 	// subscribed and producing, so run() reports ready once its pre-roll is
 	// flushed rather than waiting for a first live frame.
 	armed bool
+	// awaitLiveSegmentReset makes the first random-access frame of the LIVE
+	// tail open a fresh segment. Set once the pre-roll has been written: the
+	// flush is a burst of disk work during which the hub may have dropped
+	// frames despite the drain (see drainDuring), so any gap between the
+	// pre-roll and the tail is made to land on a segment boundary rather than
+	// inside a file a decoder reads as one continuous timeline.
+	awaitLiveSegmentReset bool
+	// preRollFlushHook is a test seam over the pre-roll write loop, in the
+	// style of captureReceipt above: it is called after each buffered frame is
+	// written, so a test can make the flush slow enough to prove the live
+	// frames arriving during it are not lost.
+	preRollFlushHook func()
 }
 
 func (c *cameraCapture) receiptNow() (int64, int64, int64, error) {
@@ -536,6 +558,19 @@ func (c *cameraCapture) run() {
 			c.notes = append([]string{"pipeline PTS unavailable; canonical time uses bounded agent receipt"}, c.notes...)
 		}
 		subscriberDrops := c.hub.unsubscribe(c.subID) + c.carriedDrops
+		// An armed capture inherited a subscription that had been delivering
+		// since the campaign armed, so its hub drop counter already held the
+		// armed period's losses when the trigger arrived. Those frames were
+		// never candidates for this episode (the ring keeps only the last
+		// `buffer` seconds), so they are reported separately instead of being
+		// folded into the episode's own drop figure. Losses inside the
+		// pre-roll window do reach Drops, through the sequence gaps between
+		// the frames the ring retained.
+		subscriberDrops = saturatingSub(subscriberDrops, c.dropBaseline)
+		if c.armed {
+			armed := c.armedDrops
+			c.result.ArmedDrops = &armed
+		}
 		end := int64(0)
 		if _, receipt, _, err := c.receiptNow(); err == nil {
 			end = receipt
@@ -575,21 +610,39 @@ func (c *cameraCapture) run() {
 	// times before the live loop takes over on the same subscription. An
 	// undecodable leading frame (should not happen: the ring only retains from a
 	// keyframe) is skipped rather than failing the episode.
-	for i := range c.preRoll {
-		if err := c.writeBufferedFrame(c.preRoll[i]); errors.Is(err, errAwaitCameraRandomAccess) {
-			continue
-		} else if err != nil {
+	if len(c.preRoll) > 0 {
+		// The flush is disk work (MkdirAll, OpenFile, per-segment Sync) taking
+		// far longer than a frame interval, and the subscriber channel it is
+		// not reading during that time is four frames deep. Draining it into a
+		// bounded side buffer from a helper goroutine is what keeps the frames
+		// immediately after the trigger, which are the most interesting ones in
+		// the episode, out of the hub's drop counter.
+		drain, err := c.drainDuring(c.flushPreRoll)
+		if err != nil {
 			c.runErr = err
 			c.signalReady(err)
 			return
 		}
-	}
-	c.preRoll = nil
-	// The armed subscription was already producing while the ring filled, so the
-	// capture is ready as soon as its pre-roll is on disk; the live loop then
-	// continues. A never-armed capture leaves preRoll empty and signals ready on
-	// its first live frame below, exactly as before.
-	if c.armed {
+		c.carriedDrops += drain.dropped
+		c.awaitLiveSegmentReset = true
+		// The armed subscription was already producing while the ring filled,
+		// so the capture is ready as soon as its pre-roll is on disk; the live
+		// loop then continues.
+		if c.armed {
+			c.signalReady(nil)
+		}
+		for _, frame := range drain.frames {
+			if err := c.handleFrame(frame); errors.Is(err, errAwaitCameraRandomAccess) {
+				continue
+			} else if err != nil {
+				c.runErr = err
+				c.signalReady(err)
+				return
+			}
+		}
+	} else if c.armed {
+		// An armed capture whose ring held nothing still reports ready here
+		// rather than waiting for a first live frame.
 		c.signalReady(nil)
 	}
 
@@ -780,7 +833,13 @@ func (c *cameraCapture) writeFrame(frame *videoFrame) error {
 	if c.rateCap > 0 && c.gateGOP(frame, receipt) {
 		return nil
 	}
-	if err := c.writeEncodedFrame(frame, canonical, uncertainty, mappingID, receipt, false); err != nil {
+	newStream := false
+	if c.awaitLiveSegmentReset {
+		if _, randomAccess := frameRandomAccess(frame); randomAccess {
+			newStream, c.awaitLiveSegmentReset = true, false
+		}
+	}
+	if err := c.writeEncodedFrame(frame, canonical, uncertainty, mappingID, receipt, newStream); err != nil {
 		return err
 	}
 	if !c.haveRateStart {

--- a/go/internal/agent/services/data_camera_preroll.go
+++ b/go/internal/agent/services/data_camera_preroll.go
@@ -22,6 +22,13 @@ import (
 // counted per armed source against the device's memory.
 const preRollCameraLimitBytes = 64 << 20
 
+// preRollGOPWindowFactor bounds how far past the requested buffer one
+// undivided group of pictures may reach before the ring gives up on it. A
+// producer emitting keyframes at all keeps GOPs well inside a factor of eight;
+// a stream that does not is a stream the ring cannot trim at all, so the only
+// bound left is to start over.
+const preRollGOPWindowFactor = 8
+
 // bufferedCameraFrame is one encoded frame held in an armed campaign's standby
 // ring. The frame pointer is retained, not copied: hub frames are immutable
 // from the moment they are broadcast (identity, receipt, and payload never
@@ -96,13 +103,26 @@ func (r *cameraPreRollRing) evict() {
 	for r.bytesFrom(keep) > r.limitBytes {
 		next := r.nextKeyframeAfter(keep)
 		if next < 0 {
-			// One group of pictures left: cannot shrink further without leaving
-			// the ring undecodable. Keep it and let the byte total ride; the flush
-			// reports the shortened reach.
-			break
+			// One group of pictures left and it alone exceeds the cap. Keeping
+			// it would let a producer that emits a single very long GOP grow
+			// the ring without bound, because every other eviction rule works
+			// at keyframe boundaries and there is no second boundary to move
+			// to. The ring is dropped whole and refilled from the next
+			// keyframe, which is the only bound available that still leaves a
+			// decodable ring.
+			r.restart()
+			return
 		}
 		keep = next
 		r.droppedForBytes = true
+	}
+	// The same trap measured in time rather than bytes: one undivided group of
+	// pictures reaching far past the requested buffer is a ring nothing can
+	// trim, so it is dropped rather than allowed to keep growing.
+	if r.nextKeyframeAfter(keep) < 0 &&
+		newest-r.frames[keep].frame.receiptBootNanos > preRollGOPWindowFactor*r.buffer.Nanoseconds() {
+		r.restart()
+		return
 	}
 	if keep <= 0 {
 		return
@@ -115,6 +135,19 @@ func (r *cameraPreRollRing) evict() {
 		r.frames[i] = bufferedCameraFrame{}
 	}
 	r.frames = r.frames[:n]
+}
+
+// restart drops the whole ring and waits for the next keyframe to begin a new
+// one. It is the eviction of last resort, used when a single group of pictures
+// has grown past a bound and there is no keyframe boundary left to trim at.
+// The retained pre-roll is honestly shorter afterwards, which droppedForBytes
+// reports, and the frames that follow open a new stream because the discarded
+// tail leaves a gap no decoder should be asked to cross.
+func (r *cameraPreRollRing) restart() {
+	r.frames = r.frames[:0]
+	r.bytes = 0
+	r.droppedForBytes = true
+	r.nextResetSegment = true
 }
 
 // lastKeyframeAtOrBefore returns the index of the newest retained keyframe whose
@@ -166,6 +199,105 @@ func (r *cameraPreRollRing) flush(triggerBoot int64) (frames []bufferedCameraFra
 	return frames, earliest - triggerBoot, earliest <= windowStart
 }
 
+// preRollFlushDrainLimitBytes bounds the side buffer that holds live frames
+// arriving while the pre-roll is written. It is a quarter of the ring's own
+// cap: the flush is bounded work, so the buffer only has to cover a burst
+// lasting as long as writing at most preRollCameraLimitBytes to disk, and a
+// bound is still needed because a stalled disk must cost memory no faster than
+// the ring itself does.
+const preRollFlushDrainLimitBytes = preRollCameraLimitBytes / 4
+
+// frameDrain is what a drain goroutine collected while a slow operation held
+// the capture goroutine.
+type frameDrain struct {
+	frames []*videoFrame
+	bytes  int
+	// dropped counts frames the side buffer refused because it was full. They
+	// are charged to the capture's drop total, exactly like a hub-side drop:
+	// the frame existed and the episode does not have it.
+	dropped uint64
+	// closed records that the subscription ended during the drain. The live
+	// loop discovers the same thing on its next receive (a closed channel
+	// yields immediately), so nothing special has to be done with it here.
+	closed bool
+}
+
+// drainDuring runs fn while a helper goroutine keeps consuming c.frames into a
+// bounded side buffer, and returns what it collected.
+//
+// This exists because of what the pre-roll flush is: activate hands the LIVE
+// hub subscription straight to the capture, and run then spends the flush
+// writing every buffered frame to disk before it reaches the live select. The
+// subscriber channel is four frames deep, so on any real camera the frames
+// immediately after the trigger, the ones the episode exists to record, were
+// dropped by the hub while the flush ran, and the tail resumed mid group of
+// pictures. Keeping a reader on the channel throughout is what removes that
+// loss; the frames collected are replayed through the ordinary live path
+// afterwards, in order, so they are written exactly as if the flush had been
+// instantaneous.
+//
+// The goroutine owns c.frames for the duration and is joined before this
+// returns, so the caller resumes as its sole reader with no data race.
+func (c *cameraCapture) drainDuring(fn func() error) (*frameDrain, error) {
+	d := &frameDrain{}
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-stop:
+				return
+			case frame, ok := <-c.frames:
+				if !ok {
+					d.closed = true
+					return
+				}
+				if d.bytes+len(frame.data) > preRollFlushDrainLimitBytes {
+					d.dropped++
+					continue
+				}
+				d.frames = append(d.frames, frame)
+				d.bytes += len(frame.data)
+			}
+		}
+	}()
+	err := fn()
+	close(stop)
+	<-done
+	return d, err
+}
+
+// flushPreRoll writes every frame of the activated standby ring. An
+// undecodable leading frame (which should not happen: the ring only retains
+// from a keyframe) is skipped rather than failing the episode.
+func (c *cameraCapture) flushPreRoll() error {
+	for i := range c.preRoll {
+		if err := c.writeBufferedFrame(c.preRoll[i]); errors.Is(err, errAwaitCameraRandomAccess) {
+			continue
+		} else if err != nil {
+			return err
+		}
+		if c.preRollFlushHook != nil {
+			c.preRollFlushHook()
+		}
+	}
+	c.preRoll = nil
+	return nil
+}
+
+// saturatingSub subtracts b from a without wrapping. The drop baselines it
+// guards are read from the same monotonic counter as the totals, so a > b
+// always holds in practice; a counter that wrapped the other way would turn a
+// small overcount into an astronomically wrong drop figure in the manifest,
+// which is exactly the kind of number a reader would believe.
+func saturatingSub(a, b uint64) uint64 {
+	if b > a {
+		return 0
+	}
+	return a - b
+}
+
 // armedCameraSource is one camera source's standby state for a campaign that
 // requested a buffer. It subscribes to the device hub as a NON-owning consumer
 // (asserting no stream parameters, exactly like the sensor path), so it never
@@ -188,10 +320,11 @@ type armedCameraSource struct {
 	subID  int
 	frames chan *videoFrame
 	ring   *cameraPreRollRing
-	// lastDrops tracks the hub's drop counter for this subscription so a reattach
-	// carries the unaccounted drops forward as a ring stream reset rather than
-	// losing them silently.
-	lastDrops uint64
+	// carriedDrops accumulates the hub drop counters of subscriptions this
+	// armed source has already left, so a mid-arm producer restart does not
+	// lose the count. activate hands the total to the capture, which reports
+	// it as the episode's armed-period drops.
+	carriedDrops uint64
 	// alive reports that the subscription is still delivering. The fill goroutine
 	// clears it if the producer stops or a reattach fails, so activate knows to
 	// re-subscribe for the live tail instead of handing capture a dead channel.
@@ -238,13 +371,16 @@ func (a *armedCameraSource) fill(ctx context.Context) {
 }
 
 func (a *armedCameraSource) reattach(ctx context.Context) error {
-	a.lastDrops += a.hub.unsubscribe(a.subID)
+	carried := a.carriedDrops + a.hub.unsubscribe(a.subID)
 	hub, subID, frames, err := a.video.joinHub(ctx, a.key, &agentpb.StreamVideoRequest{DeviceId: a.devID})
 	if err != nil {
+		// The count still belongs to this armed source even when the rejoin
+		// failed: activate reports it whether or not a live tail follows.
+		a.carriedDrops = carried
 		return err
 	}
 	a.hub, a.subID, a.frames = hub, subID, frames
-	a.lastDrops = 0
+	a.carriedDrops = carried
 	a.ring.markStreamReset()
 	return nil
 }
@@ -314,11 +450,26 @@ func (a *armedCameraSource) activate(session data.CaptureSession) (*cameraCaptur
 	rejoin := func(ctx context.Context) (*deviceHub, int, chan *videoFrame, error) {
 		return a.video.joinHub(ctx, a.key, &agentpb.StreamVideoRequest{DeviceId: devID})
 	}
+	// Everything the hub dropped for this subscription up to now happened
+	// during the ARMED period. The capture subtracts it from its own total and
+	// reports it separately, so the episode's Drops describe the recording
+	// rather than the whole standby watch that preceded it.
+	// baseline is what the INHERITED subscription's own counter already holds;
+	// it is the part the capture's teardown will read back and must subtract.
+	// The armed total additionally carries the counters of subscriptions this
+	// armed source already left across a mid-arm producer restart, which the
+	// capture will never see.
+	var baseline uint64
+	if a.hub != nil {
+		baseline = a.hub.drops(a.subID)
+	}
+	armedDrops := a.carriedDrops + baseline
 	c := &cameraCapture{
 		source: a.source, session: session, dir: dir, hub: a.hub, subID: a.subID, frames: a.frames,
 		rejoin: rejoin, index: index, mappingFile: mappings, ctx: captureCtx, cancel: cancel,
 		done: make(chan struct{}), ready: make(chan error, 1), mode: "continuous", rateCap: rateCap,
 		notes: notes, lastSnapshotIdx: -1, preRoll: preRoll, armed: true,
+		dropBaseline: baseline, armedDrops: armedDrops,
 	}
 	go c.run()
 	select {

--- a/go/internal/agent/services/data_camera_preroll_test.go
+++ b/go/internal/agent/services/data_camera_preroll_test.go
@@ -267,3 +267,222 @@ func TestArmedCampaignFlushesPreRollOnTrigger(t *testing.T) {
 		t.Fatal("no index entry carries a before-trigger canonical time with a real sample id")
 	}
 }
+
+// The pre-roll flush is disk work far longer than a frame interval, and the
+// live hub subscription it inherits is four frames deep. Before the drain, the
+// frames arriving during the flush, which are the most interesting ones in the
+// episode, were dropped by the hub and the tail resumed mid group of pictures.
+func TestPreRollFlushLosesNoFramesWhileWriting(t *testing.T) {
+	const preRollFrames = 4
+	const liveFrames = 12
+
+	video := NewVideoService(context.Background(), zap.NewNop())
+	hub, _ := newDefaultHub(t, video, "/dev/video0")
+	subID, frames, err := hub.subscribe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	trigger := int64(10 * time.Second)
+	c := newTestCameraCapture(t, &fakeReceipt{now: trigger})
+	c.session = data.CaptureSession{RequestBootNanos: trigger}
+	c.hub, c.subID, c.frames = hub, subID, frames
+	c.armed, c.mode = true, "continuous"
+	c.ctx, c.cancel = context.WithCancel(context.Background())
+	c.done, c.ready = make(chan struct{}), make(chan error, 1)
+	for i := 0; i < preRollFrames; i++ {
+		c.preRoll = append(c.preRoll, bufferedCameraFrame{
+			frame:        preRollFrame(trigger-int64(preRollFrames-i)*100*ms, uint64(i+1), i == 0),
+			randomAccess: i == 0,
+			resetSegment: i == 0,
+		})
+	}
+
+	// The producer keeps delivering at a steady rate throughout the flush, and
+	// each written pre-roll frame takes long enough for several of them to
+	// arrive: without a reader on the channel the four-deep buffer overflows.
+	produced := make(chan struct{})
+	c.preRollFlushHook = func() { time.Sleep(20 * time.Millisecond) }
+	go func() {
+		defer close(produced)
+		for i := 0; i < liveFrames; i++ {
+			payload := testInterFrame
+			if i%4 == 0 {
+				payload = testRAUFrame
+			}
+			hub.produce(testH264Frame(payload))
+			time.Sleep(5 * time.Millisecond)
+		}
+	}()
+
+	go c.run()
+	if err := <-c.ready; err != nil {
+		t.Fatalf("capture never became ready: %v", err)
+	}
+	<-produced
+	// Let the live loop drain whatever is still queued, then stop.
+	time.Sleep(100 * time.Millisecond)
+	c.cancel()
+	<-c.done
+
+	// The capture's teardown has already unsubscribed, so the hub's own
+	// counter is gone; the figure that survives is the one the manifest would
+	// carry.
+	if c.result.Drops == nil || *c.result.Drops != 0 {
+		t.Fatalf("capture reports %d drops; the drain must lose no frame during the flush", *c.result.Drops)
+	}
+	if c.result.Count < preRollFrames+liveFrames {
+		t.Fatalf("wrote %d frames, want at least the %d pre-roll plus %d live ones",
+			c.result.Count, preRollFrames, liveFrames)
+	}
+}
+
+// Any gap the flush could not avoid must land on a segment boundary rather
+// than inside a file a decoder reads as one continuous timeline.
+func TestLiveTailAfterPreRollOpensANewSegmentAtTheNextKeyframe(t *testing.T) {
+	trigger := int64(10 * time.Second)
+	clock := &fakeReceipt{now: trigger}
+	c := newTestCameraCapture(t, clock)
+	c.session = data.CaptureSession{RequestBootNanos: trigger}
+	c.mode = "continuous"
+
+	c.preRoll = []bufferedCameraFrame{
+		{frame: preRollFrame(trigger-200*ms, 1, true), randomAccess: true, resetSegment: true},
+		{frame: preRollFrame(trigger-100*ms, 2, false)},
+	}
+	if err := c.flushPreRoll(); err != nil {
+		t.Fatal(err)
+	}
+	preRollSegment := c.segmentRel
+	c.awaitLiveSegmentReset = true
+
+	// An inter frame stays in the pre-roll's segment: rotating here would
+	// leave a file no decoder can open.
+	clock.now = trigger + 50*ms
+	if err := c.handleFrame(testH264Frame(testInterFrame)); err != nil {
+		t.Fatal(err)
+	}
+	if c.segmentRel != preRollSegment {
+		t.Fatal("the live tail rotated the segment on an inter frame")
+	}
+	// The first live keyframe opens the new one.
+	clock.now = trigger + 100*ms
+	if err := c.handleFrame(testH264Frame(testRAUFrame)); err != nil {
+		t.Fatal(err)
+	}
+	if c.segmentRel == preRollSegment {
+		t.Fatal("the first live keyframe after the flush did not open a new segment")
+	}
+	if c.awaitLiveSegmentReset {
+		t.Fatal("the pending reset was not cleared, so every later keyframe would rotate too")
+	}
+}
+
+// A producer emitting one very long group of pictures gives the ring no
+// keyframe boundary to trim at, so the byte cap must be enforced by starting
+// over rather than by letting the ring grow without bound.
+func TestPreRollRingRestartsWhenOneGOPExceedsTheByteCap(t *testing.T) {
+	const cap = 4096
+	r := &cameraPreRollRing{buffer: time.Second, limitBytes: cap}
+	big := func(receipt int64, id uint64, key bool) *videoFrame {
+		f := preRollFrame(receipt, id, key)
+		f.data = append(append([]byte(nil), f.data...), make([]byte, 1024)...)
+		return f
+	}
+	r.add(big(0, 1, true))
+	for i := 1; i <= 40; i++ {
+		r.add(big(int64(i)*10*ms, uint64(i+1), false))
+		if r.bytes > cap+1024 {
+			t.Fatalf("ring holds %d bytes after %d keyframe-free frames, above the %d cap", r.bytes, i, cap)
+		}
+	}
+	if !r.droppedForBytes {
+		t.Fatal("the ring did not report that the byte cap bounded it")
+	}
+	// After the restart the ring waits for a keyframe and opens a new stream.
+	r.add(big(500*ms, 100, false))
+	if len(r.frames) != 0 {
+		t.Fatal("the restarted ring retained an inter frame before its next keyframe")
+	}
+	r.add(big(600*ms, 101, true))
+	if len(r.frames) != 1 || !r.frames[0].resetSegment {
+		t.Fatalf("the restarted ring did not begin a new stream on its next keyframe: %+v", r.frames)
+	}
+}
+
+// A mid-arm producer restart must not lose the drops it had already counted,
+// and the armed period's drops must be reported apart from the episode's own.
+func TestArmedDropsAreCarriedAndReportedSeparately(t *testing.T) {
+	video := NewVideoService(context.Background(), zap.NewNop())
+	hub, _ := newDefaultHub(t, video, "/dev/video0")
+	adapter := &cameraDataAdapter{video: video}
+	source := data.Source{ID: "v4l2:/dev/video0", Kind: "camera"}
+
+	adapter.Arm("cam", 5*time.Second, []data.Source{source})
+	adapter.armedMu.Lock()
+	armed := adapter.armed["cam"][source.ID]
+	adapter.armedMu.Unlock()
+	if armed == nil {
+		t.Fatal("the campaign armed no source")
+	}
+	// Stand in for a long armed period during which the hub fell behind.
+	const armedPeriodDrops = 7
+	hub.mu.Lock()
+	hub.subDrops[armed.subID] += armedPeriodDrops
+	hub.mu.Unlock()
+
+	_, origin, _, err := data.CaptureReceipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	session := data.CaptureSession{Directory: t.TempDir(), RequestBootNanos: origin, CampaignKey: "cam"}
+	// One keyframe so the ring holds something to flush.
+	hub.produce(testH264Frame(testRAUFrame))
+	time.Sleep(20 * time.Millisecond)
+
+	capture, err := adapter.Start(context.Background(), session, []data.Source{source})
+	if err != nil {
+		t.Fatal(err)
+	}
+	results, err := capture.Stop(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want 1", len(results))
+	}
+	res := results[0]
+	if res.ArmedDrops == nil || *res.ArmedDrops != armedPeriodDrops {
+		t.Fatalf("armed-period drops = %v, want %d reported separately", res.ArmedDrops, armedPeriodDrops)
+	}
+	if res.Drops == nil || *res.Drops != 0 {
+		t.Fatalf("episode drops = %v, want 0: the armed period's losses are not the episode's", res.Drops)
+	}
+}
+
+// A reattach during arming must keep the count it had already accumulated
+// rather than zeroing it the moment after adding to it.
+func TestArmedSourceKeepsDropsAcrossAReattach(t *testing.T) {
+	video := NewVideoService(context.Background(), zap.NewNop())
+	hub, _ := newDefaultHub(t, video, "/dev/video0")
+	subID, frames, err := hub.subscribe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	hub.mu.Lock()
+	hub.subDrops[subID] += 3
+	hub.mu.Unlock()
+
+	a := &armedCameraSource{
+		video: video, source: data.Source{ID: "v4l2:/dev/video0"}, key: "/dev/video0",
+		devID: 0, buffer: time.Second, hub: hub, subID: subID, frames: frames, alive: true,
+		ring: &cameraPreRollRing{buffer: time.Second, limitBytes: preRollCameraLimitBytes},
+	}
+	if err := a.reattach(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if a.carriedDrops != 3 {
+		t.Fatalf("carried drops = %d, want the 3 the left subscription had counted", a.carriedDrops)
+	}
+	a.hub.unsubscribe(a.subID)
+}

--- a/go/internal/agent/services/hub_loopback_pump.go
+++ b/go/internal/agent/services/hub_loopback_pump.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 	"go.uber.org/zap"
@@ -38,15 +39,27 @@ type loopbackFrameWriter interface {
 	Close() error
 }
 
-// openLoopbackFrameWriter opens a node for writing. Implemented per platform;
-// non-Linux builds return an error, which makes the whole data plane a no-op
-// there rather than a compile break.
+// openLoopbackFrameWriter opens a node for writing. There is one
+// implementation (hub_loopback_writer.go): it builds everywhere, because it
+// speaks V4L2 through golang.org/x/sys/unix rather than through a Linux-only
+// package, and simply fails to open the node on a host that has none. The
+// indirection exists so tests can inject a fake writer, not to select a
+// platform.
 var openLoopbackFrameWriter = openLoopbackFrameWriterPlatform
 
 // errLoopbackDataPlaneUnsupported is returned by the pump when the running build
 // or the source cannot support a sound binding. It is deliberately a refusal
 // rather than a degraded mode.
 var errLoopbackDataPlaneUnsupported = errors.New("two-plane camera data path unavailable on this build")
+
+// errSourceNotBindable reports that a producer's frames cannot carry a frame
+// identity binding at all: the transport does not deliver whole access units,
+// so no loopback sequence could name a frame. It is a property of the
+// producer's pipeline, not a transient condition, so a refusal wrapping it is
+// permanent for as long as that producer is what the source runs. The node
+// lifecycle uses it to stop recreating a data path the pump will refuse again
+// (see VideoService.twoPlaneRefused).
+var errSourceNotBindable = errors.New("source cannot carry a frame identity binding")
 
 // hubLoopbackPump feeds one v4l2loopback node from the producer hub and records
 // the identity binding for every frame it writes.
@@ -68,11 +81,35 @@ type hubLoopbackPump struct {
 	// reads it concurrently.
 	bindings *loopbackBindingTable
 
-	// mu guards the identity subscriber set.
+	// mu guards the identity subscriber set and the closed flag.
 	mu     sync.Mutex
-	subs   map[int]chan loopbackBinding
+	subs   map[int]*identitySubscriber
 	nextID int
+	// closed marks that Run has returned, so no further identity will ever be
+	// published. Subscribers are closed at that point and a late subscribe
+	// hands back an already-closed channel rather than one that never speaks.
+	closed bool
+	// now is the clock the drop-log rate limiter reads. A field only so a test
+	// can drive the limiter without sleeping.
+	now func() time.Time
 }
+
+// identitySubscriber is one control-plane subscriber's queue plus the state
+// the drop-log rate limiter keeps for it.
+type identitySubscriber struct {
+	ch chan loopbackBinding
+	// dropped counts identities discarded since the last warning about this
+	// subscriber, so the log reports a count rather than one line per frame.
+	dropped  uint64
+	lastWarn time.Time
+}
+
+// identityDropLogInterval bounds how often one subscriber falling behind is
+// logged. Without it a stalled subscriber produces a warning per frame, which
+// at capture rate is tens of lines a second per source and buries everything
+// else in the agent's log. The count accumulated between warnings is reported
+// with each one, so nothing about the loss is hidden by the rate limit.
+const identityDropLogInterval = 10 * time.Second
 
 // identitySubscriberBuffer is the per-subscriber queue depth for the control
 // plane. Identities are a few dozen bytes each, so this is cheap, and the depth
@@ -86,28 +123,60 @@ func newHubLoopbackPump(logger *zap.Logger, sourceID, nodePath string) *hubLoopb
 		sourceID: sourceID,
 		nodePath: nodePath,
 		bindings: newLoopbackBindingTable(loopbackBindingRetention),
-		subs:     map[int]chan loopbackBinding{},
+		subs:     map[int]*identitySubscriber{},
+		now:      time.Now,
 	}
 }
 
 // subscribeIdentities registers a control-plane subscriber and returns its
 // channel plus a cancel function that unregisters and closes it.
+//
+// A subscriber that arrives after the pump has stopped gets an already-closed
+// channel rather than a live one: nothing will ever publish to it, and a
+// subscriber blocked forever on Next would report "no frames" where the honest
+// answer is "this source has no data plane any more".
 func (p *hubLoopbackPump) subscribeIdentities() (<-chan loopbackBinding, func()) {
 	ch := make(chan loopbackBinding, identitySubscriberBuffer)
 	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		close(ch)
+		return ch, func() {}
+	}
 	id := p.nextID
 	p.nextID++
-	p.subs[id] = ch
+	p.subs[id] = &identitySubscriber{ch: ch}
 	p.mu.Unlock()
 
 	var once sync.Once
 	return ch, func() {
 		once.Do(func() {
 			p.mu.Lock()
+			// closeSubscribers may already have closed and removed this one.
+			_, live := p.subs[id]
 			delete(p.subs, id)
 			p.mu.Unlock()
-			close(ch)
+			if live {
+				close(ch)
+			}
 		})
+	}
+}
+
+// closeSubscribers ends every identity subscription and marks the pump closed.
+// Run calls it on the way out: the data plane has stopped, so a subscriber
+// still waiting on Next must be told rather than left hanging on a channel
+// nobody will write to again.
+func (p *hubLoopbackPump) closeSubscribers() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return
+	}
+	p.closed = true
+	for id, sub := range p.subs {
+		delete(p.subs, id)
+		close(sub.ch)
 	}
 }
 
@@ -123,12 +192,21 @@ func (p *hubLoopbackPump) subscribeIdentities() (<-chan loopbackBinding, func())
 func (p *hubLoopbackPump) publishIdentity(b loopbackBinding) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	for id, ch := range p.subs {
+	for id, sub := range p.subs {
 		select {
-		case ch <- b:
+		case sub.ch <- b:
 		default:
-			p.logger.Warn("two-plane: frame identity subscriber is behind; dropping an identity",
-				zap.String("source", p.sourceID), zap.Int("subscriber", id))
+			// A stalled subscriber drops at frame rate, so the warning is rate
+			// limited and carries the count accumulated since the last one.
+			sub.dropped++
+			now := p.now()
+			if !sub.lastWarn.IsZero() && now.Sub(sub.lastWarn) < identityDropLogInterval {
+				continue
+			}
+			p.logger.Warn("two-plane: frame identity subscriber is behind; dropping identities",
+				zap.String("source", p.sourceID), zap.Int("subscriber", id),
+				zap.Uint64("dropped_since_last_warning", sub.dropped))
+			sub.dropped, sub.lastWarn = 0, now
 		}
 	}
 }
@@ -160,6 +238,10 @@ var errLoopbackHubRestarted = errors.New("producer hub restarted by episode capt
 // its picture size in the bitstream's own parameter sets (see
 // hub_loopback_writer.go), so the writer stays open across the restart.
 func (p *hubLoopbackPump) Run(ctx context.Context, svc *VideoService, src videoSource, devID uint32) error {
+	// Whatever ends the pump, the control plane must learn of it: a subscriber
+	// waiting on Next would otherwise hang on a channel nothing writes to
+	// again, and a later subscriber would join a pump that has already stopped.
+	defer p.closeSubscribers()
 	writer, err := openLoopbackFrameWriter(p.nodePath)
 	if err != nil {
 		return fmt.Errorf("opening loopback node %s: %w", p.nodePath, err)
@@ -264,7 +346,7 @@ func (p *hubLoopbackPump) pumpFrom(ctx context.Context, hub *deviceHub, subID in
 					zap.String("source", p.sourceID),
 					zap.String("node", p.nodePath),
 					zap.String("reason", reason))
-				return 0, fmt.Errorf("source %s: %s", p.sourceID, reason)
+				return 0, fmt.Errorf("%w: %s: %s", errSourceNotBindable, p.sourceID, reason)
 			}
 
 			if awaitRandomAccess {

--- a/go/internal/agent/services/hub_loopback_pump_test.go
+++ b/go/internal/agent/services/hub_loopback_pump_test.go
@@ -8,7 +8,15 @@ import (
 
 	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
+
+// observedLogger returns a logger whose entries a test can read back.
+func observedLogger() (*zap.Logger, *observer.ObservedLogs) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	return zap.New(core), logs
+}
 
 // fakeLoopbackWriter stands in for the v4l2loopback node.
 //
@@ -553,5 +561,121 @@ func TestPumpReportsCarriedLossesOnFirstBinding(t *testing.T) {
 	}
 	if binding.HubDropsBefore != 4 {
 		t.Fatalf("HubDropsBefore = %d, want the 4 carried losses", binding.HubDropsBefore)
+	}
+}
+
+// A refused source must be refused by NAME, so the node lifecycle can tell a
+// permanent property of the producer's pipeline from a transient fault and
+// stop rebuilding a data path that cannot work.
+func TestPumpRefusalNamesAnUnbindableSource(t *testing.T) {
+	hub, subID, frames := newPumpTestHub(t)
+	writer := newFakeLoopbackWriter(1)
+	pump := newHubLoopbackPump(zap.NewNop(), "ipcamera:200", "/dev/video200")
+
+	frames <- &videoFrame{
+		data:      []byte{1, 2, 3},
+		codec:     agentpb.VideoCodec_VIDEO_CODEC_H264,
+		auAligned: false,
+		sampleID:  1,
+	}
+	err := pump.pump(context.Background(), hub, subID, frames, writer)
+	if !errors.Is(err, errSourceNotBindable) {
+		t.Fatalf("pump returned %v, want an error wrapping errSourceNotBindable", err)
+	}
+}
+
+// A subscriber waiting on Next must be told when the pump stops. Its channel
+// was previously closed only by its own cancel, so a subscription outliving
+// the pump waited forever on a channel nothing would ever write to again.
+func TestIdentitySubscriberEndsWhenThePumpStops(t *testing.T) {
+	svc := newTestVideoService(nil, nil)
+	installFakeProducers(svc)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	restore := openLoopbackFrameWriter
+	openLoopbackFrameWriter = func(string) (loopbackFrameWriter, error) { return newFakeLoopbackWriter(1), nil }
+	defer func() { openLoopbackFrameWriter = restore }()
+
+	pump := newHubLoopbackPump(zap.NewNop(), "v4l2:/dev/video0", "/dev/video200")
+	ch, cancelSub := pump.subscribeIdentities()
+	defer cancelSub()
+
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- pump.Run(ctx, svc, videoSource{kind: sourceV4L2, key: "/dev/video0", path: "/dev/video0"}, 0)
+	}()
+
+	sub := &pumpIdentitySubscription{sourceID: "v4l2:/dev/video0", nodePath: "/dev/video200", ch: ch, cancel: cancelSub}
+	next := make(chan error, 1)
+	go func() {
+		_, err := sub.Next(context.Background())
+		next <- err
+	}()
+
+	// Stopping the pump must wake the subscriber rather than leave it blocked.
+	cancel()
+	select {
+	case err := <-next:
+		if !errors.Is(err, errNoDataPlane) {
+			t.Fatalf("Next returned %v, want errNoDataPlane once the pump stopped", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Next never returned after the pump stopped; the subscriber hangs forever")
+	}
+	<-runDone
+
+	// A subscriber that arrives after the pump has stopped gets the same
+	// answer immediately instead of a channel nobody will write to.
+	late, cancelLate := pump.subscribeIdentities()
+	defer cancelLate()
+	select {
+	case _, ok := <-late:
+		if ok {
+			t.Fatal("a late subscriber received an identity from a stopped pump")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("a late subscriber's channel is open on a stopped pump")
+	}
+}
+
+// A stalled subscriber drops at frame rate. The warning must be rate limited
+// and carry the count, not print one line per lost identity.
+func TestIdentityDropWarningsAreRateLimited(t *testing.T) {
+	logs, observed := observedLogger()
+	pump := newHubLoopbackPump(logs, "v4l2:/dev/video0", "/dev/video200")
+	now := time.Unix(0, 0)
+	pump.now = func() time.Time { return now }
+
+	ch, cancelSub := pump.subscribeIdentities()
+	defer cancelSub()
+	// Fill the subscriber's queue so every further publish drops.
+	for i := 0; i < identitySubscriberBuffer; i++ {
+		pump.publishIdentity(loopbackBinding{LoopbackSequence: uint32(i)})
+	}
+	if len(ch) != identitySubscriberBuffer {
+		t.Fatalf("subscriber queue holds %d, want it full at %d", len(ch), identitySubscriberBuffer)
+	}
+	for i := 0; i < 500; i++ {
+		pump.publishIdentity(loopbackBinding{LoopbackSequence: uint32(i)})
+	}
+	if got := observed.Len(); got != 1 {
+		t.Fatalf("warnings logged = %d, want 1 for 500 dropped identities inside one interval", got)
+	}
+
+	now = now.Add(identityDropLogInterval + time.Second)
+	pump.publishIdentity(loopbackBinding{})
+	if got := observed.Len(); got != 2 {
+		t.Fatalf("warnings logged = %d, want a second one after the interval elapsed", got)
+	}
+	entry := observed.All()[1]
+	var dropped int64
+	for _, f := range entry.Context {
+		if f.Key == "dropped_since_last_warning" {
+			dropped = f.Integer
+		}
+	}
+	if dropped != 500 {
+		t.Fatalf("second warning reports %d dropped, want the 500 accumulated since the first", dropped)
 	}
 }

--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -1616,6 +1616,24 @@ func (s *VideoService) joinHubReportingParams(ctx context.Context, key string, r
 // the wrapped message names the holder and both parameter sets.
 var errCameraHeldExplicitly = errors.New("camera is held at explicitly requested stream parameters")
 
+// errCameraReleaseTimeout is the named refusal for a capture takeover whose
+// outgoing producer did not release the device within hubTeardownTimeout.
+// Starting the replacement anyway is worse than refusing: the old producer
+// still holds the file descriptor, VIDIOC_S_FMT returns EBUSY, and the
+// replacement hub fails to produce anything at all, so every parameter-less
+// subscriber that reattached to it loses the camera as well as the campaign
+// losing its capture. Refusing costs this one campaign source its clip and
+// leaves the running stream untouched.
+var errCameraReleaseTimeout = errors.New("camera did not release in time for a capture takeover")
+
+// isCameraCaptureRefusal reports whether err is one of the named camera
+// refusals a campaign records in its manifest instead of failing the whole
+// episode. Both mean "this one source was not captured, and here is exactly
+// why"; neither means the episode is broken.
+func isCameraCaptureRefusal(err error) bool {
+	return errors.Is(err, errCameraHeldExplicitly) || errors.Is(err, errCameraReleaseTimeout)
+}
+
 // joinHubForCapture is the episode-capture join. It implements the parameter
 // priority the capture policy promises:
 //
@@ -1765,7 +1783,20 @@ func (s *VideoService) takeOverDefaultedHub(ctx context.Context, key string, req
 			abort()
 			return nil, 0, nil, false, ctx.Err()
 		}
-		s.logger.Warn("timed out waiting for hub teardown before capture takeover", zap.String("device", key))
+		// The old producer still holds the device. Starting the replacement now
+		// would bind nothing (EBUSY on VIDIOC_S_FMT) and take the camera away
+		// from every parameter-less subscriber that reattached to the hub
+		// installed above, so the takeover is abandoned instead: abort() puts
+		// the subscribers back on the "producer stopped" path rather than
+		// leaving them on a hub whose producer will never start, and the
+		// campaign gets a named refusal for its manifest.
+		waitCancel()
+		abort()
+		s.logger.Warn("abandoning capture takeover: camera did not release in time",
+			zap.String("device", key), zap.Duration("waited", hubTeardownTimeout))
+		return nil, 0, nil, false, fmt.Errorf(
+			"%w: %s was still held by the previous producer after %s; refusing to start a replacement that cannot bind the device",
+			errCameraReleaseTimeout, key, hubTeardownTimeout)
 	}
 	waitCancel()
 
@@ -2244,8 +2275,12 @@ func (s *VideoService) pumpFrames(stream grpc.ServerStreamingServer[agentpb.Vide
 				// sequence parameter sets into it mid-timeline; the client
 				// reconnects and joins the restarted producer as a new stream.
 				if h.wasRestarted() {
-					return status.Errorf(codes.Unavailable,
-						"video stream ended: episode capture restarted the camera producer at the campaign's requested parameters; reconnect to join the new stream")
+					// Machine-readable so a client can tell this apart from
+					// every other Unavailable and rejoin by itself; the CLI's
+					// `camera view` does exactly that.
+					return streamreason.New(codes.Unavailable,
+						"video stream ended: episode capture restarted the camera producer at the campaign's requested parameters; reconnect to join the new stream",
+						streamreason.CameraProducerRestarted, nil)
 				}
 				// If the hub context was cancelled (e.g. service shutdown), propagate that.
 				if err := h.ctx.Err(); err != nil {

--- a/go/internal/agent/services/video_service_takeover_test.go
+++ b/go/internal/agent/services/video_service_takeover_test.go
@@ -344,3 +344,76 @@ func hubSubscriberCount(h *deviceHub) int {
 	defer h.mu.Unlock()
 	return len(h.subs)
 }
+
+// installSlowProducers is installFakeProducers whose teardown takes longer
+// than hubTeardownTimeout, standing in for a producer still holding the device
+// file descriptor when the takeover's wait expires.
+func installSlowProducers(svc *VideoService, teardown time.Duration) *fakeProducers {
+	fp := &fakeProducers{}
+	svc.startProducer = func(ctx context.Context, h *deviceHub, path string, req *agentpb.StreamVideoRequest) {
+		fp.mu.Lock()
+		fp.started = append(fp.started, req)
+		fp.hubs = append(fp.hubs, h)
+		fp.mu.Unlock()
+		go func() {
+			<-ctx.Done()
+			time.Sleep(teardown)
+			svc.mu.Lock()
+			if svc.hubs[path] == h {
+				delete(svc.hubs, path)
+			}
+			svc.mu.Unlock()
+			h.mu.Lock()
+			for _, sub := range h.subs {
+				if !sub.closed {
+					sub.closed = true
+					close(sub.ch)
+				}
+			}
+			h.mu.Unlock()
+			close(h.done)
+		}()
+	}
+	return fp
+}
+
+// A takeover whose outgoing producer does not release the device in time must
+// be abandoned with a named refusal. Starting the replacement anyway would
+// fail to bind (EBUSY) and take the camera from every parameter-less
+// subscriber that had reattached to the replacement hub.
+func TestTakeoverAbortsWhenTheCameraDoesNotReleaseInTime(t *testing.T) {
+	svc := newTestVideoService(nil, nil)
+	fp := installSlowProducers(svc, 2*hubTeardownTimeout)
+	ctx := context.Background()
+
+	oldHub, sensorID, _, err := svc.joinHub(ctx, "/dev/video0", &agentpb.StreamVideoRequest{DeviceId: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer oldHub.unsubscribe(sensorID)
+
+	req := &agentpb.StreamVideoRequest{DeviceId: 0, Width: 640, Height: 480, Framerate: 15}
+	_, _, _, _, _, _, _, err = svc.joinHubForCapture(ctx, "/dev/video0", req)
+	if !errors.Is(err, errCameraReleaseTimeout) {
+		t.Fatalf("takeover returned %v, want a refusal wrapping errCameraReleaseTimeout", err)
+	}
+	if !isCameraCaptureRefusal(err) {
+		t.Fatal("the refusal is not one the campaign records in its manifest")
+	}
+	if !strings.Contains(err.Error(), "/dev/video0") {
+		t.Fatalf("refusal does not name the camera: %v", err)
+	}
+	// Exactly one producer was ever started: no replacement was launched
+	// against a device the old producer still holds.
+	if got := fp.count(); got != 1 {
+		t.Fatalf("producers started = %d, want 1: a replacement was started for a device that had not been released", got)
+	}
+	// The abandoned replacement hub must not be left in the map for a
+	// reattaching subscriber to join.
+	svc.mu.Lock()
+	_, stillMapped := svc.hubs["/dev/video0"]
+	svc.mu.Unlock()
+	if stillMapped {
+		t.Fatal("the abandoned replacement hub was left registered for the device")
+	}
+}

--- a/go/internal/agent/services/video_service_two_plane.go
+++ b/go/internal/agent/services/video_service_two_plane.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
 	"sync"
 
 	"go.uber.org/zap"
@@ -11,6 +13,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/wendylabsinc/wendy/go/internal/agent/ipcam"
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
 )
 
 // The two-plane data path's node and pump lifecycle.
@@ -73,9 +76,18 @@ type twoPlaneNode struct {
 // Demand is not per-source, matching the existing camera loopback behaviour: the
 // entitlements are device-wide, not per-device-node.
 func (s *VideoService) SetTwoPlaneContainerConsumers(ctx context.Context, containerIDs []string) {
+	fingerprint := consumerFingerprint(containerIDs)
 	s.twoPlaneMu.Lock()
 	s.twoPlaneDemand = len(containerIDs) > 0
 	demand := s.twoPlaneDemand
+	if s.twoPlaneConsumers != fingerprint {
+		// A different set of entitled containers is a different question, so
+		// earlier refusals stop counting: the new consumer deserves one honest
+		// attempt at every source rather than inheriting a verdict reached for
+		// somebody else.
+		s.twoPlaneConsumers = fingerprint
+		s.twoPlaneRefused = nil
+	}
 	s.twoPlaneMu.Unlock()
 
 	if !demand {
@@ -101,11 +113,26 @@ func (s *VideoService) ensureTwoPlaneForLocalCameras(ctx context.Context) {
 		s.logger.Warn("two-plane: listing cameras failed", zap.Error(err))
 		return
 	}
+	local := make([]*agentpb.VideoDevice, 0, len(devices))
+	candidates := make([]string, 0, len(devices))
 	for _, dev := range devices {
 		if dev.GetId() >= uint32(ipcam.IDBandStart) {
 			continue // a network camera, served by the existing loopback path
 		}
+		local = append(local, dev)
+		candidates = append(candidates, "v4l2:"+dev.GetPath())
+	}
+	s.forgetStaleTwoPlaneRefusals(candidates)
+
+	for _, dev := range local {
 		sourceID := "v4l2:" + dev.GetPath()
+		if s.twoPlaneSourceRefused(sourceID) {
+			// The pump already refused this source's frames as unbindable, and
+			// that is a property of the producer's pipeline rather than a
+			// transient fault. Recreating the node every sweep would start and
+			// tear down the camera pipeline forever, producing nothing.
+			continue
+		}
 		if err := s.ensureTwoPlaneNode(ctx, sourceID, dev.GetId()); err != nil {
 			s.logger.Warn("two-plane: starting data path failed",
 				zap.String("source", sourceID), zap.Error(err))
@@ -113,9 +140,69 @@ func (s *VideoService) ensureTwoPlaneForLocalCameras(ctx context.Context) {
 	}
 }
 
+// consumerFingerprint reduces a set of container IDs to one comparable string,
+// order-independent, so a re-ordered but unchanged set is not read as a change.
+func consumerFingerprint(containerIDs []string) string {
+	ids := append([]string(nil), containerIDs...)
+	sort.Strings(ids)
+	return strings.Join(ids, "\x00")
+}
+
+// twoPlaneSourceRefused reports whether the pump has already refused this
+// source's frames as unbindable.
+func (s *VideoService) twoPlaneSourceRefused(sourceID string) bool {
+	s.twoPlaneMu.Lock()
+	defer s.twoPlaneMu.Unlock()
+	return s.twoPlaneRefused[sourceID]
+}
+
+// noteTwoPlaneRefusal records that a source's pump refused its frames, so
+// later sweeps skip it instead of rebuilding a data path that cannot work.
+func (s *VideoService) noteTwoPlaneRefusal(sourceID string) {
+	s.twoPlaneMu.Lock()
+	defer s.twoPlaneMu.Unlock()
+	if s.twoPlaneRefused == nil {
+		s.twoPlaneRefused = map[string]bool{}
+	}
+	s.twoPlaneRefused[sourceID] = true
+}
+
+// forgetStaleTwoPlaneRefusals drops refusals for sources the current device
+// list no longer offers. A camera that was unplugged and plugged back in, or
+// replaced by a different one on the same node, is a new producer and gets a
+// fresh attempt; a source still present keeps its verdict.
+func (s *VideoService) forgetStaleTwoPlaneRefusals(present []string) {
+	s.twoPlaneMu.Lock()
+	defer s.twoPlaneMu.Unlock()
+	if len(s.twoPlaneRefused) == 0 {
+		return
+	}
+	live := make(map[string]bool, len(present))
+	for _, id := range present {
+		live[id] = true
+	}
+	for id := range s.twoPlaneRefused {
+		if !live[id] {
+			delete(s.twoPlaneRefused, id)
+		}
+	}
+}
+
 // ensureTwoPlaneNode allocates a node and starts its pump for one source, if it
 // does not already have one running.
+//
+// Node creation is serialised across sources by twoPlaneStartMu. The aux node
+// number comes from the loopback module's own free-number search, which cannot
+// see a number this service has picked but not yet created: two concurrent
+// sweeps would be handed the SAME number, both create it, and the second one
+// to fail its map insertion would remove the node the first is pumping into.
+// Serialising the allocate-and-create step is what makes the number reservation
+// atomic. The lock is never held while twoPlaneMu is held, and node creation is
+// rare and off the frame path, so the cost is nil.
 func (s *VideoService) ensureTwoPlaneNode(ctx context.Context, sourceID string, devID uint32) error {
+	s.twoPlaneStartMu.Lock()
+	defer s.twoPlaneStartMu.Unlock()
+
 	s.twoPlaneMu.Lock()
 	if s.twoPlane == nil {
 		s.twoPlane = map[string]*twoPlaneNode{}
@@ -150,8 +237,10 @@ func (s *VideoService) ensureTwoPlaneNode(ctx context.Context, sourceID string, 
 	node := &twoPlaneNode{pump: pump, cancel: cancel, done: make(chan struct{}), nodeNr: nodeNr, path: path}
 
 	s.twoPlaneMu.Lock()
-	if _, running := s.twoPlane[sourceID]; running {
-		// Lost a race with a concurrent nudge; the other one owns the node.
+	if !s.twoPlaneDemand {
+		// Demand was withdrawn while the node was being created, and
+		// stopAllTwoPlane has already passed over a map this node was not in
+		// yet. Undo the creation here rather than leaving an unowned node.
 		s.twoPlaneMu.Unlock()
 		cancel()
 		s.loopback.RemoveAuxNode(nodeNr)
@@ -165,12 +254,16 @@ func (s *VideoService) ensureTwoPlaneNode(ctx context.Context, sourceID string, 
 		err := pump.Run(pumpCtx, s, src, devID)
 		if err != nil && !errors.Is(err, context.Canceled) {
 			// A pump that stops on its own is not retried here. The usual reason
-			// is frameBindableToLoopback refusing the source, which will refuse it
-			// again on every retry, so a retry loop would spin producing nothing.
-			// The node is left in place but idle, and the source reports no data
-			// plane, which is the honest state.
+			// is frameBindableToLoopback refusing the source, which will refuse
+			// it again on every retry, so a retry loop would spin producing
+			// nothing. The node and its pump are torn down below and the source
+			// reports no data plane, which is the honest state; a refusal is
+			// remembered so the next sweep does not rebuild the whole thing.
 			s.logger.Warn("two-plane: pump stopped",
 				zap.String("source", sourceID), zap.String("node", path), zap.Error(err))
+			if errors.Is(err, errSourceNotBindable) {
+				s.noteTwoPlaneRefusal(sourceID)
+			}
 		}
 		s.twoPlaneMu.Lock()
 		if cur, ok := s.twoPlane[sourceID]; ok && cur == node {
@@ -272,4 +365,16 @@ type twoPlaneState struct {
 	twoPlaneMu     sync.Mutex
 	twoPlane       map[string]*twoPlaneNode
 	twoPlaneDemand bool
+	// twoPlaneRefused names sources whose pump refused their frames as
+	// unbindable. Guarded by twoPlaneMu. Cleared when the entitled consumer set
+	// changes or when a source leaves the device list, the two events that can
+	// make the verdict wrong; otherwise it stands, because the reason for a
+	// refusal is a fixed property of the producer's pipeline.
+	twoPlaneRefused map[string]bool
+	// twoPlaneConsumers fingerprints the entitled container set the refusals
+	// above were reached under. Guarded by twoPlaneMu.
+	twoPlaneConsumers string
+	// twoPlaneStartMu serialises node allocation and creation. See
+	// ensureTwoPlaneNode for why the allocation cannot be left unsynchronised.
+	twoPlaneStartMu sync.Mutex
 }

--- a/go/internal/agent/services/video_service_two_plane_test.go
+++ b/go/internal/agent/services/video_service_two_plane_test.go
@@ -1,0 +1,128 @@
+package services
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	agentpb "github.com/wendylabsinc/wendy/go/proto/gen/agentpb"
+	"go.uber.org/zap"
+)
+
+// newTwoPlaneTestService builds a VideoService that enumerates exactly one
+// local camera and whose loopback is a recording double, with a hub already
+// running for that camera so a pump joins it instead of opening a device.
+func newTwoPlaneTestService(t *testing.T) (*VideoService, *fakeLoopback, *deviceHub) {
+	t.Helper()
+	video := NewVideoService(context.Background(), zap.NewNop())
+	loop := newFakeLoopback()
+	video.loopback = loop
+	video.globDevices = func() ([]string, error) { return []string{"/dev/video0"}, nil }
+	video.hasVideoCapture = func(string) bool { return true }
+	video.readDeviceName = func(string) (string, error) { return "test camera", nil }
+	video.readStableNames = func() map[string]stableNames { return nil }
+	hub, _ := newDefaultHub(t, video, "/dev/video0")
+
+	original := openLoopbackFrameWriter
+	t.Cleanup(func() { openLoopbackFrameWriter = original })
+	openLoopbackFrameWriter = func(string) (loopbackFrameWriter, error) {
+		return newFakeLoopbackWriter(9), nil
+	}
+	t.Cleanup(video.stopAllTwoPlane)
+	return video, loop, hub
+}
+
+func (f *fakeLoopback) auxCreatedCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.auxCreated)
+}
+
+// waitFor polls until cond holds, failing the test if it never does. The
+// two-plane lifecycle runs on its own goroutine, so every assertion about it
+// is an assertion about a state the sweep eventually reaches.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// A source whose pump refuses its frames must not have its node rebuilt on the
+// next sweep. Before the refusal was remembered, ensureTwoPlaneForLocalCameras
+// recreated the node every minute and on every container lifecycle nudge, so
+// the camera pipeline was started and torn down forever.
+func TestTwoPlaneRefusedSourceIsNotRecreated(t *testing.T) {
+	video, loop, hub := newTwoPlaneTestService(t)
+	ctx := context.Background()
+
+	video.SetTwoPlaneContainerConsumers(ctx, []string{"container-a"})
+	waitFor(t, "the first node to be created", func() bool { return loop.auxCreatedCount() == 1 })
+	// The pump joins the hub on its own goroutine; a frame produced before it
+	// subscribes would simply never reach it.
+	waitFor(t, "the pump to join the hub", func() bool { return hubSubscriberCount(hub) == 2 })
+
+	// A byte-chunked frame: whole access units are what a binding needs, so
+	// frameBindableToLoopback refuses this source permanently.
+	hub.produce(&videoFrame{
+		data:      []byte{0, 0, 0, 1, 0x65, 0x11},
+		codec:     agentpb.VideoCodec_VIDEO_CODEC_H264,
+		auAligned: false,
+	})
+	waitFor(t, "the refusal to be recorded", func() bool {
+		return video.twoPlaneSourceRefused("v4l2:/dev/video0")
+	})
+
+	// The minute sweep and every container lifecycle nudge land here.
+	video.ensureTwoPlaneForLocalCameras(ctx)
+	video.ensureTwoPlaneForLocalCameras(ctx)
+	if got := loop.auxCreatedCount(); got != 1 {
+		t.Fatalf("aux nodes created = %d, want 1: a refused source was rebuilt by a later sweep", got)
+	}
+
+	// A different entitled container set is a different question, so the
+	// refusal stops standing and the source gets one honest attempt again.
+	video.SetTwoPlaneContainerConsumers(ctx, []string{"container-b"})
+	waitFor(t, "the node to be rebuilt for a new consumer set", func() bool {
+		return loop.auxCreatedCount() == 2
+	})
+}
+
+// Two concurrent sweeps must not both allocate the same aux node number: the
+// loser used to remove the node the winner was pumping into.
+func TestTwoPlaneConcurrentSweepsAllocateOneNode(t *testing.T) {
+	video, loop, _ := newTwoPlaneTestService(t)
+	ctx := context.Background()
+	video.twoPlaneMu.Lock()
+	video.twoPlaneDemand = true
+	video.twoPlaneMu.Unlock()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			video.ensureTwoPlaneForLocalCameras(ctx)
+		}()
+	}
+	wg.Wait()
+
+	if got := loop.auxCreatedCount(); got != 1 {
+		t.Fatalf("aux nodes created = %d, want exactly 1 across concurrent sweeps", got)
+	}
+	loop.mu.Lock()
+	removed := len(loop.auxRemoved)
+	loop.mu.Unlock()
+	if removed != 0 {
+		t.Fatalf("aux nodes removed = %d, want 0: a losing sweep tore down the winner's node", removed)
+	}
+	if _, ok := video.TwoPlaneNodePath("v4l2:/dev/video0"); !ok {
+		t.Fatal("no node is registered for the source after the sweeps")
+	}
+}

--- a/go/internal/agent/services/video_service_two_plane_test.go
+++ b/go/internal/agent/services/video_service_two_plane_test.go
@@ -39,10 +39,10 @@ func (f *fakeLoopback) auxCreatedCount() int {
 	return len(f.auxCreated)
 }
 
-// waitFor polls until cond holds, failing the test if it never does. The
+// waitUntilTwoPlane polls until cond holds, failing the test if it never does. The
 // two-plane lifecycle runs on its own goroutine, so every assertion about it
 // is an assertion about a state the sweep eventually reaches.
-func waitFor(t *testing.T, what string, cond func() bool) {
+func waitUntilTwoPlane(t *testing.T, what string, cond func() bool) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
@@ -63,10 +63,10 @@ func TestTwoPlaneRefusedSourceIsNotRecreated(t *testing.T) {
 	ctx := context.Background()
 
 	video.SetTwoPlaneContainerConsumers(ctx, []string{"container-a"})
-	waitFor(t, "the first node to be created", func() bool { return loop.auxCreatedCount() == 1 })
+	waitUntilTwoPlane(t, "the first node to be created", func() bool { return loop.auxCreatedCount() == 1 })
 	// The pump joins the hub on its own goroutine; a frame produced before it
 	// subscribes would simply never reach it.
-	waitFor(t, "the pump to join the hub", func() bool { return hubSubscriberCount(hub) == 2 })
+	waitUntilTwoPlane(t, "the pump to join the hub", func() bool { return hubSubscriberCount(hub) == 2 })
 
 	// A byte-chunked frame: whole access units are what a binding needs, so
 	// frameBindableToLoopback refuses this source permanently.
@@ -75,7 +75,7 @@ func TestTwoPlaneRefusedSourceIsNotRecreated(t *testing.T) {
 		codec:     agentpb.VideoCodec_VIDEO_CODEC_H264,
 		auAligned: false,
 	})
-	waitFor(t, "the refusal to be recorded", func() bool {
+	waitUntilTwoPlane(t, "the refusal to be recorded", func() bool {
 		return video.twoPlaneSourceRefused("v4l2:/dev/video0")
 	})
 
@@ -89,7 +89,7 @@ func TestTwoPlaneRefusedSourceIsNotRecreated(t *testing.T) {
 	// A different entitled container set is a different question, so the
 	// refusal stops standing and the source gets one honest attempt again.
 	video.SetTwoPlaneContainerConsumers(ctx, []string{"container-b"})
-	waitFor(t, "the node to be rebuilt for a new consumer set", func() bool {
+	waitUntilTwoPlane(t, "the node to be rebuilt for a new consumer set", func() bool {
 		return loop.auxCreatedCount() == 2
 	})
 }

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
@@ -150,7 +150,21 @@ now.
 source, a buffer and explicit stream parameters are mutually exclusive in this
 release: a buffered camera is armed into a standby subscription that asserts no
 stream parameters, so it never takes a running camera away from a viewer and
-never changes the stream parameters part way through a clip. A source that sets
+never changes the stream parameters part way through a clip.
+
+There is exactly one exception to that promise, and it belongs to the other
+half of the same rule. A capture that *does* name explicit stream parameters
+(`max_resolution` or `rate`, with no buffer) restarts the camera producer at
+those parameters when the only consumers holding it asked for nothing in
+particular. Those parameter-less consumers, a plain `wendy device camera view`
+among them, have their stream ended rather than spliced onto the new stream:
+the replacement producer emits a new sequence parameter set, and a decoder
+handed both in one timeline produces garbage. The agent marks the ended stream
+with the machine-readable reason `CAMERA_PRODUCER_RESTARTED`, and
+`wendy device camera view` rejoins the replacement stream automatically,
+printing one line when it does. A consumer that named its own stream
+parameters is never taken over; a campaign that conflicts with it is refused
+and says so in the episode manifest. A source that sets
 both a buffer and an explicit `max_resolution` or `rate` therefore records both
 its pre-roll and its live tail at whatever parameters the producer is already
 running, and the explicit values are reported as requested but not achieved in

--- a/go/internal/cli/assets/docs/hardware/camera.mdx
+++ b/go/internal/cli/assets/docs/hardware/camera.mdx
@@ -41,6 +41,14 @@ If you want to pipe the encoded stream instead of opening a local preview window
 wendy device camera view --id 0 --stdout
 ```
 
+A view that names no `--width`, `--height` or `--fps` joins the camera at
+whatever it is already doing, and an episode capture whose campaign does name
+stream parameters may restart the producer under it. The stream is ended rather
+than spliced, because the replacement producer emits a new sequence parameter
+set; `camera view` then rejoins the new stream by itself and prints one line
+saying so. Naming stream parameters yourself makes the view a holder that no
+campaign can take over.
+
 For broad hardware inspection, filter the device capability list:
 
 ```bash

--- a/go/internal/cli/commands/camera.go
+++ b/go/internal/cli/commands/camera.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -401,18 +402,20 @@ func newCameraStreamCmd(use string, hidden bool) *cobra.Command {
 			// not while constructing the stream. Wrap both phases so a missing IP
 			// camera login is resolved and retried exactly once wherever gRPC
 			// surfaces it. Local cameras never take this path.
-			stream, err := streamVideoWithCredentialRetry(startStream, resolveCredentials)
-			if err != nil {
-				return fmt.Errorf("starting video stream: %w", cameraStreamDiagnostic(err))
+			open := func() (videoStream, error) {
+				stream, err := streamVideoWithCredentialRetry(startStream, resolveCredentials)
+				if err != nil {
+					return nil, err
+				}
+				return &cameraDiagnosticStream{videoStream: stream}, nil
 			}
-			diagnosticStream := &cameraDiagnosticStream{videoStream: stream}
-
-			cliLogln("Streaming video (Ctrl+C to stop)...")
-
-			if toStdout {
-				return pipeVideoToStdout(diagnosticStream, cmd.OutOrStdout())
+			play := func(stream videoStream) error {
+				if toStdout {
+					return pipeVideoToStdout(stream, cmd.OutOrStdout())
+				}
+				return playVideoWithGStreamer(ctx, stream)
 			}
-			return playVideoWithGStreamer(ctx, diagnosticStream)
+			return streamCameraRejoiningRestarts(ctx, open, play)
 		},
 	}
 
@@ -426,6 +429,58 @@ func newCameraStreamCmd(use string, hidden bool) *cobra.Command {
 	cmd.Flags().BoolVar(&raw, "raw", false, "With --stdout: write the camera's uncompressed capture frames (one whole frame per message, layout printed to stderr) instead of encoded video. Only cameras captured in a raw pixel format offer this; viewers of the same camera keep receiving H.264.")
 
 	return cmd
+}
+
+// cameraRejoinDelay is how long the viewer waits before rejoining a camera
+// whose producer an episode capture restarted. It is a pause, not a backoff:
+// the replacement producer is started by the agent as part of the same
+// takeover, so the camera is normally back within one pipeline start. The wait
+// only keeps the client from arriving before the new hub exists.
+const cameraRejoinDelay = 500 * time.Millisecond
+
+// cameraRejoinAttempts bounds the rejoins one `camera view` will make. A
+// takeover is a rare event driven by a campaign trigger; a stream that keeps
+// being restarted is a device busy recording, and saying so beats reconnecting
+// forever in a loop the operator has to notice and break.
+const cameraRejoinAttempts = 5
+
+// streamCameraRejoiningRestarts plays a camera stream, rejoining when the
+// agent ends it because an episode capture restarted the producer.
+//
+// The agent's capture policy takes a camera over only from viewers that
+// asserted no stream parameters, and `wendy camera view` with no --width,
+// --height or --fps is exactly such a viewer. The stream is deliberately ended
+// rather than spliced, because a new producer means a new sequence parameter
+// set and a decoder handed both in one timeline produces garbage. Ending it is
+// therefore right; leaving the operator staring at a dead window is not, so
+// the viewer rejoins the replacement stream and says that it did.
+func streamCameraRejoiningRestarts(ctx context.Context, open func() (videoStream, error), play func(videoStream) error) error {
+	for attempt := 0; ; attempt++ {
+		stream, err := open()
+		if err != nil {
+			return fmt.Errorf("starting video stream: %w", cameraStreamDiagnostic(err))
+		}
+		if attempt == 0 {
+			cliLogln("Streaming video (Ctrl+C to stop)...")
+		}
+		err = play(stream)
+		if !streamreason.Has(err, streamreason.CameraProducerRestarted) {
+			return err
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if attempt+1 >= cameraRejoinAttempts {
+			return fmt.Errorf("camera producer was restarted by episode capture %d times; the device is busy recording: %w",
+				cameraRejoinAttempts, err)
+		}
+		cliLogln("Camera producer restarted by an episode capture; rejoining the new stream...")
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(cameraRejoinDelay):
+		}
+	}
 }
 
 // videoStream is the receive side of the StreamVideo gRPC stream.

--- a/go/internal/cli/commands/camera_test.go
+++ b/go/internal/cli/commands/camera_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -727,5 +728,98 @@ func TestH264FeedBuffer_TakeBlocksUntilPush(t *testing.T) {
 	}
 	if !bytes.Equal(data, idr) {
 		t.Errorf("take = %v, want %v", data, idr)
+	}
+}
+
+// producerRestartedError is the status the agent returns to a parameter-less
+// viewer whose camera an episode capture took over.
+func producerRestartedError(t *testing.T) error {
+	t.Helper()
+	return streamreason.New(codes.Unavailable,
+		"video stream ended: episode capture restarted the camera producer at the campaign's requested parameters; reconnect to join the new stream",
+		streamreason.CameraProducerRestarted, nil)
+}
+
+// Capture takeover ends a parameter-less viewer's stream on purpose: a new
+// producer means a new sequence parameter set, and splicing both into one
+// timeline would corrupt the decode. `camera view` is parameter-less by
+// default, so it must rejoin rather than leave the operator with a dead
+// window.
+func TestCameraViewRejoinsAfterAProducerRestart(t *testing.T) {
+	opens := 0
+	open := func() (videoStream, error) {
+		opens++
+		if opens == 1 {
+			return &mockVideoStream{err: producerRestartedError(t)}, nil
+		}
+		return &mockVideoStream{frames: []*agentpb.VideoFrame{{Data: []byte("frame")}}}, nil
+	}
+	var played [][]byte
+	play := func(stream videoStream) error {
+		for {
+			frame, err := stream.Recv()
+			if err == io.EOF {
+				return nil
+			}
+			if err != nil {
+				// The real playback paths wrap the receive error; the rejoin
+				// decision must see through that wrapping.
+				return fmt.Errorf("receiving video: %w", err)
+			}
+			played = append(played, frame.GetData())
+		}
+	}
+
+	if err := streamCameraRejoiningRestarts(context.Background(), open, play); err != nil {
+		t.Fatalf("streamCameraRejoiningRestarts: %v", err)
+	}
+	if opens != 2 {
+		t.Fatalf("streams opened = %d, want 2 (the original and the rejoin)", opens)
+	}
+	if len(played) != 1 || string(played[0]) != "frame" {
+		t.Fatalf("frames played = %q, want the one frame from the replacement stream", played)
+	}
+}
+
+// Any other error ends the viewer as before: only the restart is recoverable.
+func TestCameraViewDoesNotRejoinOnOtherErrors(t *testing.T) {
+	opens := 0
+	open := func() (videoStream, error) {
+		opens++
+		return &mockVideoStream{err: status.Error(codes.Unavailable, "device gone")}, nil
+	}
+	play := func(stream videoStream) error {
+		_, err := stream.Recv()
+		return err
+	}
+	if err := streamCameraRejoiningRestarts(context.Background(), open, play); err == nil {
+		t.Fatal("a plain Unavailable was swallowed")
+	}
+	if opens != 1 {
+		t.Fatalf("streams opened = %d, want 1: only a producer restart is rejoined", opens)
+	}
+}
+
+// A device that keeps restarting its producer is busy recording. Say so rather
+// than reconnecting forever.
+func TestCameraViewGivesUpAfterRepeatedRestarts(t *testing.T) {
+	opens := 0
+	open := func() (videoStream, error) {
+		opens++
+		return &mockVideoStream{err: producerRestartedError(t)}, nil
+	}
+	play := func(stream videoStream) error {
+		_, err := stream.Recv()
+		return err
+	}
+	err := streamCameraRejoiningRestarts(context.Background(), open, play)
+	if err == nil {
+		t.Fatal("the viewer rejoined forever instead of reporting a busy device")
+	}
+	if !strings.Contains(err.Error(), "busy recording") {
+		t.Fatalf("error does not say the device is busy recording: %v", err)
+	}
+	if opens != cameraRejoinAttempts {
+		t.Fatalf("streams opened = %d, want %d", opens, cameraRejoinAttempts)
 	}
 }

--- a/go/internal/episodeexport/playable.go
+++ b/go/internal/episodeexport/playable.go
@@ -57,6 +57,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -70,6 +71,19 @@ import (
 // per-sample duration stays inside the 32-bit stts field for any gap short of
 // 71 minutes.
 const playableTimescale = 1_000_000
+
+// maxSampleDurationTicks is the largest per-sample duration the 32-bit stts
+// field can carry. At playableTimescale that is a little over 71 minutes, so a
+// gap between two consecutive index entries longer than this cannot be written
+// and is refused by name rather than silently wrapping to a short duration.
+const maxSampleDurationTicks = int64(math.MaxUint32)
+
+// singleFrameNominalTicks is the display duration given to a clip that holds
+// exactly one frame. Nothing recorded how long a lone frame was shown, and a
+// zero-duration sample makes players report an empty movie, so the frame is
+// held for a nominal thirtieth of a second. It is the only duration in a clip
+// that is not derived from the index, and ClipResult reports it as such.
+const singleFrameNominalTicks = playableTimescale / 30
 
 // PlayableFileName is the derived MP4 written into a camera source directory
 // at seal time by ConvertSourceInPlace. The agent's manifest code and the
@@ -133,6 +147,17 @@ type ClipResult struct {
 	// inter-frame intervals actually written. They differ from each other
 	// whenever the capture rate varied, which is the point.
 	MinInterval, MaxInterval, MeanInterval time.Duration
+	// TimestampInversions counts index entries whose canonical timestamp is
+	// earlier than the entry before them. The index is written in capture
+	// order, which for this device's encoder is coded order, and the remux
+	// preserves that order because reordering coded H.264 frames corrupts the
+	// decode. An inversion therefore means the recorded timing disagrees with
+	// the coded order, and the clip's timing cannot be vouched for.
+	TimestampInversions int
+	// NominalHold is non-zero only for a clip holding exactly one frame, whose
+	// display duration no index entry records; it names the invented duration
+	// so the caller can say the clip's length was not measured.
+	NominalHold time.Duration
 }
 
 // Convert writes one playable MP4 per camera source found under
@@ -217,6 +242,7 @@ func convertSource(episodeDir, sourceDir, indexPath, out string) (ClipResult, er
 	result.SyncSamples = stats.syncSamples
 	result.ParameterSetChanges = stats.parameterSetChanges
 	result.MinInterval, result.MaxInterval, result.MeanInterval = stats.min, stats.max, stats.mean
+	result.NominalHold = stats.nominalHold
 	if err := errors.Join(writeErr, closeErr); err != nil {
 		return result, err
 	}
@@ -238,10 +264,18 @@ type cameraIndexLine struct {
 	Codec                 string `json:"codec"`
 }
 
-// readCameraIndex reads the frame index and returns its H.264 frames sorted by
-// canonical episode time. Lines that are not valid records, which is what the
-// tail of an interrupted episode's index looks like, are counted and skipped
-// rather than guessed at.
+// readCameraIndex reads the frame index and returns its H.264 frames in the
+// order the index records them, which is capture order. Lines that are not
+// valid records, which is what the tail of an interrupted episode's index
+// looks like, are counted and skipped rather than guessed at.
+//
+// The order is deliberately left alone. Sorting by canonical timestamp would
+// reorder coded H.264 frames whenever two timestamps invert, and an inter
+// frame moved before the picture it references decodes to garbage from that
+// point on. Capture order is coded order, so it is preserved and an inversion
+// is counted instead: buildMoov clamps the resulting negative delta to zero so
+// the container stays well formed, and TimestampInversions tells the caller
+// the timing is not trustworthy.
 func readCameraIndex(path string) ([]cameraIndexLine, ClipResult, error) {
 	var result ClipResult
 	b, err := os.ReadFile(path)
@@ -266,9 +300,11 @@ func readCameraIndex(path string) ([]cameraIndexLine, ClipResult, error) {
 		}
 		frames = append(frames, rec)
 	}
-	sort.SliceStable(frames, func(i, j int) bool {
-		return frames[i].CanonicalEpisodeNanos < frames[j].CanonicalEpisodeNanos
-	})
+	for i := 1; i < len(frames); i++ {
+		if frames[i].CanonicalEpisodeNanos < frames[i-1].CanonicalEpisodeNanos {
+			result.TimestampInversions++
+		}
+	}
 	return frames, result, nil
 }
 
@@ -298,6 +334,9 @@ type muxStats struct {
 	// parameterSetChanges counts SPS/PPS units that differ byte-wise from the
 	// first ones seen; identical repeats before each IDR are not counted.
 	parameterSetChanges int
+	// nominalHold is non-zero only when the clip holds a single frame, whose
+	// display duration was invented rather than read from the index.
+	nominalHold time.Duration
 }
 
 // isBSlice reports whether a VCL NAL unit carries a B slice. It matters
@@ -468,6 +507,9 @@ func muxAnnexBToMP4(w *os.File, episodeDir string, frames []cameraIndexLine) (mu
 		return stats, err
 	}
 	stats.min, stats.max, stats.mean = intervalSpread(durations)
+	if len(durations) == 1 {
+		stats.nominalHold = time.Duration(durations[0]) * (time.Second / playableTimescale)
+	}
 	return stats, nil
 }
 
@@ -526,7 +568,13 @@ func (s *segmentReader) read(frame cameraIndexLine) ([]byte, error) {
 	// this frame. The model-input ledger's payload_bytes can exceed it for a
 	// frame that opens a segment, because the segment begins at the
 	// parameter-set prefix inside that payload rather than at its first byte.
-	if frame.ByteOffset < 0 || frame.ByteOffset+int64(frame.ByteSize) > s.size {
+	//
+	// The three conditions are written without summing offset and size on
+	// purpose: an index naming a byte_size near MaxInt64 would overflow the
+	// sum back into a small positive number, pass the check, and then panic in
+	// make() on an absurd allocation.
+	if frame.ByteOffset < 0 || frame.ByteSize <= 0 ||
+		int64(frame.ByteSize) > s.size || frame.ByteOffset > s.size-int64(frame.ByteSize) {
 		return nil, fmt.Errorf("frame at offset %d size %d exceeds %s (%d bytes on disk)",
 			frame.ByteOffset, frame.ByteSize, frame.Segment, s.size)
 	}
@@ -753,7 +801,18 @@ func buildMoov(samples []sample, sps, pps []byte, width, height int) ([]byte, []
 		if i+1 < len(samples) {
 			d := samples[i+1].timestamp - samples[i].timestamp
 			if d < 0 {
+				// The index recorded two frames out of order. Capture order is
+				// preserved (see readCameraIndex), so the pair is written with
+				// no gap between them rather than with a negative one; the
+				// clip is flagged through ClipResult.TimestampInversions.
 				d = 0
+			}
+			if d > maxSampleDurationTicks {
+				return nil, nil, fmt.Errorf(
+					"gap of %s between consecutive frames exceeds the %s a 32-bit sample duration can carry at %d ticks per second",
+					time.Duration(d)*time.Microsecond,
+					time.Duration(maxSampleDurationTicks)*time.Microsecond,
+					playableTimescale)
 			}
 			durations[i] = uint32(d)
 			continue
@@ -765,7 +824,12 @@ func buildMoov(samples []sample, sps, pps []byte, width, height int) ([]byte, []
 		// the clip's duration still matches the index span to within one frame.
 		if i > 0 {
 			durations[i] = durations[i-1]
+			continue
 		}
+		// A lone frame has no measured interval to borrow either, and a
+		// zero-duration only sample makes players report an empty movie, so it
+		// is held for a nominal thirtieth of a second.
+		durations[i] = singleFrameNominalTicks
 	}
 	var total uint64
 	for _, d := range durations {

--- a/go/internal/episodeexport/playable_test.go
+++ b/go/internal/episodeexport/playable_test.go
@@ -1,12 +1,14 @@
 package episodeexport
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -416,5 +418,158 @@ func TestIsBSlice(t *testing.T) {
 	// caller must be able to tell "no B slices" from "could not tell".
 	if isB, parsed := isBSlice([]byte{0x41}); isB || parsed {
 		t.Errorf("a truncated slice header should report unknown, got isB=%v parsed=%v", isB, parsed)
+	}
+}
+
+// writeSingleSourceEpisode lays out an episode with one camera source whose
+// index holds exactly the given entries, all pointing into one segment built
+// from the payloads. It is the smallest fixture that lets a test choose the
+// canonical timestamps and byte ranges an index records.
+func writeSingleSourceEpisode(t *testing.T, stamps []int64, payloads [][]byte) (dir, sourceDir string) {
+	t.Helper()
+	if len(stamps) != len(payloads) {
+		t.Fatalf("fixture needs one timestamp per payload: %d vs %d", len(stamps), len(payloads))
+	}
+	dir = t.TempDir()
+	sourceDir = filepath.Join(dir, "cameras", "cam")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	type entry struct {
+		CanonicalEpisodeNanos int64  `json:"canonical_episode_nanos"`
+		Segment               string `json:"segment"`
+		ByteOffset            int64  `json:"byte_offset"`
+		ByteSize              int    `json:"byte_size"`
+		Codec                 string `json:"codec"`
+	}
+	var segment, index []byte
+	for i, payload := range payloads {
+		b, _ := json.Marshal(entry{stamps[i], "cameras/cam/segment-000001.h264", int64(len(segment)), len(payload), "h264"})
+		index = append(append(index, b...), '\n')
+		segment = append(segment, payload...)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "segment-000001.h264"), segment, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "index.jsonl"), index, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir, sourceDir
+}
+
+// keyframeAndInter returns one random-access access unit and one inter frame,
+// both built from the real parameter sets.
+func keyframeAndInter(t *testing.T) (key, inter []byte) {
+	t.Helper()
+	sps, pps := mustHex(t, realSPS), mustHex(t, realPPS)
+	return annexB(sps, pps, append([]byte{0x65}, make([]byte, 40)...)),
+		annexB(append([]byte{0x41}, make([]byte, 30)...))
+}
+
+// A gap a 32-bit sample duration cannot carry must be refused by name rather
+// than wrapping silently to a short duration.
+func TestMuxRefusesGapBeyondSampleDurationLimit(t *testing.T) {
+	key, inter := keyframeAndInter(t)
+	// Two frames 80 minutes apart: beyond the 71 minutes and change that fits
+	// in a 32-bit duration at microsecond ticks.
+	gap := int64(80 * time.Minute)
+	dir, sourceDir := writeSingleSourceEpisode(t, []int64{0, gap}, [][]byte{key, inter})
+
+	_, err := ConvertSourceInPlace(dir, sourceDir)
+	if err == nil {
+		t.Fatal("an 80-minute inter-frame gap was muxed; it cannot fit a 32-bit sample duration")
+	}
+	if !strings.Contains(err.Error(), "exceeds") || !strings.Contains(err.Error(), "sample duration") {
+		t.Fatalf("error does not name the limit: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(sourceDir, PlayableFileName)); !os.IsNotExist(statErr) {
+		t.Fatalf("a refused mux left a playable file behind: %v", statErr)
+	}
+}
+
+// Two inverted timestamps must not reorder the coded frames: capture order is
+// kept, the inversion is counted, and the clip is refused at seal time.
+func TestInvertedTimestampsKeepCaptureOrderAndAreCounted(t *testing.T) {
+	key, inter := keyframeAndInter(t)
+	// The third and fourth entries are swapped in time but not in the index.
+	stamps := []int64{0, 10_000_000, 30_000_000, 20_000_000}
+	payloads := [][]byte{key, inter, inter, inter}
+	dir, sourceDir := writeSingleSourceEpisode(t, stamps, payloads)
+
+	frames, result, err := readCameraIndex(filepath.Join(sourceDir, "index.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.TimestampInversions != 1 {
+		t.Fatalf("inversions counted = %d, want 1", result.TimestampInversions)
+	}
+	for i, want := range stamps {
+		if frames[i].CanonicalEpisodeNanos != want {
+			t.Fatalf("frame %d canonical = %d, want %d: capture order was not preserved",
+				i, frames[i].CanonicalEpisodeNanos, want)
+		}
+	}
+
+	clip, err := ConvertSourceInPlace(dir, sourceDir)
+	if err != nil {
+		t.Fatalf("the clip should still be written for the caller to judge: %v", err)
+	}
+	if clip.TimestampInversions != 1 {
+		t.Fatalf("ClipResult inversions = %d, want 1", clip.TimestampInversions)
+	}
+}
+
+// An index naming a byte_size near MaxInt64 must be refused by the bounds
+// check rather than overflowing the sum and panicking in make().
+func TestSegmentReadRefusesByteSizeNearMaxInt64(t *testing.T) {
+	dir := t.TempDir()
+	segDir := filepath.Join(dir, "cameras", "cam")
+	if err := os.MkdirAll(segDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(segDir, "segment-000001.h264"), make([]byte, 64), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := &segmentReader{root: dir, seen: map[string]bool{}}
+	defer s.Close()
+
+	// An offset whose sum with the size wraps back into a small positive
+	// number is the case a naive `offset+size > size-on-disk` check passes.
+	huge := int(int64(1)<<62) + 8
+	for _, frame := range []cameraIndexLine{
+		{Segment: "cameras/cam/segment-000001.h264", ByteOffset: 1 << 62, ByteSize: huge},
+		{Segment: "cameras/cam/segment-000001.h264", ByteOffset: 0, ByteSize: huge},
+		{Segment: "cameras/cam/segment-000001.h264", ByteOffset: -1, ByteSize: 8},
+	} {
+		if _, err := s.read(frame); err == nil {
+			t.Fatalf("read accepted offset %d size %d against a 64-byte segment", frame.ByteOffset, frame.ByteSize)
+		}
+	}
+}
+
+// A clip holding one frame gets a nominal hold rather than a zero-duration
+// sample, and says so.
+func TestSingleFrameClipGetsNominalHold(t *testing.T) {
+	key, _ := keyframeAndInter(t)
+	dir, sourceDir := writeSingleSourceEpisode(t, []int64{7_000_000_000}, [][]byte{key})
+
+	clip, err := ConvertSourceInPlace(dir, sourceDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if clip.Frames != 1 {
+		t.Fatalf("frames written = %d, want 1", clip.Frames)
+	}
+	want := time.Duration(singleFrameNominalTicks) * (time.Second / playableTimescale)
+	if clip.NominalHold != want {
+		t.Fatalf("nominal hold = %s, want %s", clip.NominalHold, want)
+	}
+	// The movie header must report that duration, not zero.
+	b, err := os.ReadFile(clip.Output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(b, u32(uint32(singleFrameNominalTicks))) {
+		t.Fatal("the sample table carries no nominal duration; players would see an empty movie")
 	}
 }

--- a/go/internal/shared/streamreason/streamreason.go
+++ b/go/internal/shared/streamreason/streamreason.go
@@ -19,6 +19,12 @@ const (
 	// uncompressed frames to give (MJPEG or native H.264 capture, a network
 	// camera, one shared through PipeWire). The message names the cause.
 	RawUnavailable = "RAW_UNAVAILABLE"
+	// CameraProducerRestarted: an episode capture with explicit campaign
+	// parameters restarted the camera producer, so this stream ended rather
+	// than being spliced onto a different sequence parameter set mid-timeline.
+	// It is the one case where a live viewer's stream is ended by the agent,
+	// and it is recoverable: reconnecting joins the replacement stream.
+	CameraProducerRestarted = "CAMERA_PRODUCER_RESTARTED"
 )
 
 // Domain scopes the reasons to us, so a client can tell ours from a third party's.


### PR DESCRIPTION
## Problem

Thirteen review findings across four areas of the camera path.

The pre-roll flush stopped reading its hub subscription while it wrote the ring to disk. That subscription's channel is four frames deep, so on any real camera the frames immediately after the trigger, the ones the episode exists to record, were dropped by the hub and the live tail resumed in the middle of a group of pictures (GOP), inside the same segment file.

A two-plane loopback pump that refused its source deleted its map entry and removed its aux node, and the next minute sweep or container lifecycle nudge recreated both. Any camera that is not native V4L2 H.264 therefore had its pipeline started and torn down forever. Two comments in that code described behaviour it does not have.

A capture takeover waited 500 ms for the outgoing producer and then started the replacement regardless. If the old producer still held the device the replacement failed with EBUSY and every parameter-less subscriber lost the camera as well as the campaign losing its capture.

The episode export wrapped an inter-frame gap of 2^32 microseconds or more silently, sorted index entries by timestamp before muxing (reordering coded frames when two timestamps invert), summed offset and size in its bounds check, and gave a lone frame a zero duration.

## Cause

Each finding is the same shape: a bound, an ordering, or a lifetime that a comment describes and the code does not enforce. The pre-roll flush's comment says the same subscription continues "so there is no gap and no duplicate"; the timescale constant's comment names 71 minutes as the limit without checking it; the pump goroutine's comment says the node is left in place while the code removes it.

## Solution

| Finding | Verdict | Change |
|---|---|---|
| S7b-F1 pre-roll flush drops the post-trigger frames | FIXED | `drainDuring` keeps a reader on the subscription while the ring is written, into a bounded side buffer; the collected frames are replayed through the ordinary live path. The first live keyframe after the flush opens a new segment, so any residual gap lands on a segment boundary. |
| S7b-F2 refused two-plane source recreated every sweep | FIXED | `twoPlaneRefused` remembers refusals per source, cleared when the entitled consumer set or the device list changes. `errSourceNotBindable` names the permanent refusal. The stale goroutine comment is corrected. |
| S7b-F3 takeover ends parameter-less viewers with no reconnect | FIXED | Agent marks the ended stream `CAMERA_PRODUCER_RESTARTED`; `wendy device camera view` rejoins the replacement stream with a printed notice, bounded to five attempts. The exception is documented where the promise is made and in the camera hardware guide. |
| S7b-F4 takeover starts a producer that cannot bind | FIXED | On teardown timeout the takeover is abandoned and `errCameraReleaseTimeout` returned, a named refusal the campaign records in its manifest alongside `errCameraHeldExplicitly`. |
| S7b-F5 aux node number allocated outside the lock | FIXED | `twoPlaneStartMu` serialises allocate-and-create, which is what makes the number reservation atomic; the losing-race branch is replaced by a demand recheck. |
| S7b-F6 accumulated arming drops immediately zeroed | FIXED | `lastDrops` renamed `carriedDrops`, kept across a reattach, and handed to the capture at activate. |
| S7b-F7 episode Drops folds in the whole armed period | FIXED | The capture subtracts the inherited subscription's baseline and reports the armed period separately as the new `armed_period_drops` manifest field. Losses inside the pre-roll window still reach Drops through the sequence gaps between retained frames. |
| S7b-F8 one long GOP makes the ring unbounded | FIXED | A single group of pictures over the byte cap, or reaching past `preRollGOPWindowFactor` times the buffer, restarts the ring and records `droppedForBytes`. |
| S7b-F10 a drop warning per frame | FIXED | Rate limited to once per ten seconds per subscriber, carrying the count accumulated since the last warning. |
| S7b-F11 identity subscribers hang after the pump stops | FIXED | `Run` closes every subscriber on the way out and marks the pump closed; a late subscribe gets an already-closed channel. Both misleading comments corrected. |
| S7a-F1 sample duration wraps past 71 minutes | FIXED | `buildMoov` returns an error naming the gap and the limit; the seal already turns a mux error into a `playable_notes` refusal. |
| S7a-F2 index sorted by timestamp reorders coded frames | FIXED | Capture order is preserved, inversions counted in `ClipResult.TimestampInversions`, negative deltas clamped to zero, and the seal refuses such a clip with a note. |
| S7a-F5 bounds check overflows, no recover on the seal | FIXED | The three conditions are checked without summing offset and size; `muxPlayableClips` converts a panic into an ordinary mux error so a derived artifact can never bring the seal down. |
| S7a-F10 single-frame clip has duration zero | FIXED | A lone frame is held for a nominal thirtieth of a second, reported as `ClipResult.NominalHold` and named in the manifest notes. |

Every finding verified against current code before changing anything; none were already fixed or refuted.

## Tests

New regression tests, one per finding where a behaviour is observable:

- `TestPreRollFlushLosesNoFramesWhileWriting` drives a real hub producing at a steady rate through a deliberately slow flush and asserts the capture reports no drops. Mutation checked: reverting the drain makes it fail.
- `TestLiveTailAfterPreRollOpensANewSegmentAtTheNextKeyframe`
- `TestTwoPlaneRefusedSourceIsNotRecreated`, `TestTwoPlaneConcurrentSweepsAllocateOneNode`
- `TestCameraViewRejoinsAfterAProducerRestart`, `TestCameraViewDoesNotRejoinOnOtherErrors`, `TestCameraViewGivesUpAfterRepeatedRestarts`
- `TestTakeoverAbortsWhenTheCameraDoesNotReleaseInTime`
- `TestArmedSourceKeepsDropsAcrossAReattach`, `TestArmedDropsAreCarriedAndReportedSeparately`
- `TestPreRollRingRestartsWhenOneGOPExceedsTheByteCap`
- `TestIdentityDropWarningsAreRateLimited`, `TestIdentitySubscriberEndsWhenThePumpStops`, `TestPumpRefusalNamesAnUnbindableSource`
- `TestMuxRefusesGapBeyondSampleDurationLimit`, `TestInvertedTimestampsKeepCaptureOrderAndAreCounted`, `TestSegmentReadRefusesByteSizeNearMaxInt64`, `TestSingleFrameClipGetsNominalHold`
- `TestSealRefusesClipWithInvertedTimestamps`, `TestConvertPlayableClipTurnsAPanicIntoAnError`

Verification run from `go/`: `gofmt -l -s .` clean, `go build ./...` clean, `go vet` clean for the changed packages, and `go test -race -count=1` green for `internal/agent/services`, `internal/episodeexport`, `internal/agent/data` and `internal/shared/streamreason`.

`internal/cli/commands` is green apart from `TestBuildCmd_MultiService_BuildsFromManifestOnly`, which fails identically on `origin/feature/wendy-data-platform-complete`: it compares a temporary directory path that macOS resolves through the `/private/var` symlink. It is unrelated to this change and does not fail on the Linux runner.
