### PR TITLE
fix(data): review findings across the CLI, app data socket and protos

### DIFF
--- a/Examples/WendyDataCampaign/README.md
+++ b/Examples/WendyDataCampaign/README.md
@@ -23,6 +23,10 @@ when a device has exactly one. ROS 2 topic entries select the device's healthy
 ROS graph recorders; requested topics are retained separately in the Episode
 manifest.
 
-Application records honor the requested pre-trigger buffer. Camera and ROS 2
-adapters currently begin at the trigger and record their achieved source offset
-in the manifest; deployment prints this limitation when it applies.
+Application records and camera streams honor the requested pre-trigger buffer:
+a buffered camera arms a standby subscription and keeps a keyframe-aligned ring
+of encoded frames, so the clip reaches back before the trigger. Audio and ROS 2
+adapters still begin at the trigger. Every source records the offset it
+actually achieved in the manifest, which is shorter than the request whenever a
+ring's byte cap was reached first, and deployment warns when a campaign asks for a
+buffer on a source that cannot honor it.

--- a/Examples/WendyDataModelApp/campaign.yaml
+++ b/Examples/WendyDataModelApp/campaign.yaml
@@ -30,10 +30,13 @@ sources:
       mode: continuous
 
 capture:
-  # Ten seconds of pre-trigger APPLICATION records: the predictions leading up
-  # to the detection are included. Camera bytes are not: sensor pre-roll needs
-  # an armed-standby adapter that does not exist yet, so the video starts AT
-  # the detection. The manifest records the offset it actually achieved.
+  # Ten seconds of pre-trigger buffer. It covers the APPLICATION records, so
+  # the predictions leading up to the detection are included, and it covers the
+  # CAMERA stream, so the video reaches back before the detection too: a
+  # buffered camera arms a standby subscription and keeps a keyframe-aligned
+  # ring of encoded frames. Audio and ROS 2 streams still start AT the trigger.
+  # The manifest records the offset each source actually achieved, which is
+  # shorter than the request whenever the ring's byte cap was reached first.
   buffer: 10s
 
   # Ten seconds after the trigger, so the episode IS the fragment around the

--- a/Proto/cloud/data_ingest.proto
+++ b/Proto/cloud/data_ingest.proto
@@ -103,6 +103,13 @@ enum EpisodeFileRole {
 // The full manifest JSON rides in attributes_json for fidelity; the typed
 // fields are what the catalog indexes on.
 message EpisodeManifest {
+  // Field numbers 2 and 3 carried a uint64 org_id and asset_id. Tenant identity
+  // comes from the caller's certificate and never from the manifest, so they
+  // were removed rather than retyped; reserving them stops a later edit from
+  // giving the numbers a new meaning that an older device would fill in with
+  // the identity it used to claim.
+  reserved 2, 3;
+
   string episode_id = 1;
 
   // Campaign name: the `name:` field of the campaign file that armed this
@@ -313,10 +320,28 @@ message QueryEpisodesRequest {
 
   // Maximum episodes returned, newest first. Zero means the server default.
   uint32 limit = 7;
+
+  // Opaque continuation token from a previous QueryEpisodesResponse's
+  // next_page_token. Empty asks for the first page, which is what every client
+  // that predates this field sends. Clients must treat the value as opaque:
+  // its contents are the server's to define and to change.
+  //
+  // Additive and not yet load bearing: the catalog read path lives outside this
+  // service, and the ingest answers this RPC with UNIMPLEMENTED, so nothing on
+  // a device reads or writes this field today. It is declared now so the shape
+  // is right before any client depends on it; retrofitting pagination onto a
+  // deployed query is the expensive version of this change.
+  string page_token = 8;
 }
 
 message QueryEpisodesResponse {
   repeated Episode episodes = 1;
+
+  // Token to pass as the next request's page_token. EMPTY means this is the
+  // last page, which is the only value a server that does not paginate ever
+  // sends; a client must therefore stop on empty rather than on a short page,
+  // because a full page with no token is also the last one.
+  string next_page_token = 2;
 }
 
 message GetEpisodeRequest {

--- a/Proto/wendy/agent/services/v2/data_service.proto
+++ b/Proto/wendy/agent/services/v2/data_service.proto
@@ -46,6 +46,15 @@ message DataStartRequest {
   string name = 1;
   repeated string sources = 2;
   repeated string exclude_sources = 3;
+  // Refuse to start unless fresh UTC evidence bounds the device clock to within
+  // this many nanoseconds.
+  //
+  // ZERO MEANS NO REQUIREMENT, not "demand a perfect clock". It is the value
+  // every caller that does not care sends, including every client that predates
+  // the field, so a server that read it as a bound would refuse to start at all.
+  //
+  // Signed, and a negative value is invalid rather than meaningful: see the
+  // signedness note on DataDownloadChunk.
   int64 require_utc_uncertainty_nanos = 4;
   repeated DataCalibration calibrations = 5;
 }
@@ -66,11 +75,35 @@ message DataEpisode {
 message DataStatusResponse { DataEpisode active = 1; }
 message DataEpisodesResponse { repeated DataEpisode episodes = 1; }
 message DataInspectResponse { bytes manifest_json = 1; repeated string verification_errors = 2; }
+// One chunk of one file of an episode.
+//
+// size and sha256 describe the WHOLE FILE, not this chunk, and both are
+// repeated on every chunk of the stream rather than sent once. A receiver
+// therefore learns the file's length and digest from the first chunk and can
+// check every later chunk against the same pair; it must not read them as a
+// description of the bytes in this message, and must not accumulate them.
+//
+// This message is not the file list. What an episode contains is the manifest
+// JSON (DataInspectResponse.manifest_json), whose files array carries each
+// path, its size and its sha256; a downloader reads that first and then asks
+// for each path in turn. Nothing in this stream enumerates paths.
+//
+// Signedness, stated once for the whole file: every numeric field here is
+// int64, sizes and durations included. That differs from the cloud ingest
+// contract, where a size or a byte count is uint64 and only a point on a
+// timeline is signed. Devices already ship this contract, so the types stay as
+// they are; the rule for a reader is that size, offset and any duration in this
+// file are non-negative, and a negative value is a protocol error to reject
+// rather than a range to interpret.
 message DataDownloadChunk {
   string path = 1;
+  // Byte offset of data within the file. Chunks arrive in order with no gaps,
+  // starting at the offset the request asked to resume from.
   int64 offset = 2;
   bytes data = 3;
+  // Total size of the whole file, repeated on every chunk.
   int64 size = 4;
+  // Lowercase hex SHA-256 of the whole file, repeated on every chunk.
   string sha256 = 5;
   bool eof = 6;
 }

--- a/go/internal/agent/containerd/client.go
+++ b/go/internal/agent/containerd/client.go
@@ -291,6 +291,60 @@ func (c *Client) RestoreAppSystemAPISockets(ctx context.Context) {
 			}
 		}
 	}
+	c.sweepOrphanedSocketRoots(appIDsFromLabels(labelSets))
+}
+
+// appSocketSweeper is the optional capability of a socket provider to discard
+// directories that belong to no app. It is an interface of its own, rather than
+// a method on the provider interfaces, so a provider that cannot sweep stays
+// usable unchanged.
+type appSocketSweeper interface {
+	SweepOrphanedRoots(activeAppIDs []string)
+}
+
+// sweepOrphanedSocketRoots discards socket directories left behind by apps that
+// no longer have any container.
+//
+// A directory is named by a hash of the app identity, and the only record of
+// that identity is the container's own label. Delete the last container of an
+// app and the identity is gone with it, so nothing afterwards can work out
+// which directory belonged to it: the one-service app deleted by service name
+// leaves a directory that no Release call could ever name. Restore is the point
+// where the live set is known exactly, so it is where a directory outside that
+// set is provably an orphan.
+func (c *Client) sweepOrphanedSocketRoots(activeAppIDs []string) {
+	// A nil provider is a nil interface, which fails the assertion, so no
+	// separate nil check is needed.
+	if sweeper, ok := c.systemAPISocketProvider.(appSocketSweeper); ok {
+		sweeper.SweepOrphanedRoots(activeAppIDs)
+	}
+	if sweeper, ok := c.dataSocketProvider.(appSocketSweeper); ok {
+		sweeper.SweepOrphanedRoots(activeAppIDs)
+	}
+}
+
+// appIDsFromLabels lists the distinct, valid app identities present in a set of
+// container label maps. Labels are external state, so each identity is
+// re-validated before it is treated as one (SOC2-CC6, NIST-SI-10): an
+// unvalidated value here would decide which socket directories survive a sweep.
+func appIDsFromLabels(labelSets []map[string]string) []string {
+	seen := make(map[string]struct{}, len(labelSets))
+	out := make([]string, 0, len(labelSets))
+	for _, labels := range labelSets {
+		appID := labels[labelKeyAppID]
+		if appID == "" {
+			continue
+		}
+		if err := appconfig.ValidateAppID(appID); err != nil {
+			continue
+		}
+		if _, ok := seen[appID]; ok {
+			continue
+		}
+		seen[appID] = struct{}{}
+		out = append(out, appID)
+	}
+	return out
 }
 
 func NewClient(logger *zap.Logger, address string, proxyMgr *dbusproxy.Manager) (*Client, error) {
@@ -3971,6 +4025,45 @@ func (c *Client) deleteOne(ctx context.Context, ctr containerd.Container, wantIm
 	return imgName, nil
 }
 
+// releaseSocketsAfterDelete gives back the per-app socket ownership held by the
+// containers DeleteContainer just removed.
+//
+// wholeApp means the delete addressed every container of the app, so the whole
+// socket goes: ReleaseApp drops all owners at once and removes the directory.
+//
+// When it does NOT, one service of a multi-service app was deleted by name and
+// the app's other services still hold the socket. Releasing only on wholeApp
+// left that service registered as an owner forever, which matters because the
+// socket's owner set is what an app's allowlist union is computed from: the
+// union stayed as wide as the deleted service made it until the agent
+// restarted. Release names the departing service so the owner set narrows
+// immediately, and the socket survives for the services that remain.
+//
+// Nothing is released when a delete partially failed: a container that is still
+// there is still an owner.
+func (c *Client) releaseSocketsAfterDelete(appID string, deletedServices []string, wholeApp, allDeleted bool) {
+	if !allDeleted {
+		return
+	}
+	if wholeApp {
+		if c.systemAPISocketProvider != nil {
+			c.systemAPISocketProvider.ReleaseApp(appID)
+		}
+		if c.dataSocketProvider != nil {
+			c.dataSocketProvider.ReleaseApp(appID)
+		}
+		return
+	}
+	for _, serviceName := range deletedServices {
+		if c.systemAPISocketProvider != nil {
+			c.systemAPISocketProvider.Release(appID, serviceName)
+		}
+		if c.dataSocketProvider != nil {
+			c.dataSocketProvider.Release(appID, serviceName)
+		}
+	}
+}
+
 // DeleteContainer deletes all containers belonging to appID. For multi-service
 // apps all service containers are removed. When deleteImage is true, each
 // distinct image is deleted once (services sharing an image are handled safely).
@@ -4014,7 +4107,15 @@ func (c *Client) DeleteContainer(ctx context.Context, name string, deleteImage b
 
 	seen := make(map[string]bool)
 	var errs []error
+	var deletedServices []string
 	for _, ctr := range ctrs {
+		// Read the service label before the container is gone: it is the only
+		// record of which socket owner this container was, and releaseSockets
+		// below needs it.
+		serviceName := ""
+		if labels, labelErr := ctr.Labels(ctx); labelErr == nil {
+			serviceName = labels[labelKeyServiceName]
+		}
 		imgName, delErr := c.deleteOne(ctx, ctr, deleteImage)
 		if delErr != nil {
 			c.logger.Error("Failed to delete service container",
@@ -4023,6 +4124,7 @@ func (c *Client) DeleteContainer(ctx context.Context, name string, deleteImage b
 			errs = append(errs, delErr)
 			continue
 		}
+		deletedServices = append(deletedServices, serviceName)
 		if imgName != "" && !seen[imgName] {
 			seen[imgName] = true
 			imgSvc := c.client.ImageService()
@@ -4033,13 +4135,7 @@ func (c *Client) DeleteContainer(ctx context.Context, name string, deleteImage b
 			}
 		}
 	}
-	// The system-API socket is per app: only release it once the app is gone.
-	if len(errs) == 0 && wholeApp && c.systemAPISocketProvider != nil {
-		c.systemAPISocketProvider.ReleaseApp(appID)
-	}
-	if len(errs) == 0 && wholeApp && c.dataSocketProvider != nil {
-		c.dataSocketProvider.ReleaseApp(appID)
-	}
+	c.releaseSocketsAfterDelete(appID, deletedServices, wholeApp, len(errs) == 0)
 
 	// Recompute camera-loopback nodes/consumers from truth now that some or
 	// all of this app's containers are gone (unconditional: even a partial

--- a/go/internal/agent/containerd/socket_release_test.go
+++ b/go/internal/agent/containerd/socket_release_test.go
@@ -1,0 +1,141 @@
+package containerd
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/shared/appconfig"
+)
+
+// recordingSocketProvider records the release calls a delete made. It stands in
+// for both the System API and the data socket managers, whose Release and
+// ReleaseApp signatures differ only in Ensure.
+type recordingSocketProvider struct {
+	released    [][2]string
+	releasedApp []string
+	swept       [][]string
+}
+
+func (p *recordingSocketProvider) Release(appID, serviceName string) {
+	p.released = append(p.released, [2]string{appID, serviceName})
+}
+func (p *recordingSocketProvider) ReleaseApp(appID string) {
+	p.releasedApp = append(p.releasedApp, appID)
+}
+func (p *recordingSocketProvider) SweepOrphanedRoots(activeAppIDs []string) {
+	p.swept = append(p.swept, activeAppIDs)
+}
+
+type recordingSystemAPIProvider struct{ recordingSocketProvider }
+
+func (p *recordingSystemAPIProvider) Ensure(string, string, []string) (string, error) {
+	return "", nil
+}
+
+type recordingDataProvider struct{ recordingSocketProvider }
+
+func (p *recordingDataProvider) Ensure(string, string) (string, error) { return "", nil }
+
+// TestReleaseSocketsAfterDeleteReleasesEachDeletedService covers the leak: a
+// delete that removed one service of a multi-service app released nothing,
+// because the release was conditioned on the delete having addressed the whole
+// app. The departing service stayed registered as a socket owner until the
+// agent restarted, and the app's allowlist union stayed as wide as that service
+// had made it.
+func TestReleaseSocketsAfterDeleteReleasesEachDeletedService(t *testing.T) {
+	systemAPI := &recordingSystemAPIProvider{}
+	dataSocket := &recordingDataProvider{}
+	client := &Client{systemAPISocketProvider: systemAPI, dataSocketProvider: dataSocket}
+
+	client.releaseSocketsAfterDelete("com.example.app", []string{"worker"}, false, true)
+
+	want := [][2]string{{"com.example.app", "worker"}}
+	if !reflect.DeepEqual(systemAPI.released, want) {
+		t.Fatalf("System API releases = %v, want %v", systemAPI.released, want)
+	}
+	if !reflect.DeepEqual(dataSocket.released, want) {
+		t.Fatalf("data socket releases = %v, want %v", dataSocket.released, want)
+	}
+	if len(systemAPI.releasedApp) != 0 || len(dataSocket.releasedApp) != 0 {
+		t.Fatalf("a partial delete released the whole app: %v %v", systemAPI.releasedApp, dataSocket.releasedApp)
+	}
+}
+
+// TestReleaseSocketsAfterDeleteWholeAppReleasesOnce keeps the existing
+// behaviour: when the delete took every container, the socket goes as a whole
+// rather than one owner at a time.
+func TestReleaseSocketsAfterDeleteWholeAppReleasesOnce(t *testing.T) {
+	systemAPI := &recordingSystemAPIProvider{}
+	dataSocket := &recordingDataProvider{}
+	client := &Client{systemAPISocketProvider: systemAPI, dataSocketProvider: dataSocket}
+
+	client.releaseSocketsAfterDelete("com.example.app", []string{"api", "worker"}, true, true)
+
+	want := []string{"com.example.app"}
+	if !reflect.DeepEqual(systemAPI.releasedApp, want) || !reflect.DeepEqual(dataSocket.releasedApp, want) {
+		t.Fatalf("whole-app releases = %v %v, want %v", systemAPI.releasedApp, dataSocket.releasedApp, want)
+	}
+	if len(systemAPI.released) != 0 || len(dataSocket.released) != 0 {
+		t.Fatalf("whole-app delete also released per service: %v %v", systemAPI.released, dataSocket.released)
+	}
+}
+
+// TestReleaseSocketsAfterDeleteKeepsOwnersWhenADeleteFailed states the safety
+// rule: a container that is still there is still an owner.
+func TestReleaseSocketsAfterDeleteKeepsOwnersWhenADeleteFailed(t *testing.T) {
+	systemAPI := &recordingSystemAPIProvider{}
+	dataSocket := &recordingDataProvider{}
+	client := &Client{systemAPISocketProvider: systemAPI, dataSocketProvider: dataSocket}
+
+	client.releaseSocketsAfterDelete("com.example.app", []string{"worker"}, false, false)
+	client.releaseSocketsAfterDelete("com.example.app", []string{"worker"}, true, false)
+
+	if len(systemAPI.released)+len(systemAPI.releasedApp)+len(dataSocket.released)+len(dataSocket.releasedApp) != 0 {
+		t.Fatal("a failed delete released socket ownership")
+	}
+}
+
+// TestReleaseSocketsAfterDeleteToleratesMissingProviders covers the agent
+// configurations that wire in neither socket manager.
+func TestReleaseSocketsAfterDeleteToleratesMissingProviders(t *testing.T) {
+	client := &Client{}
+	client.releaseSocketsAfterDelete("com.example.app", []string{"worker"}, false, true)
+	client.releaseSocketsAfterDelete("com.example.app", nil, true, true)
+}
+
+// TestSweepOrphanedSocketRootsPassesTheLiveAppSet checks the restore-time
+// sweep reaches both providers with the set of apps that still have containers.
+func TestSweepOrphanedSocketRootsPassesTheLiveAppSet(t *testing.T) {
+	systemAPI := &recordingSystemAPIProvider{}
+	dataSocket := &recordingDataProvider{}
+	client := &Client{systemAPISocketProvider: systemAPI, dataSocketProvider: dataSocket}
+
+	client.sweepOrphanedSocketRoots([]string{"com.example.app"})
+
+	want := [][]string{{"com.example.app"}}
+	if !reflect.DeepEqual(systemAPI.swept, want) || !reflect.DeepEqual(dataSocket.swept, want) {
+		t.Fatalf("sweeps = %v %v, want %v", systemAPI.swept, dataSocket.swept, want)
+	}
+}
+
+// TestAppIDsFromLabelsIsDistinctAndValidated pins what the sweep is told is
+// live. Labels are external state, so a value that is not a legal app identity
+// must not decide which socket directories survive; duplicates from a
+// multi-service app collapse to one.
+func TestAppIDsFromLabelsIsDistinctAndValidated(t *testing.T) {
+	notifications := []appconfig.Entitlement{{Type: appconfig.EntitlementNotifications}}
+	labels := []map[string]string{
+		wendyLabels("com.example.app", "api", "1", nil, notifications, "", nil),
+		wendyLabels("com.example.app", "worker", "1", nil, notifications, "", nil),
+		wendyLabels("com.example.other", "", "1", nil, nil, "", nil),
+		{labelKeyAppID: "../tampered"},
+		{labelKeyAppID: ""},
+		{},
+	}
+
+	got := appIDsFromLabels(labels)
+	want := []string{"com.example.app", "com.example.other"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("appIDsFromLabels = %v, want %v", got, want)
+	}
+}

--- a/go/internal/agent/services/app_data_socket.go
+++ b/go/internal/agent/services/app_data_socket.go
@@ -31,6 +31,27 @@ const (
 	// dataRatePerSecond bounds records accepted per app across all of the
 	// app's connections combined (see appDataSocket.limiter).
 	dataRatePerSecond = 200
+	// dataMaxLiveConnectionsPerApp bounds how many connections one app may hold
+	// open on its data socket at once.
+	//
+	// The record rate limiter above bounds records, not connections, so it does
+	// nothing about a reconnect loop: an app that dials, fails to write, and
+	// dials again costs one goroutine and one file descriptor per attempt, none
+	// of which the rate limiter sees. Sixteen is well above what a legitimate
+	// app needs (one connection per service of the app, and every service of an
+	// app shares this one socket), and low enough that a loop is stopped long
+	// before the agent's descriptor budget is.
+	//
+	// Refusing is safe for a correct app: the refusal arrives as a normal
+	// rejected ack, so the client learns why instead of seeing a bare close.
+	dataMaxLiveConnectionsPerApp = 16
+	// dataRefusalLogInterval throttles the connection-cap warning. A reconnect
+	// loop is exactly the situation where one line per refusal would flood the
+	// journal with the same fact.
+	dataRefusalLogInterval = time.Minute
+	// dataRefusalWriteTimeout bounds how long the accept loop will spend
+	// telling one peer it was refused.
+	dataRefusalWriteTimeout = 2 * time.Second
 )
 
 // peerCredentials identifies the process on the far end of a data-socket
@@ -58,6 +79,11 @@ type appDataSocket struct {
 	// limiter is shared by every connection the app opens, so the rate limit
 	// is enforced per app rather than per connection.
 	limiter *notificationRateLimiter
+	// live counts the connections currently being served for this app and
+	// lastRefusalLog is when the connection cap last logged. Both are guarded
+	// by AppDataSocketManager.mu.
+	live           int
+	lastRefusalLog time.Time
 }
 type AppDataSocketManager struct {
 	ctx     context.Context
@@ -117,6 +143,13 @@ func (m *AppDataSocketManager) Ensure(appID, service string) (string, error) {
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return "", err
 	}
+	// MkdirAll applies the process umask to the requested mode, so the
+	// directory that guards an app's private socket would otherwise be as tight
+	// as the agent's umask happened to be. State the mode instead of inheriting
+	// it, exactly as the sibling System API socket manager does.
+	if err := os.Chmod(dir, 0o750); err != nil {
+		return "", err
+	}
 	if os.Geteuid() == 0 {
 		if err := os.Chown(dir, 0, dataSocketGroupGID); err != nil {
 			return "", err
@@ -158,7 +191,7 @@ func (m *AppDataSocketManager) Release(appID, service string) {
 	delete(m.sockets, key)
 	m.mu.Unlock()
 	s.listener.Close()
-	_ = os.RemoveAll(filepath.Join(AppDataSocketRootPath, key))
+	m.removeRootUnlessRecreated(key)
 }
 func (m *AppDataSocketManager) ReleaseApp(appID string) {
 	key := appDataKey(appID)
@@ -168,7 +201,73 @@ func (m *AppDataSocketManager) ReleaseApp(appID string) {
 	m.mu.Unlock()
 	if s != nil {
 		s.listener.Close()
-		_ = os.RemoveAll(filepath.Join(AppDataSocketRootPath, key))
+		m.removeRootUnlessRecreated(key)
+	}
+}
+
+// removeRootUnlessRecreated deletes an app's socket directory, unless a
+// concurrent redeploy has already recreated the entry for the same app between
+// the listener being closed and this call. Removing it then would delete a
+// live socket out from under the new listener, which is why the check is taken
+// under the lock and the removal happens with the lock still held. The sibling
+// System API socket manager guards its own removal the same way.
+func (m *AppDataSocketManager) removeRootUnlessRecreated(key string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.sockets[key] != nil {
+		return
+	}
+	if err := os.RemoveAll(filepath.Join(AppDataSocketRootPath, key)); err != nil && m.logger != nil {
+		m.logger.Warn("cannot remove unused app data socket directory", zap.Error(err))
+	}
+}
+
+// SweepOrphanedRoots removes socket directories under AppDataSocketRootPath
+// that belong to none of the given app identities.
+//
+// It exists because a directory can outlive every owner that could release it:
+// deleting the only service of an app by its service name removes the
+// container, and with it any later chance to learn the app identity whose hash
+// named the directory. The sweep runs at restore, where the set of apps that
+// still have containers is known exactly, and a directory whose name matches
+// no live app's hash therefore belongs to nothing.
+//
+// Directories currently served are never swept even if the caller omits their
+// app, because an in-memory socket entry is proof of a live owner.
+func (m *AppDataSocketManager) SweepOrphanedRoots(activeAppIDs []string) {
+	live := make(map[string]struct{}, len(activeAppIDs))
+	for _, appID := range activeAppIDs {
+		live[appDataKey(appID)] = struct{}{}
+	}
+	entries, err := os.ReadDir(AppDataSocketRootPath)
+	if err != nil {
+		if !os.IsNotExist(err) && m.logger != nil {
+			m.logger.Warn("cannot sweep app data socket directories", zap.Error(err))
+		}
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		key := entry.Name()
+		if _, ok := live[key]; ok {
+			continue
+		}
+		if m.sockets[key] != nil {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(AppDataSocketRootPath, key)); err != nil {
+			if m.logger != nil {
+				m.logger.Warn("cannot remove orphaned app data socket directory", zap.String("directory", key), zap.Error(err))
+			}
+			continue
+		}
+		if m.logger != nil {
+			m.logger.Info("removed orphaned app data socket directory", zap.String("directory", key))
+		}
 	}
 }
 func (m *AppDataSocketManager) stopAll() {
@@ -194,7 +293,56 @@ func (m *AppDataSocketManager) serve(s *appDataSocket) {
 			}
 			return
 		}
-		go m.serveConn(s, c)
+		if !m.admit(s) {
+			// The refusal is written from the accept loop, so it must not be
+			// able to block it: a peer that connects and never reads would
+			// otherwise stall every later accept, which is the same denial the
+			// cap exists to prevent.
+			_ = c.SetWriteDeadline(time.Now().Add(dataRefusalWriteTimeout))
+			_ = writeDataFrame(c, dataAck{Version: 1, State: "rejected", Error: "too many open connections for this app"})
+			_ = c.Close()
+			continue
+		}
+		go func() {
+			defer m.finish(s)
+			m.serveConn(s, c)
+		}()
+	}
+}
+
+// admit reserves one of the app's live-connection slots, or reports that the
+// app is already at dataMaxLiveConnectionsPerApp. The over-cap warning is
+// logged at most once per dataRefusalLogInterval per app.
+func (m *AppDataSocketManager) admit(s *appDataSocket) bool {
+	now := time.Now()
+	m.mu.Lock()
+	if s.live >= dataMaxLiveConnectionsPerApp {
+		warn := s.lastRefusalLog.IsZero() || now.Sub(s.lastRefusalLog) >= dataRefusalLogInterval
+		if warn {
+			s.lastRefusalLog = now
+		}
+		live := s.live
+		appID := s.appID
+		m.mu.Unlock()
+		if warn && m.logger != nil {
+			m.logger.Warn("app data socket refused connection over the per-app limit",
+				zap.String("app_id", appID),
+				zap.Int("live_connections", live),
+				zap.Int("limit", dataMaxLiveConnectionsPerApp))
+		}
+		return false
+	}
+	s.live++
+	m.mu.Unlock()
+	return true
+}
+
+// finish returns the slot admit reserved.
+func (m *AppDataSocketManager) finish(s *appDataSocket) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if s.live > 0 {
+		s.live--
 	}
 }
 

--- a/go/internal/agent/services/app_data_socket_limits_test.go
+++ b/go/internal/agent/services/app_data_socket_limits_test.go
@@ -1,0 +1,153 @@
+package services
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/data"
+)
+
+// TestAppDataSocketRefusesConnectionsOverPerAppLimit covers the unbounded
+// accept loop: the per-app rate limiter bounds records, not connections, so a
+// reconnect loop cost one goroutine and one descriptor per attempt with nothing
+// to stop it. The cap+1th live connection must be refused with a reason the
+// client can read.
+func TestAppDataSocketRefusesConnectionsOverPerAppLimit(t *testing.T) {
+	manager := newTestDataSocketManager(t)
+	dir, err := manager.Ensure("com.example.a", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	socket := filepath.Join(dir, DataSocketFilename)
+
+	// Hold the cap open. Each connection sends one record and waits for its
+	// ack, which is what proves the manager has counted it live before the next
+	// dial: an accepted-but-unserved connection would make this racy.
+	held := make([]net.Conn, 0, dataMaxLiveConnectionsPerApp)
+	for i := 0; i < dataMaxLiveConnectionsPerApp; i++ {
+		conn, dialErr := net.Dial("unix", socket)
+		if dialErr != nil {
+			t.Fatalf("connection %d refused: %v", i, dialErr)
+		}
+		t.Cleanup(func() { conn.Close() })
+		held = append(held, conn)
+		if ack := exchangeRecord(t, conn, fmt.Sprintf("ready-%d", i)); ack.State != "buffered" {
+			t.Fatalf("connection %d got ack %+v, want a buffered record", i, ack)
+		}
+	}
+
+	over, err := net.Dial("unix", socket)
+	if err != nil {
+		// A refusal at the kernel backlog would also be a refusal, but the
+		// point of the cap is that the client is told why.
+		t.Fatalf("connection %d was refused without a reason: %v", dataMaxLiveConnectionsPerApp, err)
+	}
+	defer over.Close()
+	// Without the cap this connection is simply accepted and waits for a record
+	// that never comes, so bound the read: the test must fail, not hang.
+	if err = over.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	body, err := readDataFrame(over)
+	if err != nil {
+		t.Fatalf("connection over the cap was closed without an ack: %v", err)
+	}
+	var ack dataAck
+	if err = json.Unmarshal(body, &ack); err != nil {
+		t.Fatal(err)
+	}
+	if ack.State != "rejected" || !strings.Contains(ack.Error, "too many open connections") {
+		t.Fatalf("connection over the cap got ack %+v, want a rejection naming the connection limit", ack)
+	}
+
+	// Closing one accepted connection returns its slot, so the cap throttles
+	// rather than permanently locking the app out.
+	held[0].Close()
+	waitForLiveConnections(t, manager, "com.example.a", dataMaxLiveConnectionsPerApp-1)
+	replacement, err := net.Dial("unix", socket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer replacement.Close()
+	if ack := exchangeRecord(t, replacement, "after-close"); ack.State != "buffered" {
+		t.Fatalf("replacement connection got ack %+v, want a buffered record", ack)
+	}
+}
+
+// exchangeRecord writes one valid application record and reads the ack.
+func exchangeRecord(t *testing.T, conn net.Conn, name string) dataAck {
+	t.Helper()
+	return sendRecord(t, conn, data.ApplicationRecord{Version: 1, Type: "event", Name: name, ClientBootID: "unavailable"})
+}
+
+// waitForLiveConnections blocks until the manager has observed a closed
+// connection. The serving goroutine returns the slot asynchronously, so
+// polling is the honest way to wait for it.
+func waitForLiveConnections(t *testing.T, m *AppDataSocketManager, appID string, want int) {
+	t.Helper()
+	key := appDataKey(appID)
+	for i := 0; i < 200; i++ {
+		m.mu.Lock()
+		socket := m.sockets[key]
+		live := -1
+		if socket != nil {
+			live = socket.live
+		}
+		m.mu.Unlock()
+		if live == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("live connection count never reached %d", want)
+}
+
+// TestAppDataSocketSweepRemovesOnlyOrphanedRoots covers the directory that no
+// Release call can ever name: deleting the only service of an app removes the
+// container, and with it the only record of the app identity whose hash named
+// the directory.
+func TestAppDataSocketSweepRemovesOnlyOrphanedRoots(t *testing.T) {
+	manager := newTestDataSocketManager(t)
+	if _, err := manager.Ensure("com.example.live", ""); err != nil {
+		t.Fatal(err)
+	}
+	served := filepath.Join(AppDataSocketRootPath, appDataKey("com.example.live"))
+	orphan := filepath.Join(AppDataSocketRootPath, appDataKey("com.example.gone"))
+	if err := os.MkdirAll(orphan, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	// A directory for an app that still has containers but whose socket this
+	// manager is not serving: it must survive, because the caller named it.
+	inactive := filepath.Join(AppDataSocketRootPath, appDataKey("com.example.stopped"))
+	if err := os.MkdirAll(inactive, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	stray := filepath.Join(AppDataSocketRootPath, "not-a-directory")
+	if err := os.WriteFile(stray, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	manager.SweepOrphanedRoots([]string{"com.example.live", "com.example.stopped"})
+
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Fatalf("orphaned directory survived the sweep: %v", err)
+	}
+	for _, keep := range []string{served, inactive, stray} {
+		if _, err := os.Stat(keep); err != nil {
+			t.Fatalf("sweep removed %s: %v", keep, err)
+		}
+	}
+
+	// A sweep that names no app at all must still spare a directory this
+	// manager is actively serving: the in-memory entry is proof of an owner.
+	manager.SweepOrphanedRoots(nil)
+	if _, err := os.Stat(served); err != nil {
+		t.Fatalf("sweep removed a directory it is serving: %v", err)
+	}
+}

--- a/go/internal/agent/services/app_data_socket_mode_unix_test.go
+++ b/go/internal/agent/services/app_data_socket_mode_unix_test.go
@@ -1,0 +1,34 @@
+//go:build unix
+
+package services
+
+import (
+	"os"
+	"syscall"
+	"testing"
+)
+
+// TestAppDataSocketDirectoryModeIsStated covers the umask dependency: MkdirAll
+// applies the process umask to the requested mode, so without an explicit
+// Chmod the directory guarding an app's private socket was as tight, or as
+// loose, as the agent's umask happened to be.
+func TestAppDataSocketDirectoryModeIsStated(t *testing.T) {
+	// A restrictive umask is the case that actually bit: 0o027 would have left
+	// the directory at 0o750 by luck, so use one that clears a bit the mode
+	// asks for.
+	previous := syscall.Umask(0o077)
+	t.Cleanup(func() { syscall.Umask(previous) })
+
+	manager := newTestDataSocketManager(t)
+	dir, err := manager.Ensure("com.example.a", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o750 {
+		t.Fatalf("socket directory mode = %o, want 750; the umask decided it", got)
+	}
+}

--- a/go/internal/agent/services/app_system_api_socket_manager.go
+++ b/go/internal/agent/services/app_system_api_socket_manager.go
@@ -222,6 +222,43 @@ func (m *AppSystemAPISocketManager) ReleaseApp(appID string) {
 	}
 }
 
+// SweepOrphanedRoots removes System API socket directories that belong to none
+// of the given app identities. See AppDataSocketManager.SweepOrphanedRoots for
+// why a directory can outlive every owner able to release it, and why restore
+// is the one place the live set is known exactly.
+func (m *AppSystemAPISocketManager) SweepOrphanedRoots(activeAppIDs []string) {
+	live := make(map[string]struct{}, len(activeAppIDs))
+	for _, appID := range activeAppIDs {
+		live[appSystemAPIKey(appID)] = struct{}{}
+	}
+	entries, err := os.ReadDir(AppSystemAPISocketRootPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			m.logger.Warn("cannot sweep app System API directories", zap.Error(err))
+		}
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		key := entry.Name()
+		if _, ok := live[key]; ok {
+			continue
+		}
+		if m.sockets[key] != nil {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(AppSystemAPISocketRootPath, key)); err != nil {
+			m.logger.Warn("cannot remove orphaned app System API directory", zap.String("directory", key), zap.Error(err))
+			continue
+		}
+		m.logger.Info("removed orphaned app System API directory", zap.String("directory", key))
+	}
+}
+
 func (m *AppSystemAPISocketManager) authorize(socket *appSystemAPISocket) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		capability := systemAPICapabilityForMethod(info.FullMethod)

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
@@ -76,6 +76,26 @@ wendy data sources --kind camera,telemetry
 wendy data sources --kind audio            # every audio source, nothing summarised
 ```
 
+### The `--json` dialect
+
+Every `data` subcommand whose payload is a protocol buffer message prints it as
+canonical protobuf JSON on one compact line, with protocol buffer field names
+exactly as the `.proto` declares them, and unpopulated fields omitted. That
+covers `sources`, `episodes`, `record`, `stop`, `campaign list` and
+`campaign trigger`.
+
+Some payloads are already a JSON document the device produced, and those bytes
+are written through untouched so they stay checkable against the device:
+`inspect` emits the episode manifest, and `campaign deploy` and
+`campaign inspect` emit the canonical campaign plan. `campaign inspect` emits
+the plan whether or not `--json` is given, because the plan is the whole output
+of the command.
+
+`download` reports what it wrote to the local filesystem, which no wire message
+describes, so under `--json` it prints an object of its own: `episode`,
+`destination`, `files` (paths relative to the destination, including the
+`manifest.json` the command writes itself) and `bytes`.
+
 Episode IDs are stable opaque identifiers. Their readable UTC prefix is only a
 convenience; canonical ordering comes from the Episode's `CLOCK_BOOTTIME`
 timestamps and boot ID.
@@ -318,12 +338,13 @@ nothing:
 # From the repository root.
 CGO_ENABLED=0 go build -o bin/episode-playable ./go/cmd/episode-playable
 
-wendy data download <episode-id> -o /absolute/path/to/episode --device <device-hostname>
-./bin/episode-playable -o /absolute/path/to/playable /absolute/path/to/episode
+wendy data download <episode-id> -o ./episode --device <device-hostname>
+./bin/episode-playable -o ./playable ./episode
 ```
 
-Note that `wendy data download` needs an absolute `-o` path; a relative one
-fails with "server file path escapes destination".
+`wendy data download` takes either an absolute or a relative `-o` path. A
+trailing separator is fine too: the destination is cleaned before the staging
+directory beside it is named.
 
 One `<source>.mp4` is written per camera source into the output directory,
 which must be somewhere other than the Episode. The command prints the index

--- a/go/internal/cli/commands/data.go
+++ b/go/internal/cli/commands/data.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -17,7 +18,45 @@ import (
 
 	"github.com/spf13/cobra"
 	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
+
+// encodeProtoJSON writes one protocol buffer message as canonical protobuf
+// JSON and is the single --json dialect of every "wendy data" subcommand whose
+// payload is a protocol buffer message. The dialect is: protocol buffer field
+// names exactly as the .proto declares them (snake_case, not lowerCamelCase),
+// unpopulated fields omitted, one compact line per message.
+//
+// It is used everywhere rather than encoding/json on the generated struct
+// because the two disagree on the wire: encoding/json renders enums as their
+// numbers and has no defined mapping for well-known types, while protobuf JSON
+// is the mapping the protocol itself specifies, so a script can read the output
+// of any subcommand the same way.
+//
+// The one deliberate exception is a payload that is ALREADY JSON produced
+// elsewhere: the campaign plan (DataCampaign.plan_json) and the episode
+// manifest (DataInspectResponse.manifest_json) are byte fields carrying a
+// document the device sealed. Those bytes are written through untouched,
+// because re-encoding them would lose the byte fidelity that makes them
+// checkable against the device.
+//
+// protojson varies its whitespace deliberately between runs, so the result is
+// compacted before it is written; without that no two invocations of the same
+// command agree byte for byte.
+func encodeProtoJSON(out io.Writer, message proto.Message) error {
+	raw, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(message)
+	if err != nil {
+		return err
+	}
+	var compact bytes.Buffer
+	if err = json.Compact(&compact, raw); err != nil {
+		return err
+	}
+	compact.WriteByte('\n')
+	_, err = out.Write(compact.Bytes())
+	return err
+}
 
 func newDataCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "data", Short: "Record and retrieve synchronized device data"}
@@ -63,7 +102,7 @@ func newDataCampaignListCmd() *cobra.Command {
 				return err
 			}
 			if jsonOutput {
-				return json.NewEncoder(cmd.OutOrStdout()).Encode(response)
+				return encodeProtoJSON(cmd.OutOrStdout(), response)
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), "CAMPAIGN\tSTATE\tREVISION\tFLEET")
 			for _, campaign := range response.GetCampaigns() {
@@ -152,9 +191,9 @@ const sourceKindFloodLimit = 6
 // filtered set, which is what the caller asked for.
 func encodeDataSourcesJSON(out io.Writer, response *agentpbv2.DataSourcesResponse, wanted []string) error {
 	if len(wanted) == 0 {
-		return json.NewEncoder(out).Encode(response)
+		return encodeProtoJSON(out, response)
 	}
-	return json.NewEncoder(out).Encode(&agentpbv2.DataSourcesResponse{Sources: filterSourcesByKind(response.GetSources(), wanted)})
+	return encodeProtoJSON(out, &agentpbv2.DataSourcesResponse{Sources: filterSourcesByKind(response.GetSources(), wanted)})
 }
 
 func normalizeSourceKinds(kinds []string) []string {
@@ -356,7 +395,7 @@ func newDataEpisodesCmd() *cobra.Command {
 				return e
 			}
 			if jsonOutput {
-				return json.NewEncoder(cmd.OutOrStdout()).Encode(r)
+				return encodeProtoJSON(cmd.OutOrStdout(), r)
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), "EPISODE\tSTATE\tSIZE\tNAME")
 			for _, x := range r.GetEpisodes() {
@@ -506,16 +545,42 @@ type downloadManifest struct {
 	} `json:"files"`
 }
 
+// downloadDestination resolves the destination directory and the staging
+// directory that is renamed onto it once every file verifies.
+//
+// The destination is cleaned first. filepath.Clean strips a trailing separator,
+// so "-o ./ep/" stages at "./ep.partial" NEXT TO the destination rather than at
+// "./ep/.partial" INSIDE it. Without the clean, os.MkdirAll created the
+// destination as a side effect of creating the staging directory, the final
+// rename failed with ENOTEMPTY because the destination then held the staging
+// directory, and every re-run refused with "destination already exists".
+func downloadDestination(id, output string) (destination, stage string) {
+	if output == "" {
+		output = id
+	}
+	destination = filepath.Clean(output)
+	return destination, destination + ".partial"
+}
+
+// dataDownloadResult is the --json payload of "wendy data download". Unlike
+// every other data subcommand this one reports what it wrote to the local
+// filesystem, which no wire message describes, so it is a command-shaped struct
+// rather than a protocol buffer message. Paths are relative to destination and
+// include the manifest the command writes itself; bytes is the total written.
+type dataDownloadResult struct {
+	Episode     string   `json:"episode"`
+	Destination string   `json:"destination"`
+	Files       []string `json:"files"`
+	Bytes       int64    `json:"bytes"`
+}
+
 func newDataDownloadCmd() *cobra.Command {
 	var output string
 	c := &cobra.Command{Use: "download <episode>", Short: "Resume and verify an episode download", Args: cobra.ExactArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
 		id := args[0]
-		if output == "" {
-			output = id
-		}
-		stage := output + ".partial"
-		if _, e := os.Stat(output); e == nil {
-			return fmt.Errorf("destination already exists: %s", output)
+		destination, stage := downloadDestination(id, output)
+		if _, e := os.Stat(destination); e == nil {
+			return fmt.Errorf("destination already exists: %s", destination)
 		}
 		return withDataClient(cmd.Context(), func(client agentpbv2.DataServiceClient) error {
 			inspect, e := client.Inspect(cmd.Context(), &agentpbv2.DataInspectRequest{Episode: id})
@@ -529,18 +594,26 @@ func newDataDownloadCmd() *cobra.Command {
 			if e = os.MkdirAll(stage, 0o750); e != nil {
 				return e
 			}
+			result := dataDownloadResult{Episode: id, Destination: destination}
 			for _, meta := range mf.Files {
 				if e = downloadOne(cmd.Context(), client, id, stage, meta.Path, meta.Size, meta.SHA256); e != nil {
 					return e
 				}
+				result.Files = append(result.Files, meta.Path)
+				result.Bytes += meta.Size
 			}
 			if e = os.WriteFile(filepath.Join(stage, "manifest.json"), inspect.GetManifestJson(), 0o640); e != nil {
 				return e
 			}
-			if e = os.Rename(stage, output); e != nil {
+			result.Files = append(result.Files, "manifest.json")
+			result.Bytes += int64(len(inspect.GetManifestJson()))
+			if e = os.Rename(stage, destination); e != nil {
 				return e
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Downloaded %s to %s\n", id, output)
+			if jsonOutput {
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(result)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Downloaded %s to %s\n", id, destination)
 			return nil
 		})
 	}}
@@ -587,7 +660,7 @@ func downloadOne(ctx context.Context, c agentpbv2.DataServiceClient, id, root, r
 	}
 	offset := st.Size()
 	if offset > size {
-		return fmt.Errorf("staged file %s is larger than manifest", rel)
+		return discardStagedFile(f, p, fmt.Errorf("staged file for %s holds %d bytes but the manifest declares %d", rel, offset, size))
 	}
 	if _, e = f.Seek(offset, io.SeekStart); e != nil {
 		return e
@@ -621,8 +694,16 @@ func downloadOne(ctx context.Context, c agentpbv2.DataServiceClient, id, root, r
 	if e = f.Sync(); e != nil {
 		return e
 	}
+	if offset > size {
+		// The device sent past the declared end. Nothing about the file can be
+		// trusted, and the surplus would wedge the next run's resume, so drop it.
+		return discardStagedFile(f, p, fmt.Errorf("device sent %d bytes for %s but the manifest declares %d", offset, rel, size))
+	}
 	if offset != size {
-		return fmt.Errorf("downloaded size mismatch for %s", rel)
+		// Short of the declared size but consistent with it: the stream ended
+		// early. Those bytes are good, and the next run resumes from them, so
+		// they are kept deliberately.
+		return fmt.Errorf("download of %s ended at %d of %d bytes; re-run to resume from the staged file %s", rel, offset, size, p)
 	}
 	if _, e = f.Seek(0, io.SeekStart); e != nil {
 		return e
@@ -631,15 +712,32 @@ func downloadOne(ctx context.Context, c agentpbv2.DataServiceClient, id, root, r
 	if _, e = io.Copy(h, f); e != nil {
 		return e
 	}
-	if hex.EncodeToString(h.Sum(nil)) != wantHash {
-		return fmt.Errorf("checksum mismatch for %s", rel)
+	if got := hex.EncodeToString(h.Sum(nil)); got != wantHash {
+		return discardStagedFile(f, p, fmt.Errorf("checksum mismatch for %s: got %s, manifest declares %s", rel, got, wantHash))
 	}
 	return nil
 }
 
+// discardStagedFile truncates a staged file that cannot be resumed and returns
+// an error naming both the cause and the staged path.
+//
+// Resume starts from the staged file's own size (see downloadOne), so a staged
+// file that is already the full size with the wrong contents, or longer than
+// the manifest declares, is not a transient failure: every later run reads the
+// same size, asks for no bytes, and fails the same way. Truncating to zero is
+// what makes the next run refetch the file. The path is named because the file
+// lives under a ".partial" sibling of the destination that the user never asked
+// for by name and would otherwise have to guess at.
+func discardStagedFile(f *os.File, path string, cause error) error {
+	if err := f.Truncate(0); err != nil {
+		return fmt.Errorf("%w; the staged file %s could not be discarded (%v), so remove it by hand before retrying", cause, path, err)
+	}
+	return fmt.Errorf("%w; discarded the staged file %s, so a re-run refetches it", cause, path)
+}
+
 func printEpisode(cmd *cobra.Command, e *agentpbv2.DataEpisode) error {
 	if jsonOutput {
-		return json.NewEncoder(cmd.OutOrStdout()).Encode(e)
+		return encodeProtoJSON(cmd.OutOrStdout(), e)
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "Episode %s: %s\n", e.GetId(), e.GetState())
 	return nil

--- a/go/internal/cli/commands/data_download_test.go
+++ b/go/internal/cli/commands/data_download_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -76,5 +77,132 @@ func TestStagedFilePathRejectsUnsafePaths(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+// TestDownloadDestinationCleansTrailingSeparator guards the regression where
+// `wendy data download <episode> -o ./ep/` staged INSIDE its own destination.
+// The staging directory is named by appending ".partial" to the destination, so
+// an uncleaned "./ep/" produced "./ep/.partial": os.MkdirAll then created the
+// destination as a side effect, the final rename failed with ENOTEMPTY because
+// the destination now held the staging directory, and every re-run refused with
+// "destination already exists".
+func TestDownloadDestinationCleansTrailingSeparator(t *testing.T) {
+	sep := string(os.PathSeparator)
+	cases := []struct {
+		name      string
+		id        string
+		output    string
+		wantDest  string
+		wantStage string
+	}{
+		{"trailing separator", "ep1", "." + sep + "ep" + sep, filepath.Join(".", "ep"), filepath.Join(".", "ep") + ".partial"},
+		{"bare relative", "ep1", "ep", "ep", "ep.partial"},
+		{"dot slash", "ep1", "." + sep + "ep", filepath.Join(".", "ep"), filepath.Join(".", "ep") + ".partial"},
+		{"default is the episode id", "ep1", "", "ep1", "ep1.partial"},
+		{"redundant separators", "ep1", "out" + sep + sep + "ep" + sep, filepath.Join("out", "ep"), filepath.Join("out", "ep") + ".partial"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dest, stage := downloadDestination(tc.id, tc.output)
+			if dest != tc.wantDest {
+				t.Fatalf("downloadDestination(%q, %q) destination = %q, want %q", tc.id, tc.output, dest, tc.wantDest)
+			}
+			if stage != tc.wantStage {
+				t.Fatalf("downloadDestination(%q, %q) stage = %q, want %q", tc.id, tc.output, stage, tc.wantStage)
+			}
+			// The staging directory must be a sibling of the destination, never
+			// a child of it: a child is what made the rename fail.
+			if strings.HasPrefix(stage, dest+sep) {
+				t.Fatalf("stage %q is inside destination %q", stage, dest)
+			}
+		})
+	}
+}
+
+// TestDownloadOneDiscardsOversizedStagedFile covers the resume wedge: resume
+// starts from the staged file's own size, so a staged file longer than the
+// manifest declares fails identically on every re-run until something discards
+// it. The error must also name the staged path, which the user never chose and
+// would otherwise have to guess.
+func TestDownloadOneDiscardsOversizedStagedFile(t *testing.T) {
+	root := t.TempDir()
+	staged := filepath.Join(root, "events.jsonl")
+	if err := os.WriteFile(staged, []byte("way too many bytes"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	// The size check runs before the first RPC, so no client is needed.
+	err := downloadOne(context.Background(), nil, "ep1", root, "events.jsonl", 4, "unused")
+	if err == nil {
+		t.Fatal("downloadOne accepted a staged file longer than the manifest")
+	}
+	if !strings.Contains(err.Error(), staged) {
+		t.Fatalf("error does not name the staged path %q: %v", staged, err)
+	}
+	info, statErr := os.Stat(staged)
+	if statErr != nil {
+		t.Fatal(statErr)
+	}
+	if info.Size() != 0 {
+		t.Fatalf("staged file kept %d bytes; the next run would wedge the same way", info.Size())
+	}
+}
+
+// TestDownloadOneDiscardsStagedFileWithWrongHash is the other wedge: a staged
+// file that is already the full size asks the device for no bytes at all, so a
+// re-run recomputes the same wrong hash forever.
+func TestDownloadOneDiscardsStagedFileWithWrongHash(t *testing.T) {
+	root := t.TempDir()
+	staged := filepath.Join(root, "events.jsonl")
+	contents := []byte("corrupt!")
+	if err := os.WriteFile(staged, contents, 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	client := &stubDataClient{}
+	err := downloadOne(context.Background(), client, "ep1", root, "events.jsonl", int64(len(contents)), strings.Repeat("0", 64))
+	if err == nil {
+		t.Fatal("downloadOne accepted a staged file whose hash does not match the manifest")
+	}
+	if !strings.Contains(err.Error(), staged) {
+		t.Fatalf("error does not name the staged path %q: %v", staged, err)
+	}
+	if !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("error does not name the cause: %v", err)
+	}
+	info, statErr := os.Stat(staged)
+	if statErr != nil {
+		t.Fatal(statErr)
+	}
+	if info.Size() != 0 {
+		t.Fatalf("staged file kept %d bytes; the next run would wedge the same way", info.Size())
+	}
+	if client.downloadOffset != int64(len(contents)) {
+		t.Fatalf("resume offset = %d, want %d", client.downloadOffset, len(contents))
+	}
+}
+
+// TestDownloadOneKeepsShortStagedFile is the counterpart: a staged file shorter
+// than the manifest is a stream that ended early, its bytes are good, and the
+// next run resumes from them. Discarding those would turn a slow uplink into an
+// endless restart.
+func TestDownloadOneKeepsShortStagedFile(t *testing.T) {
+	root := t.TempDir()
+	staged := filepath.Join(root, "events.jsonl")
+	if err := os.WriteFile(staged, []byte("half"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	err := downloadOne(context.Background(), &stubDataClient{}, "ep1", root, "events.jsonl", 128, strings.Repeat("0", 64))
+	if err == nil {
+		t.Fatal("downloadOne reported success for a truncated download")
+	}
+	info, statErr := os.Stat(staged)
+	if statErr != nil {
+		t.Fatal(statErr)
+	}
+	if info.Size() != 4 {
+		t.Fatalf("staged file size = %d, want the 4 resumable bytes kept", info.Size())
 	}
 }

--- a/go/internal/cli/commands/data_json_test.go
+++ b/go/internal/cli/commands/data_json_test.go
@@ -1,0 +1,127 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	agentpbv2 "github.com/wendylabsinc/wendy/go/proto/gen/agentpb/v2"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// stubDataClient is a DataServiceClient that answers Download with an
+// immediately exhausted stream and refuses everything else. It exists so the
+// download tests can exercise the resume and verification paths without a
+// device; the offset the command asked to resume from is recorded.
+type stubDataClient struct {
+	downloadOffset int64
+}
+
+func unimplemented(method string) error {
+	return status.Errorf(codes.Unimplemented, "stubDataClient does not serve %s", method)
+}
+
+func (s *stubDataClient) Sources(context.Context, *agentpbv2.DataSourcesRequest, ...grpc.CallOption) (*agentpbv2.DataSourcesResponse, error) {
+	return nil, unimplemented("Sources")
+}
+func (s *stubDataClient) Start(context.Context, *agentpbv2.DataStartRequest, ...grpc.CallOption) (*agentpbv2.DataEpisode, error) {
+	return nil, unimplemented("Start")
+}
+func (s *stubDataClient) Stop(context.Context, *agentpbv2.DataStopRequest, ...grpc.CallOption) (*agentpbv2.DataEpisode, error) {
+	return nil, unimplemented("Stop")
+}
+func (s *stubDataClient) Status(context.Context, *agentpbv2.DataStatusRequest, ...grpc.CallOption) (*agentpbv2.DataStatusResponse, error) {
+	return nil, unimplemented("Status")
+}
+func (s *stubDataClient) Episodes(context.Context, *agentpbv2.DataEpisodesRequest, ...grpc.CallOption) (*agentpbv2.DataEpisodesResponse, error) {
+	return nil, unimplemented("Episodes")
+}
+func (s *stubDataClient) Inspect(context.Context, *agentpbv2.DataInspectRequest, ...grpc.CallOption) (*agentpbv2.DataInspectResponse, error) {
+	return nil, unimplemented("Inspect")
+}
+func (s *stubDataClient) Download(_ context.Context, in *agentpbv2.DataDownloadRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[agentpbv2.DataDownloadChunk], error) {
+	s.downloadOffset = in.GetOffset()
+	return &exhaustedDownloadStream{}, nil
+}
+func (s *stubDataClient) CampaignDeploy(context.Context, *agentpbv2.DataCampaignDeployRequest, ...grpc.CallOption) (*agentpbv2.DataCampaign, error) {
+	return nil, unimplemented("CampaignDeploy")
+}
+func (s *stubDataClient) Campaigns(context.Context, *agentpbv2.DataCampaignsRequest, ...grpc.CallOption) (*agentpbv2.DataCampaignsResponse, error) {
+	return nil, unimplemented("Campaigns")
+}
+func (s *stubDataClient) CampaignInspect(context.Context, *agentpbv2.DataCampaignInspectRequest, ...grpc.CallOption) (*agentpbv2.DataCampaign, error) {
+	return nil, unimplemented("CampaignInspect")
+}
+func (s *stubDataClient) CampaignTrigger(context.Context, *agentpbv2.DataCampaignTriggerRequest, ...grpc.CallOption) (*agentpbv2.DataEpisode, error) {
+	return nil, unimplemented("CampaignTrigger")
+}
+
+// exhaustedDownloadStream yields no chunks. grpc.ClientStream is embedded for
+// the methods downloadOne never calls; calling one panics rather than silently
+// reporting a zero value.
+type exhaustedDownloadStream struct {
+	grpc.ClientStream
+}
+
+func (e *exhaustedDownloadStream) Recv() (*agentpbv2.DataDownloadChunk, error) { return nil, io.EOF }
+
+// TestEncodeProtoJSONDialect pins the documented --json dialect: protocol
+// buffer field names as the .proto declares them, one compact line, and stable
+// bytes across runs (protojson randomises its whitespace, so the encoder
+// compacts before writing).
+func TestEncodeProtoJSONDialect(t *testing.T) {
+	message := &agentpbv2.DataEpisode{Id: "ep1", Name: "commissioning", State: "sealed", StartedUnixNanos: 5, SizeBytes: 9}
+
+	var first, second bytes.Buffer
+	if err := encodeProtoJSON(&first, message); err != nil {
+		t.Fatalf("encodeProtoJSON: %v", err)
+	}
+	if err := encodeProtoJSON(&second, message); err != nil {
+		t.Fatalf("encodeProtoJSON: %v", err)
+	}
+	if first.String() != second.String() {
+		t.Fatalf("output is not stable across runs:\n%s\n%s", first.String(), second.String())
+	}
+
+	got := first.String()
+	if !strings.HasSuffix(got, "\n") {
+		t.Fatalf("output is not newline terminated: %q", got)
+	}
+	line := strings.TrimSuffix(got, "\n")
+	if strings.ContainsAny(line, "\n\t") {
+		t.Fatalf("output is not a single compact line: %q", got)
+	}
+	for _, want := range []string{`"id":"ep1"`, `"started_unix_nanos"`, `"size_bytes"`} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("output %q does not carry %s; the dialect is protocol buffer field names", line, want)
+		}
+	}
+	if strings.Contains(line, "startedUnixNanos") {
+		t.Fatalf("output %q uses lowerCamelCase; the dialect is protocol buffer field names", line)
+	}
+	if !json.Valid([]byte(line)) {
+		t.Fatalf("output is not valid JSON: %q", line)
+	}
+	// Unpopulated fields stay out, exactly as protobuf JSON specifies.
+	if strings.Contains(line, "boot_id") {
+		t.Fatalf("output %q carries an unpopulated field", line)
+	}
+
+	var canonical bytes.Buffer
+	raw, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(message)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = json.Compact(&canonical, raw); err != nil {
+		t.Fatal(err)
+	}
+	if line != canonical.String() {
+		t.Fatalf("output %q is not canonical protobuf JSON %q", line, canonical.String())
+	}
+}

--- a/go/internal/cli/commands/data_sources_test.go
+++ b/go/internal/cli/commands/data_sources_test.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -244,13 +243,14 @@ func TestWriteDataSourcesFloodKeepsOtherKinds(t *testing.T) {
 	}
 }
 
-// --json without --kind must stay byte-for-byte the full proto encoding,
-// because scripts consume it.
+// --json without --kind must stay the full response the device sent, in the
+// canonical protobuf JSON dialect every data subcommand emits, because scripts
+// consume it.
 func TestDataSourcesJSONUnchangedWithoutKind(t *testing.T) {
 	response := &agentpbv2.DataSourcesResponse{Sources: orinNanoSources()}
 
 	var want bytes.Buffer
-	if err := json.NewEncoder(&want).Encode(response); err != nil {
+	if err := encodeProtoJSON(&want, response); err != nil {
 		t.Fatalf("encode: %v", err)
 	}
 

--- a/go/internal/shared/appconfig/annotation.go
+++ b/go/internal/shared/appconfig/annotation.go
@@ -23,6 +23,12 @@ const EntitlementAnnotationKeyPrefix = "sh.wendy/entitlement."
 // an identifier followed by '='. Entitlements with no parameters produce an
 // empty string.
 //
+// The format therefore assumes no list element contains ',' or '='. Pins and
+// ports are numeric and cannot. Allowlist entries are author-supplied strings,
+// so the assumption is enforced upstream at validation time by
+// validateAllowlistEntries in appconfig.go, which is the only place able to
+// tell the author what to change.
+//
 // Examples:
 //
 //	bluetooth                → ""

--- a/go/internal/shared/appconfig/annotation_test.go
+++ b/go/internal/shared/appconfig/annotation_test.go
@@ -3,6 +3,7 @@ package appconfig
 import (
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -232,5 +233,70 @@ func TestSplitAnnotationParams(t *testing.T) {
 		if !reflect.DeepEqual(got, tc.want) {
 			t.Errorf("splitAnnotationParams(%q) = %v; want %v", tc.input, got, tc.want)
 		}
+	}
+}
+
+// TestValidateRejectsAllowlistDelimiters covers the codec assumption that
+// EntitlementAnnotationValue makes and cannot itself enforce: an entitlement
+// travels to the device as a container label of comma-separated key=value
+// pairs, with the allowlist folded into one segment by joining on commas. An
+// entry containing a comma is silently split into two entries, and one
+// containing ",key=" terminates the allowlist and overwrites a sibling field.
+// Validation is where an author can still be told, so it is where the two
+// characters are refused.
+func TestValidateRejectsAllowlistDelimiters(t *testing.T) {
+	cases := []struct {
+		name  string
+		entry string
+		// corrupts records whether today's codec actually mangles the entry. A
+		// comma does; a bare '=' does not, and is refused only because it is
+		// the pair separator itself (see validateAllowlistEntries).
+		corrupts bool
+	}{
+		{"comma splits the entry in two", "/dev/video0,/dev/video1", true},
+		{"comma plus key overwrites a sibling field", "/dev/video0,mode=host", true},
+		{"bare equals", "name=/dev/video0", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &AppConfig{
+				AppID:        "com.example.app",
+				Entitlements: []Entitlement{{Type: EntitlementCamera, Mode: "detect", Allowlist: []string{tc.entry}}},
+			}
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatalf("Validate() accepted allowlist entry %q", tc.entry)
+			}
+			if !strings.Contains(err.Error(), "allowlist[0]") {
+				t.Fatalf("error does not name the offending entry: %v", err)
+			}
+
+			// Show what the codec would have done with it, so the test states
+			// the harm rather than only the rule.
+			round := ParseEntitlementAnnotation(EntitlementCamera, EntitlementAnnotationValue(cfg.Entitlements[0]))
+			intact := len(round.Allowlist) == 1 && round.Allowlist[0] == tc.entry && round.Mode == "detect"
+			if tc.corrupts && intact {
+				t.Fatalf("entry %q survives the codec intact; the rule may no longer be needed", tc.entry)
+			}
+			if !tc.corrupts && !intact {
+				t.Fatalf("entry %q now corrupts the codec; validateAllowlistEntries should say so", tc.entry)
+			}
+		})
+	}
+}
+
+// TestValidateAcceptsOrdinaryAllowlistEntries confirms the rule rejects nothing
+// that any shipped source identifier grammar produces.
+func TestValidateAcceptsOrdinaryAllowlistEntries(t *testing.T) {
+	cfg := &AppConfig{
+		AppID: "com.example.app",
+		Entitlements: []Entitlement{{
+			Type:      EntitlementCamera,
+			Mode:      "detect",
+			Allowlist: []string{"/dev/video0", "/dev/video1", "v4l2:/dev/video2", "usb-046d_C920-video-index0"},
+		}},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() rejected ordinary allowlist entries: %v", err)
 	}
 }

--- a/go/internal/shared/appconfig/appconfig.go
+++ b/go/internal/shared/appconfig/appconfig.go
@@ -411,6 +411,41 @@ func LoadFromBytes(data []byte) (*AppConfig, error) {
 	return &cfg, nil
 }
 
+// validateAllowlistEntries rejects the two characters an allowlist entry may
+// not contain.
+//
+// An entitlement travels to the device as a container label whose value is a
+// comma-separated list of key=value pairs, with list-valued fields such as the
+// allowlist folded into one segment by joining on commas
+// (EntitlementAnnotationValue in annotation.go).
+//
+// A comma corrupts that encoding outright. The parser splits on the commas that
+// precede a new "key=" and cannot tell those apart from a comma inside an
+// entry, so an entry containing one is silently split into two allowlist
+// entries, and an entry containing ",key=" is worse: it terminates the
+// allowlist and overwrites a sibling field of the entitlement, such as the
+// mode.
+//
+// An '=' does not corrupt anything today, because the parser takes only the
+// first '=' of a segment as the separator and keeps the rest as the value. It
+// is refused anyway: '=' IS the pair separator, so an entry carrying one is
+// ambiguous by construction, and it is the one character that would turn any
+// future change to the key-detection rule into silent corruption of exactly
+// this field.
+//
+// No source identifier the platform emits today contains either character, so
+// this rejects nothing that works. It is enforced here, at the point where the
+// value enters the system from an author's wendy.json, rather than at the codec,
+// because the codec has no way to report a problem to the person who can fix it.
+func validateAllowlistEntries(allowlist []string, prefix string, index int) error {
+	for j, entry := range allowlist {
+		if strings.ContainsAny(entry, ",=") {
+			return fmt.Errorf("%s[%d]: allowlist[%d] must not contain ',' or '=', got %q; those characters delimit the container label the entitlement is carried in and would corrupt it", prefix, index, j, entry)
+		}
+	}
+	return nil
+}
+
 // validateEntitlements checks a slice of entitlements for required fields and
 // valid types. The prefix string is used in error messages (e.g.
 // "entitlement" for top-level or "services[\"foo\"].entitlement" for service-
@@ -422,6 +457,9 @@ func validateEntitlements(entitlements []Entitlement, prefix string) error {
 		}
 		if !slices.Contains(ValidEntitlementTypes, e.Type) {
 			return fmt.Errorf("%s[%d]: unknown type %q", prefix, i, e.Type)
+		}
+		if err := validateAllowlistEntries(e.Allowlist, prefix, i); err != nil {
+			return err
 		}
 
 		switch e.Type {


### PR DESCRIPTION
## Problem

Ten review findings on the Wendy Data platform branch. Two of them are real
defects a user hits on the first try: `wendy data download -o ./ep/` fails and
then refuses to run again, and a bad staged file wedges resume permanently with
an error that names neither the file nor the remedy. Two are resource and
lifecycle leaks in the agent: the app data socket accepts connections without
limit, and deleting one service of an app never releases that service's socket
ownership. The rest are correctness of the contract and of what we tell people:
an entitlement allowlist can silently corrupt the container label it travels
in, two removed protocol buffer field numbers can be reused by accident, the
`--json` output shape differs between sibling subcommands, and three documents
describe behaviour this branch does not have.

## Cause

Each one is a small assumption that stopped holding.

`stage := output + ".partial"` assumes `output` has no trailing separator. With
one, the staging directory lands INSIDE the destination, `os.MkdirAll` creates
the destination as a side effect, the rename fails with `ENOTEMPTY`, and the
next run sees the destination it created itself.

`downloadOne` resumes from `st.Size()`. That is right for a stream that ended
early and wrong for a file that is already complete and wrong, or longer than
the manifest: those read the same size forever, request no bytes, and fail
identically on every attempt.

The per-app rate limiter counts records. A reconnect loop never sends one, so
nothing in the accept path sees it.

`DeleteContainer` released socket ownership only when the delete addressed the
whole app, because the socket is per app. But the OWNER SET is per service, and
that is what the allowlist union is computed from.

`EntitlementAnnotationValue` joins list values with commas into a format whose
own separators are `,` and `=`. Nothing checked that an allowlist entry
contains neither.

`EpisodeManifest` had fields 2 and 3 deleted with no `reserved` statement, so
the numbers are free for a future edit to re-use with a different meaning.

## Solution

Minimal, per finding, with a regression test for each code fix. No wire type or
field name changed: devices ship this contract and the cloud side vendors the
same file.

Two design notes worth flagging:

- The `--json` dialect is now stated once, in a comment on `encodeProtoJSON`
  and in the command page. Protocol buffer messages go out as canonical
  protobuf JSON with protocol buffer field names, compacted to one line because
  protojson deliberately varies its whitespace between runs. Payloads that are
  already a JSON document the device sealed (the episode manifest, the campaign
  plan) are still written through untouched, because byte fidelity is the point
  of those. `download` gets an object of its own: it reports the local
  filesystem, which no wire message describes.
- The restore-time sweep is a new optional interface, `appSocketSweeper`, that
  a socket provider may implement. It exists because a socket directory is
  named by a hash of the app identity and the only record of that identity is
  the container label: delete the last container and nothing afterwards can
  work out which directory belonged to it. Restore is the one point where the
  live set is known exactly.

## Findings

| Finding | Verdict | What changed |
| --- | --- | --- |
| S7a-F3 trailing-slash `-o` wedges download | FIXED | `downloadDestination` cleans the destination before naming the staging sibling; five-case test including the trailing separator |
| S7a-F4 unusable staged file wedges resume | FIXED | Over-size and wrong-digest staged files are truncated and the error names the `.partial` path; a short staged file is deliberately kept as resumable; three tests |
| S7a-F7 doc says `-o` must be absolute | FIXED | Corrected in the command page; the example there now uses a relative path, matching `TestStagedFilePathAcceptsRelativeRoot` |
| S7a-F8 examples say camera pre-roll does not exist | FIXED | Both comments now describe the real behaviour: the buffer covers application records and camera streams, audio and ROS 2 start at the trigger |
| S7a-F9 inconsistent `--json` shape | FIXED | One `encodeProtoJSON` helper for every protocol buffer payload, a JSON object from `download`, the dialect documented in code and in the command page |
| S4-F2 unbounded connections per app | FIXED | `dataMaxLiveConnectionsPerApp = 16`, a readable refusal ack, a warning throttled to one per minute, and a write deadline so the refusal cannot stall the accept loop; test asserts the cap+1th is refused and that closing one frees a slot |
| S4-F4 allowlist entry corrupts its label | FIXED | `validateAllowlistEntries` refuses `,` and `=`; the test also demonstrates what today's codec does to a comma, and asserts ordinary identifiers still pass |
| S4-F6 per-service socket release missing | FIXED | `releaseSocketsAfterDelete` releases each deleted container's owner when the delete was partial, plus a restore-time sweep on both socket managers; five unit tests over mock providers |
| S4-F7 socket directory mode is umask dependent | FIXED | Explicit `os.Chmod(dir, 0o750)` and the sibling manager's recreate guard on removal; test runs under a 0o077 umask |
| S3-F4 removed field numbers not reserved | FIXED (stubs pending) | `reserved 2, 3;` on `EpisodeManifest` with the reason |
| S3-F5 `QueryEpisodes` has no page token | FIXED (stubs pending) | `page_token = 8` and `next_page_token = 2`, additive, documented as not yet load bearing |
| S3-F7 chunk `size`/`sha256` semantics undocumented | FIXED | `DataDownloadChunk` documents that both are whole-file values repeated on every chunk, and that the manifest JSON is the file list contract |
| S3-F8 zero semantics and signedness undocumented | FIXED | `require_utc_uncertainty_nanos` documents that zero means no requirement; the signedness convention is stated once on `DataDownloadChunk` |
| S3-F6, S3-F9 wire conventions | DEFERRED by instruction | See follow-ups below |

### Two notes on the findings as written

`S4-F4` names `go/internal/agent/containerd/client.go` as the consumer that
restores allowlists from labels. It is `helpers.go` in the same package
(`parseEntitlementFromAnnotation`, around line 462). The finding itself holds.

`S4-F6`'s socket-directory orphan is fixed for both socket managers, not only
the data socket, because `DeleteContainer` had the identical `wholeApp`
condition on both providers.

## Generated stubs need regeneration

The `.proto` edits are NOT reflected in `go/proto/gen`. The committed stubs
were generated with protoc 35.1 (`v7.35.1` in their headers) and only 36.0 is
installed here; regenerating with it rewrites the version line in 75 files,
which is churn unrelated to this change. Nothing hand-edited.

- `reserved 2, 3;` produces no stub change at all, so that finding is complete
  as committed.
- The `page_token` and `next_page_token` fields DO need a regeneration before
  any Go caller can use them. Nothing uses them today: the reader door in the
  data repository serves `QueryEpisodes` and `GetEpisode`, and the ingest
  answers both with `UNIMPLEMENTED`.

The same `data_ingest.proto` is vendored in `wendylabsinc/data` at
`proto/wendycloud/data/v1/data_ingest.proto` on branch `work/org-buckets`. That
repository is untouched here and needs the same two edits to stay in step.

## Follow-ups, deliberately not done

- **S3-F6** device-side state (`DataEpisode.state`, `DataCampaign.state`) and
  **S3-F9** trigger reason are strings where an enum would be the right shape.
  Devices ship the string contract, so changing it is a coordinated migration,
  not a review fix.
- `DataDownloadChunk.size` is `int64` where the cloud contract uses `uint64`
  for a byte count. Documented rather than changed, for the same reason.
- The System API socket manager now implements the same sweep as the data
  socket manager; neither sweeps on a path other than restore.

## Verification

From `go/`, matching `.github/workflows/go-tests.yml`:

- `go build ./...` clean.
- `GOOS=linux go vet` clean on `./internal/agent/services`,
  `./internal/agent/containerd`, `./internal/shared/appconfig`. Host `go vet
  ./internal/cli/...` clean. `GOOS=linux go vet ./internal/cli/...` cannot run
  on this macOS host: `github.com/google/gousb` needs a Linux cgo toolchain.
  That is a pre-existing cross-compile limitation, not a change here.
- `go test -race` green on `./internal/cli/commands/`,
  `./internal/shared/appconfig/`, `./internal/agent/services/` and
  `./internal/agent/containerd/` (full packages, not only the new tests).
- `gofmt -l -s .` clean; the Windows cross-compile steps
  (`GOOS=windows go build ./internal/cli/... ./cmd/wendy/` and
  `go test -c ./internal/cli/commands`) both pass, which is what the
  `//go:build unix` guard on the umask test is for.
- Both edited `.proto` files parse under `protoc`.
- Each new test was mutation checked: reverting the fix it guards makes it
  fail. `TestBuildCmd_MultiService_BuildsFromManifestOnly` fails on this macOS
  host for an unrelated `/private` symlink reason; verified it fails identically
  on the base branch.
