### PR TITLE
fix(data): durability, recovery, clock status and campaign validation

### DIFF
--- a/go/cmd/wendy-agent/main.go
+++ b/go/cmd/wendy-agent/main.go
@@ -308,8 +308,8 @@ func main() {
 	// space. A device whose data partition wants different bounds sets these
 	// rather than being stuck with the built-in numbers.
 	dataManager.SetQuota(
-		envBytes(logger, "WENDY_DATA_MAX_BYTES", agentdata.DefaultMaxQuotaBytes),
-		envBytes(logger, "WENDY_DATA_RESERVE_BYTES", agentdata.DefaultReserveBytes),
+		envBytes(logger, "WENDY_DATA_MAX_BYTES", agentdata.DefaultMaxQuotaBytes, 1),
+		envBytes(logger, "WENDY_DATA_RESERVE_BYTES", agentdata.DefaultReserveBytes, 0),
 	)
 	dataSvc := services.NewDataService(dataManager)
 	dataSvc.SetAudioService(audioSvc)
@@ -1333,15 +1333,23 @@ func handleUtilityCommand(args []string) (bool, int) {
 // when the variable is unset. A value that is present but unusable is reported
 // rather than silently ignored: a device configured with a bad quota should
 // learn that its configuration did not take.
-func envBytes(logger *zap.Logger, name string, fallback int64) int64 {
+//
+// minimum is the smallest value the setting accepts. It exists because the two
+// callers disagree about zero: a reserve of zero is a real choice ("keep no
+// headroom"), while a maximum quota of zero is not a store that holds nothing,
+// it is a value SetQuota discards in favour of the default. Accepting zero for
+// the quota therefore produced a device running on 50 GiB while its operator
+// believed they had capped it, with nothing logged either way.
+func envBytes(logger *zap.Logger, name string, fallback, minimum int64) int64 {
 	raw, ok := os.LookupEnv(name)
 	if !ok || strings.TrimSpace(raw) == "" {
 		return fallback
 	}
 	v, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
-	if err != nil || v < 0 {
+	if err != nil || v < minimum {
 		logger.Warn("ignoring unusable byte count in environment; using the default",
-			zap.String("variable", name), zap.String("value", raw), zap.Int64("default", fallback))
+			zap.String("variable", name), zap.String("value", raw),
+			zap.Int64("minimum", minimum), zap.Int64("default", fallback))
 		return fallback
 	}
 	return v

--- a/go/cmd/wendy-agent/main_test.go
+++ b/go/cmd/wendy-agent/main_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"go.uber.org/zap/zaptest"
+)
 
 func TestBrokerURLForCloudHost(t *testing.T) {
 	tests := []struct {
@@ -31,5 +35,41 @@ func TestBrokerURLForCloudHost(t *testing.T) {
 				t.Fatalf("brokerURLForCloudHost(%q) = %q, want %q", tt.cloudHost, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestEnvBytesRejectsBelowMinimum covers WENDY_DATA_MAX_BYTES=0. Zero passed
+// the old "not negative" check, reached SetQuota, and was discarded there in
+// favour of the built-in default, so a device ran on 50 GiB while its operator
+// believed they had capped its episode store, and nothing was logged either
+// way. Zero remains valid for the reserve, where it genuinely means "keep no
+// headroom".
+func TestEnvBytesRejectsBelowMinimum(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	const fallback = int64(4096)
+	for _, tc := range []struct {
+		name    string
+		value   string
+		minimum int64
+		want    int64
+	}{
+		{"quota zero is rejected", "0", 1, fallback},
+		{"quota negative is rejected", "-1", 1, fallback},
+		{"quota positive is taken", "8192", 1, 8192},
+		{"reserve zero is taken", "0", 0, 0},
+		{"reserve negative is rejected", "-1", 0, fallback},
+		{"unparseable is rejected", "lots", 1, fallback},
+		{"whitespace is trimmed", "  8192  ", 1, 8192},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("WENDY_TEST_BYTES", tc.value)
+			if got := envBytes(logger, "WENDY_TEST_BYTES", fallback, tc.minimum); got != tc.want {
+				t.Fatalf("envBytes(%q, minimum %d) = %d, want %d", tc.value, tc.minimum, got, tc.want)
+			}
+		})
+	}
+	// An unset variable is not a misconfiguration; it is the default.
+	if got := envBytes(logger, "WENDY_TEST_BYTES_UNSET", fallback, 1); got != fallback {
+		t.Fatalf("an unset variable gave %d, want the %d default", got, fallback)
 	}
 }

--- a/go/internal/agent/data/campaign.go
+++ b/go/internal/agent/data/campaign.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"os"
 	"path/filepath"
@@ -16,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/wendylabsinc/wendy/go/internal/shared/atomicfile"
 	"gopkg.in/yaml.v3"
 )
 
@@ -141,9 +143,7 @@ type CampaignCapture struct {
 	Buffer string `json:"buffer" yaml:"buffer"`
 	// Drain holds the episode open for late application records after its
 	// capture adapters stop. An empty value takes DefaultSealDrain; "0s" opts
-	// out. The omitempty tag is load-bearing: planOnly is marshalled to JSON to
-	// compute Revision, so a field rendered on every campaign would change the
-	// revision digest of every already-deployed campaign.
+	// out.
 	Drain        string            `json:"drain,omitempty" yaml:"drain,omitempty"`
 	AfterTrigger string            `json:"after_trigger" yaml:"after_trigger"`
 	Triggers     []CampaignTrigger `json:"triggers" yaml:"triggers"`
@@ -252,9 +252,18 @@ func ParseCampaign(contents []byte) (Campaign, error) {
 	if err := decoder.Decode(&campaign); err != nil {
 		return Campaign{}, fmt.Errorf("parsing campaign YAML: %w", err)
 	}
+	// Only a clean end of input proves there was no second document. Testing
+	// for a nil error accepted anything that failed to parse, so a plan with a
+	// malformed second document deployed with the second document silently
+	// dropped, and the operator's whole intent for it went nowhere with no
+	// error anywhere. Any other error is that second document failing to
+	// parse, and is reported as such.
 	var trailing any
-	if err := decoder.Decode(&trailing); err == nil {
+	switch err := decoder.Decode(&trailing); {
+	case err == nil:
 		return Campaign{}, errors.New("campaign YAML must contain exactly one document")
+	case !errors.Is(err, io.EOF):
+		return Campaign{}, fmt.Errorf("campaign YAML must contain exactly one document; the text after the first one does not parse: %w", err)
 	}
 	if err := campaign.validate(); err != nil {
 		return Campaign{}, err
@@ -266,7 +275,7 @@ func ParseCampaign(contents []byte) (Campaign, error) {
 	if campaign.Privacy == nil {
 		campaign.Privacy = []CampaignPrivacy{}
 	}
-	canonical, err := json.Marshal(campaign.planOnly())
+	canonical, err := json.Marshal(campaign.planDigestInput())
 	if err != nil {
 		return Campaign{}, err
 	}
@@ -275,12 +284,97 @@ func ParseCampaign(contents []byte) (Campaign, error) {
 	return campaign, nil
 }
 
-// planOnly strips deployment state before hashing. The author-declared
-// schema version and every plan field, including per-source capture policy,
-// upload policy, and retention, feed the revision digest.
-func (c Campaign) planOnly() Campaign {
-	c.State, c.Revision, c.DeployedUnixNanos, c.Warnings = "", "", 0, nil
-	return c
+// revisionSchema versions the field list below. A campaign's revision is the
+// identity operators and the fleet backend use to tell "the plan changed" from
+// "the same plan was redeployed", so what feeds it is part of the on-device
+// schema and changes only with this number.
+const revisionSchema = 1
+
+// planDigestInput is the exact, enumerated set of author-declared plan fields
+// the revision digest covers.
+//
+// It is an explicit map rather than a marshalled Campaign struct. Hashing the
+// struct meant the digest covered every field the struct would ever have, so
+// adding an unrelated field to Campaign in a later agent release changed the
+// revision of every already-deployed campaign on every device that took the
+// upgrade: an operator saw plans they had not touched appear to have been
+// edited, and the fleet backend saw a fleet-wide plan change that never
+// happened. The digest now covers what the author wrote and nothing else, so a
+// new field is invisible to it until it is added here deliberately.
+//
+// The map is marshalled with encoding/json, which sorts object keys, so the
+// encoding is deterministic without an ordering convention of its own.
+//
+// Adding a field here is a schema change: bump revisionSchema with it. Note
+// that this fix itself moves every existing campaign to a new revision once,
+// because the digest no longer covers the struct's zero-valued fields.
+func (c Campaign) planDigestInput() map[string]any {
+	sources := make([]map[string]any, 0, len(c.Sources))
+	for _, source := range c.Sources {
+		entry := map[string]any{
+			"camera":               source.Camera,
+			"audio":                source.Audio,
+			"ros2":                 source.ROS2,
+			"telemetry":            source.Telemetry,
+			"calibration_revision": source.Calibration,
+		}
+		if capture := source.Capture; capture != nil {
+			entry["capture"] = map[string]any{
+				"mode":           capture.Mode,
+				"interval":       capture.Interval,
+				"rate":           capture.Rate,
+				"pre":            capture.Pre,
+				"post":           capture.Post,
+				"trigger":        capture.Trigger,
+				"fragment":       capture.Fragment,
+				"max_resolution": capture.MaxResolution,
+			}
+		}
+		sources = append(sources, entry)
+	}
+	triggers := make([]map[string]any, 0, len(c.Capture.Triggers))
+	for _, trigger := range c.Capture.Triggers {
+		triggers = append(triggers, map[string]any{
+			"event":             trigger.Event,
+			"model_uncertainty": trigger.ModelUncertainty,
+		})
+	}
+	privacy := make([]map[string]any, 0, len(c.Privacy))
+	for _, transform := range c.Privacy {
+		privacy = append(privacy, map[string]any{
+			"name":     transform.Name,
+			"revision": transform.Revision,
+		})
+	}
+	plan := map[string]any{
+		"revision_schema": revisionSchema,
+		"version":         c.Version,
+		"name":            c.Name,
+		"fleet":           c.Fleet,
+		"sources":         sources,
+		"capture": map[string]any{
+			"buffer":        c.Capture.Buffer,
+			"drain":         c.Capture.Drain,
+			"after_trigger": c.Capture.AfterTrigger,
+			"triggers":      triggers,
+		},
+		"upload": map[string]any{
+			"when":        c.Upload.When,
+			"destination": c.Upload.Destination,
+			"max_rate":    c.Upload.MaxRate,
+		},
+		"retention": map[string]any{"local_quota": c.Retention.LocalQuota},
+		"export":    map[string]any{"annotation": c.Export.Annotation},
+		"models":    c.Models,
+		"privacy":   privacy,
+	}
+	if c.Notify != nil {
+		// Only the fields this schema version knows. UnknownKeys is deploy-time
+		// state a newer cloud may add and is deliberately excluded, exactly as
+		// it is excluded from the stored plan.
+		plan["notify"] = map[string]any{"on": c.Notify.On}
+	}
+	return plan
 }
 
 func (c Campaign) validate() error {
@@ -297,14 +391,29 @@ func (c Campaign) validate() error {
 		return errors.New("campaign must define at least one source")
 	}
 	for i, source := range c.Sources {
+		// A selector that is present but holds nothing but whitespace is
+		// rejected outright rather than counted as absent. Validation trimmed
+		// before testing while resolution did not, so `camera: "  "` beside a
+		// real audio selector validated as a one-kind source and then took the
+		// camera branch at resolution, where an empty selector substring-matched
+		// every camera detail on the device and the audio source was never
+		// resolved at all. The plan recorded a camera the author did not choose
+		// and dropped the microphone they did.
+		for _, selector := range []struct{ field, value string }{
+			{"camera", source.Camera}, {"audio", source.Audio}, {"ros2", source.ROS2},
+		} {
+			if selector.value != "" && strings.TrimSpace(selector.value) == "" {
+				return fmt.Errorf("sources[%d].%s is blank; remove the key or name a source", i, selector.field)
+			}
+		}
 		kinds := 0
-		if strings.TrimSpace(source.Camera) != "" {
+		if source.Camera != "" {
 			kinds++
 		}
-		if strings.TrimSpace(source.Audio) != "" {
+		if source.Audio != "" {
 			kinds++
 		}
-		if strings.TrimSpace(source.ROS2) != "" {
+		if source.ROS2 != "" {
 			kinds++
 		}
 		if source.Telemetry {
@@ -483,11 +592,20 @@ func (m *Manager) DeployCampaign(contents []byte) (Campaign, error) {
 		return Campaign{}, err
 	}
 	b = append(b, '\n')
-	tmp := filepath.Join(dir, campaign.Name+".json.tmp")
-	if err := os.WriteFile(tmp, b, 0o640); err != nil {
-		return Campaign{}, err
-	}
-	if err := os.Rename(tmp, filepath.Join(dir, campaign.Name+".json")); err != nil {
+	// Serialized, and written through atomicfile.
+	//
+	// Two deploys of the same campaign name used to race on one fixed
+	// temporary filename, <name>.json.tmp: both opened it, both wrote into it,
+	// and the file that was renamed into place held one plan's bytes overlaid
+	// with the other's. A campaign plan that is a blend of two deploys is not
+	// something either operator asked for, and nothing downstream can detect
+	// it, because the result is still valid JSON. atomicfile takes a unique
+	// temporary name per write and fsyncs the file and the directory, so the
+	// loser of the race is overwritten whole rather than interleaved, and a
+	// power cut cannot leave an empty plan behind.
+	m.campaignMu.Lock()
+	defer m.campaignMu.Unlock()
+	if err := atomicfile.Write(filepath.Join(dir, campaign.Name+".json"), b, 0o640); err != nil {
 		return Campaign{}, err
 	}
 	return campaign, nil

--- a/go/internal/agent/data/campaign_test.go
+++ b/go/internal/agent/data/campaign_test.go
@@ -388,12 +388,19 @@ upload: {when: wifi, destination: example-episodes}
 export: {annotation: cvat}
 `
 
-// drainDigestPinRevision is the SHA-256 of drainDigestPinYAML's canonical plan,
-// recorded before capture.drain was added. Every deployed campaign is
-// identified by this digest, so a drain-less plan must keep hashing to exactly
-// the same value; that is what the omitempty tag on CampaignCapture.Drain buys.
-// Changing this constant to match new output would be defeating the test.
-const drainDigestPinRevision = "bbb81df5f017616a7c3156f7aaeb064ed00e632ae01546cfce265610a4129e23"
+// drainDigestPinRevision is the SHA-256 of drainDigestPinYAML's canonical
+// plan. Every deployed campaign is identified by this digest, so a plan whose
+// text has not changed must keep hashing to exactly the same value; changing
+// this constant to match new output is defeating the test.
+//
+// It was re-pinned exactly once, when the digest stopped covering a
+// marshalled Campaign struct and started covering the enumerated list of
+// author-declared plan fields in planDigestInput. That change is the whole
+// point: under the old scheme every campaign on the fleet changed revision
+// whenever an agent release added a field to the struct, and TestCampaign
+// RevisionIgnoresUnrelatedStructFields is the guard that it cannot happen
+// again. Re-pinning is allowed only alongside a revisionSchema bump.
+const drainDigestPinRevision = "db663ad55675808849a6dfe0a869ada20a008d0ccd5155cac860a3aac049a458"
 
 func TestCampaignDrainValidation(t *testing.T) {
 	withDrain := func(drain string) []byte {
@@ -428,11 +435,11 @@ func TestCampaignDrainValidation(t *testing.T) {
 	if accepted.DrainDuration() != maxSealDrain {
 		t.Fatalf("capture.drain 30s gives %s, want %s", accepted.DrainDuration(), maxSealDrain)
 	}
-	// The digest pin. A campaign that says nothing about the drain must hash
-	// exactly as it did before the field existed, or every already-deployed
-	// campaign silently changes revision on upgrade.
+	// The digest pin. A campaign whose text has not changed must keep hashing
+	// to the same value, or every already-deployed campaign silently changes
+	// revision on upgrade.
 	if base.Revision != drainDigestPinRevision {
-		t.Fatalf("a drain-less campaign now hashes to %s, want the pre-existing %s: capture.drain must stay omitempty", base.Revision, drainDigestPinRevision)
+		t.Fatalf("a drain-less campaign now hashes to %s, want the pinned %s", base.Revision, drainDigestPinRevision)
 	}
 	// A declared drain is part of the plan and must change the digest.
 	if optedOut.Revision == base.Revision {

--- a/go/internal/agent/data/manager.go
+++ b/go/internal/agent/data/manager.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
@@ -17,6 +18,7 @@ import (
 	"time"
 
 	"github.com/wendylabsinc/wendy/go/internal/agent/timesync"
+	"github.com/wendylabsinc/wendy/go/internal/shared/atomicfile"
 	"golang.org/x/sys/unix"
 )
 
@@ -73,9 +75,14 @@ var (
 const AdHocEpisodeKey = ""
 
 type Manager struct {
-	mu     sync.Mutex
-	root   string
-	active map[string]*activeEpisode
+	mu sync.Mutex
+	// campaignMu serializes campaign plan writes. It is separate from mu
+	// because deploying a plan touches no episode state and must not queue
+	// behind (or block) recording, and because DeployCampaign resolves audio
+	// sources through Sources, which takes mu itself.
+	campaignMu sync.Mutex
+	root       string
+	active     map[string]*activeEpisode
 	// sealing holds episodes that have stopped capturing and are inside their
 	// post-seal drain. They still receive application records, but they no
 	// longer hold their campaign key: an episode whose cameras are already off
@@ -103,6 +110,13 @@ type Manager struct {
 	sourceProvider func(context.Context) []Source
 	appObserver    func(string, ApplicationRecord)
 	warn           func(string)
+	// deferredWarnings holds warnings raised before a logger was attached.
+	// NewManager recovers crash-interrupted episodes, and quarantining or
+	// deleting one is precisely the kind of event an operator must see, but
+	// the agent can only call SetWarnLogger once NewManager has returned. They
+	// are replayed there rather than discarded, and capped so a store full of
+	// damaged partials cannot grow this without bound.
+	deferredWarnings []string
 	// maxQuota and reserve bound the episode store. They default to
 	// DefaultMaxQuotaBytes and DefaultReserveBytes and are overridden through
 	// SetQuota, which is how the agent applies its configuration and how the
@@ -131,9 +145,20 @@ func (m *Manager) SetQuota(maxQuota, reserve int64) {
 // that has not been uploaded yet) to the agent's logger.
 func (m *Manager) SetWarnLogger(warn func(string)) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	m.warn = warn
+	deferred := m.deferredWarnings
+	m.deferredWarnings = nil
+	m.mu.Unlock()
+	if warn == nil {
+		return
+	}
+	for _, message := range deferred {
+		warn(message)
+	}
 }
+
+// maxDeferredWarnings caps the pre-logger warning buffer.
+const maxDeferredWarnings = 64
 
 // Warnf routes an operational warning through the manager's configured logger.
 // Unlike the internal warnf it takes the lock, so it is safe to call from a
@@ -148,9 +173,14 @@ func (m *Manager) Warnf(format string, args ...any) {
 }
 
 func (m *Manager) warnf(format string, args ...any) {
-	if m.warn != nil {
-		m.warn(fmt.Sprintf(format, args...))
+	message := fmt.Sprintf(format, args...)
+	if m.warn == nil {
+		if len(m.deferredWarnings) < maxDeferredWarnings {
+			m.deferredWarnings = append(m.deferredWarnings, message)
+		}
+		return
 	}
+	m.warn(message)
 }
 
 // SetSourceProvider adds device-backed sources discovered by capture adapters.
@@ -172,6 +202,30 @@ func (m *Manager) Sources(ctx context.Context) []Source {
 	}
 	sort.SliceStable(out, func(i, j int) bool { return out[i].ID < out[j].ID })
 	return out
+}
+
+// sourceDiscoveryTimeout bounds the source provider on the episode start path.
+// Discovery is out-of-process for some adapters (the ROS 2 one shells out to
+// `ros2 topic list -t` inside a container), and an adapter that hangs must
+// cost a starting episode a bounded delay rather than blocking it forever.
+// Sources the provider misses inside the budget simply cannot be selected,
+// which surfaces as the ordinary "unknown or unhealthy source" refusal.
+const sourceDiscoveryTimeout = 3 * time.Second
+
+// discoverSources snapshots the built-in and adapter sources for an episode
+// start. It MUST be called without m.mu held: the provider is foreign code
+// that may call back into the manager.
+func (m *Manager) discoverSources() []Source {
+	m.mu.Lock()
+	provider := m.sourceProvider
+	m.mu.Unlock()
+	out := DiscoverSources()
+	if provider == nil {
+		return out
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), sourceDiscoveryTimeout)
+	defer cancel()
+	return append(out, provider(ctx)...)
 }
 
 type bufferedRecord struct {
@@ -253,6 +307,33 @@ type activeEpisode struct {
 	// awaitConsensus reports that the episode's opening Roughtime consensus was
 	// moved off the start path and is still to be attached (see Start).
 	awaitConsensus bool
+	// telemetryLost counts consecutive telemetry rows the 1 Hz sampler could
+	// not write, and telemetryWarnAt rate-limits the warning about them. Both
+	// are touched only by the sampler goroutine, under m.mu.
+	telemetryLost   uint64
+	telemetryWarnAt time.Time
+}
+
+// telemetryWarnInterval bounds how often a failing telemetry write warns. A
+// disk that is full fails every second; one line per second in the agent log
+// buries everything else and is no more informative than one per minute.
+const telemetryWarnInterval = time.Minute
+
+// noteTelemetryDropLocked records one lost telemetry row on the episode's
+// telemetry source. Callers hold m.mu.
+func (a *activeEpisode) noteTelemetryDropLocked() {
+	for i := range a.manifest.Sources {
+		if a.manifest.Sources[i].Source.ID != "telemetry" {
+			continue
+		}
+		drops := uint64(1)
+		if a.manifest.Sources[i].Drops != nil {
+			drops = *a.manifest.Sources[i].Drops + 1
+		}
+		a.manifest.Sources[i].Drops = &drops
+		a.manifest.Sources[i].DropAccounting = "exact"
+		return
+	}
 }
 
 // consensusQueryTimeout bounds one Roughtime consensus query. It is the budget
@@ -349,16 +430,31 @@ func observeUTC(origin int64, _ string, source string) (UTCObservation, error) {
 // may record one active episode at a time, and one ad-hoc (campaign-less)
 // episode may record beside them.
 func (m *Manager) Start(opts StartOptions) (Manifest, error) {
+	key := opts.Trigger.CampaignName
+	// Two things happen before the lock is taken, both of which used to happen
+	// under it. Scanning the store walks every file of every sealed episode,
+	// and the source provider is an out-of-process question: the ROS 2 adapter
+	// answers it by running `ros2 topic list -t` in a container. Holding m.mu
+	// across either stalled every record, status query and adapter callback on
+	// the device; holding it across the provider could also deadlock outright,
+	// because a provider is entitled to call Warnf, Status or ActiveSession,
+	// all of which take the same mutex. Sources() has always called the
+	// provider without the lock for exactly this reason.
+	scan, err := scanEpisodeStore(m.root)
+	if err != nil {
+		return Manifest{}, err
+	}
+	discovered := m.discoverSources()
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	key := opts.Trigger.CampaignName
 	if m.active[key] != nil {
 		if key == AdHocEpisodeKey {
 			return Manifest{}, errors.New("an episode is already active")
 		}
 		return Manifest{}, fmt.Errorf("an episode is already active for campaign %s", key)
 	}
-	if err := m.enforceQuota(); err != nil {
+	if err := m.enforceQuotaLocked(scan); err != nil {
 		return Manifest{}, err
 	}
 	origin, err := readBootTime()
@@ -404,10 +500,6 @@ func (m *Manager) Start(opts StartOptions) (Manifest, error) {
 	if err := os.Mkdir(dir, 0o750); err != nil {
 		return Manifest{}, err
 	}
-	discovered := DiscoverSources()
-	if m.sourceProvider != nil {
-		discovered = append(discovered, m.sourceProvider(context.Background())...)
-	}
 	selected, err := selectSources(discovered, opts.Sources, opts.ExcludeSources)
 	if err != nil {
 		_ = os.Remove(dir)
@@ -449,7 +541,7 @@ func (m *Manager) Start(opts StartOptions) (Manifest, error) {
 	}
 	manifest := Manifest{Version: ManifestVersion, ID: id, Name: opts.Name, State: "recording", Device: deviceIdentity(currentBootID), CanonicalClock: "CLOCK_BOOTTIME", BootID: currentBootID, RequestBootNanos: origin, StartedUnixNanos: time.Now().UnixNano(), Trigger: trigger, CollectorVersion: collectorVersion, ModelVersions: modelVersions, RequestedTopics: requestedTopics, UTCObservations: []UTCObservation{obs}, PreRollAccounting: "exact", SystemClockStatus: "system_reported", Calibrations: []Calibration{}, Privacy: privacy, Upload: upload, Labeling: labeling, Files: []File{}, ModelIO: newModelIO()}
 	if consensus != nil {
-		manifest.Roughtime = append(manifest.Roughtime, *consensus)
+		recordConsensus(dir, &manifest, *consensus)
 		manifest.SystemClockStatus = clockAgreement(obs, *consensus)
 	}
 	for _, s := range selected {
@@ -680,9 +772,29 @@ func (m *Manager) sampleEpisode(ctx context.Context, a *activeEpisode) {
 				continue
 			}
 			sample := map[string]any{"episode_nanos": now - a.manifest.RequestBootNanos, "agent_receipt_boottime_nanos": now, "values": telemetryValues()}
+			// A row lost to a full disk or an I/O error used to vanish
+			// silently: the sampler took the next tick and the manifest went on
+			// saying drop_accounting "unavailable", so an episode with an hour
+			// of missing telemetry was indistinguishable from a complete one.
+			// The loss is now counted on the telemetry source (which is what
+			// drops and drop_accounting are for), carried into the next row
+			// that does land, and warned about at a bounded rate.
+			if lost := a.telemetryLost; lost > 0 {
+				sample["rows_lost_before"] = lost
+			}
 			b, _ := json.Marshal(sample)
-			if err = appendJSONL(filepath.Join(a.dir, "telemetry.jsonl"), b); err == nil {
-				m.mu.Lock()
+			err = appendJSONL(filepath.Join(a.dir, "telemetry.jsonl"), b)
+			m.mu.Lock()
+			if err != nil {
+				a.telemetryLost++
+				a.noteTelemetryDropLocked()
+				warn := a.telemetryWarnAt.IsZero() || time.Since(a.telemetryWarnAt) >= telemetryWarnInterval
+				if warn {
+					a.telemetryWarnAt = time.Now()
+					m.warnf("episode %s: writing a telemetry row failed (%v); %d row(s) lost so far and counted as telemetry drops", a.manifest.ID, err, a.telemetryLost)
+				}
+			} else {
+				a.telemetryLost = 0
 				if m.active[a.key] == a {
 					for i := range a.manifest.Sources {
 						if a.manifest.Sources[i].Source.ID == "telemetry" {
@@ -690,8 +802,8 @@ func (m *Manager) sampleEpisode(ctx context.Context, a *activeEpisode) {
 						}
 					}
 				}
-				m.mu.Unlock()
 			}
+			m.mu.Unlock()
 		case <-clockTicker.C:
 			m.queryAndAttachConsensus(ctx, a, false)
 		}
@@ -717,7 +829,7 @@ func (m *Manager) queryAndAttachConsensus(ctx context.Context, a *activeEpisode,
 	if m.active[a.key] != a {
 		return
 	}
-	a.manifest.Roughtime = append(a.manifest.Roughtime, c)
+	recordConsensus(a.dir, &a.manifest, c)
 	if opening {
 		a.awaitConsensus = false
 		if len(a.manifest.UTCObservations) > 0 {
@@ -727,7 +839,159 @@ func (m *Manager) queryAndAttachConsensus(ctx context.Context, a *activeEpisode,
 	_ = writeManifest(a.dir, a.manifest)
 }
 
-func (m *Manager) enforceQuota() error {
+// evictionCandidate is one sealed or quarantined episode directory the quota
+// may remove, with everything the decision needs already read off disk.
+type evictionCandidate struct {
+	path          string
+	started, size int64
+	id, campaign  string
+	tier          int
+	// quarantined marks a directory recovery could not read, kept under
+	// <id>.unrecoverable. It carries no manifest, so it is described by its
+	// directory name and evicted first.
+	quarantined bool
+}
+
+// storeScan is one pass over the episode store: every directory's byte total
+// and, for the sealed ones, the manifest fields eviction sorts on.
+//
+// It is deliberately a free function taking a root rather than a method taking
+// the manager lock. Scanning means reading every sealed episode's manifest and
+// walking every file in the store, which on a full device is thousands of stat
+// calls, and Start used to do all of it with m.mu held: every application
+// record, every capture-adapter callback and every status query on the device
+// blocked behind one episode's start. The scan needs no manager state, so it
+// runs before the lock is taken and only the decision is made under it.
+type storeScan struct {
+	used       int64
+	candidates []evictionCandidate
+	// partialBytes is what the in-flight .partial directories occupy. They are
+	// counted toward the quota (they are real bytes on the same filesystem)
+	// but are never eviction candidates: an episode that is still recording
+	// must not have its directory pulled out from under it.
+	partialBytes int64
+	// readFailures names the directories whose manifest could not be read.
+	readFailures []string
+}
+
+func dirBytes(dir string) int64 {
+	var size int64
+	_ = filepath.WalkDir(dir, func(_ string, d os.DirEntry, e error) error {
+		if e == nil && !d.IsDir() {
+			if info, x := d.Info(); x == nil {
+				size += info.Size()
+			}
+		}
+		return nil
+	})
+	return size
+}
+
+// unrecoverableSuffix marks a crash-interrupted episode directory that
+// recovery could neither read nor repair. See quarantinePartial.
+const unrecoverableSuffix = ".unrecoverable"
+
+func scanEpisodeStore(root string) (storeScan, error) {
+	var scan storeScan
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return scan, err
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		dir := filepath.Join(root, e.Name())
+		size := dirBytes(dir)
+		scan.used += size
+		switch {
+		case strings.HasSuffix(e.Name(), ".partial"):
+			scan.partialBytes += size
+			continue
+		case strings.HasSuffix(e.Name(), unrecoverableSuffix):
+			// A quarantined directory holds bytes that can never be read,
+			// uploaded or labeled. Counting them without ever evicting them
+			// would let one damaged episode wedge the quota permanently, so it
+			// is the first thing to go and the warning says so.
+			started := int64(0)
+			if info, statErr := e.Info(); statErr == nil {
+				started = info.ModTime().UnixNano()
+			}
+			scan.candidates = append(scan.candidates, evictionCandidate{
+				path: dir, started: started, size: size,
+				id: strings.TrimSuffix(e.Name(), unrecoverableSuffix), tier: 0, quarantined: true,
+			})
+			continue
+		}
+		mf, err := readManifest(dir)
+		if err != nil {
+			scan.readFailures = append(scan.readFailures, e.Name())
+			continue
+		}
+		scan.candidates = append(scan.candidates, evictionCandidate{
+			path: dir, started: mf.StartedUnixNanos, size: size,
+			id: mf.ID, campaign: mf.Trigger.CampaignName, tier: evictionTier(mf.Upload.State),
+		})
+	}
+	return scan, nil
+}
+
+// recordConsensus files one Roughtime consensus round: the full round, with
+// its nonce and raw signed responses, is appended to the episode's evidence
+// sidecar, and the manifest keeps only the bounds.
+//
+// The manifest is rewritten in full on every round. Keeping the raw evidence
+// in it meant a day-long episode, which queries Roughtime every five minutes,
+// rewrote a manifest that had grown by several kilobytes of base64 per round,
+// and by the end the clock evidence was larger than everything else in the
+// file put together. The sidecar is sealed and checksummed exactly like every
+// other episode file, so nothing is lost: the bytes needed to independently
+// reverify a round are still in the episode, they are just not in the file a
+// consumer reads to find out when the episode started.
+//
+// The manifest keeps the first round and the most recent one, which are the
+// two a consumer actually reads: the bound the episode opened with, and the
+// bound it currently holds. RoughtimeRounds says how many the sidecar has.
+func recordConsensus(dir string, mf *Manifest, c timesync.Consensus) {
+	if err := appendRoughtimeEvidence(dir, c); err != nil {
+		// The bounds still reach the manifest: losing the ability to reverify
+		// a round is not a reason to also lose the round.
+		mf.RecoveryActions = append(mf.RecoveryActions, "roughtime evidence sidecar write failed: "+err.Error())
+	} else {
+		mf.RoughtimeEvidenceLog = RoughtimeEvidenceFile
+	}
+	mf.RoughtimeRounds++
+	bounds := c
+	bounds.Evidence = nil
+	switch len(mf.Roughtime) {
+	case 0:
+		mf.Roughtime = []timesync.Consensus{bounds}
+	case 1:
+		mf.Roughtime = append(mf.Roughtime, bounds)
+	default:
+		mf.Roughtime[len(mf.Roughtime)-1] = bounds
+	}
+}
+
+func appendRoughtimeEvidence(dir string, c timesync.Consensus) error {
+	b, err := json.Marshal(c)
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(filepath.Join(dir, RoughtimeEvidenceFile), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o640)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err := f.Write(append(b, '\n')); err != nil {
+		return err
+	}
+	return syncFile(f)
+}
+
+// enforceQuotaLocked evicts against an already-taken store scan. Callers hold
+// m.mu; the scan itself was taken without it.
+func (m *Manager) enforceQuotaLocked(scan storeScan) error {
 	var stat unix.Statfs_t
 	if err := unix.Statfs(m.root, &stat); err != nil {
 		return fmt.Errorf("data filesystem quota: %w", err)
@@ -739,40 +1003,16 @@ func (m *Manager) enforceQuota() error {
 		quota = m.maxQuota
 	}
 	reserve := m.reserve
-	type candidate struct {
-		path          string
-		started, size int64
-		id, campaign  string
-		tier          int
+	used := scan.used
+	for _, name := range scan.readFailures {
+		m.warnf("episode %s has an unreadable manifest; its bytes count against the data quota but it can never be uploaded or evicted by state", name)
 	}
-	var candidates []candidate
-	var used int64
-	entries, err := os.ReadDir(m.root)
-	if err != nil {
-		return err
-	}
-	for _, e := range entries {
-		if !e.IsDir() || strings.HasSuffix(e.Name(), ".partial") {
+	candidates := make([]evictionCandidate, 0, len(scan.candidates))
+	for _, c := range scan.candidates {
+		if !c.quarantined && m.downloads[c.id] > 0 {
 			continue
 		}
-		dir := filepath.Join(m.root, e.Name())
-		mf, err := readManifest(dir)
-		if err != nil {
-			continue
-		}
-		var size int64
-		_ = filepath.WalkDir(dir, func(_ string, d os.DirEntry, e error) error {
-			if e == nil && !d.IsDir() {
-				if info, x := d.Info(); x == nil {
-					size += info.Size()
-				}
-			}
-			return nil
-		})
-		used += size
-		if m.downloads[mf.ID] == 0 {
-			candidates = append(candidates, candidate{dir, mf.StartedUnixNanos, size, mf.ID, mf.Trigger.CampaignName, evictionTier(mf.Upload.State)})
-		}
+		candidates = append(candidates, c)
 	}
 	// Lower tier is evicted first; within a tier the oldest goes first.
 	sort.Slice(candidates, func(i, j int) bool {
@@ -785,10 +1025,12 @@ func (m *Manager) enforceQuota() error {
 		if used <= quota && free >= reserve {
 			break
 		}
-		switch c.tier {
-		case 2:
+		switch {
+		case c.quarantined:
+			m.warnf("evicting quarantined episode %s, which recovery could not read, to preserve the data quota", c.id)
+		case c.tier == 2:
 			m.warnf("evicting episode %s (campaign %s) before its upload completed to preserve the data quota", c.id, c.campaign)
-		case 1:
+		case c.tier == 1:
 			m.warnf("evicting episode %s (campaign %s), which failed to upload and was never retried, to preserve the data quota", c.id, c.campaign)
 		}
 		if err := os.RemoveAll(c.path); err != nil {
@@ -798,6 +1040,9 @@ func (m *Manager) enforceQuota() error {
 		free += c.size
 	}
 	if used > quota || free < reserve {
+		if scan.partialBytes > 0 {
+			return fmt.Errorf("data store holds %d bytes (%d of them in episodes still recording) against a %d byte quota and cannot preserve %d bytes free", used, scan.partialBytes, quota, reserve)
+		}
 		return fmt.Errorf("data store holds %d bytes against a %d byte quota and cannot preserve %d bytes free", used, quota, reserve)
 	}
 	return nil
@@ -991,6 +1236,11 @@ func (m *Manager) preRollLostInWindowLocked(origin int64, requested time.Duratio
 // a record can only reach a window it was physically present for. The offset
 // arithmetic still uses the stamp, so ActualOffset keeps its meaning and
 // offsets stay within [-window, 0].
+// The flush opens events.jsonl once and fsyncs it once, rather than reopening
+// and fsyncing per record. Every record in the ring is written in the same
+// call, so the intermediate syncs bought no durability that the final one does
+// not: they only forced up to preRollLimit worth of separate disk barriers
+// onto the start path, with m.mu held, before the first frame was captured.
 func (m *Manager) flushPreRoll(dir string, origin int64, requested time.Duration) (uint64, *int64, error) {
 	window := preRollWindow
 	if requested > 0 && requested < window {
@@ -999,6 +1249,12 @@ func (m *Manager) flushPreRoll(dir string, origin int64, requested time.Duration
 	cutoff := origin - window.Nanoseconds()
 	var count uint64
 	var earliest *int64
+	var events *os.File
+	defer func() {
+		if events != nil {
+			_ = events.Close()
+		}
+	}()
 	for _, r := range m.preRoll {
 		if r.receiptNanos < cutoff || r.receiptNanos > origin || r.bootNanos < cutoff || r.bootNanos > origin {
 			continue
@@ -1014,13 +1270,32 @@ func (m *Manager) flushPreRoll(dir string, origin int64, requested time.Duration
 			earliest = &value
 		}
 		b, _ := json.Marshal(stored)
-		if err := appendJSONL(filepath.Join(dir, "events.jsonl"), b); err != nil {
+		if events == nil {
+			f, err := os.OpenFile(filepath.Join(dir, "events.jsonl"), os.O_WRONLY|os.O_APPEND, 0)
+			if err != nil {
+				return count, earliest, err
+			}
+			events = f
+		}
+		if _, err := events.Write(append(b, '\n')); err != nil {
 			return count, earliest, err
 		}
 		count++
 	}
+	if events == nil {
+		return count, earliest, nil
+	}
+	if err := syncFile(events); err != nil {
+		return count, earliest, err
+	}
 	return count, earliest, nil
 }
+
+// syncFile is the fsync every JSONL append goes through. It is a variable so a
+// test can count the disk barriers one operation costs, which is the only way
+// to hold the pre-roll flush to a single fsync rather than one per record.
+var syncFile = func(f *os.File) error { return f.Sync() }
+
 func appendJSONL(path string, b []byte) error {
 	f, e := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0)
 	if e != nil {
@@ -1030,7 +1305,7 @@ func appendJSONL(path string, b []byte) error {
 	if _, e = f.Write(append(b, '\n')); e != nil {
 		return e
 	}
-	return f.Sync()
+	return syncFile(f)
 }
 func abs64(v int64) int64 {
 	if v < 0 {
@@ -1096,6 +1371,17 @@ func (m *Manager) beginSeal(key string, drain bool) (*activeEpisode, error) {
 	m.mu.Unlock()
 	if a.done != nil {
 		<-a.done
+	}
+	// Stamp when capture actually ended, here, rather than letting the seal's
+	// stopped_episode_nanos stand for it. The drain below is a window for late
+	// application records, not recording time: nothing is captured during it,
+	// so a consumer computing episode length from stopped_episode_nanos
+	// over-reported every drained episode by the whole drain. Both numbers are
+	// now in the manifest and each means what it says.
+	if now, timeErr := readBootTime(); timeErr == nil {
+		m.mu.Lock()
+		a.manifest.CaptureStoppedEpisodeNS = now - a.manifest.RequestBootNanos
+		m.mu.Unlock()
 	}
 	if !drain || !a.wantsDrain() {
 		return a, nil
@@ -1220,9 +1506,9 @@ func (m *Manager) sealDetached(a *activeEpisode, consensus func(context.Context)
 		c, queryErr := consensus(ctx)
 		cancel()
 		if queryErr == nil {
-			a.manifest.Roughtime = append(a.manifest.Roughtime, c)
-			if len(a.manifest.UTCObservations) > 0 && clockAgreement(a.manifest.UTCObservations[len(a.manifest.UTCObservations)-1], c) == "conflict" {
-				a.manifest.SystemClockStatus = "conflict"
+			recordConsensus(a.dir, &a.manifest, c)
+			if len(a.manifest.UTCObservations) > 0 && clockAgreement(a.manifest.UTCObservations[len(a.manifest.UTCObservations)-1], c) == ClockStatusConflict {
+				a.manifest.SystemClockStatus = ClockStatusConflict
 			}
 		}
 	}
@@ -1279,9 +1565,21 @@ func (m *Manager) forgetLocked(a *activeEpisode) {
 	}
 }
 
+// EpisodeStateDraining is the state Status reports for an episode that has
+// stopped capturing and is serving its post-seal drain. It never reaches a
+// manifest on disk: a drained episode seals as "complete" or "interrupted"
+// like any other. It exists so that a status query during the drain says the
+// episode is finishing rather than that nothing is happening, which is what
+// "no active episode" claimed while Stop was still sleeping.
+const EpisodeStateDraining = "draining"
+
 // Status reports one active episode for status displays: the ad-hoc episode
-// when present, otherwise the earliest-started campaign episode. Use
-// ActiveEpisodeKeys and ActiveSession to enumerate concurrent episodes.
+// when present, otherwise the earliest-started campaign episode. An episode
+// serving its post-seal drain is reported with State EpisodeStateDraining once
+// no capturing episode is left, so the seal is visible rather than looking
+// like an idle device. Use ActiveEpisodeKeys and ActiveSession to enumerate
+// concurrent episodes; those deliberately exclude draining ones, because a
+// draining episode's campaign is free to start its next episode.
 func (m *Manager) Status() *Manifest {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -1295,10 +1593,20 @@ func (m *Manager) Status() *Manifest {
 			earliest = a
 		}
 	}
+	if earliest != nil {
+		v := snapshotManifest(earliest.manifest)
+		return &v
+	}
+	for _, a := range m.sealing {
+		if earliest == nil || a.manifest.StartedUnixNanos < earliest.manifest.StartedUnixNanos {
+			earliest = a
+		}
+	}
 	if earliest == nil {
 		return nil
 	}
 	v := snapshotManifest(earliest.manifest)
+	v.State = EpisodeStateDraining
 	return &v
 }
 
@@ -1508,7 +1816,12 @@ func (m *Manager) OpenFile(id, rel string, offset int64) (*os.File, File, error)
 }
 
 func (m *Manager) episodeDir(id string) (string, error) {
-	if id == "" || safeName(id) != id {
+	// "." and ".." survive safeName untouched, because it preserves dots so
+	// that identifiers and calibration filenames keep theirs. Joined onto the
+	// root they name the store itself and its parent, so an RPC asking to
+	// inspect or download episode ".." was reading outside the episode store
+	// entirely. Neither is a generated identifier, so both are simply refused.
+	if id == "" || id == "." || id == ".." || safeName(id) != id {
 		return "", ErrInvalidEpisodeID
 	}
 	p := filepath.Join(m.root, id)
@@ -1521,6 +1834,16 @@ func (m *Manager) episodeDir(id string) (string, error) {
 	return p, nil
 }
 
+// recoverPartials repairs every crash-interrupted episode directory left in
+// the store, and is the only thing standing between a power cut and a
+// permanently unreadable episode.
+//
+// No single damaged directory may stop the agent from starting. Failing
+// NewManager over one unreadable partial bricked data capture on the device
+// until somebody logged in and deleted a directory by hand, and the episode
+// that caused it was unreadable either way. A directory that cannot be
+// repaired is therefore quarantined under <id>.unrecoverable and named in a
+// warning, and recovery moves on to the next one.
 func (m *Manager) recoverPartials() error {
 	entries, err := os.ReadDir(m.root)
 	if err != nil {
@@ -1531,52 +1854,87 @@ func (m *Manager) recoverPartials() error {
 			continue
 		}
 		dir := filepath.Join(m.root, e.Name())
-		mf, err := readManifest(dir)
-		if err != nil {
-			continue
-		}
-		_ = filepath.WalkDir(dir, func(path string, d os.DirEntry, walkErr error) error {
-			if walkErr == nil && !d.IsDir() && strings.HasSuffix(d.Name(), ".jsonl") {
-				truncateJSONL(path)
-			}
-			return nil
-		})
-		reason := "agent_restart"
-		if current := bootID(); mf.BootID != "" && mf.BootID != current {
-			reason = "reboot"
-		}
-		mf.State, mf.Interruption = "interrupted", reason
-		mf.RecoveryActions = append(mf.RecoveryActions, "truncated incomplete JSONL tail", "recomputed sealed-file checksums")
-		// The summary counters are folded in memory and written only at seal, so
-		// an interrupted episode arrives here with all of them at zero while its
-		// ledger and outcome log are intact on disk. Publishing those zeros would
-		// be a manifest that lies about what the model consumed, so recompute
-		// them from the files that survived rather than annotating the lie.
-		reconciled, reconcileErr := reconcileModelIO(dir, &mf)
-		if reconcileErr != nil {
-			return fmt.Errorf("recovering episode %s: reconciling model input/outcome accounting: %w", mf.ID, reconcileErr)
-		}
-		if reconciled {
-			mf.RecoveryActions = append(mf.RecoveryActions, "recomputed model input/outcome counters from "+ModelInputLedgerFile+" and "+mf.ModelIO.OutcomeLog)
-		}
-		// Recovery is the other path that seals an episode, so it derives the
-		// same playable clips; the truncated index tails above were already
-		// cut, and the muxer counts a partial trailing line as unusable
-		// rather than guessing at it.
-		mf.PlayableNotes = muxPlayableClips(dir)
-		mf.Files, err = sealFiles(dir)
-		if err != nil {
-			return fmt.Errorf("recovering episode %s: %w", mf.ID, err)
-		}
-		associateFileSources(mf.Files, mf.Sources)
-		if err := writeManifest(dir, mf); err != nil {
-			return err
-		}
-		if err := os.Rename(dir, strings.TrimSuffix(dir, ".partial")); err != nil {
-			return err
+		if err := m.recoverPartial(dir); err != nil {
+			m.warnf("episode %s could not be recovered (%v); quarantining it", strings.TrimSuffix(e.Name(), ".partial"), err)
+			m.quarantinePartial(dir)
 		}
 	}
 	return nil
+}
+
+// quarantinePartial takes an unrepairable directory out of the recovery path.
+// A directory with no manifest at all is deleted rather than kept: it was
+// created between Mkdir and the first manifest write, so it holds no episode
+// and there is nothing in it to salvage. Anything else is renamed, so the
+// bytes stay on disk for an operator to look at, stop being retried on every
+// agent start, and become visible to (and evictable by) the quota.
+func (m *Manager) quarantinePartial(dir string) {
+	if _, err := os.Stat(filepath.Join(dir, "manifest.json")); errors.Is(err, os.ErrNotExist) {
+		if err := os.RemoveAll(dir); err != nil {
+			m.warnf("removing empty episode directory %s failed: %v", filepath.Base(dir), err)
+		}
+		return
+	}
+	target := strings.TrimSuffix(dir, ".partial") + unrecoverableSuffix
+	if err := os.Rename(dir, target); err != nil {
+		m.warnf("quarantining episode directory %s failed: %v", filepath.Base(dir), err)
+	}
+}
+
+func (m *Manager) recoverPartial(dir string) error {
+	mf, err := readManifest(dir)
+	if err != nil {
+		return fmt.Errorf("reading manifest: %w", err)
+	}
+	// A manifest that already says "complete" was fully sealed: its files were
+	// checksummed and listed, and the crash landed in the one instruction
+	// between writing that manifest and renaming the directory. Rerunning
+	// recovery over it would relabel a complete episode as interrupted and
+	// blame a reboot for a rename, so the only thing left to do is the rename.
+	if mf.State == "complete" {
+		return os.Rename(dir, strings.TrimSuffix(dir, ".partial"))
+	}
+	_ = filepath.WalkDir(dir, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr == nil && !d.IsDir() && strings.HasSuffix(d.Name(), ".jsonl") {
+			truncateJSONL(path)
+		}
+		return nil
+	})
+	reason := "agent_restart"
+	if current := bootID(); mf.BootID != "" && mf.BootID != current {
+		reason = "reboot"
+	}
+	mf.State, mf.Interruption = "interrupted", reason
+	mf.RecoveryActions = append(mf.RecoveryActions, "truncated incomplete JSONL tail", "recomputed sealed-file checksums")
+	// The summary counters are folded in memory and written only at seal, so
+	// an interrupted episode arrives here with all of them at zero while its
+	// ledger and outcome log are intact on disk. Publishing those zeros would
+	// be a manifest that lies about what the model consumed, so recompute
+	// them from the files that survived rather than annotating the lie.
+	reconciled, reconcileErr := reconcileModelIO(dir, &mf)
+	if reconcileErr != nil {
+		return fmt.Errorf("reconciling model input/outcome accounting: %w", reconcileErr)
+	}
+	if reconciled {
+		mf.RecoveryActions = append(mf.RecoveryActions, "recomputed model input/outcome counters from "+ModelInputLedgerFile+" and "+mf.ModelIO.OutcomeLog)
+	}
+	for _, note := range mf.ModelIO.RecoveryNotes {
+		m.warnf("episode %s: %s", mf.ID, note)
+	}
+	// Recovery is the other path that seals an episode, so it derives the
+	// same playable clips; the truncated index tails above were already
+	// cut, and the muxer counts a partial trailing line as unusable
+	// rather than guessing at it.
+	mf.PlayableNotes = muxPlayableClips(dir)
+	mf.Files, err = sealFiles(dir)
+	if err != nil {
+		return fmt.Errorf("sealing files: %w", err)
+	}
+	associateFileSources(mf.Files, mf.Sources)
+	if err := writeManifest(dir, mf); err != nil {
+		return fmt.Errorf("writing manifest: %w", err)
+	}
+	return os.Rename(dir, strings.TrimSuffix(dir, ".partial"))
 }
 
 func selectSources(all []Source, include, exclude []string) ([]Source, error) {
@@ -1809,17 +2167,22 @@ func associateFileSources(files []File, sources []SourceStats) {
 	}
 }
 
+// writeManifest replaces the episode manifest durably.
+//
+// It goes through atomicfile rather than a bare WriteFile plus Rename: the
+// previous version fsynced neither the temporary file nor the directory, so a
+// device that lost power just after the rename could come back with the
+// manifest entry pointing at a file whose contents had never left the page
+// cache. On embedded hardware that loses power without warning, which is what
+// this package records on, a zero-length manifest makes the whole episode
+// unreadable even though every payload byte survived.
 func writeManifest(dir string, m Manifest) error {
 	b, e := json.MarshalIndent(m, "", "  ")
 	if e != nil {
 		return e
 	}
 	b = append(b, '\n')
-	tmp := filepath.Join(dir, "manifest.json.tmp")
-	if e = os.WriteFile(tmp, b, 0o640); e != nil {
-		return e
-	}
-	return os.Rename(tmp, filepath.Join(dir, "manifest.json"))
+	return atomicfile.Write(filepath.Join(dir, "manifest.json"), b, 0o640)
 }
 func readManifest(dir string) (Manifest, error) {
 	var m Manifest
@@ -1830,25 +2193,78 @@ func readManifest(dir string) (Manifest, error) {
 	e = json.Unmarshal(b, &m)
 	return m, e
 }
+
+// truncateJSONLChunk is how much of a JSONL tail is read at a time when
+// hunting for the last complete line. One read covers any line this package
+// writes; a file whose tail holds no newline within a chunk is scanned
+// backwards a chunk at a time rather than in one allocation.
+const truncateJSONLChunk = 64 << 10
+
+// truncateJSONL cuts a torn trailing line off a crash-interrupted JSONL file.
+//
+// It scans backwards in bounded chunks instead of reading the file into
+// memory. The previous implementation did os.ReadFile followed by string(b),
+// which holds two copies of the whole file at once: an episode that recorded a
+// multi-gigabyte telemetry or event log made recovery allocate twice its size
+// on a device that has a few hundred megabytes of RAM, and the agent was
+// killed by the out-of-memory killer at exactly the moment it was trying to
+// repair itself.
 func truncateJSONL(p string) {
-	b, e := os.ReadFile(p)
-	if e != nil {
+	f, err := os.Open(p)
+	if err != nil {
 		return
 	}
-	i := strings.LastIndexByte(string(b), '\n')
-	if i < 0 {
-		_ = os.Truncate(p, 0)
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
 		return
 	}
-	_ = os.Truncate(p, int64(i+1))
+	size := info.Size()
+	if size == 0 {
+		return
+	}
+	buf := make([]byte, truncateJSONLChunk)
+	for end := size; end > 0; {
+		start := end - int64(len(buf))
+		if start < 0 {
+			start = 0
+		}
+		chunk := buf[:end-start]
+		if _, err := f.ReadAt(chunk, start); err != nil {
+			return
+		}
+		if i := bytes.LastIndexByte(chunk, '\n'); i >= 0 {
+			if keep := start + int64(i) + 1; keep != size {
+				_ = os.Truncate(p, keep)
+			}
+			return
+		}
+		end = start
+	}
+	// No newline anywhere: the file holds nothing but a torn first line.
+	_ = os.Truncate(p, 0)
 }
 
+// clockAgreement judges the device's system clock against a Roughtime
+// consensus. It returns one of the ClockStatus constants in model.go.
+//
+// An unbounded system observation has no interval to compare: observeUTC
+// leaves both offset bounds at zero when adjtimex reports the clock
+// unsynchronized. Comparing that empty interval against a real consensus
+// declared a conflict on every episode recorded by every device without a
+// synced clock, which is most of them at first boot, and a conflict that no
+// evidence supports is worse than no status at all. Such an episode reports
+// roughtime_only: the consensus is its sole UTC evidence, and the system clock
+// is not disagreeing with it, it is simply saying nothing.
 func clockAgreement(system UTCObservation, consensus timesync.Consensus) string {
 	if consensus.Confidence == "unbounded" {
-		return "system_reported"
+		return ClockStatusSystemReported
+	}
+	if system.Confidence == "unbounded" {
+		return ClockStatusRoughtimeOnly
 	}
 	if system.OffsetUpperNanos < consensus.LowerOffsetNanos || consensus.UpperOffsetNanos < system.OffsetLowerNanos {
-		return "conflict"
+		return ClockStatusConflict
 	}
-	return "agreement"
+	return ClockStatusAgreement
 }

--- a/go/internal/agent/data/manager.go
+++ b/go/internal/agent/data/manager.go
@@ -1378,9 +1378,19 @@ func (m *Manager) beginSeal(key string, drain bool) (*activeEpisode, error) {
 	// so a consumer computing episode length from stopped_episode_nanos
 	// over-reported every drained episode by the whole drain. Both numbers are
 	// now in the manifest and each means what it says.
+	//
+	// The stillOpenLocked check is the same fence finalize relies on, and it is
+	// load-bearing rather than defensive. A concurrent Stop and Interrupt can
+	// both leave the block above holding this episode; the one that reaches
+	// finalize first detaches it under this mutex and then seals it with the
+	// mutex released, so writing to the manifest here after that detachment
+	// would race the seal's own reads. Once the episode is detached it is not
+	// ours to stamp, and the seal has already read the clock itself.
 	if now, timeErr := readBootTime(); timeErr == nil {
 		m.mu.Lock()
-		a.manifest.CaptureStoppedEpisodeNS = now - a.manifest.RequestBootNanos
+		if m.stillOpenLocked(a) {
+			a.manifest.CaptureStoppedEpisodeNS = now - a.manifest.RequestBootNanos
+		}
 		m.mu.Unlock()
 	}
 	if !drain || !a.wantsDrain() {
@@ -1457,8 +1467,9 @@ var sealMux = muxPlayableClips
 //     second Stop or Interrupt can claim it.
 //  2. With the lock released the episode's clock is read, its ledger is
 //     flushed, and its bytes are muxed and hashed. Nothing else can reach the
-//     episode by then, and enforceQuota skips ".partial" directories, so the
-//     store cannot evict it mid-seal either.
+//     episode by then, and the quota counts a ".partial" directory's bytes but
+//     never offers one as an eviction candidate, so the store cannot evict it
+//     mid-seal either.
 //  3. The lock is retaken to write the manifest and rename the directory out
 //     of ".partial", which is what publishes the episode to every path that
 //     walks the store.

--- a/go/internal/agent/data/model.go
+++ b/go/internal/agent/data/model.go
@@ -13,6 +13,47 @@ const (
 	ClockAlgorithm  = "wendy-sandwich-v1"
 )
 
+// The system_clock_status vocabulary. It reports what the episode knows about
+// the device's own system clock, judged against the Roughtime consensus when
+// one is available. Every value an episode manifest can carry is here, and
+// nothing outside this list is ever written.
+const (
+	// ClockStatusSystemReported means no Roughtime consensus was available to
+	// judge the system clock against, so the manifest carries only the
+	// system's own reported uncertainty (which may itself be unbounded).
+	ClockStatusSystemReported = "system_reported"
+	// ClockStatusAgreement means the system observation's Coordinated
+	// Universal Time (UTC) offset interval overlaps the Roughtime consensus
+	// interval.
+	ClockStatusAgreement = "agreement"
+	// ClockStatusConflict means the two intervals are disjoint: the system
+	// clock and the Roughtime consensus cannot both be right.
+	ClockStatusConflict = "conflict"
+	// ClockStatusRoughtimeOnly means the device has no synchronized system
+	// clock (adjtimex reports STA_UNSYNC, or no error bound at all), so the
+	// system observation is unbounded and carries no interval to compare. The
+	// Roughtime consensus is the episode's only UTC evidence.
+	//
+	// This is deliberately NOT "conflict". An unbounded observation records
+	// zero for both interval bounds, and comparing that empty interval against
+	// a real consensus made every episode on an unsynchronized device report a
+	// clock conflict that no evidence supported.
+	ClockStatusRoughtimeOnly = "roughtime_only"
+)
+
+// RoughtimeEvidenceFile is the episode-relative path of the Roughtime evidence
+// sidecar: one JSON object per consensus round, each holding that round's full
+// evidence including the nonce and the raw signed responses. It is sealed and
+// checksummed exactly like every other episode file.
+//
+// The raw evidence used to live in the manifest, which is rewritten in full on
+// every consensus round. A long episode queries Roughtime every five minutes,
+// so the manifest grew by several kilobytes of base64 per round and a
+// day-long episode ended with a manifest dominated by clock evidence. The
+// bounds a consumer actually reads stay in the manifest; the bytes needed to
+// independently reverify a round live here.
+const RoughtimeEvidenceFile = "roughtime.jsonl"
+
 type ClockSample struct {
 	BootBeforeNanos int64 `json:"boot_before_nanos"`
 	TargetNanos     int64 `json:"target_nanos"`
@@ -132,6 +173,12 @@ type ModelIO struct {
 	// are not among the episode's own sources. The ledger records what the
 	// model consumed; the episode holds no payload bytes for them.
 	Uncaptured []SourceModelInputs `json:"uncaptured_sources,omitempty"`
+	// RecoveryNotes records what crash recovery could not account for while
+	// recomputing the counters above: lines in the ledger or the outcome log
+	// that it had to skip. A skipped line is a counter that is low by an
+	// unknown amount, and a counter that is quietly low is exactly the kind of
+	// number a training pipeline trusts. Absent on a normally sealed episode.
+	RecoveryNotes []string `json:"recovery_notes,omitempty"`
 }
 
 // ModelInput is one sample handed to a model subscriber, as recorded in the
@@ -293,24 +340,44 @@ type WorkflowState struct {
 }
 
 type Manifest struct {
-	Version           int                     `json:"version"`
-	ID                string                  `json:"id"`
-	Name              string                  `json:"name,omitempty"`
-	State             string                  `json:"state"`
-	Interruption      string                  `json:"interruption,omitempty"`
-	Device            DeviceIdentity          `json:"device"`
-	CanonicalClock    string                  `json:"canonical_clock"`
-	BootID            string                  `json:"boot_id"`
-	RequestBootNanos  int64                   `json:"request_boottime_nanos"`
-	StartedEpisodeNS  int64                   `json:"started_episode_nanos"`
-	StartedUnixNanos  int64                   `json:"started_unix_nanos"`
-	StoppedEpisodeNS  int64                   `json:"stopped_episode_nanos,omitempty"`
-	Trigger           EpisodeTrigger          `json:"trigger"`
-	CollectorVersion  string                  `json:"collector_version"`
-	ModelVersions     map[string]string       `json:"model_versions"`
-	RequestedTopics   []string                `json:"requested_ros2_topics"`
-	UTCObservations   []UTCObservation        `json:"utc_observations"`
-	Roughtime         []timesync.Consensus    `json:"roughtime_observations,omitempty"`
+	Version          int            `json:"version"`
+	ID               string         `json:"id"`
+	Name             string         `json:"name,omitempty"`
+	State            string         `json:"state"`
+	Interruption     string         `json:"interruption,omitempty"`
+	Device           DeviceIdentity `json:"device"`
+	CanonicalClock   string         `json:"canonical_clock"`
+	BootID           string         `json:"boot_id"`
+	RequestBootNanos int64          `json:"request_boottime_nanos"`
+	StartedEpisodeNS int64          `json:"started_episode_nanos"`
+	StartedUnixNanos int64          `json:"started_unix_nanos"`
+	StoppedEpisodeNS int64          `json:"stopped_episode_nanos,omitempty"`
+	// CaptureStoppedEpisodeNS is when this episode's capture adapters actually
+	// stopped, which is earlier than StoppedEpisodeNS by the post-seal drain.
+	// The drain is a window for late application records, not recording time:
+	// nothing was captured during it, so a consumer measuring how long the
+	// episode recorded must use this field. StoppedEpisodeNS remains the point
+	// past which no record was accepted, which is what an event timeline needs.
+	// Absent on episodes sealed before this field existed.
+	CaptureStoppedEpisodeNS int64             `json:"capture_stopped_episode_nanos,omitempty"`
+	Trigger                 EpisodeTrigger    `json:"trigger"`
+	CollectorVersion        string            `json:"collector_version"`
+	ModelVersions           map[string]string `json:"model_versions"`
+	RequestedTopics         []string          `json:"requested_ros2_topics"`
+	UTCObservations         []UTCObservation  `json:"utc_observations"`
+	// Roughtime holds the bounds of this episode's first and most recent
+	// Roughtime consensus rounds, and never their raw evidence. Every round,
+	// in full, is appended to RoughtimeEvidenceFile instead, so the manifest
+	// stays a fixed size however long the episode records. RoughtimeRounds
+	// counts what the sidecar holds.
+	Roughtime []timesync.Consensus `json:"roughtime_observations,omitempty"`
+	// RoughtimeEvidenceLog names the sidecar, absent when no round landed.
+	RoughtimeEvidenceLog string `json:"roughtime_evidence_log,omitempty"`
+	// RoughtimeRounds counts the consensus rounds the sidecar holds, so a
+	// consumer can tell a two-round episode from a two-hundred-round one
+	// without reading the sidecar.
+	RoughtimeRounds uint64 `json:"roughtime_rounds,omitempty"`
+	// SystemClockStatus is one of the ClockStatus constants above.
 	SystemClockStatus string                  `json:"system_clock_status"`
 	Sources           []SourceStats           `json:"sources"`
 	Calibrations      []Calibration           `json:"calibrations"`

--- a/go/internal/agent/data/model_io.go
+++ b/go/internal/agent/data/model_io.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
 )
 
 // ModelInputLedgerFile is the episode-relative path of the model-input ledger.
@@ -240,6 +241,26 @@ func reconcileModelInputs(dir string, mf *Manifest) (bool, error) {
 	}
 	defer f.Close()
 
+	// The retention class and its note are decided while the episode is
+	// recording, from the campaign's capture policy, and are the only record
+	// of it: SourceCapture is excluded from the manifest JSON (Source.Capture
+	// is `json:"-"`), so a manifest read back off disk has no policy left to
+	// classify from. Rebuilding the block from that nil policy relabelled
+	// every snapshot and every rate-capped source as
+	// captured_subject_to_drop_accounting, which tells a training pipeline the
+	// episode holds a payload for every sample the model saw when it holds a
+	// fraction of them. Only the counters are recomputed here; the
+	// classification that survived the crash is kept.
+	retained := make(map[string]SourceModelInputs, len(mf.Sources)+len(mf.ModelIO.Uncaptured))
+	for i := range mf.Sources {
+		if block := mf.Sources[i].ModelInputs; block != nil {
+			retained[mf.Sources[i].Source.ID] = *block
+		}
+	}
+	for _, block := range mf.ModelIO.Uncaptured {
+		retained[block.SourceID] = block
+	}
+
 	mf.ModelIO.InputLedger = ModelInputLedgerFile
 	mf.ModelIO.SamplesDelivered = 0
 	mf.ModelIO.Uncaptured = nil
@@ -249,6 +270,7 @@ func reconcileModelInputs(dir string, mf *Manifest) (bool, error) {
 
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 0, 64*1024), maxLedgerLineBytes)
+	var skipped uint64
 	for scanner.Scan() {
 		line := bytes.TrimSpace(scanner.Bytes())
 		if len(line) == 0 {
@@ -256,11 +278,16 @@ func reconcileModelInputs(dir string, mf *Manifest) (bool, error) {
 		}
 		var input ModelInput
 		if err := json.Unmarshal(line, &input); err != nil {
+			skipped++
 			continue
 		}
 		stats := manifestModelInputs(mf, input.SourceID)
 		if stats.Delivered == 0 {
 			stats.FirstSampleID = input.SampleID
+			if prior, ok := retained[input.SourceID]; ok && prior.PayloadRetention != "" {
+				stats.PayloadRetention = prior.PayloadRetention
+				stats.Note = prior.Note
+			}
 		}
 		stats.Delivered++
 		stats.SubscriberDrops += input.DroppedBefore
@@ -268,7 +295,20 @@ func reconcileModelInputs(dir string, mf *Manifest) (bool, error) {
 		mf.ModelIO.SamplesDelivered++
 	}
 	if err := scanner.Err(); err != nil {
-		return false, err
+		if !errors.Is(err, bufio.ErrTooLong) {
+			return false, err
+		}
+		// One line longer than the buffer stops the scanner dead, so every
+		// line after it is unread and the counters below it are silently low.
+		// Reading past it is not worth a second pass over the file, but
+		// pretending the count is complete is not an option either.
+		skipped++
+		mf.ModelIO.RecoveryNotes = append(mf.ModelIO.RecoveryNotes,
+			ModelInputLedgerFile+" holds a line longer than the "+strconv.Itoa(maxLedgerLineBytes)+" byte recovery limit; the delivery counters stop at it and are lower than what the ledger holds")
+	}
+	if skipped > 0 {
+		mf.ModelIO.RecoveryNotes = append(mf.ModelIO.RecoveryNotes,
+			"recovery skipped "+strconv.FormatUint(skipped, 10)+" unparseable line(s) in "+ModelInputLedgerFile)
 	}
 	return true, nil
 }
@@ -294,6 +334,7 @@ func reconcileOutcomes(dir string, mf *Manifest) (bool, error) {
 
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 0, 64*1024), maxLedgerLineBytes)
+	var skipped uint64
 	for scanner.Scan() {
 		line := bytes.TrimSpace(scanner.Bytes())
 		if len(line) == 0 {
@@ -301,6 +342,7 @@ func reconcileOutcomes(dir string, mf *Manifest) (bool, error) {
 		}
 		var record ApplicationRecord
 		if err := json.Unmarshal(line, &record); err != nil {
+			skipped++
 			continue
 		}
 		if record.Type != "prediction" {
@@ -318,7 +360,20 @@ func reconcileOutcomes(dir string, mf *Manifest) (bool, error) {
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return false, err
+		// An application record over the recovery line limit used to abort the
+		// whole reconciliation, which aborted NewManager, which stopped the
+		// agent from starting at all. One outsized record must cost its own
+		// outcome counters, not the device's ability to record.
+		if !errors.Is(err, bufio.ErrTooLong) {
+			return false, err
+		}
+		skipped++
+		mf.ModelIO.RecoveryNotes = append(mf.ModelIO.RecoveryNotes,
+			name+" holds a line longer than the "+strconv.Itoa(maxLedgerLineBytes)+" byte recovery limit; the outcome counters stop at it and are lower than what the log holds")
+	}
+	if skipped > 0 {
+		mf.ModelIO.RecoveryNotes = append(mf.ModelIO.RecoveryNotes,
+			"recovery skipped "+strconv.FormatUint(skipped, 10)+" unparseable line(s) in "+name)
 	}
 	return true, nil
 }

--- a/go/internal/agent/data/review_fixes_test.go
+++ b/go/internal/agent/data/review_fixes_test.go
@@ -1,0 +1,891 @@
+package data
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wendylabsinc/wendy/go/internal/agent/timesync"
+)
+
+// TestClockAgreementWithUnboundedSystemClock is the guard on a status that
+// lied. A device whose system clock is not synchronized reports an unbounded
+// observation, whose offset interval is [0, 0] because there is no interval to
+// report. Comparing that against a real Roughtime consensus put every episode
+// such a device recorded at system_clock_status "conflict", which reads as
+// evidence that the two clocks disagree when in fact only one of them spoke.
+func TestClockAgreementWithUnboundedSystemClock(t *testing.T) {
+	bounded := UTCObservation{Confidence: "system_reported", OffsetLowerNanos: 900, OffsetUpperNanos: 1100}
+	unbounded := UTCObservation{Confidence: "unbounded"}
+	consensus := timesync.Consensus{Confidence: "bounded", LowerOffsetNanos: 1000, UpperOffsetNanos: 2000}
+	disjoint := timesync.Consensus{Confidence: "bounded", LowerOffsetNanos: 5000, UpperOffsetNanos: 6000}
+	noConsensus := timesync.Consensus{Confidence: "unbounded"}
+
+	for _, tc := range []struct {
+		name      string
+		system    UTCObservation
+		consensus timesync.Consensus
+		want      string
+	}{
+		{"bounded system, overlapping consensus", bounded, consensus, ClockStatusAgreement},
+		{"bounded system, disjoint consensus", bounded, disjoint, ClockStatusConflict},
+		{"unbounded system, consensus present", unbounded, consensus, ClockStatusRoughtimeOnly},
+		{"unbounded system, no consensus", unbounded, noConsensus, ClockStatusSystemReported},
+		// The fourth combination's mirror: a bounded system clock with no
+		// consensus to judge it against is still just the system's own claim.
+		{"bounded system, no consensus", bounded, noConsensus, ClockStatusSystemReported},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clockAgreement(tc.system, tc.consensus); got != tc.want {
+				t.Fatalf("clockAgreement = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRecoveryKeepsPersistedPayloadRetention pins the honesty of the recovered
+// model-input accounting. SourceCapture is excluded from the manifest JSON, so
+// a manifest read back off disk carries no capture policy; rebuilding the
+// retention class from that nil policy relabelled a snapshot or rate-capped
+// source as "captured_subject_to_drop_accounting", telling a training pipeline
+// the episode holds every payload the model saw when it holds a fraction.
+func TestRecoveryKeepsPersistedPayloadRetention(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "20260101T000000Z-abcdef0123456789.partial")
+	if err := os.Mkdir(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	const note = "capture mode snapshot keeps less than the model consumed; ledger entries with no matching capture-index entry have no payload bytes in this episode"
+	// A live mid-episode manifest: the ModelInputs block was written with the
+	// correct class while the capture policy was still in memory.
+	manifest := Manifest{
+		Version: ManifestVersion, ID: "20260101T000000Z-abcdef0123456789", State: "recording",
+		BootID: bootID(), CanonicalClock: "CLOCK_BOOTTIME", ModelIO: newModelIO(),
+		Sources: []SourceStats{{
+			Source: Source{ID: "v4l2:/dev/video0", Kind: "camera", ClockDomain: "CLOCK_BOOTTIME", Healthy: true},
+			ModelInputs: &SourceModelInputs{
+				SourceID: "v4l2:/dev/video0", Delivered: 3, FirstSampleID: 1, LastSampleID: 3,
+				PayloadRetention: RetentionPolicySubset, Note: note,
+			},
+		}},
+	}
+	manifest.ModelIO.InputLedger = ModelInputLedgerFile
+	if err := writeManifest(dir, manifest); err != nil {
+		t.Fatal(err)
+	}
+	var ledger strings.Builder
+	for i := 1; i <= 5; i++ {
+		b, err := json.Marshal(ModelInput{AppID: "sh.wendy.model", SourceID: "v4l2:/dev/video0", SampleID: uint64(i), PayloadBytes: 64})
+		if err != nil {
+			t.Fatal(err)
+		}
+		ledger.Write(b)
+		ledger.WriteByte('\n')
+	}
+	if err := os.WriteFile(filepath.Join(dir, ModelInputLedgerFile), []byte(ledger.String()), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := NewManager(root); err != nil {
+		t.Fatal(err)
+	}
+	recovered := readRecoveredManifest(t, root, manifest.ID)
+	if recovered.State != "interrupted" {
+		t.Fatalf("state = %q, want interrupted", recovered.State)
+	}
+	if len(recovered.Sources) != 1 || recovered.Sources[0].ModelInputs == nil {
+		t.Fatalf("model-input accounting missing after recovery: %+v", recovered.Sources)
+	}
+	stats := recovered.Sources[0].ModelInputs
+	if stats.PayloadRetention != RetentionPolicySubset {
+		t.Fatalf("payload_retention = %q, want %q: the persisted class was rebuilt from a capture policy the manifest cannot carry",
+			stats.PayloadRetention, RetentionPolicySubset)
+	}
+	if stats.Note != note {
+		t.Fatalf("note = %q, want the persisted one", stats.Note)
+	}
+	// The counters are still recomputed from the ledger, which is the whole
+	// reason reconciliation runs at all.
+	if stats.Delivered != 5 || recovered.ModelIO.SamplesDelivered != 5 {
+		t.Fatalf("delivered = %d / %d, want 5 from the five ledger lines", stats.Delivered, recovered.ModelIO.SamplesDelivered)
+	}
+}
+
+// TestRecoveryLeavesCompleteManifestAlone covers the crash that lands between
+// writing the sealed manifest and renaming the directory. The episode is
+// complete: every file was checksummed and listed. Relabelling it interrupted
+// and blaming a reboot invents a failure that never happened.
+func TestRecoveryLeavesCompleteManifestAlone(t *testing.T) {
+	root := t.TempDir()
+	manager, err := NewManager(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := manager.Start(StartOptions{Name: "sealed", Sources: []string{"applications"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.Stop(AdHocEpisodeKey); err != nil {
+		t.Fatal(err)
+	}
+	// Undo just the rename, which is exactly the state a crash between the
+	// manifest write and the rename leaves behind.
+	final := filepath.Join(root, started.ID)
+	partial := final + ".partial"
+	if err := os.Rename(final, partial); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := NewManager(root); err != nil {
+		t.Fatal(err)
+	}
+	recovered := readRecoveredManifest(t, root, started.ID)
+	if recovered.State != "complete" {
+		t.Fatalf("state = %q, want complete: a fully sealed episode was relabelled by recovery", recovered.State)
+	}
+	if recovered.Interruption != "" {
+		t.Fatalf("interruption = %q, want none", recovered.Interruption)
+	}
+	if len(recovered.RecoveryActions) != 0 {
+		t.Fatalf("recovery_actions = %v, want none: nothing was repaired", recovered.RecoveryActions)
+	}
+}
+
+// TestRecoveryQuarantinesUnreadableManifest covers a partial directory whose
+// manifest cannot be parsed. Skipping it silently left it on disk forever,
+// invisible to the quota and retried on every agent start.
+func TestRecoveryQuarantinesUnreadableManifest(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "20260101T000000Z-0badc0de0badc0de.partial")
+	if err := os.Mkdir(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "manifest.json"), []byte("{not json"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "events.jsonl"), []byte("{}\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	manager, err := NewManager(root)
+	if err != nil {
+		t.Fatalf("one damaged partial stopped the agent from starting: %v", err)
+	}
+	quarantined := filepath.Join(root, "20260101T000000Z-0badc0de0badc0de"+unrecoverableSuffix)
+	if _, err := os.Stat(quarantined); err != nil {
+		t.Fatalf("the unreadable partial was not quarantined: %v", err)
+	}
+	if _, err := os.Stat(dir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("the .partial directory is still there and will be retried on every start")
+	}
+	// The warning survives NewManager, where no logger can be attached yet.
+	var warnings []string
+	manager.SetWarnLogger(func(message string) { warnings = append(warnings, message) })
+	if !containsSubstring(warnings, "could not be recovered") {
+		t.Fatalf("recovery said nothing about quarantining the episode: %v", warnings)
+	}
+}
+
+// TestRecoveryDeletesPartialWithNoManifest covers the directory a crash
+// between Mkdir and the first manifest write leaves behind. It holds no
+// episode, so there is nothing to quarantine and nothing to salvage.
+func TestRecoveryDeletesPartialWithNoManifest(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "20260101T000000Z-1111111111111111.partial")
+	if err := os.Mkdir(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewManager(root); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("the manifest-less directory survived recovery: %v", entries)
+	}
+}
+
+// TestQuotaCountsPartialAndQuarantinedBytes pins that bytes the store cannot
+// evict are still bytes. Skipping .partial directories entirely meant an
+// episode mid-recording, and a quarantined one that can never be read, were
+// both invisible to the quota, so the store could exceed it without anything
+// noticing.
+func TestQuotaCountsPartialAndQuarantinedBytes(t *testing.T) {
+	root := t.TempDir()
+	partial := filepath.Join(root, "20260101T000000Z-2222222222222222.partial")
+	quarantined := filepath.Join(root, "20260101T000000Z-3333333333333333"+unrecoverableSuffix)
+	for _, dir := range []string{partial, quarantined} {
+		if err := os.Mkdir(dir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "payload.bin"), make([]byte, 4096), 0o640); err != nil {
+			t.Fatal(err)
+		}
+	}
+	scan, err := scanEpisodeStore(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scan.used < 8192 {
+		t.Fatalf("used = %d, want at least the 8192 bytes in the two directories", scan.used)
+	}
+	if scan.partialBytes < 4096 {
+		t.Fatalf("partialBytes = %d, want at least the 4096 bytes of the recording episode", scan.partialBytes)
+	}
+	// The recording episode must never be an eviction candidate; the
+	// quarantined one must be, or one damaged episode wedges the quota.
+	var sawQuarantined bool
+	for _, c := range scan.candidates {
+		if c.path == partial {
+			t.Fatal("an episode that is still recording was offered as an eviction candidate")
+		}
+		if c.path == quarantined {
+			sawQuarantined = true
+			if c.tier != 0 || !c.quarantined {
+				t.Fatalf("quarantined candidate has tier %d, quarantined=%v; want tier 0 and true", c.tier, c.quarantined)
+			}
+		}
+	}
+	if !sawQuarantined {
+		t.Fatal("the quarantined directory can never be evicted, so its bytes leak forever")
+	}
+}
+
+// TestPreRollFlushSyncsOnce pins the cost of starting an episode. The flush
+// used to reopen events.jsonl and fsync it once per buffered record, so a full
+// pre-roll ring forced hundreds of separate disk barriers onto the start path
+// with the manager lock held, before the first frame was captured.
+func TestPreRollFlushSyncsOnce(t *testing.T) {
+	var syncs atomic.Int64
+	original := syncFile
+	syncFile = func(f *os.File) error {
+		syncs.Add(1)
+		return f.Sync()
+	}
+	t.Cleanup(func() { syncFile = original })
+
+	manager, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	now, err := readBootTime()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const records = 25
+	for i := 0; i < records; i++ {
+		if _, err := manager.RecordApplication("com.example.app", ApplicationRecord{
+			Version: 1, Type: "event", Name: "ready", ClientBootNanos: now, ClientBootID: bootID(),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	syncs.Store(0)
+	started, err := manager.Start(StartOptions{Sources: []string{"applications"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := syncs.Load(); got != 1 {
+		t.Fatalf("starting an episode with %d pre-roll records cost %d fsyncs, want 1", records, got)
+	}
+	// All of them still reached the episode, durably.
+	b, err := os.ReadFile(filepath.Join(manager.root, started.ID+".partial", "events.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lines := strings.Count(strings.TrimSpace(string(b)), "\n") + 1; lines != records {
+		t.Fatalf("events.jsonl holds %d lines, want %d", lines, records)
+	}
+}
+
+// TestStartCallsSourceProviderWithoutTheLock is the deadlock guard. Sources()
+// has always called the provider outside m.mu because a provider is entitled
+// to call back into the manager; Start called it while holding the lock, so
+// any provider that logged a warning or asked for the active session hung the
+// agent for good. It also fixes a provider that shells out under the lock.
+func TestStartCallsSourceProviderWithoutTheLock(t *testing.T) {
+	manager, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager.SetWarnLogger(func(string) {})
+	var deadline bool
+	manager.SetSourceProvider(func(ctx context.Context) []Source {
+		// Every one of these takes m.mu. Under the old code the first would
+		// deadlock and this test would time out rather than fail.
+		manager.Warnf("provider is discovering sources")
+		manager.Status()
+		manager.ActiveSession(AdHocEpisodeKey)
+		if _, ok := ctx.Deadline(); ok {
+			deadline = true
+		}
+		return []Source{{ID: "probe:0", Kind: "camera", ClockDomain: "CLOCK_BOOTTIME", Healthy: true}}
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		_, startErr := manager.Start(StartOptions{Sources: []string{"probe:0"}})
+		done <- startErr
+	}()
+	select {
+	case startErr := <-done:
+		if startErr != nil {
+			t.Fatalf("Start: %v", startErr)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Start deadlocked: the source provider was called with the manager lock held")
+	}
+	if !deadline {
+		t.Fatal("the source provider was called with an unbounded context; an adapter that hangs stalls the episode forever")
+	}
+}
+
+// TestRecoveryToleratesOversizedOutcomeLine covers a single application record
+// longer than the recovery line limit. It used to abort reconciliation, which
+// aborted NewManager, which stopped the agent from recording anything at all
+// until somebody deleted the directory by hand.
+func TestRecoveryToleratesOversizedOutcomeLine(t *testing.T) {
+	root := t.TempDir()
+	manager, err := NewManager(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := manager.Start(StartOptions{Name: "oversized", Sources: []string{"applications"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.RecordApplication("sh.wendy.model", ApplicationRecord{
+		Version: 1, Type: "prediction", Model: "detector", Value: 1,
+		Inputs: []SampleRef{{SourceID: "applications", SampleID: 1}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	partial := filepath.Join(root, started.ID+".partial")
+	events, err := os.OpenFile(filepath.Join(partial, "events.jsonl"), os.O_WRONLY|os.O_APPEND, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oversized, err := json.Marshal(storedApplicationRecord{ApplicationRecord: ApplicationRecord{
+		Version: 1, Type: "prediction", Model: "detector",
+		Attributes: map[string]any{"blob": strings.Repeat("x", maxLedgerLineBytes+1)},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := events.Write(append(oversized, '\n')); err != nil {
+		t.Fatal(err)
+	}
+	if err := events.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	recoverer, err := NewManager(root)
+	if err != nil {
+		t.Fatalf("one oversized record stopped the agent from starting: %v", err)
+	}
+	recovered := readRecoveredManifest(t, root, started.ID)
+	if recovered.State != "interrupted" {
+		t.Fatalf("state = %q, want interrupted", recovered.State)
+	}
+	if len(recovered.ModelIO.RecoveryNotes) == 0 {
+		t.Fatal("the manifest says nothing about the line recovery could not read, so its counters are silently low")
+	}
+	if !containsSubstring(recovered.ModelIO.RecoveryNotes, "longer than the") {
+		t.Fatalf("recovery notes do not name the over-long line: %v", recovered.ModelIO.RecoveryNotes)
+	}
+	var warnings []string
+	recoverer.SetWarnLogger(func(message string) { warnings = append(warnings, message) })
+	if !containsSubstring(warnings, "longer than the") {
+		t.Fatalf("the operator was told nothing about the unreadable line: %v", warnings)
+	}
+}
+
+// TestRecoveryQuarantinesEpisodeWithSymlink covers the other per-partial
+// failure that used to fail NewManager outright: sealFiles refuses to
+// checksum a symlink, correctly, but the whole agent paid for it.
+func TestRecoveryQuarantinesEpisodeWithSymlink(t *testing.T) {
+	root := t.TempDir()
+	manager, err := NewManager(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := manager.Start(StartOptions{Name: "symlinked", Sources: []string{"applications"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	partial := filepath.Join(root, started.ID+".partial")
+	if err := os.Symlink("/etc/passwd", filepath.Join(partial, "sneaky")); err != nil {
+		t.Skipf("this filesystem does not support symlinks: %v", err)
+	}
+
+	if _, err := NewManager(root); err != nil {
+		t.Fatalf("one episode holding a symlink stopped the agent from starting: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, started.ID+unrecoverableSuffix)); err != nil {
+		t.Fatalf("the unsealable episode was not quarantined: %v", err)
+	}
+}
+
+// TestTruncateJSONLScansBackwards covers the bounded backwards scan. The
+// previous implementation read the whole file and then copied it into a
+// string, so recovering a large log allocated twice its size on a device that
+// has a few hundred megabytes of memory.
+func TestTruncateJSONLScansBackwards(t *testing.T) {
+	dir := t.TempDir()
+	for _, tc := range []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{"torn tail", "{\"a\":1}\n{\"b\":2}\n{\"c\":", "{\"a\":1}\n{\"b\":2}\n"},
+		{"clean tail", "{\"a\":1}\n", "{\"a\":1}\n"},
+		{"no newline at all", "{\"a\":", ""},
+		{"empty", "", ""},
+		// Longer than one chunk with the last newline in an earlier chunk,
+		// which is the case the backwards scan has to loop for.
+		{"tail longer than a chunk", "{\"a\":1}\n" + strings.Repeat("x", truncateJSONLChunk+512), "{\"a\":1}\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := filepath.Join(dir, strings.ReplaceAll(tc.name, " ", "_")+".jsonl")
+			if err := os.WriteFile(p, []byte(tc.content), 0o640); err != nil {
+				t.Fatal(err)
+			}
+			truncateJSONL(p)
+			got, err := os.ReadFile(p)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != tc.want {
+				t.Fatalf("truncateJSONL left %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCampaignRejectsBlankSelector covers the selector that validated as
+// absent and resolved as present. Validation trimmed before testing while
+// resolution did not, so a blank camera selector beside a real audio one
+// passed validation, then matched every camera on the device by empty
+// substring and dropped the microphone entirely.
+func TestCampaignRejectsBlankSelector(t *testing.T) {
+	plan := []byte(`version: 1
+name: blank-selector
+sources:
+  - camera: "   "
+  - audio: default
+capture:
+  buffer: 0s
+  after_trigger: 5s
+  triggers:
+    - event: go
+upload: {when: manual}
+export: {annotation: cvat}
+`)
+	_, err := ParseCampaign(plan)
+	if err == nil {
+		t.Fatal("a whitespace-only camera selector was accepted")
+	}
+	if !strings.Contains(err.Error(), "sources[0].camera") {
+		t.Fatalf("error does not name the blank selector: %v", err)
+	}
+}
+
+// TestCampaignRevisionIgnoresUnrelatedStructFields is the guard against a
+// fleet-wide phantom plan change. The digest used to be taken over a
+// marshalled Campaign struct, so an agent release that added any field to that
+// struct changed the revision of every already-deployed campaign on every
+// device that took the upgrade. The digest now covers an enumerated list of
+// author-declared plan fields, so a field that is not on the list, at its zero
+// value or not, cannot move it.
+func TestCampaignRevisionIgnoresUnrelatedStructFields(t *testing.T) {
+	campaign, err := ParseCampaign([]byte(drainDigestPinYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := campaign.Revision
+
+	// Stand in for the next release's new struct field by setting fields that
+	// are not part of the author-declared plan. Under the struct-marshalling
+	// digest each of these moved the revision.
+	mutated := campaign
+	mutated.State = "disarmed"
+	mutated.DeployedUnixNanos = time.Now().UnixNano()
+	mutated.Warnings = []string{"a warning the next release adds"}
+	mutated.Notify = nil
+	digest, err := json.Marshal(mutated.planDigestInput())
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseline, err := json.Marshal(campaign.planDigestInput())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(digest) != string(baseline) {
+		t.Fatalf("deploy-time state reached the revision digest:\n got %s\nwant %s", digest, baseline)
+	}
+
+	// Reparsing the same text must give the same revision, which is the
+	// property operators rely on to tell a redeploy from an edit.
+	again, err := ParseCampaign([]byte(drainDigestPinYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again.Revision != before {
+		t.Fatalf("the same plan hashed to %s and then %s", before, again.Revision)
+	}
+
+	// A real plan change still moves it.
+	edited, err := ParseCampaign([]byte(strings.Replace(drainDigestPinYAML, "buffer: 1s", "buffer: 2s", 1)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if edited.Revision == before {
+		t.Fatal("editing capture.buffer did not change the revision")
+	}
+}
+
+// TestCampaignRejectsUnparseableSecondDocument covers the second YAML document
+// that failed to parse. Testing the trailing decode for a nil error treated
+// "this does not parse" as "there is nothing here", so a plan with a malformed
+// second document deployed with that document silently dropped.
+func TestCampaignRejectsUnparseableSecondDocument(t *testing.T) {
+	plan := []byte(`version: 1
+name: two-docs
+sources:
+  - telemetry: true
+capture:
+  buffer: 0s
+  after_trigger: 5s
+  triggers:
+    - event: go
+upload: {when: manual}
+export: {annotation: cvat}
+---
+: : {{{
+`)
+	_, err := ParseCampaign(plan)
+	if err == nil {
+		t.Fatal("a second, unparseable YAML document was silently dropped")
+	}
+	if !strings.Contains(err.Error(), "exactly one document") {
+		t.Fatalf("error does not explain the rejection: %v", err)
+	}
+}
+
+// TestEpisodeDirRejectsDotSegments covers "." and "..", which survive safeName
+// untouched and, joined onto the store root, name the store itself and its
+// parent directory.
+func TestEpisodeDirRejectsDotSegments(t *testing.T) {
+	manager, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{".", ".."} {
+		if _, err := manager.episodeDir(id); !errors.Is(err, ErrInvalidEpisodeID) {
+			t.Fatalf("episodeDir(%q) = %v, want ErrInvalidEpisodeID", id, err)
+		}
+		if _, _, err := manager.Inspect(id, false); !errors.Is(err, ErrInvalidEpisodeID) {
+			t.Fatalf("Inspect(%q) = %v, want ErrInvalidEpisodeID", id, err)
+		}
+	}
+}
+
+// TestConcurrentDeployOfTheSameCampaign covers two deploys racing on what used
+// to be one fixed temporary filename. Both wrote into it and the file renamed
+// into place held one plan's bytes overlaid with the other's, which is still
+// valid JSON and therefore undetectable downstream.
+func TestConcurrentDeployOfTheSameCampaign(t *testing.T) {
+	manager, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := func(annotation string, triggers int) []byte {
+		var b strings.Builder
+		b.WriteString("version: 1\nname: racer\nsources:\n  - telemetry: true\ncapture:\n  buffer: 0s\n  after_trigger: 5s\n  triggers:\n")
+		for i := 0; i < triggers; i++ {
+			b.WriteString("    - event: e" + strings.Repeat("0", i) + strings.Repeat("long", 200) + "\n")
+		}
+		b.WriteString("upload: {when: manual}\nexport: {annotation: " + annotation + "}\n")
+		return []byte(b.String())
+	}
+	var wg sync.WaitGroup
+	errs := make(chan error, 16)
+	for i := 0; i < 8; i++ {
+		annotation, triggers := "cvat", 1
+		if i%2 == 1 {
+			annotation, triggers = "labelstudio", 6
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := manager.DeployCampaign(plan(annotation, triggers)); err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("concurrent deploy failed: %v", err)
+	}
+	// Whichever deploy won, the file on disk must be exactly one of the two
+	// plans and not a blend of both.
+	stored, err := manager.Campaign("racer")
+	if err != nil {
+		t.Fatalf("the stored plan is unreadable, so the deploys interleaved: %v", err)
+	}
+	switch {
+	case stored.Export.Annotation == "cvat" && len(stored.Capture.Triggers) == 1:
+	case stored.Export.Annotation == "labelstudio" && len(stored.Capture.Triggers) == 6:
+	default:
+		t.Fatalf("the stored plan is a blend of two deploys: annotation %q with %d triggers",
+			stored.Export.Annotation, len(stored.Capture.Triggers))
+	}
+	if _, err := os.Stat(filepath.Join(manager.campaignDir(), "racer.json.tmp")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatal("a fixed temporary filename is still in use")
+	}
+}
+
+// TestRoughtimeEvidenceGoesToASidecar pins that the manifest stops growing
+// with the episode. Raw Roughtime evidence (a nonce and the signed response
+// bytes per server) used to be appended to the manifest on every consensus
+// round and rewritten in full each time, so a long episode ended with a
+// manifest dominated by clock evidence.
+func TestRoughtimeEvidenceGoesToASidecar(t *testing.T) {
+	root := t.TempDir()
+	manager, err := NewManager(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Every round renders to the same number of bytes, so any growth in the
+	// manifest is structural (a round that was appended rather than replaced)
+	// rather than a wider integer.
+	manager.SetConsensusProvider(func(context.Context) (timesync.Consensus, error) {
+		return timesync.Consensus{
+			Confidence: "bounded", LowerOffsetNanos: 1_000_000, UpperOffsetNanos: 1_000_500,
+			Quorum: 3, ObservedUnixNanos: 1_700_000_000_000_000_000,
+			Evidence: []timesync.RoughtimeEvidence{{
+				Server: "example", Address: "roughtime.example:2002", Included: true,
+				Nonce: make([]byte, 32), RawResponse: make([]byte, 8192),
+			}},
+		}, nil
+	})
+	started, err := manager.Start(StartOptions{Name: "clocked", Sources: []string{"applications"}, RequireUTCUncertainty: time.Hour})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(root, started.ID+".partial")
+	manifestSize := func() int64 {
+		info, statErr := os.Stat(filepath.Join(dir, "manifest.json"))
+		if statErr != nil {
+			t.Fatal(statErr)
+		}
+		return info.Size()
+	}
+	// Drive further rounds the way the in-episode clock sampler does. The
+	// manifest keeps the opening round and the latest one, so it reaches its
+	// steady size at the second round and must not move after that however
+	// many more land.
+	manager.mu.Lock()
+	episode := manager.active[AdHocEpisodeKey]
+	manager.mu.Unlock()
+	if episode == nil {
+		t.Fatal("the episode is not active")
+	}
+	manager.queryAndAttachConsensus(context.Background(), episode, false)
+	steady := manifestSize()
+	const extraRounds = 12
+	for i := 0; i < extraRounds; i++ {
+		manager.queryAndAttachConsensus(context.Background(), episode, false)
+	}
+	// The only thing in the manifest that may still move with the round count
+	// is the decimal width of roughtime_rounds itself. Anything beyond that is
+	// evidence accumulating in the manifest again; one round of the evidence
+	// used to cost over eight kilobytes.
+	const counterDigits = 16
+	if got := manifestSize(); got-steady > counterDigits {
+		t.Fatalf("the manifest grew from %d to %d bytes over %d further consensus rounds", steady, got, extraRounds)
+	}
+
+	sidecar, err := os.ReadFile(filepath.Join(dir, RoughtimeEvidenceFile))
+	if err != nil {
+		t.Fatalf("the evidence sidecar is missing, so the rounds cannot be reverified: %v", err)
+	}
+	rows := strings.Count(strings.TrimSpace(string(sidecar)), "\n") + 1
+	if rows != extraRounds+2 {
+		t.Fatalf("the sidecar holds %d rows, want %d", rows, extraRounds+2)
+	}
+
+	// The manifest keeps the bounds and drops the bytes; the sidecar keeps
+	// both, and the sealed episode lists and checksums it.
+	stopped, err := manager.Stop(AdHocEpisodeKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stopped.RoughtimeEvidenceLog != RoughtimeEvidenceFile {
+		t.Fatalf("roughtime_evidence_log = %q, want %q", stopped.RoughtimeEvidenceLog, RoughtimeEvidenceFile)
+	}
+	if stopped.RoughtimeRounds != uint64(extraRounds+3) {
+		t.Fatalf("roughtime_rounds = %d, want %d (the seal adds one more)", stopped.RoughtimeRounds, extraRounds+3)
+	}
+	if len(stopped.Roughtime) > 2 {
+		t.Fatalf("the manifest kept %d consensus rounds, want at most the opening one and the latest", len(stopped.Roughtime))
+	}
+	for _, c := range stopped.Roughtime {
+		if len(c.Evidence) != 0 {
+			t.Fatal("raw Roughtime evidence is still in the manifest")
+		}
+		if c.LowerOffsetNanos == 0 || c.UpperOffsetNanos == 0 {
+			t.Fatalf("the manifest kept no usable bounds: %+v", c)
+		}
+	}
+	var listed bool
+	for _, f := range stopped.Files {
+		if f.Path == RoughtimeEvidenceFile {
+			listed = true
+			if f.SHA256 == "" || f.Size == 0 {
+				t.Fatalf("the sidecar was listed without a checksum: %+v", f)
+			}
+		}
+	}
+	if !listed {
+		t.Fatal("the sidecar is not in the sealed file list, so it is neither checksummed nor uploaded")
+	}
+	if _, failures, err := manager.Inspect(stopped.ID, true); err != nil || len(failures) != 0 {
+		t.Fatalf("verifying the sealed episode: %v %v", err, failures)
+	}
+}
+
+// TestTelemetryWriteFailureIsVisible covers the 1 Hz sampler swallowing a
+// write error. Rows vanished silently on a full disk, and the manifest went on
+// saying the telemetry source had drop accounting "unavailable", so an episode
+// missing an hour of telemetry looked exactly like a complete one.
+func TestTelemetryWriteFailureIsVisible(t *testing.T) {
+	root := t.TempDir()
+	manager, err := NewManager(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	warnings := make(chan string, 8)
+	manager.SetWarnLogger(func(message string) {
+		select {
+		case warnings <- message:
+		default:
+		}
+	})
+	started, err := manager.Start(StartOptions{Name: "telemetry", Sources: []string{"telemetry"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Make the append fail the way a full disk does: the sampler opens
+	// telemetry.jsonl for append on every tick, so removing it is enough.
+	if err := os.Remove(filepath.Join(root, started.ID+".partial", "telemetry.jsonl")); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case message := <-warnings:
+		if !strings.Contains(message, "telemetry row") {
+			t.Fatalf("unexpected warning: %s", message)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("a failing telemetry write said nothing at all")
+	}
+	stopped, err := manager.Stop(AdHocEpisodeKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, stats := range stopped.Sources {
+		if stats.Source.ID != "telemetry" {
+			continue
+		}
+		if stats.Drops == nil || *stats.Drops == 0 {
+			t.Fatalf("the lost rows are not counted as drops: %+v", stats)
+		}
+		if stats.DropAccounting != "exact" {
+			t.Fatalf("drop_accounting = %q, want exact: the loss is counted precisely", stats.DropAccounting)
+		}
+		return
+	}
+	t.Fatal("the episode has no telemetry source")
+}
+
+// TestCaptureStopIsStampedBeforeTheDrain covers episode length. The post-seal
+// drain is a window for late application records, not recording time, but
+// stopped_episode_nanos was stamped after it, so every drained episode
+// reported itself as having recorded for the whole drain longer than it did.
+func TestCaptureStopIsStampedBeforeTheDrain(t *testing.T) {
+	manager, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	const drain = 300 * time.Millisecond
+	if _, err := manager.Start(StartOptions{Name: "drained", Sources: []string{"applications"}, DrainDuration: drain}); err != nil {
+		t.Fatal(err)
+	}
+
+	// While the drain runs, Status must say the episode is finishing rather
+	// than that the device is idle.
+	statuses := make(chan *Manifest, 1)
+	go func() {
+		time.Sleep(drain / 3)
+		statuses <- manager.Status()
+	}()
+	stopped, err := manager.Stop(AdHocEpisodeKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	during := <-statuses
+	if during == nil {
+		t.Fatal("Status reported no episode while Stop was still draining")
+	}
+	if during.State != EpisodeStateDraining {
+		t.Fatalf("Status during the drain reported state %q, want %q", during.State, EpisodeStateDraining)
+	}
+
+	if stopped.CaptureStoppedEpisodeNS == 0 {
+		t.Fatal("capture_stopped_episode_nanos was never stamped")
+	}
+	if stopped.CaptureStoppedEpisodeNS >= stopped.StoppedEpisodeNS {
+		t.Fatalf("capture stop %d is not before the seal at %d", stopped.CaptureStoppedEpisodeNS, stopped.StoppedEpisodeNS)
+	}
+	// The gap between them is the drain, which is what BI was previously
+	// counting as recording time.
+	if gap := stopped.StoppedEpisodeNS - stopped.CaptureStoppedEpisodeNS; gap < int64(drain/2) {
+		t.Fatalf("the seal is only %dns after capture stopped, want about the %s drain", gap, drain)
+	}
+	// A sealed episode never leaves the draining state on disk.
+	if stopped.State != "complete" {
+		t.Fatalf("state = %q, want complete", stopped.State)
+	}
+}
+
+func readRecoveredManifest(t *testing.T, root, id string) Manifest {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(root, id, "manifest.json"))
+	if err != nil {
+		t.Fatalf("the episode was not recovered: %v", err)
+	}
+	var mf Manifest
+	if err := json.Unmarshal(raw, &mf); err != nil {
+		t.Fatal(err)
+	}
+	return mf
+}
+
+func containsSubstring(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if strings.Contains(s, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/data.md
@@ -7,6 +7,25 @@ manifest retains UTC correlation intervals, native clock mappings, source and
 device identity, drop accounting, calibration revisions, lifecycle state, file
 sizes, formats, and SHA-256 checksums.
 
+### Clock status
+
+The manifest's `system_clock_status` says what the Episode knows about the
+device's own system clock, judged against the Roughtime consensus. It is one of
+four values and never anything else.
+
+| Value | Meaning |
+|---|---|
+| `system_reported` | No Roughtime consensus was available, so the manifest carries only the system's own reported uncertainty. |
+| `agreement` | The system observation's UTC offset interval overlaps the Roughtime consensus interval. |
+| `conflict` | The two intervals are disjoint: the system clock and the Roughtime consensus cannot both be right. |
+| `roughtime_only` | The device has no synchronized system clock, so its observation is unbounded and there is no interval to compare. Roughtime is the Episode's only UTC evidence. This is not a disagreement; the system clock simply said nothing. |
+
+Each Roughtime round's full evidence, including the nonce and the raw signed
+responses, is appended to `roughtime.jsonl` in the Episode, which is sealed and
+checksummed like every other file. The manifest keeps the bounds of the first
+and most recent rounds in `roughtime_observations` and counts the rounds in
+`roughtime_rounds`, so it stays a fixed size however long the Episode records.
+
 ## Episode commands
 
 | Command | Description |
@@ -179,7 +198,12 @@ an ad-hoc `wendy data record` Episode can avoid the wait, and only by leaving
 the applications source out with `--source` or `--exclude-source`, as described
 above. The wait is added
 to the Episode's own lifetime, after `after_trigger` has expired, and it is
-included in the `stopped_episode_nanos` the manifest records.
+included in the `stopped_episode_nanos` the manifest records. Nothing is
+captured during it, so the manifest also records
+`capture_stopped_episode_nanos`, the point at which the capture adapters
+actually stopped. Measure how long an Episode recorded from that field;
+`stopped_episode_nanos` is the point past which no record was accepted, which
+is what an event timeline needs. The difference between them is the drain.
 
 A draining Episode has already stopped capturing, so it no longer holds its
 campaign. A trigger that matches during the drain starts the campaign's next


### PR DESCRIPTION
## Problem

Fourteen review findings in the agent's episode data package (`go/internal/agent/data`), all of the same shape. A device that loses power, crashes, or simply has no synchronized clock ends up with an episode manifest that is either unreadable or quietly wrong, and in three cases with an agent that will not start at all.

The quiet-wrongness cases matter most. A device without a synced system clock stamped `system_clock_status: conflict` on every episode it ever recorded. Crash recovery relabelled a snapshot or rate-capped source as holding every payload the model consumed. Recovery also relabelled a fully sealed episode as `interrupted` and blamed a reboot for what was a failed rename. None of these produce an error anywhere; they produce a number a training pipeline has no reason to disbelieve.

## Cause

* **Durability.** `writeManifest` and the campaign plan write were `os.WriteFile` into a temporary file followed by `os.Rename`, fsyncing neither the file nor the directory. The complete branch already carries `go/internal/shared/atomicfile`, which does both.
* **Recovery.** `recoverPartials` treated every `.partial` directory as interrupted, ignoring a manifest that already said `complete`; skipped an unreadable manifest with a bare `continue`, leaving the directory to be retried forever and invisible to the quota; and returned an error from the whole loop when one directory could not be sealed, which fails `NewManager` and therefore the agent.
* **Clock status.** `observeUTC` leaves both offset bounds at zero when adjtimex reports the clock unsynchronized. `clockAgreement` compared that empty interval against the Roughtime consensus, which is disjoint from it for any real offset.
* **Locking.** `Start` held `m.mu` across a full walk of every sealed episode's files and across `m.sourceProvider`, which `Sources()` deliberately calls without the lock because a provider is entitled to call back into the manager. The ROS 2 provider answers by running `ros2 topic list -t` in a container, with no timeout.
* **Campaign validation.** `validate` trimmed selectors before testing them while resolution did not, so a blank `camera:` validated as absent and then resolved as an empty substring that matches every camera. The revision digest was `sha256(json.Marshal(campaign.planOnly()))` over the whole `Campaign` struct, so any future struct field changed the revision of every deployed campaign. The trailing-document check treated a parse error as "no second document".

## Solution

Manifest and campaign writes go through `atomicfile`. Recovery is now per episode: a `complete` manifest is only renamed, an unrepairable directory is quarantined as `<id>.unrecoverable` and warned about, and a directory with no manifest at all is deleted. Warnings raised inside `NewManager` are buffered and replayed when `SetWarnLogger` attaches, since the agent cannot attach one earlier. Quarantined and in-flight bytes count toward the quota, and quarantined ones are evicted first so one damaged episode cannot wedge it permanently.

An unbounded system clock reports the new `roughtime_only` status. `Start` scans the store and discovers sources before taking the lock, with a three second bounded context for the provider. Raw Roughtime evidence moves to a sealed, checksummed `roughtime.jsonl` sidecar, and the manifest keeps the opening and latest bounds plus a round count. The revision digest covers an enumerated, versioned list of author-declared plan fields.

**Two behavior changes worth calling out.** Every campaign moves to a new revision exactly once with this change, because the digest no longer covers the struct's zero-valued fields; `TestCampaignRevisionIgnoresUnrelatedStructFields` is the guard that it cannot happen again for an unrelated reason. And `Status()` now reports an episode inside its post-seal drain with the state `draining` rather than reporting no episode at all; `draining` never reaches a manifest on disk.

## Findings

| Finding | Verdict | Fix | Test |
|---|---|---|---|
| S1-2-F1 clock conflict on unbounded system clock | FIXED | `clockAgreement` returns `roughtime_only`; vocabulary documented in `model.go` and `Docs/clients/wendy-cli/commands/data.md` | `TestClockAgreementWithUnboundedSystemClock` (table over all four combinations) |
| S1-2-F2 recovery discards persisted retention class | FIXED | `reconcileModelInputs` preserves `PayloadRetention` and `Note`, recomputes only counters | `TestRecoveryKeepsPersistedPayloadRetention` |
| S1-2-F4 no fsync; complete manifest relabelled | FIXED | `atomicfile.Write` for manifest and campaign; `recoverPartial` renames a `complete` manifest and stops | `TestRecoveryLeavesCompleteManifestAlone` |
| S1-2-F5 silent unreadable partial; quota blind to `.partial` | FIXED | Warn and quarantine, or delete when no manifest exists; scan counts `.partial` and `.unrecoverable` bytes | `TestRecoveryQuarantinesUnreadableManifest`, `TestRecoveryDeletesPartialWithNoManifest`, `TestQuotaCountsPartialAndQuarantinedBytes` |
| S1-2-F6 lock held over store walk; fsync per pre-roll record | FIXED | Store scan moved out of the lock; flush opens once and syncs once | `TestPreRollFlushSyncsOnce` (asserts exactly one fsync for 25 records) |
| S1-2-F7 / S7c-F9 source provider called under the lock, unbounded | FIXED | `discoverSources` snapshots before the lock with a three second context | `TestStartCallsSourceProviderWithoutTheLock` (provider calls `Warnf`, `Status`, `ActiveSession`) |
| S1-2-F9 over-long line and symlink fail `NewManager`; `truncateJSONL` reads twice | FIXED | Per-partial quarantine; `bufio.ErrTooLong` counted into `model_io.recovery_notes`; backwards chunked scan | `TestRecoveryToleratesOversizedOutcomeLine`, `TestRecoveryQuarantinesEpisodeWithSymlink`, `TestTruncateJSONLScansBackwards` |
| S1-2-F10 whitespace-only selector | FIXED | `validate` rejects a present but blank `camera`, `audio` or `ros2` | `TestCampaignRejectsBlankSelector` |
| S1-2-F11 revision hash covers future struct fields | FIXED | `planDigestInput`, a versioned explicit map (`revisionSchema = 1`) | `TestCampaignRevisionIgnoresUnrelatedStructFields`; the existing digest pin was re-pinned once with the reason recorded |
| S1-2-F12 unparseable second document ignored | FIXED | Anything but `io.EOF` from the trailing decode rejects | `TestCampaignRejectsUnparseableSecondDocument` |
| S1-2-F13 `episodeDir` accepts `.` and `..` | FIXED | Both refused with `ErrInvalidEpisodeID` | `TestEpisodeDirRejectsDotSegments` |
| S1-2-F14 unlocked deploy on a fixed temp name | FIXED | `campaignMu` plus `atomicfile` (unique temp per write) | `TestConcurrentDeployOfTheSameCampaign` (eight racing deploys of one name) |
| S1-2-F15 raw Roughtime evidence grows the manifest | FIXED | Sealed `roughtime.jsonl` sidecar; manifest keeps bounds, `roughtime_evidence_log`, `roughtime_rounds` | `TestRoughtimeEvidenceGoesToASidecar` |
| S6-F8 telemetry write failure swallowed | FIXED | Counted as an exact drop on the telemetry source, carried as `rows_lost_before` into the next row, warned at most once a minute | `TestTelemetryWriteFailureIsVisible` |
| S5-F11 `WENDY_DATA_MAX_BYTES=0` silently ignored | FIXED | `envBytes` takes a minimum: 1 for the quota, 0 for the reserve | `TestEnvBytesRejectsBelowMinimum` |
| S7c-F8 `stopped_episode_nanos` includes the drain | FIXED | `capture_stopped_episode_nanos` stamped in `beginSeal`; `Status` reports `draining` | `TestCaptureStopIsStampedBeforeTheDrain` |

Every finding was verified against current code before being fixed; none were refuted and none were already fixed.

The seal path is untouched apart from one line in `finalizeLocked`, which now calls the shared `recordConsensus` helper instead of appending to `manifest.Roughtime` directly, so that the final consensus round reaches the sidecar like every other one.

## Verification

From `go/`, matching `.github/workflows/go-tests.yml`:

* `go build ./...` clean
* `go vet ./...` clean, and `GOOS=linux go vet ./internal/agent/data/...` for the Linux-only files
* `gofmt -l -s .` clean
* `go test -race -count=1 ./internal/agent/data/ ./internal/agent/services/ ./cmd/wendy-agent/` all pass
* `go test -p=1 ./... -race -count=1` shows one unrelated pre-existing macOS failure, `TestBuildCmd_MultiService_BuildsFromManifestOnly` in `internal/cli/commands`, which compares a `/private/var` path against `/var` on a symlinked temporary directory and does not touch anything in this change

Each of the new tests was checked against a reverted implementation and fails without the fix.

Continuous integration is green on this branch: Test, Vet, Format Check and Install script tests all pass.

A second commit follows the first. The base branch's seal now detaches an episode under the manager mutex and then seals it with the mutex released, so the new `capture_stopped_episode_nanos` stamp in `beginSeal` had to take the same `stillOpenLocked` fence: a racing Stop and Interrupt could otherwise both hold the episode, and the stamp would write to a manifest the winner was already reading unlocked. The race detector caught it in `TestManagerConcurrentLifecycleStress` on the Linux runner; it now passes under `-race -count=5`.
