### PR TITLE
Rename WendyComDeviceInfo.board to target, add real board id field

### DIFF
--- a/Proto/wendy/lite/wendy_com_msg.proto
+++ b/Proto/wendy/lite/wendy_com_msg.proto
@@ -121,12 +121,14 @@ message WendyComDeviceInfo {
     string os = 1; // typically "wendy-lite"
     string os_version = 2;
     string cpu_architecture = 3;
-    // Board can be "esp32c6", but this doesn't mean that this field contains
-    // the SoC name. Here "esp32c6" means "generic esp32c6 board". Should
-    // probably be replaced by "esp32c6-generic" in the future.
-    string board = 4;
+    // SoC name, e.g. "esp32c6" or "esp32s3".
+    string target = 4;
     bool wasm_app_support = 5;
     bool native_app_support = 6;
+    // Board identifier, e.g. "esp32c6_generic" or "esp32s3_seeed_xiao_native".
+    // Empty when the board is not known, which is typically the case when
+    // wendy-lite is compiled and flashed manually.
+    string board = 7;
 }
 
 // Command sent host -> device — the oneof variant identifies the command.

--- a/go/internal/cli/assets/docs/wendy-lite/wendy-com.md
+++ b/go/internal/cli/assets/docs/wendy-lite/wendy-com.md
@@ -249,6 +249,7 @@ Queries the device for information about its hardware and software. The device r
 - `os` — the operating system name, typically `wendy-lite`.
 - `os_version` — the operating system version.
 - `cpu_architecture` — the CPU architecture.
-- `board` — the board identifier (e.g. `esp32c6`, meaning a generic ESP32-C6 board).
+- `target` — the SoC name (e.g. `esp32c6` or `esp32s3`).
 - `wasm_app_support` — whether the device can run WASM applications.
 - `native_app_support` — whether the device can run native applications.
+- `board` — the board identifier (e.g. `esp32c6_generic` or `esp32s3_seeed_xiao_native`). Empty when the board is not known.

--- a/go/internal/cli/liteclient/client.go
+++ b/go/internal/cli/liteclient/client.go
@@ -41,9 +41,13 @@ type DeviceIdentity struct {
 }
 
 type DeviceInfo struct {
-	OS               string
-	OSVersion        string
-	CPUArchitecture  string
+	OS              string
+	OSVersion       string
+	CPUArchitecture string
+	// Target is the SoC name, e.g. "esp32c6".
+	Target string
+	// Board identifies the board, e.g. "esp32s3_seeed_xiao_native". Empty when
+	// the device does not know which board it runs on.
 	Board            string
 	WasmAppSupport   bool
 	NativeAppSupport bool
@@ -508,6 +512,7 @@ func (c *WendyLiteClient) GetDeviceInfo(timeout time.Duration) (*DeviceInfo, err
 		OS:               di.GetOs(),
 		OSVersion:        di.GetOsVersion(),
 		CPUArchitecture:  di.GetCpuArchitecture(),
+		Target:           di.GetTarget(),
 		Board:            di.GetBoard(),
 		WasmAppSupport:   di.GetWasmAppSupport(),
 		NativeAppSupport: di.GetNativeAppSupport(),

--- a/go/internal/cli/providers/microwendy.go
+++ b/go/internal/cli/providers/microwendy.go
@@ -549,16 +549,6 @@ func (p *MicroWendyProvider) buildSwift(ctx context.Context, device models.Exter
 	}, nil
 }
 
-// boardToTarget returns the IDF target (SoC name, e.g. "esp32c6") firmware
-// must be built for to run on the given board. A board and a target are
-// different concepts: the device reports "esp32c6" meaning "generic esp32c6
-// board", not the SoC name — they merely coincide for the boards supported
-// today, so the mapping is the identity for now. A real lookup goes here once
-// board names diverge from SoC names.
-func boardToTarget(board string) string {
-	return board
-}
-
 // espIdfBinaryPath returns the path of the firmware binary an ESP-IDF build
 // produces in projectPath's build folder. The binary is named after the CMake
 // project() name, falling back to product when no project() declaration is
@@ -608,7 +598,7 @@ func (p *MicroWendyProvider) buildEspIdf(ctx context.Context, device models.Exte
 	}
 
 	// check if the project has been configured for the right target
-	target := boardToTarget(di.DeviceType)
+	target := di.DeviceType
 	if strings.ContainsAny(target, " \t\r\n") {
 		return nil, fmt.Errorf("invalid device target %q", target)
 	}
@@ -845,7 +835,7 @@ func (p *MicroWendyProvider) GetDeviceInfo(ctx context.Context, device models.Ex
 		OS:               di.OS,
 		OSVersion:        di.OSVersion,
 		CPUArchitecture:  di.CPUArchitecture,
-		DeviceType:       di.Board,
+		DeviceType:       di.Target,
 		WasmAppSupport:   di.WasmAppSupport,
 		NativeAppSupport: di.NativeAppSupport,
 	}, nil

--- a/go/internal/cli/providers/microwendy_test.go
+++ b/go/internal/cli/providers/microwendy_test.go
@@ -78,14 +78,6 @@ func TestEspIdfBinaryPath(t *testing.T) {
 	}
 }
 
-func TestBoardToTarget(t *testing.T) {
-	// Boards currently map to targets one-to-one by name; this pins the
-	// identity mapping until real board names diverge from SoC names.
-	if got := boardToTarget("esp32c6"); got != "esp32c6" {
-		t.Errorf("boardToTarget(esp32c6) = %q, want %q", got, "esp32c6")
-	}
-}
-
 func TestSerialExternalDeviceUnresponsive(t *testing.T) {
 	p := &MicroWendyProvider{}
 	dev := p.serialExternalDevice(discovery.SerialDevice{Port: "/dev/cu.usbmodem2101", Responsive: false})

--- a/go/internal/cli/providers/provider.go
+++ b/go/internal/cli/providers/provider.go
@@ -58,7 +58,7 @@ type ProviderDeviceInfo struct {
 	OS               string
 	OSVersion        string
 	CPUArchitecture  string // e.g. "riscv" for wendy-lite ESP32 boards
-	DeviceType       string // e.g. the board name for wendy-lite
+	DeviceType       string // e.g. the SoC/IDF target name for wendy-lite
 	WasmAppSupport   bool
 	NativeAppSupport bool
 }

--- a/go/proto/gen/litepb/wendy_com_msg.pb.go
+++ b/go/proto/gen/litepb/wendy_com_msg.pb.go
@@ -1217,14 +1217,16 @@ type WendyComDeviceInfo struct {
 	Os              string                 `protobuf:"bytes,1,opt,name=os,proto3" json:"os,omitempty"` // typically "wendy-lite"
 	OsVersion       string                 `protobuf:"bytes,2,opt,name=os_version,json=osVersion,proto3" json:"os_version,omitempty"`
 	CpuArchitecture string                 `protobuf:"bytes,3,opt,name=cpu_architecture,json=cpuArchitecture,proto3" json:"cpu_architecture,omitempty"`
-	// Board can be "esp32c6", but this doesn't mean that this field contains
-	// the SoC name. Here "esp32c6" means "generic esp32c6 board". Should
-	// probably be replaced by "esp32c6-generic" in the future.
-	Board            string `protobuf:"bytes,4,opt,name=board,proto3" json:"board,omitempty"`
+	// SoC name, e.g. "esp32c6" or "esp32s3".
+	Target           string `protobuf:"bytes,4,opt,name=target,proto3" json:"target,omitempty"`
 	WasmAppSupport   bool   `protobuf:"varint,5,opt,name=wasm_app_support,json=wasmAppSupport,proto3" json:"wasm_app_support,omitempty"`
 	NativeAppSupport bool   `protobuf:"varint,6,opt,name=native_app_support,json=nativeAppSupport,proto3" json:"native_app_support,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// Board identifier, e.g. "esp32c6_generic" or "esp32s3_seeed_xiao_native".
+	// Empty when the board is not known, which is typically the case when
+	// wendy-lite is compiled and flashed manually.
+	Board         string `protobuf:"bytes,7,opt,name=board,proto3" json:"board,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *WendyComDeviceInfo) Reset() {
@@ -1278,9 +1280,9 @@ func (x *WendyComDeviceInfo) GetCpuArchitecture() string {
 	return ""
 }
 
-func (x *WendyComDeviceInfo) GetBoard() string {
+func (x *WendyComDeviceInfo) GetTarget() string {
 	if x != nil {
-		return x.Board
+		return x.Target
 	}
 	return ""
 }
@@ -1297,6 +1299,13 @@ func (x *WendyComDeviceInfo) GetNativeAppSupport() bool {
 		return x.NativeAppSupport
 	}
 	return false
+}
+
+func (x *WendyComDeviceInfo) GetBoard() string {
+	if x != nil {
+		return x.Board
+	}
+	return ""
 }
 
 // Command sent host -> device — the oneof variant identifies the command.
@@ -2361,15 +2370,16 @@ const file_wendy_lite_wendy_com_msg_proto_rawDesc = "" +
 	"\x02io\x18\x01 \x01(\x0e2\x12.WendyComConsoleIoR\x02io\x12\x10\n" +
 	"\x03gap\x18\x02 \x01(\bR\x03gap\x12\x12\n" +
 	"\x04data\x18\x03 \x01(\fR\x04data\"\x14\n" +
-	"\x12WendyComConsoleEnd\"\xdc\x01\n" +
+	"\x12WendyComConsoleEnd\"\xf4\x01\n" +
 	"\x12WendyComDeviceInfo\x12\x0e\n" +
 	"\x02os\x18\x01 \x01(\tR\x02os\x12\x1d\n" +
 	"\n" +
 	"os_version\x18\x02 \x01(\tR\tosVersion\x12)\n" +
-	"\x10cpu_architecture\x18\x03 \x01(\tR\x0fcpuArchitecture\x12\x14\n" +
-	"\x05board\x18\x04 \x01(\tR\x05board\x12(\n" +
+	"\x10cpu_architecture\x18\x03 \x01(\tR\x0fcpuArchitecture\x12\x16\n" +
+	"\x06target\x18\x04 \x01(\tR\x06target\x12(\n" +
 	"\x10wasm_app_support\x18\x05 \x01(\bR\x0ewasmAppSupport\x12,\n" +
-	"\x12native_app_support\x18\x06 \x01(\bR\x10nativeAppSupport\"\xc2\a\n" +
+	"\x12native_app_support\x18\x06 \x01(\bR\x10nativeAppSupport\x12\x14\n" +
+	"\x05board\x18\a \x01(\tR\x05board\"\xc2\a\n" +
 	"\x0fWendyComCommand\x12\x1d\n" +
 	"\n" +
 	"request_id\x18\x01 \x01(\rR\trequestId\x12)\n" +


### PR DESCRIPTION
## Summary
- `WendyComDeviceInfo` field 4 only ever held the SoC name (e.g. "esp32c6"); it was misleadingly named `board`, so it's renamed to `target`.
- A new field 7, `board`, is added to carry a real board identifier (e.g. "esp32s3_seeed_xiao_native") for future use — not yet consumed anywhere.
- Updated the ESP-IDF provider (`go/internal/cli/providers/microwendy.go`), which read the old field expecting the SoC name, to use the renamed `target` field instead, preserving the same `idf.py set-target` behavior as before.
- Removed the now-obsolete `boardToTarget` identity helper and its test, and reworded a stale doc comment in `provider.go`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/cli/providers/... ./internal/cli/liteclient/...`
- [x] `gofmt -l` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)