### PR TITLE
agent: let the v4l2 driver pick its own encoder input format

### DIFF
--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -2962,8 +2962,8 @@ func isValidGSTElementName(name string) bool {
 }
 
 // encoderSegment returns the GStreamer pipeline segment for the given encoder element.
-// H.264 encoders force I420 (4:2:0) input to avoid 4:4:4 output paths that can make
-// encoders such as x264enc select profile 244 (High 4:4:4 Predictive), which
+// H.264 encoders are offered only 8-bit 4:2:0 input, to avoid 4:4:4 output paths that can
+// make encoders such as x264enc select profile 244 (High 4:4:4 Predictive), which
 // VideoToolbox and most hardware decoders reject. This input cap does not by itself
 // enforce a specific H.264 output profile; explicit profile caps are added only where needed
 // (for example, v4l2h264enc is capped to baseline below).
@@ -2984,12 +2984,15 @@ func encoderSegment(encoder string, hasH264Parse bool, gop int) string {
 		enc = "videoconvert ! video/x-raw,format=NV12 ! nvvidconv ! " +
 			"video/x-raw(memory:NVMM),format=NV12 ! nvv4l2h264enc" + kf
 	case "v4l2h264enc":
+		// This element wraps whatever M2M driver the board has, so the input
+		// format belongs to the driver: bcm2835-codec takes I420, qcom-iris NV12.
+		//
 		// The Raspberry Pi bcm2835-codec rejects frames ("Failed to process
 		// frame") unless the output H.264 level is pinned — a bare or
 		// profile-only capsfilter lets it negotiate a level the driver can't
 		// process. level 4 covers up to 1080p30, the encoder's ceiling
 		// (verified on a Pi 4, WDY-1603).
-		enc = "videoconvert ! video/x-raw,format=I420 ! v4l2h264enc" + kf + " ! video/x-h264,profile=baseline,level=(string)4"
+		enc = "videoconvert ! video/x-raw,format={I420,NV12} ! v4l2h264enc" + kf + " ! video/x-h264,profile=baseline,level=(string)4"
 	case "x264enc":
 		enc = "videoconvert ! video/x-raw,format=I420 ! x264enc tune=zerolatency" + kf + " ! video/x-h264,profile=high"
 	case "openh264enc":

--- a/go/internal/agent/services/video_service_test.go
+++ b/go/internal/agent/services/video_service_test.go
@@ -373,6 +373,19 @@ func TestBuildGStreamerArgs_V4L2PinsH264Level(t *testing.T) {
 	}
 }
 
+func TestBuildGStreamerArgs_V4L2LetsTheDriverPickItsInputFormat(t *testing.T) {
+	// v4l2h264enc wraps whatever M2M driver the board has, and the accepted input
+	// format is the driver's: bcm2835-codec takes I420, qcom-iris NV12 only.
+	// Pinning one fails to link on boards wanting the other.
+	req := &agentpb.StreamVideoRequest{}
+	args := mustBuildGStreamerArgs(t, "/usr/bin/gst-launch-1.0", "/dev/video0", req, "v4l2h264enc", true)
+	joined := strings.Join(args, " ")
+	const want = "videoconvert ! video/x-raw,format={I420,NV12} ! v4l2h264enc"
+	if !strings.Contains(joined, want) {
+		t.Errorf("v4l2h264enc input caps must offer both formats (%q): %v", want, args)
+	}
+}
+
 func TestBuildGStreamerArgs_NVV4L2HardwareEncoder(t *testing.T) {
 	req := &agentpb.StreamVideoRequest{}
 	args := mustBuildGStreamerArgs(t, "/usr/bin/gst-launch-1.0", "/dev/video0", req, "nvv4l2h264enc", true)


### PR DESCRIPTION
The Dragonwing IQ-8275 encoder is qcom-iris, which accepts NV12 and nothing else, so the pipeline cannot link at all:
```
    could not link videoconvert0 to v4l2h264enc0,
    v4l2h264enc0 can't handle caps video/x-raw, format=(string)I420
```