### PR TITLE
Mint the device identity, and hold the device name to Cloud's rule

### DIFF
--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/enroll.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/device/enroll.md
@@ -28,10 +28,18 @@ Before connecting to the device, enrollment checks your certificate and attempts
 › the urn:wendy SAN, exactly as before. The cloud certificate service
 › validates these SANs against the enrollment token at issuance time.
 
-The enrolled device is registered in Wendy Cloud under a human-readable **name**. The name can be changed later with `wendy device rename`, so the command resolves it as follows:
+## Name and identity are two different things
+
+Enrollment produces two identifiers, and only one of them is yours to choose.
+
+The **identity** is minted by the command as a UUID. pki-core stamps it into the device's certificate as `spiffe://wendy.sh/tenant/‹tenant›/device/‹uuid›` and carries it across every renewal for the life of the device. It is irreversible and it is never derived from the name, so relabelling a device cannot rewrite an identity that has already been issued.
+
+The **name** is how you and `wendy` find the device. It is unique within your organization, compared without regard to case, and you can change it later with `wendy device rename`. Because it has to match the device's own hostname, it is a single lowercase DNS label: it starts with `a`–`z`, continues with lowercase letters, digits or `-`, is at most 63 characters, and does not end in `-`. A name that breaks that rule is refused before anything is enrolled.
+
+The command resolves the name as follows:
 
 1. **`--name <name>`** — always wins when provided.
-2. **Hostname default** — when `--name` is omitted and the device is reachable by hostname (e.g. `playful-reed.local`), the name defaults to that hostname with any `.local` suffix stripped (so `playful-reed.local` → `playful-reed`).
+2. **Hostname default** — when `--name` is omitted and the device is reachable by hostname (e.g. `Playful-Reed.local`), the name defaults to that hostname lowercased with any `.local` suffix stripped (so `Playful-Reed.local` → `playful-reed`). A hostname that is not otherwise a DNS label is reported rather than repaired.
 3. **Interactive prompt** — in a terminal, when no `--name` is given the command prompts for a name. When a hostname default is available it is shown in brackets and used if you press Enter without typing anything:
 
    ```
@@ -47,12 +55,15 @@ The enrolled device is registered in Wendy Cloud under a human-readable **name**
 
 > **Naming an unnamed device:** A device enrolled without a usable name shows up with an empty name in [`wendy cloud discover`](../cloud/discover.md). You can still address it by its numeric asset ID — see [`wendy cloud tunnel --device <id>`](../cloud/tunnel.md).
 
+If Cloud refuses the name — because it breaks the rule above, or because another device in the organization already holds it — it says so and stops. Nothing is minted on that path, so retrying with a different name costs nothing.
+
 ## Flags
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--name` | hostname (`.local` stripped) | Human-readable device name. Defaults to the device hostname when omitted; required when the device is reachable only by a bare IP address in a non-interactive environment. |
 | `--cloud-grpc` | `""` | Cloud / pki-core gRPC endpoint to use. Overrides session selection; when omitted, the persisted default (set with `wendy auth use`) is used if available, otherwise an interactive picker appears. |
+| `--acme-directory-url` | derived | ACME directory URL for a custom pki-core deployment. OIDC sessions only; when omitted it is derived from the session's own pki-core identity endpoint. |
 
 ## Examples
 

--- a/go/internal/cli/commands/device.go
+++ b/go/internal/cli/commands/device.go
@@ -875,12 +875,16 @@ func promptWifiIfNeeded(ctx context.Context, conn *grpcclient.AgentConnection) {
 
 // defaultEnrollmentName derives a device name from the connected host,
 // stripping a .local suffix. Returns "" for bare IP addresses (no usable name).
+// defaultEnrollmentName proposes the device's own advertised hostname. Cloud
+// compares names without regard to case, so the suggestion is lowercased --
+// but nothing else is repaired: a host that is not a DNS label is reported by
+// validateHostnameArg rather than quietly mangled into one.
 func defaultEnrollmentName(host string) string {
 	h := strings.TrimSpace(host)
 	if h == "" || net.ParseIP(h) != nil {
 		return ""
 	}
-	return strings.TrimSuffix(h, ".local")
+	return strings.ToLower(strings.TrimSuffix(h, ".local"))
 }
 
 func enrollmentDeviceName(conn *grpcclient.AgentConnection, name string) (string, error) {
@@ -908,6 +912,14 @@ func enrollmentDeviceName(conn *grpcclient.AgentConnection, name string) (string
 				return "", fmt.Errorf("device name is required")
 			}
 		}
+	}
+
+	// The same rule 'wendy device rename' enforces, and the same one Cloud
+	// applies to the asset row: a device whose hostname and Cloud row disagree
+	// is one an operator cannot find by either name. Checking it here keeps a
+	// bad name from reaching an enrollment that would refuse it anyway.
+	if err := validateHostnameArg(name); err != nil {
+		return "", fmt.Errorf("device name %q is not usable: %w", name, err)
 	}
 
 	return name, nil

--- a/go/internal/cli/commands/device_enroll_oidc.go
+++ b/go/internal/cli/commands/device_enroll_oidc.go
@@ -18,8 +18,11 @@ import (
 )
 
 // Resolve and validate the destination before Cloud mints a once-only credential.
-func oidcEnrollmentConfig(auth *config.AuthConfig, name, directoryURL string) (acmeenroll.Config, error) {
-	cfg := acmeenroll.Config{DeviceID: name, DirectoryURL: directoryURL}
+//
+// deviceID is the permanent identity, not the operator-typed name: it becomes
+// the device's SPIFFE SAN and pki-core carries it across every renewal.
+func oidcEnrollmentConfig(auth *config.AuthConfig, deviceID, directoryURL string) (acmeenroll.Config, error) {
+	cfg := acmeenroll.Config{DeviceID: deviceID, DirectoryURL: directoryURL}
 	u, err := url.Parse(auth.Certificates[0].PrincipalURI)
 	if err != nil || u.Scheme != "spiffe" || u.Host != "wendy.sh" || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
 		return cfg, fmt.Errorf("OIDC session has no valid operator identity; re-run 'wendy auth login'")
@@ -44,7 +47,7 @@ func oidcEnrollmentConfig(auth *config.AuthConfig, name, directoryURL string) (a
 	if err != nil {
 		return cfg, err
 	}
-	if principal != "spiffe://wendy.sh/tenant/"+tenant.String()+"/device/"+name {
+	if principal != "spiffe://wendy.sh/tenant/"+tenant.String()+"/device/"+deviceID {
 		return cfg, fmt.Errorf("ACME enrollment tenant does not match the selected OIDC session")
 	}
 	return cfg, nil
@@ -61,7 +64,13 @@ func runOIDCEnrollDevice(ctx context.Context, conn *grpcclient.AgentConnection, 
 	if err != nil {
 		return err
 	}
-	cfg, err := oidcEnrollmentConfig(auth, name, directoryURL)
+	// The identity is minted here and never derived from the name. device_id is
+	// irreversible -- it becomes the SPIFFE SAN for the life of the device --
+	// while the name is a renameable, organization-unique discovery key, so
+	// deriving one from the other would make a relabelling rewrite an identity
+	// that pki-core has already stamped into certificates.
+	deviceID := uuid.NewString()
+	cfg, err := oidcEnrollmentConfig(auth, deviceID, directoryURL)
 	if err != nil {
 		return err
 	}
@@ -88,7 +97,7 @@ func runOIDCEnrollDevice(ctx context.Context, conn *grpcclient.AgentConnection, 
 	if err != nil {
 		return err
 	}
-	artifact, err := cloudrequest.EnrollmentRequest(auth, name)
+	artifact, err := cloudrequest.EnrollmentRequest(auth, deviceID)
 	if err != nil {
 		return fmt.Errorf("signing enrollment request: %w", err)
 	}
@@ -98,13 +107,22 @@ func runOIDCEnrollDevice(ctx context.Context, conn *grpcclient.AgentConnection, 
 	}
 	defer cloudConn.Close()
 
-	fmt.Printf("Enrolling %s with PKI...\n", name)
+	fmt.Printf("Enrolling %s as %s with PKI...\n", name, deviceID)
 	credential, err := cloudpbv2.NewDeviceEnrollmentServiceClient(cloudConn).EnrollDevice(tokenCtx, &cloudpbv2.EnrollDeviceRequest{
-		DeviceId: name, DeviceClass: cloudpbv2.DeviceClass_DEVICE_CLASS_B,
+		DeviceId: deviceID, DeviceClass: cloudpbv2.DeviceClass_DEVICE_CLASS_B,
 		EnrollmentRequestJws: artifact, Name: name,
 	})
-	if status.Code(err) == codes.Unimplemented {
+	switch status.Code(err) {
+	case codes.Unimplemented:
 		return fmt.Errorf("this Cloud deployment does not support OIDC device enrollment; it needs DeviceEnrollmentService/EnrollDevice")
+	case codes.AlreadyExists, codes.InvalidArgument:
+		// Cloud validates the name and checks its unique indexes BEFORE it
+		// relays to pki-core, so nothing was minted. Saying so is the whole
+		// point of separating this case: the operator's default assumption
+		// about a single-use credential is that they have just spent one.
+		// Cloud's own message is appended verbatim because it names which
+		// constraint was hit, and this side cannot tell the two indexes apart.
+		return fmt.Errorf("Cloud refused this enrollment before minting anything, so no credential was spent: %w", err)
 	}
 	if err != nil {
 		return fmt.Errorf("creating PKI enrollment credential: %w", err)
@@ -131,6 +149,6 @@ func runOIDCEnrollDevice(ctx context.Context, conn *grpcclient.AgentConnection, 
 	if resp.GetPrincipalUri() != expected {
 		return fmt.Errorf("agent returned an unexpected enrollment identity")
 	}
-	fmt.Printf("Device enrolled (%s, asset: %s).\n", resp.GetPrincipalUri(), credential.GetAssetId())
+	fmt.Printf("Device enrolled (name: %s, identity: %s, asset: %s).\n", name, resp.GetPrincipalUri(), credential.GetAssetId())
 	return nil
 }

--- a/go/internal/cli/commands/device_enroll_oidc_test.go
+++ b/go/internal/cli/commands/device_enroll_oidc_test.go
@@ -154,7 +154,8 @@ func verifyEnrollmentJWS(t *testing.T, compact string) map[string]any {
 }
 
 func TestOIDCEnrollmentAutomaticCloudRelay(t *testing.T) {
-	for _, name := range []string{"sim", "fleet-a/box-01", ""} {
+	minted := map[string]bool{}
+	for _, name := range []string{"sim", "box-01", ""} {
 		t.Run(name, func(t *testing.T) {
 			cloud := &oidcEnrollmentServer{response: &cloudpbv2.EnrollDeviceResponse{AssetId: "asset-uuid", CredentialKind: "eab", EabKeyId: "eab-id", EabHmacKey: strings.Repeat("ab", 32)}}
 			agent := &acmeProvisioningServer{}
@@ -169,14 +170,30 @@ func TestOIDCEnrollmentAutomaticCloudRelay(t *testing.T) {
 			if name == "" {
 				name = "sim"
 			}
-			if cloud.req.GetDeviceId() != name || cloud.req.GetName() != name || cloud.req.GetDeviceClass() != cloudpbv2.DeviceClass_DEVICE_CLASS_B {
+
+			// The identity is a freshly minted UUID and the name is carried
+			// beside it: the operator's label never becomes the permanent SAN.
+			deviceID := cloud.req.GetDeviceId()
+			if _, err := uuid.Parse(deviceID); err != nil {
+				t.Fatalf("device_id %q is not a UUID", deviceID)
+			}
+			if deviceID == name {
+				t.Fatal("device identity was derived from the name")
+			}
+			if minted[deviceID] {
+				t.Fatal("device identity was reused across enrollments")
+			}
+			minted[deviceID] = true
+			if cloud.req.GetName() != name || cloud.req.GetDeviceClass() != cloudpbv2.DeviceClass_DEVICE_CLASS_B {
 				t.Fatal("incorrect Cloud enrollment request")
 			}
 			if got := cloud.md.Get("authorization"); len(got) != 1 || got[0] != "Bearer test-access-token" {
 				t.Fatal("missing OIDC bearer")
 			}
 			artifact := verifyEnrollmentJWS(t, string(cloud.req.GetEnrollmentRequestJws()))
-			if artifact["tenant"] != testOperatorTenant || artifact["device_id"] != name || artifact["device_class"] != "B" {
+			// Cloud refuses on disagreement, so the signed id and the request
+			// id have to be the same string.
+			if artifact["tenant"] != testOperatorTenant || artifact["device_id"] != deviceID || artifact["device_class"] != "B" {
 				t.Fatal("incorrect PKI claims")
 			}
 			if _, err := uuid.Parse(artifact["jti"].(string)); err != nil {
@@ -192,14 +209,40 @@ func TestOIDCEnrollmentAutomaticCloudRelay(t *testing.T) {
 			}
 			descriptor := verifyEnrollmentJWS(t, envelope[0])
 			target := descriptor["target"].(map[string]any)
-			if descriptor["operation"] != "wendycloud.v2.DeviceEnrollmentService/EnrollDevice" || target["tenant"] != testOperatorTenant || target["resource"] != "org/"+testOperatorTenant+"/device/"+name {
+			if descriptor["operation"] != "wendycloud.v2.DeviceEnrollmentService/EnrollDevice" || target["tenant"] != testOperatorTenant || target["resource"] != "org/"+testOperatorTenant+"/device/"+deviceID {
 				t.Fatal("incorrect Cloud request scope")
 			}
-			if agent.req.GetDeviceId() != name || agent.req.GetEabKeyId() != "eab-id" || agent.req.GetEabHmacKey() != strings.Repeat("ab", 32) || agent.req.GetCloudHost() != host {
+			if agent.req.GetDeviceId() != deviceID || agent.req.GetEabKeyId() != "eab-id" || agent.req.GetEabHmacKey() != strings.Repeat("ab", 32) || agent.req.GetCloudHost() != host {
 				t.Fatal("credential handoff mismatch")
 			}
 			if agent.req.GetDirectoryUrl() != "https://acme.dev.pki.wendy.sh/"+testOperatorTenant+"/acme/directory" {
 				t.Fatal("incorrect directory")
+			}
+		})
+	}
+}
+
+// A name Cloud would refuse has to be refused here, before the RPC that mints
+// a single-use credential is made at all.
+func TestOIDCEnrollmentRejectsNamesCloudWouldRefuse(t *testing.T) {
+	for _, name := range []string{"Box-01", "fleet-a/box-01", "box.01", "1box", "box-", strings.Repeat("b", 64)} {
+		t.Run(name, func(t *testing.T) {
+			cloud := &oidcEnrollmentServer{response: &cloudpbv2.EnrollDeviceResponse{AssetId: "asset-uuid", CredentialKind: "eab", EabKeyId: "eab-id", EabHmacKey: strings.Repeat("ab", 32)}}
+			agent := &acmeProvisioningServer{}
+			conn, host := enrollmentServers(t, cloud, agent)
+			auth := oidcEnrollmentAuth(t)
+			auth.CloudGRPC = host
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			err := runEnrollDevice(ctx, conn, auth, name, 0)
+			if err == nil {
+				t.Fatal("expected the enrollment to be refused")
+			}
+			if !strings.Contains(err.Error(), "not usable") {
+				t.Fatalf("err = %v, want the device-name rule", err)
+			}
+			if cloud.req != nil {
+				t.Fatal("a refused name still reached Cloud")
 			}
 		})
 	}


### PR DESCRIPTION
- **Advances:** [WDY-2943 Move `wendy auth refresh-certs` and `wendy device enroll` off cloudpb.CertificateService](https://linear.app/wendylabsinc/issue/WDY-2943)
- **Base:** `jo/oidc-fixes` (#1955), per sem's ruling of 2026-09-12 01:40 making that branch the integration base for v2 CLI/agent work.

> **In plain terms:** `wendy device enroll` used the name you type as the device's permanent cryptographic identity, so renaming a device left its certificate asserting the old label forever. The identity is now a UUID minted at enrollment and the name travels beside it. The name is also checked against the rule Cloud actually enforces, so a bad one is caught here instead of after a round trip.

## Summary
- `device_id` is `uuid.NewString()`, signed into the enrollment request and sent alongside `name`. It is irreversible — pki-core stamps it into `spiffe://wendy.sh/tenant/<tenant>/device/<id>` and carries it across every renewal — so deriving it from a renameable label was the wrong shape. Ruled on 2026-09-07 (`ad31c158`) and again in the #1919 carve list (DROP 1).
- Both enroll paths now run `validateHostnameArg`, the same validator `wendy device rename` uses, and the hostname-derived default is lowercased. Cloud's `validatedDeviceLabel` requires a single lowercase DNS label; `defaultEnrollmentName` only stripped `.local`, so a host like `wendy-SER9.local` produced a name Cloud refuses.
- `ALREADY_EXISTS` and `INVALID_ARGUMENT` from `EnrollDevice` now state that nothing was minted. Cloud validates and reserves against its unique indexes before relaying to pki-core, and that is the one fact the operator cannot infer — the default assumption about a single-use credential is that it has just been spent. Cloud's message is appended verbatim because `ALREADY_EXISTS` covers two indexes whose remedies differ.

## Boundary changes
- **CLI:** `wendy device enroll` refuses a device name that is not a single lowercase DNS label (`a`–`z` first, then `a`–`z`/`0`–`9`/`-`, ≤63, no trailing `-`) instead of sending it to Cloud. This applies to the legacy enrollment path too, which previously passed any string through. A hostname-derived default is now lowercased rather than passed through as typed.
- **CLI:** success output changes from `Device enrolled (<principal>, asset: <id>)` to `Device enrolled (name: <name>, identity: <principal>, asset: <id>)`.
- **gRPC (client side, additive):** `EnrollDeviceRequest.device_id` now carries a UUID rather than the value of `name`. No field, number, or type changes; `StartProvisioningRequest` field 5 is untouched.

## Tests
- `go build ./... && go vet ./... && gofmt -l go` — clean
- `go test ./go/... -count=1` — passes except the four pre-existing `internal/agent/oci` GPU tests, which fail identically on `jo/oidc-fixes` with no NVIDIA device present
- New: `TestOIDCEnrollmentRejectsNamesCloudWouldRefuse` pins that six names Cloud would reject never reach the minting RPC; `TestOIDCEnrollmentAutomaticCloudRelay` now pins that the id parses as a UUID, differs from the name, differs between enrollments, and matches the id inside the signed enrollment request and the Cloud request-signature resource