### PR TITLE
Derive pki-core frontends from the session's own PKI, by label

### DIFF
--- a/go/docs/oidc-device-enrollment.md
+++ b/go/docs/oidc-device-enrollment.md
@@ -39,16 +39,21 @@ validates it against PKI's own CA material. Including the ML-DSA intermediates
 would exceed the broker's 16 KiB HTTP/2 header limit alongside the bearer token.
 The enrollment JWS retains the full chain in the protobuf body.
 
-Cloud does not return an ACME directory URL. For sessions using
-`identity.dev.pki.wendy.sh`, the CLI uses:
+Cloud does not return an ACME directory URL. The CLI derives one from the
+pki-core identity endpoint the session already holds, by replacing its leading
+`identity.` label:
 
 ```text
-https://acme.dev.pki.wendy.sh/<session-tenant>/acme/directory
+https://identity.<rest>/v1/identity/certificate
+  -> https://acme.<rest>/<session-tenant>/acme/directory
 ```
 
-Custom deployments can supply `--acme-directory-url <url>`. The directory must
-use HTTPS (HTTP is allowed on loopback development servers), and its tenant
-must match the selected login.
+That keeps the derivation inside one PKI deployment and names no environment,
+so a self-hosted pki-core derives its own directory exactly as the hosted one
+does. A session whose identity endpoint is not an `https://identity.<rest>`
+URL derives nothing and must supply `--acme-directory-url <url>`. The directory
+must use HTTPS (HTTP is allowed on loopback development servers), and its
+tenant must match the selected login.
 
 ## Device-side behavior and failures
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/auth/refresh-certs.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/auth/refresh-certs.md
@@ -26,11 +26,16 @@ wendy auth refresh-certs
 
 `WENDY_PKI_RENEW_ENDPOINT` names pki-core's renew frontend, e.g.
 `https://renew.pki.example:8451/v1/renew`, and overrides deployment defaults.
-Sessions whose identity endpoint is `identity.dev.pki.wendy.sh` default to
-`https://renew.dev.pki.wendy.sh/v1/renew`. Every other session requires the
-override, including a session that knows only its Cloud endpoint: which cloud
-answers says nothing about which PKI mints, so no renew host is derived from
-one.
+Without it, the renew frontend is derived from the pki-core identity endpoint
+the session already holds, by replacing its leading `identity.` label:
+`https://identity.<rest>/...` becomes `https://renew.<rest>/v1/renew`, port
+included. The derivation therefore stays inside one PKI deployment and names no
+environment.
+
+A session whose identity endpoint is not an `https://identity.<rest>` URL
+derives nothing and requires the override. That includes a session which knows
+only its Cloud endpoint: which cloud answers says nothing about which PKI
+mints, so no renew host is ever derived from one.
 
 ## It also runs by itself
 

--- a/go/internal/cli/assets/docs/clients/wendy-cli/commands/auth/refresh-certs.md
+++ b/go/internal/cli/assets/docs/clients/wendy-cli/commands/auth/refresh-certs.md
@@ -26,10 +26,11 @@ wendy auth refresh-certs
 
 `WENDY_PKI_RENEW_ENDPOINT` names pki-core's renew frontend, e.g.
 `https://renew.pki.example:8451/v1/renew`, and overrides deployment defaults.
-Sessions using `identity.dev.pki.wendy.sh`, or certificate-only sessions using
-`api.dev.wendy.sh:443`, default to `https://renew.dev.pki.wendy.sh/v1/renew`.
-Custom deployments still require the override; a custom identity endpoint is
-never replaced by the Cloud dev default.
+Sessions whose identity endpoint is `identity.dev.pki.wendy.sh` default to
+`https://renew.dev.pki.wendy.sh/v1/renew`. Every other session requires the
+override, including a session that knows only its Cloud endpoint: which cloud
+answers says nothing about which PKI mints, so no renew host is derived from
+one.
 
 ## It also runs by itself
 

--- a/go/internal/cli/commands/auth_refresh_certs_test.go
+++ b/go/internal/cli/commands/auth_refresh_certs_test.go
@@ -173,7 +173,7 @@ func TestRenewalRefusalsOfferRelogin(t *testing.T) {
 	}
 }
 
-func TestRefreshCertsForAuthUsesDevRenewEndpoint(t *testing.T) {
+func TestRefreshCertsForAuthDerivesTheRenewEndpoint(t *testing.T) {
 	t.Setenv(renewEndpointEnv, "")
 	orig := renewViaPKICore
 	var endpoint string

--- a/go/internal/cli/commands/auth_refresh_certs_test.go
+++ b/go/internal/cli/commands/auth_refresh_certs_test.go
@@ -182,7 +182,11 @@ func TestRefreshCertsForAuthUsesDevRenewEndpoint(t *testing.T) {
 		return "leaf", "chain", "key", nil
 	}
 	t.Cleanup(func() { renewViaPKICore = orig })
-	auth := &config.AuthConfig{CloudGRPC: "api.dev.wendy.sh:443", Certificates: []config.CertificateInfo{{PemCertificate: leafWithURIs(t, testTenantPrincipal)}}}
+	auth := &config.AuthConfig{
+		CloudGRPC:    "api.dev.wendy.sh:443",
+		PKIEndpoint:  "https://identity.dev.pki.wendy.sh/v1/identity/certificate",
+		Certificates: []config.CertificateInfo{{PemCertificate: leafWithURIs(t, testTenantPrincipal)}},
+	}
 	if err := refreshCertsForAuth(cancelledCtx(t), auth); err != nil {
 		t.Fatal(err)
 	}

--- a/go/internal/cli/commands/certrenew.go
+++ b/go/internal/cli/commands/certrenew.go
@@ -142,19 +142,15 @@ func renewEndpoint(auth *config.AuthConfig) string {
 	if auth == nil {
 		return ""
 	}
-	const devRenewEndpoint = "https://renew.dev.pki.wendy.sh/v1/renew"
-	if auth.PKIEndpoint != "" {
-		u, err := url.Parse(auth.PKIEndpoint)
-		if err == nil && u.Scheme == "https" && u.Host == "identity.dev.pki.wendy.sh" && u.User == nil {
-			return devRenewEndpoint
-		}
-		// An explicit custom PKI deployment takes precedence over Cloud defaults.
-		return ""
-	}
-	// Imported operator certificates may have no OIDC/identity configuration.
-	// The known dev API still identifies the deployment to renew them against.
-	if auth.CloudGRPC == "api.dev.wendy.sh:443" {
-		return devRenewEndpoint
+	// The renew frontend is derived from the session's own pki-core identity
+	// endpoint and from nothing else. Deriving one service's host from
+	// another's is WDY-2799, where enrollment tokens went to the wrong place
+	// in cleartext: a cloud host says which cloud answers, never which PKI
+	// mints. A session with no identity endpoint is not configured for
+	// renewal, and says so rather than guessing.
+	u, err := url.Parse(auth.PKIEndpoint)
+	if err == nil && u.Scheme == "https" && u.Host == "identity.dev.pki.wendy.sh" && u.User == nil {
+		return "https://renew.dev.pki.wendy.sh/v1/renew"
 	}
 	return ""
 }

--- a/go/internal/cli/commands/certrenew.go
+++ b/go/internal/cli/commands/certrenew.go
@@ -142,17 +142,36 @@ func renewEndpoint(auth *config.AuthConfig) string {
 	if auth == nil {
 		return ""
 	}
-	// The renew frontend is derived from the session's own pki-core identity
-	// endpoint and from nothing else. Deriving one service's host from
-	// another's is WDY-2799, where enrollment tokens went to the wrong place
-	// in cleartext: a cloud host says which cloud answers, never which PKI
-	// mints. A session with no identity endpoint is not configured for
-	// renewal, and says so rather than guessing.
-	u, err := url.Parse(auth.PKIEndpoint)
-	if err == nil && u.Scheme == "https" && u.Host == "identity.dev.pki.wendy.sh" && u.User == nil {
-		return "https://renew.dev.pki.wendy.sh/v1/renew"
+	if host := pkiSiblingHost(auth.PKIEndpoint, "renew"); host != "" {
+		return "https://" + host + "/v1/renew"
 	}
 	return ""
+}
+
+// pkiSiblingHost rewrites a pki-core identity frontend into a sibling frontend
+// of the same deployment: identity.<rest> becomes <label>.<rest>, port and all.
+//
+// The only input is the identity endpoint the session already holds, so this
+// stays inside one PKI host family. Reading a PKI host out of a *cloud* host is
+// WDY-2799, where enrollment tokens went to the wrong place in cleartext: which
+// cloud answers says nothing about which PKI mints. Nor is any environment
+// named here -- a hardcoded "identity.dev.pki.wendy.sh" only works for one
+// deployment and silently declines to derive for every other, which is how the
+// dev hostname ends up load-bearing.
+//
+// A URL that is not an https identity frontend derives nothing. The caller
+// reports the deployment as unconfigured, which is the WDY-2799 rule: unset
+// means not configured, never "guess".
+func pkiSiblingHost(identityEndpoint, label string) string {
+	u, err := url.Parse(identityEndpoint)
+	if err != nil || u.Scheme != "https" || u.User != nil {
+		return ""
+	}
+	rest, ok := strings.CutPrefix(u.Host, "identity.")
+	if !ok || rest == "" {
+		return ""
+	}
+	return label + "." + rest
 }
 
 // splitLeafAndChain splits a PEM bundle into its first certificate and the

--- a/go/internal/cli/commands/certrenew_test.go
+++ b/go/internal/cli/commands/certrenew_test.go
@@ -317,10 +317,11 @@ func TestRenewEndpointUsesKnownDeployment(t *testing.T) {
 		auth           *config.AuthConfig
 		override, want string
 	}{
-		{name: "dev certificate session", auth: &config.AuthConfig{CloudGRPC: "api.dev.wendy.sh:443"}, want: "https://renew.dev.pki.wendy.sh/v1/renew"},
+		{name: "cloud host alone derives nothing", auth: &config.AuthConfig{CloudGRPC: "api.dev.wendy.sh:443"}},
 		{name: "identity deployment", auth: &config.AuthConfig{PKIEndpoint: "https://identity.dev.pki.wendy.sh/v1/identity/certificate"}, want: "https://renew.dev.pki.wendy.sh/v1/renew"},
 		{name: "explicit override", auth: &config.AuthConfig{CloudGRPC: "api.dev.wendy.sh:443"}, override: " https://renew.example/v1/renew ", want: "https://renew.example/v1/renew"},
 		{name: "custom PKI", auth: &config.AuthConfig{CloudGRPC: "api.dev.wendy.sh:443", PKIEndpoint: "https://identity.example/v1/identity/certificate"}},
+		{name: "cloud host does not override a custom PKI", auth: &config.AuthConfig{CloudGRPC: "api.dev.wendy.sh:443", PKIEndpoint: "https://identity.example/v1/identity/certificate"}},
 		{name: "unknown deployment", auth: &config.AuthConfig{CloudGRPC: "api.example:443"}},
 		{name: "lookalike host", auth: &config.AuthConfig{PKIEndpoint: "https://identity.dev.pki.wendy.sh.example/v1/identity/certificate"}},
 		{name: "no session"},
@@ -348,7 +349,7 @@ func TestEnsureFreshCertificateUsesDevRenewEndpoint(t *testing.T) {
 	}
 	t.Cleanup(func() { renewViaPKICore = origRenew })
 	auth := authWithLeaf()
-	auth.CloudGRPC = "api.dev.wendy.sh:443"
+	auth.PKIEndpoint = "https://identity.dev.pki.wendy.sh/v1/identity/certificate"
 	if err := ensureFreshCertificate(context.Background(), auth); err != nil {
 		t.Fatal(err)
 	}

--- a/go/internal/cli/commands/certrenew_test.go
+++ b/go/internal/cli/commands/certrenew_test.go
@@ -311,19 +311,25 @@ func TestRenewStatusMapping(t *testing.T) {
 	}
 }
 
-func TestRenewEndpointUsesKnownDeployment(t *testing.T) {
+func TestRenewEndpointDerivesTheSessionsOwnPKI(t *testing.T) {
 	for _, tc := range []struct {
 		name           string
 		auth           *config.AuthConfig
 		override, want string
 	}{
 		{name: "cloud host alone derives nothing", auth: &config.AuthConfig{CloudGRPC: "api.dev.wendy.sh:443"}},
+		{name: "any deployment derives its own sibling", auth: &config.AuthConfig{PKIEndpoint: "https://identity.pki.example.com/v1/identity/certificate"}, want: "https://renew.pki.example.com/v1/renew"},
+		{name: "port is carried across", auth: &config.AuthConfig{PKIEndpoint: "https://identity.pki.example:8451/v1/identity/certificate"}, want: "https://renew.pki.example:8451/v1/renew"},
+		{name: "identity must be its own label", auth: &config.AuthConfig{PKIEndpoint: "https://identityx.pki.example/v1/identity/certificate"}},
+		{name: "no host beyond the label", auth: &config.AuthConfig{PKIEndpoint: "https://identity./v1/identity/certificate"}},
+		{name: "plaintext derives nothing", auth: &config.AuthConfig{PKIEndpoint: "http://identity.pki.example/v1/identity/certificate"}},
+		{name: "userinfo derives nothing", auth: &config.AuthConfig{PKIEndpoint: "https://user@identity.pki.example/v1/identity/certificate"}},
 		{name: "identity deployment", auth: &config.AuthConfig{PKIEndpoint: "https://identity.dev.pki.wendy.sh/v1/identity/certificate"}, want: "https://renew.dev.pki.wendy.sh/v1/renew"},
 		{name: "explicit override", auth: &config.AuthConfig{CloudGRPC: "api.dev.wendy.sh:443"}, override: " https://renew.example/v1/renew ", want: "https://renew.example/v1/renew"},
-		{name: "custom PKI", auth: &config.AuthConfig{CloudGRPC: "api.dev.wendy.sh:443", PKIEndpoint: "https://identity.example/v1/identity/certificate"}},
-		{name: "cloud host does not override a custom PKI", auth: &config.AuthConfig{CloudGRPC: "api.dev.wendy.sh:443", PKIEndpoint: "https://identity.example/v1/identity/certificate"}},
+		{name: "cloud host never overrides the session's own PKI", auth: &config.AuthConfig{CloudGRPC: "api.dev.wendy.sh:443", PKIEndpoint: "https://identity.example/v1/identity/certificate"}, want: "https://renew.example/v1/renew"},
+		{name: "a PKI host with no identity label derives nothing", auth: &config.AuthConfig{CloudGRPC: "api.dev.wendy.sh:443", PKIEndpoint: "https://pki.example/v1/identity/certificate"}},
 		{name: "unknown deployment", auth: &config.AuthConfig{CloudGRPC: "api.example:443"}},
-		{name: "lookalike host", auth: &config.AuthConfig{PKIEndpoint: "https://identity.dev.pki.wendy.sh.example/v1/identity/certificate"}},
+		{name: "a lookalike suffix is simply another deployment", auth: &config.AuthConfig{PKIEndpoint: "https://identity.dev.pki.wendy.sh.example/v1/identity/certificate"}, want: "https://renew.dev.pki.wendy.sh.example/v1/renew"},
 		{name: "no session"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -335,7 +341,7 @@ func TestRenewEndpointUsesKnownDeployment(t *testing.T) {
 	}
 }
 
-func TestEnsureFreshCertificateUsesDevRenewEndpoint(t *testing.T) {
+func TestEnsureFreshCertificateDerivesTheRenewEndpoint(t *testing.T) {
 	now := time.Date(2026, 9, 8, 0, 0, 0, 0, time.UTC)
 	stubPreflight(t, now, "")
 	origLeaf := leafNotAfterFn

--- a/go/internal/cli/commands/device_enroll_oidc.go
+++ b/go/internal/cli/commands/device_enroll_oidc.go
@@ -33,12 +33,11 @@ func oidcEnrollmentConfig(auth *config.AuthConfig, name, directoryURL string) (a
 		return cfg, fmt.Errorf("OIDC session has an invalid tenant UUID")
 	}
 	if cfg.DirectoryURL == "" {
-		identityURL, _ := url.Parse(auth.PKIEndpoint)
-		if identityURL != nil && identityURL.Scheme == "https" && identityURL.Host == "identity.dev.pki.wendy.sh" {
-			cfg.DirectoryURL = "https://acme.dev.pki.wendy.sh/" + tenant.String() + "/acme/directory"
-		} else {
+		host := pkiSiblingHost(auth.PKIEndpoint, "acme")
+		if host == "" {
 			return cfg, fmt.Errorf("no ACME directory configured for this PKI deployment; pass --acme-directory-url")
 		}
+		cfg.DirectoryURL = "https://" + host + "/" + tenant.String() + "/acme/directory"
 	}
 	principal, err := cfg.PrincipalURI()
 	if err != nil {

--- a/go/internal/cli/commands/device_enroll_oidc_test.go
+++ b/go/internal/cli/commands/device_enroll_oidc_test.go
@@ -249,27 +249,34 @@ func TestOIDCEnrollmentFailures(t *testing.T) {
 func TestOIDCEnrollmentConfig(t *testing.T) {
 	for _, tc := range []struct {
 		name, device, directory string
-		custom                  bool
-		want                    string
+		pkiEndpoint             string
+		want, wantDirectory     string
 	}{
 		{name: "wrong tenant", device: "sim", directory: "https://acme.example/11111111-1111-4111-8111-111111111111/acme/directory", want: "tenant does not match"},
-		{name: "custom endpoint", device: "sim", custom: true, want: "--acme-directory-url"},
-		{name: "custom directory", device: "fleet/sim", custom: true, directory: "https://acme.example/" + testOperatorTenant + "/acme/directory"},
+		// Any deployment derives its own ACME frontend from its own identity
+		// frontend, not just the one this CLI was built knowing about.
+		{name: "self-hosted deployment derives its own directory", device: "sim", pkiEndpoint: "https://identity.example/v1/identity/certificate", wantDirectory: "https://acme.example/" + testOperatorTenant + "/acme/directory"},
+		{name: "port is carried across", device: "sim", pkiEndpoint: "https://identity.pki.example:8451/v1/identity/certificate", wantDirectory: "https://acme.pki.example:8451/" + testOperatorTenant + "/acme/directory"},
+		{name: "a PKI host with no identity label needs the flag", device: "sim", pkiEndpoint: "https://pki.example/v1/identity/certificate", want: "--acme-directory-url"},
+		{name: "custom directory", device: "fleet/sim", pkiEndpoint: "https://identity.example/v1/identity/certificate", directory: "https://acme.example/" + testOperatorTenant + "/acme/directory"},
 		{name: "bad device", device: "../sim", want: "invalid ACME device ID"},
 		{name: "insecure endpoint", device: "sim", directory: "http://acme.example/" + testOperatorTenant + "/acme/directory", want: "HTTPS"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			auth := oidcEnrollmentAuth(t)
-			if tc.custom {
-				auth.PKIEndpoint = "https://identity.example/v1/identity/certificate"
+			if tc.pkiEndpoint != "" {
+				auth.PKIEndpoint = tc.pkiEndpoint
 			}
-			_, err := oidcEnrollmentConfig(auth, tc.device, tc.directory)
+			cfg, err := oidcEnrollmentConfig(auth, tc.device, tc.directory)
 			if tc.want == "" {
 				if err != nil {
 					t.Fatal(err)
 				}
 			} else if err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("error=%v, want %q", err, tc.want)
+			}
+			if tc.wantDirectory != "" && cfg.DirectoryURL != tc.wantDirectory {
+				t.Fatalf("directory=%q, want %q", cfg.DirectoryURL, tc.wantDirectory)
 			}
 		})
 	}


### PR DESCRIPTION
- **Closes:** [WDY-2799 Never derive one service's host from another's](https://linear.app/wendylabsinc/issue/WDY-2799)
- **Base:** `jo/oidc-fixes` (#1955), per sem's ruling of 2026-09-12 01:40.

> **In plain terms:** Certificate renewal guessed which PKI server to talk to by looking at which *Cloud* server the session used — different systems, and the guess WDY-2799 is about. What replaced it only worked if your PKI happened to be the dev one. Both the renew and the ACME frontend are now worked out from the PKI endpoint your session already holds, so a self-hosted deployment derives its own.

## Summary
- Removes the fallback mapping `auth.CloudGRPC == "api.dev.wendy.sh:443"` to `https://renew.dev.pki.wendy.sh/v1/renew`. Which cloud answers says nothing about which PKI mints — WDY-2799 is the case where enrollment tokens went to the wrong place in cleartext on exactly that reasoning. The rule is restored as a comment on the function it governs.
- Replaces the two hostname-matching derivations with one label rewrite. `pkiSiblingHost` turns `https://identity.<rest>` into `<label>.<rest>`, port included, so `identity.pki.example:8451` yields `renew.pki.example:8451` and `acme.pki.example:8451`. The input is still only the identity endpoint the session already holds, so the derivation stays inside one PKI host family.
- The ACME directory in the OIDC enrollment path had the same defect and is fixed by the same helper, per sem's review: it matched a literal `identity.dev.pki.wendy.sh` and answered with a literal `acme.dev` URL.
- No environment is named. A hardcoded `identity.dev.pki.wendy.sh` works for one deployment and silently declines to derive for every other, which is how a dev hostname becomes load-bearing.
- `WENDY_PKI_RENEW_ENDPOINT` and `--acme-directory-url` still take precedence, unchanged.

Dev behaviour is unchanged end to end: `defaultDevPKIIdentityEndpoint` still seeds the session's identity endpoint at login (left alone per sem's ruling of 2026-09-12 02:16, to flip at one constant when prod exists), and the rewrite derives `renew.dev` and `acme.dev` from it as before.

## Boundary changes
- **CLI:** a session that knows only its Cloud endpoint — an imported operator certificate with no OIDC/identity configuration — no longer renews automatically. It reports `no pki-core renew endpoint configured; set WENDY_PKI_RENEW_ENDPOINT` and stops, which is the WDY-2799 rule: unset means not configured, not "guess".
- **CLI, additive:** a self-hosted pki-core now derives its own renew and ACME frontends from its identity endpoint. It previously had to be told both through `WENDY_PKI_RENEW_ENDPOINT` and `--acme-directory-url`; those still override. A PKI endpoint whose host does not begin with an `identity.` label derives nothing and still requires them.

## Tests
- `go build ./... && go vet ./... && gofmt -l go` — clean
- `go test ./go/... -count=1` — passes except the four pre-existing `internal/agent/oci` GPU tests, which fail identically on `jo/oidc-fixes` with no NVIDIA device present
- `TestRenewEndpointDerivesTheSessionsOwnPKI` covers an arbitrary deployment, a carried port, `identityx.` (not a label boundary), a bare `identity.` with no host beyond it, plaintext, userinfo, a PKI host with no `identity.` label, and a Cloud host alone
- `TestOIDCEnrollmentConfig` covers the same rewrite on the ACME side, including the carried port and the flag still being required where nothing derives