### PR TITLE
Raise complete AI review input limits to 512 KB

### DIFF
--- a/.github/scripts/api_review.py
+++ b/.github/scripts/api_review.py
@@ -11,7 +11,7 @@ import re
 import sys
 from typing import Any
 
-MAX_DIFF_BYTES = 200_000
+MAX_DIFF_BYTES = 512_000
 CATEGORIES = {"network", "protobuf", "storage", "config", "cli", "other"}
 IMPACTS = {"additive", "breaking", "behavioral"}
 RISKS = {"low", "mid", "high"}

--- a/.github/scripts/security_review.py
+++ b/.github/scripts/security_review.py
@@ -19,7 +19,7 @@ from typing import Any
 COMMENT_MARKER = "<!-- ai-security-review:v1 -->"
 BLOCKING_MARKER = "<!-- ai-security-review:has-blocking=true -->"
 CREDIT_WARNING_MARKER = "<!-- ai-security-review:credit-unavailable -->"
-MAX_DIFF_BYTES = 140_000
+MAX_DIFF_BYTES = 512_000
 MAX_COMMENT_BYTES = 65_000
 TRUST_BOUNDARY_TAGS = (
     "<untrusted_pr_content>",


### PR DESCRIPTION
The chat CLI PR (#1959) has a complete 504 KB diff, so the current security and API review input limits reject it before either review runs. Raise both limits to 512,000 bytes so these changes can receive a complete review.

The validators continue to reject oversized or incomplete diffs without partial review or truncation.

Validation: all 76 review automation tests pass, and both updated validators accept the complete 62-file, 504,018-byte diff from #1959 with no truncation.

This is separate from the chat feature so the limit change can land first. The API workflow loads its review scripts from the trusted base revision, so its larger limit takes effect after this change is merged into that base.

CI: security/API review, Go tests, and vet pass. The device integration job has three multiservice failures after its session socket disappears (`connect: no such file or directory`); this PR changes only review input limits.
