### PR TITLE
Add quiet GPT Live voice mode to Wendy chat

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/ebitengine/oto/v3 v3.4.0
 	github.com/ebitengine/purego v0.9.0
 	github.com/fsnotify/fsnotify v1.10.1
+	github.com/gen2brain/malgo v0.11.26
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/google/go-containerregistry v0.21.8
 	github.com/google/gousb v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -126,6 +126,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
+github.com/gen2brain/malgo v0.11.26 h1:k5WcPIKw1bbJAbPqrvNPt7nehPLoaPNcOFde2+eruiM=
+github.com/gen2brain/malgo v0.11.26/go.mod h1:xLVG3ROA33Bzol1quF3e4ehqcFuqh8QK4B8T6LQUs/M=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/go/internal/cli/assets/docs/guides/chat.mdx
+++ b/go/internal/cli/assets/docs/guides/chat.mdx
@@ -79,6 +79,50 @@ definitions. Tool accuracy depends on the model and its server's tool-call
 parser/template. A model that only generates plain text can chat but cannot
 execute Wendy tools.
 
+## Use your voice
+
+Start with voice enabled:
+
+```sh
+wendy chat --voice
+```
+
+Or type `/voice` during a conversation to turn it on. Type `/voice` again to
+turn it off and continue typing. `/voice on` and `/voice off` also work.
+
+Voice uses your computer's default microphone and speakers with OpenAI
+**GPT Live (`gpt-live-1`)**. Your selected chat model still handles reasoning,
+files, tests, deployment, and device tools. That model can be local. Voice itself
+requires OpenAI access and sends microphone audio and brief task context to
+OpenAI, even when the reasoning model runs locally.
+
+Wendy keeps voice brief: it listens while you work, shows tool progress in the
+terminal, and speaks short results or questions when your input is needed.
+It does not narrate each action. File changes, commands, and device changes
+still show their arguments for approval in the terminal; press `y` or `n`.
+Speech does not approve tool calls.
+
+If needed, Wendy opens a private OpenAI key prompt. It can reuse the key from
+an official OpenAI chat connection, or use `OPENAI_API_KEY` or
+`WENDY_VOICE_API_KEY`. A separate key entered for voice is saved privately in
+`~/.wendy/voice.json`; environment keys are not copied there. Use `/voice setup`
+to replace the voice key. OpenAI API usage is billed separately from ChatGPT.
+
+Use headphones to avoid microphone feedback. The terminal shows when voice is
+on. `/voice off` closes the microphone, playback, and Live connection while
+ongoing agent work continues in text. Escape
+cancels active work and interrupts speech; cancellation cannot undo completed
+tool actions. If voice fails, the text conversation remains available.
+
+Native audio requires a CLI built with cgo on macOS, Linux, or Windows and
+permission to use the microphone. Builds without cgo still support text chat
+and explain when native voice is unavailable. Current Windows release builds
+disable cgo.
+
+The integration uses the [GPT Live WebSocket API](https://developers.openai.com/api/docs/guides/voice-websockets)
+with [client delegation](https://developers.openai.com/api/docs/guides/live-delegation),
+so voice and reasoning models are selected independently.
+
 ## Select a project and device
 
 The current directory is the project workspace. Use `-C` to select another
@@ -122,6 +166,8 @@ documentation through the `wendy_docs` tool.
 | `/help` | Show chat controls |
 | `/tools` or Ctrl+T | Show or hide full tool details |
 | `/setup` | Change your AI or enter an API key privately |
+| `/voice` | Turn GPT Live voice on or off |
+| `/voice setup` | Enter or replace the OpenAI voice key privately |
 | `/clear` | Start a fresh conversation |
 | `/quit` | Exit |
 

--- a/go/internal/cli/chat/discovery.go
+++ b/go/internal/cli/chat/discovery.go
@@ -282,7 +282,7 @@ func chatModelName(id, provider string) bool {
 		// as "image-assistant" may still be a conversational vision model.
 		return true
 	}
-	for _, part := range []string{"moderation", "whisper", "tts-", "audio", "realtime", "transcribe", "dall-e", "image", "sora"} {
+	for _, part := range []string{"moderation", "whisper", "tts-", "audio", "realtime", "gpt-live", "transcribe", "dall-e", "image", "sora"} {
 		if strings.Contains(id, part) {
 			return false
 		}

--- a/go/internal/cli/chat/discovery_test.go
+++ b/go/internal/cli/chat/discovery_test.go
@@ -31,7 +31,7 @@ func TestListModelsCompatible(t *testing.T) {
 		if r.Header.Get("Authorization") != "Bearer test-key" {
 			t.Error("missing API key")
 		}
-		fmt.Fprint(w, `{"data":[{"id":"gpt-4.1-2025-04-14"},{"id":"text-embedding-3-large"},{"id":"gpt-4o-audio-preview"},{"id":"gpt-image-1"},{"id":"gpt-4.1"},{"id":"gpt-4.1"},{"id":"gpt-3.5-turbo-instruct"},{"id":"gpt-5-codex"},{"id":"gpt-4o-search-preview"},{"id":"gpt-5-pro"},{"id":"o3-deep-research"},{"id":""},{"id":"\u001b[2J"}]}`)
+		fmt.Fprint(w, `{"data":[{"id":"gpt-4.1-2025-04-14"},{"id":"text-embedding-3-large"},{"id":"gpt-4o-audio-preview"},{"id":"gpt-live-1"},{"id":"gpt-live-1-mini"},{"id":"gpt-image-1"},{"id":"gpt-4.1"},{"id":"gpt-4.1"},{"id":"gpt-3.5-turbo-instruct"},{"id":"gpt-5-codex"},{"id":"gpt-4o-search-preview"},{"id":"gpt-5-pro"},{"id":"o3-deep-research"},{"id":""},{"id":"\u001b[2J"}]}`)
 	}))
 	defer server.Close()
 	models, err := ListModels(context.Background(), Config{Provider: "openai", BaseURL: server.URL + "/v1", APIKey: "test-key"})

--- a/go/internal/cli/chat/tui.go
+++ b/go/internal/cli/chat/tui.go
@@ -31,6 +31,8 @@ type UIOptions struct {
 	Device        string
 	InitialPrompt string
 	AutoApprove   bool
+	Voice         bool
+	VoiceFactory  func(context.Context) (VoiceSession, error)
 	Input         io.Reader
 	Output        io.Writer
 }
@@ -39,10 +41,15 @@ type UIOptions struct {
 // canceled and the same engine resumes. A new connection uses a fresh state.
 type UIState struct {
 	transcript []chatEntry
+	composer   string
+	Voice      bool
 }
 
 // ErrReconfigure asks the command to reopen private connection setup.
 var ErrReconfigure = errors.New("chat setup requested")
+
+// ErrVoiceSetup asks the command to configure voice credentials privately.
+var ErrVoiceSetup = errors.New("voice setup requested")
 
 // Run opens a full-screen chat session, restoring the original terminal on exit.
 // All agent work and pending approvals are canceled before Run returns.
@@ -57,6 +64,8 @@ func Run(ctx context.Context, opts UIOptions) error {
 		m.workers.Wait()
 		if opts.State != nil {
 			opts.State.transcript = append([]chatEntry(nil), m.transcript...)
+			opts.State.composer = m.composer.Value()
+			opts.State.Voice = m.voiceEnabled
 		}
 	}()
 	options := []tea.ProgramOption{tea.WithContext(ctx), tea.WithAltScreen(), tea.WithMouseCellMotion()}
@@ -72,6 +81,9 @@ func Run(ctx context.Context, opts UIOptions) error {
 	}
 	if err == nil && m.reconfigure {
 		return ErrReconfigure
+	}
+	if err == nil && m.voiceSetup {
+		return ErrVoiceSetup
 	}
 	return err
 }
@@ -97,6 +109,17 @@ type turnMessage struct {
 
 type initialPromptMessage struct{}
 
+type voiceMessage struct {
+	id      uint64
+	session VoiceSession
+	event   VoiceEvent
+}
+
+type voiceDelegation struct {
+	id, prompt, display string
+	generation          uint64
+}
+
 type chatModel struct {
 	ctx     context.Context
 	opts    UIOptions
@@ -120,6 +143,24 @@ type chatModel struct {
 	reconfigure bool
 	approval    *approvalRequest
 	preview     viewport.Model
+
+	voiceEnabled      bool
+	voiceStarting     bool
+	voiceSetup        bool
+	voiceID           uint64
+	voiceSession      VoiceSession
+	voiceCtx          context.Context
+	voiceCancel       context.CancelFunc
+	voiceClosed       <-chan struct{}
+	voiceEvents       <-chan voiceMessage
+	voiceSend         chan<- voiceMessage
+	delegation        *voiceDelegation
+	pendingDelegation *voiceDelegation
+	turnReply         string
+	voiceSeen         map[string]bool
+	voiceActionTail   <-chan struct{}
+	turnSpeechCtx     context.Context
+	turnSpeechCancel  context.CancelFunc
 }
 
 var (
@@ -162,6 +203,7 @@ func newChatModel(ctx context.Context, opts UIOptions) *chatModel {
 	}
 	if opts.State != nil && len(opts.State.transcript) > 0 {
 		m.transcript = append([]chatEntry(nil), opts.State.transcript...)
+		m.composer.SetValue(opts.State.composer)
 	}
 	m.resize(80, 24)
 	if m.removeStandaloneCredential(m.opts.InitialPrompt) {
@@ -171,10 +213,14 @@ func newChatModel(ctx context.Context, opts UIOptions) *chatModel {
 }
 
 func (m *chatModel) Init() tea.Cmd {
-	if strings.TrimSpace(m.opts.InitialPrompt) != "" {
-		return tea.Batch(textarea.Blink, func() tea.Msg { return initialPromptMessage{} })
+	cmds := []tea.Cmd{textarea.Blink}
+	if m.opts.Voice {
+		cmds = append(cmds, m.startVoice())
 	}
-	return textarea.Blink
+	if strings.TrimSpace(m.opts.InitialPrompt) != "" {
+		cmds = append(cmds, func() tea.Msg { return initialPromptMessage{} })
+	}
+	return tea.Batch(cmds...)
 }
 
 func (m *chatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -189,22 +235,33 @@ func (m *chatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.submit(prompt)
 		}
 		return m, nil
+	case voiceMessage:
+		return m, m.handleVoiceMessage(msg)
 	case turnMessage:
 		if msg.id != m.turnID || !m.active {
 			return m, nil
 		}
 		if msg.done {
+			canceled := m.canceling || errors.Is(msg.err, context.Canceled)
 			m.active = false
 			m.approval = nil
 			m.cancelTurn()
 			m.cancelTurn = nil
 			m.status = "Ready"
-			if m.canceling || errors.Is(msg.err, context.Canceled) {
+			if canceled {
 				m.appendEntry("notice", "Canceled", "You can send another message.")
 			} else if msg.err != nil {
 				m.appendEntry("error", "Agent error", msg.err.Error())
 			}
 			m.canceling = false
+			m.finishVoiceTurn(msg.err, canceled)
+			if next := m.pendingDelegation; next != nil {
+				m.pendingDelegation = nil
+				if m.voiceEnabled && next.generation == m.voiceID {
+					cmd := m.startVoiceTurn(next)
+					return m, tea.Batch(cmd, m.composer.Focus())
+				}
+			}
 			return m, m.composer.Focus()
 		}
 		if !m.canceling {
@@ -216,6 +273,9 @@ func (m *chatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.status = "Approval required"
 				m.refreshApproval()
 				m.preview.GotoTop()
+				m.voiceActionFor(m.turnSpeechCtx, func(ctx context.Context, session VoiceSession) error {
+					return session.Reply(ctx, "", "Please review the tool call in the terminal and press y or n.")
+				})
 			}
 		}
 		return m, m.waitForEvent()
@@ -236,6 +296,8 @@ func (m *chatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.refreshTranscript()
 			return m, nil
 		case "ctrl+c":
+			m.interruptVoice()
+			m.pendingDelegation = nil
 			if m.active {
 				m.cancelActiveTurn()
 				return m, nil
@@ -243,6 +305,8 @@ func (m *chatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.quitting = true
 			return m, tea.Quit
 		case "esc":
+			m.interruptVoice()
+			m.pendingDelegation = nil
 			if m.active {
 				m.cancelActiveTurn()
 			}
@@ -269,10 +333,11 @@ func (m *chatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		if msg.String() == "enter" {
-			if m.active {
+			prompt := m.composer.Value()
+			control := strings.TrimSpace(prompt)
+			if m.active && !(strings.HasPrefix(control, "/voice") || control == "/setup" || control == "/quit" || control == "/help" || control == "/tools") {
 				return m, nil
 			}
-			prompt := m.composer.Value()
 			m.composer.Reset()
 			return m, m.submit(prompt)
 		}
@@ -312,26 +377,45 @@ func (m *chatModel) submit(prompt string) tea.Cmd {
 		m.quitting = true
 		return tea.Quit
 	case "/clear":
+		wasVoice := m.voiceEnabled
+		m.stopVoice()
 		m.opts.Engine.Reset()
 		m.transcript = nil
-		m.appendEntry("notice", "Conversation cleared", "Your next message starts a new conversation.")
+		text := "Your next message starts a new conversation."
+		if wasVoice {
+			text += " Voice is off so its previous context is discarded; use /voice to start listening again."
+		}
+		m.appendEntry("notice", "Conversation cleared", text)
 		return nil
 	case "/setup":
 		if m.active {
-			m.appendEntry("notice", "Setup", "Press Esc to cancel the current response before changing your AI setup.")
-			return nil
+			m.cancelActiveTurn()
 		}
 		m.reconfigure = true
 		m.quitting = true
 		return tea.Quit
+	case "/voice", "/voice on", "/voice off", "/voice setup":
+		if prompt == "/voice setup" {
+			return m.requestVoiceSetup()
+		}
+		if prompt == "/voice off" || (prompt == "/voice" && m.voiceEnabled) {
+			m.stopVoice()
+			m.appendEntry("notice", "Voice off", "The microphone and voice connection are shutting down. Text chat remains available.")
+			return nil
+		}
+		if !m.voiceEnabled {
+			return m.startVoice()
+		}
+		return nil
 	case "/help":
-		m.appendEntry("notice", "Chat commands", "/help   Show this help\n/tools  Show or hide full tool details (Ctrl+T)\n/setup  Change your AI or enter an API key privately\n/clear  Clear the transcript and model conversation\n/quit   Exit chat\n\nEnter sends a message. Alt+Enter or Ctrl+J adds a new line.\nPgUp/PgDn scroll the transcript; Ctrl+Home/End jump to its start/end.\nEsc or Ctrl+C cancels active work. Ctrl+C exits when idle.\nFor tool approvals, review the arguments and press y to allow once or n to deny.\nScroll the approval with ↑/↓, PgUp/PgDn, or the mouse wheel.")
+		m.appendEntry("notice", "Chat commands", "/help   Show this help\n/tools  Show or hide full tool details (Ctrl+T)\n/setup  Change your AI or enter an API key privately\n/voice  Toggle voice; /voice setup changes voice credentials privately\n/clear  Clear the transcript and model conversation\n/quit   Exit chat\n\nEnter sends a message. Alt+Enter or Ctrl+J adds a new line.\nPgUp/PgDn scroll the transcript; Ctrl+Home/End jump to its start/end.\nEsc or Ctrl+C cancels active work and stops voice playback. Ctrl+C exits when idle.\nFor tool approvals, review the arguments and press y to allow once or n to deny. Spoken approval is never accepted.\nScroll the approval with ↑/↓, PgUp/PgDn, or the mouse wheel.")
 		return nil
 	}
 	if strings.HasPrefix(prompt, "/") && !strings.ContainsAny(prompt, " \n\t") {
 		m.appendEntry("notice", "Unknown command", "Use /help to see the available chat commands.")
 		return nil
 	}
+	m.voiceContext("Typed request (handled by the text agent): " + prompt)
 	return m.startTurn(prompt)
 }
 
@@ -361,6 +445,16 @@ func looksLikeStandaloneCredential(value string) bool {
 }
 
 func (m *chatModel) startTurn(prompt string) tea.Cmd {
+	return m.startTurnWithDisplay(prompt, prompt)
+}
+
+func (m *chatModel) startTurnWithDisplay(prompt, display string) tea.Cmd {
+	if m.turnSpeechCancel != nil {
+		m.turnSpeechCancel()
+	}
+	m.turnSpeechCtx, m.turnSpeechCancel = context.WithCancel(m.ctx)
+	m.delegation = nil
+	m.turnReply = ""
 	m.turnID++
 	id := m.turnID
 	ctx, cancel := context.WithCancel(m.ctx)
@@ -368,7 +462,7 @@ func (m *chatModel) startTurn(prompt string) tea.Cmd {
 	m.active = true
 	m.canceling = false
 	m.status = "Thinking"
-	m.appendEntry("user", "You", prompt)
+	m.appendEntry("user", "You", display)
 	m.viewport.GotoBottom()
 	events := make(chan turnMessage, 64)
 	m.events = events
@@ -434,6 +528,9 @@ func (m *chatModel) waitForEvent() tea.Cmd {
 }
 
 func (m *chatModel) cancelActiveTurn() {
+	if m.turnSpeechCancel != nil {
+		m.turnSpeechCancel()
+	}
 	m.canceling = true
 	m.status = "Canceling…"
 	m.approval = nil
@@ -442,12 +539,272 @@ func (m *chatModel) cancelActiveTurn() {
 	}
 }
 
+func (m *chatModel) requestVoiceSetup() tea.Cmd {
+	if m.active {
+		m.cancelActiveTurn()
+	}
+	m.stopVoice()
+	m.voiceSetup = true
+	m.quitting = true
+	return tea.Quit
+}
+
+func (m *chatModel) startVoice() tea.Cmd {
+	if m.opts.VoiceFactory == nil {
+		return m.requestVoiceSetup()
+	}
+	m.voiceID++
+	id := m.voiceID
+	ctx, cancel := context.WithCancel(m.ctx)
+	m.voiceCtx, m.voiceCancel = ctx, cancel
+	m.voiceEnabled, m.voiceStarting = true, true
+	m.voiceSeen = make(map[string]bool)
+	m.voiceActionTail = nil
+	events := make(chan voiceMessage, 64)
+	m.voiceEvents, m.voiceSend = events, events
+	previousClosed := m.voiceClosed
+	closed := make(chan struct{})
+	m.voiceClosed = closed
+	factory := m.opts.VoiceFactory
+	m.workers.Add(1)
+	go func() {
+		defer m.workers.Done()
+		defer close(closed)
+		send := func(msg voiceMessage) bool {
+			msg.id = id
+			select {
+			case events <- msg:
+				return true
+			case <-ctx.Done():
+				return false
+			}
+		}
+		// A quick off/on toggle must finish closing the previous microphone
+		// before attempting to open it again.
+		if previousClosed != nil {
+			select {
+			case <-previousClosed:
+			case <-ctx.Done():
+				return
+			}
+		}
+		session, err := factory(ctx)
+		if err == nil && session == nil {
+			err = errors.New("voice provider returned no session")
+		}
+		if err != nil {
+			send(voiceMessage{event: VoiceEvent{Type: "error", Err: err}})
+			return
+		}
+		defer session.Close()
+		if !send(voiceMessage{session: session}) {
+			return
+		}
+		for {
+			select {
+			case event, ok := <-session.Events():
+				if !ok {
+					send(voiceMessage{event: VoiceEvent{Type: "done"}})
+					return
+				}
+				if !send(voiceMessage{event: event}) || event.Type == "done" || event.Type == "error" {
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return m.waitForVoiceEvent()
+}
+
+func (m *chatModel) waitForVoiceEvent() tea.Cmd {
+	ctx, events := m.voiceCtx, m.voiceEvents
+	return func() tea.Msg {
+		select {
+		case msg := <-events:
+			return msg
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+func (m *chatModel) stopVoice() {
+	if m.turnSpeechCancel != nil {
+		m.turnSpeechCancel()
+	}
+	if m.voiceCancel != nil {
+		m.voiceCancel()
+	}
+	m.voiceEnabled, m.voiceStarting = false, false
+	m.voiceSession = nil
+	m.pendingDelegation, m.delegation = nil, nil
+}
+
+func (m *chatModel) voiceAction(action func(context.Context, VoiceSession) error) {
+	m.voiceActionFor(m.voiceCtx, action)
+}
+
+func (m *chatModel) voiceActionFor(actionCtx context.Context, action func(context.Context, VoiceSession) error) {
+	if !m.voiceEnabled || m.voiceSession == nil {
+		return
+	}
+	ctx, session, id, events := m.voiceCtx, m.voiceSession, m.voiceID, m.voiceSend
+	if actionCtx == nil {
+		actionCtx = ctx
+	}
+	previous := m.voiceActionTail
+	finished := make(chan struct{})
+	m.voiceActionTail = finished
+	m.workers.Add(1)
+	go func() {
+		defer m.workers.Done()
+		defer close(finished)
+		if previous != nil {
+			select {
+			case <-previous:
+			case <-ctx.Done():
+				return
+			}
+		}
+		if ctx.Err() != nil || actionCtx.Err() != nil {
+			return
+		}
+		// Task speech has its own lifetime: correction/escape invalidates a
+		// queued result. Once a write begins it uses the session lifetime, so
+		// canceling one task cannot tear down the live connection mid-write.
+		if err := action(ctx, session); err != nil && ctx.Err() == nil {
+			select {
+			case events <- voiceMessage{id: id, event: VoiceEvent{Type: "error", Err: err}}:
+			case <-ctx.Done():
+			}
+		}
+	}()
+}
+
+func (m *chatModel) interruptVoice() {
+	// Playback interruption must not wait behind queued context or speech.
+	m.voiceActionTail = nil
+	m.voiceAction(func(ctx context.Context, session VoiceSession) error { return session.Interrupt(ctx) })
+}
+
+func (m *chatModel) voiceContext(text string) {
+	m.voiceAction(func(ctx context.Context, session VoiceSession) error { return session.SendContext(ctx, text) })
+}
+
+func (m *chatModel) handleVoiceMessage(msg voiceMessage) tea.Cmd {
+	if msg.id != m.voiceID || !m.voiceEnabled {
+		return nil
+	}
+	if msg.session != nil {
+		m.voiceSession = msg.session
+		contextText := "The current workspace is " + m.opts.Workspace + ". Device preference: " + m.opts.Device + ". The terminal handles all action approvals with keyboard y/n; spoken approval is never sufficient."
+		// Voice can be enabled in the middle of a text conversation. Seed recent
+		// visible exchanges without waiting on an engine that may be working.
+		for _, entry := range m.transcript[max(0, len(m.transcript)-8):] {
+			if entry.kind == "user" || entry.kind == "assistant" {
+				text := []rune(entry.text)
+				if len(text) > 2000 {
+					text = text[:2000]
+				}
+				contextText += "\n" + entry.title + ": " + string(text)
+			}
+		}
+		m.voiceContext(contextText)
+		return m.waitForVoiceEvent()
+	}
+	event := msg.event
+	switch event.Type {
+	case "ready":
+		m.voiceStarting = false
+		m.appendEntry("notice", "Voice on · microphone sent to OpenAI · /voice to stop", "Speak naturally. Approvals stay in the terminal.")
+	case "input", "output":
+		if event.Text != "" {
+			title := "You · voice"
+			if event.Type == "output" {
+				title = "Voice"
+			}
+			kind := "voice_" + event.Type
+			last := len(m.transcript) - 1
+			if last >= 0 && m.transcript[last].kind == kind {
+				m.transcript[last].text += event.Text
+				m.refreshTranscript()
+			} else {
+				m.appendEntry(kind, title, event.Text)
+			}
+		}
+	case "delegation":
+		if event.DelegationID == "" || strings.TrimSpace(event.Text) == "" || m.voiceSeen[event.DelegationID] {
+			break
+		}
+		m.voiceSeen[event.DelegationID] = true
+		prompt := event.Prompt
+		if prompt == "" {
+			prompt = event.Text
+		}
+		next := &voiceDelegation{id: event.DelegationID, prompt: prompt, display: event.Text, generation: m.voiceID}
+		if m.active {
+			m.pendingDelegation = next
+			m.cancelActiveTurn()
+		} else {
+			cmd := m.startVoiceTurn(next)
+			return tea.Batch(cmd, m.waitForVoiceEvent())
+		}
+	case "error", "done":
+		m.stopVoice()
+		if event.Type == "error" {
+			detail := "Voice connection failed."
+			if event.Err != nil {
+				detail = event.Err.Error()
+			}
+			m.appendEntry("error", "Voice unavailable", detail+"\nText chat remains available. Use /voice to retry or /voice setup to change credentials privately.")
+		} else {
+			m.appendEntry("notice", "Voice disconnected", "Text chat remains available. Use /voice to reconnect.")
+		}
+		return nil
+	}
+	return m.waitForVoiceEvent()
+}
+
+func (m *chatModel) finishVoiceTurn(err error, canceled bool) {
+	delegation := m.delegation
+	m.delegation = nil
+	if canceled || m.pendingDelegation != nil {
+		return
+	}
+	text := strings.TrimSpace(m.turnReply)
+	if err != nil {
+		text = "I couldn't complete the task: " + err.Error()
+	}
+	if text == "" {
+		return
+	}
+	if delegation != nil {
+		if delegation.generation == m.voiceID {
+			m.voiceActionFor(m.turnSpeechCtx, func(ctx context.Context, session VoiceSession) error {
+				return session.Reply(ctx, delegation.id, text)
+			})
+		}
+	} else {
+		m.voiceContext("Text agent result (context only): " + text)
+	}
+}
+
+func (m *chatModel) startVoiceTurn(delegation *voiceDelegation) tea.Cmd {
+	prompt := delegation.prompt + "\n\nThis request came from voice. Perform the requested work, then give a concise final result suitable for speaking. Do not narrate tool progress aloud; keep required action approvals in the terminal."
+	cmd := m.startTurnWithDisplay(prompt, delegation.display)
+	m.delegation = delegation
+	return cmd
+}
+
 func (m *chatModel) handleEvent(event Event) {
 	switch event.Type {
 	case "text":
 		if event.Text == "" {
 			return
 		}
+		m.turnReply += event.Text
 		last := len(m.transcript) - 1
 		if last >= 0 && m.transcript[last].kind == "assistant" {
 			m.transcript[last].text += event.Text
@@ -457,6 +814,7 @@ func (m *chatModel) handleEvent(event Event) {
 		m.status = "Responding"
 		m.refreshTranscript()
 	case "tool_start":
+		m.turnReply = ""
 		name, arguments := "tool", ""
 		if event.Call != nil {
 			name, arguments = event.Call.Name, prettyArguments(event.Call.Arguments)
@@ -595,7 +953,7 @@ func (m *chatModel) resize(width, height int) {
 	m.preview.Width = contentWidth
 	m.preview.Height = max(1, m.height-8)
 	if m.compact {
-		m.preview.Height = max(1, m.height-2)
+		m.preview.Height = max(1, m.height-3)
 	}
 	// The textarea setters only change geometry. Rendering refreshes its
 	// private viewport's wrapped content before Update repositions the caret.
@@ -700,22 +1058,26 @@ func (m *chatModel) View() string {
 		frame = strings.Join([]string{
 			header, "", line(chatWarn.Render("Allow tool: " + chatSingleLine(m.approval.call.Name) + "?")),
 			m.preview.View(),
-			line(chatDim.Render(fmt.Sprintf("Arguments · %.0f%% · ↑/↓ PgUp/PgDn scroll", m.preview.ScrollPercent()*100))),
+			line(chatDim.Render(fmt.Sprintf("Arguments · %.0f%% · ↑/↓ PgUp/PgDn scroll · %s", m.preview.ScrollPercent()*100, m.voiceStatus()))),
 			line(chatWarn.Render("[y] Allow once   [n] Deny   [Esc] Cancel turn")),
 		}, "\n")
 		if m.compact {
 			question := line(chatWarn.Render("Allow " + chatSingleLine(m.approval.call.Name) + "?"))
 			controls := line(chatWarn.Render("[y] Allow [n] Deny"))
+			mic := line(chatDim.Render(m.voiceStatus()))
 			parts := []string{controls}
-			if m.height >= 3 {
-				parts = []string{question, m.preview.View(), controls}
+			if m.height >= 4 {
+				parts = []string{question, m.preview.View(), mic, controls}
+			} else if m.height == 3 {
+				parts = []string{question, mic, controls}
 			} else if m.height == 2 {
-				parts = []string{question, controls}
+				parts = []string{mic, controls}
 			}
 			frame = strings.Join(parts, "\n")
 		}
 	} else {
 		status := chatSingleLine(m.status)
+		status += " · " + m.voiceStatus()
 		if m.active {
 			status = m.spinner.View() + " " + status
 		}
@@ -745,6 +1107,26 @@ func (m *chatModel) View() string {
 		lines[i] = " " + ansi.Truncate(lines[i], max(0, m.width-1), "")
 	}
 	return strings.Join(lines, "\n")
+}
+
+func (m *chatModel) voiceStatus() string {
+	if !m.voiceEnabled {
+		if m.voiceClosed != nil {
+			select {
+			case <-m.voiceClosed:
+			default:
+				return "mic stopping"
+			}
+		}
+		return "mic muted"
+	}
+	if m.voiceStarting {
+		return "voice connecting"
+	}
+	if m.active {
+		return "voice on · working"
+	}
+	return "voice on · listening"
 }
 
 func prettyArguments(raw json.RawMessage) string {

--- a/go/internal/cli/chat/tui_voice_test.go
+++ b/go/internal/cli/chat/tui_voice_test.go
@@ -1,0 +1,440 @@
+package chat
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+)
+
+type uiVoiceReply struct{ id, text string }
+
+type uiVoiceSession struct {
+	events      chan VoiceEvent
+	replies     chan uiVoiceReply
+	contexts    chan string
+	closed      chan struct{}
+	closeOnce   sync.Once
+	interrupts  atomic.Int32
+	contextGate <-chan struct{}
+}
+
+func newUIVoiceSession() *uiVoiceSession {
+	return &uiVoiceSession{
+		events: make(chan VoiceEvent, 32), replies: make(chan uiVoiceReply, 32),
+		contexts: make(chan string, 32), closed: make(chan struct{}),
+	}
+}
+
+func (s *uiVoiceSession) Events() <-chan VoiceEvent { return s.events }
+func (s *uiVoiceSession) SendContext(ctx context.Context, text string) error {
+	if s.contextGate != nil {
+		select {
+		case <-s.contextGate:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	select {
+	case s.contexts <- text:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+func (s *uiVoiceSession) Reply(ctx context.Context, id, text string) error {
+	select {
+	case s.replies <- uiVoiceReply{id: id, text: text}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+func (s *uiVoiceSession) Interrupt(context.Context) error {
+	s.interrupts.Add(1)
+	return nil
+}
+func (s *uiVoiceSession) Close() error {
+	s.closeOnce.Do(func() { close(s.closed) })
+	return nil
+}
+
+func uiNextVoiceEvent(t *testing.T, m *chatModel) voiceMessage {
+	t.Helper()
+	select {
+	case event := <-m.voiceEvents:
+		return event
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for voice event")
+		return voiceMessage{}
+	}
+}
+
+func uiSendVoice(t *testing.T, m *chatModel, session *uiVoiceSession, event VoiceEvent) {
+	t.Helper()
+	session.events <- event
+	m.Update(uiNextVoiceEvent(t, m))
+}
+
+func uiConnectVoice(t *testing.T, m *chatModel) *uiVoiceSession {
+	t.Helper()
+	session := newUIVoiceSession()
+	m.opts.VoiceFactory = func(context.Context) (VoiceSession, error) { return session, nil }
+	m.startVoice()
+	m.Update(uiNextVoiceEvent(t, m))
+	uiSendVoice(t, m, session, VoiceEvent{Type: "ready"})
+	if !m.voiceEnabled || m.voiceStarting || m.voiceSession == nil {
+		t.Fatal("voice did not transition to listening")
+	}
+	select {
+	case reply := <-session.replies:
+		t.Fatalf("voice must not speak an initial greeting: %+v", reply)
+	default:
+	}
+	return session
+}
+
+func uiNextVoiceReply(t *testing.T, session *uiVoiceSession) uiVoiceReply {
+	t.Helper()
+	select {
+	case reply := <-session.replies:
+		return reply
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for spoken reply")
+		return uiVoiceReply{}
+	}
+}
+
+func uiVoiceStopAndWait(t *testing.T, m *chatModel, session *uiVoiceSession) {
+	t.Helper()
+	m.stopVoice()
+	select {
+	case <-session.closed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("voice connection and microphone were not closed")
+	}
+	m.workers.Wait()
+}
+
+func TestUIVoiceDelegationUsesEngineApprovalsAndOnlySpeaksFinalResult(t *testing.T) {
+	for _, decision := range []string{"y", "n"} {
+		t.Run(decision, func(t *testing.T) {
+			call := ToolCall{ID: "write", Name: "workspace_write", Arguments: json.RawMessage(`{"path":"app.txt","content":"hello"}`)}
+			executor := &uiExecutor{tools: []Tool{{Name: call.Name, RequiresApproval: true}}}
+			provider := uiProviderFunc(func(ctx context.Context, messages []Message, tools []Tool, emit func(string)) (Message, error) {
+				if messages[len(messages)-1].Role == "tool" {
+					text := "Created app.txt."
+					if strings.Contains(messages[len(messages)-1].Content, "denied") {
+						text = "The file was not changed."
+					}
+					emit(text)
+					return Message{Content: text}, nil
+				}
+				emit("I will first write the file and check its contents.")
+				return Message{ToolCalls: []ToolCall{call}}, nil
+			})
+			m := uiModel(t, provider, executor, false)
+			session := uiConnectVoice(t, m)
+			uiSendVoice(t, m, session, VoiceEvent{Type: "delegation", DelegationID: "task-1", Text: "Create app.txt"})
+			uiWaitForApproval(t, m)
+			approval := uiNextVoiceReply(t, session)
+			if approval.id != "" || !strings.Contains(approval.text, "press y or n") {
+				t.Fatalf("expected a short approval notice without completing the task, got %+v", approval)
+			}
+			// An affirmative spoken transcript can never authorize the file write.
+			uiSendVoice(t, m, session, VoiceEvent{Type: "input", Text: "yes, approved"})
+			if m.approval == nil || executor.executed.Load() != 0 {
+				t.Fatal("spoken words bypassed keyboard approval")
+			}
+			m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(decision)})
+			uiDrainTurn(t, m)
+			final := uiNextVoiceReply(t, session)
+			want, runs := "Created app.txt.", int32(1)
+			if decision == "n" {
+				want, runs = "The file was not changed.", 0
+			}
+			if final.id != "task-1" || final.text != want || executor.executed.Load() != runs {
+				t.Fatalf("final reply=%+v, tool executions=%d; want %q, %d", final, executor.executed.Load(), want, runs)
+			}
+			uiVoiceStopAndWait(t, m, session)
+			if len(session.replies) != 0 {
+				t.Fatal("tool progress was spoken or final result was spoken more than once")
+			}
+		})
+	}
+}
+
+func TestUIVoiceCorrectionCancelsOldTurnBeforeStartingNewAndDropsLateResult(t *testing.T) {
+	oldStarted := make(chan struct{})
+	var calls atomic.Int32
+	provider := uiProviderFunc(func(ctx context.Context, messages []Message, tools []Tool, emit func(string)) (Message, error) {
+		if calls.Add(1) == 1 {
+			close(oldStarted)
+			<-ctx.Done()
+			// Deliberately return a late completion to model a provider race.
+			return Message{Content: "STALE result from the first request"}, nil
+		}
+		if !strings.Contains(messages[len(messages)-1].Content, "corrected task") {
+			t.Error("the replacement request did not reach the backend engine")
+		}
+		return Message{Content: "Corrected task finished."}, nil
+	})
+	m := uiModel(t, provider, &uiExecutor{}, false)
+	session := uiConnectVoice(t, m)
+	uiSendVoice(t, m, session, VoiceEvent{Type: "delegation", DelegationID: "old", Text: "first task"})
+	select {
+	case <-oldStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("first backend turn did not start")
+	}
+	uiSendVoice(t, m, session, VoiceEvent{Type: "delegation", DelegationID: "new", Text: "corrected task"})
+	if !m.canceling || m.pendingDelegation == nil || calls.Load() != 1 {
+		t.Fatal("replacement turn must wait for cancellation of the old turn")
+	}
+	uiDrainTurn(t, m)
+	final := uiNextVoiceReply(t, session)
+	if final.id != "new" || final.text != "Corrected task finished." {
+		t.Fatalf("stale result was spoken: %+v", final)
+	}
+	// Duplicate events from the live transport must not run a task twice.
+	uiSendVoice(t, m, session, VoiceEvent{Type: "delegation", DelegationID: "new", Text: "corrected task"})
+	if m.active || calls.Load() != 2 {
+		t.Fatal("a duplicate delegation executed another backend turn")
+	}
+	uiVoiceStopAndWait(t, m, session)
+	if len(session.replies) != 0 {
+		t.Fatal("the canceled task produced a late spoken result")
+	}
+}
+
+func TestUIVoiceTypedMessagesRemainUsableAndContextOnly(t *testing.T) {
+	provider := uiProviderFunc(func(context.Context, []Message, []Tool, func(string)) (Message, error) {
+		return Message{Content: "Typed answer."}, nil
+	})
+	m := uiModel(t, provider, &uiExecutor{}, false)
+	session := uiConnectVoice(t, m)
+	m.submit("Typed question")
+	uiDrainTurn(t, m)
+	var contexts []string
+	for len(contexts) < 3 {
+		select {
+		case text := <-session.contexts:
+			contexts = append(contexts, text)
+		case <-time.After(3 * time.Second):
+			t.Fatal("typed turn did not finish sending voice context")
+		}
+	}
+	uiVoiceStopAndWait(t, m, session)
+	joined := strings.Join(contexts, "\n")
+	if !strings.Contains(joined, "Typed question") || !strings.Contains(joined, "Typed answer.") {
+		t.Fatalf("typed conversation was not mirrored as context: %q", joined)
+	}
+	if len(session.replies) != 0 {
+		t.Fatal("typed messages should update context without unsolicited narration")
+	}
+	if len(m.opts.Engine.Messages()) != 3 {
+		t.Fatal("turning voice off must preserve the text conversation")
+	}
+	if !strings.Contains(ansi.Strip(m.View()), "mic muted") {
+		t.Fatal("voice-off state needs a visible muted indicator")
+	}
+}
+
+func TestUIVoiceFailureFallsBackToTextAndClosesSession(t *testing.T) {
+	m := uiModel(t, nil, &uiExecutor{}, false)
+	session := uiConnectVoice(t, m)
+	uiSendVoice(t, m, session, VoiceEvent{Type: "error", Err: errors.New("connection lost")})
+	if m.voiceEnabled || m.quitting || !strings.Contains(ansi.Strip(m.View()), "Text chat remains available") {
+		t.Fatal("voice failure must leave a usable text session")
+	}
+	select {
+	case <-session.closed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("failed voice session was not closed")
+	}
+}
+
+func TestUIVoiceSetupExitsPrivatelyAndPreservesConversation(t *testing.T) {
+	state := &UIState{transcript: []chatEntry{{kind: "assistant", title: "Wendy", text: "Existing conversation"}}, composer: "unfinished draft"}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	err := Run(ctx, UIOptions{
+		Engine: NewEngine(nil, &uiExecutor{}, ""), State: state, InitialPrompt: "/voice",
+		Input: strings.NewReader(""), Output: &bytes.Buffer{},
+	})
+	if !errors.Is(err, ErrVoiceSetup) || state.Voice || state.composer != "unfinished draft" || len(state.transcript) != 1 {
+		t.Fatalf("voice setup lost state or enabled voice before setup: err=%v state=%+v", err, state)
+	}
+}
+
+func TestUIVoiceEscapeInterruptsPlaybackAndCancelsEngine(t *testing.T) {
+	provider := uiProviderFunc(func(ctx context.Context, messages []Message, tools []Tool, emit func(string)) (Message, error) {
+		<-ctx.Done()
+		return Message{}, ctx.Err()
+	})
+	m := uiModel(t, provider, &uiExecutor{}, false)
+	session := uiConnectVoice(t, m)
+	uiSendVoice(t, m, session, VoiceEvent{Type: "delegation", DelegationID: "task", Text: "wait"})
+	m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	uiDrainTurn(t, m)
+	deadline := time.After(3 * time.Second)
+	for session.interrupts.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("Escape did not stop live playback")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+	if m.active || !m.voiceEnabled || m.quitting {
+		t.Fatal("Escape should stop active work and keep the conversation available")
+	}
+	uiVoiceStopAndWait(t, m, session)
+	if len(session.replies) != 0 {
+		t.Fatal("interrupted voice task must not speak a result")
+	}
+}
+
+func TestUIVoiceFactoryCancellationDoesNotLeak(t *testing.T) {
+	m := uiModel(t, nil, &uiExecutor{}, false)
+	started, stopped := make(chan struct{}), make(chan struct{})
+	m.opts.VoiceFactory = func(ctx context.Context) (VoiceSession, error) {
+		close(started)
+		<-ctx.Done()
+		close(stopped)
+		return nil, ctx.Err()
+	}
+	m.startVoice()
+	select {
+	case <-started:
+	case <-time.After(3 * time.Second):
+		t.Fatal("voice factory did not start")
+	}
+	m.submit("/voice off")
+	select {
+	case <-stopped:
+	case <-time.After(3 * time.Second):
+		t.Fatal("voice setup did not cancel when toggled off")
+	}
+	if m.voiceEnabled || m.quitting {
+		t.Fatal("turning off connecting voice should leave text chat open")
+	}
+}
+
+func TestUIVoiceCaptionsCoalesceAndClearDiscardsVoiceContext(t *testing.T) {
+	m := uiModel(t, nil, &uiExecutor{}, false)
+	session := uiConnectVoice(t, m)
+	before := len(m.transcript)
+	for _, text := range []string{"Check", " my", " device."} {
+		uiSendVoice(t, m, session, VoiceEvent{Type: "input", Text: text})
+	}
+	if len(m.transcript) != before+1 || m.transcript[len(m.transcript)-1].text != "Check my device." {
+		t.Fatal("consecutive voice transcript deltas must form one readable caption")
+	}
+	m.submit("/clear")
+	if m.voiceEnabled || len(m.transcript) != 1 || !strings.Contains(m.transcript[0].text, "previous context is discarded") {
+		t.Fatal("/clear must discard voice context as well as the text conversation")
+	}
+	select {
+	case <-session.closed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("/clear left the previous voice session alive")
+	}
+}
+
+func TestUIVoiceOffKeepsDelegatedWorkAndApprovalsInText(t *testing.T) {
+	call := ToolCall{ID: "write", Name: "workspace_write", Arguments: json.RawMessage(`{"path":"app.txt","content":"hello"}`)}
+	executor := &uiExecutor{tools: []Tool{{Name: call.Name, RequiresApproval: true}}}
+	m := uiModel(t, uiApprovalProvider(call), executor, false)
+	session := uiConnectVoice(t, m)
+	uiSendVoice(t, m, session, VoiceEvent{Type: "delegation", DelegationID: "task", Text: "write app.txt"})
+	uiWaitForApproval(t, m)
+	_ = uiNextVoiceReply(t, session) // The short keyboard-approval notice.
+	m.submit("/voice off")
+	if !m.active || m.canceling || m.approval == nil || m.voiceEnabled {
+		t.Fatal("turning voice off must retain the running task and its pending approval")
+	}
+	m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	uiDrainTurn(t, m)
+	uiVoiceStopAndWait(t, m, session)
+	if executor.executed.Load() != 1 || !strings.Contains(ansi.Strip(m.View()), "Finished.") {
+		t.Fatal("task did not finish normally in text after voice was disabled")
+	}
+	if len(session.replies) != 0 {
+		t.Fatal("voice-off task completion must remain in text without speech")
+	}
+}
+
+func TestUIVoiceQueuedResultIsDiscardedWhenAnotherDelegationArrives(t *testing.T) {
+	var calls atomic.Int32
+	provider := uiProviderFunc(func(context.Context, []Message, []Tool, func(string)) (Message, error) {
+		if calls.Add(1) == 1 {
+			return Message{Content: "Old result queued for speech."}, nil
+		}
+		return Message{Content: "Current result."}, nil
+	})
+	m := uiModel(t, provider, &uiExecutor{}, false)
+	session := newUIVoiceSession()
+	gate := make(chan struct{})
+	session.contextGate = gate
+	m.opts.VoiceFactory = func(context.Context) (VoiceSession, error) { return session, nil }
+	m.startVoice()
+	m.Update(uiNextVoiceEvent(t, m))
+	uiSendVoice(t, m, session, VoiceEvent{Type: "ready"})
+	uiSendVoice(t, m, session, VoiceEvent{Type: "delegation", DelegationID: "old", Text: "old task"})
+	uiDrainTurn(t, m)
+	uiSendVoice(t, m, session, VoiceEvent{Type: "delegation", DelegationID: "new", Text: "new task"})
+	uiDrainTurn(t, m)
+	close(gate)
+	final := uiNextVoiceReply(t, session)
+	if final.id != "new" || final.text != "Current result." {
+		t.Fatalf("expired queued speech was sent after a correction: %+v", final)
+	}
+	uiVoiceStopAndWait(t, m, session)
+	if len(session.replies) != 0 {
+		t.Fatal("old queued result was spoken after the corrected task")
+	}
+}
+
+func TestUIVoiceBackendContextIsNotDisplayedAsUserSpeech(t *testing.T) {
+	received := make(chan string, 1)
+	provider := uiProviderFunc(func(ctx context.Context, messages []Message, tools []Tool, emit func(string)) (Message, error) {
+		received <- messages[len(messages)-1].Content
+		return Message{Content: "Done."}, nil
+	})
+	m := uiModel(t, provider, &uiExecutor{}, false)
+	session := uiConnectVoice(t, m)
+	uiSendVoice(t, m, session, VoiceEvent{
+		Type: "delegation", DelegationID: "task", Text: "Inspect my device",
+		Prompt: `{"internal_context_marker":"Inspect my device with prior context"}`,
+	})
+	uiDrainTurn(t, m)
+	if prompt := <-received; !strings.Contains(prompt, "internal_context_marker") {
+		t.Fatal("full delegation context did not reach the backend")
+	}
+	for _, entry := range m.transcript {
+		if strings.Contains(entry.text, "internal_context_marker") {
+			t.Fatal("internal delegation JSON appeared in the conversation display")
+		}
+	}
+	_ = uiNextVoiceReply(t, session)
+	uiVoiceStopAndWait(t, m, session)
+}
+
+func TestUICompactToolLabelIsSanitized(t *testing.T) {
+	m := uiModel(t, nil, &uiExecutor{}, false)
+	m.transcript = nil
+	m.handleEvent(Event{Type: "tool_start", Call: &ToolCall{Name: "read\n\x1b[2Jfile\u202e", Arguments: json.RawMessage(`{}`)}})
+	view := m.viewport.View()
+	if strings.Contains(view, "\x1b[2J") || strings.Contains(view, "\u202e") {
+		t.Fatal("compact tool label retained untrusted terminal control sequences")
+	}
+}

--- a/go/internal/cli/chat/voice_audio.go
+++ b/go/internal/cli/chat/voice_audio.go
@@ -1,0 +1,256 @@
+package chat
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+)
+
+const (
+	voiceSampleRate = 24000
+	voiceSampleSize = 2
+	// Keep at most half a second of audio in each native queue. Capture drops
+	// stale samples when the network stalls; playback applies backpressure.
+	voiceBufferBytes = voiceSampleRate * voiceSampleSize / 2
+)
+
+var ErrVoicePlaybackInterrupted = errors.New("voice playback interrupted")
+
+// VoiceAudio streams mono, signed 16-bit little-endian PCM at 24 kHz through the
+// microphone and speakers on the computer running Wendy. Close releases both
+// devices and unblocks pending reads/writes. Flush drops queued playback and
+// interrupts pending writes with ErrVoicePlaybackInterrupted.
+type VoiceAudio interface {
+	Read([]byte) (int, error)
+	Write([]byte) (int, error)
+	Flush() error
+	Close() error
+}
+
+type voiceAudioDevice interface {
+	Start() error
+	Close() error
+}
+
+type bufferedVoiceAudio struct {
+	mu                 sync.Mutex
+	writeMu            sync.Mutex
+	captureReady       *sync.Cond
+	playbackReady      *sync.Cond
+	capture            voicePCMQueue
+	playback           voicePCMQueue
+	playbackGeneration uint64
+	nativeBigEndian    bool
+	closed             bool
+	readError          error
+	device             voiceAudioDevice
+	closeOnce          sync.Once
+	closeError         error
+}
+
+func newBufferedVoiceAudio() *bufferedVoiceAudio {
+	a := &bufferedVoiceAudio{
+		capture:         voicePCMQueue{data: make([]byte, voiceBufferBytes)},
+		playback:        voicePCMQueue{data: make([]byte, voiceBufferBytes)},
+		nativeBigEndian: binary.NativeEndian.Uint16([]byte{1, 0}) != 1,
+	}
+	a.captureReady = sync.NewCond(&a.mu)
+	a.playbackReady = sync.NewCond(&a.mu)
+	return a
+}
+
+// startVoiceAudio keeps device setup injectable, so tests exercise cleanup and
+// native callbacks without opening the microphone or speakers.
+func startVoiceAudio(open func(*bufferedVoiceAudio) (voiceAudioDevice, error)) (VoiceAudio, error) {
+	a := newBufferedVoiceAudio()
+	device, err := open(a)
+	if err != nil {
+		_ = a.Close()
+		return nil, err
+	}
+	a.device = device
+	if err := device.Start(); err != nil {
+		_ = a.Close()
+		return nil, fmt.Errorf("start microphone and speakers: %w; check your terminal's microphone permission and default audio devices", err)
+	}
+	return a, nil
+}
+
+func (a *bufferedVoiceAudio) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	// Read whole samples so dropping old capture data cannot shift PCM frames.
+	p = p[:len(p)&^1]
+	if len(p) == 0 {
+		return 0, fmt.Errorf("voice audio reads need room for a 16-bit sample")
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for a.capture.size == 0 && !a.closed {
+		a.captureReady.Wait()
+	}
+	if a.closed {
+		if a.readError != nil {
+			return 0, a.readError
+		}
+		return 0, io.EOF
+	}
+	return a.capture.read(p), nil
+}
+
+func (a *bufferedVoiceAudio) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if len(p)%voiceSampleSize != 0 {
+		return 0, fmt.Errorf("voice playback requires complete 16-bit samples")
+	}
+	a.mu.Lock()
+	generation := a.playbackGeneration
+	a.mu.Unlock()
+	// Concurrent writes remain contiguous in the speaker queue. Take the
+	// generation first so Flush also cancels writers waiting for this mutex.
+	a.writeMu.Lock()
+	defer a.writeMu.Unlock()
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	written := 0
+	for written < len(p) {
+		if a.closed {
+			return written, io.ErrClosedPipe
+		}
+		if generation != a.playbackGeneration {
+			return written, ErrVoicePlaybackInterrupted
+		}
+		if a.playback.size == len(a.playback.data) {
+			a.playbackReady.Wait()
+			continue
+		}
+		written += a.playback.write(p[written:])
+	}
+	return written, nil
+}
+
+func (a *bufferedVoiceAudio) Flush() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.closed {
+		return io.ErrClosedPipe
+	}
+	a.playback.reset()
+	a.playbackGeneration++
+	a.playbackReady.Broadcast()
+	return nil
+}
+
+func (a *bufferedVoiceAudio) Close() error {
+	a.closeOnce.Do(func() {
+		a.mu.Lock()
+		a.closeBuffersLocked()
+		a.mu.Unlock()
+		// Device shutdown waits for any native callback to finish. Never hold
+		// the buffer mutex while waiting, or the callback could deadlock.
+		if a.device != nil {
+			a.closeError = a.device.Close()
+		}
+	})
+	return a.closeError
+}
+
+func (a *bufferedVoiceAudio) closeBuffersLocked() {
+	a.closed = true
+	a.capture.reset()
+	a.playback.reset()
+	a.captureReady.Broadcast()
+	a.playbackReady.Broadcast()
+}
+
+// samples is called only by the native audio callback. It never waits for
+// capture consumers or playback producers, and allocates no audio buffers.
+func (a *bufferedVoiceAudio) samples(output, input []byte) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	clear(output)
+	if a.closed {
+		return
+	}
+	if len(input) > 0 {
+		input = input[:len(input)&^1]
+		if len(input) > len(a.capture.data) {
+			input = input[len(input)-len(a.capture.data):]
+		}
+		if excess := a.capture.size + len(input) - len(a.capture.data); excess > 0 {
+			a.capture.discard(excess)
+		}
+		start := (a.capture.head + a.capture.size) % len(a.capture.data)
+		a.capture.write(input)
+		// miniaudio uses native-endian samples; the voice protocol is always
+		// little-endian. Swap our copy without modifying the native input.
+		if a.nativeBigEndian {
+			for i := 0; i < len(input); i += voiceSampleSize {
+				pos := (start + i) % len(a.capture.data)
+				a.capture.data[pos], a.capture.data[pos+1] = a.capture.data[pos+1], a.capture.data[pos]
+			}
+		}
+		a.captureReady.Broadcast()
+	}
+	if a.playback.read(output[:len(output)&^1]) > 0 {
+		a.playbackReady.Broadcast()
+	}
+	if a.nativeBigEndian {
+		for i := 0; i+1 < len(output); i += voiceSampleSize {
+			output[i], output[i+1] = output[i+1], output[i]
+		}
+	}
+}
+
+// A device can stop after an unplug or permission change. Wake the session's
+// reader immediately and finish cleanup outside the native callback thread.
+func (a *bufferedVoiceAudio) deviceStopped() {
+	a.mu.Lock()
+	if a.closed {
+		a.mu.Unlock()
+		return
+	}
+	a.readError = errors.New("voice audio device stopped; check your microphone and speakers, then enable voice again")
+	a.closeBuffersLocked()
+	a.mu.Unlock()
+	go func() { _ = a.Close() }()
+}
+
+// voicePCMQueue is a fixed-size byte ring; its owner holds the buffer mutex.
+type voicePCMQueue struct {
+	data []byte
+	head int
+	size int
+}
+
+func (q *voicePCMQueue) write(p []byte) int {
+	n := min(len(p), len(q.data)-q.size)
+	tail := (q.head + q.size) % len(q.data)
+	first := copy(q.data[tail:], p[:n])
+	copy(q.data, p[first:n])
+	q.size += n
+	return n
+}
+
+func (q *voicePCMQueue) read(p []byte) int {
+	n := min(len(p), q.size)
+	first := copy(p[:n], q.data[q.head:])
+	copy(p[first:n], q.data[:n-first])
+	q.discard(n)
+	return n
+}
+
+func (q *voicePCMQueue) discard(n int) {
+	q.head = (q.head + n) % len(q.data)
+	q.size -= n
+}
+
+func (q *voicePCMQueue) reset() {
+	clear(q.data)
+	q.head, q.size = 0, 0
+}

--- a/go/internal/cli/chat/voice_audio_native.go
+++ b/go/internal/cli/chat/voice_audio_native.go
@@ -1,0 +1,63 @@
+//go:build cgo && (darwin || linux || windows)
+
+package chat
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/gen2brain/malgo"
+)
+
+// VoiceSupportError checks this build's voice capability without opening an
+// audio device or requesting microphone permission.
+func VoiceSupportError() error { return nil }
+
+func openVoiceAudio() (VoiceAudio, error) {
+	return startVoiceAudio(func(audio *bufferedVoiceAudio) (voiceAudioDevice, error) {
+		// Explicit real backends prevent miniaudio's null backend from reporting
+		// success on a machine without usable microphone/speaker support.
+		backends := map[string][]malgo.Backend{
+			"darwin":  {malgo.BackendCoreaudio},
+			"linux":   {malgo.BackendPulseaudio, malgo.BackendAlsa, malgo.BackendJack},
+			"windows": {malgo.BackendWasapi, malgo.BackendDsound, malgo.BackendWinmm},
+		}[runtime.GOOS]
+		ctx, err := malgo.InitContext(backends, malgo.ContextConfig{}, nil)
+		if err != nil {
+			return nil, fmt.Errorf("audio is unavailable on this computer: %w", err)
+		}
+		config := malgo.DefaultDeviceConfig(malgo.Duplex)
+		config.SampleRate = voiceSampleRate
+		config.Capture.Format = malgo.FormatS16
+		config.Capture.Channels = 1
+		config.Playback.Format = malgo.FormatS16
+		config.Playback.Channels = 1
+		config.PeriodSizeInMilliseconds = 10
+		config.Periods = 2
+		config.Alsa.NoMMap = 1
+		device, err := malgo.InitDevice(ctx.Context, config, malgo.DeviceCallbacks{
+			Data: func(output, input []byte, _ uint32) { audio.samples(output, input) },
+			Stop: audio.deviceStopped,
+		})
+		if err != nil {
+			_ = ctx.Uninit()
+			ctx.Free()
+			return nil, fmt.Errorf("open microphone and speakers: %w; allow microphone access for your terminal and check your default audio devices", err)
+		}
+		return &nativeVoiceAudioDevice{device: device, context: ctx}, nil
+	})
+}
+
+type nativeVoiceAudioDevice struct {
+	device  *malgo.Device
+	context *malgo.AllocatedContext
+}
+
+func (d *nativeVoiceAudioDevice) Start() error { return d.device.Start() }
+
+func (d *nativeVoiceAudioDevice) Close() error {
+	d.device.Uninit()
+	err := d.context.Uninit()
+	d.context.Free()
+	return err
+}

--- a/go/internal/cli/chat/voice_audio_native_test.go
+++ b/go/internal/cli/chat/voice_audio_native_test.go
@@ -1,0 +1,12 @@
+//go:build cgo && (darwin || linux || windows)
+
+package chat
+
+import "testing"
+
+func TestVoiceAudioNativeBuildCapability(t *testing.T) {
+	// This is a pure build-capability check; it must never open the microphone.
+	if err := VoiceSupportError(); err != nil {
+		t.Fatalf("native build should include voice support: %v", err)
+	}
+}

--- a/go/internal/cli/chat/voice_audio_test.go
+++ b/go/internal/cli/chat/voice_audio_test.go
@@ -1,0 +1,241 @@
+package chat
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+)
+
+type fakeVoiceAudioDevice struct {
+	startError error
+	closeCount atomic.Int32
+	onClose    func()
+}
+
+func (d *fakeVoiceAudioDevice) Start() error { return d.startError }
+func (d *fakeVoiceAudioDevice) Close() error {
+	d.closeCount.Add(1)
+	if d.onClose != nil {
+		d.onClose()
+	}
+	return nil
+}
+
+func TestVoiceAudioCaptureCopiesAndPreservesSamples(t *testing.T) {
+	a := newBufferedVoiceAudio()
+	defer a.Close()
+	input := []byte{1, 2, 3, 4}
+	a.samples(nil, input)
+	clear(input)
+	output := make([]byte, 3)
+	n, err := a.Read(output)
+	if err != nil || n != 2 || !bytes.Equal(output[:n], []byte{1, 2}) {
+		t.Fatalf("capture did not preserve one whole sample: %v, %v", output[:n], err)
+	}
+	n, err = a.Read(output)
+	if err != nil || n != 2 || !bytes.Equal(output[:n], []byte{3, 4}) {
+		t.Fatalf("remaining sample was lost or retained the native buffer: %v, %v", output[:n], err)
+	}
+}
+
+func TestVoiceAudioCaptureBoundsLatency(t *testing.T) {
+	a := newBufferedVoiceAudio()
+	defer a.Close()
+	older := bytes.Repeat([]byte{1, 2}, voiceBufferBytes/2)
+	newer := []byte{3, 4, 5, 6}
+	a.samples(nil, older)
+	a.samples(nil, newer)
+	output := make([]byte, voiceBufferBytes)
+	n, err := a.Read(output)
+	if err != nil || n != voiceBufferBytes || !bytes.Equal(output[:n-4], older[4:]) || !bytes.Equal(output[n-4:n], newer) {
+		t.Fatalf("capture did not drop stale samples: bytes=%d error=%v", n, err)
+	}
+	oversized := append(bytes.Repeat([]byte{7, 8}, voiceBufferBytes/2), 9, 10)
+	a.samples(nil, oversized)
+	n, err = a.Read(output)
+	if err != nil || n != voiceBufferBytes || !bytes.Equal(output[:n], oversized[2:]) || len(a.capture.data) != voiceBufferBytes {
+		t.Fatalf("oversized capture grew the queue or kept old samples: bytes=%d error=%v", n, err)
+	}
+}
+
+func TestVoiceAudioConvertsNativeEndianWithoutChangingInput(t *testing.T) {
+	a := newBufferedVoiceAudio()
+	defer a.Close()
+	a.nativeBigEndian = true
+	input := []byte{0x12, 0x34, 0x56, 0x78}
+	a.samples(nil, input)
+	wire := make([]byte, len(input))
+	if _, err := a.Read(wire); err != nil || !bytes.Equal(wire, []byte{0x34, 0x12, 0x78, 0x56}) {
+		t.Fatalf("microphone samples were not converted to little-endian: %v, %v", wire, err)
+	}
+	if !bytes.Equal(input, []byte{0x12, 0x34, 0x56, 0x78}) {
+		t.Fatal("capture conversion modified the native input buffer")
+	}
+	if _, err := a.Write(wire); err != nil {
+		t.Fatal(err)
+	}
+	output := make([]byte, len(input))
+	a.samples(output, nil)
+	if !bytes.Equal(output, input) {
+		t.Fatalf("speaker samples were not converted to native-endian: %v", output)
+	}
+}
+
+func TestVoiceAudioPlaybackOrderAndSilence(t *testing.T) {
+	a := newBufferedVoiceAudio()
+	defer a.Close()
+	for _, chunk := range [][]byte{{1, 2}, {3, 4, 5, 6}} {
+		if n, err := a.Write(chunk); err != nil || n != len(chunk) {
+			t.Fatalf("queue playback: bytes=%d error=%v", n, err)
+		}
+	}
+	output := bytes.Repeat([]byte{0xff}, 8)
+	a.samples(output, nil)
+	if !bytes.Equal(output, []byte{1, 2, 3, 4, 5, 6, 0, 0}) {
+		t.Fatalf("playback reordered samples or replayed stale bytes: %v", output)
+	}
+	a.samples(output, nil)
+	if !bytes.Equal(output, make([]byte, len(output))) {
+		t.Fatalf("empty playback did not output silence: %v", output)
+	}
+}
+
+func TestVoiceAudioPlaybackBackpressure(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		a := newBufferedVoiceAudio()
+		defer a.Close()
+		first := bytes.Repeat([]byte{1, 2}, voiceBufferBytes/2)
+		second := bytes.Repeat([]byte{3, 4}, voiceBufferBytes/2)
+		done := make(chan error, 1)
+		go func() { _, err := a.Write(append(first, second...)); done <- err }()
+		synctest.Wait()
+		select {
+		case err := <-done:
+			t.Fatalf("playback grew instead of waiting for the device: %v", err)
+		default:
+		}
+		if a.playback.size != voiceBufferBytes || len(a.playback.data) != voiceBufferBytes {
+			t.Fatal("playback queue exceeded its latency bound")
+		}
+		output := make([]byte, voiceBufferBytes)
+		a.samples(output, nil)
+		if !bytes.Equal(output, first) {
+			t.Fatal("backpressure reordered the first audio chunk")
+		}
+		synctest.Wait()
+		if err := <-done; err != nil {
+			t.Fatal(err)
+		}
+		a.samples(output, nil)
+		if !bytes.Equal(output, second) {
+			t.Fatal("backpressure reordered the remaining audio")
+		}
+	})
+}
+
+func TestVoiceAudioFlushCancelsPendingPlayback(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		a := newBufferedVoiceAudio()
+		defer a.Close()
+		a.samples(nil, []byte{8, 9})
+		if _, err := a.Write(make([]byte, voiceBufferBytes)); err != nil {
+			t.Fatal(err)
+		}
+		done := make(chan error, 1)
+		go func() { _, err := a.Write([]byte{1, 2}); done <- err }()
+		synctest.Wait()
+		if err := a.Flush(); err != nil {
+			t.Fatal(err)
+		}
+		synctest.Wait()
+		if err := <-done; !errors.Is(err, ErrVoicePlaybackInterrupted) {
+			t.Fatalf("interrupted writer was not canceled: %v", err)
+		}
+		output := []byte{0xff, 0xff}
+		a.samples(output, nil)
+		if !bytes.Equal(output, []byte{0, 0}) {
+			t.Fatalf("audio continued after interruption: %v", output)
+		}
+		if _, err := a.Write([]byte{3, 4}); err != nil {
+			t.Fatal(err)
+		}
+		a.samples(output, nil)
+		if !bytes.Equal(output, []byte{3, 4}) {
+			t.Fatal("interruption prevented the next reply from playing")
+		}
+		if _, err := a.Read(output); err != nil || !bytes.Equal(output, []byte{8, 9}) {
+			t.Fatalf("playback interruption discarded microphone input: %v", err)
+		}
+	})
+}
+
+func TestVoiceAudioCloseUnblocksIOAndReleasesDevice(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		device := &fakeVoiceAudioDevice{}
+		var buffers *bufferedVoiceAudio
+		audio, err := startVoiceAudio(func(a *bufferedVoiceAudio) (voiceAudioDevice, error) { buffers = a; return device, nil })
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Teardown can wait for a final native callback; Close must not hold
+		// the buffer lock while waiting, or retain input from that callback.
+		device.onClose = func() { buffers.samples(make([]byte, 2), []byte{9, 9}) }
+		readDone, writeDone := make(chan error, 1), make(chan error, 1)
+		go func() { _, err := audio.Read(make([]byte, 2)); readDone <- err }()
+		go func() { _, err := audio.Write(make([]byte, voiceBufferBytes+2)); writeDone <- err }()
+		synctest.Wait()
+		if err := audio.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := audio.Close(); err != nil {
+			t.Fatal(err)
+		}
+		synctest.Wait()
+		if err := <-readDone; !errors.Is(err, io.EOF) {
+			t.Fatalf("closing voice did not release microphone reader: %v", err)
+		}
+		if err := <-writeDone; !errors.Is(err, io.ErrClosedPipe) {
+			t.Fatalf("closing voice did not release speaker writer: %v", err)
+		}
+		if device.closeCount.Load() != 1 || buffers.capture.size != 0 || buffers.playback.size != 0 {
+			t.Fatal("closing voice retained audio or closed the device more than once")
+		}
+		if err := audio.Flush(); !errors.Is(err, io.ErrClosedPipe) {
+			t.Fatalf("closed device accepted playback flush: %v", err)
+		}
+	})
+}
+
+func TestVoiceAudioStartFailureReleasesDevice(t *testing.T) {
+	startError := errors.New("microphone access denied")
+	device := &fakeVoiceAudioDevice{startError: startError}
+	audio, err := startVoiceAudio(func(a *bufferedVoiceAudio) (voiceAudioDevice, error) { return device, nil })
+	if audio != nil || !errors.Is(err, startError) || device.closeCount.Load() != 1 {
+		t.Fatalf("failed startup leaked the device or lost its error: %v", err)
+	}
+}
+
+func TestVoiceAudioDeviceFailureWakesReaderAndCloses(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		device := &fakeVoiceAudioDevice{}
+		audio, err := startVoiceAudio(func(a *bufferedVoiceAudio) (voiceAudioDevice, error) { return device, nil })
+		if err != nil {
+			t.Fatal(err)
+		}
+		done := make(chan error, 1)
+		go func() { _, err := audio.Read(make([]byte, 2)); done <- err }()
+		synctest.Wait()
+		audio.(*bufferedVoiceAudio).deviceStopped()
+		synctest.Wait()
+		if err := <-done; err == nil || errors.Is(err, io.EOF) {
+			t.Fatalf("microphone disconnect was not reported: %v", err)
+		}
+		if device.closeCount.Load() != 1 {
+			t.Fatal("microphone disconnect retained native resources")
+		}
+		_ = audio.Close()
+	})
+}

--- a/go/internal/cli/chat/voice_audio_unsupported.go
+++ b/go/internal/cli/chat/voice_audio_unsupported.go
@@ -1,0 +1,15 @@
+//go:build !cgo || (!darwin && !linux && !windows)
+
+package chat
+
+import "fmt"
+
+func openVoiceAudio() (VoiceAudio, error) {
+	return nil, VoiceSupportError()
+}
+
+// VoiceSupportError checks this build's voice capability without opening an
+// audio device or requesting microphone permission.
+func VoiceSupportError() error {
+	return fmt.Errorf("this Wendy build does not include microphone support; use a native audio build for macOS, Linux, or Windows (built with CGO_ENABLED=1), or continue in text chat")
+}

--- a/go/internal/cli/chat/voice_audio_unsupported_test.go
+++ b/go/internal/cli/chat/voice_audio_unsupported_test.go
@@ -1,0 +1,22 @@
+//go:build !cgo || (!darwin && !linux && !windows)
+
+package chat
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestVoiceAudioUnsupportedIsActionable(t *testing.T) {
+	capabilityError := VoiceSupportError()
+	if capabilityError == nil || !strings.Contains(capabilityError.Error(), "CGO_ENABLED=1") {
+		t.Fatalf("build capability check did not explain unavailable audio: %v", capabilityError)
+	}
+	audio, err := openVoiceAudio()
+	if audio != nil || err == nil || !strings.Contains(err.Error(), "CGO_ENABLED=1") || !strings.Contains(err.Error(), "text chat") {
+		t.Fatalf("unsupported build did not explain how to continue: %v", err)
+	}
+	if err.Error() != capabilityError.Error() {
+		t.Fatalf("opening audio and capability preflight disagree: %v", err)
+	}
+}

--- a/go/internal/cli/chat/voice_live.go
+++ b/go/internal/cli/chat/voice_live.go
@@ -1,0 +1,739 @@
+package chat
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"golang.org/x/net/websocket"
+)
+
+// VoiceEvent carries display transcripts and complete, reconciled delegations.
+// Only a delegation event authorizes the TUI to start an agent turn.
+type VoiceEvent struct {
+	Type         string
+	Text         string
+	Prompt       string // Optional timestamped backend context; Text stays readable.
+	DelegationID string
+	Err          error
+}
+
+// VoiceSession keeps listening while the existing agent runs or awaits approval.
+type VoiceSession interface {
+	Events() <-chan VoiceEvent
+	SendContext(context.Context, string) error
+	Reply(context.Context, string, string) error
+	Interrupt(context.Context) error
+	Close() error
+}
+
+const liveEndpoint = "wss://api.openai.com/v1/live/sessions"
+const liveModel = "gpt-live-1"
+
+const liveInstructions = `You are Wendy's quiet voice interface to a coding and hardware agent. Keep listening; do not greet first. Speak briefly only for clarification, an explicit approval prompt, a blocker, or verified completion. Stay silent while the backend thinks or uses tools. Do not narrate plans, code, logs, or routine progress.
+Backchannel policy: No routine listening sounds or filler.
+Interruption policy: Stop speaking when the user interrupts and listen.
+Delegation policy: The backend can inspect and edit the local project, build and test code, and discover, control, deploy to, and debug Wendy devices. Delegate requests for those tasks or careful reasoning. Delegate corrections or cancellation of active work. Do not delegate greetings or requests to repeat a verified result. If a request is unclear, ask one short clarification. Delegate before a result-dependent answer; never invent results. Agent actions requiring approval are approved only through terminal y/n; spoken yes does not approve them. Context appended as thinking is background information and needs no spoken acknowledgment. Announce only the concise final result supplied by the backend.`
+
+type liveWire interface {
+	Send(context.Context, any) error
+	Receive(any) error
+	Close() error
+}
+
+type liveSocket struct {
+	conn *websocket.Conn
+	gate chan struct{}
+}
+
+func dialLive(ctx context.Context, key string) (liveWire, error) {
+	config, err := websocket.NewConfig(liveEndpoint, "https://api.openai.com")
+	if err != nil {
+		return nil, err
+	}
+	config.Header = http.Header{"Authorization": {"Bearer " + key}}
+	conn, err := config.DialContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	conn.MaxPayloadBytes = 2 << 20
+	return &liveSocket{conn: conn, gate: make(chan struct{}, 1)}, nil
+}
+
+func (w *liveSocket) Send(ctx context.Context, value any) error {
+	select {
+	case w.gate <- struct{}{}:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	defer func() { <-w.gate }()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
+		deadline = d
+	}
+	if err := w.conn.SetWriteDeadline(deadline); err != nil {
+		return err
+	}
+	// Closing the socket also releases a write blocked inside the TLS transport.
+	stop := context.AfterFunc(ctx, func() { _ = w.conn.Close() })
+	defer stop()
+	return websocket.JSON.Send(w.conn, value)
+}
+
+func (w *liveSocket) Receive(value any) error { return websocket.JSON.Receive(w.conn, value) }
+func (w *liveSocket) Close() error            { return w.conn.Close() }
+
+type liveServerEvent struct {
+	Type          string   `json:"type"`
+	EventID       string   `json:"event_id"`
+	ClientEventID string   `json:"client_event_id"`
+	Delta         string   `json:"delta"`
+	StartMS       *float64 `json:"start_ms"`
+	EndMS         *float64 `json:"end_ms"`
+	OffsetMS      *float64 `json:"offset_ms"`
+	Delegation    struct {
+		ID     string `json:"id"`
+		Type   string `json:"type"`
+		Target string `json:"target"`
+	} `json:"delegation"`
+	Error struct {
+		Type          string `json:"type"`
+		Code          string `json:"code"`
+		Message       string `json:"message"`
+		ClientEventID string `json:"client_event_id"`
+	} `json:"error"`
+}
+
+type livePlayback struct {
+	data       []byte
+	generation uint64
+}
+
+type liveSession struct {
+	ctx          context.Context
+	cancel       context.CancelFunc
+	wire         liveWire
+	audio        VoiceAudio
+	key          string
+	events       chan VoiceEvent
+	playback     chan livePlayback
+	done         chan struct{}
+	remoteClosed chan struct{}
+	wg           sync.WaitGroup
+	closeOnce    sync.Once
+	closing      atomic.Bool
+	sequence     atomic.Uint64
+	generation   atomic.Uint64
+
+	mu          sync.Mutex
+	transcript  liveTranscript
+	activeID    string
+	replied     map[string]bool
+	acks        map[string]chan error
+	interrupted bool
+	interruptID uint64
+	lastOutput  time.Time
+	interruptAt time.Time
+	settle      time.Duration
+	closeWait   time.Duration
+}
+
+// StartVoice opens GPT-Live's native session protocol, with client delegation so
+// the configured agent provider and its existing approval policy remain in use.
+func StartVoice(ctx context.Context, key string) (VoiceSession, error) {
+	return startVoice(ctx, key, dialLive, openVoiceAudio)
+}
+
+func startVoice(ctx context.Context, key string, dial func(context.Context, string) (liveWire, error), openAudio func() (VoiceAudio, error)) (VoiceSession, error) {
+	key = strings.TrimSpace(key)
+	if key == "" || strings.IndexFunc(key, unicode.IsControl) >= 0 {
+		return nil, errors.New("voice requires a valid OpenAI API key; run wendy chat --voice to configure it")
+	}
+	startup, cancelStartup := context.WithTimeout(ctx, 15*time.Second)
+	defer cancelStartup()
+	wire, err := dial(startup, key)
+	if err != nil {
+		return nil, liveError(key, "connect to GPT-Live", err)
+	}
+	stop := context.AfterFunc(startup, func() { _ = wire.Close() })
+	defer stop()
+	started := false
+	defer func() {
+		if !started {
+			_ = wire.Close()
+		}
+	}()
+	request := map[string]any{
+		"type": "session.start", "event_id": "wendy-start",
+		"session": map[string]any{
+			"model": liveModel, "instructions": liveInstructions, "store": false,
+			"audio":      map[string]any{"format": map[string]any{"type": "audio/pcm", "rate": 24000}, "output": map[string]any{"voice": "marin"}},
+			"delegation": map[string]any{"type": "client"},
+		},
+	}
+	if err := wire.Send(startup, request); err != nil {
+		return nil, liveError(key, "start GPT-Live", err)
+	}
+	var hello liveServerEvent
+	if err := wire.Receive(&hello); err != nil {
+		if startup.Err() != nil {
+			err = startup.Err()
+		}
+		return nil, liveError(key, "start GPT-Live", err)
+	}
+	if hello.Type == "error" {
+		return nil, liveError(key, "GPT-Live", errors.New(hello.Error.Message))
+	}
+	if hello.Type != "session.started" {
+		return nil, errors.New("GPT-Live did not acknowledge session.start")
+	}
+	if err := startup.Err(); err != nil {
+		return nil, err
+	}
+	audio, err := openAudio()
+	if err != nil {
+		return nil, fmt.Errorf("open voice audio: %w", err)
+	}
+	if !stop() || startup.Err() != nil {
+		_ = audio.Close()
+		return nil, startup.Err()
+	}
+	// Parent cancellation must stop microphone capture immediately while still
+	// allowing a bounded session.close handshake on the live connection.
+	sessionCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	s := &liveSession{
+		ctx: sessionCtx, cancel: cancel, wire: wire, audio: audio, key: key,
+		events: make(chan VoiceEvent, 256), playback: make(chan livePlayback, 8),
+		done: make(chan struct{}), remoteClosed: make(chan struct{}),
+		replied: make(map[string]bool), acks: make(map[string]chan error),
+		settle: 300 * time.Millisecond, closeWait: 3 * time.Second,
+	}
+	s.events <- VoiceEvent{Type: "ready"}
+	s.wg.Add(4)
+	stopParent := context.AfterFunc(ctx, func() { _ = s.Close() })
+	go s.capture()
+	go s.play()
+	go s.receive()
+	go s.reconcile()
+	go func() {
+		defer stopParent()
+		<-s.ctx.Done()
+		_ = s.wire.Close()
+		_ = s.audio.Close()
+		s.wg.Wait()
+		select {
+		case s.events <- VoiceEvent{Type: "done"}:
+		default:
+		}
+		close(s.events)
+		close(s.done)
+	}()
+	started = true
+	return s, nil
+}
+
+func liveError(key, action string, err error) error {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	provider := httpProvider{config: Config{APIKey: key}}
+	return fmt.Errorf("%s: %s", action, provider.safeError(err.Error()))
+}
+
+func (s *liveSession) Events() <-chan VoiceEvent { return s.events }
+
+func (s *liveSession) publish(event VoiceEvent) {
+	select {
+	case s.events <- event:
+	default:
+		// Losing a display delta is harmless. Losing an action would not be;
+		// stop the session rather than silently dropping a delegated request.
+		if event.Type == "delegation" {
+			s.cancel()
+		}
+	}
+}
+
+func (s *liveSession) fail(err error) {
+	if s.ctx.Err() == nil && !s.closing.Load() {
+		s.publish(VoiceEvent{Type: "error", Err: liveError(s.key, "voice", err)})
+	}
+	s.cancel()
+}
+
+func (s *liveSession) send(ctx context.Context, value any) error {
+	if err := s.ctx.Err(); err != nil {
+		return err
+	}
+	bounded, cancel := context.WithTimeout(ctx, 5*time.Second)
+	stop := context.AfterFunc(s.ctx, cancel)
+	defer stop()
+	defer cancel()
+	if err := s.wire.Send(bounded, value); err != nil {
+		return liveError(s.key, "send voice event", err)
+	}
+	return nil
+}
+
+func (s *liveSession) capture() {
+	defer s.wg.Done()
+	buffer := make([]byte, 4801)
+	remaining := 0
+	for s.ctx.Err() == nil && !s.closing.Load() {
+		n, err := s.audio.Read(buffer[remaining:4800])
+		if n > 0 {
+			n += remaining
+			complete := n - n%2
+			if complete > 0 && !s.closing.Load() {
+				if sendErr := s.send(s.ctx, map[string]any{"type": "session.input_audio.append", "audio": base64.StdEncoding.EncodeToString(buffer[:complete])}); sendErr != nil {
+					s.fail(sendErr)
+					return
+				}
+			}
+			remaining = n - complete
+			if remaining != 0 {
+				buffer[0] = buffer[complete]
+			}
+		}
+		if err != nil {
+			if !s.closing.Load() && s.ctx.Err() == nil {
+				s.fail(fmt.Errorf("microphone stopped: %w", err))
+			}
+			return
+		}
+	}
+}
+
+func (s *liveSession) play() {
+	defer s.wg.Done()
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case packet := <-s.playback:
+			if packet.generation != s.generation.Load() {
+				continue
+			}
+			n, err := s.audio.Write(packet.data)
+			if err == nil && n != len(packet.data) {
+				err = io.ErrShortWrite
+			}
+			if packet.generation != s.generation.Load() {
+				_ = s.audio.Flush()
+			}
+			if err != nil && !errors.Is(err, ErrVoicePlaybackInterrupted) && s.ctx.Err() == nil && !s.closing.Load() {
+				s.fail(fmt.Errorf("speaker stopped: %w", err))
+				return
+			}
+		}
+	}
+}
+
+func (s *liveSession) receive() {
+	defer s.wg.Done()
+	for {
+		var event liveServerEvent
+		if err := s.wire.Receive(&event); err != nil {
+			if errors.Is(err, io.EOF) {
+				err = errors.New("GPT-Live disconnected before session.closed")
+			}
+			s.fail(err)
+			return
+		}
+		switch event.Type {
+		case "session.output_audio.delta":
+			if len(event.Delta) > 128*1024 {
+				s.fail(errors.New("GPT-Live audio frame exceeds playback limit"))
+				return
+			}
+			data, err := base64.StdEncoding.DecodeString(event.Delta)
+			if err != nil || len(data)%2 != 0 {
+				s.fail(errors.New("GPT-Live sent malformed PCM audio"))
+				return
+			}
+			now := time.Now()
+			s.mu.Lock()
+			// Live has no response.cancel/audio-done event. An explicit local
+			// interruption discards the current burst until a quiet audio gap.
+			if s.interrupted && now.Sub(s.lastOutput) > 350*time.Millisecond && now.Sub(s.interruptAt) > 500*time.Millisecond {
+				s.interrupted = false
+			}
+			s.lastOutput = now
+			drop := s.interrupted
+			s.mu.Unlock()
+			if drop || len(data) == 0 || s.closing.Load() {
+				continue
+			}
+			packet := livePlayback{data: data, generation: s.generation.Load()}
+			select {
+			case s.playback <- packet:
+			default:
+				// Bound latency if the device cannot keep up. Flush unblocks a
+				// pending write; transcript/control handling never waits on audio.
+				s.generation.Add(1)
+				_ = s.audio.Flush()
+			}
+		case "session.input_transcript.delta", "session.output_transcript.delta":
+			if event.StartMS == nil || event.EndMS == nil || *event.StartMS < 0 || *event.EndMS < *event.StartMS || len(event.Delta) > 16*1024 {
+				s.fail(errors.New("GPT-Live sent invalid transcript timestamps"))
+				return
+			}
+			speaker := "user"
+			kind := "input"
+			if event.Type == "session.output_transcript.delta" {
+				speaker, kind = "assistant", "output"
+			}
+			s.mu.Lock()
+			added := s.transcript.add(event.EventID, speaker, event.Delta, *event.StartMS, *event.EndMS, time.Now())
+			s.mu.Unlock()
+			if added {
+				s.publish(VoiceEvent{Type: kind, Text: event.Delta})
+			}
+		case "session.delegation.created":
+			if event.Delegation.ID == "" || event.Delegation.Type != "delegation" || event.Delegation.Target != "client" || event.OffsetMS == nil || *event.OffsetMS < 0 {
+				s.fail(errors.New("GPT-Live sent an invalid client delegation"))
+				return
+			}
+			s.mu.Lock()
+			if s.transcript.delegate(event.Delegation.ID, *event.OffsetMS, time.Now()) {
+				// Invalidate an old result as soon as a correction is delegated,
+				// before its delayed transcript has finished reconciling.
+				s.activeID = event.Delegation.ID
+			}
+			s.mu.Unlock()
+		case "session.thinking.appended", "session.commentary.appended", "session.instructions.appended":
+			s.ack(event.ClientEventID, nil)
+		case "error":
+			err := liveError(s.key, "GPT-Live", errors.New(event.Error.Message))
+			s.ack(event.Error.ClientEventID, err)
+			s.fail(err)
+			return
+		case "session.closed":
+			close(s.remoteClosed)
+			s.cancel()
+			return
+		case "":
+			s.fail(errors.New("GPT-Live sent an event without a type"))
+			return
+		default:
+			// Allow additive protocol events (usage and diagnostics).
+		}
+	}
+}
+
+func (s *liveSession) ack(id string, err error) {
+	s.mu.Lock()
+	waiter := s.acks[id]
+	delete(s.acks, id)
+	s.mu.Unlock()
+	if waiter != nil {
+		waiter <- err
+	}
+}
+
+func (s *liveSession) append(ctx context.Context, kind, id, content string) error {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return nil
+	}
+	// A Live context append is limited to 500 tokens. Byte-bounded UTF-8 text
+	// stays below that limit even for code and non-English speech, without a
+	// model-specific tokenizer. Large artifacts remain in the terminal.
+	content = liveBrief(content, 440)
+	eventID := fmt.Sprintf("wendy-%d", s.sequence.Add(1))
+	var delegationID any
+	if id != "" {
+		delegationID = id
+	}
+	waiter := make(chan error, 1)
+	s.mu.Lock()
+	s.acks[eventID] = waiter
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		delete(s.acks, eventID)
+		s.mu.Unlock()
+	}()
+	if err := s.send(ctx, map[string]any{"type": "session." + kind + ".append", "event_id": eventID, "delegation_id": delegationID, "content": content}); err != nil {
+		return err
+	}
+	// Acknowledgment means the context was injected, not that it was spoken.
+	timer := time.NewTimer(15 * time.Second)
+	defer timer.Stop()
+	select {
+	case err := <-waiter:
+		return err
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return errors.New("GPT-Live did not acknowledge the voice context")
+	}
+}
+
+func liveBrief(text string, limit int) string {
+	if len(text) <= limit {
+		return text
+	}
+	const suffix = "… Details are in the terminal."
+	end := limit - len(suffix)
+	for end > 0 && !utf8.RuneStart(text[end]) {
+		end--
+	}
+	return strings.TrimSpace(text[:end]) + suffix
+}
+
+func (s *liveSession) SendContext(ctx context.Context, text string) error {
+	text = strings.ToValidUTF8(text, "�")
+	// Preserve the workspace prefix and the latest exchanges if a long text
+	// conversation is attached. Each ordered append obeys Live's 500-token
+	// limit; none asks the voice model to acknowledge the context aloud.
+	const limit = 8 * 1024
+	if len(text) > limit {
+		const omitted = "\n[Earlier context omitted.]\n"
+		headEnd := 1024
+		for !utf8.RuneStart(text[headEnd]) {
+			headEnd--
+		}
+		tailStart := len(text) - (limit - headEnd - len(omitted))
+		for tailStart < len(text) && !utf8.RuneStart(text[tailStart]) {
+			tailStart++
+		}
+		text = text[:headEnd] + omitted + text[tailStart:]
+	}
+	for text != "" {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		end := min(440, len(text))
+		if end < len(text) {
+			for !utf8.RuneStart(text[end]) {
+				end--
+			}
+			// Prefer whole words/lines while keeping chunks reasonably full.
+			if split := strings.LastIndexAny(text[:end], " \n\t"); split >= end/2 {
+				end = split + 1
+			}
+		}
+		if err := s.append(ctx, "thinking", "", text[:end]); err != nil {
+			return err
+		}
+		text = text[end:]
+	}
+	return nil
+}
+
+func (s *liveSession) Reply(ctx context.Context, id, text string) error {
+	s.mu.Lock()
+	interruptID, activeID := s.interruptID, s.activeID
+	if id != "" {
+		if id != s.activeID || s.replied[id] {
+			s.mu.Unlock()
+			return nil // A newer spoken correction supersedes the old result.
+		}
+		s.replied[id] = true
+	}
+	s.mu.Unlock()
+	if err := s.append(ctx, "commentary", id, text); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	// An accepted fresh result or approval question begins new speech even
+	// when it immediately follows the interrupted audio burst. A delayed ACK
+	// for superseded speech must not undo a newer interruption or correction.
+	s.mu.Lock()
+	if strings.TrimSpace(text) != "" && s.interruptID == interruptID && s.activeID == activeID && s.ctx.Err() == nil && !s.closing.Load() {
+		s.interrupted = false
+	}
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *liveSession) Interrupt(ctx context.Context) error {
+	s.mu.Lock()
+	s.interrupted = true
+	s.interruptID++
+	s.interruptAt = time.Now()
+	s.lastOutput = s.interruptAt
+	s.mu.Unlock()
+	s.generation.Add(1)
+	if err := s.audio.Flush(); err != nil {
+		return err
+	}
+	return s.append(ctx, "instructions", "", "Stop speaking now and listen. Remain silent until the user requests speech or the backend supplies a new final result or approval question. This instruction stops speech only; it does not cancel any backend action.")
+}
+
+func (s *liveSession) Close() error {
+	s.closeOnce.Do(func() {
+		s.closing.Store(true)
+		_ = s.audio.Close()
+		if s.ctx.Err() == nil {
+			ctx, cancel := context.WithTimeout(context.Background(), s.closeWait)
+			_ = s.send(ctx, map[string]any{"type": "session.close", "event_id": fmt.Sprintf("wendy-%d", s.sequence.Add(1))})
+			select {
+			case <-s.remoteClosed:
+			case <-s.ctx.Done():
+			case <-ctx.Done():
+			}
+			cancel()
+		}
+		s.cancel()
+	})
+	<-s.done
+	return nil
+}
+
+type liveTranscriptPart struct {
+	Speaker string  `json:"speaker"`
+	Text    string  `json:"text"`
+	StartMS float64 `json:"start_ms"`
+	EndMS   float64 `json:"end_ms"`
+	seq     uint64
+}
+
+type liveDelegation struct {
+	id      string
+	offset  float64
+	created time.Time
+}
+
+// Live supplies timestamped fragments, not completed user turns or task text.
+// Reconcile around delegation offsets and allow delayed transcripts to arrive.
+type liveTranscript struct {
+	parts        []liveTranscriptPart
+	events       map[string]bool
+	delegations  map[string]bool
+	sequence     uint64
+	delivered    uint64
+	deliveredMS  float64
+	pending      *liveDelegation
+	lastFragment time.Time
+	bytes        int
+}
+
+func (t *liveTranscript) add(id, speaker, text string, start, end float64, now time.Time) bool {
+	if text == "" {
+		return false
+	}
+	if t.events == nil {
+		t.events = make(map[string]bool)
+	}
+	if id != "" {
+		if t.events[id] {
+			return false
+		}
+		if len(t.events) >= 8192 {
+			t.events = make(map[string]bool)
+		}
+		t.events[id] = true
+	}
+	t.sequence++
+	t.parts = append(t.parts, liveTranscriptPart{Speaker: speaker, Text: text, StartMS: start, EndMS: end, seq: t.sequence})
+	t.bytes += len(text)
+	if speaker == "user" {
+		t.lastFragment = now
+	}
+	for t.bytes > 16*1024 && len(t.parts) > 1 {
+		t.bytes -= len(t.parts[0].Text)
+		t.parts = t.parts[1:]
+	}
+	return true
+}
+
+func (t *liveTranscript) delegate(id string, offset float64, now time.Time) bool {
+	if t.delegations == nil {
+		t.delegations = make(map[string]bool)
+	}
+	if t.delegations[id] {
+		return false
+	}
+	// Bound state across arbitrarily long microphone sessions. Transcript
+	// offsets still prevent an evicted old ID from repeating completed work.
+	if len(t.delegations) >= 8192 {
+		t.delegations = make(map[string]bool)
+	}
+	t.delegations[id] = true
+	if offset > 0 && offset <= t.deliveredMS {
+		return false
+	}
+	t.pending = &liveDelegation{id: id, offset: offset, created: now}
+	return true
+}
+
+func (t *liveTranscript) ready(now time.Time, settle time.Duration) (VoiceEvent, bool) {
+	pending := t.pending
+	if pending == nil || now.Sub(pending.created) < settle || (now.Sub(t.lastFragment) < settle && now.Sub(pending.created) < 2*time.Second) {
+		return VoiceEvent{}, false
+	}
+	var recent, fresh []liveTranscriptPart
+	var delivered uint64
+	for _, part := range t.parts {
+		if pending.offset > 0 && part.StartMS > pending.offset {
+			continue
+		}
+		if part.Speaker == "user" && part.seq > t.delivered && (t.deliveredMS == 0 || part.EndMS > t.deliveredMS) {
+			fresh = append(fresh, part)
+			if part.seq > delivered {
+				delivered = part.seq
+			}
+		} else {
+			recent = append(recent, part)
+		}
+	}
+	if len(fresh) == 0 {
+		if now.Sub(pending.created) >= 2*time.Second {
+			t.pending = nil // Never execute a task from missing or repeated speech.
+		}
+		return VoiceEvent{}, false
+	}
+	t.pending = nil
+	t.delivered = delivered
+	t.deliveredMS = pending.offset
+	// Keep speaker boundaries and timestamps explicit; speech is user data,
+	// never instructions for the voice transport or a terminal approval.
+	history, _ := json.Marshal(recent)
+	request, _ := json.Marshal(fresh)
+	var spoken strings.Builder
+	for _, part := range fresh {
+		spoken.WriteString(part.Text)
+	}
+	return VoiceEvent{Type: "delegation", DelegationID: pending.id, Text: strings.TrimSpace(spoken.String()), Prompt: "The user delegated a spoken request to the Wendy agent. Act on the latest request or correction below; earlier requests may already be handled. Spoken agreement does not replace terminal approval. Transcription can be imperfect; clarify ambiguity before consequential actions.\nEarlier voice conversation (timestamped transcript data):\n" + string(history) + "\nLatest user request/correction (timestamped transcript data):\n" + string(request)}, true
+}
+
+func (s *liveSession) reconcile() {
+	defer s.wg.Done()
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case now := <-ticker.C:
+			s.mu.Lock()
+			event, ready := s.transcript.ready(now, s.settle)
+			if ready {
+				s.activeID = event.DelegationID
+			}
+			s.mu.Unlock()
+			if ready {
+				s.publish(event)
+			}
+		}
+	}
+}

--- a/go/internal/cli/chat/voice_live_test.go
+++ b/go/internal/cli/chat/voice_live_test.go
@@ -1,0 +1,735 @@
+package chat
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"golang.org/x/net/websocket"
+)
+
+// Tests never open a real microphone, connect to OpenAI, or read credentials.
+type testLiveWire struct {
+	in        chan []byte
+	out       chan map[string]any
+	done      chan struct{}
+	once      sync.Once
+	autoAck   bool
+	autoClose bool
+}
+
+func newTestLiveWire() *testLiveWire {
+	return &testLiveWire{in: make(chan []byte, 64), out: make(chan map[string]any, 64), done: make(chan struct{}), autoAck: true, autoClose: true}
+}
+
+func (w *testLiveWire) push(v any) {
+	data, _ := json.Marshal(v)
+	w.in <- data
+}
+
+func (w *testLiveWire) Send(ctx context.Context, v any) error {
+	data, _ := json.Marshal(v)
+	var event map[string]any
+	_ = json.Unmarshal(data, &event)
+	select {
+	case w.out <- event:
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-w.done:
+		return io.ErrClosedPipe
+	}
+	kind, _ := event["type"].(string)
+	if w.autoAck && (kind == "session.thinking.append" || kind == "session.commentary.append" || kind == "session.instructions.append") {
+		w.push(map[string]any{"type": kind + "ed", "client_event_id": event["event_id"]})
+	}
+	if w.autoClose && kind == "session.close" {
+		w.push(map[string]any{"type": "session.closed"})
+	}
+	return nil
+}
+
+func (w *testLiveWire) Receive(v any) error {
+	select {
+	case data := <-w.in:
+		return json.Unmarshal(data, v)
+	case <-w.done:
+		return io.EOF
+	}
+}
+
+func (w *testLiveWire) Close() error {
+	w.once.Do(func() { close(w.done) })
+	return nil
+}
+
+type testLiveAudio struct {
+	input   chan []byte
+	writes  chan []byte
+	blocked chan struct{}
+	flush   chan struct{}
+	done    chan struct{}
+	once    sync.Once
+	mu      sync.Mutex
+	flushes int
+}
+
+func newTestLiveAudio() *testLiveAudio {
+	return &testLiveAudio{input: make(chan []byte, 16), writes: make(chan []byte, 16), flush: make(chan struct{}, 16), done: make(chan struct{})}
+}
+
+func (a *testLiveAudio) Read(p []byte) (int, error) {
+	select {
+	case data := <-a.input:
+		return copy(p, data), nil
+	case <-a.done:
+		return 0, io.EOF
+	}
+}
+
+func (a *testLiveAudio) Write(p []byte) (int, error) {
+	a.writes <- append([]byte(nil), p...)
+	if a.blocked != nil {
+		select {
+		case <-a.blocked:
+		case <-a.flush:
+			return 0, ErrVoicePlaybackInterrupted
+		case <-a.done:
+			return 0, io.ErrClosedPipe
+		}
+	}
+	return len(p), nil
+}
+
+func (a *testLiveAudio) Flush() error {
+	a.mu.Lock()
+	a.flushes++
+	a.mu.Unlock()
+	select {
+	case a.flush <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func (a *testLiveAudio) Close() error {
+	a.once.Do(func() { close(a.done) })
+	return nil
+}
+
+func startTestLive(t *testing.T, wire *testLiveWire, audio *testLiveAudio) *liveSession {
+	t.Helper()
+	wire.push(map[string]any{"type": "session.started"})
+	ctx, cancel := context.WithCancel(context.Background())
+	session, err := startVoice(ctx, "test-secret", func(context.Context, string) (liveWire, error) { return wire, nil }, func() (VoiceAudio, error) { return audio, nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := session.(*liveSession)
+	t.Cleanup(func() { cancel(); _ = s.Close() })
+	return s
+}
+
+func awaitLiveSent(t *testing.T, wire *testLiveWire, kind string) map[string]any {
+	t.Helper()
+	timeout := time.After(2 * time.Second)
+	for {
+		select {
+		case event := <-wire.out:
+			if event["type"] == kind {
+				return event
+			}
+		case <-timeout:
+			t.Fatalf("no outbound %s", kind)
+			return nil
+		}
+	}
+}
+
+func awaitLiveEvent(t *testing.T, session VoiceSession, kind string) VoiceEvent {
+	t.Helper()
+	timeout := time.After(2 * time.Second)
+	for {
+		select {
+		case event, ok := <-session.Events():
+			if !ok {
+				t.Fatalf("events closed before %s", kind)
+			}
+			if event.Type == kind {
+				return event
+			}
+		case <-timeout:
+			t.Fatalf("no voice event %s", kind)
+			return VoiceEvent{}
+		}
+	}
+}
+
+func TestLiveStartupAndQuietContext(t *testing.T) {
+	wire, audio := newTestLiveWire(), newTestLiveAudio()
+	s := startTestLive(t, wire, audio)
+	start := awaitLiveSent(t, wire, "session.start")
+	spec := start["session"].(map[string]any)
+	if spec["model"] != "gpt-live-1" || spec["store"] != false || spec["delegation"].(map[string]any)["type"] != "client" {
+		t.Fatalf("unexpected session configuration: %#v", spec)
+	}
+	format := spec["audio"].(map[string]any)["format"].(map[string]any)
+	if format["type"] != "audio/pcm" || format["rate"] != float64(24000) {
+		t.Fatalf("unexpected audio format: %#v", format)
+	}
+	awaitLiveEvent(t, s, "ready")
+	if err := s.SendContext(context.Background(), "The workspace is /test/project."); err != nil {
+		t.Fatal(err)
+	}
+	contextEvent := awaitLiveSent(t, wire, "session.thinking.append")
+	if id, ok := contextEvent["delegation_id"]; !ok || id != nil {
+		t.Fatalf("general context must include explicit null delegation_id: %#v", contextEvent)
+	}
+	select {
+	case extra := <-wire.out:
+		t.Fatalf("startup or context produced unwanted event: %#v", extra)
+	default:
+	}
+}
+
+func TestLiveAudioPreservesSampleBoundaries(t *testing.T) {
+	wire, audio := newTestLiveWire(), newTestLiveAudio()
+	_ = startTestLive(t, wire, audio)
+	audio.input <- []byte{1, 2, 3}
+	audio.input <- []byte{4, 5, 6}
+	var result []byte
+	for range 2 {
+		event := awaitLiveSent(t, wire, "session.input_audio.append")
+		data, err := base64.StdEncoding.DecodeString(event["audio"].(string))
+		if err != nil || len(data)%2 != 0 {
+			t.Fatalf("invalid PCM frame: %v %v", data, err)
+		}
+		result = append(result, data...)
+	}
+	if string(result) != string([]byte{1, 2, 3, 4, 5, 6}) {
+		t.Fatalf("lost microphone bytes: %v", result)
+	}
+}
+
+func TestLiveDelegationContinuesWhileSpeakerBlocked(t *testing.T) {
+	wire, audio := newTestLiveWire(), newTestLiveAudio()
+	audio.blocked = make(chan struct{})
+	s := startTestLive(t, wire, audio)
+	wire.push(map[string]any{"type": "session.output_audio.delta", "delta": base64.StdEncoding.EncodeToString([]byte{1, 2})})
+	select {
+	case <-audio.writes:
+	case <-time.After(time.Second):
+		t.Fatal("playback did not start")
+	}
+	wire.push(map[string]any{"type": "session.input_transcript.delta", "event_id": "speech1", "delta": "Deploy the project.", "start_ms": 100, "end_ms": 500})
+	wire.push(map[string]any{"type": "session.delegation.created", "offset_ms": 600, "delegation": map[string]any{"id": "opaque-id", "type": "delegation", "target": "client"}})
+	event := awaitLiveEvent(t, s, "delegation")
+	if event.DelegationID != "opaque-id" || !strings.Contains(event.Text, "Deploy the project.") {
+		t.Fatalf("lost delegation while speaker blocked: %#v", event)
+	}
+	if err := s.Reply(context.Background(), "opaque-id", "Deployment completed."); err != nil {
+		t.Fatal(err)
+	}
+	reply := awaitLiveSent(t, wire, "session.commentary.append")
+	if reply["delegation_id"] != "opaque-id" {
+		t.Fatalf("wrong result delegation: %#v", reply)
+	}
+	if err := s.Reply(context.Background(), "", "Review the terminal and press y or n."); err != nil {
+		t.Fatal(err)
+	}
+	notice := awaitLiveSent(t, wire, "session.commentary.append")
+	if notice["delegation_id"] != nil {
+		t.Fatalf("approval notice consumed delegation: %#v", notice)
+	}
+	if err := s.Interrupt(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	stop := awaitLiveSent(t, wire, "session.instructions.append")
+	if stop["delegation_id"] != nil || !strings.Contains(stop["content"].(string), "Stop speaking") {
+		t.Fatalf("wrong interruption command: %#v", stop)
+	}
+	if s.ctx.Err() != nil {
+		t.Fatal("expected playback interruption killed session")
+	}
+}
+
+func TestLiveFailureClosesAudioAndRedactsCredential(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		send func(*testLiveWire)
+	}{
+		{"api", func(w *testLiveWire) {
+			w.push(map[string]any{"type": "error", "error": map[string]any{"message": "rejected test-secret"}})
+		}},
+		{"audio", func(w *testLiveWire) { w.push(map[string]any{"type": "session.output_audio.delta", "delta": "%%%"}) }},
+		{"odd_audio", func(w *testLiveWire) { w.push(map[string]any{"type": "session.output_audio.delta", "delta": "AQ=="}) }},
+		{"missing_transcript_timestamps", func(w *testLiveWire) {
+			w.push(map[string]any{"type": "session.input_transcript.delta", "delta": "Deploy."})
+		}},
+		{"missing_delegation_offset", func(w *testLiveWire) {
+			w.push(map[string]any{"type": "session.delegation.created", "delegation": map[string]any{"id": "bad", "type": "delegation", "target": "client"}})
+		}},
+		{"json", func(w *testLiveWire) { w.in <- []byte("{") }},
+		{"eof", func(w *testLiveWire) { _ = w.Close() }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			wire, audio := newTestLiveWire(), newTestLiveAudio()
+			s := startTestLive(t, wire, audio)
+			tc.send(wire)
+			event := awaitLiveEvent(t, s, "error")
+			if event.Err == nil || strings.Contains(event.Err.Error(), "test-secret") {
+				t.Fatalf("missing or unsafe error: %v", event.Err)
+			}
+			select {
+			case <-audio.done:
+			case <-time.After(time.Second):
+				t.Fatal("failure left microphone open")
+			}
+		})
+	}
+}
+
+func TestLiveStartupFailureNeverOpensMicrophone(t *testing.T) {
+	wire := newTestLiveWire()
+	wire.push(map[string]any{"type": "error", "error": map[string]any{"message": "invalid key test-secret"}})
+	_, err := startVoice(context.Background(), "test-secret", func(context.Context, string) (liveWire, error) { return wire, nil }, func() (VoiceAudio, error) { t.Fatal("microphone opened before session accepted"); return nil, nil })
+	if err == nil || strings.Contains(err.Error(), "test-secret") {
+		t.Fatalf("unexpected startup error: %v", err)
+	}
+	select {
+	case <-wire.done:
+	default:
+		t.Fatal("failed startup left connection open")
+	}
+}
+
+func TestLiveContextCancellationUnblocksAppendAndAudio(t *testing.T) {
+	wire, audio := newTestLiveWire(), newTestLiveAudio()
+	wire.autoAck = false
+	s := startTestLive(t, wire, audio)
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() { result <- s.SendContext(ctx, "quiet context") }()
+	awaitLiveSent(t, wire, "session.thinking.append")
+	cancel()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected canceled append, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("append ignored cancellation")
+	}
+	s.cancel()
+	select {
+	case <-s.done:
+	case <-time.After(time.Second):
+		t.Fatal("session cancellation did not release workers")
+	}
+}
+
+func TestLiveCloseAcknowledgedAndBounded(t *testing.T) {
+	for _, ack := range []bool{true, false} {
+		wire, audio := newTestLiveWire(), newTestLiveAudio()
+		wire.autoClose = ack
+		s := startTestLive(t, wire, audio)
+		s.closeWait = 30 * time.Millisecond
+		closed := make(chan error, 1)
+		go func() { closed <- s.Close() }()
+		awaitLiveSent(t, wire, "session.close")
+		select {
+		case err := <-closed:
+			if err != nil {
+				t.Fatal(err)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("Close hung (ack=%t)", ack)
+		}
+		select {
+		case <-audio.done:
+		default:
+			t.Fatal("Close left microphone open")
+		}
+	}
+}
+
+func TestLiveTranscriptReconcilesDelayedFragmentsAndCorrections(t *testing.T) {
+	var transcript liveTranscript
+	now := time.Now()
+	transcript.add("p1", "user", "Deploy ", 100, 200, now)
+	transcript.delegate("first", 500, now)
+	if _, ready := transcript.ready(now.Add(200*time.Millisecond), 300*time.Millisecond); ready {
+		t.Fatal("executed raw fragment before reconciliation")
+	}
+	transcript.add("p2", "user", "the project.", 200, 400, now.Add(250*time.Millisecond))
+	if transcript.add("p2", "user", "the project.", 200, 400, now) {
+		t.Fatal("duplicate transcript event was added")
+	}
+	if _, ready := transcript.ready(now.Add(400*time.Millisecond), 300*time.Millisecond); ready {
+		t.Fatal("did not allow delayed final fragment to settle")
+	}
+	event, ready := transcript.ready(now.Add(600*time.Millisecond), 300*time.Millisecond)
+	if !ready || event.DelegationID != "first" || !strings.Contains(event.Text, "the project.") {
+		t.Fatalf("missing complete delegated request: %#v", event)
+	}
+	if transcript.delegate("first", 500, now.Add(time.Second)) {
+		t.Fatal("duplicate delegation accepted")
+	}
+	// A fragment arriving after its request completed must not cause a fresh
+	// delegation to repeat that earlier action.
+	transcript.add("late", "user", " please", 400, 450, now.Add(time.Second))
+	transcript.delegate("duplicate-task", 600, now.Add(time.Second))
+	if _, ready := transcript.ready(now.Add(4*time.Second), 300*time.Millisecond); ready {
+		t.Fatal("re-executed already delivered speech")
+	}
+	transcript.add("p3", "user", "Actually cancel deployment.", 700, 900, now.Add(5*time.Second))
+	transcript.delegate("correction", 1000, now.Add(5*time.Second))
+	event, ready = transcript.ready(now.Add(6*time.Second), 300*time.Millisecond)
+	if !ready || event.DelegationID != "correction" {
+		t.Fatal("fresh correction was lost")
+	}
+	latest := strings.Split(event.Prompt, "Latest user request/correction")[1]
+	if !strings.Contains(latest, "Actually cancel") || strings.Contains(latest, "Deploy ") || strings.Contains(latest, "please") {
+		t.Fatalf("latest request includes already handled utterance: %s", latest)
+	}
+}
+
+func TestLiveTranscriptOnlyDelegationsTriggerActions(t *testing.T) {
+	var transcript liveTranscript
+	now := time.Now()
+	transcript.add("part", "user", "Read the project", 100, 200, now)
+	if _, ready := transcript.ready(now.Add(time.Hour), 0); ready {
+		t.Fatal("transcript alone triggered an action")
+	}
+	transcript.delegate("old", 300, now)
+	transcript.add("correction", "user", "No, just list files", 400, 500, now)
+	transcript.delegate("new", 600, now)
+	event, ready := transcript.ready(now.Add(time.Second), 0)
+	if !ready || event.DelegationID != "new" {
+		t.Fatalf("latest pending delegation did not supersede old: %#v", event)
+	}
+}
+
+func TestLiveBriefBoundedUTF8(t *testing.T) {
+	for _, text := range []string{strings.Repeat("界", 1000), strings.Repeat("a", 1000)} {
+		brief := liveBrief(text, 440)
+		if !utf8.ValidString(brief) || len(brief) > 440 || !strings.Contains(brief, "Details are in the terminal") {
+			t.Fatalf("unsafe append: %q", brief)
+		}
+	}
+}
+
+func TestLiveParentCancellationClosesSessionBeforeSocket(t *testing.T) {
+	wire, audio := newTestLiveWire(), newTestLiveAudio()
+	wire.push(map[string]any{"type": "session.started"})
+	ctx, cancel := context.WithCancel(context.Background())
+	session, err := startVoice(ctx, "test-secret", func(context.Context, string) (liveWire, error) { return wire, nil }, func() (VoiceAudio, error) { return audio, nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { cancel(); _ = session.Close() })
+	cancel()
+	awaitLiveSent(t, wire, "session.close")
+	select {
+	case <-audio.done:
+	default:
+		t.Fatal("session.close sent before microphone stopped")
+	}
+	select {
+	case <-session.(*liveSession).done:
+	case <-time.After(time.Second):
+		t.Fatal("parent cancellation failed to finish acknowledged close")
+	}
+}
+
+func TestLiveCanceledStartupAndAudioFailureCloseSocket(t *testing.T) {
+	t.Run("canceled_handshake", func(t *testing.T) {
+		wire := newTestLiveWire()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		result := make(chan error, 1)
+		go func() {
+			_, err := startVoice(ctx, "test-secret", func(context.Context, string) (liveWire, error) { return wire, nil }, func() (VoiceAudio, error) { return nil, errors.New("unexpected audio open") })
+			result <- err
+		}()
+		awaitLiveSent(t, wire, "session.start")
+		cancel()
+		select {
+		case err := <-result:
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("got %v instead of canceled handshake", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("startup ignored cancellation")
+		}
+	})
+	t.Run("audio_open", func(t *testing.T) {
+		wire := newTestLiveWire()
+		wire.push(map[string]any{"type": "session.started"})
+		_, err := startVoice(context.Background(), "test-secret", func(context.Context, string) (liveWire, error) { return wire, nil }, func() (VoiceAudio, error) { return nil, errors.New("no microphone") })
+		if err == nil || !strings.Contains(err.Error(), "no microphone") {
+			t.Fatalf("unexpected audio failure: %v", err)
+		}
+		select {
+		case <-wire.done:
+		default:
+			t.Fatal("failed audio open leaked live socket")
+		}
+	})
+}
+
+func TestLiveCorrectionDropsStaleAndDuplicateReplies(t *testing.T) {
+	wire, audio := newTestLiveWire(), newTestLiveAudio()
+	s := startTestLive(t, wire, audio)
+	wire.push(map[string]any{"type": "session.input_transcript.delta", "event_id": "first-speech", "delta": "Deploy.", "start_ms": 100, "end_ms": 200})
+	wire.push(map[string]any{"type": "session.delegation.created", "offset_ms": 300, "delegation": map[string]any{"id": "first", "type": "delegation", "target": "client"}})
+	awaitLiveEvent(t, s, "delegation")
+	wire.push(map[string]any{"type": "session.input_transcript.delta", "event_id": "second-speech", "delta": "Actually cancel.", "start_ms": 400, "end_ms": 500})
+	wire.push(map[string]any{"type": "session.delegation.created", "offset_ms": 600, "delegation": map[string]any{"id": "second", "type": "delegation", "target": "client"}})
+	// The acknowledgment follows the correction on the receive queue, so the
+	// old final result must already be invalid while new speech is settling.
+	if err := s.SendContext(context.Background(), "The terminal is active."); err != nil {
+		t.Fatal(err)
+	}
+	awaitLiveSent(t, wire, "session.thinking.append")
+	if err := s.Reply(context.Background(), "first", "Obsolete result"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case event := <-wire.out:
+		t.Fatalf("stale result reached voice: %#v", event)
+	default:
+	}
+	awaitLiveEvent(t, s, "delegation")
+	if err := s.Reply(context.Background(), "second", "Canceled."); err != nil {
+		t.Fatal(err)
+	}
+	awaitLiveSent(t, wire, "session.commentary.append")
+	if err := s.Reply(context.Background(), "second", "Canceled."); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case event := <-wire.out:
+		t.Fatalf("duplicate final result reached voice: %#v", event)
+	default:
+	}
+}
+
+func TestLiveWebSocketProtocolWithLocalServer(t *testing.T) {
+	serverEvents := make(chan map[string]any, 16)
+	serverErrors := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/live/sessions" || r.URL.RawQuery != "" || r.Header.Get("Authorization") != "Bearer test-secret" {
+			http.Error(w, "invalid test handshake", http.StatusBadRequest)
+			return
+		}
+		websocket.Handler(func(conn *websocket.Conn) {
+			defer conn.Close()
+			_ = conn.SetDeadline(time.Now().Add(3 * time.Second))
+			for {
+				var event map[string]any
+				if err := websocket.JSON.Receive(conn, &event); err != nil {
+					serverErrors <- err
+					return
+				}
+				serverEvents <- event
+				switch event["type"] {
+				case "session.start":
+					_ = websocket.JSON.Send(conn, map[string]any{"type": "session.started"})
+				case "session.input_audio.append":
+					_ = websocket.JSON.Send(conn, map[string]any{"type": "session.delegation.created", "offset_ms": 500, "delegation": map[string]any{"id": "live-opaque", "type": "delegation", "target": "client"}})
+					_ = websocket.JSON.Send(conn, map[string]any{"type": "session.input_transcript.delta", "event_id": "late-transcript", "start_ms": 100, "end_ms": 400, "delta": "List the devices."})
+				case "session.commentary.append":
+					_ = websocket.JSON.Send(conn, map[string]any{"type": "session.commentary.appended", "client_event_id": event["event_id"]})
+				case "session.close":
+					_ = websocket.JSON.Send(conn, map[string]any{"type": "session.closed"})
+					return
+				}
+			}
+		}).ServeHTTP(w, r)
+	}))
+	defer server.Close()
+	audio := newTestLiveAudio()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	session, err := startVoice(ctx, "test-secret", func(ctx context.Context, key string) (liveWire, error) {
+		config, err := websocket.NewConfig("ws"+strings.TrimPrefix(server.URL, "http")+"/v1/live/sessions", server.URL)
+		if err != nil {
+			return nil, err
+		}
+		config.Header.Set("Authorization", "Bearer "+key)
+		conn, err := config.DialContext(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return &liveSocket{conn: conn, gate: make(chan struct{}, 1)}, nil
+	}, func() (VoiceAudio, error) { return audio, nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+	audio.input <- []byte{1, 0, 2, 0}
+	event := awaitLiveEvent(t, session, "delegation")
+	if event.Text != "List the devices." || !strings.Contains(event.Prompt, "start_ms") {
+		t.Fatalf("unexpected reconciled delegation: %#v", event)
+	}
+	if err := session.Reply(ctx, event.DelegationID, "Two devices are available."); err != nil {
+		t.Fatal(err)
+	}
+	if err := session.Close(); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"session.start", "session.input_audio.append", "session.commentary.append", "session.close"} {
+		select {
+		case event := <-serverEvents:
+			if event["type"] != want {
+				t.Fatalf("expected %s, got %#v", want, event)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("server did not receive %s", want)
+		}
+	}
+	select {
+	case err := <-serverErrors:
+		t.Fatalf("server protocol failed: %v", err)
+	default:
+	}
+}
+
+func TestLiveQuietContextPreservesLatestConversationInBoundedChunks(t *testing.T) {
+	wire, audio := newTestLiveWire(), newTestLiveAudio()
+	s := startTestLive(t, wire, audio)
+	awaitLiveSent(t, wire, "session.start")
+	contextText := "Workspace: /test/project. Terminal approval remains required.\n" + strings.Repeat("Earlier discussion about the device 界.\n", 600) + "\nLatest request: inspect the blue Jetson."
+	if err := s.SendContext(context.Background(), contextText); err != nil {
+		t.Fatal(err)
+	}
+	var contents []string
+	var bytes int
+	for {
+		select {
+		case event := <-wire.out:
+			content, _ := event["content"].(string)
+			if event["type"] != "session.thinking.append" || event["delegation_id"] != nil || len(content) > 440 || !utf8.ValidString(content) {
+				t.Fatalf("invalid quiet context append: %#v", event)
+			}
+			if strings.Contains(content, "Details are in the terminal") {
+				t.Fatal("quiet context was truncated as if it were a spoken result")
+			}
+			contents = append(contents, content)
+			bytes += len(content)
+		default:
+			combined := strings.Join(contents, "\n")
+			if len(contents) < 2 || bytes > 8*1024 || !strings.Contains(combined, "Workspace: /test/project") || !strings.Contains(combined, "Latest request: inspect the blue Jetson.") {
+				t.Fatalf("context lost workspace/latest request or exceeded bound: chunks=%d bytes=%d", len(contents), bytes)
+			}
+			return
+		}
+	}
+}
+
+func TestLiveQuietContextStopsChunksOnCancellationOrRejection(t *testing.T) {
+	for _, rejection := range []bool{false, true} {
+		wire, audio := newTestLiveWire(), newTestLiveAudio()
+		wire.autoAck = false
+		s := startTestLive(t, wire, audio)
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan error, 1)
+		go func() { done <- s.SendContext(ctx, strings.Repeat("Long quiet context. ", 200)) }()
+		first := awaitLiveSent(t, wire, "session.thinking.append")
+		if rejection {
+			wire.push(map[string]any{"type": "error", "error": map[string]any{"message": "Context rejected", "client_event_id": first["event_id"]}})
+		} else {
+			cancel()
+		}
+		select {
+		case err := <-done:
+			if err == nil {
+				t.Fatal("canceled/rejected context succeeded")
+			}
+		case <-time.After(time.Second):
+			t.Fatal("context ignored cancellation/rejection")
+		}
+		cancel()
+		select {
+		case event := <-wire.out:
+			t.Fatalf("sent another chunk after cancellation/rejection: %#v", event)
+		default:
+		}
+	}
+}
+
+func TestLiveOnlyAcceptedFreshCommentaryResumesInterruptedPlayback(t *testing.T) {
+	for _, mode := range []string{"accepted", "canceled", "rejected", "newer_interrupt", "newer_delegation"} {
+		t.Run(mode, func(t *testing.T) {
+			wire, audio := newTestLiveWire(), newTestLiveAudio()
+			wire.autoAck = false
+			s := startTestLive(t, wire, audio)
+			interrupt := func() {
+				t.Helper()
+				done := make(chan error, 1)
+				go func() { done <- s.Interrupt(context.Background()) }()
+				event := awaitLiveSent(t, wire, "session.instructions.append")
+				wire.push(map[string]any{"type": "session.instructions.appended", "client_event_id": event["event_id"]})
+				if err := <-done; err != nil {
+					t.Fatal(err)
+				}
+			}
+			interrupt()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			done := make(chan error, 1)
+			go func() { done <- s.Reply(ctx, "", "Please approve the new action in the terminal.") }()
+			event := awaitLiveSent(t, wire, "session.commentary.append")
+			s.mu.Lock()
+			beforeACK := s.interrupted
+			s.mu.Unlock()
+			if !beforeACK {
+				t.Fatal("commentary reopened playback before acceptance")
+			}
+			switch mode {
+			case "canceled":
+				cancel()
+			case "rejected":
+				wire.push(map[string]any{"type": "error", "error": map[string]any{"message": "Rejected commentary", "client_event_id": event["event_id"]}})
+			case "newer_interrupt":
+				interrupt()
+			case "newer_delegation":
+				wire.push(map[string]any{"type": "session.delegation.created", "offset_ms": 500, "delegation": map[string]any{"id": "new-task", "type": "delegation", "target": "client"}})
+			}
+			if mode != "rejected" {
+				wire.push(map[string]any{"type": "session.commentary.appended", "client_event_id": event["event_id"]})
+			}
+			select {
+			case err := <-done:
+				if (mode == "canceled" || mode == "rejected") != (err != nil) {
+					t.Fatalf("unexpected reply result: %v", err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("commentary did not complete")
+			}
+			s.mu.Lock()
+			muted := s.interrupted
+			s.mu.Unlock()
+			if muted != (mode != "accepted") {
+				t.Fatalf("wrong playback state after %s commentary: muted=%t", mode, muted)
+			}
+			if mode == "accepted" {
+				wire.push(map[string]any{"type": "session.output_audio.delta", "delta": "AQACAA=="})
+				select {
+				case <-audio.writes:
+				case <-time.After(time.Second):
+					t.Fatal("fresh speech was discarded after accepted commentary")
+				}
+			}
+		})
+	}
+}

--- a/go/internal/cli/chat/voice_setup.go
+++ b/go/internal/cli/chat/voice_setup.go
@@ -1,0 +1,83 @@
+package chat
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// VoiceKey resolves credentials independently of the reasoning model. A local
+// or custom backend credential must never be forwarded to OpenAI for voice.
+func VoiceKey(backend Config) string {
+	path, err := voiceSettingsPath()
+	if err != nil {
+		return resolveVoiceKey(backend, Config{})
+	}
+	saved, _ := loadSettings(path)
+	return resolveVoiceKey(backend, saved)
+}
+
+func resolveVoiceKey(backend, saved Config) string {
+	key := firstValue(os.Getenv("WENDY_VOICE_API_KEY"), os.Getenv("OPENAI_API_KEY"))
+	if RequiredAPIKeyEnv(saved) == "OPENAI_API_KEY" {
+		key = firstValue(key, saved.APIKey)
+	}
+	if RequiredAPIKeyEnv(backend) == "OPENAI_API_KEY" {
+		key = firstValue(key, backend.APIKey)
+	}
+	return key
+}
+
+func voiceSettingsPath() (string, error) {
+	path, err := settingsPath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(filepath.Dir(path), "voice.json"), nil
+}
+
+// SetupVoice opens private credential entry outside the full-screen chat. Voice
+// credentials are saved separately so local backend settings remain intact.
+func SetupVoice(ctx context.Context, backend Config, input io.Reader, output io.Writer) (string, error) {
+	path, err := voiceSettingsPath()
+	if err != nil {
+		return "", err
+	}
+	return setupVoice(ctx, VoiceKey(backend), &terminalSetupUI{input: input, output: output}, func(key string) error {
+		return saveSettings(path, Config{Provider: "openai", BaseURL: defaultBaseURL("openai"), Model: "gpt-live-1", APIKey: key})
+	})
+}
+
+func setupVoice(ctx context.Context, existing string, ui setupUI, save func(string) error) (string, error) {
+	ui.Note("Voice uses your computer's microphone with OpenAI GPT Live. Your selected AI still handles reasoning and Wendy tools. Audio and brief task context go to OpenAI; API usage is billed separately.")
+	if existing != "" {
+		choice, err := ui.Choose(ctx, "OpenAI voice connection", "Keep the configured OpenAI key or enter a replacement privately.", []setupChoice{
+			{"keep-key", "Keep current key", "Use the configured key for voice."},
+			{"replace-key", "Enter a different API key", "Save a separate key for voice."},
+		})
+		if err != nil {
+			return "", err
+		}
+		if choice == "keep-key" {
+			return existing, nil
+		}
+	}
+	for {
+		key, err := ui.Text(ctx, "Connect GPT Live", "Create an OpenAI API key at https://platform.openai.com/api-keys, then paste it here.\nThe key is hidden and saved privately for voice. Your chat model stays the same.", "", true)
+		if err != nil {
+			return "", err
+		}
+		key = strings.TrimSpace(key)
+		if key == "" || strings.ContainsAny(key, "\r\n") {
+			ui.Note("Paste one API key to connect, or press Esc to keep using text chat.")
+			continue
+		}
+		if err := save(key); err != nil {
+			return "", fmt.Errorf("save voice connection: %w", err)
+		}
+		return key, nil
+	}
+}

--- a/go/internal/cli/chat/voice_setup_test.go
+++ b/go/internal/cli/chat/voice_setup_test.go
@@ -1,0 +1,61 @@
+package chat
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
+)
+
+func TestVoiceKeyIsIndependentOfLocalCredentials(t *testing.T) {
+	clearProviderEnv(t)
+	t.Setenv("WENDY_VOICE_API_KEY", "")
+	t.Setenv("WENDY_CHAT_API_KEY", "custom-server-key")
+	local := Config{Provider: "local", BaseURL: "http://localhost:1234/v1", APIKey: "local-only-key"}
+	if got := resolveVoiceKey(local, Config{}); got != "" {
+		t.Fatal("local credential must not be used for OpenAI voice")
+	}
+	cloud := Config{Provider: "openai", BaseURL: defaultBaseURL("openai"), APIKey: "backend-key"}
+	if got := resolveVoiceKey(cloud, Config{}); got != "backend-key" {
+		t.Fatal("official OpenAI backend credential should be reusable")
+	}
+	saved := Config{Provider: "openai", BaseURL: defaultBaseURL("openai"), APIKey: "saved-voice-key"}
+	if got := resolveVoiceKey(cloud, saved); got != "saved-voice-key" {
+		t.Fatal("a separately chosen voice key should override the backend key")
+	}
+	t.Setenv("OPENAI_API_KEY", "openai-env-key")
+	if got := resolveVoiceKey(local, saved); got != "openai-env-key" {
+		t.Fatal("OpenAI environment should override saved voice credentials")
+	}
+	t.Setenv("WENDY_VOICE_API_KEY", "voice-env-key")
+	if got := resolveVoiceKey(local, saved); got != "voice-env-key" {
+		t.Fatal("voice-specific environment should take precedence")
+	}
+}
+
+func TestVoiceSetupPrivateKeyAndEnvironmentReuse(t *testing.T) {
+	u := &scriptedSetupUI{t: t, texts: []string{"", "fake-test-voice-key"}}
+	var saved string
+	key, err := setupVoice(context.Background(), "", u, func(key string) error { saved = key; return nil })
+	if err != nil || key != "fake-test-voice-key" || saved != key || u.secretInputs != 2 {
+		t.Fatalf("private setup failed: err=%v, secret prompts=%d", err, u.secretInputs)
+	}
+	if strings.Contains(strings.Join(u.notes, "\n"), key) {
+		t.Fatal("voice key leaked into setup notes")
+	}
+	for _, choice := range []string{"keep-key", "cancel"} {
+		u := &scriptedSetupUI{t: t, choices: []string{choice}}
+		_, err := setupVoice(context.Background(), "fake-env-key", u, func(string) error {
+			t.Fatal("keeping an environment key or canceling must not save it")
+			return nil
+		})
+		if choice == "cancel" && !errors.Is(err, tui.ErrCancelled) {
+			t.Fatalf("cancel returned %v", err)
+		}
+		if choice == "keep-key" && err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/go/internal/cli/commands/chat.go
+++ b/go/internal/cli/commands/chat.go
@@ -16,7 +16,7 @@ import (
 func newChatCmd() *cobra.Command {
 	var cfg chat.Config
 	var directory string
-	var autoApprove, setup, helpAll bool
+	var autoApprove, setup, helpAll, voice bool
 	var preferredDevice string
 	cmd := &cobra.Command{
 		Use:   "chat [prompt...]",
@@ -55,6 +55,16 @@ Use --setup whenever you want to change your AI or model.`,
 			if err != nil {
 				return err
 			}
+			voiceKey := chat.VoiceKey(resolved)
+			voiceSupportError := chat.VoiceSupportError()
+			if voice && voiceKey == "" && voiceSupportError == nil {
+				voiceKey, err = chat.SetupVoice(cmd.Context(), resolved, cmd.InOrStdin(), cmd.OutOrStdout())
+				if errors.Is(err, tui.ErrCancelled) {
+					voice = false
+				} else if err != nil {
+					return err
+				}
+			}
 			executable, err := os.Executable()
 			if err != nil {
 				return fmt.Errorf("locating Wendy executable: %w", err)
@@ -77,13 +87,34 @@ Use --setup whenever you want to change your AI or model.`,
 					}
 					engine = chat.NewEngine(provider, toolset, chat.SystemPrompt(workspace, preferredDevice))
 				}
+				var voiceFactory func(context.Context) (chat.VoiceSession, error)
+				if voiceSupportError != nil {
+					voiceFactory = func(context.Context) (chat.VoiceSession, error) { return nil, voiceSupportError }
+				} else if voiceKey != "" {
+					key := voiceKey
+					voiceFactory = func(ctx context.Context) (chat.VoiceSession, error) { return chat.StartVoice(ctx, key) }
+				}
 				err = chat.Run(ctx, chat.UIOptions{
 					Engine: engine, Provider: resolved.Provider, Model: resolved.Model,
 					State:     state,
 					Workspace: workspace, Device: preferredDevice,
 					InitialPrompt: initialPrompt, AutoApprove: autoApprove,
+					Voice: voice, VoiceFactory: voiceFactory,
 					Input: cmd.InOrStdin(), Output: cmd.OutOrStdout(),
 				})
+				initialPrompt = ""
+				voice = state.Voice
+				if errors.Is(err, chat.ErrVoiceSetup) {
+					key, setupErr := chat.SetupVoice(ctx, resolved, cmd.InOrStdin(), cmd.OutOrStdout())
+					if errors.Is(setupErr, tui.ErrCancelled) {
+						continue
+					}
+					if setupErr != nil {
+						return setupErr
+					}
+					voiceKey, voice = key, true
+					continue
+				}
 				if !errors.Is(err, chat.ErrReconfigure) {
 					return err
 				}
@@ -104,6 +135,7 @@ Use --setup whenever you want to change your AI or model.`,
 		},
 	}
 	cmd.Flags().BoolVar(&setup, "setup", false, "Choose or change your AI and model")
+	cmd.Flags().BoolVar(&voice, "voice", false, "Listen and speak with GPT Live (or use /voice in chat)")
 	cmd.Flags().BoolVar(&helpAll, "help-all", false, "Show advanced connection options")
 	cmd.Flags().StringVarP(&preferredDevice, "device", "d", "", "Preferred Wendy device (you can also choose while chatting)")
 	cmd.Flags().StringVar(&cfg.Provider, "provider", "", "Model API: openai, anthropic, ollama, or local (WENDY_CHAT_PROVIDER)")

--- a/go/internal/cli/commands/chat_test.go
+++ b/go/internal/cli/commands/chat_test.go
@@ -20,7 +20,7 @@ func TestChatVisibleWithLocalModelHelp(t *testing.T) {
 	if err := root.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"Just run wendy chat", "--setup", "--help-all", "--directory", "--device"} {
+	for _, want := range []string{"Just run wendy chat", "--setup", "--help-all", "--directory", "--device", "--voice", "/voice"} {
 		if !strings.Contains(buf.String(), want) {
 			t.Errorf("chat help missing %q", want)
 		}

--- a/go/scripts/licenses.csv
+++ b/go/scripts/licenses.csv
@@ -26,6 +26,7 @@ github.com/containerd/typeurl/v2,https://github.com/containerd/typeurl/blob/v2.2
 github.com/creack/goselect,https://github.com/creack/goselect/blob/v0.1.3/LICENSE,MIT
 github.com/distribution/reference,https://github.com/distribution/reference/blob/v0.6.0/LICENSE,Apache-2.0
 github.com/felixge/httpsnoop,https://github.com/felixge/httpsnoop/blob/v1.0.4/LICENSE.txt,MIT
+github.com/gen2brain/malgo,https://github.com/gen2brain/malgo/blob/v0.11.26/LICENSE,Unlicense
 github.com/go-logr/logr,https://github.com/go-logr/logr/blob/v1.4.3/LICENSE,Apache-2.0
 github.com/go-logr/stdr,https://github.com/go-logr/stdr/blob/v1.2.2/LICENSE,Apache-2.0
 github.com/goccy/go-json,https://github.com/goccy/go-json/blob/v0.10.6/LICENSE,MIT


### PR DESCRIPTION
This voice implementation is now included in #1959 after the chat branch was updated. Follow ongoing fixes and validation there.

Adds `wendy chat --voice` and `/voice` so users can speak tasks while the selected chat model does the reasoning and operates Wendy tools. GPT Live provides continuous listening and brief spoken results; it stays quiet during tool execution. The reasoning model can still run locally.

- Connect to the GPT Live primary WebSocket API with client delegation, PCM microphone/speaker audio, transcript captions, and interruption. Delegate through the existing serial agent loop and suppress stale results when a request changes.
- Keep file, command, and device approvals in the terminal. Spoken agreement does not authorize tools. `/voice off` releases the microphone and connection while ongoing work continues in text; voice failures also fall back to text.
- Guide users through masked key entry when needed, reuse an official OpenAI key when available, and support `/voice setup` and a separate private voice configuration. Local/custom backend credentials are never sent to OpenAI for voice.
- Support native audio on macOS, Linux, and Windows through miniaudio. Builds without cgo retain text chat and show an actionable message when voice is requested.

This is a follow-up to #1959 and targets `jo/chat`. It inherits that PR's camera perception, compact tool display, and terminal resize fixes. Voice can delegate camera inspection to a vision-capable reasoning model; GPT Live receives the resulting brief text context.

Validation:

- Chat race tests, command/MCP tests, and vet.
- Full native `make`, plus Linux/Windows cross-compilation with cgo disabled.
- Fake Live WebSocket tests for session setup, PCM transport, delegation ordering, context, acknowledgement, interruption, cancellation, and cleanup.
- TUI tests for voice toggles, corrections, quiet final replies, keyboard approvals, setup cancellation, and text fallback.
- Real terminal smoke checks with a local mock model, Wendy MCP status, allowed/denied workspace writes, and repeated terminal resizing.

The Live WebSocket upgrade and exact session.start/session.close exchange were subsequently verified against OpenAI without opening a microphone or sending audio. No physical microphone/speaker test was performed. Voice sends audio and brief task context to OpenAI even with a local reasoning model, and requires separately billed API access. Headphones are recommended because this implementation does not add acoustic echo cancellation. Current Windows release builds disable cgo, so they retain text chat until built with native audio support.
