### PR TITLE
Fix delayed voice requests and interruption in Wendy chat

### DIFF
--- a/go/internal/cli/assets/docs/guides/chat.mdx
+++ b/go/internal/cli/assets/docs/guides/chat.mdx
@@ -112,7 +112,9 @@ Use headphones to avoid microphone feedback. The terminal shows when voice is
 on. `/voice off` closes the microphone, playback, and Live connection while
 ongoing agent work continues in text. Escape
 cancels active work and interrupts speech; cancellation cannot undo completed
-tool actions. If voice fails, the text conversation remains available.
+tool actions. Escape also discards an answer waiting to be spoken after the
+agent finishes, while keeping the answer in the transcript and voice listening
+for your next request. If voice fails, the text conversation remains available.
 
 Native audio requires a CLI built with cgo on macOS, Linux, or Windows and
 permission to use the microphone. Builds without cgo still support text chat

--- a/go/internal/cli/chat/tui.go
+++ b/go/internal/cli/chat/tui.go
@@ -340,7 +340,7 @@ func (m *chatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.String() == "enter" {
 			prompt := m.composer.Value()
 			control := strings.TrimSpace(prompt)
-			if m.active && !(strings.HasPrefix(control, "/voice") || control == "/setup" || control == "/quit" || control == "/help" || control == "/tools") {
+			if m.active && !(control == "/voice" || control == "/voice on" || control == "/voice off" || control == "/voice setup" || control == "/setup" || control == "/quit" || control == "/help" || control == "/tools") {
 				return m, nil
 			}
 			m.composer.Reset()
@@ -703,6 +703,11 @@ func (m *chatModel) voiceActionFor(actionCtx context.Context, action func(contex
 
 func (m *chatModel) interruptVoice() {
 	m.voiceInputCaption, m.voiceInputPending, m.voiceOutputCaption = -1, -1, -1
+	// A completed turn can still have speech queued behind context updates.
+	// Escape must invalidate that reply even when the engine is already idle.
+	if m.turnSpeechCancel != nil {
+		m.turnSpeechCancel()
+	}
 	// Playback interruption must not wait behind queued context or speech.
 	m.voiceActionTail = nil
 	m.voiceAction(func(ctx context.Context, session VoiceSession) error { return session.Interrupt(ctx) })

--- a/go/internal/cli/chat/tui_voice_test.go
+++ b/go/internal/cli/chat/tui_voice_test.go
@@ -259,6 +259,41 @@ func TestUIVoiceTypedMessagesRemainUsableAndContextOnly(t *testing.T) {
 	}
 }
 
+func TestUIVoiceUnknownCommandPreservesActiveTurn(t *testing.T) {
+	started, canceled := make(chan struct{}), make(chan struct{})
+	provider := uiProviderFunc(func(ctx context.Context, messages []Message, tools []Tool, emit func(string)) (Message, error) {
+		close(started)
+		<-ctx.Done()
+		close(canceled)
+		return Message{}, ctx.Err()
+	})
+	m := uiModel(t, provider, &uiExecutor{}, false)
+	session := uiConnectVoice(t, m)
+	m.submit("Inspect my device")
+	select {
+	case <-started:
+	case <-time.After(3 * time.Second):
+		t.Fatal("backend turn did not start")
+	}
+	events, turnID := m.events, m.turnID
+	m.composer.SetValue("/voice status")
+	m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !m.active || m.canceling || m.events != events || m.turnID != turnID {
+		t.Fatal("an unknown voice command replaced the running task")
+	}
+	if m.composer.Value() != "/voice status" {
+		t.Fatal("the unsubmitted command should remain editable")
+	}
+	m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	uiDrainTurn(t, m)
+	select {
+	case <-canceled:
+	default:
+		t.Fatal("Escape lost access to the original task's cancellation")
+	}
+	uiVoiceStopAndWait(t, m, session)
+}
+
 func TestUIVoiceFailureFallsBackToTextAndClosesSession(t *testing.T) {
 	m := uiModel(t, nil, &uiExecutor{}, false)
 	session := uiConnectVoice(t, m)
@@ -413,6 +448,46 @@ func TestUIVoiceQueuedResultIsDiscardedWhenAnotherDelegationArrives(t *testing.T
 	if len(session.replies) != 0 {
 		t.Fatal("old queued result was spoken after the corrected task")
 	}
+}
+
+func TestUIVoiceIdleEscapeDiscardsQueuedResult(t *testing.T) {
+	provider := uiProviderFunc(func(context.Context, []Message, []Tool, func(string)) (Message, error) {
+		return Message{Content: "A result waiting to be spoken."}, nil
+	})
+	m := uiModel(t, provider, &uiExecutor{}, false)
+	session := newUIVoiceSession()
+	gate := make(chan struct{})
+	session.contextGate = gate
+	m.opts.VoiceFactory = func(context.Context) (VoiceSession, error) { return session, nil }
+	m.startVoice()
+	m.Update(uiNextVoiceEvent(t, m))
+	uiSendVoice(t, m, session, VoiceEvent{Type: "ready"})
+	uiSendVoice(t, m, session, VoiceEvent{Type: "delegation", DelegationID: "task", Text: "check my device"})
+	uiDrainTurn(t, m)
+	if m.active {
+		t.Fatal("the backend should have finished before Escape")
+	}
+	queuedReply := m.voiceActionTail
+	m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	interrupt := m.voiceActionTail
+	close(gate)
+	for _, done := range []<-chan struct{}{queuedReply, interrupt} {
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			t.Fatal("queued speech or interruption failed to finish")
+		}
+	}
+	if session.interrupts.Load() != 1 || !m.voiceEnabled || m.quitting {
+		t.Fatal("idle Escape should interrupt playback and keep voice available")
+	}
+	if len(session.replies) != 0 {
+		t.Fatal("a completed task's queued result was spoken after idle Escape")
+	}
+	if !strings.Contains(ansi.Strip(m.View()), "A result waiting to be spoken.") {
+		t.Fatal("interrupting queued speech should preserve the visible result")
+	}
+	uiVoiceStopAndWait(t, m, session)
 }
 
 func TestUIVoiceBackendContextIsNotDisplayedAsUserSpeech(t *testing.T) {

--- a/go/internal/cli/chat/voice_audio.go
+++ b/go/internal/cli/chat/voice_audio.go
@@ -29,6 +29,13 @@ type VoiceAudio interface {
 	Close() error
 }
 
+// voicePlaybackWriter lets the live session reject a stale packet even when an
+// interruption occurs just before Write begins. stillCurrent must not block;
+// it is checked while holding the native playback queue mutex.
+type voicePlaybackWriter interface {
+	writePlayback(p []byte, stillCurrent func() bool) (int, error)
+}
+
 type voiceAudioDevice interface {
 	Start() error
 	Close() error
@@ -102,6 +109,10 @@ func (a *bufferedVoiceAudio) Read(p []byte) (int, error) {
 }
 
 func (a *bufferedVoiceAudio) Write(p []byte) (int, error) {
+	return a.writePlayback(p, nil)
+}
+
+func (a *bufferedVoiceAudio) writePlayback(p []byte, stillCurrent func() bool) (int, error) {
 	if len(p) == 0 {
 		return 0, nil
 	}
@@ -122,7 +133,7 @@ func (a *bufferedVoiceAudio) Write(p []byte) (int, error) {
 		if a.closed {
 			return written, io.ErrClosedPipe
 		}
-		if generation != a.playbackGeneration {
+		if generation != a.playbackGeneration || (stillCurrent != nil && !stillCurrent()) {
 			return written, ErrVoicePlaybackInterrupted
 		}
 		if a.playback.size == len(a.playback.data) {

--- a/go/internal/cli/chat/voice_audio_test.go
+++ b/go/internal/cli/chat/voice_audio_test.go
@@ -172,6 +172,71 @@ func TestVoiceAudioFlushCancelsPendingPlayback(t *testing.T) {
 	})
 }
 
+func TestVoiceAudioGuardRejectsPacketStartedAfterFlush(t *testing.T) {
+	a := newBufferedVoiceAudio()
+	defer a.Close()
+	var sessionGeneration atomic.Uint64
+	packetGeneration := sessionGeneration.Load()
+	stillCurrent := func() bool { return packetGeneration == sessionGeneration.Load() }
+	// The session already selected this packet. An interruption wins before
+	// the native writer begins and snapshots its own playback generation.
+	sessionGeneration.Add(1)
+	if err := a.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	if n, err := a.writePlayback([]byte{1, 2}, stillCurrent); n != 0 || !errors.Is(err, ErrVoicePlaybackInterrupted) {
+		t.Fatalf("late stale packet reached playback: bytes=%d, error=%v", n, err)
+	}
+	output := []byte{0xff, 0xff}
+	a.samples(output, nil)
+	if !bytes.Equal(output, []byte{0, 0}) {
+		t.Fatalf("stale audio was audible after interruption: %v", output)
+	}
+	// Fresh output remains playable after rejecting the old packet.
+	packetGeneration = sessionGeneration.Load()
+	if n, err := a.writePlayback([]byte{3, 4}, stillCurrent); err != nil || n != 2 {
+		t.Fatalf("fresh packet rejected: bytes=%d, error=%v", n, err)
+	}
+	a.samples(output, nil)
+	if !bytes.Equal(output, []byte{3, 4}) {
+		t.Fatalf("fresh audio lost after interruption: %v", output)
+	}
+}
+
+func TestVoiceAudioGuardRechecksAfterBackpressure(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		a := newBufferedVoiceAudio()
+		defer a.Close()
+		var sessionGeneration atomic.Uint64
+		packetGeneration := sessionGeneration.Load()
+		stillCurrent := func() bool { return packetGeneration == sessionGeneration.Load() }
+		done := make(chan error, 1)
+		go func() {
+			_, err := a.writePlayback(bytes.Repeat([]byte{1, 2}, voiceBufferBytes), stillCurrent)
+			done <- err
+		}()
+		synctest.Wait()
+		select {
+		case err := <-done:
+			t.Fatalf("write did not wait for playback: %v", err)
+		default:
+		}
+		// Invalidate while the writer waits. Simulate the next device callback
+		// before Flush acquires the queue lock; no stale tail may be enqueued.
+		sessionGeneration.Add(1)
+		a.samples(make([]byte, voiceBufferBytes), nil)
+		synctest.Wait()
+		if err := <-done; !errors.Is(err, ErrVoicePlaybackInterrupted) {
+			t.Fatalf("stale writer resumed after backpressure: %v", err)
+		}
+		output := []byte{0xff, 0xff}
+		a.samples(output, nil)
+		if !bytes.Equal(output, []byte{0, 0}) {
+			t.Fatalf("stale tail reached playback: %v", output)
+		}
+	})
+}
+
 func TestVoiceAudioCloseUnblocksIOAndReleasesDevice(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		device := &fakeVoiceAudioDevice{}

--- a/go/internal/cli/chat/voice_live.go
+++ b/go/internal/cli/chat/voice_live.go
@@ -401,7 +401,15 @@ func (s *liveSession) play() {
 			if packet.generation != s.generation.Load() {
 				continue
 			}
-			n, err := s.audio.Write(packet.data)
+			var n int
+			var err error
+			if writer, ok := s.audio.(voicePlaybackWriter); ok {
+				// Native audio checks the packet's session generation while
+				// holding its queue lock, including after backpressure wakes.
+				n, err = writer.writePlayback(packet.data, func() bool { return packet.generation == s.generation.Load() })
+			} else {
+				n, err = s.audio.Write(packet.data)
+			}
 			if err == nil && n != len(packet.data) {
 				err = io.ErrShortWrite
 			}
@@ -447,17 +455,20 @@ func (s *liveSession) receive() {
 			}
 			s.lastOutput = now
 			drop := s.interrupted
+			generation := s.generation.Load()
 			s.mu.Unlock()
 			if drop || len(data) == 0 || s.closing.Load() {
 				continue
 			}
-			packet := livePlayback{data: data, generation: s.generation.Load()}
+			packet := livePlayback{data: data, generation: generation}
 			select {
 			case s.playback <- packet:
 			default:
 				// Bound latency if the device cannot keep up. Flush unblocks a
 				// pending write; transcript/control handling never waits on audio.
+				s.mu.Lock()
 				s.generation.Add(1)
+				s.mu.Unlock()
 				_ = s.audio.Flush()
 			}
 		case "session.input_transcript.delta", "session.output_transcript.delta":
@@ -472,6 +483,11 @@ func (s *liveSession) receive() {
 			}
 			s.mu.Lock()
 			added := s.transcript.add(event.EventID, speaker, event.Delta, *event.StartMS, *event.EndMS, time.Now())
+			if added && speaker == "user" && s.transcript.pending != nil && s.transcript.pending.hasSpeech {
+				// Delegation metadata may arrive before its transcript. Invalidate
+				// the old result once the corresponding new speech is known.
+				s.activeID = s.transcript.pending.id
+			}
 			s.mu.Unlock()
 			if added {
 				s.publish(VoiceEvent{Type: kind, Text: event.Delta})
@@ -482,9 +498,9 @@ func (s *liveSession) receive() {
 				return
 			}
 			s.mu.Lock()
-			if s.transcript.delegate(event.Delegation.ID, *event.OffsetMS, time.Now()) {
-				// Invalidate an old result as soon as a correction is delegated,
-				// before its delayed transcript has finished reconciling.
+			if s.transcript.delegate(event.Delegation.ID, *event.OffsetMS, time.Now()) && s.transcript.pending.hasSpeech {
+				// Metadata alone does not establish a new task. Preserve the
+				// current result until relevant fresh speech confirms a correction.
 				s.activeID = event.Delegation.ID
 			}
 			s.mu.Unlock()
@@ -645,8 +661,8 @@ func (s *liveSession) Interrupt(ctx context.Context) error {
 	s.interruptID++
 	s.interruptAt = time.Now()
 	s.lastOutput = s.interruptAt
-	s.mu.Unlock()
 	s.generation.Add(1)
+	s.mu.Unlock()
 	if err := s.audio.Flush(); err != nil {
 		return err
 	}
@@ -682,9 +698,10 @@ type liveTranscriptPart struct {
 }
 
 type liveDelegation struct {
-	id      string
-	offset  float64
-	created time.Time
+	id        string
+	offset    float64
+	created   time.Time
+	hasSpeech bool
 }
 
 // Live supplies timestamped fragments, not completed user turns or task text.
@@ -727,6 +744,9 @@ func (t *liveTranscript) add(id, speaker, text string, start, end float64, now t
 		t.bytes -= len(t.parts[0].Text)
 		t.parts = t.parts[1:]
 	}
+	if t.pending != nil {
+		t.refreshPendingSpeech()
+	}
 	return true
 }
 
@@ -747,12 +767,33 @@ func (t *liveTranscript) delegate(id string, offset float64, now time.Time) bool
 		return false
 	}
 	t.pending = &liveDelegation{id: id, offset: offset, created: now}
+	t.refreshPendingSpeech()
 	return true
+}
+
+func (t *liveTranscript) freshSpeech(part liveTranscriptPart, pending *liveDelegation) bool {
+	return part.Speaker == "user" && part.seq > t.delivered &&
+		(t.deliveredMS == 0 || part.EndMS > t.deliveredMS) &&
+		(pending.offset == 0 || part.StartMS <= pending.offset)
+}
+
+func (t *liveTranscript) refreshPendingSpeech() {
+	t.pending.hasSpeech = false
+	for _, part := range t.parts {
+		if t.freshSpeech(part, t.pending) && strings.TrimSpace(part.Text) != "" {
+			t.pending.hasSpeech = true
+			return
+		}
+	}
 }
 
 func (t *liveTranscript) ready(now time.Time, settle time.Duration) (VoiceEvent, bool) {
 	pending := t.pending
-	if pending == nil || now.Sub(pending.created) < settle || (now.Sub(t.lastFragment) < settle && now.Sub(pending.created) < 2*time.Second) {
+	// There is no transcript delivery deadline or transcript-done event in
+	// Live. Keep one pending delegation until its speech arrives or a newer
+	// delegation replaces it. The cached speech flag avoids polling the full
+	// history while waiting, and delayed fragments still get a settling gap.
+	if pending == nil || !pending.hasSpeech || now.Sub(pending.created) < settle || now.Sub(t.lastFragment) < settle {
 		return VoiceEvent{}, false
 	}
 	var recent, fresh []liveTranscriptPart
@@ -761,7 +802,7 @@ func (t *liveTranscript) ready(now time.Time, settle time.Duration) (VoiceEvent,
 		if pending.offset > 0 && part.StartMS > pending.offset {
 			continue
 		}
-		if part.Speaker == "user" && part.seq > t.delivered && (t.deliveredMS == 0 || part.EndMS > t.deliveredMS) {
+		if t.freshSpeech(part, pending) {
 			fresh = append(fresh, part)
 			if part.seq > delivered {
 				delivered = part.seq
@@ -771,9 +812,7 @@ func (t *liveTranscript) ready(now time.Time, settle time.Duration) (VoiceEvent,
 		}
 	}
 	if len(fresh) == 0 {
-		if now.Sub(pending.created) >= 2*time.Second {
-			t.pending = nil // Never execute a task from missing or repeated speech.
-		}
+		pending.hasSpeech = false
 		return VoiceEvent{}, false
 	}
 	t.pending = nil

--- a/go/internal/cli/chat/voice_live_test.go
+++ b/go/internal/cli/chat/voice_live_test.go
@@ -127,7 +127,7 @@ func (a *testLiveAudio) Close() error {
 	return nil
 }
 
-func startTestLive(t *testing.T, wire *testLiveWire, audio *testLiveAudio) *liveSession {
+func startTestLive(t *testing.T, wire *testLiveWire, audio VoiceAudio) *liveSession {
 	t.Helper()
 	wire.push(map[string]any{"type": "session.started"})
 	ctx, cancel := context.WithCancel(context.Background())
@@ -702,6 +702,7 @@ func TestLiveOnlyAcceptedFreshCommentaryResumesInterruptedPlayback(t *testing.T)
 			case "newer_interrupt":
 				interrupt()
 			case "newer_delegation":
+				wire.push(map[string]any{"type": "session.input_transcript.delta", "event_id": "new-task-speech", "start_ms": 100, "end_ms": 400, "delta": "Cancel that task."})
 				wire.push(map[string]any{"type": "session.delegation.created", "offset_ms": 500, "delegation": map[string]any{"id": "new-task", "type": "delegation", "target": "client"}})
 			}
 			if mode != "rejected" {
@@ -834,5 +835,155 @@ func TestLiveUpgradeCancellationClosesBlockedHTTPRead(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("handshake waited for its deadline instead of honoring cancellation")
+	}
+}
+
+func TestLiveDelegationWaitsForTranscriptBeyondTwoSeconds(t *testing.T) {
+	var transcript liveTranscript
+	now := time.Now()
+	transcript.delegate("delayed", 1000, now)
+	for _, delay := range []time.Duration{3 * time.Second, time.Hour} {
+		if _, ready := transcript.ready(now.Add(delay), 300*time.Millisecond); ready || transcript.pending == nil || transcript.pending.hasSpeech {
+			t.Fatal("metadata alone executed or expired the pending delegation")
+		}
+	}
+	transcript.add("late-first", "user", "Inspect ", 100, 400, now.Add(3*time.Second))
+	if _, ready := transcript.ready(now.Add(3100*time.Millisecond), 300*time.Millisecond); ready {
+		t.Fatal("old delegation bypassed settling for delayed speech")
+	}
+	transcript.add("late-last", "user", "the device.", 400, 800, now.Add(3250*time.Millisecond))
+	if _, ready := transcript.ready(now.Add(3400*time.Millisecond), 300*time.Millisecond); ready {
+		t.Fatal("executed before the delayed final fragment settled")
+	}
+	event, ready := transcript.ready(now.Add(3600*time.Millisecond), 300*time.Millisecond)
+	if !ready || event.DelegationID != "delayed" || event.Text != "Inspect the device." {
+		t.Fatalf("lost delayed delegated request: %#v", event)
+	}
+	if _, ready := transcript.ready(now.Add(time.Hour), 300*time.Millisecond); ready {
+		t.Fatal("executed delayed speech more than once")
+	}
+}
+
+func TestLiveMetadataWithoutFreshSpeechKeepsCurrentResult(t *testing.T) {
+	wire, audio := newTestLiveWire(), newTestLiveAudio()
+	s := startTestLive(t, wire, audio)
+	wire.push(map[string]any{"type": "session.input_transcript.delta", "event_id": "first-input", "delta": "Inspect the device.", "start_ms": 100, "end_ms": 200})
+	wire.push(map[string]any{"type": "session.delegation.created", "offset_ms": 300, "delegation": map[string]any{"id": "working", "type": "delegation", "target": "client"}})
+	awaitLiveEvent(t, s, "delegation")
+	wire.push(map[string]any{"type": "session.delegation.created", "offset_ms": 600, "delegation": map[string]any{"id": "unresolved", "type": "delegation", "target": "client"}})
+	if err := s.SendContext(context.Background(), "The backend is working."); err != nil {
+		t.Fatal(err)
+	}
+	awaitLiveSent(t, wire, "session.thinking.append")
+	s.mu.Lock()
+	active := s.activeID
+	_, fired := s.transcript.ready(time.Now().Add(time.Hour), s.settle)
+	pending := s.transcript.pending
+	s.mu.Unlock()
+	if active != "working" || fired || pending == nil || pending.id != "unresolved" || pending.hasSpeech {
+		t.Fatal("metadata-only delegation superseded active work or disappeared")
+	}
+	if err := s.Reply(context.Background(), "working", "The device is healthy."); err != nil {
+		t.Fatal(err)
+	}
+	result := awaitLiveSent(t, wire, "session.commentary.append")
+	if result["delegation_id"] != "working" {
+		t.Fatal("running task result was lost to metadata-only delegation")
+	}
+}
+
+func TestLiveLateCorrectionInvalidatesOldReplyWhenSpeechArrives(t *testing.T) {
+	wire, audio := newTestLiveWire(), newTestLiveAudio()
+	s := startTestLive(t, wire, audio)
+	wire.push(map[string]any{"type": "session.input_transcript.delta", "event_id": "first-input", "delta": "Deploy.", "start_ms": 100, "end_ms": 200})
+	wire.push(map[string]any{"type": "session.delegation.created", "offset_ms": 300, "delegation": map[string]any{"id": "old", "type": "delegation", "target": "client"}})
+	awaitLiveEvent(t, s, "delegation")
+	wire.push(map[string]any{"type": "session.delegation.created", "offset_ms": 600, "delegation": map[string]any{"id": "correction", "type": "delegation", "target": "client"}})
+	wire.push(map[string]any{"type": "session.input_transcript.delta", "event_id": "correction-space", "delta": " ", "start_ms": 400, "end_ms": 405})
+	awaitLiveEvent(t, s, "input")
+	s.mu.Lock()
+	before := s.activeID
+	s.mu.Unlock()
+	if before != "old" {
+		t.Fatal("whitespace without a request invalidated the current result")
+	}
+	wire.push(map[string]any{"type": "session.input_transcript.delta", "event_id": "correction-input", "delta": "Actually cancel.", "start_ms": 410, "end_ms": 500})
+	awaitLiveEvent(t, s, "input")
+	s.mu.Lock()
+	active, pending := s.activeID, s.transcript.pending
+	s.mu.Unlock()
+	if active != "correction" || pending == nil || !pending.hasSpeech {
+		t.Fatal("late fresh correction did not invalidate the old reply immediately")
+	}
+	if err := s.Reply(context.Background(), "old", "Obsolete result"); err != nil {
+		t.Fatal(err)
+	}
+	for {
+		select {
+		case event := <-wire.out:
+			if event["type"] == "session.commentary.append" {
+				t.Fatal("old result was spoken while the known correction settled")
+			}
+		default:
+			awaitLiveEvent(t, s, "delegation")
+			return
+		}
+	}
+}
+
+type testGuardedLiveAudio struct {
+	*testLiveAudio
+	entered chan func() bool
+	resume  chan struct{}
+	wrote   chan struct{}
+}
+
+func (a *testGuardedLiveAudio) Write([]byte) (int, error) {
+	return 0, errors.New("playback bypassed the generation guard")
+}
+
+func (a *testGuardedLiveAudio) writePlayback(data []byte, current func() bool) (int, error) {
+	defer close(a.wrote)
+	a.entered <- current
+	select {
+	case <-a.resume:
+	case <-a.done:
+		return 0, io.ErrClosedPipe
+	}
+	if !current() {
+		return 0, ErrVoicePlaybackInterrupted
+	}
+	return a.testLiveAudio.Write(data)
+}
+
+func TestLivePlaybackGuardRejectsWriteStartingAfterInterrupt(t *testing.T) {
+	wire := newTestLiveWire()
+	audio := &testGuardedLiveAudio{testLiveAudio: newTestLiveAudio(), entered: make(chan func() bool, 1), resume: make(chan struct{}), wrote: make(chan struct{})}
+	s := startTestLive(t, wire, audio)
+	wire.push(map[string]any{"type": "session.output_audio.delta", "delta": "AQACAA=="})
+	select {
+	case current := <-audio.entered:
+		if !current() {
+			t.Fatal("fresh packet started with a stale generation")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("native guarded playback path was not used")
+	}
+	if err := s.Interrupt(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	close(audio.resume)
+	select {
+	case <-audio.wrote:
+	case <-time.After(time.Second):
+		t.Fatal("guarded write did not finish")
+	}
+	select {
+	case <-audio.writes:
+		t.Fatal("stale packet entered playback after Flush completed")
+	default:
+	}
+	if s.ctx.Err() != nil {
+		t.Fatal("expected stale-write interruption killed the session")
 	}
 }


### PR DESCRIPTION
A delayed GPT Live transcript could lose a spoken request after two seconds, and Escape after task completion could leave an answer queued to speak later. Keep one pending delegation until its transcript arrives or a newer delegation replaces it, and cancel queued speech on Escape even when the backend has finished. Delegation metadata without fresh speech no longer suppresses an existing task's result.

Check the playback generation inside the native audio buffer lock so an interruption also rejects a stale packet whose write starts after the flush. Unknown `/voice` commands can no longer replace a running task or strand its cancellation and approval channels.

This is a stacked follow-up to #1959, targeting `jo/chat`.

Validation:

- `go test -race ./internal/cli/chat -count=1`
- `CGO_ENABLED=0 go test ./internal/cli/chat -count=1`
- `go vet ./internal/cli/chat ./internal/cli/commands ./cmd/wendy`
- `make`
- Two OpenAI GPT Live round trips using locally synthesized speech: transcription, one client delegation, and spoken output from a simulated backend result. No microphone, speakers, or hardware tools were opened by these checks.

Regressions cover transcripts delayed beyond two seconds, unresolved delegation metadata, late corrections, native playback interrupted before a write or during backpressure, idle Escape with a queued answer, and an unknown voice command during active work. Physical microphone and speaker quality still needs hands-on QA.
