### PR TITLE
chat: --prompt runs one turn headless, with a JSON event stream

### DIFF
--- a/go/internal/cli/assets/docs/guides/chat.mdx
+++ b/go/internal/cli/assets/docs/guides/chat.mdx
@@ -211,7 +211,54 @@ Settings and API keys pasted during setup are saved in `~/.wendy/chat.json`,
 with file permissions restricted to your user. API keys supplied through
 environment variables are not copied into that file.
 
-Chat requires interactive stdin and stdout and does not support `--json`.
+The chat screen requires interactive stdin and stdout. Scripts use `--prompt`
+instead, described next.
+
+## Run one turn from a script
+
+`--prompt` runs a single turn without the chat screen and exits. It uses the
+setup you saved with `wendy chat --setup`, or the connection flags below, and
+never opens a setup screen. Use it from shell scripts, CI, or another program
+that wants Wendy's reasoning and tools without its terminal.
+
+```sh
+wendy chat --prompt "Which of my devices are online?"
+```
+
+When stdout is a terminal, the assistant's final text is printed. When stdout
+is a pipe or a file, or with `--json`, each event is printed as it happens, one
+JSON object per line, following the CLI's usual rule that non-interactive
+output is JSON. Notices go to stderr, so stdout is only the stream:
+
+```sh
+wendy chat --prompt "Why does app A on device X keep restarting?" --json
+```
+
+```json
+{"type":"status","text":"Thinking…"}
+{"type":"text","text":"Let me look at the logs. "}
+{"type":"tool_start","id":"call_1","tool":"telemetry_logs","arguments":{"app_name":"A","min_severity":"error"}}
+{"type":"tool_result","id":"call_1","tool":"telemetry_logs","text":"..."}
+{"type":"text","text":"The app cannot reach port 8080..."}
+{"type":"done","text":"Let me look at the logs. The app cannot reach port 8080..."}
+```
+
+Event types are `status`, `text` (streamed chunks), `tool_start`,
+`approval`, `tool_result`, and a final `done` or `error`. The `done` event
+carries the complete assistant text. A non-zero exit status accompanies
+`error`.
+
+Tools that would ask a person, such as shell commands, file writes, and
+device changes, are **denied** in this mode: there is nobody to answer. The
+stream reports each denial as an `approval` event with `"approved":false`, and
+the model is told the tool did not run. Pass `--yes` to allow them:
+
+```sh
+wendy chat --prompt "Redeploy the relay to Unitree G1 Nx" --json --yes
+```
+
+`--prompt` cannot be combined with `--setup` or `--voice`. Each run is a fresh
+conversation; there is no memory between prompts.
 
 ## Advanced configuration
 

--- a/go/internal/cli/chat/headless.go
+++ b/go/internal/cli/chat/headless.go
@@ -1,0 +1,124 @@
+package chat
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+)
+
+// HeadlessOptions runs one turn without the terminal UI, for scripts and for
+// other programs that want the agent's reasoning and tools but not its screen.
+type HeadlessOptions struct {
+	Engine *Engine
+	Prompt string
+	// JSON writes one event per line as it happens; otherwise only the final
+	// assistant text is written, followed by a newline.
+	JSON   bool
+	Output io.Writer
+	// AutoApprove runs tools that would ask a person. Without it, such tools
+	// are denied: there is nobody to ask, and silently running a shell command
+	// or a device change is worse than declining it.
+	AutoApprove bool
+}
+
+// headlessEvent is the wire form of Event. It carries the fields a consumer
+// needs to reconstruct the turn and nothing that names a terminal.
+type headlessEvent struct {
+	Type      string          `json:"type"`
+	Text      string          `json:"text,omitempty"`
+	ID        string          `json:"id,omitempty"`
+	Tool      string          `json:"tool,omitempty"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+	Approved  *bool           `json:"approved,omitempty"`
+}
+
+// RunHeadless sends Prompt to the engine and reports what happened.
+//
+// With JSON, events are written in order as newline-delimited objects:
+// status, text (streamed chunks), tool_start, approval, tool_result, then a
+// final done or error. Without JSON the assistant's complete text is written
+// once the turn ends. Denied approvals are reported, not hidden: a consumer
+// that sees approved:false knows to rerun with --yes or to ask a person.
+func RunHeadless(ctx context.Context, opts HeadlessOptions) error {
+	if opts.Engine == nil {
+		return errors.New("chat requires an engine")
+	}
+	if strings.TrimSpace(opts.Prompt) == "" {
+		return errors.New("prompt must not be empty")
+	}
+	if opts.Output == nil {
+		opts.Output = io.Discard
+	}
+	var mu sync.Mutex
+	var full strings.Builder
+	write := func(ev headlessEvent) {
+		if !opts.JSON {
+			return
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		line, err := json.Marshal(ev)
+		if err != nil {
+			return
+		}
+		_, _ = opts.Output.Write(append(line, '\n'))
+	}
+	emit := func(event Event) {
+		ev := headlessEvent{Type: event.Type, Text: event.Text}
+		if event.Call != nil {
+			ev.ID, ev.Tool = event.Call.ID, event.Call.Name
+			if event.Type == "tool_start" {
+				ev.Arguments = compactArguments(event.Call.Arguments)
+			}
+		}
+		if event.Type == "text" {
+			mu.Lock()
+			full.WriteString(event.Text)
+			mu.Unlock()
+		}
+		write(ev)
+	}
+	approve := func(ctx context.Context, call ToolCall) (bool, error) {
+		if err := ctx.Err(); err != nil {
+			return false, err
+		}
+		allowed := opts.AutoApprove
+		write(headlessEvent{Type: "approval", ID: call.ID, Tool: call.Name, Approved: &allowed,
+			Text: approvalText(allowed)})
+		return allowed, nil
+	}
+	err := opts.Engine.Turn(ctx, opts.Prompt, emit, approve)
+	mu.Lock()
+	text := full.String()
+	mu.Unlock()
+	if err != nil {
+		write(headlessEvent{Type: "error", Text: err.Error()})
+		return err
+	}
+	if opts.JSON {
+		write(headlessEvent{Type: "done", Text: text})
+		return nil
+	}
+	if text != "" && !strings.HasSuffix(text, "\n") {
+		text += "\n"
+	}
+	_, werr := io.WriteString(opts.Output, text)
+	return werr
+}
+
+func approvalText(allowed bool) string {
+	if allowed {
+		return "approved by --yes"
+	}
+	return "denied: this tool needs approval and headless mode has nobody to ask; rerun with --yes to allow it"
+}
+
+func compactArguments(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 || !json.Valid(raw) {
+		return json.RawMessage(`{}`)
+	}
+	return raw
+}

--- a/go/internal/cli/chat/headless_test.go
+++ b/go/internal/cli/chat/headless_test.go
@@ -1,0 +1,122 @@
+package chat
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func headlessFixture(t *testing.T) (*Engine, *engineTestExecutor) {
+	t.Helper()
+	executor := &engineTestExecutor{tools: []Tool{
+		{Name: "device_info"},
+		{Name: "workspace_exec", RequiresApproval: true},
+	}}
+	round := 0
+	provider := engineTestProvider(func(_ context.Context, messages []Message, _ []Tool, emit func(string)) (Message, error) {
+		round++
+		switch round {
+		case 1:
+			emit("Checking. ")
+			return Message{Content: "Checking. ", ToolCalls: []ToolCall{
+				{ID: "a", Name: "device_info", Arguments: json.RawMessage(`{}`)},
+				{ID: "b", Name: "workspace_exec", Arguments: json.RawMessage(`{"command":"ls"}`)},
+			}}, nil
+		default:
+			last := messages[len(messages)-1].Content
+			emit("Done: " + last)
+			return Message{Content: "Done: " + last}, nil
+		}
+	})
+	return NewEngine(provider, executor, "system"), executor
+}
+
+func decodeLines(t *testing.T, out string) []map[string]any {
+	t.Helper()
+	var events []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		var ev map[string]any
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			t.Fatalf("line %q is not JSON: %v", line, err)
+		}
+		events = append(events, ev)
+	}
+	return events
+}
+
+func TestHeadlessJSONStreamsEventsAndDeniesWithoutYes(t *testing.T) {
+	engine, executor := headlessFixture(t)
+	out := new(bytes.Buffer)
+	if err := RunHeadless(context.Background(), HeadlessOptions{Engine: engine, Prompt: "what is up", JSON: true, Output: out}); err != nil {
+		t.Fatal(err)
+	}
+	events := decodeLines(t, out.String())
+	var types []string
+	for _, ev := range events {
+		types = append(types, ev["type"].(string))
+	}
+	joined := strings.Join(types, " ")
+	for _, want := range []string{"status", "text", "tool_start", "approval", "tool_result", "done"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("missing %q event in %s", want, joined)
+		}
+	}
+	if types[len(types)-1] != "done" {
+		t.Errorf("stream must end with done, got %s", joined)
+	}
+	if len(executor.calls) != 1 || executor.calls[0].Name != "device_info" {
+		t.Fatalf("only the read tool may run without --yes, ran %+v", executor.calls)
+	}
+	for _, ev := range events {
+		switch ev["type"] {
+		case "approval":
+			if ev["approved"] != false || ev["tool"] != "workspace_exec" {
+				t.Errorf("approval event = %v", ev)
+			}
+		case "tool_start":
+			if ev["tool"] == "workspace_exec" && ev["arguments"].(map[string]any)["command"] != "ls" {
+				t.Errorf("tool_start must carry the arguments: %v", ev)
+			}
+		case "done":
+			if !strings.HasPrefix(ev["text"].(string), "Checking. Done: User denied permission") {
+				t.Errorf("done text = %q", ev["text"])
+			}
+		}
+	}
+}
+
+func TestHeadlessYesRunsApprovedToolsAndPrintsPlainText(t *testing.T) {
+	engine, executor := headlessFixture(t)
+	out := new(bytes.Buffer)
+	if err := RunHeadless(context.Background(), HeadlessOptions{Engine: engine, Prompt: "run it", Output: out, AutoApprove: true}); err != nil {
+		t.Fatal(err)
+	}
+	if len(executor.calls) != 2 {
+		t.Fatalf("--yes must run both tools, ran %+v", executor.calls)
+	}
+	if got := out.String(); got != "Checking. Done: ok\n" {
+		t.Fatalf("plain output = %q", got)
+	}
+}
+
+func TestHeadlessReportsErrorsAsEvents(t *testing.T) {
+	provider := engineTestProvider(func(context.Context, []Message, []Tool, func(string)) (Message, error) {
+		return Message{}, context.DeadlineExceeded
+	})
+	engine := NewEngine(provider, &engineTestExecutor{}, "")
+	out := new(bytes.Buffer)
+	err := RunHeadless(context.Background(), HeadlessOptions{Engine: engine, Prompt: "x", JSON: true, Output: out})
+	if err == nil {
+		t.Fatal("expected the provider error")
+	}
+	events := decodeLines(t, out.String())
+	last := events[len(events)-1]
+	if last["type"] != "error" || !strings.Contains(last["text"].(string), "deadline") {
+		t.Fatalf("last event = %v", last)
+	}
+	if err := RunHeadless(context.Background(), HeadlessOptions{Engine: engine, Prompt: "  "}); err == nil {
+		t.Fatal("empty prompt must be rejected")
+	}
+}

--- a/go/internal/cli/commands/chat.go
+++ b/go/internal/cli/commands/chat.go
@@ -17,7 +17,7 @@ func newChatCmd() *cobra.Command {
 	var cfg chat.Config
 	var directory string
 	var autoApprove, setup, helpAll, voice bool
-	var preferredDevice string
+	var preferredDevice, headlessPrompt string
 	cmd := &cobra.Command{
 		Use:   "chat [prompt...]",
 		Short: "Build apps and work with your devices through a conversation",
@@ -26,11 +26,17 @@ func newChatCmd() *cobra.Command {
 Just run wendy chat. I'll help you choose a local AI or a cloud service,
 connect it, and pick a model. Your choice is remembered for next time.
 
-Use --setup whenever you want to change your AI or model.`,
+Use --setup whenever you want to change your AI or model.
+
+Scripts and other programs can run one turn without the chat screen with
+--prompt. Add --json for one event per line; add --yes to allow tools that
+would otherwise ask a person.`,
 		Example: `  wendy chat
   wendy chat "Help me get this project running"
   wendy chat --setup
-  wendy chat -C ./my-app`,
+  wendy chat -C ./my-app
+  wendy chat --prompt "Which of my devices are online?"
+  wendy chat --prompt "Why does app A on device X fail?" --json --yes`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if helpAll {
@@ -39,6 +45,12 @@ Use --setup whenever you want to change your AI or model.`,
 			workspace, err := chatWorkspace(directory)
 			if err != nil {
 				return err
+			}
+			if headlessPrompt != "" {
+				return runChatHeadless(cmd, chatHeadlessOptions{
+					Config: cfg, Prompt: headlessPrompt, Workspace: workspace, Device: preferredDevice,
+					AutoApprove: autoApprove, JSON: jsonOutput, Voice: voice, Setup: setup,
+				})
 			}
 			if !isInteractiveTerminal() {
 				return fmt.Errorf("wendy chat requires an interactive terminal (stdin and stdout must be TTYs)")
@@ -136,6 +148,7 @@ Use --setup whenever you want to change your AI or model.`,
 	}
 	cmd.Flags().BoolVar(&setup, "setup", false, "Choose or change your AI and model")
 	cmd.Flags().BoolVar(&voice, "voice", false, "Listen and speak with GPT Live (or use /voice in chat)")
+	cmd.Flags().StringVarP(&headlessPrompt, "prompt", "p", "", "Run one turn without the chat screen and exit; combine with --json and --yes")
 	cmd.Flags().BoolVar(&helpAll, "help-all", false, "Show advanced connection options")
 	cmd.Flags().StringVarP(&preferredDevice, "device", "d", "", "Preferred Wendy device (you can also choose while chatting)")
 	cmd.Flags().StringVar(&cfg.Provider, "provider", "", "Model API: openai, anthropic, ollama, or local (WENDY_CHAT_PROVIDER)")
@@ -170,6 +183,62 @@ Options:
 {{.LocalFlags.FlagUsages}}`)
 	_ = cmd.MarkFlagDirname("directory")
 	return cmd
+}
+
+type chatHeadlessOptions struct {
+	Config      chat.Config
+	Prompt      string
+	Workspace   string
+	Device      string
+	AutoApprove bool
+	JSON        bool
+	Voice       bool
+	Setup       bool
+}
+
+// runChatHeadless is wendy chat for a caller that is not a person at a
+// terminal: a script, a CI job, or another agent. It uses the saved setup or
+// the connection flags, never the guided setup screens, and it writes either
+// the final answer or one JSON event per line to stdout.
+func runChatHeadless(cmd *cobra.Command, opts chatHeadlessOptions) error {
+	if opts.Setup {
+		return fmt.Errorf("--setup is interactive; run wendy chat --setup once, then use --prompt")
+	}
+	if opts.Voice {
+		return fmt.Errorf("--voice needs a microphone and a person; remove it to use --prompt")
+	}
+	saved, err := chat.LoadSettings()
+	if err != nil {
+		saved = chat.Config{}
+	}
+	resolved, err := chat.ResolveConfig(chat.MergeSettings(opts.Config, saved))
+	if err != nil {
+		return fmt.Errorf("chat is not set up for headless use: %w\nRun wendy chat --setup once, or pass --provider, --model and --base-url", err)
+	}
+	executable, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locating Wendy executable: %w", err)
+	}
+	ctx, cancel := context.WithCancel(cmd.Context())
+	defer cancel()
+	toolset, err := chat.NewTools(ctx, executable, opts.Workspace, opts.Device)
+	if err != nil {
+		return err
+	}
+	defer toolset.Close()
+	provider, err := chat.NewProvider(resolved)
+	if err != nil {
+		return err
+	}
+	engine := chat.NewEngine(provider, toolset, chat.SystemPrompt(opts.Workspace, opts.Device))
+	err = chat.RunHeadless(ctx, chat.HeadlessOptions{
+		Engine: engine, Prompt: opts.Prompt, JSON: opts.JSON,
+		Output: cmd.OutOrStdout(), AutoApprove: opts.AutoApprove,
+	})
+	if errors.Is(err, context.Canceled) {
+		return ErrUserCancelled
+	}
+	return err
 }
 
 func chatWorkspace(directory string) (string, error) {

--- a/go/internal/cli/commands/chat_test.go
+++ b/go/internal/cli/commands/chat_test.go
@@ -20,17 +20,22 @@ func TestChatVisibleWithLocalModelHelp(t *testing.T) {
 	if err := root.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"Just run wendy chat", "--setup", "--help-all", "--directory", "--device", "--voice", "/voice"} {
+	for _, want := range []string{"Just run wendy chat", "--setup", "--help-all", "--directory", "--device", "--voice", "/voice", "--prompt"} {
 		if !strings.Contains(buf.String(), want) {
 			t.Errorf("chat help missing %q", want)
 		}
 	}
-	for _, advanced := range []string{"--provider", "--base-url", "--model", "WENDY_CHAT_API_KEY", "--json"} {
+	for _, advanced := range []string{"--provider", "--base-url", "--model", "WENDY_CHAT_API_KEY"} {
 		if strings.Contains(buf.String(), advanced) {
 			t.Errorf("ordinary help overwhelms setup with %q", advanced)
 		}
 	}
-	if len(strings.Split(buf.String(), "\n")) > 30 {
+	// --json is inherited and only meaningful with --prompt; help may name it
+	// there, but must not list it as a flag of its own.
+	if strings.Contains(buf.String(), "--json   ") {
+		t.Errorf("ordinary help lists --json as a chat flag: %s", buf.String())
+	}
+	if len(strings.Split(buf.String(), "\n")) > 36 {
 		t.Errorf("ordinary help should fit on one screen: %s", buf.String())
 	}
 	if err := UnknownSubcommandError([]string{"chat", "inspect", "my", "devices"}); err != nil {
@@ -99,6 +104,45 @@ func TestChatWorkspace(t *testing.T) {
 	for _, path := range []string{file, filepath.Join(dir, "missing")} {
 		if _, err := chatWorkspace(path); err == nil {
 			t.Errorf("accepted invalid directory %q", path)
+		}
+	}
+}
+
+func TestChatPromptDoesNotNeedATerminalAndAllowsJSON(t *testing.T) {
+	orig := isInteractiveTerminalFn
+	origJSON := jsonOutput
+	t.Cleanup(func() { isInteractiveTerminalFn = orig; jsonOutput = origJSON })
+	isInteractiveTerminalFn = func() bool { return false }
+	jsonOutput = true
+	// An unset HOME keeps the developer's saved chat setup out of the test.
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	for _, env := range []string{"WENDY_CHAT_PROVIDER", "WENDY_CHAT_MODEL", "WENDY_CHAT_BASE_URL", "WENDY_CHAT_API_KEY"} {
+		t.Setenv(env, "")
+	}
+	cmd := newChatCmd()
+	cmd.SetArgs([]string{"--prompt", "hello", "-C", t.TempDir()})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("headless chat with no saved setup must explain what to do")
+	}
+	for _, unwanted := range []string{"interactive terminal", "remove --json"} {
+		if strings.Contains(err.Error(), unwanted) {
+			t.Fatalf("--prompt must bypass the terminal and --json checks, got %v", err)
+		}
+	}
+	if !strings.Contains(err.Error(), "--setup") {
+		t.Fatalf("expected setup guidance, got %v", err)
+	}
+}
+
+func TestChatPromptRefusesInteractiveOnlyFlags(t *testing.T) {
+	for _, args := range [][]string{{"--prompt", "x", "--setup"}, {"--prompt", "x", "--voice"}} {
+		cmd := newChatCmd()
+		cmd.SetArgs(append(args, "-C", t.TempDir()))
+		err := cmd.Execute()
+		if err == nil || !strings.Contains(err.Error(), "--prompt") {
+			t.Fatalf("%v: expected an error naming --prompt, got %v", args, err)
 		}
 	}
 }


### PR DESCRIPTION
Stacked on #1959. Adds a non-interactive mode to `wendy chat` so scripts and other programs can use the agent's reasoning and Wendy tools without the terminal UI.

## What

- `wendy chat --prompt "..."` (or `-p`) runs a single turn and exits. It uses the saved setup or the connection flags, never the guided setup screens.
- On a terminal, stdout is the assistant's final text. When piped, or with `--json`, stdout is one JSON event per line: `status`, `text` (streamed chunks), `tool_start` (with arguments), `approval`, `tool_result`, then a final `done` (with the complete text) or `error`. Notices stay on stderr.
- Tools that need approval are **denied** unless `--yes`. Each denial is reported as an `approval` event with `"approved": false`, and the model is told the tool did not run, so a consumer can see why and rerun with `--yes` or ask a person.
- `--setup` and `--voice` are refused together with `--prompt`, with a message saying what to do instead.
- Documented in `guides/chat.mdx` with an example stream.

```sh
wendy chat --prompt "Which of my devices are online?"
wendy chat --prompt "Why does app A on device X keep restarting?" --json
wendy chat --prompt "Redeploy the relay" --json --yes
```

## Why

The engine, tools and providers in #1959 are exactly what a robot-side agent or a CI job wants, but the only entry point is a TUI. One flag makes the same loop callable. Our immediate use is a local-model fallback for the Wendy voice agent when a conference venue has no internet: `wendy chat --prompt --json` against Ollama, with the device tools already wired.

## Design notes

- Implemented as `chat.RunHeadless` next to `chat.Run`, reusing `Engine.Turn`'s emit/approve hooks. No changes to the engine, providers, tools or TUI.
- Piped stdout implies JSON, following the root command's existing rule for non-interactive output.
- Each run is a fresh conversation; there is no memory between prompts. Approval is all-or-nothing per run. Both are fine for the first consumers and easy to extend later.
- The existing help test asserted `--json` never appears in ordinary help. It is now a meaningful option with `--prompt`, so the test allows the mention but still fails if `--json` is listed as a flag of its own.

## Testing

- New unit tests: `headless_test.go` (JSON stream shape, denial without `--yes`, `--yes` runs approved tools, plain-text output, errors as events, empty prompt rejected) and two command tests (`--prompt` bypasses the TTY and `--json` checks and gives setup guidance; `--setup`/`--voice` refused).
- `go test ./internal/cli/chat ./internal/cli/commands` passes in full.
- Smoke-tested the built binary against a fake OpenAI-compatible streaming server: tool call, denial, `--yes`, and the refusal paths behave as documented. Not yet run against a real model or device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019fE7CYkHwmcUsa3YEfEeKf