### PR TITLE
Clarify unpin recovery after device identity changes

### DIFF
--- a/go/cmd/wendy/main.go
+++ b/go/cmd/wendy/main.go
@@ -57,7 +57,7 @@ func main() {
 
 	exitCode := 0
 	if err != nil && !errors.Is(err, commands.ErrUserCancelled) && !errors.Is(err, commands.ErrDefaultCleared) {
-		fmt.Fprintln(os.Stderr, tui.ErrorMessage(formatError(err).Error()))
+		fmt.Fprintln(os.Stderr, renderError(err))
 		exitCode = 1
 	}
 	// Windows: when this process owns its console window (UAC-relaunched or
@@ -236,6 +236,20 @@ func errorClass(err error) string {
 		return "context_deadline"
 	}
 	return "other"
+}
+
+// renderError lets actionable errors style their heading separately from the
+// recovery steps. Use errors.As because commands may add context with %w.
+func renderError(err error) string {
+	var diagnostic interface {
+		error
+		CLIMessage() string
+	}
+	if errors.As(err, &diagnostic) && strings.Contains(err.Error(), diagnostic.Error()) {
+		// Preserve surrounding action context and any joined sibling errors.
+		return strings.Replace(err.Error(), diagnostic.Error(), diagnostic.CLIMessage(), 1)
+	}
+	return tui.ErrorMessage(formatError(err).Error())
 }
 
 func formatError(err error) error {

--- a/go/cmd/wendy/main_test.go
+++ b/go/cmd/wendy/main_test.go
@@ -19,6 +19,29 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+type diagnosticTestError struct{}
+
+func (diagnosticTestError) Error() string { return "plain programmatic error" }
+func (diagnosticTestError) CLIMessage() string {
+	return "✗ Connection blocked\n\n  wendy device unpin device.local"
+}
+
+func TestRenderErrorKeepsDiagnosticPresentationAndContext(t *testing.T) {
+	diagnostic := diagnosticTestError{}
+	for _, tc := range []struct {
+		err  error
+		want string
+	}{
+		{diagnostic, diagnostic.CLIMessage()},
+		{fmt.Errorf("connecting: %w", diagnostic), "connecting: " + diagnostic.CLIMessage()},
+		{errors.Join(diagnostic, errors.New("other device failed")), diagnostic.CLIMessage() + "\nother device failed"},
+	} {
+		if got := renderError(tc.err); got != tc.want {
+			t.Errorf("diagnostic lost context or was restyled: got %q, want %q", got, tc.want)
+		}
+	}
+}
+
 type capturedEvent struct {
 	event string
 	props map[string]string

--- a/go/internal/cli/assets/docs/pki/README.md
+++ b/go/internal/cli/assets/docs/pki/README.md
@@ -57,7 +57,7 @@ The pin is deliberately not a certificate fingerprint — a device legitimately 
 | Same org + cloud + asset (renewed or re-enrolled cert) | Connects normally |
 | Different org or cloud host | Refused, no prompt |
 | Same org + cloud, **different asset id** | Refused, no prompt — the hostname now resolves to a different machine, or the device was wiped and re-enrolled as a new asset |
-| **No mTLS identity at all**, on a hostname that was pinned | Refused, no prompt — an enrolled device does not drop its certificate on its own; it has been reflashed or factory reset, or another machine has taken its name |
+| **No mTLS identity at all**, on a hostname that was pinned | Refused, no prompt — the device may have been unenrolled, reflashed, or reset, or another machine may have taken its name |
 | No mTLS identity, hostname never pinned | Connects normally (ordinary out-of-the-box device) |
 
 The asset id is read only from a certificate that passed chain and org verification, so an impostor cannot assert its way past the pin. On the dial ladder, a wrong-device rejection aborts the whole ladder immediately — no further certificate or port is tried — and a hostname that carries any pin at all is never offered the unauthenticated plaintext rung, regardless of what its (attacker-controlled) mDNS TXT records claim about it.
@@ -74,6 +74,17 @@ This clears the local pin only — it never dials the device, so it works even w
 Both forms are accepted because the two stores are keyed differently. The identity-change refusals above name a hostname, and the hostname form clears it. The **SPKI** refusal (point 4 above) can only name the certificate identity URN, because that is what `known_devices.json` is keyed by and there is often no hostname to offer: `wendy device list` and the device picker dial the device's IP, and an agent that never advertises `orgid` in its mDNS records leaves nothing locally that maps a name to an asset. Copy the URN out of the refusal and pass it back — it clears the SPKI entry and any `devicePins` entry naming the same asset.
 
 Unpinning by hostname also clears pins filed under the device's *other* names (the cloud roster's asset name, its mesh name), because one device is legitimately pinned under several — but only when those pins name the same organisation and asset. Those alternate names come from mDNS, which is unauthenticated, so a pin naming a *different* asset is a different device's pin and is left alone. Whatever is cleared is printed, one line per entry, so an unpin never removes trust state silently.
+
+### Re-enrolling after an intentional reset or organization move
+
+Unenrolling a device does not clear the identity saved by this CLI. If you intentionally unenrolled, reset, or reflashed it, or know it is moving to another organization, clear the old local pin before retrying enrollment:
+
+```sh
+wendy device unpin wendyos-ccr1.local
+wendy device enroll --device wendyos-ccr1.local
+```
+
+Use the hostname printed in the refusal. Unpinning does not enroll the device or delete its cloud asset. If unenrollment reported a cloud cleanup failure, finish that cleanup in the Wendy Cloud dashboard separately. If the identity change was unexpected, keep the pin and verify the device first; check `wendy auth login` if this CLI is missing the organization's credentials.
 
 ## Pin sources and precedence
 

--- a/go/internal/cli/commands/device_pin.go
+++ b/go/internal/cli/commands/device_pin.go
@@ -141,7 +141,7 @@ type devicePinDiagnostic struct {
 
 func (d devicePinDiagnostic) message(styled bool) string {
 	heading := d.heading
-	command := "wendy device unpin " + d.hostname
+	command := "wendy device unpin " + shellQuoteArg(d.hostname)
 	details := d.details
 	if styled {
 		heading = tui.ErrorMessage(heading)
@@ -236,6 +236,29 @@ func clearDevicePinForRepin(hostname string) {
 		return
 	}
 	_ = config.Save(cfg)
+}
+
+// shellQuoteArg renders s so a copy-paste of the recovery command survives a
+// POSIX shell as a single argument. d.hostname can be an mDNS display alias
+// copied verbatim from unauthenticated discovery data, so a name like
+// `foo; rm -rf ~` must not turn the suggested command into something else, and
+// one containing spaces must still reach `device unpin` as one arg (it enforces
+// ExactArgs(1)). An ordinary, unsurprising name is left bare.
+func shellQuoteArg(s string) string {
+	unsafe := strings.ContainsFunc(s, func(r rune) bool {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			return false
+		default:
+			return !strings.ContainsRune("-_.:/@%+=", r)
+		}
+	})
+	if s != "" && !unsafe {
+		return s
+	}
+	// POSIX single-quoting: everything is literal inside '...', and an embedded
+	// single quote is closed, escaped, and reopened.
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 func assetSuffix(assetID string) string {

--- a/go/internal/cli/commands/device_pin.go
+++ b/go/internal/cli/commands/device_pin.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/wendylabsinc/wendy/go/internal/cli/grpcclient"
 	"github.com/wendylabsinc/wendy/go/internal/cli/tui"
@@ -118,23 +119,69 @@ func enforceDeviceIdentity(hostname string, obs observedDeviceIdentity) error {
 		return nil
 	default: // config.PinMismatch
 		prev, _ := cfg.DevicePinFor(hostname)
-		printIdentityChangeWarning(hostname, prev, obs, cloud)
-		return refuseIdentity("device %q identity changed (organization/cloud/asset); refusing to connect — if this is expected, run 'wendy device unpin %s'", hostname, hostname)
+		return refuseDevicePin(devicePinDiagnostic{
+			hostname: hostname,
+			heading:  fmt.Sprintf("Connection blocked: device %q identity changed.", hostname),
+			details: fmt.Sprintf("Saved: organization %d via %s%s\nNow:   organization %d via %s%s",
+				prev.OrgID, displayCloud(prev.CloudGRPC), assetSuffix(prev.AssetID),
+				obs.orgID, displayCloud(cloud), assetSuffix(obs.assetID)),
+		})
 	}
 }
 
-// printIdentityChangeWarning explains a pin mismatch in terms of what actually
-// changed. A different asset within the same org+cloud is a different physical
-// device; a different org or cloud is a different trust domain entirely.
-func printIdentityChangeWarning(hostname string, prev config.DevicePin, obs observedDeviceIdentity, cloud string) {
-	fmt.Fprintln(os.Stderr, tui.ErrorMessage(fmt.Sprintf("Device %q now presents a different identity than the one you pinned.", hostname)))
-	fmt.Fprintln(os.Stderr, tui.ErrorMessage(fmt.Sprintf("  pinned: organization %d via %s%s", prev.OrgID, displayCloud(prev.CloudGRPC), assetSuffix(prev.AssetID))))
-	fmt.Fprintln(os.Stderr, tui.ErrorMessage(fmt.Sprintf("  now:    organization %d via %s%s", obs.orgID, displayCloud(cloud), assetSuffix(obs.assetID))))
-	if prev.OrgID == obs.orgID && prev.CloudGRPC == cloud {
-		fmt.Fprintln(os.Stderr, tui.ErrorMessage("Same organization and cloud, but a different device: this hostname now resolves to another machine, or the device was wiped and re-enrolled as a new asset."))
-	} else {
-		fmt.Fprintln(os.Stderr, tui.ErrorMessage("A renewed or re-enrolled certificate keeps the same organization and cloud, so this change is unexpected — it may be a man-in-the-middle or a swapped device."))
+// devicePinDiagnostic puts intentional unenrollment and organization changes
+// next to the recovery command. The same information is kept in Error() for
+// MCP and other callers; only the CLI presentation adds styling.
+type devicePinDiagnostic struct {
+	hostname   string
+	heading    string
+	details    string
+	checkLogin bool
+}
+
+func (d devicePinDiagnostic) message(styled bool) string {
+	heading := d.heading
+	command := "wendy device unpin " + d.hostname
+	details := d.details
+	if styled {
+		heading = tui.ErrorMessage(heading)
+		command = tui.Command(command)
+		detailLines := strings.Split(details, "\n")
+		for i, line := range detailLines {
+			detailLines[i] = tui.Dim(line)
+		}
+		details = strings.Join(detailLines, "\n")
 	}
+	lines := []string{
+		heading,
+		"This CLI still remembers its previous enrollment (a local pin).",
+		"",
+		"If you intentionally unenrolled, reset, reflashed, or changed this device's organization:",
+		"  " + command,
+		"Then retry your command. Unpinning only clears this CLI's saved device identity.",
+		"",
+		"If this change was unexpected, keep the pin and verify the device first.",
+	}
+	if d.checkLogin {
+		lines = append(lines, "Missing organization credentials? Run 'wendy auth login', then retry.")
+	}
+	return strings.Join(append(lines, "", details), "\n")
+}
+
+func refuseDevicePin(diagnostic devicePinDiagnostic) error {
+	err := refuseIdentity("%s", diagnostic.message(false))
+	err.diagnostic = &diagnostic
+	return err
+}
+
+// CLIMessage is rendered once by the CLI entry point, including when wrapped.
+// Rendering here avoids painting the recovery instructions red along with the
+// heading, or printing a second copy while the error is propagated.
+func (e *deviceIdentityRefusalError) CLIMessage() string {
+	if e.diagnostic == nil {
+		return tui.ErrorMessage(e.Error())
+	}
+	return e.diagnostic.message(true)
 }
 
 // challengeUnprovisionedDevice handles a connection with no verifiable identity
@@ -152,12 +199,13 @@ func challengeUnprovisionedDevice(cfg *config.Config, hostname string) error {
 		return nil
 	}
 
-	fmt.Fprintln(os.Stderr, tui.ErrorMessage(fmt.Sprintf("Device %q was enrolled, but is now answering without an identity.", hostname)))
-	fmt.Fprintln(os.Stderr, tui.ErrorMessage(fmt.Sprintf("  pinned: organization %d via %s%s", prev.OrgID, displayCloud(prev.CloudGRPC), assetSuffix(prev.AssetID))))
-	fmt.Fprintln(os.Stderr, tui.ErrorMessage("  now:    unprovisioned (no mTLS)"))
-	fmt.Fprintln(os.Stderr, tui.ErrorMessage("An enrolled device does not drop its certificate on its own — it has been reflashed or factory reset, another machine has taken its name or address, or this CLI no longer holds credentials for its organization (try 'wendy auth login'). Anything you run over this connection would be unauthenticated."))
-
-	return refuseIdentity("device %q was enrolled but is now answering unprovisioned; refusing to connect — re-enroll it, check 'wendy auth login', or run 'wendy device unpin %s' if this is expected", hostname, hostname)
+	return refuseDevicePin(devicePinDiagnostic{
+		hostname: hostname,
+		heading:  fmt.Sprintf("Connection blocked: device %q has no enrolled identity.", hostname),
+		details: fmt.Sprintf("Saved: organization %d via %s%s\nNow:   unprovisioned (no mTLS)",
+			prev.OrgID, displayCloud(prev.CloudGRPC), assetSuffix(prev.AssetID)),
+		checkLogin: true,
+	})
 }
 
 // clearDevicePinForRepin drops the stored pins for hostname so the next

--- a/go/internal/cli/commands/device_pin_diagnostic_test.go
+++ b/go/internal/cli/commands/device_pin_diagnostic_test.go
@@ -1,0 +1,75 @@
+package commands
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/muesli/termenv"
+	"github.com/wendylabsinc/wendy/go/internal/shared/config"
+)
+
+func TestDevicePinRefusalRecoveryPresentation(t *testing.T) {
+	profile := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(profile) })
+	readPins := writePinTestConfig(t, map[string]config.DevicePin{
+		"wendyos-ccr1": {OrgID: 2, CloudGRPC: "cloud.example:443", AssetID: "481"},
+	})
+	var err error
+	out := captureStderr(t, func() {
+		err = enforceDeviceIdentity("wendyos-ccr1.local", observedDeviceIdentity{})
+	})
+	if out != "" {
+		t.Fatalf("refusal printed before the CLI rendered it: %q", out)
+	}
+	if !errors.Is(err, errDeviceIdentityRefused) || !blocksUnauthenticatedFallback(err) {
+		t.Fatalf("refusal must still block unauthenticated fallback: %v", err)
+	}
+	if pin := readPins()["wendyos-ccr1"]; pin.OrgID != 2 || pin.AssetID != "481" {
+		t.Fatalf("refusal changed the saved pin: %+v", pin)
+	}
+	msg := err.Error()
+	command := "\n  wendy device unpin wendyos-ccr1.local\n"
+	for _, want := range []string{
+		"local pin", "intentionally unenrolled", "changed this device's organization",
+		command, "retry your command", "only clears this CLI", "keep the pin", "wendy auth login",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("refusal missing %q:\n%s", want, msg)
+		}
+	}
+	if strings.Contains(msg, "\x1b") {
+		t.Fatalf("programmatic error contains terminal styling: %q", msg)
+	}
+	if strings.Index(msg, command) > strings.Index(msg, "Saved:") {
+		t.Errorf("recovery command is buried after certificate details:\n%s", msg)
+	}
+	var diagnostic interface{ CLIMessage() string }
+	if !errors.As(err, &diagnostic) {
+		t.Fatalf("refusal has no CLI presentation: %v", err)
+	}
+	rendered := diagnostic.CLIMessage()
+	if got := ansi.Strip(rendered); got != "✗ "+msg {
+		t.Errorf("CLI and programmatic recovery guidance differ:\n%s\n%s", got, msg)
+	}
+	if strings.Count(rendered, "✗") != 1 {
+		t.Errorf("want one error heading:\n%s", rendered)
+	}
+	lines := strings.Split(rendered, "\n")
+	if !strings.Contains(lines[0], "\x1b[") {
+		t.Error("test precondition: heading must be colored")
+	}
+	for _, line := range lines[1:] {
+		plain := ansi.Strip(line)
+		if strings.HasPrefix(plain, "  wendy device unpin ") || strings.HasPrefix(plain, "Saved:") || strings.HasPrefix(plain, "Now:") {
+			continue
+		}
+		if strings.Contains(line, "\x1b[") {
+			t.Errorf("recovery prose should be plain: %q", line)
+		}
+	}
+	t.Log("\n" + rendered)
+}

--- a/go/internal/cli/commands/device_pin_diagnostic_test.go
+++ b/go/internal/cli/commands/device_pin_diagnostic_test.go
@@ -11,6 +11,36 @@ import (
 	"github.com/wendylabsinc/wendy/go/internal/shared/config"
 )
 
+func TestShellQuoteArg(t *testing.T) {
+	for _, tc := range []struct {
+		in, want string
+	}{
+		{"wendyos-ccr1.local", "wendyos-ccr1.local"}, // ordinary name left bare
+		{"", "''"},
+		{"has space", "'has space'"},
+		{"foo;rm -rf ~", "'foo;rm -rf ~'"},
+		{"$(reboot)", "'$(reboot)'"},
+		{"a'b", `'a'\''b'`}, // embedded single quote
+	} {
+		if got := shellQuoteArg(tc.in); got != tc.want {
+			t.Errorf("shellQuoteArg(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// A pin keyed by an mDNS display alias can carry arbitrary bytes. The recovery
+// command must not paste into a shell as anything but a single, inert argument.
+func TestDevicePinRefusalQuotesUntrustedAlias(t *testing.T) {
+	const alias = "evil; rm -rf ~ #"
+	msg := devicePinDiagnostic{hostname: alias, heading: "blocked", details: "x"}.message(false)
+	if want := "wendy device unpin '" + alias + "'\n"; !strings.Contains(msg, want) {
+		t.Errorf("recovery command not shell-quoted, want %q in:\n%s", want, msg)
+	}
+	if strings.Contains(msg, "unpin evil;") {
+		t.Errorf("unquoted injection reached the recovery command:\n%s", msg)
+	}
+}
+
 func TestDevicePinRefusalRecoveryPresentation(t *testing.T) {
 	profile := lipgloss.ColorProfile()
 	lipgloss.SetColorProfile(termenv.TrueColor)

--- a/go/internal/cli/commands/device_unpin.go
+++ b/go/internal/cli/commands/device_unpin.go
@@ -65,7 +65,8 @@ func newDeviceUnpinCmd() *cobra.Command {
 			"records a fresh identity instead of being challenged against the old one.\n" +
 			"Accepts either the hostname you connect to or the identity URN a refusal\n" +
 			"prints (urn:wendy:org:<org>:asset:<id>).\n" +
-			"Use this after a legitimate reflash, factory reset, or re-enrollment —\n" +
+			"Use this after an intentional unenrollment, reflash, factory reset,\n" +
+			"or move to another organization —\n" +
 			"anything that made 'wendy device unpin' the CLI's own suggestion.",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/go/internal/cli/commands/dial_target.go
+++ b/go/internal/cli/commands/dial_target.go
@@ -333,7 +333,10 @@ var errDeviceIdentityRefused = errors.New("device identity refused")
 // deviceIdentityRefusalError carries a refusal's full user-facing text while
 // staying recognisable to errors.Is. The text is the whole message rather than
 // a wrap so the refusals read exactly as they did before this type existed.
-type deviceIdentityRefusalError struct{ msg string }
+type deviceIdentityRefusalError struct {
+	msg        string
+	diagnostic *devicePinDiagnostic
+}
 
 func (e *deviceIdentityRefusalError) Error() string { return e.msg }
 
@@ -344,7 +347,7 @@ func (e *deviceIdentityRefusalError) Is(target error) bool {
 // refuseIdentity builds a refusal that errors.Is(err, errDeviceIdentityRefused)
 // recognises. Every refusal raised because the wrong device answered — here and
 // in device_pin.go — must go through it.
-func refuseIdentity(format string, args ...any) error {
+func refuseIdentity(format string, args ...any) *deviceIdentityRefusalError {
 	return &deviceIdentityRefusalError{msg: fmt.Sprintf(format, args...)}
 }
 
@@ -356,9 +359,11 @@ func identityRefusal(pinKey string, im *certs.IdentityMismatchError) error {
 	if im.GotAsset != "" {
 		got = fmt.Sprintf("asset %s in organization %d", im.GotAsset, im.GotOrg)
 	}
-	return refuseIdentity(
-		"device %q is pinned to asset %s in organization %d, but the host answering presented %s; refusing to connect — if this device was legitimately replaced or re-enrolled, run 'wendy device unpin %s'",
-		pinKey, im.WantAsset, im.WantOrg, got, pinKey)
+	return refuseDevicePin(devicePinDiagnostic{
+		hostname: pinKey,
+		heading:  fmt.Sprintf("Connection blocked: device %q identity changed.", pinKey),
+		details:  fmt.Sprintf("Saved: asset %s in organization %d\nNow:   %s", im.WantAsset, im.WantOrg, got),
+	})
 }
 
 // errNoAuthenticatedEndpoint is what a "nothing answered" refusal answers

--- a/go/internal/cli/commands/dial_target_test.go
+++ b/go/internal/cli/commands/dial_target_test.go
@@ -592,9 +592,10 @@ func TestWrongDeviceAbortsLadder(t *testing.T) {
 	if err == nil {
 		t.Fatal("ladder returned no error for a wrong-device rejection")
 	}
-	want := `device "orin.local" is pinned to asset 42 in organization 7, but the host answering presented asset 43 in organization 7`
-	if !strings.Contains(err.Error(), want) || !strings.Contains(err.Error(), "wendy device unpin orin.local") {
-		t.Fatalf("err = %v, want the identity refusal naming both identities and the unpin escape hatch", err)
+	for _, want := range []string{`device "orin.local" identity changed`, "asset 42 in organization 7", "asset 43 in organization 7", "wendy device unpin orin.local", "changed this device's organization"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("err = %v, want the identity refusal to include %q", err, want)
+		}
 	}
 	if mtlsErr == nil {
 		t.Fatal("mtlsErr = nil, want the mTLS probe failure preserved alongside the refusal")


### PR DESCRIPTION
A device that was intentionally unenrolled or moved to another organization can still have its old identity pinned by the CLI. The next enrollment attempt currently prints repeated red diagnostics and buries the unpin command behind a circular suggestion to re-enroll.

Show one red refusal heading, explain the saved local pin, and put the exact unpin command directly below the condition for an intentional change. Keep identity details muted at the end. The same guidance covers organization/asset mismatches rejected during the TLS handshake. Add a short recovery example to the PKI docs and mention unenrollment and organization moves in `device unpin --help`.

Before (all red, abbreviated):

```text
✗ Device "wendyos-ccr1.local" was enrolled, but is now answering without an identity.
✗ pinned: organization 2 ... asset 481
✗ now: unprovisioned (no mTLS)
✗ An enrolled device does not drop its certificate on its own — ...
✗ ... refusing to connect — re-enroll it, check 'wendy auth login', or run 'wendy device unpin wendyos-ccr1.local' if this is expected
```

After (only the heading is red; the command is blue):

```text
✗ Connection blocked: device "wendyos-ccr1.local" has no enrolled identity.
This CLI still remembers its previous enrollment (a local pin).

If you intentionally unenrolled, reset, reflashed, or changed this device's organization:
  wendy device unpin wendyos-ccr1.local
Then retry your command. Unpinning only clears this CLI's saved device identity.

If this change was unexpected, keep the pin and verify the device first.
Missing organization credentials? Run 'wendy auth login', then retry.

Saved: organization 2 via cloud.example:443, asset 481
Now:   unprovisioned (no mTLS)
```

Connections still fail closed, pins remain intact, and there is no trust confirmation prompt. Plain errors retain all guidance for programmatic callers; CLI rendering preserves wrapped action context and joined errors. Cloud cleanup behavior is unchanged.

Validation: focused output and identity/refusal/unpin tests, CLI and commands package tests, `go vet` for both packages, and `git diff --check`.
