### PR TITLE
Drop a presence lease the broker refuses

### DIFF
--- a/go/internal/shared/cloudrelay/agent.go
+++ b/go/internal/shared/cloudrelay/agent.go
@@ -229,6 +229,28 @@ func (a *Agent) runOnce(parent context.Context) error {
 		return err
 	}
 	defer conn.Close()
+	// Past this point the lease is committed to one broker process, and a lease
+	// outlives that process by nothing: every boot mints a fresh 256-bit
+	// audience, so a restart invalidates every lease Cloud signed against the
+	// old one. The broker then refuses admission, and re-presenting the same
+	// lease can never start working -- it has to be replaced. Dropping it here
+	// costs one extra IssuePresenceLease on reconnect; keeping it costs
+	// presence until the lease expires, up to a quarter of an hour, on every
+	// ordinary broker deploy.
+	keepLease := false
+	defer func() {
+		// A cancelled parent is the agent shutting down, not the broker
+		// refusing anything: the lease is still good and is what lets the next
+		// start resume presence without a round trip to Cloud.
+		if keepLease || parent.Err() != nil {
+			return
+		}
+		a.lease, a.leaseClaims = nil, claims{}
+		// The same dead lease is otherwise reloaded after an agent restart:
+		// validateLease checks Cloud's signature, which a stale lease still
+		// carries, not whether the broker still knows it.
+		_ = os.Remove(filepath.Join(a.StateDir, "lease.pb"))
+	}()
 	stream, err := pb.NewTunnelBrokerV2ServiceClient(conn).RegisterPresence(metadata.NewOutgoingContext(ctx, metadata.MD{}))
 	if err != nil {
 		return err
@@ -308,8 +330,11 @@ func (a *Agent) runOnce(parent context.Context) error {
 				return e
 			}
 			if n.Aud != c.Aud || n.Route != c.Route || l.Broker.Endpoint != lease.Broker.Endpoint {
+				// Freshly issued against the broker Cloud now names, so it is
+				// the one lease that survives this attempt.
 				a.lease = l
 				a.leaseClaims = n
+				keepLease = true
 				return fmt.Errorf("Cloud selected a new presence route; reconnecting")
 			}
 			renewing = l

--- a/go/internal/shared/cloudrelay/relay_test.go
+++ b/go/internal/shared/cloudrelay/relay_test.go
@@ -24,15 +24,18 @@ import (
 	pb "github.com/wendylabsinc/wendy/go/proto/gen/relaypb"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type testRelay struct {
-	renewOnly bool
-	renewed   chan struct{}
+	refusePresence bool
+	renewOnly      bool
+	renewed        chan struct{}
 	pb.UnimplementedTunnelAuthorizationServiceServer
 	pb.UnimplementedTunnelBrokerV2ServiceServer
 	t                   *testing.T
@@ -120,6 +123,11 @@ func verifyProof(pub *ecdsa.PublicKey, domain string, c claims, artifact, role s
 }
 func (r *testRelay) RegisterPresence(s grpc.BidiStreamingServer[pb.RegisterPresenceRequest, pb.RegisterPresenceResponse]) error {
 	assertAnonymous(r.t, s.Context())
+	if r.refusePresence {
+		// What a restarted broker does with a lease minted against the audience
+		// its previous incarnation generated: it has never heard of it.
+		return status.Error(codes.PermissionDenied, "unknown presence lease")
+	}
 	m, e := s.Recv()
 	if e != nil {
 		return e
@@ -521,5 +529,47 @@ func TestAgentRenewsProvenPresence(t *testing.T) {
 	}
 	if stored.PresenceLeaseJws != r.leaseJWS {
 		t.Fatal("renewal was not persisted for reconnect")
+	}
+}
+
+// A broker restart mints a new audience and invalidates every outstanding
+// lease, so a refused admission is the normal outcome of an ordinary deploy.
+// Re-presenting the refused lease can never begin to work -- the agent has to
+// drop it, on disk as well as in memory, or it stays out of contact until the
+// lease expires.
+func TestRefusedAdmissionDropsTheLease(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	verifier := &Verifier{Issuer: "https://cloud.test", fetched: time.Now(), keys: map[string]jwk{"test": {Kid: "test", Kty: "EC", Alg: "ES256", Crv: "P-256", X: b64.EncodeToString(key.X.FillBytes(make([]byte, 32))), Y: b64.EncodeToString(key.Y.FillBytes(make([]byte, 32)))}}}
+	listener, e := net.Listen("tcp", "127.0.0.1:0")
+	if e != nil {
+		t.Fatal(e)
+	}
+	r := &testRelay{t: t, endpoint: listener.Addr().String(), cloudKey: key, verifier: verifier, refusePresence: true}
+	srv := grpc.NewServer()
+	pb.RegisterTunnelAuthorizationServiceServer(srv, r)
+	pb.RegisterTunnelBrokerV2ServiceServer(srv, r)
+	go srv.Serve(listener)
+	defer srv.Stop()
+	dial := func(endpoint string) (*grpc.ClientConn, error) {
+		return grpc.NewClient(endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
+	verifier.relayDial = dial
+	agent := &Agent{Endpoint: r.endpoint, Verifier: verifier, StateDir: t.TempDir(), Credentials: func() (string, string, []byte) { return "", "", nil }, Logger: zap.NewNop(), dialCloud: func(endpoint, _, _ string, _ []byte) (*grpc.ClientConn, error) { return dial(endpoint) }}
+
+	if err := agent.runOnce(ctx); err == nil {
+		t.Fatal("expected the refused admission to fail the attempt")
+	}
+	// Cloud did issue one -- the refusal is the broker's, downstream of a
+	// perfectly valid lease -- so this is genuinely a discard, not a no-op.
+	if r.leaseJWS == "" {
+		t.Fatal("no lease was ever issued, so nothing was under test")
+	}
+	if agent.lease != nil || agent.leaseClaims != (claims{}) {
+		t.Fatal("the refused lease is still cached and would be presented again")
+	}
+	if _, err := os.Stat(filepath.Join(agent.StateDir, "lease.pb")); !os.IsNotExist(err) {
+		t.Fatalf("the refused lease survives on disk and would be reloaded at next start (stat err = %v)", err)
 	}
 }


### PR DESCRIPTION
- **Advances:** [WDY-2367 Implement wendy-agent presence leases and D18 session joins](https://linear.app/wendylabsinc/issue/WDY-2367)
- **Base:** `jo/oidc-fixes`, per sem's ruling of 2026-09-12 01:40.

> **In plain terms:** When the tunnel broker restarts, every agent's presence lease stops being valid. The agent kept offering the dead one anyway, so an ordinary broker deploy took devices out of contact for up to fifteen minutes. It now throws the lease away and asks Cloud for a new one.

## Summary
- A presence lease is signed against one broker process incarnation: every boot mints a fresh, unpredictable 256-bit audience and "restart therefore invalidates every earlier presence lease, attestation, and grant" (AAA contract v0.20 §5.8). The broker refuses admission for a lease from a previous incarnation.
- `runOnce` replaced `a.lease` only when it was missing or within 30s of expiry, so the reconnect loop re-presented the refused lease — which cannot start working — until it aged out. With the backoff capping at one minute, that is roughly fifteen failed cycles of no presence per broker deploy.
- The lease is now discarded once the attempt that committed to it fails, in memory **and on disk**: `validateLease` checks Cloud's signature, which a stale lease still carries, so a persisted one would otherwise be reloaded and re-presented at the next start.
- Two cases deliberately keep it: the lease Cloud issues when it moves the agent to a new route, which was minted against the broker Cloud now names; and a cancelled parent context, which is the agent shutting down rather than the broker refusing anything.

Costs one extra `IssuePresenceLease` per reconnect.

## Tests
- `go build ./... && go vet ./... && gofmt -l go` — clean
- `go test ./go/... -count=1` — passes except the four pre-existing `internal/agent/oci` GPU tests, which fail identically on `jo/oidc-fixes` with no NVIDIA device present
- New `TestRefusedAdmissionDropsTheLease` drives a broker that refuses `RegisterPresence` the way a restarted incarnation does, and asserts the lease is gone from memory and from disk. Verified against the unmodified `agent.go` from `jo/oidc-fixes`: it fails there with `the refused lease is still cached and would be presented again`.