### PR TITLE
Inject the avahi restart into updateAvahiService

### DIFF
--- a/go/internal/agent/configpartition/apply.go
+++ b/go/internal/agent/configpartition/apply.go
@@ -342,6 +342,24 @@ func applyDeviceName(logger *zap.Logger, name string) error {
 	return nil
 }
 
+// restartAvahiDaemon restarts avahi-daemon so it re-reads the service files.
+//
+// --reload (SIGHUP) only refreshes service files; it does not re-read the
+// hostname from gethostname(), so %h would stay stale. A full restart picks up
+// both the new service file and the updated hostname.
+//
+// Use the absolute path: exec.Command resolves binaries from the calling
+// process's PATH, not from cmd.Env, so bare "systemctl" would not be found.
+func restartAvahiDaemon(logger *zap.Logger, env []string) bool {
+	restart := exec.Command("/usr/bin/systemctl", "restart", "avahi-daemon")
+	restart.Env = env
+	if out, err := restart.CombinedOutput(); err != nil {
+		logger.Warn("systemctl restart avahi-daemon failed", zap.Error(err), zap.String("output", string(out)))
+		return false
+	}
+	return true
+}
+
 // updateAvahiDeviceName rewrites the name/displayname/fqdn TXT records in the
 // avahi service file and reloads avahi-daemon so mDNS picks up the new name.
 func updateAvahiDeviceName(logger *zap.Logger, name string, env []string) {
@@ -365,16 +383,7 @@ func updateAvahiDeviceName(logger *zap.Logger, name string, env []string) {
 		return
 	}
 
-	// --reload (SIGHUP) only refreshes service files; it does not re-read the
-	// hostname from gethostname(), so %h would stay stale. A full restart picks
-	// up both the new service file and the updated hostname.
-	// Use the absolute path: exec.Command resolves binaries from the calling
-	// process's PATH, not from cmd.Env, so bare "systemctl" would not be found.
-	restart := exec.Command("/usr/bin/systemctl", "restart", "avahi-daemon")
-	restart.Env = env
-	if out, err := restart.CombinedOutput(); err != nil {
-		logger.Warn("systemctl restart avahi-daemon failed", zap.Error(err), zap.String("output", string(out)))
-	} else {
+	if restartAvahiDaemon(logger, env) {
 		logger.Info("Restarted avahi-daemon with new device name", zap.String("name", name))
 	}
 }
@@ -385,7 +394,9 @@ func updateAvahiDeviceName(logger *zap.Logger, name string, env []string) {
 // restarts avahi-daemon so the mDNS advertisement reflects that the device is
 // now provisioned.
 func UpdateAvahiForProvisioning(logger *zap.Logger, mtlsPort int, assetID, orgID int32) {
-	updateAvahiService(logger, defaultAvahiServiceDir, mtlsPort, true, assetID, orgID)
+	updateAvahiService(logger, defaultAvahiServiceDir, mtlsPort, true, assetID, orgID, func() bool {
+		return restartAvahiDaemon(logger, nil)
+	})
 }
 
 // UpdateAvahiForUnprovisioning reverts the _wendyos._udp service block to
@@ -394,7 +405,9 @@ func UpdateAvahiForProvisioning(logger *zap.Logger, mtlsPort int, assetID, orgID
 // inverse of UpdateAvahiForProvisioning, used when a device is unprovisioned
 // so it is rediscoverable for re-enrollment.
 func UpdateAvahiForUnprovisioning(logger *zap.Logger, plaintextPort int) {
-	updateAvahiService(logger, defaultAvahiServiceDir, plaintextPort, false, 0, 0)
+	updateAvahiService(logger, defaultAvahiServiceDir, plaintextPort, false, 0, 0, func() bool {
+		return restartAvahiDaemon(logger, nil)
+	})
 }
 
 // defaultAvahiServiceDir is the directory scanned for avahi service files on
@@ -406,7 +419,13 @@ const defaultAvahiServiceDir = "/etc/avahi/services"
 // image (e.g. wendyos-mdns.service or wendy-agent.service), so we scan all
 // files in serviceDir and update the first one that contains a _wendyos._udp
 // block.
-func updateAvahiService(logger *zap.Logger, serviceDir string, port int, tls bool, assetID, orgID int32) {
+//
+// The avahi restart is injected, like the equivalent helpers in
+// internal/agent/services: a test drives this with a real service file in a
+// temporary directory, so every guard passes and the restart is reached for
+// real. Left un-injected it prompts for polkit authorization on a developer
+// machine and blocks the package's tests for the length of that timeout.
+func updateAvahiService(logger *zap.Logger, serviceDir string, port int, tls bool, assetID, orgID int32, restartAvahi func() bool) {
 	entries, err := os.ReadDir(serviceDir)
 	if err != nil {
 		logger.Warn("Could not read avahi services dir", zap.String("path", serviceDir), zap.Error(err))
@@ -433,11 +452,7 @@ func updateAvahiService(logger *zap.Logger, serviceDir string, port int, tls boo
 			return
 		}
 
-		restart := exec.Command("/usr/bin/systemctl", "restart", "avahi-daemon")
-		if out, err := restart.CombinedOutput(); err != nil {
-			logger.Warn("systemctl restart avahi-daemon failed",
-				zap.Error(err), zap.String("output", string(out)))
-		} else {
+		if restartAvahi() {
 			logger.Info("Updated avahi advertisement",
 				zap.String("file", e.Name()), zap.Int("port", port), zap.Bool("tls", tls), zap.Int32("assetId", assetID), zap.Int32("orgId", orgID))
 		}
@@ -574,11 +589,7 @@ func UpdateAvahiSensorlink(logger *zap.Logger, on bool) {
 			return
 		}
 
-		restart := exec.Command("/usr/bin/systemctl", "restart", "avahi-daemon")
-		if out, err := restart.CombinedOutput(); err != nil {
-			logger.Warn("systemctl restart avahi-daemon failed",
-				zap.Error(err), zap.String("output", string(out)))
-		} else {
+		if restartAvahiDaemon(logger, nil) {
 			logger.Info("Updated avahi sensorlink advertisement",
 				zap.String("file", e.Name()), zap.Bool("sensorlink", on))
 		}

--- a/go/internal/agent/configpartition/apply_test.go
+++ b/go/internal/agent/configpartition/apply_test.go
@@ -526,7 +526,11 @@ func TestUpdateAvahiService_ProvisioningWritesAssetIDTXTRecord(t *testing.T) {
 	}
 
 	logger, _ := zap.NewDevelopment()
-	updateAvahiService(logger, dir, 50052, true, 215, 0)
+	restarts := 0
+	updateAvahiService(logger, dir, 50052, true, 215, 0, func() bool { restarts++; return true })
+	if restarts != 1 {
+		t.Errorf("restarted avahi %d times, want 1", restarts)
+	}
 
 	got, err := os.ReadFile(serviceFile)
 	if err != nil {
@@ -549,7 +553,11 @@ func TestUpdateAvahiService_UnprovisioningRemovesAssetID(t *testing.T) {
 	}
 
 	logger, _ := zap.NewDevelopment()
-	updateAvahiService(logger, dir, 50051, false, 0, 0)
+	restarts := 0
+	updateAvahiService(logger, dir, 50051, false, 0, 0, func() bool { restarts++; return true })
+	if restarts != 1 {
+		t.Errorf("restarted avahi %d times, want 1", restarts)
+	}
 
 	got, err := os.ReadFile(serviceFile)
 	if err != nil {


### PR DESCRIPTION
> **In plain terms:** Two tests in `configpartition` really ran `systemctl restart avahi-daemon`, which asks for a polkit password on a developer machine. The package's tests sat waiting out that prompt — 50 seconds every full test run. The restart is now injected in tests, exactly as the equivalent helpers in `internal/agent/services` already do it.

## Summary
- `TestUpdateAvahiService_ProvisioningWritesAssetIDTXTRecord` and `TestUpdateAvahiService_UnprovisioningRemovesAssetID` hand `updateAvahiService` a temp directory holding a real `_wendyos._udp` service file. That is the point of them — and it passes every guard the function has, so `exec.Command("/usr/bin/systemctl", "restart", "avahi-daemon")` ran for real.
- `updateAvahiService` now takes the restart as a parameter, like `reassertHostnameAdvertisement` and `ensureDeviceTypeAdvertisement`. Its two production callers pass the real one.
- The three copies of the exec collapse into one `restartAvahiDaemon` helper.
- `go test ./go/internal/agent/configpartition/` goes from **50.0s to 0.014s**.

Production behaviour is unchanged: same binary, same absolute path, same argv, same env, same log lines.

`avahi-daemon` reports `NRestarts=0` on the machine where this was found, so no run ever got past the prompt — the cost was the prompt and the wait, not a disturbed daemon.

## Tests
- `go build ./... && go vet ./... && gofmt -l go` — clean
- `go test ./go/... -count=1` — passes except two pre-existing failures, both confirmed identical on an untouched `jo/oidc-fixes` checkout on this machine: the four `internal/agent/oci` GPU tests (no NVIDIA device) and `TestHashicorpStreamBackendLiveAdvertise` in `internal/shared/discovery` (live mDNS, fails 2/2 on the base and 3/3 here)
- Both avahi tests now assert the restart happened exactly once, which the old versions could not check at all