### PR TITLE
agent: probe every capture pixel format when enumerating a camera's frame sizes

### DIFF
--- a/go/internal/agent/services/video_framesize_test.go
+++ b/go/internal/agent/services/video_framesize_test.go
@@ -136,3 +136,49 @@ func TestBuildGStreamerArgs_USB_RawWhenNoJpegdec(t *testing.T) {
 		t.Fatalf("expected raw capture without jpegdec available, got: %s", joined)
 	}
 }
+
+// A thermal module offers none of the formats a webcam does. The PureThermal
+// carrying a FLIR Lepton advertises Y16, UYVY and GREY — so probing only
+// {YUYV, MJPEG} found nothing, the agent concluded the camera had no frame
+// sizes, and zero dimensions took out the whole capture path: no caps on the
+// pipeline, no frame ever negotiated, and the raw tap declined for "no discrete
+// frame size". Observed on enmax01 with the agent holding /dev/video2 open in a
+// pipeline that could never produce a frame.
+func TestFrameSizeProbeFormatsCoversThermalPixelFormats(t *testing.T) {
+	probed := frameSizeProbeFormats()
+
+	seen := make(map[uint32]bool, len(probed))
+	for _, f := range probed {
+		seen[f] = true
+	}
+
+	for _, want := range []struct {
+		name   string
+		pixfmt uint32
+	}{
+		{"YUYV", v4l2PixFmtYUYV},
+		{"UYVY", v4l2PixFmtUYVY},
+		{"Y16", v4l2PixFmtY16},
+		{"GREY", v4l2PixFmtGrey},
+		{"MJPEG", v4l2PixFmtMJPEG},
+	} {
+		if !seen[want.pixfmt] {
+			t.Errorf("frame size probe omits %s (0x%08x); a camera offering only "+
+				"that format reports no sizes and becomes unstreamable", want.name, want.pixfmt)
+		}
+	}
+
+	// Every format the raw tap can capture must be probed, or the tap can be
+	// offered a format whose sizes were never enumerated.
+	for _, f := range rawPixelFormats {
+		if !seen[f.v4l2] {
+			t.Errorf("raw tap handles %q but the frame size probe does not ask about it",
+				strings.TrimSpace(f.fourcc))
+		}
+	}
+
+	// The common webcam path must be unchanged: YUYV is still tried first.
+	if len(probed) == 0 || probed[0] != v4l2PixFmtYUYV {
+		t.Errorf("probe order changed: want YUYV first, got %v", probed)
+	}
+}

--- a/go/internal/agent/services/video_service.go
+++ b/go/internal/agent/services/video_service.go
@@ -200,6 +200,29 @@ func bestDefaultFrameSize(fd int, pixfmt uint32) (uint32, uint32) {
 	return fallbackW, fallbackH
 }
 
+// frameSizeProbeFormats lists the pixel formats worth asking a camera about when
+// enumerating its frame sizes: every raw format the capture path can actually
+// negotiate (rawPixelFormats), plus MJPEG.
+//
+// It used to be a hardcoded {YUYV, MJPEG}. A camera offering neither answered
+// nothing, so the agent concluded it had no sizes at all — and a thermal module
+// offers neither: a FLIR Lepton behind a PureThermal advertises Y16, UYVY and
+// GREY. Zero dimensions then propagate: the caps get no width or height, the
+// GStreamer pipeline has nothing to negotiate with, no frame ever arrives, and
+// the raw tap is declined for "no discrete frame size". rawPixelFormats already
+// names the formats the tap handles, Y16 among them, so the two lists were
+// describing the same capability and disagreeing about it.
+//
+// YUYV stays first via rawPixelFormats' own ordering, so the webcam path that
+// every other camera takes is unchanged.
+func frameSizeProbeFormats() []uint32 {
+	formats := make([]uint32, 0, len(rawPixelFormats)+1)
+	for _, f := range rawPixelFormats {
+		formats = append(formats, f.v4l2)
+	}
+	return append(formats, v4l2PixFmtMJPEG)
+}
+
 // bestDefaultFrameSizeForDevice opens path just long enough to ask what the
 // camera can do, and returns the largest discrete size across the pixel formats
 // the GStreamer path can negotiate. (0,0) when the device cannot be opened or
@@ -220,7 +243,7 @@ var bestDefaultFrameSizeForDevice = func(path string) (uint32, uint32) {
 	defer unix.Close(fd) //nolint:errcheck
 
 	var bestW, bestH uint32
-	for _, pixfmt := range []uint32{v4l2PixFmtYUYV, v4l2PixFmtMJPEG} {
+	for _, pixfmt := range frameSizeProbeFormats() {
 		w, h := bestDefaultFrameSize(fd, pixfmt)
 		if uint64(w)*uint64(h) > uint64(bestW)*uint64(bestH) {
 			bestW, bestH = w, h
@@ -1531,7 +1554,7 @@ func deviceAdvertisesFrameSize(path string, w, h uint32) (advertised, known bool
 	}
 	defer unix.Close(fd) //nolint:errcheck
 
-	for _, pixfmt := range []uint32{v4l2PixFmtYUYV, v4l2PixFmtMJPEG} {
+	for _, pixfmt := range frameSizeProbeFormats() {
 		for index := uint32(0); index < 64; index++ {
 			fse := v4l2FrmSizeEnum{Index: index, PixelFormat: pixfmt}
 			if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), vidiocEnumFramesizes,


### PR DESCRIPTION
## What

`bestDefaultFrameSizeForDevice` and `deviceAdvertisesFrameSize` both enumerated a
camera's frame sizes against a hardcoded `{YUYV, MJPEG}`. They now probe
`rawPixelFormats` — the table the raw tap already uses — plus MJPEG.

```go
-	for _, pixfmt := range []uint32{v4l2PixFmtYUYV, v4l2PixFmtMJPEG} {
+	for _, pixfmt := range frameSizeProbeFormats() {
```

## Why

A camera that offers neither of those two formats answers nothing, so the agent
concludes it has **no frame sizes at all** — and a thermal module offers neither.
A FLIR Lepton behind a PureThermal advertises `Y16`, `UYVY`, `GREY`, `RGBP`,
`BGR3`.

Those zero dimensions then propagate through the entire capture path:

| Stage | Result |
|---|---|
| `capsParts` | stays empty, so `if len(capsParts) > 0` appends no caps element |
| GStreamer | `v4l2src device=/dev/video2` with no width, height or format to negotiate |
| Producer | `camera produced no video within 20s` |
| Raw tap | declined at `case capW == 0 \|\| capH == 0:` — *"camera advertises no discrete frame size to capture raw frames at"* |
| `validateStreamParams` | `deviceAdvertisesFrameSize` returns `known=false`, so it falls back to the webcam allowlist and refuses an explicit `160x120` — a size the camera **does** advertise — as *"unsupported resolution"* |

**The producer holds the device throughout**, and respawns seconds after being
killed, so the camera is denied to every other consumer as well as to the agent
itself. On enmax01 this left `/dev/video2` permanently occupied by a pipeline
that could never produce a frame:

```
gst 126859 <- ppid 1413 (wendy-agent)   device=/dev/video0  width=512,height=484   works
gst 162676 <- ppid 1413 (wendy-agent)   device=/dev/video2  (no caps)              never produces
```

```
{"level":"error","msg":"video producer exited with error",
 "device":"/dev/video2","error":"camera produced no video within 20s"}
```

The two lists were already describing the same capability and disagreeing about
it. `rawPixelFormats` names the formats the raw tap handles, with a comment on
the Y16 entry calling it *"the one that matters for thermal"* — while the size
probe, two functions away, never asked about it.

## Scope

Affects every camera whose modes are advertised only under a non-YUYV raw
format: FLIR Lepton carriers (PureThermal, tCam-Mini over USB) and thermal cores
that expose 16-bit data directly rather than stacking it onto a picture.

The TOPDON TC001 is unaffected — it advertises YUYV and was already found.

## Compatibility

`YUYV` stays first through `rawPixelFormats`' existing ordering, so the format
chosen for every camera that already worked is unchanged. The probe only ever
*adds* formats to ask about; a camera that answered before answers identically.

## Tests

`TestFrameSizeProbeFormatsCoversThermalPixelFormats` asserts the probe covers
Y16, UYVY and GREY, that it stays in sync with `rawPixelFormats` (so the tap can
never be offered a format whose sizes were never enumerated), and that YUYV
remains first.

Verified failing without the fix:

```
--- FAIL: TestFrameSizeProbeFormatsCoversThermalPixelFormats
    frame size probe omits UYVY (0x59565955); a camera offering only that format
      reports no sizes and becomes unstreamable
    frame size probe omits Y16 (0x20363159); ...
    raw tap handles "Y16" but the frame size probe does not ask about it
```

`go build ./...`, `go vet`, and the existing `Video|Camera|Frame|Raw` suite pass.

## Hardware verification

Side-loaded onto `enmax01` (Orin, WendyOS 0.18.2) with
`wendy device update --binary`, alongside a TOPDON TC001 on `/dev/video0` and a
PureThermal + FLIR Lepton on `/dev/video2`.

**The enumeration fix works.** The PureThermal's refusal changed:

```
before:  raw frames are not available for this camera:
         camera advertises no discrete frame size to capture raw frames at
after:   GStreamer pipeline failed; see agent logs for details
```

The agent now finds a frame size for a camera that advertises only Y16/UYVY/GREY,
where before it found none. That is exactly the behaviour this change is for.

**No regression on the camera that already worked.** The TC001 on `/dev/video0`:

| | |
|---|---|
| H.264 | 3.7 MB and 4.4 MB over two 35 s runs |
| raw | 9.9 MB, `512x484 YUYV, 1024 bytes per line, 495616 bytes per frame` — byte-identical layout to before |

It advertises only `YUYV`, so the widened probe cannot change which mode is
selected for it. Any camera that answered before answers the same.

**Frames from the PureThermal are still not flowing**, and that is not this
change. The camera is not delivering data at all — a bare capture with no
encoder in the graph fails the same way:

```
gst-launch-1.0 v4l2src device=/dev/video2 num-buffers=5 !
  video/x-raw,format=GRAY16_LE,width=160,height=122 ! fakesink
ERROR: from element GstV4l2Src:v4l2src0: Internal data stream error.
```

`v4l2-ctl --stream-count=5` on the same node also returns zero bytes with the
device otherwise free. The camera had been held open and reopened repeatedly by
the capless pipeline this change removes, and now needs a physical replug. So the
end of the path is unverified on hardware: this fixes the enumeration, and
whether that alone gets frames out of a healthy Lepton still wants confirming on
a camera in a good state.

The agent's own pipeline additionally reported `Can not initialize x264 encoder`
at 160x122 before the capture error surfaced. Whether x264 genuinely rejects that
geometry or that was downstream of the dead capture could not be separated while
the camera produces nothing — worth checking on healthy hardware, since a Lepton
that cannot be H.264-encoded would still fail for viewers even once capture works.

## Not covered here

A producer that times out with no frames still holds the V4L2 node and respawns,
so one camera it cannot drive denies that device to everything else. That is a
separate fix and probably wants its own issue — this change removes the cause for
Lepton-class cameras but not the general failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
